### PR TITLE
Change the Chart.yaml from 0.6.0 to 0.7.0 and create kubeconfig for platform operator

### DIFF
--- a/operator/config/scripts/run.sh
+++ b/operator/config/scripts/run.sh
@@ -52,7 +52,6 @@ if [ ${MODE} == "NOOP" ]; then
   exit 0
 elif [ ${MODE} == "INSTALL" ]; then
   # Create a kubeconfig and run the installation
-  create-kubeconfig
   ./install/1-install-istio.sh || dump-install-logs 1
   ./install/2-install-system-components.sh || dump-install-logs 1
   ./install/3-install-verrazzano.sh || dump-install-logs 1
@@ -65,5 +64,6 @@ elif [ ${MODE} == "UNINSTALL" ]; then
   dump-uninstall-logs 0
 else
   # Run the operator
+  create-kubeconfig
   /usr/local/bin/verrazzano-platform-operator $*
 fi

--- a/operator/config/scripts/run.sh
+++ b/operator/config/scripts/run.sh
@@ -52,6 +52,7 @@ if [ ${MODE} == "NOOP" ]; then
   exit 0
 elif [ ${MODE} == "INSTALL" ]; then
   # Create a kubeconfig and run the installation
+  create-kubeconfig
   ./install/1-install-istio.sh || dump-install-logs 1
   ./install/2-install-system-components.sh || dump-install-logs 1
   ./install/3-install-verrazzano.sh || dump-install-logs 1
@@ -64,6 +65,6 @@ elif [ ${MODE} == "UNINSTALL" ]; then
   dump-uninstall-logs 0
 else
   # Run the operator
-  create-kubeconfig
+    create-kubeconfig
   /usr/local/bin/verrazzano-platform-operator $*
 fi

--- a/operator/scripts/install/chart/Chart.yaml
+++ b/operator/scripts/install/chart/Chart.yaml
@@ -3,5 +3,5 @@
 apiVersion: v1
 description: A Helm chart for Verrazzano
 name: verrazzano
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.7.0
+appVersion: 0.7.0


### PR DESCRIPTION
Change the Chart.yaml from 0.6.0 to 0.7.0

Create kubeconfig for platform operator.  This got removed is recent commit but is needed for helm to run during upgrade.