### PR TITLE
Add SAN to webhook certificate

### DIFF
--- a/operator/internal/certificate/certificate.go
+++ b/operator/internal/certificate/certificate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certificate
@@ -40,6 +40,7 @@ func CreateWebhookCertificates(certDir string) (*bytes.Buffer, error) {
 
 	// CA config
 	ca := &x509.Certificate{
+		DNSNames:     []string{commonName},
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,


### PR DESCRIPTION
Rename misspelled file certicates.go to certificates.go
Add SAN to webhook certificate to avoid errors in later golang versions to resolve this error:

"operator/config/samples/install-default.yaml": Internal error occurred: failed calling webhook "install.verrazzano.io": Post "https://verrazzano-platform-operator.verrazzano-install.svc:443/validate-install-verrazzano-io-v1alpha1-verrazzano?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0