### PR TITLE
WIP: Install should check for istio port access

### DIFF
--- a/install/3-install-verrazzano.sh
+++ b/install/3-install-verrazzano.sh
@@ -45,9 +45,11 @@ function check_ingress_ports() {
 
       # Attempt to access the port on the $INGRESS_IP
       if [ $TARGETPORT == "https" ]; then
-        curl -k https://$INGRESS_IP:$PORT
+        ARGS=(-k https://$INGRESS_IP:$PORT)
+        call_curl 0 response http_code ARGS
       else
-        curl http://$INGRESS_IP:$PORT
+        ARGS=(http://$INGRESS_IP:$PORT)
+        call_curl 0 response http_code ARGS
       fi
 
       # Check the result of the curl call

--- a/install/common.sh
+++ b/install/common.sh
@@ -173,6 +173,112 @@ function logDt() {
   echo -e $(date -u "+%Y-%m-%d %H:%M%:%S %Z") $@
 }
 
+function get_rancher_access_token {
+    # args  $1 = rancher hostname, $2 = rancher password
+  logDt "Retrieving the rancher admin token from Rancher at $1"
+
+  # Use external retries instead of curl retries, since curl does not retry for all
+  # the scenarios we want (e.g. connection errors)
+  retries=0
+  until [ $retries -ge 10 ]
+  do
+    ARGS=(-k --connect-timeout 30 \
+    -d '{"Username":"admin", "Password":"'$2'"}' \
+    -H "Content-Type: application/json" \
+    -X POST https://$1/v3-public/localProviders/local?action=login)
+    call_curl 201 response http_code ARGS
+    if [ $? -eq 0 ]; then
+      RANCHER_ADMIN_TOKEN=$(echo $response | jq -r '.token')
+
+      if [ ! -z "$RANCHER_ADMIN_TOKEN" ] ; then
+        break
+      fi
+    fi
+    logDt "Retrying get RANCHER_ADMIN_TOKEN"
+    retries=$(($retries+1))
+    sleep 30
+  done
+
+  if [ -z "$RANCHER_ADMIN_TOKEN" ] ; then
+      echo "RANCHER_ADMIN_TOKEN is empty! Did you run the scripts to install Istio and system components?"
+      return 1
+  fi
+
+  logDt "Retrieving the access token from Rancher at $1"
+
+  # Use external retries instead of curl retries, since curl does not retry for all
+  # the scenarios we want (e.g. connection errors)
+  retries=0
+  until [ "$retries" -ge 10 ]
+  do
+    ARGS=(-k --connect-timeout 30 \
+    -d '{"type":"token", "description":"automation"}' \
+    -H "Content-Type: application/json"
+    -H "Authorization: Bearer ${RANCHER_ADMIN_TOKEN}" \
+    -X POST https://$1/v3/token )
+    call_curl 201 response http_code ARGS
+    if [ $? -eq 0 ]; then
+      RANCHER_ACCESS_TOKEN=$(echo $response | jq -r '.token')
+
+      if [ ! -z "$RANCHER_ACCESS_TOKEN" ] ; then
+        break
+      fi
+    fi
+    logDt "Retrying get RANCHER_ACCESS_TOKEN"
+    retries=$(($retries+1))
+    sleep 30
+  done
+
+  if [ -z "$RANCHER_ACCESS_TOKEN" ] ; then
+      logDt "RANCHER_ACCESS_TOKEN is empty!\n"
+      echo
+      echo "Dumping additional detail below"
+      dump_rancher_ingress
+      return 1
+  fi
+}
+
+# Call curl with the given arguments and set the given variables for response body and http code.
+# $1 the expected http response code; pass 0 to indicate that the http code shouldn't be checked
+# $2 the variable to set with the response body
+# $3 the variable to set with the http response code
+# $4 array of arguments to pass to the curl call
+# Exit code: success (0); error code (1) if the curl call fails or if the expected http code is not returned
+function call_curl {
+  local resp
+  local exitcode
+  local expected_code=$1
+  local resp_body=$2
+  local http_code=$3
+  local arg_name=$4[@]
+  local curl_args=("${!arg_name}")
+  local regex="(.*)-- http_code:(.*)"
+
+  # make the curl call
+  resp=$(curl -s -w '-- http_code:%{http_code}\n' "${curl_args[@]}"); exitcode=$?
+
+  # if the curl command succeeded
+  if [ $exitcode -eq 0 ]; then
+    # use regex to capture the response body and http code
+    if [[ $resp  =~ $regex ]];  then
+      local body='"${BASH_REMATCH[1]}"'
+      eval $resp_body=$body
+      local code=${BASH_REMATCH[2]}
+      eval $http_code=$code
+      # check for the expected http code response
+      if [ $expected_code -gt 0 ] && [ $code -ne $expected_code ]; then
+        echo "ERROR: Expected http response code" $expected_code "but got" $code"!  Response: " $resp
+        return 1
+      fi
+      return 0
+    fi
+    echo "ERROR: Can't parse curl response: " $resp
+  else
+    echo "ERROR: curl call failed with exit code: " $exitcode
+  fi
+  return 1
+}
+
 trap onerror ERR EXIT
 
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:=verrazzano}


### PR DESCRIPTION
The 3-install-verrazzano script now checks if the LB can reach the nginx ports.  We need the same test for the istio 80 & 443 ports.

This test currently fails!

For the Nginx ingress port check we do a curl which succeeds (with a 404) if things are okay or the curl fails if the rule for the port is missing from the seclist.

If I try to do a curl through the Istio ingress during install, the curl fails with 'curl: (56) Recv failure: Connection reset by peer' whether or not the seclist rule is set for the port.  

After I deploy the demo, obviously the curl succeeds.

I've looked into deploying a simple app during the install to do a kind of health check and then cleaning it up after the install.  Istio sample app may work ...
https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/

For the simple case (http) this only requires a few steps.

- create service
- create deployment
- create gateway

For https it also requires 

- generate cert and key
- create secret
- create gateway
- create virtual service
