### PR TITLE
VZ-1788.  Save current Verrazzano install state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,3 +221,13 @@ push-tag:
 	docker pull "${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}"; \
 	docker tag "${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}" "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"; \
 	docker push "${DOCKER_IMAGE_FULLNAME}:$$PUBLISH_TAG"
+
+.PHONY: create-test-deploy
+create-test-deploy:
+	if [ -n "${VZ_DEV_IMAGE}" ]; then \
+		echo "Building local operator deployment resource file in /tmp/operator.yaml, VZ_DEV_IMAGE=${VZ_DEV_IMAGE}"; \
+		cat operator/config/deploy/verrazzano-platform-operator.yaml | sed -e "s|IMAGE_NAME|${VZ_DEV_IMAGE}|g" > /tmp/operator.yaml; \
+		cat operator/config/crd/bases/install.verrazzano.io_verrazzanos.yaml >> /tmp/operator.yaml; \
+	else \
+		echo "VZ_DEV_IMAGE not defined, please set it to a valid image name/tag"; \
+	fi

--- a/operator/README.md
+++ b/operator/README.md
@@ -23,9 +23,11 @@ export DOCKER_NAMESPACE=<namespace for image>
 make docker-push
 
 # Create the verrrazzano-platform-operator deployment yaml file.
-# Replace <verrazzano-image> with the verrazzano-platform-operator image you created with 'make docker-push'.
-cat config/deploy/verrazzano-platform-operator.yaml | sed -e "s|IMAGE_NAME|<verrazzano-image>|g" > /tmp/operator.yaml
-cat config/crd/bases/install.verrazzano.io_verrazzanos.yaml >> /tmp/operator.yaml
+# Define the VZ_DEV_IMAGE env variable and call the create-test-deploy target
+# - Replace <verrazzano-image> with the verrazzano-platform-operator image you created with 'make docker-push'
+# - creates a valid deployment yaml file in /tmp/operator.yaml
+export VZ_DEV_IMAGE=<verrazzano-image>
+make create-test-deploy
 
 # Deploy the verrazzano-platform-operator
 kubectl apply -f /tmp/operator.yaml

--- a/operator/config/scripts/run.sh
+++ b/operator/config/scripts/run.sh
@@ -47,7 +47,12 @@ function dump-uninstall-logs {
 
 # Create a kubeconfig
 create-kubeconfig
-if [ ${MODE} == "INSTALL" ]; then
+if [ ${MODE} == "NOOP" ]; then
+  echo "*************************************************************"
+  echo " Running in NOOP mode, exiting                               "
+  echo "*************************************************************"
+  exit 0
+elif [ ${MODE} == "INSTALL" ]; then
   # Run the installation
   ./install/1-install-istio.sh || dump-install-logs 1
   ./install/2-install-system-components.sh || dump-install-logs 1

--- a/operator/controllers/verrazzano_controller.go
+++ b/operator/controllers/verrazzano_controller.go
@@ -5,8 +5,10 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/verrazzano/verrazzano/operator/internal"
 	"os"
 	"sigs.k8s.io/yaml"
 	"time"
@@ -35,10 +37,14 @@ type VerrazzanoReconciler struct {
 	Log        *zap.SugaredLogger
 	Scheme     *runtime.Scheme
 	Controller controller.Controller
+	DryRun     bool
 }
 
-// Name of finializer
+// Name of finalizer
 const finalizerName = "install.verrazzano.io"
+
+// Key into ConfigMap data for stored install Spec, the data for which will be used for update/upgrade purposes
+const configDataKey = "spec"
 
 // Reconcile will reconcile the CR
 // +kubebuilder:rbac:groups=install.verrazzano.io,resources=verrazzanos,verbs=get;list;watch;create;update;patch;delete
@@ -110,7 +116,12 @@ func (r *VerrazzanoReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		return reconcile.Result{}, err
 	}
 
-	if err := r.createInstallJob(ctx, log, vz, getConfigMapName(vz.Name)); err != nil {
+	if err := r.createInstallJob(ctx, log, vz, buildConfigMapName(vz.Name)); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create/update a configmap from spec for future comparison on update/upgrade
+	if err := r.saveVerrazzanoSpec(ctx, vz); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -120,7 +131,7 @@ func (r *VerrazzanoReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 // createServiceAccount creates a required service account
 func (r *VerrazzanoReconciler) createServiceAccount(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	// Define a new service account resource
-	serviceAccount := installjob.NewServiceAccount(vz.Namespace, getServiceAccountName(vz.Name), os.Getenv("IMAGE_PULL_SECRET"), vz.Labels)
+	serviceAccount := installjob.NewServiceAccount(vz.Namespace, buildServiceAccountName(vz.Name), os.Getenv("IMAGE_PULL_SECRET"), vz.Labels)
 
 	// Set verrazzano resource as the owner and controller of the service account resource.
 	// This reference will result in the service account resource being deleted when the verrazzano CR is deleted.
@@ -130,10 +141,10 @@ func (r *VerrazzanoReconciler) createServiceAccount(ctx context.Context, log *za
 
 	// Check if the service account for running the scripts exist
 	serviceAccountFound := &corev1.ServiceAccount{}
-	log.Infof("Checking if install service account %s exist", getServiceAccountName(vz.Name))
-	err := r.Get(ctx, types.NamespacedName{Name: getServiceAccountName(vz.Name), Namespace: vz.Namespace}, serviceAccountFound)
+	log.Infof("Checking if install service account %s exist", buildServiceAccountName(vz.Name))
+	err := r.Get(ctx, types.NamespacedName{Name: buildServiceAccountName(vz.Name), Namespace: vz.Namespace}, serviceAccountFound)
 	if err != nil && errors.IsNotFound(err) {
-		log.Infof("Creating install service account %s", getServiceAccountName(vz.Name))
+		log.Infof("Creating install service account %s", buildServiceAccountName(vz.Name))
 		err = r.Create(ctx, serviceAccount)
 		if err != nil {
 			return err
@@ -148,7 +159,7 @@ func (r *VerrazzanoReconciler) createServiceAccount(ctx context.Context, log *za
 // createClusterRoleBinding creates a required cluster role binding
 func (r *VerrazzanoReconciler) createClusterRoleBinding(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	// Define a new cluster role binding resource
-	clusterRoleBinding := installjob.NewClusterRoleBinding(vz, getClusterRoleBindingName(vz.Namespace, vz.Name), getServiceAccountName(vz.Name))
+	clusterRoleBinding := installjob.NewClusterRoleBinding(vz, buildClusterRoleBindingName(vz.Namespace, vz.Name), buildServiceAccountName(vz.Name))
 
 	// Check if the cluster role binding for running the install scripts exist
 	clusterRoleBindingFound := &rbacv1.ClusterRoleBinding{}
@@ -170,7 +181,7 @@ func (r *VerrazzanoReconciler) createClusterRoleBinding(ctx context.Context, log
 // createConfigMap creates a required config map for installation
 func (r *VerrazzanoReconciler) createConfigMap(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	// Create the configmap resource that will contain installation configuration options
-	configMap := installjob.NewConfigMap(vz.Namespace, getConfigMapName(vz.Name), vz.Labels)
+	configMap := installjob.NewConfigMap(vz.Namespace, buildConfigMapName(vz.Name), vz.Labels)
 
 	// Set the verrazzano resource as the owner and controller of the configmap
 	err := controllerutil.SetControllerReference(vz, configMap, r.Scheme)
@@ -219,7 +230,19 @@ func (r *VerrazzanoReconciler) createConfigMap(ctx context.Context, log *zap.Sug
 // createInstallJob creates the installation job
 func (r *VerrazzanoReconciler) createInstallJob(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, configMapName string) error {
 	// Define a new install job resource
-	job := installjob.NewJob(vz.Namespace, getInstallJobName(vz.Name), vz.Labels, configMapName, getServiceAccountName(vz.Name), os.Getenv("VZ_INSTALL_IMAGE"))
+	r.Log.Infof("Creating install job for %s, dry-run=%v", vz.Name, r.DryRun)
+	job := installjob.NewJob(
+		&installjob.JobConfig{
+			JobConfigCommon: internal.JobConfigCommon{
+				JobName:            buildInstallJobName(vz.Name),
+				Namespace:          vz.Namespace,
+				Labels:             vz.Labels,
+				ServiceAccountName: buildServiceAccountName(vz.Name),
+				JobImage:           os.Getenv("VZ_INSTALL_IMAGE"),
+				DryRun:             r.DryRun,
+			},
+			ConfigMapName: configMapName,
+		})
 
 	// Set verrazzano resource as the owner and controller of the job resource.
 	// This reference will result in the job resource being deleted when the verrazzano CR is deleted.
@@ -228,10 +251,10 @@ func (r *VerrazzanoReconciler) createInstallJob(ctx context.Context, log *zap.Su
 	}
 	// Check if the job for running the install scripts exist
 	jobFound := &batchv1.Job{}
-	log.Infof("Checking if install job %s exist", getInstallJobName(vz.Name))
-	err := r.Get(ctx, types.NamespacedName{Name: getInstallJobName(vz.Name), Namespace: vz.Namespace}, jobFound)
+	log.Infof("Checking if install job %s exist", buildInstallJobName(vz.Name))
+	err := r.Get(ctx, types.NamespacedName{Name: buildInstallJobName(vz.Name), Namespace: vz.Namespace}, jobFound)
 	if err != nil && errors.IsNotFound(err) {
-		log.Infof("Creating install job %s", getInstallJobName(vz.Name))
+		log.Infof("Creating install job %s", buildInstallJobName(vz.Name))
 		err = r.Create(ctx, job)
 		if err != nil {
 			return err
@@ -247,7 +270,7 @@ func (r *VerrazzanoReconciler) createInstallJob(ctx context.Context, log *zap.Su
 		}
 
 		// Delete leftover uninstall job if we find one.
-		err = r.cleanupUninstallJob(getUninstallJobName(vz.Name), vz.Namespace, log)
+		err = r.cleanupUninstallJob(buildUninstallJobName(vz.Name), vz.Namespace, log)
 		if err != nil {
 			return err
 		}
@@ -309,7 +332,19 @@ func (r *VerrazzanoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *VerrazzanoReconciler) createUninstallJob(log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	// Define a new uninstall job resource
-	job := uninstalljob.NewJob(vz.Namespace, getUninstallJobName(vz.Name), vz.Labels, getServiceAccountName(vz.Name), os.Getenv("VZ_INSTALL_IMAGE"))
+	r.Log.Infof("Creating uninstall job for %s, dry-run=%v", vz.Name, r.DryRun)
+	job := uninstalljob.NewJob(
+		&uninstalljob.JobConfig{
+			JobConfigCommon: internal.JobConfigCommon{
+				JobName:            buildUninstallJobName(vz.Name),
+				Namespace:          vz.Namespace,
+				Labels:             vz.Labels,
+				ServiceAccountName: buildServiceAccountName(vz.Name),
+				JobImage:           os.Getenv("VZ_INSTALL_IMAGE"),
+				DryRun:             r.DryRun,
+			},
+		},
+	)
 
 	// Set verrazzano resource as the owner and controller of the uninstall job resource.
 	if err := controllerutil.SetControllerReference(vz, job, r.Scheme); err != nil {
@@ -318,10 +353,10 @@ func (r *VerrazzanoReconciler) createUninstallJob(log *zap.SugaredLogger, vz *in
 
 	// Check if the job for running the uninstall scripts exist
 	jobFound := &batchv1.Job{}
-	log.Infof("Checking if uninstall job %s exist", getUninstallJobName(vz.Name))
-	err := r.Get(context.TODO(), types.NamespacedName{Name: getUninstallJobName(vz.Name), Namespace: vz.Namespace}, jobFound)
+	log.Infof("Checking if uninstall job %s exist", buildUninstallJobName(vz.Name))
+	err := r.Get(context.TODO(), types.NamespacedName{Name: buildUninstallJobName(vz.Name), Namespace: vz.Namespace}, jobFound)
 	if err != nil && errors.IsNotFound(err) {
-		log.Infof("Creating uninstall job %s", getUninstallJobName(vz.Name))
+		log.Infof("Creating uninstall job %s", buildUninstallJobName(vz.Name))
 		err = r.Create(context.TODO(), job)
 		if err != nil {
 			return err
@@ -346,29 +381,34 @@ func (r *VerrazzanoReconciler) createUninstallJob(log *zap.SugaredLogger, vz *in
 	return nil
 }
 
-// getInstallJobName returns the name of an install job based on verrazzano resource name.
-func getInstallJobName(name string) string {
+// buildInstallJobName returns the name of an install job based on verrazzano resource name.
+func buildInstallJobName(name string) string {
 	return fmt.Sprintf("verrazzano-install-%s", name)
 }
 
-// getUninstallJobName returns the name of an uninstall job based on verrazzano resource name.
-func getUninstallJobName(name string) string {
+// buildUninstallJobName returns the name of an uninstall job based on verrazzano resource name.
+func buildUninstallJobName(name string) string {
 	return fmt.Sprintf("verrazzano-uninstall-%s", name)
 }
 
-// getServiceAccountName returns the service account name for jobs based on verrazzano resource name.
-func getServiceAccountName(name string) string {
+// buildServiceAccountName returns the service account name for jobs based on verrazzano resource name.
+func buildServiceAccountName(name string) string {
 	return fmt.Sprintf("verrazzano-install-%s", name)
 }
 
-// getClusterRoleBindingName returns the clusterrolebinding name for jobs based on verrazzano resource name.
-func getClusterRoleBindingName(namespace string, name string) string {
+// buildClusterRoleBindingName returns the clusterrolebinding name for jobs based on verrazzano resource name.
+func buildClusterRoleBindingName(namespace string, name string) string {
 	return fmt.Sprintf("verrazzano-install-%s-%s", namespace, name)
 }
 
-// getConfigMapName returns the name of a config map for an install job based on verrazzano resource name.
-func getConfigMapName(name string) string {
+// buildConfigMapName returns the name of a config map for an install job based on verrazzano resource name.
+func buildConfigMapName(name string) string {
 	return fmt.Sprintf("verrazzano-install-%s", name)
+}
+
+// buildInternalConfigMapName returns the name of the internal configmap associated with an install resource.
+func buildInternalConfigMapName(name string) string {
+	return fmt.Sprintf("verrazzano-install-%s-internal", name)
 }
 
 // updateStatus updates the status in the verrazzano CR
@@ -466,6 +506,59 @@ func (r *VerrazzanoReconciler) setUninstallCondition(log *zap.SugaredLogger, job
 	}
 
 	return r.updateStatus(log, vz, "Verrazzano uninstall in progress", installv1alpha1.UninstallStarted)
+}
+
+// saveInstallSpec Saves the install spec in a configmap to use with upgrade/updates later on
+func (r *VerrazzanoReconciler) saveVerrazzanoSpec(ctx context.Context, vz *installv1alpha1.Verrazzano) (err error) {
+	installSpecBytes, err := yaml.Marshal(vz.Spec)
+	installSpec := base64.StdEncoding.EncodeToString(installSpecBytes)
+	if err == nil {
+		var installConfig *corev1.ConfigMap
+		installConfig, err = r.getInternalConfigMap(ctx, vz)
+		if err == nil {
+			// Update the configmap if the data has changed
+			currentConfigData := installConfig.Data[configDataKey]
+			if currentConfigData != installSpec {
+				installConfig.Data[configDataKey] = installSpec
+				return r.Update(ctx, installConfig)
+			}
+		} else if errors.IsNotFound(err) {
+			configMapName := buildInternalConfigMapName(vz.Name)
+			configData := make(map[string]string)
+			configData[configDataKey] = installSpec
+			// Create the configmap and set the owner reference to the VZ installer resource for garbage collection
+			installConfig = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: vz.Namespace,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: vz.APIVersion,
+						Kind:       vz.Kind,
+						Name:       vz.Name,
+						UID:        vz.UID,
+					}},
+				},
+				Data: configData,
+			}
+			err = r.Create(ctx, installConfig)
+			if err != nil {
+				r.Log.Errorf("Unable to create installer config map %s: %v", configMapName, err)
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// getInternalConfigMap Convenience method for getting the saved install ConfigMap
+func (r *VerrazzanoReconciler) getInternalConfigMap(ctx context.Context, vz *installv1alpha1.Verrazzano) (installConfig *corev1.ConfigMap, err error) {
+	key := client.ObjectKey{
+		Namespace: vz.Namespace,
+		Name:      buildInternalConfigMapName(vz.Name),
+	}
+	installConfig = &corev1.ConfigMap{}
+	err = r.Get(ctx, key, installConfig)
+	return installConfig, err
 }
 
 // containsString checks for a string in a slice of strings

--- a/operator/controllers/verrazzano_controller.go
+++ b/operator/controllers/verrazzano_controller.go
@@ -511,8 +511,8 @@ func (r *VerrazzanoReconciler) setUninstallCondition(log *zap.SugaredLogger, job
 // saveInstallSpec Saves the install spec in a configmap to use with upgrade/updates later on
 func (r *VerrazzanoReconciler) saveVerrazzanoSpec(ctx context.Context, vz *installv1alpha1.Verrazzano) (err error) {
 	installSpecBytes, err := yaml.Marshal(vz.Spec)
-	installSpec := base64.StdEncoding.EncodeToString(installSpecBytes)
 	if err == nil {
+		installSpec := base64.StdEncoding.EncodeToString(installSpecBytes)
 		var installConfig *corev1.ConfigMap
 		installConfig, err = r.getInternalConfigMap(ctx, vz)
 		if err == nil {

--- a/operator/controllers/verrazzano_controller_test.go
+++ b/operator/controllers/verrazzano_controller_test.go
@@ -5,6 +5,9 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
+	"github.com/verrazzano/verrazzano/operator/internal"
+	"sigs.k8s.io/yaml"
 	"testing"
 	"time"
 
@@ -12,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/operator/api/v1alpha1"
 	"github.com/verrazzano/verrazzano/operator/internal/installjob"
-	"github.com/verrazzano/verrazzano/operator/internal/uninstalljob"
 	"github.com/verrazzano/verrazzano/operator/mocks"
 	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
@@ -39,7 +41,7 @@ const uninstallPrefix = "verrazzano-uninstall-"
 // THEN return the generated ConfigMap name
 func TestGetConfigMapName(t *testing.T) {
 	name := "configMap"
-	configMapName := getConfigMapName(name)
+	configMapName := buildConfigMapName(name)
 	assert.Equalf(t, installPrefix+name, configMapName, "Expected ConfigMap name did not match")
 }
 
@@ -50,7 +52,7 @@ func TestGetConfigMapName(t *testing.T) {
 func TestGetClusterRoleBindingName(t *testing.T) {
 	name := "role"
 	namespace := "verrazzano"
-	roleBindingName := getClusterRoleBindingName(namespace, name)
+	roleBindingName := buildClusterRoleBindingName(namespace, name)
 	assert.Equalf(t, installPrefix+namespace+"-"+name, roleBindingName, "Expected ClusterRoleBinding name did not match")
 }
 
@@ -60,7 +62,7 @@ func TestGetClusterRoleBindingName(t *testing.T) {
 // THEN return the generated ServiceAccount name
 func TestGetServiceAccountName(t *testing.T) {
 	name := "sa"
-	saName := getServiceAccountName(name)
+	saName := buildServiceAccountName(name)
 	assert.Equalf(t, installPrefix+name, saName, "Expected ServiceAccount name did not match")
 }
 
@@ -70,7 +72,7 @@ func TestGetServiceAccountName(t *testing.T) {
 // THEN return the generated Job name
 func TestGetUninstallJobName(t *testing.T) {
 	name := "test"
-	jobName := getUninstallJobName(name)
+	jobName := buildUninstallJobName(name)
 	assert.Equalf(t, uninstallPrefix+name, jobName, "Expected uninstall job name did not match")
 }
 
@@ -80,7 +82,7 @@ func TestGetUninstallJobName(t *testing.T) {
 // THEN return the generated Job name
 func TestGetInstallJobName(t *testing.T) {
 	name := "test"
-	jobName := getInstallJobName(name)
+	jobName := buildInstallJobName(name)
 	assert.Equalf(t, installPrefix+name, jobName, "Expected install job name did not match")
 }
 
@@ -113,9 +115,11 @@ func TestSuccessfulInstall(t *testing.T) {
 			return nil
 		})
 
+	setupInstallInternalConfigMapExpectations(mock, name, namespace)
+
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -124,9 +128,9 @@ func TestSuccessfulInstall(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -135,7 +139,7 @@ func TestSuccessfulInstall(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
 			configMap.ObjectMeta = cm.ObjectMeta
@@ -144,9 +148,19 @@ func TestSuccessfulInstall(t *testing.T) {
 
 	// Expect a call to get the Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
-			newJob := installjob.NewJob(name.Namespace, name.Name, labels, getConfigMapName(name.Name), getServiceAccountName(name.Name), "image")
+			newJob := installjob.NewJob(&installjob.JobConfig{
+				JobConfigCommon: internal.JobConfigCommon{
+					JobName:            name.Name,
+					Namespace:          name.Namespace,
+					Labels:             labels,
+					ServiceAccountName: buildServiceAccountName(name.Name),
+					JobImage:           "image",
+					DryRun:             false,
+				},
+				ConfigMapName: buildConfigMapName(name.Name),
+			})
 			job.ObjectMeta = newJob.ObjectMeta
 			job.Spec = newJob.Spec
 			job.Status = batchv1.JobStatus{
@@ -209,62 +223,62 @@ func TestCreateVerrazzano(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, getServiceAccountName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
-			asserts.Equalf(getServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
+			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
 		})
 
 	// Expect a call to get the ClusterRoleBinding - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ClusterRoleBinding"}, getClusterRoleBindingName(namespace, name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ClusterRoleBinding"}, buildClusterRoleBindingName(namespace, name)))
 
 	// Expect a call to create the ClusterRoleBinding - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding, opts ...client.CreateOption) error {
 			asserts.Equalf("", clusterRoleBinding.Namespace, "ClusterRoleBinding namespace did not match")
-			asserts.Equalf(getClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
+			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
-			asserts.Equalf(getServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
+			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
 			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, getServiceAccountName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ConfigMap - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
-			asserts.Equalf(getConfigMapName(name), configMap.Name, "ConfigMap name did not match")
+			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			return nil
 		})
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getInstallJobName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, getInstallJobName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
-			asserts.Equalf(getInstallJobName(name), job.Name, "Job name did not match")
+			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
 		})
@@ -273,7 +287,7 @@ func TestCreateVerrazzano(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -288,6 +302,8 @@ func TestCreateVerrazzano(t *testing.T) {
 			asserts.Len(verrazzano.Status.Conditions, 1)
 			return nil
 		})
+
+	setupInstallInternalConfigMapExpectations(mock, name, namespace)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -338,40 +354,40 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, getServiceAccountName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
-			asserts.Equalf(getServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
+			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
 		})
 
 	// Expect a call to get the ClusterRoleBinding - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ClusterRoleBinding"}, getClusterRoleBindingName(namespace, name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ClusterRoleBinding"}, buildClusterRoleBindingName(namespace, name)))
 
 	// Expect a call to create the ClusterRoleBinding - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding, opts ...client.CreateOption) error {
 			asserts.Equalf("", clusterRoleBinding.Namespace, "ClusterRoleBinding namespace did not match")
-			asserts.Equalf(getClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
+			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
-			asserts.Equalf(getServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
+			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
 			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, getServiceAccountName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to get the DNS config secret and return it
 	mock.EXPECT().
@@ -396,7 +412,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
-			asserts.Equalf(getConfigMapName(name), configMap.Name, "ConfigMap name did not match")
+			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			asserts.NotNil(configMap.Data["config.json"], "Configuration entry not found")
 			asserts.NotNil(configMap.Data[vzapi.OciPrivateKeyFileName], "OCI Config entry not found")
@@ -405,15 +421,15 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getInstallJobName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, getInstallJobName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
-			asserts.Equalf(getInstallJobName(name), job.Name, "Job name did not match")
+			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
 		})
@@ -422,7 +438,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -437,6 +453,8 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 			asserts.Len(verrazzano.Status.Conditions, 1)
 			return nil
 		})
+
+	setupInstallInternalConfigMapExpectations(mock, name, namespace)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -493,9 +511,19 @@ func TestUninstallComplete(t *testing.T) {
 
 	// Expect a call to get the uninstall Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
-			newJob := uninstalljob.NewJob(name.Namespace, name.Name, labels, getServiceAccountName(name.Name), "image")
+			newJob := installjob.NewJob(&installjob.JobConfig{
+				JobConfigCommon: internal.JobConfigCommon{
+					JobName:            name.Name,
+					Namespace:          name.Namespace,
+					Labels:             labels,
+					ServiceAccountName: buildServiceAccountName(name.Name),
+					JobImage:           "image",
+					DryRun:             false,
+				},
+				ConfigMapName: buildConfigMapName(name.Name),
+			})
 			job.ObjectMeta = newJob.ObjectMeta
 			job.Spec = newJob.Spec
 			return nil
@@ -571,15 +599,15 @@ func TestUninstallStarted(t *testing.T) {
 
 	// Expect a call to get the uninstall Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, getUninstallJobName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildUninstallJobName(name)))
 
 	// Expect a call to create the uninstall Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
 			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
-			asserts.Equalf(getUninstallJobName(name), job.Name, "Job name did not match")
+			asserts.Equalf(buildUninstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
 		})
@@ -638,9 +666,19 @@ func TestUninstallFailed(t *testing.T) {
 
 	// Expect a call to get the uninstall Job - return that it exists and the job failed
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
-			newJob := uninstalljob.NewJob(name.Namespace, name.Name, labels, getServiceAccountName(name.Name), "image")
+			newJob := installjob.NewJob(&installjob.JobConfig{
+				JobConfigCommon: internal.JobConfigCommon{
+					JobName:            name.Name,
+					Namespace:          name.Namespace,
+					Labels:             labels,
+					ServiceAccountName: buildServiceAccountName(name.Name),
+					JobImage:           "image",
+					DryRun:             false,
+				},
+				ConfigMapName: buildConfigMapName(name.Name),
+			})
 			job.ObjectMeta = newJob.ObjectMeta
 			job.Spec = newJob.Spec
 			job.Status = batchv1.JobStatus{
@@ -713,9 +751,19 @@ func TestUninstallSucceeded(t *testing.T) {
 
 	// Expect a call to get the uninstall Job - return that it exists and the job succeeded
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
-			newJob := uninstalljob.NewJob(name.Namespace, name.Name, labels, getServiceAccountName(name.Name), "image")
+			newJob := installjob.NewJob(&installjob.JobConfig{
+				JobConfigCommon: internal.JobConfigCommon{
+					JobName:            name.Name,
+					Namespace:          name.Namespace,
+					Labels:             labels,
+					ServiceAccountName: buildServiceAccountName(name.Name),
+					JobImage:           "image",
+					DryRun:             false,
+				},
+				ConfigMapName: buildConfigMapName(name.Name),
+			})
 			job.ObjectMeta = newJob.ObjectMeta
 			job.Spec = newJob.Spec
 			job.Status = batchv1.JobStatus{
@@ -844,7 +892,7 @@ func TestServiceAccountGetError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get ServiceAccount"))
 
 	// Create and make the request
@@ -889,7 +937,7 @@ func TestServiceAccountCreateError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, name))
 
 	// Expect a call to create the ServiceAccount - return failure
@@ -939,7 +987,7 @@ func TestClusterRoleBindingGetError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -948,7 +996,7 @@ func TestClusterRoleBindingGetError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get ClusterRoleBinding"))
 
 	// Create and make the request
@@ -993,7 +1041,7 @@ func TestClusterRoleBindingCreateError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1002,7 +1050,7 @@ func TestClusterRoleBindingCreateError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ClusterRoleBinding"}, name))
 
 	// Expect a call to create the ClusterRoleBinding - return failure
@@ -1054,7 +1102,7 @@ func TestConfigMapGetError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1063,9 +1111,9 @@ func TestConfigMapGetError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1074,7 +1122,7 @@ func TestConfigMapGetError(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get ConfigMap"))
 
 	// Create and make the request
@@ -1121,7 +1169,7 @@ func TestConfigMapCreateError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1130,9 +1178,9 @@ func TestConfigMapCreateError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1141,7 +1189,7 @@ func TestConfigMapCreateError(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, name))
 
 	// Expect a call to create the ConfigMap - return failure
@@ -1193,7 +1241,7 @@ func TestJobGetError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1202,9 +1250,9 @@ func TestJobGetError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1213,7 +1261,7 @@ func TestJobGetError(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
 			configMap.ObjectMeta = cm.ObjectMeta
@@ -1222,7 +1270,7 @@ func TestJobGetError(t *testing.T) {
 
 	// Expect a call to get the Job - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Job"))
 
 	// Create and make the request
@@ -1275,7 +1323,7 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1284,9 +1332,9 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1295,8 +1343,8 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, getServiceAccountName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to get the DNS config secret but return a not found error
 	mock.EXPECT().
@@ -1347,7 +1395,7 @@ func TestJobCreateError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, "", labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -1356,9 +1404,9 @@ func TestJobCreateError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: getClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, getServiceAccountName(name.Name))
+			crb := installjob.NewClusterRoleBinding(savedVerrazzano, name.Name, buildServiceAccountName(name.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1367,7 +1415,7 @@ func TestJobCreateError(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
 			configMap.ObjectMeta = cm.ObjectMeta
@@ -1376,7 +1424,7 @@ func TestJobCreateError(t *testing.T) {
 
 	// Expect a call to get the Job - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, name))
 
 	// Expect a call to create the Job - return failure
@@ -1394,6 +1442,105 @@ func TestJobCreateError(t *testing.T) {
 	asserts.EqualError(err, "failed to create Job")
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestCreateInternalConfigMapReturnsError tests the saveVerrazzanoSpec error condition on create
+// GIVEN a call so save the internal configmap resource
+// WHEN an no internal configmap already exists
+// THEN an error is returned if the Create() call fails
+func TestCreateInternalConfigMapReturnsError(t *testing.T) {
+	namespace := "verrazzano"
+	name := "test"
+
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	vz := &vzapi.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: vzapi.VerrazzanoSpec{
+			Profile: "dev",
+		},
+	}
+
+	// Expect a call to get an existing configmap, but return a NotFound error.
+	mock.EXPECT().
+		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
+			return errors.NewNotFound(schema.GroupResource{
+				Group:    vzapi.GroupVersion.Group,
+				Resource: "configmap",
+			}, "configmap")
+		})
+
+	// Expect a call create a new configmap.
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap) error {
+			return errors.NewBadRequest("Bogus error")
+		})
+
+	reconciler := newVerrazzanoReconciler(mock)
+	err := reconciler.saveVerrazzanoSpec(context.TODO(), vz)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NotNil(err)
+}
+
+// TestUpdateInternalConfigMap tests the saveVerrazzanoSpec method to update an existing internal configmap
+// GIVEN a call so save the internal configmap resource
+// WHEN an internal configmap already exists for the install
+// THEN ensure that update is called for the configmap
+func TestUpdateInternalConfigMap(t *testing.T) {
+	namespace := "verrazzano"
+	name := "test"
+
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	vz := &vzapi.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: vzapi.VerrazzanoSpec{
+			Profile: "dev",
+		},
+	}
+
+	expectedConfigMapDataBytes, err := yaml.Marshal(vz.Spec)
+	assert.Nil(t, err, "Unexpected error marshalling expected config data")
+	expectedConfigMapData := base64.StdEncoding.EncodeToString(expectedConfigMapDataBytes)
+
+	savedMap := make(map[string]string)
+	savedMap[configDataKey] = ""
+	returnMap := corev1.ConfigMap{
+		Data: savedMap,
+	}
+	// Expect a call to get a stale uninstall job resource
+	mock.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
+			assert.NotNil(t, configMap)
+			configMap.Data = returnMap.Data
+			return nil
+		})
+
+	// Expect a call to update the Verrazzano resource
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.UpdateOption) error {
+			assert.Equal(t, expectedConfigMapData, configMap.Data[configDataKey])
+			return nil
+		})
+
+	reconciler := newVerrazzanoReconciler(mock)
+	err = reconciler.saveVerrazzanoSpec(context.TODO(), vz)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
 }
 
 // newScheme creates a new scheme that includes this package's object to use for testing
@@ -1425,4 +1572,23 @@ func newVerrazzanoReconciler(c client.Client) VerrazzanoReconciler {
 		Log:    log,
 		Scheme: scheme}
 	return reconciler
+}
+
+func setupInstallInternalConfigMapExpectations(mock *mocks.MockClient, name string, namespace string) {
+	// Expect a call to get an existing configmap, but return a NotFound error.
+	mock.EXPECT().
+		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
+			return errors.NewNotFound(schema.GroupResource{
+				Group:    vzapi.GroupVersion.Group,
+				Resource: "configmap",
+			}, "configmap")
+		})
+
+	// Expect a call create a new configmap.
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap) error {
+			return nil
+		})
 }

--- a/operator/internal/installjob/job.go
+++ b/operator/internal/installjob/job.go
@@ -28,8 +28,11 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 	if jobConfig.DryRun {
 		mode = internal.NoOpMode
 	}
-	annotations := make(map[string]string, 1)
-	annotations[internal.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
+	var annotations map[string]string = nil
+	if jobConfig.DryRun {
+		annotations = make(map[string]string, 1)
+		annotations[internal.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobConfig.JobName,

--- a/operator/internal/installjob/job.go
+++ b/operator/internal/installjob/job.go
@@ -4,42 +4,57 @@
 package installjob
 
 import (
+	"github.com/verrazzano/verrazzano/operator/internal"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
 )
 
+// JobConfig Defines the parameters for an install job
+type JobConfig struct {
+	internal.JobConfigCommon // Extending the base job config
+
+	ConfigMapName string // Name of the install configmap used by the scripts
+}
+
+// installMode value for MODE variable for install jobs
+const installMode = "INSTALL"
+
 // NewJob returns a job resource for installing Verrazzano
-// namespace - namespace of verrazzano resource
-// jobNname - name of verrazzano resource
-// labels - labels of verrazzano resource
-// saName - service account name
-// image - docker image
-func NewJob(namespace string, jobName string, labels map[string]string, configMapName string, saName string, image string) *batchv1.Job {
+func NewJob(jobConfig *JobConfig) *batchv1.Job {
 	var backOffLimit int32 = 0
+	mode := installMode
+	if jobConfig.DryRun {
+		mode = internal.NoOpMode
+	}
+	annotations := make(map[string]string, 1)
+	annotations[internal.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobName,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        jobConfig.JobName,
+			Namespace:   jobConfig.Namespace,
+			Labels:      jobConfig.Labels,
+			Annotations: annotations,
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-					Labels:    labels,
+					Name:        jobConfig.JobName,
+					Namespace:   jobConfig.Namespace,
+					Labels:      jobConfig.Labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:            "install",
-						Image:           image,
+						Image:           jobConfig.JobImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Env: []corev1.EnvVar{
 							{
 								Name:  "MODE",
-								Value: "INSTALL",
+								Value: mode,
 							},
 							{
 								Name:  "INSTALL_CONFIG_FILE",
@@ -64,14 +79,14 @@ func NewJob(namespace string, jobName string, labels map[string]string, configMa
 						},
 					}},
 					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: saName,
+					ServiceAccountName: jobConfig.ServiceAccountName,
 					Volumes: []corev1.Volume{
 						{
 							Name: "config-volume",
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configMapName,
+										Name: jobConfig.ConfigMapName,
 									},
 								},
 							},

--- a/operator/internal/installjob/job_test.go
+++ b/operator/internal/installjob/job_test.go
@@ -43,7 +43,8 @@ func TestNewJob(t *testing.T) {
 
 	assert.Equal(t, "MODE", job.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "INSTALL", job.Spec.Template.Spec.Containers[0].Env[0].Value)
-	assert.Equal(t, "false", job.Annotations["dry-run"])
+	_, ok := job.Annotations["dry-run"]
+	assert.False(t, ok)
 }
 
 // TestNewJobDryRun tests the creation of a job with dryRun=true, that the MODE env var is NOOP
@@ -72,5 +73,8 @@ func TestNewJobDryRun(t *testing.T) {
 
 	assert.Equal(t, "MODE", job.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "NOOP", job.Spec.Template.Spec.Containers[0].Env[0].Value)
-	assert.Equal(t, "true", job.Annotations["dry-run"])
+
+	dryRun, ok := job.Annotations["dry-run"]
+	assert.True(t, ok)
+	assert.Equal(t, "true", dryRun)
 }

--- a/operator/internal/jobs.go
+++ b/operator/internal/jobs.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package internal
+
+// JobConfigCommon Common configuration for install/uninstall jobs
+type JobConfigCommon struct {
+	JobName            string            // Name of the job
+	Namespace          string            // Namespace for the job
+	Labels             map[string]string // Container labels for the job
+	ServiceAccountName string            // Service account name to execute the job as
+	JobImage           string            // Image name/tag for the job
+	DryRun             bool              // Perform the job as a dry-run/no-op, for testing purposes
+}
+
+// NoOpMode value for MODE variable for no-op (test) jobs
+const NoOpMode = "NOOP"
+
+// DryRunAnnotationName annotation used on jobs to indicate dry-run state [true|false]
+const DryRunAnnotationName = "dry-run"

--- a/operator/internal/uninstalljob/job.go
+++ b/operator/internal/uninstalljob/job.go
@@ -26,8 +26,11 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 	if jobConfig.DryRun {
 		mode = internal.NoOpMode
 	}
-	annotations := make(map[string]string, 1)
-	annotations[internal.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
+	var annotations map[string]string = nil
+	if jobConfig.DryRun {
+		annotations = make(map[string]string, 1)
+		annotations[internal.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobConfig.JobName,

--- a/operator/internal/uninstalljob/job_test.go
+++ b/operator/internal/uninstalljob/job_test.go
@@ -54,7 +54,8 @@ func TestNewJob(t *testing.T) {
 	assert.Equal(t, "/home/verrazzano/kubeconfig", job.Spec.Template.Spec.Containers[0].Env[2].Value, "Expected env value did not match")
 	assert.Equal(t, "DEBUG", job.Spec.Template.Spec.Containers[0].Env[3].Name, "Expected env name did not match")
 	assert.Equal(t, "1", job.Spec.Template.Spec.Containers[0].Env[3].Value, "Expected env value did not match")
-	assert.Equal(t, "false", job.Annotations["dry-run"])
+	_, ok := job.Annotations["dry-run"]
+	assert.False(t, ok)
 }
 
 // TestNewJobDryRun tests the creation of an uninstall job in dryRun mode
@@ -81,5 +82,8 @@ func TestNewJobDryRun(t *testing.T) {
 
 	assert.Equal(t, "MODE", job.Spec.Template.Spec.Containers[0].Env[0].Name, "Expected env name did not match")
 	assert.Equal(t, "NOOP", job.Spec.Template.Spec.Containers[0].Env[0].Value, "Expected env value did not match")
-	assert.Equal(t, "true", job.Annotations["dry-run"])
+
+	dryRun, ok := job.Annotations["dry-run"]
+	assert.True(t, ok)
+	assert.Equal(t, "true", dryRun)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -64,10 +64,12 @@ func main() {
 	}
 
 	// Setup the reconciler
+	_, dryRun := os.LookupEnv("VZ_DRY_RUN") // If this var is set, the install jobs are no-ops
 	reconciler := controllers.VerrazzanoReconciler{
 		Client: mgr.GetClient(),
 		Log:    zap.S().Named("operator"),
 		Scheme: mgr.GetScheme(),
+		DryRun: dryRun,
 	}
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller")


### PR DESCRIPTION
Save the install resource spec to an internal configmap
- Also, add support for a NOOP mode for the install jobs to allow testing operator flow in-cluster without trigger actual installs/uninstalls
- add a helper make target to generate an operator deploy YAML file