### PR TITLE
Update to use verrazzano-operator v0.0.91-b4c3058-1

### DIFF
--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ docker:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: verrazzano-operator-jenkins
-  imageVersion: 8f62382eab2dd8acbe39cabce71496793e8b50ab
+  imageName: verrazzano-operator
+  imageVersion: v0.0.91-b4c3058-1
   sslVerify: true
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ docker:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: verrazzano-operator
-  imageVersion: v0.0.88-71a55ef-4
+  imageName: verrazzano-operator-jenkins
+  imageVersion: 8f62382eab2dd8acbe39cabce71496793e8b50ab
   sslVerify: true
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7


### PR DESCRIPTION
This pull request updates the verrazzano-operator tag to v0.0.91-b4c3058-1.

Test run: https://build.verrazzano.io/blue/organizations/jenkins/verrazzano/detail/rdonat%2Fvz-953/3/pipeline
JIRA: https://jira.oraclecorp.com/jira/browse/VZ-953