### PR TITLE
update verrazzano-operator to v0.0.95-2a2ed1c-1 for memory requests in Verrazzano components and VMI pods

### DIFF
--- a/install/3-install-verrazzano.sh
+++ b/install/3-install-verrazzano.sh
@@ -144,7 +144,7 @@ function install_verrazzano()
       --set clusterOperator.rancherUserName="${token_array[0]}" \
       --set clusterOperator.rancherPassword="${token_array[1]}" \
       --set clusterOperator.rancherHostname=${RANCHER_HOSTNAME} \
-      --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)"
+      --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" || return $?
 
   log "Verifying that needed secrets are created"
   retries=0

--- a/install/chart/templates/01-verrazzano-operator.yaml
+++ b/install/chart/templates/01-verrazzano-operator.yaml
@@ -67,6 +67,8 @@ spec:
               value: {{ .Values.verrazzanoOperator.prometheusRequestMemory }}
             - name: KIBANA_REQUEST_MEMORY
               value: {{ .Values.verrazzanoOperator.kibanaRequestMemory }}
+            - name: ES_MASTER_NODE_REPLICAS
+              value: "{{ .Values.verrazzanoOperator.esMasterNodeReplicas }}"
       serviceAccount: {{ .Values.verrazzanoOperator.name }}
 ---
 kind: Service

--- a/install/chart/templates/01-verrazzano-operator.yaml
+++ b/install/chart/templates/01-verrazzano-operator.yaml
@@ -55,6 +55,18 @@ spec:
               value: {{ .Values.verrazzanoOperator.helidonMicroRequestMemory }}
             - name: WLS_MICRO_REQUEST_MEMORY
               value: {{ .Values.verrazzanoOperator.wlsMicroRequestMemory }}
+            - name: ES_MASTER_NODE_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.esMasterNodeRequestMemory }}
+            - name: ES_INGEST_NODE_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.esIngestNodeRequestMemory }}
+            - name: ES_DATA_NODE_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.esDataNodeRequestMemory }}
+            - name: GRAFANA_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.grafanaRequestMemory }}
+            - name: PROMETHEUS_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.prometheusRequestMemory }}
+            - name: KIBANA_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.kibanaRequestMemory }}
       serviceAccount: {{ .Values.verrazzanoOperator.name }}
 ---
 kind: Service

--- a/install/chart/templates/01-verrazzano-operator.yaml
+++ b/install/chart/templates/01-verrazzano-operator.yaml
@@ -49,6 +49,12 @@ spec:
               value: {{ .Values.verrazzanoOperator.weblogicOperatorImage }}
             - name: FLUENTD_IMAGE
               value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.fluentdImage }}
+            - name: COH_MICRO_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.cohMicroRequestMemory }}
+            - name: HELIDON_MICRO_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.helidonMicroRequestMemory }}
+            - name: WLS_MICRO_REQUEST_MEMORY
+              value: {{ .Values.verrazzanoOperator.wlsMicroRequestMemory }}
       serviceAccount: {{ .Values.verrazzanoOperator.name }}
 ---
 kind: Service

--- a/install/chart/templates/01-verrazzano-operator.yaml
+++ b/install/chart/templates/01-verrazzano-operator.yaml
@@ -27,6 +27,9 @@ spec:
             - --verrazzanoUri={{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
             - --enableMonitoringStorage={{ .Values.config.enableMonitoringStorage }}
             - --apiServerRealm={{ .Values.verrazzanoOperator.apiServerRealm }}
+          resources:
+            requests:
+              memory: {{ .Values.verrazzanoOperator.RequestMemory }}
           env:
             - name: COH_MICRO_IMAGE
               value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.cohMicroImage }}

--- a/install/chart/templates/02-verrazzano-cluster-operator.yaml
+++ b/install/chart/templates/02-verrazzano-cluster-operator.yaml
@@ -28,6 +28,9 @@ spec:
             - --rancherUserName={{ .Values.clusterOperator.rancherUserName }}
             - --rancherPassword={{ .Values.clusterOperator.rancherPassword }}
             - --rancherHost={{ .Values.clusterOperator.rancherHostname }}
+          resources:
+            requests:
+              memory: {{ .Values.clusterOperator.RequestMemory }}
       serviceAccount: {{ .Values.clusterOperator.name }}
 ---
 apiVersion: v1

--- a/install/chart/templates/03-verrazzano-monitoring-operator.yaml
+++ b/install/chart/templates/03-verrazzano-monitoring-operator.yaml
@@ -670,6 +670,9 @@ spec:
             - containerPort: {{ .Values.monitoringOperator.metricsPort }}
               name: metrics
               protocol: TCP
+          resources:
+            requests:
+              memory: {{ .Values.monitoringOperator.RequestMemory }}
           env:
             - name: GRAFANA_IMAGE
               value: {{ .Values.monitoringOperator.grafanaImage }}

--- a/install/chart/templates/04-verrazzano-admission-controller.yaml
+++ b/install/chart/templates/04-verrazzano-admission-controller.yaml
@@ -82,6 +82,9 @@ spec:
           args:
             - --v=4
             - --verrazzanoUri={{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
+          resources:
+            requests:
+              memory: {{ .Values.verrazzanoAdmissionController.RequestMemory }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/certs

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -24,6 +24,7 @@ verrazzanoOperator:
   weblogicOperatorImage: oracle/weblogic-kubernetes-operator:3.0.0
   fluentdImage: fluentd-kubernetes-daemonset:v1.10.4-6ce326d-18
   apiServerRealm: verrazzano-system
+  RequestMemory: 72Mi
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
@@ -45,6 +46,7 @@ monitoringOperator:
   monitoringInstanceApiImage: verrazzano-monitoring-instance-api:v0.0.7
   configReloaderImage: configmap-reload:0.3-81d6423-34
   nodeExporterImage: node-exporter:0.18.1-0cca78f-10
+  RequestMemory: 48Mi
 
 clusterOperator:
   name: verrazzano-cluster-operator
@@ -54,6 +56,7 @@ clusterOperator:
   rancherUserName:
   rancherPassword:
   rancherHostname:
+  RequestMemory: 27Mi
 
 verrazzanoAdmissionController:
   name: verrazzano-validation
@@ -61,6 +64,7 @@ verrazzanoAdmissionController:
   imageName: verrazzano-admission-controller
   imageVersion: v0.0.17
   caBundle:
+  RequestMemory: 15Mi
 
 # OCI-related values
 oci:

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -13,7 +13,7 @@ docker:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: verrazzano-operator-jenkins
-  imageVersion: d77d2f430127470164b2cd3437dcfbb9a467ecf0
+  imageVersion: 2f6b4fa35aae0c3fced6192b950bdd6b87fe9140
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7
   wlsMicroImage: verrazzano-wko-operator:v0.0.10
@@ -34,11 +34,12 @@ verrazzanoOperator:
   grafanaRequestMemory: 48Mi
   prometheusRequestMemory: 128Mi
   kibanaRequestMemory: 192Mi
+  esMasterNodeReplicas: 3
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: verrazzano-monitoring-operator
-  imageVersion: v0.0.18
+  imageVersion: v0.0.19
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ docker:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: verrazzano-operator-jenkins
-  imageVersion: 2f6b4fa35aae0c3fced6192b950bdd6b87fe9140
+  imageName: verrazzano-operator
+  imageVersion: v0.0.95-2a2ed1c-1
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7
   wlsMicroImage: verrazzano-wko-operator:v0.0.10

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ docker:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: verrazzano-operator
-  imageVersion: v0.0.94-eed5952-1
+  imageName: verrazzano-operator-jenkins
+  imageVersion: a87fd83e6ee77dea769b346d00172b8d609772a8
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7
   wlsMicroImage: verrazzano-wko-operator:v0.0.10
@@ -25,6 +25,9 @@ verrazzanoOperator:
   fluentdImage: fluentd-kubernetes-daemonset:v1.10.4-6ce326d-18
   apiServerRealm: verrazzano-system
   RequestMemory: 72Mi
+  cohMicroRequestMemory: 28Mi
+  helidonMicroRequestMemory: 24Mi
+  wlsMicroRequestMemory: 32Mi
 
 monitoringOperator:
   name: verrazzano-monitoring-operator

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -13,7 +13,7 @@ docker:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: verrazzano-operator-jenkins
-  imageVersion: a87fd83e6ee77dea769b346d00172b8d609772a8
+  imageVersion: d77d2f430127470164b2cd3437dcfbb9a467ecf0
   cohMicroImage: verrazzano-coh-cluster-operator:v0.0.8
   helidonMicroImage: verrazzano-helidon-app-operator:v0.0.7
   wlsMicroImage: verrazzano-wko-operator:v0.0.10
@@ -28,6 +28,12 @@ verrazzanoOperator:
   cohMicroRequestMemory: 28Mi
   helidonMicroRequestMemory: 24Mi
   wlsMicroRequestMemory: 32Mi
+  esMasterNodeRequestMemory: 1.4Gi
+  esIngestNodeRequestMemory: 2.5Gi
+  esDataNodeRequestMemory: 4.8Gi
+  grafanaRequestMemory: 48Mi
+  prometheusRequestMemory: 128Mi
+  kibanaRequestMemory: 192Mi
 
 monitoringOperator:
   name: verrazzano-monitoring-operator


### PR DESCRIPTION
Set up memory requests in verrazzano and VMI pods.
JIRA:  https://jira.oraclecorp.com/jira/browse/VZ-830
Acceptance tests:  https://build.verrazzano.io/job/verrazzano/job/guzhang%252Fvz830_v/