### PR TITLE
VZ-1897 validation/webhook cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ docker-push: docker-build
 #
 .PHONY: unit-test
 unit-test: go-install
-	$(GO) test -v  ./operator/internal/... ./operator/controllers/...
+	$(GO) test -v  ./operator/internal/... ./operator/controllers/... ./operator/api/...
 
 .PHONY: coverage
 coverage: unit-test

--- a/operator/api/verrazzano/v1alpha1/validate.go
+++ b/operator/api/verrazzano/v1alpha1/validate.go
@@ -58,7 +58,7 @@ func ValidateVersion(requestedVersion string) error {
 		return err
 	}
 	if !requestedSemVer.IsEqualTo(chartSemVer) {
-		return fmt.Errorf("Requested version %s does not match chart version %s", requestedSemVer.VersionString, chartSemVer.VersionString)
+		return fmt.Errorf("Requested version %s does not match chart version %s", requestedVersion, chartSemVer.ToString())
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func ValidateUpgradeRequest(currentSpec *VerrazzanoSpec, newSpec *VerrazzanoSpec
 			return err
 		}
 		if requestedSemVer.IsLessThan(currentSemVer) {
-			return fmt.Errorf("Requested version %s is not newer than current version %s", requestedSemVer.VersionString, currentSemVer.VersionString)
+			return fmt.Errorf("Requested version %s is not newer than current version %s", requestedSemVer.ToString(), currentSemVer.ToString())
 		}
 	}
 

--- a/operator/api/verrazzano/v1alpha1/validate.go
+++ b/operator/api/verrazzano/v1alpha1/validate.go
@@ -22,6 +22,7 @@ type chartVersion struct {
 	AppVersion  string
 }
 
+// For unit test purposes
 var readFileFunction func(string) ([]byte, error) = ioutil.ReadFile
 
 // getCurrentChartVersion Load the current Chart.yaml into a chartVersion struct
@@ -41,7 +42,7 @@ func getCurrentChartVersion() (*semver.SemVersion, error) {
 
 // ValidateVersion check that requestedVersion matches chart requestedVersion
 func ValidateVersion(requestedVersion string) error {
-	if !env.IsCheckVersionRequired() {
+	if env.IsCheckVersionDisabled() {
 		zap.S().Infof("Version validation disabled")
 		return nil
 	}
@@ -64,6 +65,10 @@ func ValidateVersion(requestedVersion string) error {
 
 // ValidateUpgradeRequest Ensures that for the upgrade case only the version field has changed
 func ValidateUpgradeRequest(currentSpec *VerrazzanoSpec, newSpec *VerrazzanoSpec) error {
+	if env.IsCheckVersionDisabled() {
+		zap.S().Infof("Version validation disabled")
+		return nil
+	}
 	// Short-circuit if the version strings are the same
 	if currentSpec.Version == newSpec.Version {
 		return nil

--- a/operator/api/verrazzano/v1alpha1/validate.go
+++ b/operator/api/verrazzano/v1alpha1/validate.go
@@ -23,7 +23,7 @@ type chartVersion struct {
 }
 
 // For unit test purposes
-var readFileFunction func(string) ([]byte, error) = ioutil.ReadFile
+var readFileFunction = ioutil.ReadFile
 
 // getCurrentChartVersion Load the current Chart.yaml into a chartVersion struct
 func getCurrentChartVersion() (*semver.SemVersion, error) {

--- a/operator/api/verrazzano/v1alpha1/validate.go
+++ b/operator/api/verrazzano/v1alpha1/validate.go
@@ -42,7 +42,7 @@ func getCurrentChartVersion() (*semver.SemVersion, error) {
 
 // ValidateVersion check that requestedVersion matches chart requestedVersion
 func ValidateVersion(requestedVersion string) error {
-	if env.IsCheckVersionDisabled() {
+	if !env.IsVersionCheckEnabled() {
 		zap.S().Infof("Version validation disabled")
 		return nil
 	}
@@ -65,7 +65,7 @@ func ValidateVersion(requestedVersion string) error {
 
 // ValidateUpgradeRequest Ensures that for the upgrade case only the version field has changed
 func ValidateUpgradeRequest(currentSpec *VerrazzanoSpec, newSpec *VerrazzanoSpec) error {
-	if env.IsCheckVersionDisabled() {
+	if !env.IsVersionCheckEnabled() {
 		zap.S().Infof("Version validation disabled")
 		return nil
 	}

--- a/operator/api/verrazzano/v1alpha1/validate.go
+++ b/operator/api/verrazzano/v1alpha1/validate.go
@@ -57,7 +57,7 @@ func ValidateVersion(requestedVersion string) error {
 	if err != nil {
 		return err
 	}
-	if requestedSemVer.CompareTo(chartSemVer) != 0 {
+	if !requestedSemVer.IsEqualTo(chartSemVer) {
 		return fmt.Errorf("Requested version %s does not match chart version %s", requestedSemVer.VersionString, chartSemVer.VersionString)
 	}
 	return nil
@@ -95,7 +95,7 @@ func ValidateUpgradeRequest(currentSpec *VerrazzanoSpec, newSpec *VerrazzanoSpec
 			// Unable to parse the current spec version; this should never happen
 			return err
 		}
-		if requestedSemVer.CompareTo(currentSemVer) < 0 {
+		if requestedSemVer.IsLessThan(currentSemVer) {
 			return fmt.Errorf("Requested version %s is not newer than current version %s", requestedSemVer.VersionString, currentSemVer.VersionString)
 		}
 	}

--- a/operator/api/verrazzano/v1alpha1/validate_test.go
+++ b/operator/api/verrazzano/v1alpha1/validate_test.go
@@ -356,8 +356,8 @@ func TestValidVersionWithIngressChange(t *testing.T) {
 // WHEN the new version is valid and the Ingress component is changed, but version checking is disabled
 // THEN no error is returned from ValidateUpgradeRequest
 func TestValidVersionWithIngressChangeVersionCheckDisabled(t *testing.T) {
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 	assert.NoError(t, runValidateWithIngressChangeTest())
 }
 
@@ -483,8 +483,8 @@ func TestGetCurrentChartVersionBadYAML(t *testing.T) {
 // WHEN the version provided is not valid version and checking is disabled
 // THEN no error is returned
 func TestValidateVersionInvalidVersionCheckingDisabled(t *testing.T) {
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 	assert.NoError(t, ValidateVersion("blah"))
 }
 

--- a/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -13,17 +13,17 @@ import (
 )
 
 // SetupWebhookWithManager is used to let the controller manager know about the webhook
-func (newResource *Verrazzano) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (v *Verrazzano) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(newResource).
+		For(v).
 		Complete()
 }
 
 var _ webhook.Validator = &Verrazzano{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (newResource *Verrazzano) ValidateCreate() error {
-	log := zap.S().With("source", "webhook", "operation", "create", "resource", fmt.Sprintf("%s:%s", newResource.Namespace, newResource.Name))
+func (v *Verrazzano) ValidateCreate() error {
+	log := zap.S().With("source", "webhook", "operation", "create", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate create")
 
 	if env.IsValidationDisabled() {
@@ -31,7 +31,7 @@ func (newResource *Verrazzano) ValidateCreate() error {
 		return nil
 	}
 
-	if err := ValidateVersion(newResource.Spec.Version); err != nil {
+	if err := ValidateVersion(v.Spec.Version); err != nil {
 		return err
 	}
 
@@ -39,8 +39,8 @@ func (newResource *Verrazzano) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (modifiedResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
-	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", modifiedResource.Namespace, modifiedResource.Name))
+func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
+	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
 	if env.IsValidationDisabled() {
@@ -50,15 +50,15 @@ func (modifiedResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
 
 	oldResource := old.(*Verrazzano)
 	log.Debugf("oldResource: %v", oldResource)
-	log.Debugf("modifiedResource: %v", modifiedResource)
+	log.Debugf("v: %v", v)
 
 	// The profile field is immutable
-	if oldResource.Spec.Profile != modifiedResource.Spec.Profile {
-		return fmt.Errorf("Profile change is not allowed oldResource %s to %s", oldResource.Spec.Profile, modifiedResource.Spec.Profile)
+	if oldResource.Spec.Profile != v.Spec.Profile {
+		return fmt.Errorf("Profile change is not allowed oldResource %s to %s", oldResource.Spec.Profile, v.Spec.Profile)
 	}
 
 	// Check to see if the update is an upgrade request, and if it is valid and allowable
-	err := ValidateUpgradeRequest(&oldResource.Spec, &modifiedResource.Spec)
+	err := ValidateUpgradeRequest(&oldResource.Spec, &v.Spec)
 	if err != nil {
 		log.Error("Invalid upgrade request: %s", err.Error())
 		return err
@@ -67,8 +67,8 @@ func (modifiedResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (deletedResource *Verrazzano) ValidateDelete() error {
-	log := zap.S().With("source", "webhook", "operation", "delete", "resource", fmt.Sprintf("%s:%s", deletedResource.Namespace, deletedResource.Name))
+func (v *Verrazzano) ValidateDelete() error {
+	log := zap.S().With("source", "webhook", "operation", "delete", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate delete")
 
 	if env.IsValidationDisabled() {

--- a/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -26,7 +26,7 @@ func (v *Verrazzano) ValidateCreate() error {
 	log := zap.S().With("source", "webhook", "operation", "create", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate create")
 
-	if env.IsValidationDisabled() {
+	if !env.IsValidationEnabled() {
 		log.Info("Validation disabled, skipping")
 		return nil
 	}
@@ -43,7 +43,7 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
-	if env.IsValidationDisabled() {
+	if !env.IsValidationEnabled() {
 		log.Info("Validation disabled, skipping")
 		return nil
 	}
@@ -71,7 +71,7 @@ func (v *Verrazzano) ValidateDelete() error {
 	log := zap.S().With("source", "webhook", "operation", "delete", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate delete")
 
-	if env.IsValidationDisabled() {
+	if !env.IsValidationEnabled() {
 		log.Info("Validation disabled, skipping")
 		return nil
 	}

--- a/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/operator/api/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/operator/internal/util/env"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -22,31 +23,42 @@ var _ webhook.Validator = &Verrazzano{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (newResource *Verrazzano) ValidateCreate() error {
-	log := zap.S().With("source", "webhook", "resource", fmt.Sprintf("%s:%s", newResource.Namespace, newResource.Name))
+	log := zap.S().With("source", "webhook", "operation", "create", "resource", fmt.Sprintf("%s:%s", newResource.Namespace, newResource.Name))
 	log.Info("Validate create")
+
+	if env.IsValidationDisabled() {
+		log.Info("Validation disabled, skipping")
+		return nil
+	}
 
 	if err := ValidateVersion(newResource.Spec.Version); err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (newResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
-	log := zap.S().With("source", "webhook", "resource", fmt.Sprintf("%s:%s", newResource.Namespace, newResource.Name))
+func (modifiedResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
+	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", modifiedResource.Namespace, modifiedResource.Name))
 	log.Info("Validate update")
 
+	if env.IsValidationDisabled() {
+		log.Info("Validation disabled, skipping")
+		return nil
+	}
+
 	oldResource := old.(*Verrazzano)
-	log.Infof("oldResource Annotations: %v, Finalizers: %v, Spec: %v", oldResource.Annotations, oldResource.Finalizers, oldResource.Spec)
-	log.Infof("to Annotations: %v, Finalizers: %v, Spec: %v", newResource.Annotations, newResource.Finalizers, newResource.Spec)
+	log.Debugf("oldResource: %v", oldResource)
+	log.Debugf("modifiedResource: %v", modifiedResource)
 
 	// The profile field is immutable
-	if oldResource.Spec.Profile != newResource.Spec.Profile {
-		return fmt.Errorf("Profile change is not allowed oldResource %s to %s", oldResource.Spec.Profile, newResource.Spec.Profile)
+	if oldResource.Spec.Profile != modifiedResource.Spec.Profile {
+		return fmt.Errorf("Profile change is not allowed oldResource %s to %s", oldResource.Spec.Profile, modifiedResource.Spec.Profile)
 	}
 
 	// Check to see if the update is an upgrade request, and if it is valid and allowable
-	err := ValidateUpgradeRequest(&oldResource.Spec, &newResource.Spec)
+	err := ValidateUpgradeRequest(&oldResource.Spec, &modifiedResource.Spec)
 	if err != nil {
 		log.Error("Invalid upgrade request: %s", err.Error())
 		return err
@@ -55,10 +67,14 @@ func (newResource *Verrazzano) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (newResource *Verrazzano) ValidateDelete() error {
-	log := zap.S().With("source", "webhook", "resource", fmt.Sprintf("%s:%s", newResource.Namespace, newResource.Name))
+func (deletedResource *Verrazzano) ValidateDelete() error {
+	log := zap.S().With("source", "webhook", "operation", "delete", "resource", fmt.Sprintf("%s:%s", deletedResource.Namespace, deletedResource.Name))
 	log.Info("Validate delete")
 
-	// TODO(user): fill in your validation logic upon object deletion.
+	if env.IsValidationDisabled() {
+		log.Info("Validation disabled, skipping")
+		return nil
+	}
+
 	return nil
 }

--- a/operator/api/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/operator/api/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -20,6 +20,9 @@ appVersion: 0.6.0
 `
 
 // TestCreateCallbackSuccessWithVersion Tests the create callback with valid spec version
+// GIVEN a ValidateCreate() request with a valid version
+// WHEN the version provided is a valid version
+// THEN no error is returned
 func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 	chartYaml := webhookTestValidChartYAML
 	readFileFunction = func(string) ([]byte, error) {
@@ -38,6 +41,9 @@ func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 }
 
 // TestCreateCallbackSuccessWithoutVersion Tests the create callback with no spec version
+// GIVEN a ValidateCreate() request with a valid version
+// WHEN no version is provided
+// THEN no error is returned
 func TestCreateCallbackSuccessWithoutVersion(t *testing.T) {
 	chartYaml := webhookTestValidChartYAML
 	readFileFunction = func(string) ([]byte, error) {
@@ -55,11 +61,17 @@ func TestCreateCallbackSuccessWithoutVersion(t *testing.T) {
 }
 
 // TestCreateCallbackFailsWithInvalidVersion Tests the create callback with invalid spec version
+// GIVEN a ValidateCreate() request with an invalid version
+// WHEN an invalid version is provided
+// THEN an error is returned
 func TestCreateCallbackFailsWithInvalidVersion(t *testing.T) {
 	assert.Error(t, runCreateCallbackWithInvalidVersion(t))
 }
 
 // TestCreateCallbackWithInvalidVersionValidationDisabled Tests the create callback with invalid spec version passes with validation disabled
+// GIVEN a ValidateCreate() request
+// WHEN an invalid version is provided and webhook validation is disabled
+// THEN no error is returned
 func TestCreateCallbackWithInvalidVersionValidationDisabled(t *testing.T) {
 	os.Setenv(env.DisableWebHookValidation, "true")
 	defer os.Unsetenv(env.DisableWebHookValidation)
@@ -85,7 +97,10 @@ func runCreateCallbackWithInvalidVersion(t *testing.T) error {
 	return err
 }
 
-// TestUpdateCallbackSuccessWithNewVersion Tests the create callback with valid spec version
+// TestUpdateCallbackSuccessWithNewVersion Tests the update callback with valid spec version at the same chart revision
+// GIVEN a ValidateUpdate() request
+// WHEN a valid version is provided and is at the same chart value
+// THEN no error is returned
 func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 	chartYaml := webhookTestValidChartYAML
 	readFileFunction = func(string) ([]byte, error) {
@@ -109,6 +124,9 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 }
 
 // TestUpdateCallbackSuccessWithNewVersion Tests the create callback with valid spec versions in both
+// GIVEN a ValidateUpdate() request
+// WHEN valid versions exist in both specs, and the new version > old version
+// THEN no error is returned
 func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	chartYaml := webhookTestValidChartYAML
 	readFileFunction = func(string) ([]byte, error) {
@@ -133,6 +151,9 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 }
 
 // TestUpdateCallbackFailsWithOldGreaterThanNewVersion Tests the create callback with old version > new
+// GIVEN a ValidateUpdate() request
+// WHEN valid versions exist in both specs, and the new old > new version
+// THEN an error is returned
 func TestUpdateCallbackFailsWithOldGreaterThanNewVersion(t *testing.T) {
 	chartYaml := webhookTestValidChartYAML
 	readFileFunction = func(string) ([]byte, error) {
@@ -157,11 +178,17 @@ func TestUpdateCallbackFailsWithOldGreaterThanNewVersion(t *testing.T) {
 }
 
 // TestUpdateCallbackFailsWithInvalidNewVersion Tests the create callback with invalid new version
+// GIVEN a ValidateUpdate() request
+// WHEN the new version is valid but not the same as the chart version
+// THEN an error is returned
 func TestUpdateCallbackFailsWithInvalidNewVersion(t *testing.T) {
 	assert.Error(t, runUpdateWithInvalidVersionTest(t))
 }
 
 // TestUpdateCallbackFailsWithInvalidNewVersion Tests the create callback with invalid new version fails
+// GIVEN a ValidateUpdate() request
+// WHEN an invalid version is provided and webhook validation is disabled
+// THEN no error is returned
 func TestUpdateCallbackWithInvalidNewVersionValidationDisabled(t *testing.T) {
 	os.Setenv(env.DisableWebHookValidation, "true")
 	defer os.Unsetenv(env.DisableWebHookValidation)
@@ -192,11 +219,17 @@ func runUpdateWithInvalidVersionTest(t *testing.T) error {
 }
 
 // TestUpdateCallbackFailsChangeProfile Tests the create callback with a changed profile
+// GIVEN a ValidateUpdate() request
+// WHEN the profile is changed
+// THEN an error is returned
 func TestUpdateCallbackFailsChangeProfile(t *testing.T) {
 	assert.Error(t, runUpdateCallbackChangedProfileTest())
 }
 
 // TestUpdateCallbackChangeProfileValidationDisabled Tests the create callback with a changed profile passes with validation disabled
+// GIVEN a ValidateUpdate() request
+// WHEN the profile is changed and webhook validation is disabled
+// THEN no error is returned
 func TestUpdateCallbackChangeProfileValidationDisabled(t *testing.T) {
 	os.Setenv(env.DisableWebHookValidation, "true")
 	defer os.Unsetenv(env.DisableWebHookValidation)
@@ -227,17 +260,24 @@ func runUpdateCallbackChangedProfileTest() error {
 }
 
 // TestDeleteCallbackSuccess Tests the create callback with valid spec version
+// GIVEN a ValidateDelete() request
+// WHEN
+// THEN no error is returned
 func TestDeleteCallbackSuccess(t *testing.T) {
 	assert.NoError(t, runDeleteCallbackTest())
 }
 
 // TestDeleteCallbackDisabled Tests the create callback with valid spec version; largely for code coverage right now
+// GIVEN a ValidateDelete() request
+// WHEN webhook validation is disabled
+// THEN no error is returned
 func TestDeleteCallbackDisabled(t *testing.T) {
 	os.Setenv(env.DisableWebHookValidation, "true")
 	defer os.Unsetenv(env.DisableWebHookValidation)
 	assert.NoError(t, runDeleteCallbackTest())
 }
 
+// runDeleteCallbackTest shared logic for ValidateDelete tests
 func runDeleteCallbackTest() error {
 	deletedSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{

--- a/operator/api/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/operator/api/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -73,8 +73,8 @@ func TestCreateCallbackFailsWithInvalidVersion(t *testing.T) {
 // WHEN an invalid version is provided and webhook validation is disabled
 // THEN no error is returned
 func TestCreateCallbackWithInvalidVersionValidationDisabled(t *testing.T) {
-	os.Setenv(env.DisableWebHookValidation, "true")
-	defer os.Unsetenv(env.DisableWebHookValidation)
+	os.Setenv(env.WebHookValidationEnabled, "false")
+	defer os.Unsetenv(env.WebHookValidationEnabled)
 	assert.NoError(t, runCreateCallbackWithInvalidVersion(t))
 }
 
@@ -190,8 +190,8 @@ func TestUpdateCallbackFailsWithInvalidNewVersion(t *testing.T) {
 // WHEN an invalid version is provided and webhook validation is disabled
 // THEN no error is returned
 func TestUpdateCallbackWithInvalidNewVersionValidationDisabled(t *testing.T) {
-	os.Setenv(env.DisableWebHookValidation, "true")
-	defer os.Unsetenv(env.DisableWebHookValidation)
+	os.Setenv(env.WebHookValidationEnabled, "false")
+	defer os.Unsetenv(env.WebHookValidationEnabled)
 	assert.NoError(t, runUpdateWithInvalidVersionTest(t))
 }
 
@@ -231,8 +231,8 @@ func TestUpdateCallbackFailsChangeProfile(t *testing.T) {
 // WHEN the profile is changed and webhook validation is disabled
 // THEN no error is returned
 func TestUpdateCallbackChangeProfileValidationDisabled(t *testing.T) {
-	os.Setenv(env.DisableWebHookValidation, "true")
-	defer os.Unsetenv(env.DisableWebHookValidation)
+	os.Setenv(env.WebHookValidationEnabled, "false")
+	defer os.Unsetenv(env.WebHookValidationEnabled)
 	assert.NoError(t, runUpdateCallbackChangedProfileTest())
 }
 
@@ -272,8 +272,8 @@ func TestDeleteCallbackSuccess(t *testing.T) {
 // WHEN webhook validation is disabled
 // THEN no error is returned
 func TestDeleteCallbackDisabled(t *testing.T) {
-	os.Setenv(env.DisableWebHookValidation, "true")
-	defer os.Unsetenv(env.DisableWebHookValidation)
+	os.Setenv(env.WebHookValidationEnabled, "false")
+	defer os.Unsetenv(env.WebHookValidationEnabled)
 	assert.NoError(t, runDeleteCallbackTest())
 }
 

--- a/operator/controllers/upgrade_reconciler_test.go
+++ b/operator/controllers/upgrade_reconciler_test.go
@@ -144,8 +144,8 @@ func TestUpgradeStarted(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -208,8 +208,8 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -269,8 +269,8 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -348,8 +348,8 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -418,8 +418,8 @@ func TestUpgradeCompleted(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -488,8 +488,8 @@ func TestUpgradeHelmError(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv(env.CheckVersionDisabled, "true")
-	defer os.Unsetenv(env.CheckVersionDisabled)
+	os.Setenv(env.CheckVersionEnabled, "false")
+	defer os.Unsetenv(env.CheckVersionEnabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().

--- a/operator/controllers/upgrade_reconciler_test.go
+++ b/operator/controllers/upgrade_reconciler_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"github.com/verrazzano/verrazzano/operator/internal/util/env"
 	"os"
 	"os/exec"
 	"testing"
@@ -143,8 +144,8 @@ func TestUpgradeStarted(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -207,8 +208,8 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -268,8 +269,8 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -347,8 +348,8 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -417,8 +418,8 @@ func TestUpgradeCompleted(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -487,8 +488,8 @@ func TestUpgradeHelmError(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	os.Setenv("VZ_CHECK_VERSION", "false")
-	defer os.Unsetenv("VZ_CHECK_VERSION")
+	os.Setenv(env.CheckVersionDisabled, "true")
+	defer os.Unsetenv(env.CheckVersionDisabled)
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().

--- a/operator/internal/util/env/env.go
+++ b/operator/internal/util/env/env.go
@@ -10,11 +10,11 @@ import (
 
 const vzRootDir = "VZ_ROOT_DIR"
 
-// CheckVersionDisabled Disable version checking
-const CheckVersionDisabled = "VZ_DISABLE_VERSION_CHECK"
+// CheckVersionEnabled Disable version checking
+const CheckVersionEnabled = "VZ_CHECK_VERSION"
 
-// DisableWebHookValidation Disable webhook validation without removing the webhook itself
-const DisableWebHookValidation = "VZ_DISABLE_VALIDATIONS"
+// WebHookValidationEnabled Disable webhook validation without removing the webhook itself
+const WebHookValidationEnabled = "VZ_VALIDATION_ENABLED"
 
 var getEnvFunc func(string) string = os.Getenv
 
@@ -38,12 +38,12 @@ func VzChartDir() string {
 	return "/verrazzano/install/chart"
 }
 
-// IsCheckVersionDisabled If true, perform version checks on upgrade
-func IsCheckVersionDisabled() bool {
-	return getEnvFunc(CheckVersionDisabled) == "true"
+// IsVersionCheckEnabled If true, perform version checks on upgrade
+func IsVersionCheckEnabled() bool {
+	return getEnvFunc(CheckVersionEnabled) != "false"
 }
 
-// IsValidationDisabled If true, disable the webhook validation logic (webhook will still be active)
-func IsValidationDisabled() bool {
-	return getEnvFunc(DisableWebHookValidation) == "true"
+// IsValidationEnabled If true, enable the webhook validation logic
+func IsValidationEnabled() bool {
+	return getEnvFunc(WebHookValidationEnabled) != "false"
 }

--- a/operator/internal/util/env/env.go
+++ b/operator/internal/util/env/env.go
@@ -10,8 +10,10 @@ import (
 
 const vzRootDir = "VZ_ROOT_DIR"
 
+// CheckVersionDisabled Disable version checking
 const CheckVersionDisabled = "VZ_DISABLE_VERSION_CHECK"
 
+// DisableWebHookValidation Disable webhook validation without removing the webhook itself
 const DisableWebHookValidation = "VZ_DISABLE_VALIDATIONS"
 
 var getEnvFunc func(string) string = os.Getenv

--- a/operator/internal/util/env/env.go
+++ b/operator/internal/util/env/env.go
@@ -10,7 +10,9 @@ import (
 
 const vzRootDir = "VZ_ROOT_DIR"
 
-const checkVersion = "VZ_CHECK_VERSION"
+const CheckVersionDisabled = "VZ_DISABLE_VERSION_CHECK"
+
+const DisableWebHookValidation = "VZ_DISABLE_VALIDATIONS"
 
 var getEnvFunc func(string) string = os.Getenv
 
@@ -34,7 +36,12 @@ func VzChartDir() string {
 	return "/verrazzano/install/chart"
 }
 
-// IsCheckVersionRequired If true, perform version checks on upgrade
-func IsCheckVersionRequired() bool {
-	return getEnvFunc(checkVersion) != "false"
+// IsCheckVersionDisabled If true, perform version checks on upgrade
+func IsCheckVersionDisabled() bool {
+	return getEnvFunc(CheckVersionDisabled) == "true"
+}
+
+// IsValidationDisabled If true, disable the webhook validation logic (webhook will still be active)
+func IsValidationDisabled() bool {
+	return getEnvFunc(DisableWebHookValidation) == "true"
 }

--- a/operator/internal/util/env/env_test.go
+++ b/operator/internal/util/env/env_test.go
@@ -39,12 +39,22 @@ func TestVzChartDir(t *testing.T) {
 	assert.Equal("/testdir/operator/scripts/install/chart", VzChartDir(), "The chart directory is incorrect")
 }
 
-func TestIsCheckVersionRequired(t *testing.T) {
+func TestIsCheckVersionDisabled(t *testing.T) {
 	defer func() { getEnvFunc = os.Getenv }()
 	getEnvFunc = func(string) string { return "false" }
-	assert.False(t, IsCheckVersionRequired())
+	assert.False(t, IsCheckVersionDisabled())
 	getEnvFunc = func(string) string { return "" }
-	assert.True(t, IsCheckVersionRequired())
+	assert.False(t, IsCheckVersionDisabled())
 	getEnvFunc = func(string) string { return "true" }
-	assert.True(t, IsCheckVersionRequired())
+	assert.True(t, IsCheckVersionDisabled())
+}
+
+func TestIsValidationDisabled(t *testing.T) {
+	defer func() { getEnvFunc = os.Getenv }()
+	getEnvFunc = func(string) string { return "false" }
+	assert.False(t, IsValidationDisabled())
+	getEnvFunc = func(string) string { return "" }
+	assert.False(t, IsValidationDisabled())
+	getEnvFunc = func(string) string { return "true" }
+	assert.True(t, IsValidationDisabled())
 }

--- a/operator/internal/util/env/env_test.go
+++ b/operator/internal/util/env/env_test.go
@@ -39,22 +39,30 @@ func TestVzChartDir(t *testing.T) {
 	assert.Equal("/testdir/operator/scripts/install/chart", VzChartDir(), "The chart directory is incorrect")
 }
 
-func TestIsCheckVersionDisabled(t *testing.T) {
+// TestIsCheckVersionEnabled tests that when
+// GIVEN env variable VZ_CHECK_VERSION != "false", this function returns true
+//  WHEN I call IsVersionCheckEnabled
+//  THEN the value returned is true if VZ_CHECK_VERSION != "false", otherwise return false
+func TestIsCheckVersionEnabled(t *testing.T) {
 	defer func() { getEnvFunc = os.Getenv }()
 	getEnvFunc = func(string) string { return "false" }
-	assert.False(t, IsCheckVersionDisabled())
+	assert.False(t, IsVersionCheckEnabled())
 	getEnvFunc = func(string) string { return "" }
-	assert.False(t, IsCheckVersionDisabled())
+	assert.True(t, IsVersionCheckEnabled())
 	getEnvFunc = func(string) string { return "true" }
-	assert.True(t, IsCheckVersionDisabled())
+	assert.True(t, IsVersionCheckEnabled())
 }
 
-func TestIsValidationDisabled(t *testing.T) {
+// TestIsValidationEnabled tests that when
+// GIVEN env variable VZ_VALIDATION_ENABLED != "false", this function returns true
+//  WHEN I call IsVersionCheckEnabled
+//  THEN the value returned is true if VZ_VALIDATION_ENABLED != "false", otherwise return false
+func TestIsValidationEnabled(t *testing.T) {
 	defer func() { getEnvFunc = os.Getenv }()
 	getEnvFunc = func(string) string { return "false" }
-	assert.False(t, IsValidationDisabled())
+	assert.False(t, IsValidationEnabled())
 	getEnvFunc = func(string) string { return "" }
-	assert.False(t, IsValidationDisabled())
+	assert.True(t, IsValidationEnabled())
 	getEnvFunc = func(string) string { return "true" }
-	assert.True(t, IsValidationDisabled())
+	assert.True(t, IsValidationEnabled())
 }

--- a/operator/internal/util/semver/semver.go
+++ b/operator/internal/util/semver/semver.go
@@ -112,6 +112,21 @@ func (to *SemVersion) CompareTo(from *SemVersion) int {
 	return result
 }
 
+// IsEqualTo Returns true if to == from
+func (to *SemVersion) IsEqualTo(from *SemVersion) bool {
+	return to.CompareTo(from) == 0
+}
+
+// IsGreatherThan Returns true if to > from
+func (to *SemVersion) IsGreatherThan(from *SemVersion) bool {
+	return to.CompareTo(from) > 0
+}
+
+// IsLessThan Returns true if to < from
+func (to *SemVersion) IsLessThan(from *SemVersion) bool {
+	return to.CompareTo(from) < 0
+}
+
 // Returns
 // - 1 if v2 > v1
 // - -1 if v1 > v2

--- a/operator/internal/util/semver/semver.go
+++ b/operator/internal/util/semver/semver.go
@@ -20,7 +20,6 @@ type SemVersion struct {
 	Patch         int64
 	Prerelease    string
 	Build         string
-	VersionString string
 }
 
 var compiledRegEx *regexp.Regexp = nil
@@ -92,7 +91,6 @@ func NewSemVersion(version string) (*SemVersion, error) {
 		Patch:         patchVer,
 		Prerelease:    prereleaseVer,
 		Build:         buildVer,
-		VersionString: version,
 	}
 	return &semVersion, nil
 }
@@ -101,11 +99,11 @@ func NewSemVersion(version string) (*SemVersion, error) {
 // - if from > this, -1 is returned
 // - if from < this, 1 is returned
 // - if they are equal, 0 is returned
-func (to *SemVersion) CompareTo(from *SemVersion) int {
+func (v *SemVersion) CompareTo(from *SemVersion) int {
 	var result int
-	if result = compareVersion(from.Major, to.Major); result == 0 {
-		if result = compareVersion(from.Minor, to.Minor); result == 0 {
-			result = compareVersion(from.Patch, to.Patch)
+	if result = compareVersion(from.Major, v.Major); result == 0 {
+		if result = compareVersion(from.Minor, v.Minor); result == 0 {
+			result = compareVersion(from.Patch, v.Patch)
 			// Ignore pre-release/buildver fields for now
 		}
 	}
@@ -113,18 +111,22 @@ func (to *SemVersion) CompareTo(from *SemVersion) int {
 }
 
 // IsEqualTo Returns true if to == from
-func (to *SemVersion) IsEqualTo(from *SemVersion) bool {
-	return to.CompareTo(from) == 0
+func (v *SemVersion) IsEqualTo(from *SemVersion) bool {
+	return v.CompareTo(from) == 0
 }
 
 // IsGreatherThan Returns true if to > from
-func (to *SemVersion) IsGreatherThan(from *SemVersion) bool {
-	return to.CompareTo(from) > 0
+func (v *SemVersion) IsGreatherThan(from *SemVersion) bool {
+	return v.CompareTo(from) > 0
 }
 
 // IsLessThan Returns true if to < from
-func (to *SemVersion) IsLessThan(from *SemVersion) bool {
-	return to.CompareTo(from) < 0
+func (v *SemVersion) IsLessThan(from *SemVersion) bool {
+	return v.CompareTo(from) < 0
+}
+
+func (v *SemVersion) ToString() string {
+	return fmt.Sprintf("%v.%v.%v", v.Major, v.Minor, v.Patch)
 }
 
 // Returns
@@ -140,3 +142,4 @@ func compareVersion(v1 int64, v2 int64) int {
 	}
 	return 0
 }
+

--- a/operator/internal/util/semver/semver.go
+++ b/operator/internal/util/semver/semver.go
@@ -15,11 +15,11 @@ const semverRegex = "^[v|V](0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:
 
 // SemVersion Implements a basic notion a semantic version (see https://semver.org/, test page: https://regex101.com/r/vkijKf/1/)
 type SemVersion struct {
-	Major         int64
-	Minor         int64
-	Patch         int64
-	Prerelease    string
-	Build         string
+	Major      int64
+	Minor      int64
+	Patch      int64
+	Prerelease string
+	Build      string
 }
 
 var compiledRegEx *regexp.Regexp = nil
@@ -86,11 +86,11 @@ func NewSemVersion(version string) (*SemVersion, error) {
 		buildVer = versionComponents[5]
 	}
 	semVersion := SemVersion{
-		Major:         majorVer,
-		Minor:         minorVer,
-		Patch:         patchVer,
-		Prerelease:    prereleaseVer,
-		Build:         buildVer,
+		Major:      majorVer,
+		Minor:      minorVer,
+		Patch:      patchVer,
+		Prerelease: prereleaseVer,
+		Build:      buildVer,
 	}
 	return &semVersion, nil
 }
@@ -125,6 +125,7 @@ func (v *SemVersion) IsLessThan(from *SemVersion) bool {
 	return v.CompareTo(from) < 0
 }
 
+// ToString Convert to a valid semver string representation
 func (v *SemVersion) ToString() string {
 	return fmt.Sprintf("%v.%v.%v", v.Major, v.Minor, v.Patch)
 }
@@ -142,4 +143,3 @@ func compareVersion(v1 int64, v2 int64) int {
 	}
 	return 0
 }
-

--- a/operator/internal/util/semver/semver_test.go
+++ b/operator/internal/util/semver/semver_test.go
@@ -41,7 +41,7 @@ func TestValidSemver(t *testing.T) {
 		version, err := NewSemVersion(verString)
 		assert.NoError(t, err)
 		assert.NotNil(t, version)
-		assert.Equal(t, verString, version.VersionString)
+		assert.Equal(t, fmt.Sprintf("%s.%s.%s", verComponents[0], verComponents[1], verComponents[2]), version.ToString())
 		expectedMajor, _ := strconv.ParseInt(verComponents[0], 10, 64)
 		assert.Equal(t, expectedMajor, version.Major)
 		expectedMinor, _ := strconv.ParseInt(verComponents[1], 10, 64)

--- a/operator/internal/util/semver/semver_test.go
+++ b/operator/internal/util/semver/semver_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 // TestValidSemver Tests the SemVersion parser for valid version strings
+// GIVEN a set of valid version strings
+// WHEN we try to create a SemVersion
+// THEN no error is returned and a valid SemVersion object ref is returned
 func TestValidSemver(t *testing.T) {
 	testVersions := [][]string{
 		{"0", "0", "4"},
@@ -59,6 +62,9 @@ func TestValidSemver(t *testing.T) {
 }
 
 // TestInValidSemver Tests the SemVersion parser for valid version strings
+// GIVEN a set of valid inversion strings
+// WHEN we try to create a SemVersion
+// THEN an error is returned and nil is returned for the SemVersion object ref
 func TestInValidSemver(t *testing.T) {
 	invalidVersions := []string{
 		"",
@@ -68,12 +74,16 @@ func TestInValidSemver(t *testing.T) {
 		"1.1.bar",
 	}
 	for _, verString := range invalidVersions {
-		_, err := NewSemVersion(verString)
+		v, err := NewSemVersion(verString)
 		assert.Error(t, err)
+		assert.Nil(t, v)
 	}
 }
 
 // TestCompareVersion Tests comparisons of version field values
+// GIVEN a call to compareVersion
+// WHEN v1 > v2, v1 < v2, and v1 == v2
+// THEN -1 is returned when v1 > v2, 1 when > v1 < v2, and 0 when v1 == v2
 func TestCompareVersion(t *testing.T) {
 	assert.Equal(t, -1, compareVersion(2, 1))
 	assert.Equal(t, 1, compareVersion(1, 2))
@@ -81,6 +91,9 @@ func TestCompareVersion(t *testing.T) {
 }
 
 // TestCompareTo Tests comparisons between SemVersion instances
+// GIVEN a call to CompareTo with different SemVersion objects
+// WHEN v1 > v2, v1 < v2, and v1 == v2
+// THEN -1 is returned when v1 > v2, 1 when > v1 < v2, and 0 when v1 == v2
 func TestCompareTo(t *testing.T) {
 
 	v010, _ := NewSemVersion("v0.1.0")
@@ -105,4 +118,136 @@ func TestCompareTo(t *testing.T) {
 	V100, err := NewSemVersion("V1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, V100.CompareTo(v100))
+}
+
+// TestIsEqualTo Tests IsEqualTo for various combinations of SemVersion objects
+// GIVEN a call to IsEqualTo with different SemVersion objects
+// WHEN v > arg, v < arg, and v == arg
+// THEN True v == arg, false otherwise
+func TestIsEqualTo(t *testing.T) {
+	v010, _ := NewSemVersion("v0.1.0")
+	v010_2, _ := NewSemVersion("v0.1.0")
+	v020, _ := NewSemVersion("v0.2.0")
+	v011, _ := NewSemVersion("v0.1.1")
+	v100, _ := NewSemVersion("v1.0.0")
+
+	assert.True(t, v010.IsEqualTo(v010))
+	assert.True(t, v010.IsEqualTo(v010_2))
+	assert.False(t, v010.IsEqualTo(v020))
+	assert.False(t, v010.IsEqualTo(v011))
+	assert.False(t, v010.IsEqualTo(v100))
+
+	assert.False(t, v020.IsEqualTo(v010))
+	assert.False(t, v020.IsEqualTo(v010_2))
+	assert.True(t, v020.IsEqualTo(v020))
+	assert.False(t, v020.IsEqualTo(v011))
+	assert.False(t, v020.IsEqualTo(v100))
+
+	assert.False(t, v011.IsEqualTo(v010))
+	assert.False(t, v011.IsEqualTo(v010_2))
+	assert.False(t, v011.IsEqualTo(v020))
+	assert.True(t, v011.IsEqualTo(v011))
+	assert.False(t, v011.IsEqualTo(v100))
+
+	assert.False(t, v100.IsEqualTo(v010))
+	assert.False(t, v100.IsEqualTo(v010_2))
+	assert.False(t, v100.IsEqualTo(v020))
+	assert.False(t, v100.IsEqualTo(v011))
+	assert.True(t, v100.IsEqualTo(v100))
+
+	v009, _ := NewSemVersion("v0.0.9")
+	v009_2, _ := NewSemVersion("v0.0.9")
+	v0010, _ := NewSemVersion("v0.0.10")
+	assert.True(t, v009.IsEqualTo(v009_2))
+	assert.False(t, v009.IsEqualTo(v0010))
+}
+
+// TestIsLessThan Tests IsLessThan for various combinations of SemVersion objects
+// GIVEN a call to IsLessThan with different SemVersion objects
+// WHEN v > arg, v < arg, and v == arg
+// THEN True v < arg, false otherwise
+func TestIsLessThan(t *testing.T) {
+	v010, _ := NewSemVersion("v0.1.0")
+	v010_2, _ := NewSemVersion("v0.1.0")
+	v020, _ := NewSemVersion("v0.2.0")
+	v011, _ := NewSemVersion("v0.1.1")
+	v100, _ := NewSemVersion("v1.0.0")
+	v200, _ := NewSemVersion("v2.0.0")
+
+	assert.False(t, v010.IsLessThan(v010))
+	assert.False(t, v010.IsLessThan(v010_2))
+	assert.True(t, v010.IsLessThan(v020))
+	assert.True(t, v010.IsLessThan(v011))
+	assert.True(t, v010.IsLessThan(v100))
+
+	assert.False(t, v020.IsLessThan(v010))
+	assert.False(t, v020.IsLessThan(v010_2))
+	assert.False(t, v020.IsLessThan(v020))
+	assert.False(t, v020.IsLessThan(v011))
+	assert.True(t, v020.IsLessThan(v100))
+
+	assert.False(t, v011.IsLessThan(v010))
+	assert.False(t, v011.IsLessThan(v010_2))
+	assert.True(t, v011.IsLessThan(v020))
+	assert.False(t, v011.IsLessThan(v011))
+	assert.True(t, v011.IsLessThan(v100))
+
+	assert.False(t, v100.IsLessThan(v010))
+	assert.False(t, v100.IsLessThan(v010_2))
+	assert.False(t, v100.IsLessThan(v020))
+	assert.False(t, v100.IsLessThan(v011))
+	assert.False(t, v100.IsLessThan(v100))
+	assert.True(t, v100.IsLessThan(v200))
+
+	v009, _ := NewSemVersion("v0.0.9")
+	v009_2, _ := NewSemVersion("v0.0.9")
+	v0010, _ := NewSemVersion("v0.0.10")
+	assert.False(t, v009.IsLessThan(v009_2))
+	assert.True(t, v009.IsLessThan(v0010))
+	assert.False(t, v0010.IsLessThan(v009))
+}
+
+// TestIsGreatherThan Tests IsGreatherThan for various combinations of SemVersion objects
+// GIVEN a call to IsGreatherThan with different SemVersion objects
+// WHEN v > arg, v < arg, and v == arg
+// THEN True v > arg, false otherwise
+func TestIsGreatherThan(t *testing.T) {
+	v010, _ := NewSemVersion("v0.1.0")
+	v010_2, _ := NewSemVersion("v0.1.0")
+	v020, _ := NewSemVersion("v0.2.0")
+	v011, _ := NewSemVersion("v0.1.1")
+	v100, _ := NewSemVersion("v1.0.0")
+	v200, _ := NewSemVersion("v2.0.0")
+
+	assert.False(t, v010.IsGreatherThan(v010))
+	assert.False(t, v010.IsGreatherThan(v010_2))
+	assert.False(t, v010.IsGreatherThan(v020))
+	assert.False(t, v010.IsGreatherThan(v011))
+	assert.False(t, v010.IsGreatherThan(v100))
+
+	assert.True(t, v020.IsGreatherThan(v010))
+	assert.True(t, v020.IsGreatherThan(v010_2))
+	assert.False(t, v020.IsGreatherThan(v020))
+	assert.True(t, v020.IsGreatherThan(v011))
+	assert.False(t, v020.IsGreatherThan(v100))
+
+	assert.True(t, v011.IsGreatherThan(v010))
+	assert.True(t, v011.IsGreatherThan(v010_2))
+	assert.False(t, v011.IsGreatherThan(v020))
+	assert.False(t, v011.IsGreatherThan(v011))
+	assert.False(t, v011.IsGreatherThan(v100))
+
+	assert.True(t, v100.IsGreatherThan(v010))
+	assert.True(t, v100.IsGreatherThan(v010_2))
+	assert.True(t, v100.IsGreatherThan(v020))
+	assert.True(t, v100.IsGreatherThan(v011))
+	assert.False(t, v100.IsGreatherThan(v100))
+	assert.False(t, v100.IsGreatherThan(v200))
+
+	v009, _ := NewSemVersion("v0.0.9")
+	v009_2, _ := NewSemVersion("v0.0.9")
+	v0010, _ := NewSemVersion("v0.0.10")
+	assert.False(t, v009.IsGreatherThan(v009_2))
+	assert.False(t, v009.IsGreatherThan(v0010))
+	assert.True(t, v0010.IsGreatherThan(v009))
 }


### PR DESCRIPTION
Added a few more unit tests for validation code, and added comments/prologues where needed
Also, added operator/api packages to unit test suite

Updated SemVersion

- Added test comments and some new test cases
- Added some convience comparison methods (==, >, <) with unit tests
- Removed the full version string from the struct 
