### PR TITLE
Get most of the build-from-source images from ghcr.io

### DIFF
--- a/install/2a-install-system-components-magicdns.sh
+++ b/install/2a-install-system-components-magicdns.sh
@@ -131,7 +131,7 @@ function install_rancher()
     helm upgrade rancher rancher-stable/rancher \
       --install --namespace cattle-system \
       --version $RANCHER_VERSION  \
-      --set systemDefaultRegistry=container-registry.oracle.com/verrazzano \
+      --set systemDefaultRegistry=ghcr.io/verrazzano \
       --set rancherImageTag=$RANCHER_TAG \
       --set rancherImage=$RANCHER_IMAGE \
       --set hostname=rancher.${NAME}.${DNS_SUFFIX} \

--- a/install/2b-install-system-components-ocidns.sh
+++ b/install/2b-install-system-components-ocidns.sh
@@ -191,7 +191,7 @@ function install_rancher()
     helm upgrade rancher rancher-stable/rancher \
       --install --namespace cattle-system \
       --version $RANCHER_VERSION  \
-      --set systemDefaultRegistry=container-registry.oracle.com/verrazzano \
+      --set systemDefaultRegistry=ghcr.io/verrazzano \
       --set rancherImage=$RANCHER_IMAGE \
       --set rancherImageTag=$RANCHER_TAG \
       --set hostname=rancher.${NAME}.${OCI_DNS_ZONE_NAME} \

--- a/install/chart/templates/01-verrazzano-operator.yaml
+++ b/install/chart/templates/01-verrazzano-operator.yaml
@@ -38,17 +38,17 @@ spec:
             - name: WLS_MICRO_IMAGE
               value: {{ .Values.verrazzanoOperator.wlsMicroImage }}
             - name: PROMETHEUS_PUSHER_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.prometheusPusherImage }}
+              value: {{ .Values.verrazzanoOperator.prometheusPusherImage }}
             - name: NODE_EXPORTER_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.nodeExporterImage }}
+              value: {{ .Values.verrazzanoOperator.nodeExporterImage }}
             - name: FILEBEAT_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.filebeatImage }}
+              value: {{ .Values.verrazzanoOperator.filebeatImage }}
             - name: JOURNALBEAT_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.journalbeatImage }}
+              value: {{ .Values.verrazzanoOperator.journalbeatImage }}
             - name: WEBLOGIC_OPERATOR_IMAGE
               value: {{ .Values.verrazzanoOperator.weblogicOperatorImage }}
             - name: FLUENTD_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.verrazzanoOperator.fluentdImage }}
+              value: {{ .Values.verrazzanoOperator.fluentdImage }}
             - name: COH_MICRO_REQUEST_MEMORY
               value: {{ .Values.verrazzanoOperator.cohMicroRequestMemory }}
             - name: HELIDON_MICRO_REQUEST_MEMORY

--- a/install/chart/templates/03-verrazzano-monitoring-operator.yaml
+++ b/install/chart/templates/03-verrazzano-monitoring-operator.yaml
@@ -705,7 +705,7 @@ spec:
             - name: CONFIG_RELOADER_IMAGE
               value: {{ .Values.monitoringOperator.configReloaderImage }}
             - name: NODE_EXPORTER_IMAGE
-              value: {{ .Values.docker.repository }}/{{ .Values.docker.namespace }}/{{ .Values.monitoringOperator.nodeExporterImage }}
+              value: {{ .Values.monitoringOperator.nodeExporterImage }}
           livenessProbe:
             failureThreshold: 5
             httpGet:

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -20,12 +20,12 @@ verrazzanoOperator:
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:v0.0.10
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:v0.0.9
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:v0.0.12
-  prometheusPusherImage: prometheus-pusher:1.0.1-ff71638-20
-  nodeExporterImage: node-exporter:0.18.1-0cca78f-10
-  filebeatImage: filebeat:6.8.3-8218206-10
-  journalbeatImage: journalbeat:6.8.3-8218206-10
+  prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-32840da-22
+  nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-a96baf6-12
+  filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-b0f5416df-12
+  journalbeatImage: ghcr.io/verrazzano/journalbeat:6.8.3-b0f5416df-12
   weblogicOperatorImage: oracle/weblogic-kubernetes-operator:3.0.0
-  fluentdImage: fluentd-kubernetes-daemonset:v1.10.4-6ce326d-18
+  fluentdImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-7f37ac6-20
   apiServerRealm: verrazzano-system
   RequestMemory: 72Mi
   cohMicroRequestMemory: 28Mi
@@ -58,7 +58,7 @@ monitoringOperator:
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-5eab01c-4
   monitoringInstanceApiImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-api:v0.0.8
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-3a08aff-36
-  nodeExporterImage: node-exporter:0.18.1-0cca78f-10
+  nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-a96baf6-12
   RequestMemory: 48Mi
 
 clusterOperator:

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -9,10 +9,6 @@ image:
   pullPolicy: Always
   terminationGracePeriodSeconds: 60
 
-docker:
-  repository: phx.ocir.io
-  namespace: stevengreenberginc/verrazzano
-
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator

--- a/install/common.sh
+++ b/install/common.sh
@@ -271,6 +271,6 @@ NGINX_INGRESS_CONTROLLER_VERSION=1.27.0
 NGINX_DEFAULT_BACKEND_IMAGE=container-registry.oracle.com/verrazzano/nginx-ingress-default-backend
 NGINX_DEFAULT_BACKEND_TAG=0.32-aadecdc-21
 
-RANCHER_IMAGE=container-registry.oracle.com/verrazzano/rancher
+RANCHER_IMAGE=ghcr.io/verrazzano/rancher
 RANCHER_VERSION=v2.4.3
-RANCHER_TAG=v2.4.3-0cc4e86-22
+RANCHER_TAG=v2.4.3-dfd6383be-27

--- a/install/common.sh
+++ b/install/common.sh
@@ -235,29 +235,29 @@ command -v curl >/dev/null 2>&1 || {
 GLOBAL_HUB_REPO=container-registry.oracle.com/olcne
 GLOBAL_IMAGE_PULL_SECRET=verrazzano-container-registry
 
-CERT_MANAGER_IMAGE=container-registry.oracle.com/verrazzano/cert-manager-controller
-CERT_MANAGER_TAG=0.13.1-0e7394e-18
+CERT_MANAGER_IMAGE=ghcr.io/verrazzano/cert-manager-controller
+CERT_MANAGER_TAG=0.13.1-fbae6c270-21
 CERT_MANAGER_RELEASE=0.13
 CERT_MANAGER_HELM_CHART_VERSION=0.13.1
-CERT_MANAGER_SOLVER_IMAGE=container-registry.oracle.com/verrazzano/cert-manager-acmesolver
-CERT_MANAGER_SOLVER_TAG=0.13.1-0e7394e-18
+CERT_MANAGER_SOLVER_IMAGE=ghcr.io/verrazzano/cert-manager-acmesolver
+CERT_MANAGER_SOLVER_TAG=0.13.1-fbae6c270-20
 
 EXTERNAL_DNS_REPO=verrazzano/external-dns
 EXTERNAL_DNS_VERSION=2.20.0
-EXTERNAL_DNS_TAG=v0.7.1-cfe79c5-10
-EXTERNAL_DNS_REGISTRY=container-registry.oracle.com
+EXTERNAL_DNS_TAG=v0.7.1-7df1f5e2-12
+EXTERNAL_DNS_REGISTRY=ghcr.io
 
 GRAFANA_REPO=container-registry.oracle.com/olcne/grafana
 GRAFANA_TAG=v6.4.4
 
-ISTIO_CORE_DNS_PLUGIN_IMAGE=container-registry.oracle.com/verrazzano/istio-coredns-plugin
-ISTIO_CORE_DNS_PLUGIN_TAG=0.2-5caa06b-13
+ISTIO_CORE_DNS_PLUGIN_IMAGE=ghcr.io/verrazzano/istio-coredns-plugin
+ISTIO_CORE_DNS_PLUGIN_TAG=0.2-0ba26c32-15
 ISTIO_CORE_DNS_IMAGE=container-registry.oracle.com/olcne/coredns
 ISTIO_CORE_DNS_TAG=1.6.2
 ISTIO_VERSION=1.4.6
 
-KEYCLOAK_IMAGE=container-registry.oracle.com/verrazzano/keycloak
-KEYCLOAK_IMAGE_TAG=10.0.1-30d98b0-5
+KEYCLOAK_IMAGE=ghcr.io/verrazzano/keycloak
+KEYCLOAK_IMAGE_TAG=10.0.1-30d98b0-6
 KEYCLOAK_CHART_VERSION=8.2.2
 
 KEYCLOAK_THEME_IMAGE=container-registry.oracle.com/verrazzano/keycloak-oracle-theme:v0.0.1


### PR DESCRIPTION
Pull many more images from ghcr.io.

Removed the global switch of being able to select which repository to pull images from.  Now each image can individually be overridden.