### PR TITLE
Update uninstall scripts to not delete resources related to in-cluster install

### DIFF
--- a/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -68,7 +68,7 @@ function delete_istio_namepsace() {
 function finalize() {
   # Removing possible reference to verrazzano in clusterroles and clusterrolebindings
   log "Removing Verrazzano ClusterRoles and ClusterRoleBindings"
-  delete_k8s_resources clusterrolebinding ":metadata.name" "Could not delete ClusterRoleBindings" '/verrazzano/' \
+  delete_k8s_resources clusterrolebinding ":metadata.name" "Could not delete ClusterRoleBindings" '/verrazzano/ && ! /verrazzano-platform-operator/ && ! /verrazzano-install/ {print $1}' \
     || return $? # return on pipefail
 
   delete_k8s_resources clusterrole ":metadata.name" "Could not delete ClusterRoles" '/verrazzano/' \

--- a/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -68,7 +68,7 @@ function delete_istio_namepsace() {
 function finalize() {
   # Removing possible reference to verrazzano in clusterroles and clusterrolebindings
   log "Removing Verrazzano ClusterRoles and ClusterRoleBindings"
-  delete_k8s_resources clusterrolebinding ":metadata.name" "Could not delete ClusterRoleBindings" '/verrazzano/ && ! /verrazzano-platform-operator/ && ! /verrazzano-install/ {print $1}' \
+  delete_k8s_resources clusterrolebinding ":metadata.name" "Could not delete ClusterRoleBindings" '/verrazzano/ && ! /verrazzano-platform-operator/ && ! /verrazzano-install/' \
     || return $? # return on pipefail
 
   delete_k8s_resources clusterrole ":metadata.name" "Could not delete ClusterRoles" '/verrazzano/' \

--- a/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -30,7 +30,7 @@ function delete_verrazzano() {
     || return $? # return on pipefail
 
   log "Deleting Verrazzano crds"
-  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/' \
+  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/ && ! /verrazzanos.install.verrazzano.io/' \
     || return $? # return on pipefail
 
   # deleting certificatesigningrequests
@@ -38,9 +38,9 @@ function delete_verrazzano() {
   delete_k8s_resources csr ":metadata.name" "Could not delete CertificateSigningRequests from Verrazzano" '/csr-/' \
     || return $? # return on pipefail
 
-  log "Deleting ClusterRoles and ClusterRoleBindings"
+  log "Deleting ClusterRoleBindings"
   # deleting clusterrolebindings
-  delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Verrazzano" '/verrazzano/ {print $1}' \
+  delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Verrazzano" '/verrazzano/ && ! /verrazzano-platform-operator/ && ! /verrazzano-install/ {print $1}' \
     || return $? # return on pipefail
 
   # deleting clusterroles


### PR DESCRIPTION
This pull request updates the uninstall scripts to not delete resources related to in-cluster install.  For example, the verrazzanos.install.verrazzano.io crd and verrazzano-platform-operator resources should not be deleted.