### PR TITLE
JIRA:VZ-1889 add pager duty service key so failure processing succeeds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,8 @@ pipeline {
         GITHUB_API_TOKEN = credentials('github-api-token-release-assets')
         GITHUB_RELEASE_USERID = credentials('github-userid-release')
         GITHUB_RELEASE_EMAIL = credentials('github-email-release')
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
+
     }
 
     stages {


### PR DESCRIPTION
The service key is currently not set so two issues arise in the build failure processing block:

- the processing fails due to the missing property
- the notifications to slack and on-call for master and develop branch failures do not occur