### PR TITLE
Tvlatas/vz 1736

### DIFF
--- a/install/2b-install-system-components-ocidns.sh
+++ b/install/2b-install-system-components-ocidns.sh
@@ -148,6 +148,8 @@ spec:
 
 function install_external_dns()
 {
+    helm repo add stable https://charts.helm.sh/stable
+    helm repo update
     helm upgrade external-dns stable/external-dns \
         --install \
         --namespace cert-manager \

--- a/install/2b-install-system-components-ocidns.sh
+++ b/install/2b-install-system-components-ocidns.sh
@@ -148,8 +148,6 @@ spec:
 
 function install_external_dns()
 {
-    helm repo add stable https://charts.helm.sh/stable
-    helm repo update
     helm upgrade external-dns stable/external-dns \
         --install \
         --namespace cert-manager \

--- a/install/4-install-keycloak.sh
+++ b/install/4-install-keycloak.sh
@@ -43,8 +43,6 @@ function install_mysql {
       $SCRIPT_DIR/config/mysql-values-template.yaml > ${TMP_DIR}/mysql-values-sed.yaml
 
   log "Install MySQL helm chart"
-  helm repo add stable https://charts.helm.sh/stable
-  helm repo update
   helm upgrade mysql stable/mysql \
       --install \
       --namespace ${KEYCLOAK_NS} \

--- a/install/4-install-keycloak.sh
+++ b/install/4-install-keycloak.sh
@@ -41,8 +41,10 @@ function install_mysql {
   sed -e "s|MYSQL_IMAGE_TAG|${MYSQL_IMAGE_TAG}|g" \
       -e "s|MYSQL_USERNAME|${MYSQL_USERNAME}|g" \
       $SCRIPT_DIR/config/mysql-values-template.yaml > ${TMP_DIR}/mysql-values-sed.yaml
-  
+
   log "Install MySQL helm chart"
+  helm repo add stable https://charts.helm.sh/stable
+  helm repo update
   helm upgrade mysql stable/mysql \
       --install \
       --namespace ${KEYCLOAK_NS} \
@@ -79,7 +81,7 @@ function install_keycloak {
 
   # Add keycloak helm repo
   helm repo add codecentric https://codecentric.github.io/helm-charts
-  
+
   if ! kubectl get secret --namespace ${KEYCLOAK_NS} mysql ; then
     error "ERROR installing mysql. Please rerun this script."
     exit 1

--- a/install/chart/values.dev.yaml
+++ b/install/chart/values.dev.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+name: verrazzano
+
+global:
+  installProfile: dev

--- a/install/chart/values.prod.yaml
+++ b/install/chart/values.prod.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+name: verrazzano
+
+global:
+  installProfile: prod


### PR DESCRIPTION
VZ-1736 related work.

This adds in basic helm value override files. These currently only have the override for the installProfile setting which will be going away with other work going on in parallel. This sets up the automation though so we can run acceptance tests with profile values which are in values.NAME.yaml (NAME being prod, dev, whatever...)

I'm creating a separate PR for the automation side. This has the temporary workaround discussed earlier for the helm issue