### PR TITLE
Add Verrazzano Console to Helm chart

### DIFF
--- a/operator/scripts/install/4-install-keycloak.sh
+++ b/operator/scripts/install/4-install-keycloak.sh
@@ -178,6 +178,7 @@ consoleout "Grafana - https://grafana.vmi.system.${ENV_NAME}.${DNS_SUFFIX}"
 consoleout "Prometheus - https://prometheus.vmi.system.${ENV_NAME}.${DNS_SUFFIX}"
 consoleout "Kibana - https://kibana.vmi.system.${ENV_NAME}.${DNS_SUFFIX}"
 consoleout "Elasticsearch - https://elasticsearch.vmi.system.${ENV_NAME}.${DNS_SUFFIX}"
+consoleout "Verrazzano Console - https://verrazzano.${ENV_NAME}.${DNS_SUFFIX}"
 consoleout
 consoleout "You will need the credentials to access the preceding user interfaces.  They are all accessed by the same username/password."
 consoleout "User: verrazzano"

--- a/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
+++ b/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
@@ -99,28 +99,6 @@ spec:
       port: 3456
       targetPort: 3456
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  annotations:
-    external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
-    kubernetes.io/tls-acme: "true"
-  name: {{ .Values.verrazzanoOperator.name }}-ingress
-  namespace: {{ .Release.Namespace }}
-spec:
-  rules:
-    - host: api.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
-      http:
-        paths:
-          - backend:
-              serviceName: {{ .Values.verrazzanoOperator.name }}
-              servicePort: 3456
-            path: /
-  tls:
-    - hosts:
-        - api.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
-      secretName: {{ .Values.config.envName }}-secret
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/operator/scripts/install/chart/templates/05-verrazzano-console.yaml
+++ b/operator/scripts/install/chart/templates/05-verrazzano-console.yaml
@@ -1,0 +1,91 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Values.console.name }}
+  name: {{ .Values.console.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.console.name }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.console.name }}
+    spec:
+      containers:
+      - image: {{ .Values.console.imageName }}:{{ .Values.console.imageVersion }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Values.console.name }}
+        ports:
+            - containerPort: 8000
+        env:
+          - name: VZ_UI_URL
+            value: "https://verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
+          - name: VZ_KEYCLOAK_URL
+            value: "https://keycloak.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
+          - name: VZ_CLIENT_ID
+            value: webui
+      serviceAccount: {{ .Values.console.name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.console.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: console
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: {{ .Values.console.name }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+    annotations:
+      external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
+      kubernetes.io/tls-acme: "true"
+    name: {{ .Values.console.name }}-ingress
+    namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - host: verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
+      http:
+        paths:
+        - backend:
+            serviceName: {{ .Values.console.name }}
+            servicePort: 8000
+          path: /
+        - backend:
+            serviceName: {{ .Values.verrazzanoOperator.name }}
+            servicePort: 3456
+          path: /20210501
+  tls:
+  - hosts:
+    - verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
+    secretName: {{ .Values.config.envName }}-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.console.name }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}

--- a/operator/scripts/install/chart/templates/05-verrazzano-console.yaml
+++ b/operator/scripts/install/chart/templates/05-verrazzano-console.yaml
@@ -32,6 +32,8 @@ spec:
         env:
           - name: VZ_UI_URL
             value: "https://verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
+          - name: VZ_API_URL
+            value: "https://verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
           - name: VZ_KEYCLOAK_URL
             value: "https://keycloak.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
           - name: VZ_CLIENT_ID

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -93,7 +93,7 @@ verrazzanoAdmissionController:
   RequestMemory: 15Mi
 
 console:
-  name: console
+  name: verrazzano-console
   imageName: ghcr.io/verrazzano/console
   imageVersion: 0.6.0-20201118220359-ff35892
 

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -92,6 +92,11 @@ verrazzanoAdmissionController:
   caBundle:
   RequestMemory: 15Mi
 
+console:
+  name: console
+  imageName: ghcr.io/verrazzano/console
+  imageVersion: 69211f9ec669829740063cd48c654d4605a1cfc5
+
 # OCI-related values
 oci:
   region: ""

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -95,7 +95,7 @@ verrazzanoAdmissionController:
 console:
   name: console
   imageName: ghcr.io/verrazzano/console
-  imageVersion: 69211f9ec669829740063cd48c654d4605a1cfc5
+  imageVersion: 0.6.0-20201118220359-ff35892
 
 # OCI-related values
 oci:

--- a/operator/scripts/install/config/keycloak.json
+++ b/operator/scripts/install/config/keycloak.json
@@ -798,6 +798,65 @@
     } ],
     "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  },
+  {
+    "id": "223c0678-01bb-4cb8-a2a7-44d490cc70be",
+    "clientId": "webui",
+    "surrogateAuthRequired": false,
+    "enabled": true,
+    "alwaysDisplayInConsole": false,
+    "clientAuthenticatorType": "client-secret",
+    "redirectUris": [
+      "https://verrazzano.ENV_NAME.DNS_SUFFIX/*",
+      "https://verrazzano.ENV_NAME.DNS_SUFFIX/verrazzano/authcallback"
+    ],
+    "webOrigins": [
+      "https://verrazzano.ENV_NAME.DNS_SUFFIX"
+    ],
+    "notBefore": 0,
+    "bearerOnly": false,
+    "consentRequired": false,
+    "standardFlowEnabled": true,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": false,
+    "serviceAccountsEnabled": false,
+    "publicClient": true,
+    "frontchannelLogout": false,
+    "protocol": "openid-connect",
+    "attributes": {
+      "saml.assertion.signature": "false",
+      "saml.multivalued.roles": "false",
+      "saml.force.post.binding": "false",
+      "saml.encrypt": "false",
+      "saml.server.signature": "false",
+      "saml.server.signature.keyinfo.ext": "false",
+      "exclude.session.state.from.auth.response": "false",
+      "saml_force_name_id_format": "false",
+      "saml.client.signature": "false",
+      "tls.client.certificate.bound.access.tokens": "false",
+      "saml.authnstatement": "false",
+      "display.on.consent.screen": "false",
+      "pkce.code.challenge.method": "S256",
+      "saml.onetimeuse.condition": "false"
+    },
+    "authenticationFlowBindingOverrides": {},
+    "fullScopeAllowed": true,
+    "nodeReRegistrationTimeout": -1,
+    "defaultClientScopes": [
+      "web-origins",
+      "role_list",
+      "roles",
+      "profile",
+      "model-write",
+      "model-read",
+      "email"
+    ],
+    "optionalClientScopes": [
+      "address",
+      "phone",
+      "offline_access",
+      "microprofile-jwt"
+    ]
   } ],
   "clientScopes" : [ {
     "id" : "0215ee1a-116f-4d65-ad8e-217231dddbb0",


### PR DESCRIPTION
The Verrazzano Console is added to the Helm chart so that it is installed when the installer is run.