### PR TITLE
Update verrazzano CRD to use apiextensions.k8s.io/v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_IMAGE_TAG ?= local-$(shell git rev-parse --short HEAD)
 
 CREATE_LATEST_TAG=0
 
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 ifeq ($(MAKECMDGOALS),$(filter $(MAKECMDGOALS),docker-push push-tag))
 ifndef DOCKER_REPO

--- a/operator/config/crd/bases/install.verrazzano.io_verrazzanos.yaml
+++ b/operator/config/crd/bases/install.verrazzano.io_verrazzanos.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -10,11 +10,6 @@ metadata:
   creationTimestamp: null
   name: verrazzanos.install.verrazzano.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[-1:].type
-    description: The current status of the install/uninstall
-    name: Status
-    type: string
   group: install.verrazzano.io
   names:
     kind: Verrazzano
@@ -25,256 +20,261 @@ spec:
     - vzs
     singular: verrazzano
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Verrazzano is the Schema for the verrazzanos API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VerrazzanoSpec defines the desired state of Verrazzano
-          properties:
-            certificate:
-              description: Type of cert issuer for an install
-              properties:
-                acme:
-                  description: ACME cert issuer
-                  properties:
-                    emailAddress:
-                      description: email address
-                      type: string
-                    environment:
-                      description: environment
-                      type: string
-                    provider:
-                      description: Type of provider for ACME cert issuer.
-                      type: string
-                  required:
-                  - provider
-                  type: object
-                ca:
-                  description: CA cert issuer
-                  properties:
-                    clusterResourceNamespace:
-                      description: Namespace where secret is located for CA cert issuer
-                      type: string
-                    secretName:
-                      description: Name of secret for CA cert issuer
-                      type: string
-                  required:
-                  - clusterResourceNamespace
-                  - secretName
-                  type: object
-              type: object
-            dns:
-              description: Type of DNS for an install
-              properties:
-                external:
-                  description: DNS type of external. For example, OLCNE uses this
-                    type.
-                  properties:
-                    suffix:
-                      description: DNS suffix appended to EnviromentName to form DNS
-                        name
-                      type: string
-                  required:
-                  - suffix
-                  type: object
-                oci:
-                  description: DNS type of OCI (Oracle Cloud Infrastructure)
-                  properties:
-                    dnsZoneCompartmentOCID:
-                      type: string
-                    dnsZoneName:
-                      type: string
-                    dnsZoneOCID:
-                      type: string
-                    ociConfigSecret:
-                      type: string
-                  required:
-                  - dnsZoneCompartmentOCID
-                  - dnsZoneName
-                  - dnsZoneOCID
-                  - ociConfigSecret
-                  type: object
-                xip.io:
-                  description: DNS type of xio.io.  This is the default.
-                  type: object
-              type: object
-            environmentName:
-              description: Short name to identify install environment.  Default environment
-                name is "default".
-              type: string
-            ingress:
-              description: Type of Ingress for an install
-              properties:
-                application:
-                  description: Non-Verrazzano infrastructure install options
-                  properties:
-                    istioInstallArgs:
-                      description: Arguments for installing istio
-                      items:
-                        description: InstallArgs identifies a name/value or name/value
-                          list needed for install. Value and ValueList cannot both
-                          be specified.
-                        properties:
-                          name:
-                            description: Name of install argument
-                            type: string
-                          value:
-                            description: Value for named install argument
-                            type: string
-                          valueList:
-                            description: List of values for named install argument
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - name
-                        type: object
-                      type: array
-                  type: object
-                type:
-                  description: Type of ingress.  Default is LoadBalancer
-                  type: string
-                verrazzano:
-                  description: Verrazzano infrastructure install options
-                  properties:
-                    nginxInstallArgs:
-                      description: Arguments for installing nginx
-                      items:
-                        description: InstallArgs identifies a name/value or name/value
-                          list needed for install. Value and ValueList cannot both
-                          be specified.
-                        properties:
-                          name:
-                            description: Name of install argument
-                            type: string
-                          value:
-                            description: Value for named install argument
-                            type: string
-                          valueList:
-                            description: List of values for named install argument
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - name
-                        type: object
-                      type: array
-                    ports:
-                      description: Ports to be used for nginx
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          appProtocol:
-                            description: The application protocol for this port. This
-                              field follows standard Kubernetes label syntax. Un-prefixed
-                              names are reserved for IANA standard service names (as
-                              per RFC-6335 and http://www.iana.org/assignments/service-names).
-                              Non-standard protocols should use prefixed names such
-                              as mycompany.com/my-custom-protocol. Field can be enabled
-                              with ServiceAppProtocol feature gate.
-                            type: string
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            profile:
-              description: Profile is the name of the profile to install.  Default
-                is "prod".
-              type: string
-          type: object
-        status:
-          description: VerrazzanoStatus defines the observed state of Verrazzano
-          properties:
-            conditions:
-              description: The latest available observations of an object's current
-                state.
-              items:
-                description: Condition describes current state of an install.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    type: string
-                  message:
-                    description: Human readable message indicating details about last
-                      transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current status of the install/uninstall
+      jsonPath: .status.conditions[-1:].type
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Verrazzano is the Schema for the verrazzanos API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VerrazzanoSpec defines the desired state of Verrazzano
+            properties:
+              certificate:
+                description: Type of cert issuer for an install
+                properties:
+                  acme:
+                    description: ACME cert issuer
+                    properties:
+                      emailAddress:
+                        description: email address
+                        type: string
+                      environment:
+                        description: environment
+                        type: string
+                      provider:
+                        description: Type of provider for ACME cert issuer.
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  ca:
+                    description: CA cert issuer
+                    properties:
+                      clusterResourceNamespace:
+                        description: Namespace where secret is located for CA cert
+                          issuer
+                        type: string
+                      secretName:
+                        description: Name of secret for CA cert issuer
+                        type: string
+                    required:
+                    - clusterResourceNamespace
+                    - secretName
+                    type: object
+                type: object
+              dns:
+                description: Type of DNS for an install
+                properties:
+                  external:
+                    description: DNS type of external. For example, OLCNE uses this
+                      type.
+                    properties:
+                      suffix:
+                        description: DNS suffix appended to EnviromentName to form
+                          DNS name
+                        type: string
+                    required:
+                    - suffix
+                    type: object
+                  oci:
+                    description: DNS type of OCI (Oracle Cloud Infrastructure)
+                    properties:
+                      dnsZoneCompartmentOCID:
+                        type: string
+                      dnsZoneName:
+                        type: string
+                      dnsZoneOCID:
+                        type: string
+                      ociConfigSecret:
+                        type: string
+                    required:
+                    - dnsZoneCompartmentOCID
+                    - dnsZoneName
+                    - dnsZoneOCID
+                    - ociConfigSecret
+                    type: object
+                  xip.io:
+                    description: DNS type of xio.io.  This is the default.
+                    type: object
+                type: object
+              environmentName:
+                description: Short name to identify install environment.  Default
+                  environment name is "default".
+                type: string
+              ingress:
+                description: Type of Ingress for an install
+                properties:
+                  application:
+                    description: Non-Verrazzano infrastructure install options
+                    properties:
+                      istioInstallArgs:
+                        description: Arguments for installing istio
+                        items:
+                          description: InstallArgs identifies a name/value or name/value
+                            list needed for install. Value and ValueList cannot both
+                            be specified.
+                          properties:
+                            name:
+                              description: Name of install argument
+                              type: string
+                            value:
+                              description: Value for named install argument
+                              type: string
+                            valueList:
+                              description: List of values for named install argument
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  type:
+                    description: Type of ingress.  Default is LoadBalancer
+                    type: string
+                  verrazzano:
+                    description: Verrazzano infrastructure install options
+                    properties:
+                      nginxInstallArgs:
+                        description: Arguments for installing nginx
+                        items:
+                          description: InstallArgs identifies a name/value or name/value
+                            list needed for install. Value and ValueList cannot both
+                            be specified.
+                          properties:
+                            name:
+                              description: Name of install argument
+                              type: string
+                            value:
+                              description: Value for named install argument
+                              type: string
+                            valueList:
+                              description: List of values for named install argument
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      ports:
+                        description: Ports to be used for nginx
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              profile:
+                description: Profile is the name of the profile to install.  Default
+                  is "prod".
+                type: string
+            type: object
+          status:
+            description: VerrazzanoStatus defines the observed state of Verrazzano
+            properties:
+              conditions:
+                description: The latest available observations of an object's current
+                  state.
+                items:
+                  description: Condition describes current state of an install.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -61,7 +61,7 @@ spec:
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -69,11 +69,6 @@ metadata:
   creationTimestamp: null
   name: verrazzanos.install.verrazzano.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[-1:].type
-    description: The current status of the install/uninstall
-    name: Status
-    type: string
   group: install.verrazzano.io
   names:
     kind: Verrazzano
@@ -84,256 +79,261 @@ spec:
     - vzs
     singular: verrazzano
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Verrazzano is the Schema for the verrazzanos API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VerrazzanoSpec defines the desired state of Verrazzano
-          properties:
-            certificate:
-              description: Type of cert issuer for an install
-              properties:
-                acme:
-                  description: ACME cert issuer
-                  properties:
-                    emailAddress:
-                      description: email address
-                      type: string
-                    environment:
-                      description: environment
-                      type: string
-                    provider:
-                      description: Type of provider for ACME cert issuer.
-                      type: string
-                  required:
-                  - provider
-                  type: object
-                ca:
-                  description: CA cert issuer
-                  properties:
-                    clusterResourceNamespace:
-                      description: Namespace where secret is located for CA cert issuer
-                      type: string
-                    secretName:
-                      description: Name of secret for CA cert issuer
-                      type: string
-                  required:
-                  - clusterResourceNamespace
-                  - secretName
-                  type: object
-              type: object
-            dns:
-              description: Type of DNS for an install
-              properties:
-                external:
-                  description: DNS type of external. For example, OLCNE uses this
-                    type.
-                  properties:
-                    suffix:
-                      description: DNS suffix appended to EnviromentName to form DNS
-                        name
-                      type: string
-                  required:
-                  - suffix
-                  type: object
-                oci:
-                  description: DNS type of OCI (Oracle Cloud Infrastructure)
-                  properties:
-                    dnsZoneCompartmentOCID:
-                      type: string
-                    dnsZoneName:
-                      type: string
-                    dnsZoneOCID:
-                      type: string
-                    ociConfigSecret:
-                      type: string
-                  required:
-                  - dnsZoneCompartmentOCID
-                  - dnsZoneName
-                  - dnsZoneOCID
-                  - ociConfigSecret
-                  type: object
-                xip.io:
-                  description: DNS type of xio.io.  This is the default.
-                  type: object
-              type: object
-            environmentName:
-              description: Short name to identify install environment.  Default environment
-                name is "default".
-              type: string
-            ingress:
-              description: Type of Ingress for an install
-              properties:
-                application:
-                  description: Non-Verrazzano infrastructure install options
-                  properties:
-                    istioInstallArgs:
-                      description: Arguments for installing istio
-                      items:
-                        description: InstallArgs identifies a name/value or name/value
-                          list needed for install. Value and ValueList cannot both
-                          be specified.
-                        properties:
-                          name:
-                            description: Name of install argument
-                            type: string
-                          value:
-                            description: Value for named install argument
-                            type: string
-                          valueList:
-                            description: List of values for named install argument
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - name
-                        type: object
-                      type: array
-                  type: object
-                type:
-                  description: Type of ingress.  Default is LoadBalancer
-                  type: string
-                verrazzano:
-                  description: Verrazzano infrastructure install options
-                  properties:
-                    nginxInstallArgs:
-                      description: Arguments for installing nginx
-                      items:
-                        description: InstallArgs identifies a name/value or name/value
-                          list needed for install. Value and ValueList cannot both
-                          be specified.
-                        properties:
-                          name:
-                            description: Name of install argument
-                            type: string
-                          value:
-                            description: Value for named install argument
-                            type: string
-                          valueList:
-                            description: List of values for named install argument
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - name
-                        type: object
-                      type: array
-                    ports:
-                      description: Ports to be used for nginx
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          appProtocol:
-                            description: The application protocol for this port. This
-                              field follows standard Kubernetes label syntax. Un-prefixed
-                              names are reserved for IANA standard service names (as
-                              per RFC-6335 and http://www.iana.org/assignments/service-names).
-                              Non-standard protocols should use prefixed names such
-                              as mycompany.com/my-custom-protocol. Field can be enabled
-                              with ServiceAppProtocol feature gate.
-                            type: string
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            profile:
-              description: Profile is the name of the profile to install.  Default
-                is "prod".
-              type: string
-          type: object
-        status:
-          description: VerrazzanoStatus defines the observed state of Verrazzano
-          properties:
-            conditions:
-              description: The latest available observations of an object's current
-                state.
-              items:
-                description: Condition describes current state of an install.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    type: string
-                  message:
-                    description: Human readable message indicating details about last
-                      transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current status of the install/uninstall
+      jsonPath: .status.conditions[-1:].type
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Verrazzano is the Schema for the verrazzanos API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VerrazzanoSpec defines the desired state of Verrazzano
+            properties:
+              certificate:
+                description: Type of cert issuer for an install
+                properties:
+                  acme:
+                    description: ACME cert issuer
+                    properties:
+                      emailAddress:
+                        description: email address
+                        type: string
+                      environment:
+                        description: environment
+                        type: string
+                      provider:
+                        description: Type of provider for ACME cert issuer.
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  ca:
+                    description: CA cert issuer
+                    properties:
+                      clusterResourceNamespace:
+                        description: Namespace where secret is located for CA cert
+                          issuer
+                        type: string
+                      secretName:
+                        description: Name of secret for CA cert issuer
+                        type: string
+                    required:
+                    - clusterResourceNamespace
+                    - secretName
+                    type: object
+                type: object
+              dns:
+                description: Type of DNS for an install
+                properties:
+                  external:
+                    description: DNS type of external. For example, OLCNE uses this
+                      type.
+                    properties:
+                      suffix:
+                        description: DNS suffix appended to EnviromentName to form
+                          DNS name
+                        type: string
+                    required:
+                    - suffix
+                    type: object
+                  oci:
+                    description: DNS type of OCI (Oracle Cloud Infrastructure)
+                    properties:
+                      dnsZoneCompartmentOCID:
+                        type: string
+                      dnsZoneName:
+                        type: string
+                      dnsZoneOCID:
+                        type: string
+                      ociConfigSecret:
+                        type: string
+                    required:
+                    - dnsZoneCompartmentOCID
+                    - dnsZoneName
+                    - dnsZoneOCID
+                    - ociConfigSecret
+                    type: object
+                  xip.io:
+                    description: DNS type of xio.io.  This is the default.
+                    type: object
+                type: object
+              environmentName:
+                description: Short name to identify install environment.  Default
+                  environment name is "default".
+                type: string
+              ingress:
+                description: Type of Ingress for an install
+                properties:
+                  application:
+                    description: Non-Verrazzano infrastructure install options
+                    properties:
+                      istioInstallArgs:
+                        description: Arguments for installing istio
+                        items:
+                          description: InstallArgs identifies a name/value or name/value
+                            list needed for install. Value and ValueList cannot both
+                            be specified.
+                          properties:
+                            name:
+                              description: Name of install argument
+                              type: string
+                            value:
+                              description: Value for named install argument
+                              type: string
+                            valueList:
+                              description: List of values for named install argument
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  type:
+                    description: Type of ingress.  Default is LoadBalancer
+                    type: string
+                  verrazzano:
+                    description: Verrazzano infrastructure install options
+                    properties:
+                      nginxInstallArgs:
+                        description: Arguments for installing nginx
+                        items:
+                          description: InstallArgs identifies a name/value or name/value
+                            list needed for install. Value and ValueList cannot both
+                            be specified.
+                          properties:
+                            name:
+                              description: Name of install argument
+                              type: string
+                            value:
+                              description: Value for named install argument
+                              type: string
+                            valueList:
+                              description: List of values for named install argument
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      ports:
+                        description: Ports to be used for nginx
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              profile:
+                description: Profile is the name of the profile to install.  Default
+                  is "prod".
+                type: string
+            type: object
+          status:
+            description: VerrazzanoStatus defines the observed state of Verrazzano
+            properties:
+              conditions:
+                description: The latest available observations of an object's current
+                  state.
+                items:
+                  description: Condition describes current state of an install.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This pull request changes the verrazzano CRD to use apiextensions.k8s.io/v1 instead of  apiextensions.k8s.io/v1beta1