### PR TITLE
VZ-1747 : Set a default value for CRD property protocol

### DIFF
--- a/operator/scripts/install/chart/crds/verrazzano.io_verrazzanomodels_crd.yaml
+++ b/operator/scripts/install/chart/crds/verrazzano.io_verrazzanomodels_crd.yaml
@@ -1684,6 +1684,7 @@ spec:
                                       description: Protocol for port. Must be UDP,
                                         TCP, or SCTP. Defaults to "TCP".
                                       type: string
+                                      default: TCP
                                   required:
                                   - containerPort
                                   type: object
@@ -4103,6 +4104,7 @@ spec:
                                       description: Protocol for port. Must be UDP,
                                         TCP, or SCTP. Defaults to "TCP".
                                       type: string
+                                      default: TCP
                                   required:
                                   - containerPort
                                   type: object
@@ -8463,6 +8465,7 @@ spec:
                                                 be UDP, TCP, or SCTP. Defaults to
                                                 "TCP".
                                               type: string
+                                              default: TCP
                                           required:
                                           - containerPort
                                           type: object
@@ -9854,6 +9857,7 @@ spec:
                                                 be UDP, TCP, or SCTP. Defaults to
                                                 "TCP".
                                               type: string
+                                              default: TCP
                                           required:
                                           - containerPort
                                           type: object
@@ -14059,6 +14063,7 @@ spec:
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
                                                 type: string
+                                                default: TCP
                                             required:
                                             - containerPort
                                             type: object
@@ -15476,6 +15481,7 @@ spec:
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
                                                 type: string
+                                                default: TCP
                                             required:
                                             - containerPort
                                             type: object
@@ -19873,6 +19879,7 @@ spec:
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
                                                 type: string
+                                                default: TCP
                                             required:
                                             - containerPort
                                             type: object
@@ -21290,6 +21297,7 @@ spec:
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
                                                 type: string
+                                                default: TCP
                                             required:
                                             - containerPort
                                             type: object
@@ -25362,6 +25370,7 @@ spec:
                                           description: Protocol for port. Must be
                                             UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
+                                          default: TCP
                                       required:
                                       - containerPort
                                       type: object
@@ -26680,6 +26689,7 @@ spec:
                                           description: Protocol for port. Must be
                                             UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
+                                          default: TCP
                                       required:
                                       - containerPort
                                       type: object


### PR DESCRIPTION
This PR fixes the validation issue mentioned in VZ-1747, by setting a default value for protocol.  In a v1 CRD a property specified as a list-map item key must be a required property or be given a default value.

As part of this change, I have not relaxed the validation for the k8s version in operator/scripts/install/1-install-istio.sh, as supporting k8s v.1.18.10 requires some more changes, which will be taken care by VZ-1808

Acceptance test with the change, with k8s v1.17.9 for OKE Cluster : https://build.verrazzano.io/job/verrazzano-in-cluster-oke-acceptance-test-suite/job/master/125/