### PR TITLE
Remove unused secret from the bobs-books-model file

### DIFF
--- a/examples/bobs-books/bobs-books-model.yaml
+++ b/examples/bobs-books/bobs-books-model.yaml
@@ -84,7 +84,6 @@ spec:
       image: "container-registry.oracle.com/verrazzano/example-bobbys-helidon-stock-application:0.1.10-3-6e5f030-129"
       imagePullSecrets:
         - name: ocr
-        - name: github-packages
       env:
         - name: COH_CACHE_CONFIG
           value: bobbys-helidon-cache-config.xml
@@ -117,7 +116,6 @@ spec:
     - name: "bobbys-coherence"
       image: "container-registry.oracle.com/verrazzano/example-bobbys-coherence:0.1.10-3-6e5f030-129"
       imagePullSecrets:
-        - name: github-packages
         - name: ocr  # secret to pull bobbys-coherence and container-registry.oracle.com/middleware/coherence:12.2.1.4.0
       cacheConfig: "bobbys-cache-config.xml"
       pofConfig: "bobbys-pof-config.xml"


### PR DESCRIPTION
Remove the references to a secret named `github-packages` from the bobs-books-model.yaml file.  These references were inadvertently left in the file.  If this secret is not defined, then trying to apply the model file will fail because the admission-controller checks for the existence of the secret.