### PR TITLE
Document the optional image pull secret verrazzano-container-registry

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -34,7 +34,12 @@ The following software must be installed on your system.
    export CLUSTER_TYPE=OKE
    export VERRAZZANO_KUBECONFIG=<path to valid kubernetes config>
    export KUBECONFIG=$VERRAZZANO_KUBECONFIG
+```
 
+* Create the optional `imagePullSecret` named `verrazzano-container-registry`.  This step is required when one or more of the Docker images installed by Verrazzano are private.  For example, while testing a change to the `verrazzano-operator` you may be using a Docker image that requires credentials to access.
+
+```
+    kubectl create secret docker-registry verrazzano-container-registry --docker-username=<username> --docker-password=<password> --docker-server=<docker server>
 ```
 
 ### 2. Do the install


### PR DESCRIPTION
Document the optional image pull secret `verrazzano-container-registry`.  This secret is only required when Installing Verrazzano with one or more Docker images that are marked private.  For example, this may be true when you are testing a change to one of the operators (e.g. verrazzano-operator).  Your test image may be private until you have validate the changes.