### PR TITLE
remote helm kubeconfig code

### DIFF
--- a/operator/config/scripts/run.sh
+++ b/operator/config/scripts/run.sh
@@ -65,6 +65,5 @@ elif [ ${MODE} == "UNINSTALL" ]; then
   dump-uninstall-logs 0
 else
   # Run the operator
-    create-kubeconfig
   /usr/local/bin/verrazzano-platform-operator $*
 fi

--- a/operator/internal/util/helm/helmcli.go
+++ b/operator/internal/util/helm/helmcli.go
@@ -6,7 +6,6 @@ package helm
 import (
 	"fmt"
 	vz_os "github.com/verrazzano/verrazzano/operator/internal/util/os"
-	"os"
 	"os/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -26,17 +25,7 @@ func Upgrade(releaseName string, namespace string, chartDir string) (stdout []by
 		args = append(args, namespace)
 	}
 
-	// todo inject kubeconfig
-	configPath := os.Getenv("VERRAZZANO_KUBECONFIG")
-	if len(configPath) == 0 {
-		configPath = os.Getenv("KUBECONFIG")
-	}
-	if len(configPath) == 0 {
-		configPath = "/home/verrazzano/kubeconfig"
-	}
-
 	cmd := exec.Command("helm", args...)
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+configPath)
 	stdout, stderr, err = runner.Run(cmd)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Verrazzano helm upgrade failed with stderr: %s\n", string(stderr)))


### PR DESCRIPTION
remote helm kubeconfig code that is not needed.  Helm can figure out how to get kubeconfig from the cluster when running in the pod.