### PR TITLE
Find clean way to delete helm repo elements.

### DIFF
--- a/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -90,10 +90,14 @@ function finalize() {
 
   # Grab all leftover Helm repos and delete resources
   log "Deleting Helm repos"
-  helm repo ls \
-    | awk '/istio.io|stable|jetstack|rancher-stable|codecentric/ {print $1}' \
-    | xargsr -I name helm repo remove name \
-    || return $? # return on pipefail
+  local helm_ls
+  helm_ls=$(helm repo ls)
+  if [ $? -eq 0 ]; then
+    echo "$helm_ls" \
+      | awk '/istio.io|stable|jetstack|rancher-stable|codecentric/ {print $1}' \
+      | xargsr -I name helm repo remove name \
+      || return $? # return on pipefail
+  fi
 }
 
 action "Deleting Istio Components" uninstall_istio || exit 1


### PR DESCRIPTION
In finalize() ...

  ```helm repo ls \
    | awk '/istio.io|stable|jetstack|rancher-stable|codecentric/ {print $1}' \
    | xargsr -I name helm repo remove name \
    || return $?
```

```
helm repo ls
Error: no repositories to show

echo $?
1
```
gives an error output of 1 when no elements are present. This causes the pipeline to fail. This task will be completed when the uninstall avoids non-zero output with no helm repo elements, and deletes elements when they are present in the repo.