### PR TITLE
KinD support on MAC

### DIFF
--- a/operator/scripts/install/3-install-verrazzano.sh
+++ b/operator/scripts/install/3-install-verrazzano.sh
@@ -174,7 +174,7 @@ function install_verrazzano()
       --set rancher.rancherURL=https://${RANCHER_HOSTNAME} \
       --set rancher.rancherUserName="${token_array[0]}" \
       --set rancher.rancherPassword="${token_array[1]}" \
-      --set rancher.rancherHostname=${RANCHER_HOSTNAME} \
+      --set rancher.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
       --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?

--- a/operator/scripts/install/4-install-keycloak.sh
+++ b/operator/scripts/install/4-install-keycloak.sh
@@ -110,48 +110,6 @@ function install_keycloak {
   kubectl wait cert/${ENV_NAME}-secret -n keycloak --for=condition=Ready
 }
 
-function set_rancher_server_url
-{
-    local rancher_host_name="rancher.${ENV_NAME}.${DNS_SUFFIX}"
-    local rancher_server_url="https://${rancher_host_name}"
-    echo "Get Rancher admin password."
-    rancher_admin_password=$(kubectl get secret --namespace cattle-system rancher-admin-secret -o jsonpath={.data.password})
-    if [ $? -ne 0 ]; then
-      echo "Failed to get Rancher admin password. Continuing without setting Rancher server URL."
-      return 0
-    fi
-    rancher_admin_password=$(echo ${rancher_admin_password} | base64 --decode)
-    if [ $? -ne 0 ]; then
-      echo "Failed to decode Rancher admin password. Continuing without setting Rancher server URL."
-      return 0
-    fi
-    echo "Get Rancher access token."
-    get_rancher_access_token "${rancher_host_name}" "${rancher_admin_password}"
-    if [ $? -ne 0 ] ; then
-      echo "Failed to get Rancher access token. Continuing without setting Rancher server URL."
-      return 0
-    fi
-
-    if [ -z "${RANCHER_ACCESS_TOKEN}" ]; then
-      echo "Failed to get valid Rancher access token. Continuing without setting Rancher server URL."
-      return 0
-    fi
-    echo "Set Rancher server URL to ${rancher_server_url}"
-    curl_args=("${rancher_server_url}/v3/settings/server-url" $(get_rancher_resolve ${rancher_host_name}) \
-          -H 'content-type: application/json' \
-          -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" \
-          -X PUT \
-          --data-binary '{"name":"server-url","value":"'${rancher_server_url}'"}' \
-          --insecure)
-    call_curl 200 http_response http_status curl_args || true
-    if [ ${http_status:--1} -ne 200 ]; then
-      echo "Failed to set Rancher server URL. Continuing without setting Rancher server URL."
-      return 0
-    else
-      echo "Successfully set Rancher server URL."
-    fi
-}
-
 DNS_TARGET_NAME=verrazzano-ingress.${ENV_NAME}.${DNS_SUFFIX}
 REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)
 
@@ -165,7 +123,6 @@ action "Installing MySQL" install_mysql
   fi
 
 action "Installing Keycloak" install_keycloak || exit 1
-action "Setting Rancher Server URL" set_rancher_server_url || true
 
 rm -rf $TMP_DIR
 

--- a/operator/scripts/install/4-install-keycloak.sh
+++ b/operator/scripts/install/4-install-keycloak.sh
@@ -137,7 +137,7 @@ function set_rancher_server_url
       return 0
     fi
     echo "Set Rancher server URL to ${rancher_server_url}"
-    curl_args=("${rancher_server_url}/v3/settings/server-url" \
+    curl_args=("${rancher_server_url}/v3/settings/server-url" $(get_rancher_resolve ${rancher_host_name}) \
           -H 'content-type: application/json' \
           -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" \
           -X PUT \

--- a/operator/scripts/install/common.sh
+++ b/operator/scripts/install/common.sh
@@ -55,7 +55,7 @@ function get_rancher_access_token {
   # the scenarios we want (e.g. connection errors)
   until [ $retries -ge 10 ]
   do
-    ARGS=(-k --connect-timeout 30 \
+    ARGS=(-k --connect-timeout 30 $(get_rancher_resolve ${rancher_hostname}) \
     -d '{"Username":"admin", "Password":"'$rancher_password'"}' \
     -H "Content-Type: application/json" \
     -X POST https://$rancher_hostname/v3-public/localProviders/local?action=login)
@@ -85,7 +85,7 @@ function get_rancher_access_token {
   local retries=0
   until [ "$retries" -ge 10 ]
   do
-    ARGS=(-k --connect-timeout 30 \
+    ARGS=(-k --connect-timeout 30 $(get_rancher_resolve ${rancher_hostname}) \
     -d '{"type":"token", "description":"automation"}' \
     -H "Content-Type: application/json"
     -H "Authorization: Bearer ${rancher_admin_token}" \

--- a/operator/scripts/install/config.sh
+++ b/operator/scripts/install/config.sh
@@ -174,7 +174,7 @@ function get_verrazzano_ingress_ip {
 function get_application_ingress_ip {
   local ingress_type=$(get_config_value ".ingress.type")
   if [ ${ingress_type} == "NodePort" ]; then
-    # on MAC and Windows, container IP is not accessible.  Port forwarding is needed, VZ-1902.
+    # on MAC and Windows, container IP is not accessible.  Port forwarding will be needed.
     ingress_ip=$(kubectl -n istio-system get pods --selector app=istio-ingressgateway,istio=ingressgateway -o jsonpath='{.items[0].status.hostIP}')
   elif [ ${ingress_type} == "LoadBalancer" ]; then
     # Test for IP from status, if that is not present then assume an on premises installation and use the externalIPs hint

--- a/operator/scripts/install/config.sh
+++ b/operator/scripts/install/config.sh
@@ -174,7 +174,7 @@ function get_verrazzano_ingress_ip {
 function get_application_ingress_ip {
   local ingress_type=$(get_config_value ".ingress.type")
   if [ ${ingress_type} == "NodePort" ]; then
-    # on MAC and Windows, container IP is not accessible.  Port forwarding is needed, https://jira.oraclecorp.com/jira/browse/VZ-1902
+    # on MAC and Windows, container IP is not accessible.  Port forwarding is needed, VZ-1902.
     ingress_ip=$(kubectl -n istio-system get pods --selector app=istio-ingressgateway,istio=ingressgateway -o jsonpath='{.items[0].status.hostIP}')
   elif [ ${ingress_type} == "LoadBalancer" ]; then
     # Test for IP from status, if that is not present then assume an on premises installation and use the externalIPs hint

--- a/operator/scripts/install/config.sh
+++ b/operator/scripts/install/config.sh
@@ -289,8 +289,7 @@ function get_acme_environment() {
 
 # rancher needs to be accessed by the scripts running in-cluster
 # in case of NodePort, 127.0.0.1 is not accessible
-# on MAC/Windows, --resolve 127.0.0.1:host.docker.internal
-# on linux, --resolve 127.0.0.1:nginx_container_ip
+# --resolve 127.0.0.1:nginx_container_ip
 function get_rancher_resolve() {
   local rancher_hostname=$1
   local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${rancher_hostname})
@@ -305,11 +304,7 @@ function get_rancher_in_cluster_host() {
   local rancher_hostname=$1
   local rancher_in_cluster_host=${rancher_hostname}
   if [ $(get_config_value ".ingress.type") == "NodePort" ]; then
-    rancher_in_cluster_host="host.docker.internal"
-    ping -q -c1 ${rancher_in_cluster_host} > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-      rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app=nginx-ingress,component=controller -o jsonpath='{.items[0].status.hostIP}')
-    fi
+    rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app=nginx-ingress,component=controller -o jsonpath='{.items[0].status.hostIP}')
   fi
   echo ${rancher_in_cluster_host}
 }


### PR DESCRIPTION
On MAC, unlike Linux, container ip is not accessible in docker bridge network.  The workaround is to port forwarding.
Nginx ingresses are now bound to 127.0.0.1.