### PR TITLE
JIRA:VZ-1214 github action to generate pagerduty incident when an issue is opened

### DIFF
--- a/.github/workflows/pagerduty.yml
+++ b/.github/workflows/pagerduty.yml
@@ -1,0 +1,15 @@
+on:
+  issues:
+    types: [opened, reopened]
+jobs:
+  pagerduty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: web-request
+        uses: satak/webrequest-action@master
+        with:
+          url: https://events.pagerduty.com/v2/enqueue
+          method: POST
+          payload: '{"routing_key":"${{ secrets.PAGERDUTY_ROUTING_KEY }}","event_action":"trigger","payload":{"summary":"Issue https://github.com/verrazzano/verrazzano/issues/${{ github.event.issue.number }} opened or re-opened","source":"build.verrazzano.io","severity":"critical","component":"verrazzano"}}'
+          headers: '{"content-type": "application/json"}'
+


### PR DESCRIPTION
When an issue is opened or reopened in the verrazzano repo the action will be triggered and generate a pagerduty incident to alert the on-call engineer