### PR TITLE
Cleanup jenkins workspace after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,6 +261,9 @@ pipeline {
     }
 
     post {
+        always {
+            deleteDir()
+        }
         failure {
             mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
             subject: "Verrazzano: ${env.JOB_NAME} - Failed",


### PR DESCRIPTION
Clean workspace at end of Jenkins pipeline in the event agents are reused (which they were temporarily) you start w/ a clean workspace.