### PR TITLE
VZ-1164: revert verrazzano develop branch back to ocir

### DIFF
--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -7,8 +7,8 @@ image:
   terminationGracePeriodSeconds: 60
 
 docker:
-  repository: container-registry.oracle.com
-  namespace: verrazzano
+  repository: phx.ocir.io
+  namespace: stevengreenberginc/verrazzano
 
 verrazzanoOperator:
   name: verrazzano-operator


### PR DESCRIPTION
### Changes
- Change registry from OCR to OCIR on develop branch

### Tickets
- https://jira.oraclecorp.com/jira/browse/VZ-1164

### Tests
- https://build.verrazzano.io/job/verrazzano/job/kminder%252Fvz1164/