### PR TITLE
Change platform-operator to not use zapcore.FullCallerEncoder

### DIFF
--- a/operator/internal/util/log/log.go
+++ b/operator/internal/util/log/log.go
@@ -23,13 +23,9 @@ func InitLogs(opts kzap.Options) {
 	} else {
 		config.Level.SetLevel(zapcore.InfoLevel)
 	}
-	config.EncoderConfig.CallerKey = "caller"
-	config.EncoderConfig.NameKey = "name"
-	config.EncoderConfig.LevelKey = "level"
 	config.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 	config.EncoderConfig.TimeKey = "@timestamp"
 	config.EncoderConfig.MessageKey = "message"
-	config.EncoderConfig.EncodeCaller = zapcore.FullCallerEncoder
 	logger, err := config.Build()
 	if err != nil {
 		zap.S().Errorf("Error creating logger %v", err)


### PR DESCRIPTION
This pull request changes the platform operator to not use the zapcore.FullCallerEncoder for logging the caller field.
With this change the caller field looks like this: 
"caller":"log/log_test.go:19"

Prior to this change the caller field looked like this: 
"caller":"/root/go/src/github.com/verrazzano/verrazzano/operator/internal/util/log/log_test.go:18

Also, removed explicit setting the caller. level, and name keys since those are the defaults.

These changes are inline with the what the other operators (verrazzano-operatort, helidon-app-operator, etc)  are doing.
