### PR TITLE
Find alternative to grep to find resources

### DIFF
--- a/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -43,23 +43,21 @@ function initializing_uninstall {
 }
 
 function delete_bindings {
-  binding_crd=$(kubectl get crd | grep "verrazzanobinding" || true)
-  if [ -z "$binding_crd" ] ; then
-    return
+  crd=$(kubectl get crd) || return $?
+  if echo $crd | grep -q "verrazzanobinding" ; then
+    kubectl get VerrazzanoBindings --no-headers -o custom-columns=":metadata.name" \
+      | xargs kubectl delete VerrazzanoBindings \
+      || return $? # return on pipefail
   fi
-  kubectl get VerrazzanoBindings --no-headers -o custom-columns=":metadata.name" \
-    | xargs kubectl delete VerrazzanoBindings \
-    || return $? # return on pipefail
 }
 
 function delete_models {
-  model_crd=$(kubectl get crd | grep "verrazzanomodel" || true)
-  if [ -z "$binding_crd" ] ; then
-    return
+  crd=$(kubectl get crd) || return $?
+  if echo $crd | grep -q "verrazzanomodel" ; then
+    kubectl get VerrazzanoModels --no-headers -o custom-columns=":metadata.name" \
+      | xargs kubectl delete VerrazzanoModels \
+      || return $? # return on pipefail
   fi
-  kubectl get VerrazzanoModels --no-headers -o custom-columns=":metadata.name" \
-    | xargs kubectl delete VerrazzanoModels \
-    || return $? # return on pipefail
 }
 
 action "Initializing Uninstall" initializing_uninstall || exit 1

--- a/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -43,21 +43,17 @@ function initializing_uninstall {
 }
 
 function delete_bindings {
-  crd=$(kubectl get crd) || return $?
-  if echo $crd | grep -q "verrazzanobinding" ; then
-    kubectl get VerrazzanoBindings --no-headers -o custom-columns=":metadata.name" \
-      | xargs kubectl delete VerrazzanoBindings \
-      || return $? # return on pipefail
-  fi
+  kubectl get crd verrazzanobindings.verrazzano.io || return 0
+  kubectl get VerrazzanoBindings --no-headers -o custom-columns=":metadata.name" \
+    | xargs kubectl delete VerrazzanoBindings \
+    || return $? # return on pipefail
 }
 
 function delete_models {
-  crd=$(kubectl get crd) || return $?
-  if echo $crd | grep -q "verrazzanomodel" ; then
-    kubectl get VerrazzanoModels --no-headers -o custom-columns=":metadata.name" \
-      | xargs kubectl delete VerrazzanoModels \
-      || return $? # return on pipefail
-  fi
+  kubectl get crd verrazzanomodels.verrazzano.io || return 0
+  kubectl get VerrazzanoModels --no-headers -o custom-columns=":metadata.name" \
+    | xargs kubectl delete VerrazzanoModels \
+    || return $? # return on pipefail
 }
 
 action "Initializing Uninstall" initializing_uninstall || exit 1

--- a/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -12,11 +12,8 @@ set -o pipefail
 
 function delete_external_dns() {
   log "Deleting external-dns"
-  local extdns_rec=("$(helm ls -A \
-    | grep "external-dns" || true)")
-
-  printf "%s\n" "${extdns_rec[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/external-dns/ {print $1}' \
     | xargs helm uninstall -n cert-manager \
     || return $? # return on pipefail
 
@@ -29,11 +26,8 @@ function delete_external_dns() {
 function delete_nginx() {
   # uninstall ingress-nginx
   log "Deleting ingress-nginx"
-  local ingress_res=("$(helm ls -A \
-    | grep "ingress-controller" || true)")
-
-  printf "%s\n" "${ingress_res[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/ingress-controller/ {print $1}' \
     | xargs helm uninstall -n ingress-nginx \
     || return $? # return on pipefail
 
@@ -44,11 +38,8 @@ function delete_nginx() {
 
   # delete ingress-nginx namespace
   log "Deleting ingress-nginx namespace"
-  local ingress_ns_fin_res=("$(kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'ingress-nginx' || true)")
-
-  printf "%s\n" "${ingress_ns_fin_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
+    | awk '/ingress-nginx/ {print $1}' \
     | xargs kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge  \
     || return $? # return on pipefail
 
@@ -58,11 +49,8 @@ function delete_nginx() {
 function delete_cert_manager() {
   # uninstall cert manager deployment
   log "Deleting cert-manager"
-  local cert_res=("$(helm ls -A \
-    | grep "cert-manager" || true)")
-
-  printf "%s\n" "${cert_res[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/cert-manager/ {print $1}' \
     | xargs helm uninstall -n cert-manager \
     || return $? # return on pipefail
 
@@ -76,11 +64,8 @@ function delete_cert_manager() {
 
   log "Deleting cert manager namespace"
   # delete namespace finalizers
-  local cert_ns_fin_res=("$(kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'cert-manager' || true)")
-
-  printf "%s\n" "${cert_ns_fin_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
+    | awk '/cert-manager/ {print $1}' \
     | xargs kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || return $? # return on pipefail
 
@@ -91,59 +76,44 @@ function delete_cert_manager() {
 function delete_rancher() {
   # Deleting rancher components
   log "Deleting rancher"
-  local rancher_res=("$(helm ls -A \
-    | grep "rancher" || true)")
-
-  printf "%s\n" "${rancher_res[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/rancher/ {print $1}' \
     | xargs helm uninstall -n cattle-system \
     || return $? # return on pipefail
 
   log "Deleting CRDs from rancher"
 
-  local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | grep -E 'coreos.com|cattle.io' || true)
+  local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
 
   while [ "$crd_content" ]
   do
       # remove finalizers from crds
-    local rancher_crd_fin_res=("$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
-      | grep -E 'coreos.com|cattle.io' || true)")
-
-    printf "%s\n" "${rancher_crd_fin_res[@]}" \
-      | awk '{print $1}' \
+    kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
+      | awk '/coreos.com|cattle.io/ {print $1}' \
       | xargs kubectl patch crd -p '{"metadata":{"finalizers":null}}' --type=merge \
       || return $? # return on pipefail
 
     # delete crds
-    local rancher_crd_res=("$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
-      | grep -E 'coreos.com|cattle.io' || true)")
-
-    printf "%s\n" "${rancher_crd_res[@]}" \
-      | awk '{print $1}' \
+    kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
+      | awk '/coreos.com|cattle.io/ {print $1}' \
       | xargs kubectl delete crd  \
       || return $? &# return on pipefail
     sleep 30
     kill $! || true
-    crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | grep -E 'coreos.com|cattle.io' || true)
+    crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
   done
 
   # delete clusterrolebindings deployed by rancher
   log "Deleting ClusterRoleBindings"
-  local rancher_crb_res=("$(kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'cattle.io|app:rancher' || true)")
-
-  printf "%s\n" "${rancher_crb_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/cattle.io|app:rancher/ {print $1}' \
     | xargs kubectl delete clusterrolebinding \
     || return $? # return on pipefail
 
   # delete clusterroles
   log "Deleting ClusterRoles"
-  local rancher_cr_res=("$(kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'cattle.io' || true)")
-
-  printf "%s\n" "${rancher_cr_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/cattle.io/ {print $1}' \
     | xargs kubectl delete clusterrole \
     || return $? # return on pipefail
 
@@ -152,10 +122,8 @@ function delete_rancher() {
   local default_names=("default" "kube-node-lease" "kube-public" "kube-system")
   for namespace in "${default_names[@]}"
   do
-    local rancher_rb_res=("$(kubectl get rolebinding --no-headers -o custom-columns=":metadata.name" -n "${namespace}"\
-      | grep 'clusterrolebinding-' || true)")
-
-    printf "%s\n" "${rancher_rb_res[@]}" \
+    kubectl get rolebinding --no-headers -o custom-columns=":metadata.name" -n "${namespace}"\
+      | awk '/clusterrolebinding-/' \
       | xargs kubectl delete rolebinding -n "${namespace}" \
       || return $? # return on pipefail
   done
@@ -165,20 +133,14 @@ function delete_rancher() {
 
   log "Deleting cattle namespaces"
   # delete namespace finalizers
-  local rancher_ns_fin_res=("$(kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'cattle-|local|p-|user-' || true)")
-
-  printf "%s\n" "${rancher_ns_fin_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
+    | awk '/cattle-|local|p-|user-/ {print $1}' \
     | xargs kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || return $? # return on pipefail
 
   # delete cattle namespaces
-  local rancher_ns_res=("$(kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'cattle-|local|p-|user-' || true)")
-
-  printf "%s\n" "${rancher_ns_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
+    | awk '/cattle-|local|p-|user-/ {print $1}' \
     | xargs kubectl delete namespaces \
     || return $? # return on pipefail
 
@@ -186,11 +148,8 @@ function delete_rancher() {
   log "Delete Rancher Secret Annotations"
   for namespace in "${default_names[@]}"
   do
-    keycloak_ann_res=("$(kubectl get secret -n "${namespace}" --no-headers -o custom-columns=":metadata.name,:metadata.annotations" \
-      | grep -E 'field.cattle.io/projectId:' || true)")
-
-    printf "%s\n" "${keycloak_ann_res[@]}" \
-      | awk '{print $1}' \
+    kubectl get secret -n "${namespace}" --no-headers -o custom-columns=":metadata.name,:metadata.annotations" \
+      | awk '/field.cattle.io\/projectId:/ {print $1}' \
       | xargs -I resource kubectl annotate secret resource -n "${namespace}" field.cattle.io/projectId- \
       || return $? # return on pipefail
   done

--- a/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -13,11 +13,8 @@ set -o pipefail
 function delete_verrazzano() {
   # delete helm installation of Verrazzano
   log "Deleting Verrazzano"
-  local verr_res=("$(helm ls -A \
-    | grep "verrazzano" || true)")
-
-  printf "%s\n" "${verr_res[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/verrazzano/ {print $1}' \
     | xargs helm uninstall -n verrazzano-system \
     || return $? # return on pipefail
 
@@ -27,64 +24,46 @@ function delete_verrazzano() {
 
   # delete crds
   log "Deleting Verrazzano crds"
-  local verr_crd_fin_res=("$(kubectl get crds --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'verrazzano.io' || true)")
-
-  printf "%s\n" "${verr_crd_fin_res[@]}" \
+  kubectl get crds --no-headers -o custom-columns=":metadata.name" \
+    | awk '/verrazzano.io/' \
     | xargs kubectl patch crd -p '{"metadata":{"finalizers":null}}' --type=merge \
     || return $? # return on pipefail
 
-  local verr_crd_rec=("$(kubectl get crds --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'verrazzano.io' || true)")
-
-  printf "%s\n" "${verr_crd_rec[@]}" \
+  kubectl get crds --no-headers -o custom-columns=":metadata.name" \
+    | awk '/verrazzano.io/' \
     | xargs kubectl delete crd \
     || return $? # return on pipefail
 
   # deleting certificatesigningrequests
   log "Deleting CertificateSigningRequests"
-  local verr_csr_res=("$(kubectl get csr --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'csr-' || true)")
-
-  printf "%s\n" "${verr_csr_res[@]}" \
+  kubectl get csr --no-headers -o custom-columns=":metadata.name" \
+    | awk '/csr-/' \
     | xargs kubectl delete csr \
     || return $? # return on pipefail
 
   log "Deleting ClusterRoles and ClusterRoleBindings"
   # deleting clusterrolebindings
-  local verr_crb_res=("$(kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'verrazzano' || true)")
-
-  printf "%s\n" "${verr_crb_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/verrazzano/ {print $1}' \
     | xargs kubectl delete clusterrolebinding \
     || return $? # return on pipefail
 
   # deleting clusterroles
-  local verr_cr_res=("$(kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'verrazzano' || true)")
-
-  printf "%s\n" "${verr_cr_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/verrazzano/ {print $1}' \
     | xargs kubectl delete clusterrole \
     || return $? # return on pipefail
 
   # deleting namespaces
   log "Deleting Verrazzano namespaces"
   # delete namespace finalizers
-  local verr_ns_fin_res=("$(kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'k8s-app:verrazzano.io|verrazzano-system' || true)")
-
-  printf "%s\n" "${verr_ns_fin_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' \
     | xargs kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || return $? # return on pipefail
 
-  local verr_ns_res=("$(kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | grep -E 'k8s-app:verrazzano.io|verrazzano-system' || true)")
-
-  printf "%s\n" "${verr_ns_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
+    | awk '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' \
     | xargs kubectl delete namespace \
     || return $? # return on pipefail
 }

--- a/uninstall/uninstall-steps/4-uninstall-keycloak.sh
+++ b/uninstall/uninstall-steps/4-uninstall-keycloak.sh
@@ -13,11 +13,8 @@ set -o pipefail
 function delete_mysql() {
   # delete helm installation of MySQL
   log "Deleting MySQL"
-  local mysql_res=("$(helm ls -A \
-    | grep "mysql" || true)")
-
-  printf "%s\n" "${mysql_res[@]}" \
-    | awk '{print $1}' \
+  helm ls -A \
+    | awk '/mysql/ {print $1}' \
     | xargs helm delete -n keycloak \
     || return $? # return on pipefail
 }
@@ -25,20 +22,14 @@ function delete_mysql() {
 function delete_keycloak() {
   # delete helm installation of Keycloak
   log "Deleting Keycloak"
-  local keycloak_res=("$(helm ls -A \
-    | awk '{print $1}' \
-    | grep "keycloak" || true)")
-
-  printf "%s\n" "${keycloak_res[@]}" \
+  helm ls -A \
+    | awk '/keycloak/ {print $1}' \
     | xargs helm delete -n keycloak \
     || return $? # return on pipefail
 
   # delete keycloak namespace
-  local keycloak_ns_fin_res=("$(kubectl get namespace --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'keycloak' || true)")
-
-  printf "%s\n" "${keycloak_ns_fin_res[@]}" \
-    | awk '{print $1}' \
+  kubectl get namespace --no-headers -o custom-columns=":metadata.name" \
+    | awk '/keycloak/ {print $1}' \
     | xargs kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || return $? # return on pipefail
 
@@ -49,18 +40,14 @@ function delete_keycloak() {
 function delete_resources() {
   log "Deleting ClusterRoles and ClusterRoleBindings"
   # deleting clusterrolebindings
-  local crb_res=("$(kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'cattle-admin|proxy-role-binding-kubernetes-master' || true)")
-
-  printf "%s\n" "${crb_res[@]}" \
+  kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name" \
+    | awk '/cattle-admin|proxy-role-binding-kubernetes-master/' \
     | xargs kubectl delete clusterrolebinding \
     || return $? # return on pipefail
 
   # deleting clusterroles
-  local cr_res=("$(kubectl get clusterrole --no-headers -o custom-columns=":metadata.name" \
-    | grep -E 'cattle-admin|local-cluster|proxy-clusterrole-kubeapiserver' || true)")
-
-  printf "%s\n" "${cr_res[@]}" \
+  kubectl get clusterrole --no-headers -o custom-columns=":metadata.name" \
+    | awk '/cattle-admin|local-cluster|proxy-clusterrole-kubeapiserver/' \
     | xargs kubectl delete clusterrole \
     || return $? # return on pipefail
 }


### PR DESCRIPTION
Currently, some of the resources in the uninstall are grabbed by grepping for an aspect of their descriptions. Unfortunately, grep returns an error status of 1 when nothing is found. This is a functionality we want when performing the uninstall. Thus, we need a command that will grab these items but still return 0 when nothing is found to improve the error handling. then, the two part delete commands can be merged into one command again.

As an example, in 1-uninstall-istio.sh function delete_secrets() the following code block has to be written in 2 parts because `grep "istio.io" || true` will always be true.

 ```
 # delete secrets left over in kube-system
  local secret_res=("$(kubectl get secrets -n kube-system --no-headers -o custom-columns=":metadata.name,:metadata.annotations" \
  | grep "istio.io" || true)")

  printf "%s\n" "${secret_res[@]}" \
  | awk '{print $1}' \
  | xargs kubectl delete secret -n kube-system \
  || return $? # return on pipefail
```
By performing the grep functionality in the awk call we should be able to replace the above with the following code block (awk will return 0 if no match is found).
```
  # delete secrets left over in kube-system
  kubectl get secrets -n kube-system --no-headers -o custom-columns=":metadata.name,:metadata.annotations" 
  | awk '/istio.io/ {print $1}' \
  | xargs kubectl delete secret -n kube-system \
  || return $? # return on pipefail
```