### PR TITLE
VZ-1177: Add check for empty Rancher password in install step 2

### DIFF
--- a/install/2a-install-system-components-magicdns.sh
+++ b/install/2a-install-system-components-magicdns.sh
@@ -155,6 +155,12 @@ function install_rancher()
     log "Create Rancher secrets"
     RANCHER_DATA=$(kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password 2>/dev/null)
     ADMIN_PW=`echo $RANCHER_DATA | awk '{ print $NF }'`
+
+    if [ -z "$ADMIN_PW" ] ; then
+      error "ERROR: Failed to reset Rancher password"
+      return 1
+    fi
+
     kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
 }
 

--- a/install/2b-install-system-components-ocidns.sh
+++ b/install/2b-install-system-components-ocidns.sh
@@ -214,6 +214,12 @@ function install_rancher()
     log "Create Rancher secrets"
     RANCHER_DATA=$(kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password 2>/dev/null)
     ADMIN_PW=`echo $RANCHER_DATA | awk '{ print $NF }'`
+
+    if [ -z "$ADMIN_PW" ] ; then
+      error "ERROR: Failed to reset Rancher password"
+      return 1
+    fi
+
     kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
 }
 


### PR DESCRIPTION
If resetting the Rancher password fails during install step 2, the error is swallowed which causes downstream install steps to fail. This PR adds a check and fails the install if we are unable to reset the Rancher password.

Example install output showing the failure:
```
$ ./2a-install-system-components-magicdns.sh 
Output redirected to /Users/ftibbitts/go/src/github.com/verrazzano/verrazzano/install/build/logs/2a-install-system-components-magicdns.sh.log
Installing NGINX ingress controller                                          [  OK  ]
Installing certificate manager                                               [  OK  ]
Installing Rancher                                                           [  \   ]
ERROR: Failed to reset Rancher password
Installing Rancher                                                           [FAILED]

A failure occurred. Exiting with code 1. See /Users/ftibbitts/go/src/github.com/verrazzano/verrazzano/install/build/logs/2a-install-system-components-magicdns.sh.log for details.
```