### PR TITLE
Update operator.yaml to use release build

### DIFF
--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -45,14 +45,14 @@ spec:
       containers:
         - name: verrazzano-platform-operator
           imagePullPolicy: IfNotPresent
-          image: ghcr.io/verrazzano/verrazzano-platform-operator:0.6.0-20201206110259-5676a4a
+          image: ghcr.io/verrazzano/verrazzano-platform-operator:0.6.0-20201210170721-c17ef6e
           args:
             - --zap-log-level=info
           env:
             - name: MODE
               value: RUN_OPERATOR
             - name: VZ_INSTALL_IMAGE
-              value: ghcr.io/verrazzano/verrazzano-platform-operator:0.6.0-20201206110259-5676a4a
+              value: ghcr.io/verrazzano/verrazzano-platform-operator:0.6.0-20201210170721-c17ef6e
           resources:
             requests:
               memory: 72Mi


### PR DESCRIPTION
Update operator.yaml to use the release build of the verrazzano-platform-operator.  The automated process for updating this file did not work.