### PR TITLE
Fix uninstall regression

### DIFF
--- a/operator/scripts/install/common.sh
+++ b/operator/scripts/install/common.sh
@@ -9,8 +9,8 @@ SOURCE_DIR=$(cd $(dirname $BASH_SOURCE); pwd -P)
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname ${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}); pwd -P)}
 # The directory where any generated artifacts should be stored.
 BUILD_DIR="${SCRIPT_DIR}/build"
-CHARTS_DIR=$(cd $SCRIPT_DIR/../../../thirdparty/charts; pwd -P)
-MANIFESTS_DIR=$(cd $SCRIPT_DIR/../../../thirdparty/manifests; pwd -P)
+CHARTS_DIR=$(cd $SOURCE_DIR/../../../thirdparty/charts; pwd -P)
+MANIFESTS_DIR=$(cd $SOURCE_DIR/../../../thirdparty/manifests; pwd -P)
 
 . ${SOURCE_DIR}/logging.sh
 


### PR DESCRIPTION
Uninstall broke with the changes for adding the helm charts into the verrazzano repository.   The manifests folder was not being set correctly for uninstall, so the uninstall of cert-manager was failing.