### PR TITLE
Update to use verrazzano-operator v0.0.93-8be65b3-1 for VMI memory requests

### DIFF
--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -13,7 +13,7 @@ docker:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: verrazzano-operator
-  imageVersion: v0.0.92-03e362c-1
+  imageVersion: v0.0.93-8be65b3-1
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7
   wlsMicroImage: verrazzano-wko-operator:v0.0.10


### PR DESCRIPTION
JIRA: https://jira.oraclecorp.com/jira/browse/VZ-830

Test: https://build.verrazzano.io/job/verrazzano/job/guzhang%252Fvz830/