### PR TITLE
VZ-1171: istio dns not configured for olcne installs

### DIFF
--- a/install/1-install-istio.sh
+++ b/install/1-install-istio.sh
@@ -141,7 +141,7 @@ function install_istio()
 
 function update_coredns()
 {
-    if [ ${CLUSTER_TYPE} == "OKE" ]; then
+    if [ "${CLUSTER_TYPE}" == "OKE" ] || [ "${CLUSTER_TYPE}" == "OLCNE" ]; then
         local cluster_ip
         cluster_ip=$(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})
         if [ $? -ne 0 ] ; then


### PR DESCRIPTION
### Changes
- Fix 1-install-istio.sh to update core dns config for OKE and OLCNE installs.

### Testing
- https://build.verrazzano.io/job/verrazzano/job/kminder%252Fvz1171/
- Manually applied coredns-template.yaml change to a cluster.
- Manually updated 1-install-istio.sh and completed install of a cluster.

### Ticket
- https://jira.oraclecorp.com/jira/browse/VZ-1171