### PR TITLE
Update to latest docker images

### DIFF
--- a/install/chart/crds/verrazzano.io_verrazzanomodels_crd.yaml
+++ b/install/chart/crds/verrazzano.io_verrazzanomodels_crd.yaml
@@ -92,7 +92,7 @@ spec:
                                 connection
                               properties:
                                 match:
-                                  description: See  verrazzano-crd-generator/pkg/apis/networking.istio.io/v1alpha3/virtual_service.go     https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.gen.json     (istio.io/api/networking/v1alpha3/virtual_service.json)
+                                  description: List of http match rules
                                   items:
                                     description: MatchRequest specifies a http match
                                       rule
@@ -376,7 +376,7 @@ spec:
                                 connection
                               properties:
                                 match:
-                                  description: See  verrazzano-crd-generator/pkg/apis/networking.istio.io/v1alpha3/virtual_service.go     https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.gen.json     (istio.io/api/networking/v1alpha3/virtual_service.json)
+                                  description: List of http match rules
                                   items:
                                     description: MatchRequest specifies a http match
                                       rule
@@ -6509,7 +6509,7 @@ spec:
                                 connection
                               properties:
                                 match:
-                                  description: See  verrazzano-crd-generator/pkg/apis/networking.istio.io/v1alpha3/virtual_service.go     https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.gen.json     (istio.io/api/networking/v1alpha3/virtual_service.json)
+                                  description: List of http match rules
                                   items:
                                     description: MatchRequest specifies a http match
                                       rule
@@ -6785,7 +6785,7 @@ spec:
                                 connection
                               properties:
                                 match:
-                                  description: See  verrazzano-crd-generator/pkg/apis/networking.istio.io/v1alpha3/virtual_service.go     https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.gen.json     (istio.io/api/networking/v1alpha3/virtual_service.json)
+                                  description: List of http match rules
                                   items:
                                     description: MatchRequest specifies a http match
                                       rule

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -13,7 +13,7 @@ image:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.5.0-20201113120716-322d96c
+  imageVersion: 0.5.0-20201113171326-a0569e0
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ image:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.5.0-20201110144418-3e6048a
+  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
+  imageVersion: 0.5.0-20201113120716-322d96c
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -13,7 +13,7 @@ image:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.5.0-20201113171326-a0569e0
+  imageVersion: 0.5.0-20201113195628-91f137b
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61
@@ -60,8 +60,8 @@ monitoringOperator:
 
 clusterOperator:
   name: verrazzano-cluster-operator
-  imageName: ghcr.io/verrazzano/verrazzano-cluster-operator
-  imageVersion: 0.5.0-20201105145819-199162a
+  imageName: ghcr.io/verrazzano/verrazzano-cluster-operator-jenkins
+  imageVersion: 0.5.0-20201113182120-75fb439
   rancherURL:
   rancherUserName:
   rancherPassword:
@@ -71,8 +71,8 @@ clusterOperator:
 verrazzanoAdmissionController:
   name: verrazzano-validation
   controllerName: verrazzano-admission-controller
-  imageName: ghcr.io/verrazzano/verrazzano-admission-controller
-  imageVersion: 0.5.0-20201110144350-cbeed27
+  imageName: ghcr.io/verrazzano/verrazzano-admission-controller-jenkins
+  imageVersion: 0.5.0-20201113185411-d9e17c3
   caBundle:
   RequestMemory: 15Mi
 

--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -12,8 +12,8 @@ image:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.5.0-20201113195628-91f137b
+  imageName: ghcr.io/verrazzano/verrazzano-operator
+  imageVersion: 0.5.0-20201113214945-6105e62
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61
@@ -60,8 +60,8 @@ monitoringOperator:
 
 clusterOperator:
   name: verrazzano-cluster-operator
-  imageName: ghcr.io/verrazzano/verrazzano-cluster-operator-jenkins
-  imageVersion: 0.5.0-20201113182120-75fb439
+  imageName: ghcr.io/verrazzano/verrazzano-cluster-operator
+  imageVersion: 0.5.0-20201113214457-cf62537
   rancherURL:
   rancherUserName:
   rancherPassword:
@@ -71,8 +71,8 @@ clusterOperator:
 verrazzanoAdmissionController:
   name: verrazzano-validation
   controllerName: verrazzano-admission-controller
-  imageName: ghcr.io/verrazzano/verrazzano-admission-controller-jenkins
-  imageVersion: 0.5.0-20201113185411-d9e17c3
+  imageName: ghcr.io/verrazzano/verrazzano-admission-controller
+  imageVersion: 0.5.0-20201113214810-3312700
   caBundle:
   RequestMemory: 15Mi
 


### PR DESCRIPTION
Pick up latest verrazzano-operator, verrazzano-cluster-operator and verrazzano-admission-controller images.

Also an updated CRD file for models.