### PR TITLE
VZ-1653 : Update verrazzano-operator from master build# 251

### DIFF
--- a/install/chart/values.yaml
+++ b/install/chart/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.6.0-20201119220826-8319453
+  imageVersion: 0.6.0-20201120085322-82bcb1b
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61


### PR DESCRIPTION
Update the verrazzano-operator image in install/chart/values.yaml from master build#251, which contains the change submitted for VZ-1653

Acceptance Test - https://build.verrazzano.io/blue/organizations/jenkins/verrazzano/detail/pabhat%2Fvz1653/2/pipeline