### PR TITLE
Update image version for console and verrazzano-operator for isUsingSharedVMI field changes to instance api

### DIFF
--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -29,8 +29,8 @@ elasticSearch:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.7.0-20201216140520-38bc99b
+  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
+  imageVersion: 0.7.0-20201218082756-cc4572a
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.7.0-20201210184344-940208a
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.7.0-20201214161307-501df7f
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.7.0-20201210185726-82d0a2b

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -91,7 +91,7 @@ verrazzanoAdmissionController:
 console:
   name: verrazzano-console
   imageName: ghcr.io/verrazzano/console-jenkins
-  imageVersion: 0.8.0-20201221061627-008b64d
+  imageVersion: 0.8.0-20201221074355-bfb53f3
 
 rancher:
   rancherURL:

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -29,8 +29,8 @@ elasticSearch:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.8.0-20201221053307-514d3f5
+  imageName: ghcr.io/verrazzano/verrazzano-operator
+  imageVersion: 0.8.0-20201222141732-6910964
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.7.0-20201210184344-940208a
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.7.0-20201214161307-501df7f
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.7.0-20201210185726-82d0a2b
@@ -90,8 +90,8 @@ verrazzanoAdmissionController:
 
 console:
   name: verrazzano-console
-  imageName: ghcr.io/verrazzano/console-jenkins
-  imageVersion: 0.8.0-20201221074355-bfb53f3
+  imageName: ghcr.io/verrazzano/console
+  imageVersion: 0.8.0-20201222142451-75c551d
 
 rancher:
   rancherURL:

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.7.0-20201218092228-4eb9500
+  imageVersion: 0.8.0-20201221053307-514d3f5
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.7.0-20201210184344-940208a
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.7.0-20201214161307-501df7f
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.7.0-20201210185726-82d0a2b
@@ -90,8 +90,8 @@ verrazzanoAdmissionController:
 
 console:
   name: verrazzano-console
-  imageName: ghcr.io/verrazzano/console
-  imageVersion: 0.7.0-20201210220726-8a8ab27
+  imageName: ghcr.io/verrazzano/console-jenkins
+  imageVersion: 0.8.0-20201221061627-008b64d
 
 rancher:
   rancherURL:

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.7.0-20201218082756-cc4572a
+  imageVersion: 0.7.0-20201218092228-4eb9500
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.7.0-20201210184344-940208a
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.7.0-20201214161307-501df7f
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.7.0-20201210185726-82d0a2b


### PR DESCRIPTION
In https://github.com/verrazzano/console/pull/40 and https://github.com/verrazzano/verrazzano-operator/pull/217 a new field `isUsingSharedVMI` is added to instance api response and UI changes to display the telemetry links accordingly. This PR to uptake these two changes which are now merged