### PR TITLE
Create delete resource and remove finalizer functions.

### DIFF
--- a/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -54,17 +54,15 @@ function initializing_uninstall {
 function delete_bindings {
   log "Deleting VerrazzanoBindings"
   kubectl get crd verrazzanobindings.verrazzano.io || return 0
-  kubectl get VerrazzanoBindings --no-headers -o custom-columns=":metadata.name" \
-    | xargsr kubectl delete VerrazzanoBindings \
-    || err_return $? "Could not delete VerrazzanoBindings" || return $? # return on pipefail
+  delete_k8s_resources VerrazzanoBindings ":metadata.name" "Could not delete VerrazzanoBindings" \
+    || return $? # return on pipefail
 }
 
 function delete_models {
   log "Deleting VerrazzanoModels"
   kubectl get crd verrazzanomodels.verrazzano.io || return 0
-  kubectl get VerrazzanoModels --no-headers -o custom-columns=":metadata.name" \
-    | xargsr kubectl delete VerrazzanoModels \
-    || err_return $? "Could not delete VerrazzanoModels" || return $? # return on pipefail
+  delete_k8s_resources VerrazzanoModels ":metadata.name" "Could not delete VerrazzanoModels" \
+    || return $? # return on pipefail
 }
 
 action "Initializing Uninstall" initializing_uninstall || exit 1

--- a/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -130,6 +130,7 @@ function delete_rancher() {
     || return $? # return on pipefail
 
   # delete cattle namespaces
+  log "Delete rancher namespace"
   delete_k8s_resources namespaces ":metadata.name" "Could not delete namespaces from Rancher" '/cattle-|local|p-|user-/ {print $1}' \
     || return $? # return on pipefail
 

--- a/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -40,10 +40,8 @@ function delete_nginx() {
 
   # delete ingress-nginx namespace
   log "Deleting ingress-nginx namespace finalizers"
-  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | awk '/ingress-nginx/ {print $1}' \
-    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge  \
-    || err_return $? "Could not remove finalizer from namespace ingress-nginx" || return $? # return on pipefail
+  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizer from namespace ingress-nginx" '/ingress-nginx/ {print $1}' '{"metadata":{"finalizers":null}}' \
+    || return $? # return on pipefail
 
   log "Deleting ingress-nginx namespace"
   kubectl delete namespace ingress-nginx --ignore-not-found=true || err_return $? "Could not delete namespace ingress-nginx" || return $?
@@ -68,10 +66,8 @@ function delete_cert_manager() {
 
   log "Deleting cert-manager namespace finalizers"
   # delete namespace finalizers
-  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | awk '/cert-manager/ {print $1}' \
-    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
-    || err_return $? "Could not remove finalizers from namespace cert-manager" || return $? # return on pipefail
+  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespace cert-manager" '/cert-manager/ {print $1}' '{"metadata":{"finalizers":null}}' \
+    || return $? # return on pipefail
 
   # delete namespace
   log "Deleting cert-manager namespace"
@@ -93,17 +89,13 @@ function delete_rancher() {
   while [ "$crd_content" ]
   do
     # remove finalizers from crds
-    kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
-      | awk '/coreos.com|cattle.io/ {print $1}' \
-      | xargsr kubectl patch crd -p '{"metadata":{"finalizers":null}}' --type=merge \
-      || err_return $? "Could not remove finalizers from CustomResourceDefinitions in Rancher" || return $? # return on pipefail
+    patch_k8s_resources crds ":metadata.name,:spec.group" "Could not remove finalizers from CustomResourceDefinitions in Rancher" '/coreos.com|cattle.io/ {print $1}' '{"metadata":{"finalizers":null}}' \
+      || return $? # return on pipefail
 
     # delete crds
     # This process is backgrounded in order to timeout due to finalizers hanging
-    kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" \
-      | awk '/coreos.com|cattle.io/ {print $1}' \
-      | xargsr kubectl delete crd  \
-      || err_return $? "Could not delete CustomResourceDefinitions from Rancher" || return $? &# return on pipefail
+    delete_k8s_resources crds ":metadata.name,:spec.group" "Could not delete CustomResourceDefinitions from Rancher" '/coreos.com|cattle.io/ {print $1}' \
+      || return $? &# return on pipefail
     sleep 30
     kill $! || true
     crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
@@ -111,27 +103,21 @@ function delete_rancher() {
 
   # delete clusterrolebindings deployed by rancher
   log "Deleting ClusterRoleBindings"
-  kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/cattle.io|app:rancher/ {print $1}' \
-    | xargsr kubectl delete clusterrolebinding \
-    || err_return $? "Could not delete ClusterRoleBindings from Rancher" || return $? # return on pipefail
+  delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Rancher" '/cattle.io|app:rancher/ {print $1}' \
+    || return $? # return on pipefail
 
   # delete clusterroles
   log "Deleting ClusterRoles"
-  kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/cattle.io/ {print $1}' \
-    | xargsr kubectl delete clusterrole \
-    || err_return $? "Could not delete ClusterRoles from Rancher" || return $? # return on pipefail
+  delete_k8s_resources clusterrole ":metadata.name,:metadata.labels" "Could not delete ClusterRoles from Rancher" '/cattle.io/ {print $1}' \
+    || return $? # return on pipefail
 
   # delete rolebinding
   log "Deleting RoleBindings"
   local default_names=("default" "kube-node-lease" "kube-public" "kube-system")
   for namespace in "${default_names[@]}"
   do
-    kubectl get rolebinding --no-headers -o custom-columns=":metadata.name" -n "${namespace}"\
-      | awk '/clusterrolebinding-/' \
-      | xargsr kubectl delete rolebinding -n "${namespace}" \
-      || err_return $? "Could not delete RoleBindings from Rancher in namespace ${namespace}" || return $? # return on pipefail
+    delete_k8s_resources rolebinding ":metadata.name" "Could not delete RoleBindings from Rancher in namespace ${namespace}" '/clusterrolebinding-/' "${namespace}" \
+      || return $? # return on pipefail
   done
 
   # delete configmap in kube-system
@@ -140,17 +126,12 @@ function delete_rancher() {
 
   log "Deleting cattle namespaces"
   # delete namespace finalizers
-  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | awk '/cattle-|local|p-|user-/ {print $1}' \
-    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
-    || err_return $? "Could not remove finalizers from namespaces in Rancher" || return $? # return on pipefail
+  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespaces in Rancher" '/cattle-|local|p-|user-/ {print $1}' '{"metadata":{"finalizers":null}}' \
+    || return $? # return on pipefail
 
   # delete cattle namespaces
-  log "Delete rancher namespace"
-  kubectl get namespaces --no-headers -o custom-columns=":metadata.name" \
-    | awk '/cattle-|local|p-|user-/ {print $1}' \
-    | xargsr kubectl delete namespaces \
-    || err_return $? "Could not delete namespaces from Rancher" || return $? # return on pipefail
+  delete_k8s_resources namespaces ":metadata.name" "Could not delete namespaces from Rancher" '/cattle-|local|p-|user-/ {print $1}' \
+    || return $? # return on pipefail
 
   # delete annotations left in kube-system secrets
   log "Delete Rancher Secret Annotations"

--- a/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -26,51 +26,37 @@ function delete_verrazzano() {
 
   # delete crds
   log "Deleting Verrazzano crd finalizers"
-  kubectl get crds --no-headers -o custom-columns=":metadata.name" \
-    | awk '/verrazzano.io/' \
-    | xargsr kubectl patch crd -p '{"metadata":{"finalizers":null}}' --type=merge \
-    || err_return $? "Could not remove finalizers from CustomResourceDefinitions in Verrazzano" || return $? # return on pipefail
+  patch_k8s_resources crds ":metadata.name" "Could not remove finalizers from CustomResourceDefinitions in Verrazzano" '/verrazzano.io/' '{"metadata":{"finalizers":null}}' \
+    || return $? # return on pipefail
 
   log "Deleting Verrazzano crds"
-  kubectl get crds --no-headers -o custom-columns=":metadata.name" \
-    | awk '/verrazzano.io/' \
-    | xargsr kubectl delete crd \
-    || err_return $? "Could not delete CustomResourceDefinitions from Verrazzano" || return $? # return on pipefail
+  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/' \
+    || return $? # return on pipefail
 
   # deleting certificatesigningrequests
   log "Deleting CertificateSigningRequests"
-  kubectl get csr --no-headers -o custom-columns=":metadata.name" \
-    | awk '/csr-/' \
-    | xargsr kubectl delete csr \
-    || err_return $? "Could not delete CertificateSigningRequests from Verrazzano" || return $? # return on pipefail
+  delete_k8s_resources csr ":metadata.name" "Could not delete CertificateSigningRequests from Verrazzano" '/csr-/' \
+    || return $? # return on pipefail
 
   log "Deleting ClusterRoles and ClusterRoleBindings"
   # deleting clusterrolebindings
-  kubectl get clusterrolebinding --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/verrazzano/ {print $1}' \
-    | xargsr kubectl delete clusterrolebinding \
-    || err_return $? "Could not delete ClusterRoleBindings from Verrazzano" || return $? # return on pipefail
+  delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Verrazzano" '/verrazzano/ {print $1}' \
+    || return $? # return on pipefail
 
   # deleting clusterroles
   log "Deleting ClusterRoles"
-  kubectl get clusterrole --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/verrazzano/ {print $1}' \
-    | xargsr kubectl delete clusterrole \
-    || err_return $? "Could not delete ClusterRoles from Verrazzano" || return $? # return on pipefail
+  delete_k8s_resources clusterrole ":metadata.name,:metadata.labels" "Could not delete ClusterRoles from Verrazzano" '/verrazzano/ {print $1}' \
+    || return $? # return on pipefail
 
   # deleting namespaces
   log "Deleting Verrazzano namespace finalizers"
   # delete namespace finalizers
-  kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' \
-    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
-    || err_return $? "Could not remove finalizers from Verrazzano namespaces" || return $? # return on pipefail
+  patch_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not remove finalizers from Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' '{"metadata":{"finalizers":null}}' \
+    || return $? # return on pipefail
 
   log "Deleting Verrazzano namespaces"
-  kubectl get namespace --no-headers -o custom-columns=":metadata.name,:metadata.labels" \
-    | awk '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' \
-    | xargsr kubectl delete namespace \
-    || err_return $? "Could not delete Verrazzano namespaces" || return $? # return on pipefail
+  delete_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not delete Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano-system/ {print $1}' \
+    || return $? # return on pipefail
 }
 
 action "Deleting Verrazzano Components" delete_verrazzano || exit 1

--- a/uninstall/uninstall-utils.sh
+++ b/uninstall/uninstall-utils.sh
@@ -43,3 +43,36 @@ function err_return() {
   error "$message"
   return "$exit_code"
 }
+
+# utility function to delete kubernetes resources
+# $1 resource-type - type of the resources being deleted
+# $2 custom-cols   - custom columns used when getting the resources
+# $3 err-msg       - the message to log if an error is encountered
+# $4 filter-args   - arguments given to awk to filter the resource list for deletion (optional)
+# $5 namespace     - namespace for resources to be deleted (optional)
+# Usage:
+# delete_k8s_resources resource-type custom-cols [filter-args] [namespace]
+function delete_k8s_resources() {
+  ( [ -z "$5" ] && kubectl get $1 --no-headers -o custom-columns="$2" || kubectl get $1 --no-headers -o custom-columns="$2" -n "$5" ) \
+    | ( [ -z "$4" ] && cat || awk "$4" ) \
+    | ( [ -z "$5" ] && xargsr kubectl delete $1 || xargsr kubectl delete $1 -n "$5" ) \
+    || err_return $? "$3" || return $? # return on pipefail
+}
+
+# utility function to patch kubernetes resources
+# $1 resource-type - type of the resources being patched
+# $2 custom-cols   - custom columns used when getting the resources
+# $3 err-msg       - the message to log if an error is encountered
+# $4 filter-args   - arguments given to awk to filter the resource list for patching
+# $5 patch         - the patch to be applied to the resources
+# Usage:
+# patch_k8s_resources resource-type custom-cols filter-args patch
+function patch_k8s_resources() {
+  if [ -z "$5" ]; then
+    err_return 1 "The patch argument cannot be empty." || return $?
+  fi
+  kubectl get $1 --no-headers -o custom-columns="$2" \
+    | awk "$4" \
+    | xargsr kubectl patch $1 -p "$5" --type=merge \
+    || err_return $? "$3" || return $? # return on pipefail
+}


### PR DESCRIPTION
There is a lot of repeated code to maintain throughout the uninstaller. This code can be refactored to make maintaining and updating easier. 
The code should transform:
```
kubectl get csr --no-headers -o custom-columns=":metadata.name" \
    | awk '/csr-/' \
    | xargsr kubectl delete csr \
    || return $?
```
to this:
```
delete_k8s_resources csr '/csr-/' ":metadata.name" || return $?
```