### PR TITLE
WIP:  remove KIND extraPortMappings for 80 and 443

### DIFF
--- a/install/config/images
+++ b/install/config/images
@@ -42,4 +42,4 @@ phx.ocir.io/stevengreenberginc/bfs/node-exporter:0.18.1-0f43627-7
 phx.ocir.io/stevengreenberginc/bfs/configmap-reload:0.3-81d6423-33
 phx.ocir.io/stevengreenberginc/bfs/keycloak:10.0.1-2dcd823-4
 phx.ocir.io/stevengreenberginc/bfs/fluentd-kubernetes-daemonset:v1.10.4-6ce326d-17
-
+docker.pkg.github.com/verrazzano/examples/helidon-greet-app-v1:0.1.7

--- a/install/config/kind-config.yaml
+++ b/install/config/kind-config.yaml
@@ -11,15 +11,6 @@ nodes:
         kubeletExtraArgs:
           node-labels: "ingress-ready=true"
           authorization-mode: "AlwaysAllow"
-    extraPortMappings:
-      - containerPort: 80
-        hostPort: 80
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 443
-        hostPort: 443
-        listenAddress: "0.0.0.0"
-        protocol: tcp
     extraMounts:
       - containerPath: /tmp/hostpath_pv
         hostPath: /tmp/hostpath_pv


### PR DESCRIPTION
The OKE test suite result is irrelevant since the change is KIND specific.  The real test run is here:  https://build.verrazzano.io/job/verrazzano-kind-acceptance-test-suite/job/gz%252Fkind_config/3/