### PR TITLE
Pull more verrazzano-monitoring-operator related images from ghcr.io

### DIFF
--- a/install/chart/templates/03-verrazzano-monitoring-operator.yaml
+++ b/install/chart/templates/03-verrazzano-monitoring-operator.yaml
@@ -691,7 +691,7 @@ spec:
             - name: ALERT_MANAGER_IMAGE
               value: {{ .Values.monitoringOperator.alertManagerImage }}
             - name: ELASTICSEARCH_WAIT_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.monitoringOperator.esWaitImage }}
+              value: {{ .Values.monitoringOperator.esWaitImage }}
             - name: ELASTICSEARCH_IMAGE
               value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.monitoringOperator.esImage }}
             - name: ELASTICSEARCH_INIT_IMAGE
@@ -701,7 +701,7 @@ spec:
             - name: ELASTICSEARCH_WAIT_TARGET_VERSION
               value: {{ .Values.monitoringOperator.esWaitTargetVersion }}
             - name: VERRAZZANO_MONITORING_INSTANCE_API_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.monitoringOperator.monitoringInstanceApiImage }}
+              value: {{ .Values.monitoringOperator.monitoringInstanceApiImage }}
             - name: CONFIG_RELOADER_IMAGE
               value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.monitoringOperator.configReloaderImage }}
             - name: NODE_EXPORTER_IMAGE

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -41,8 +41,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
-  imageVersion: 2a31eb95974b64ad198165121b174edce8aed701
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
+  imageVersion: v0.0.22
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
@@ -53,10 +53,10 @@ monitoringOperator:
   alertManagerImage: "noimage"
   esWaitTargetVersion: 7.6.1
   esImage: elasticsearch:7.6.1-1d68e1a-3
-  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.20
+  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.22
   esInitImage: container-registry.oracle.com/os/oraclelinux:7.8
   kibanaImage: kibana:7.6.1-ccfddab-2
-  monitoringInstanceApiImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-api-jenkins:54eb4cd556a87a102c4a095d9d621b6d7fc89771
+  monitoringInstanceApiImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-api:v0.0.8
   configReloaderImage: configmap-reload:0.3-81d6423-34
   nodeExporterImage: node-exporter:0.18.1-0cca78f-10
   RequestMemory: 48Mi

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -41,8 +41,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: v0.0.20
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
+  imageVersion: 2a31eb95974b64ad198165121b174edce8aed701
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
@@ -53,10 +53,10 @@ monitoringOperator:
   alertManagerImage: "noimage"
   esWaitTargetVersion: 7.6.1
   esImage: elasticsearch:7.6.1-1d68e1a-3
-  esWaitImage: verrazzano-monitoring-instance-eswait:v0.0.19
+  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:v0.0.20
   esInitImage: container-registry.oracle.com/os/oraclelinux:7.8
   kibanaImage: kibana:7.6.1-ccfddab-2
-  monitoringInstanceApiImage: verrazzano-monitoring-instance-api:v0.0.7
+  monitoringInstanceApiImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-api-jenkins:54eb4cd556a87a102c4a095d9d621b6d7fc89771
   configReloaderImage: configmap-reload:0.3-81d6423-34
   nodeExporterImage: node-exporter:0.18.1-0cca78f-10
   RequestMemory: 48Mi


### PR DESCRIPTION
The `verrazzano-monitoring-instance-eswait` and `verrazzano-monitoring-instance-api` are not published to ghcr.io