### PR TITLE
Fix bug where the verrazzano CR Certificate.CA fields were ignored

### DIFF
--- a/operator/internal/installjob/install_config.go
+++ b/operator/internal/installjob/install_config.go
@@ -11,9 +11,13 @@ import (
 	"strconv"
 
 	installv1alpha1 "github.com/verrazzano/verrazzano/operator/api/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	defaultCAClusterResourceName string = "cattle-system"
+	defaultCASecretNamne         string = "tls-rancher"
 )
 
 // DNSType identifies the DNS type
@@ -220,8 +224,8 @@ func newXipIoInstallConfig(vz *installv1alpha1.Verrazzano) *InstallConfiguration
 		Certificates: Certificate{
 			IssuerType: CertIssuerTypeCA,
 			CA: &CertificateCA{
-				ClusterResourceNamespace: "cattle-system",
-				SecretName:               "tls-rancher",
+				ClusterResourceNamespace: getCAClusterResourceNamespace(vz.Spec.Certificate.CA),
+				SecretName:               getCASecretName(vz.Spec.Certificate.CA),
 			},
 		},
 	}
@@ -244,8 +248,8 @@ func newExternalDNSInstallConfig(vz *installv1alpha1.Verrazzano) *InstallConfigu
 		Certificates: Certificate{
 			IssuerType: CertIssuerTypeCA,
 			CA: &CertificateCA{
-				ClusterResourceNamespace: "cattle-system",
-				SecretName:               "tls-rancher",
+				ClusterResourceNamespace: getCAClusterResourceNamespace(vz.Spec.Certificate.CA),
+				SecretName:               getCASecretName(vz.Spec.Certificate.CA),
 			},
 		},
 	}
@@ -319,6 +323,7 @@ func getIngressType(ingressType installv1alpha1.IngressType) IngressType {
 	return IngressTypeNodePort
 }
 
+// getIngress returns the json representation for the ingress
 func getIngress(ingress installv1alpha1.Ingress) Ingress {
 	return Ingress{
 		Type: getIngressType(ingress.Type),
@@ -350,4 +355,24 @@ func getProfile(profileType installv1alpha1.ProfileType) InstallProfile {
 	}
 
 	return InstallProfileDev
+}
+
+// getCAClusterResourceNamespace returns the cluster resource name for a CA certificate
+func getCAClusterResourceNamespace(ca installv1alpha1.CA) string {
+	// Use default value if not specified
+	if ca.ClusterResourceNamespace == "" {
+		return defaultCAClusterResourceName
+	}
+
+	return ca.ClusterResourceNamespace
+}
+
+// getCASecretName returns the secret name for a CA certificate
+func getCASecretName(ca installv1alpha1.CA) string {
+	// Use default value if not specified
+	if ca.SecretName == "" {
+		return defaultCASecretNamne
+	}
+
+	return ca.SecretName
 }

--- a/operator/internal/installjob/install_config_test.go
+++ b/operator/internal/installjob/install_config_test.go
@@ -70,6 +70,12 @@ func TestXipIoInstallNonDefaults(t *testing.T) {
 					},
 				},
 			},
+			Certificate: installv1alpha1.Certificate{
+				CA: installv1alpha1.CA{
+					SecretName:               "customSecret",
+					ClusterResourceNamespace: "customNamespace",
+				},
+			},
 		},
 	}
 
@@ -93,8 +99,8 @@ func TestXipIoInstallNonDefaults(t *testing.T) {
 	assert.Equalf(t, "value2", config.Ingress.Application.IstioInstallArgs[0].Value, "Expected istioInstallArg name did not match")
 
 	assert.Equalf(t, CertIssuerTypeCA, config.Certificates.IssuerType, "Expected certification issuer type did not match")
-	assert.Equalf(t, "cattle-system", config.Certificates.CA.ClusterResourceNamespace, "Expected namespace did not match")
-	assert.Equalf(t, "tls-rancher", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
+	assert.Equalf(t, "customNamespace", config.Certificates.CA.ClusterResourceNamespace, "Expected namespace did not match")
+	assert.Equalf(t, "customSecret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 }
 
 // TestExternalInstall tests the creation of an external install configuration


### PR DESCRIPTION
ClusterResourceNamespace and SecretName when specified in verrazzano resource were being ignored by platform-operator. This is fixed with this pull request.
