### PR TITLE
Bump verrazzano-operator image version

### DIFF
--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.6.0-20201120085322-82bcb1b
+  imageVersion: 0.6.0-20201203172419-8204a25
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.5.0-20201112155855-709d712
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.5.0-20201112153844-e0e4790
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.5.0-20201112154348-48bbb61


### PR DESCRIPTION
Bump verrazzano-operator image version to pick up the latest version of the operator. Contains a fix for customer reported issue https://github.com/verrazzano/verrazzano/issues/339.