### PR TITLE
Add kubectl command to readmes to wait for verrazzano-platform-operator deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To install Verrazzano, follow these steps:
 5. Run the following commands in the OCI Cloud Shell:
    - `export KUBECONFIG=~/.kube/config`
    - `kubectl apply -f operator/deploy/operator.yaml`
+   - `kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator`
    - `kubectl apply -f operator/config/samples/install-default.yaml`
    - `kubectl wait --timeout=20m --for=condition=InstallComplete verrazzano/my-verrazzano`
 6. (Optional) Run the following command in the OCI Cloud Shell to monitor the installation log:

--- a/install.md
+++ b/install.md
@@ -39,6 +39,7 @@ The following software must be installed on your system.
 
 ```
     kubectl apply -f operator/deploy/operator.yaml
+    kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
 ```
 
 ### 2. Do the install


### PR DESCRIPTION
This pull requests adds 
kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
to a couple of readmes after applying operator.yaml