### PR TITLE
Fix the chart location used by upgrade

### DIFF
--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package config

--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -40,7 +40,7 @@ var instance OperatorConfig = OperatorConfig{
 	VersionCheckEnabled:      true,
 	WebhooksEnabled:          true,
 	WebhookValidationEnabled: true,
-	VerrazzanoInstallDir:     "/verrazzano/install",
+	VerrazzanoInstallDir:     "/verrazzano/operator/scripts/install",
 }
 
 // Set saves the operator config.  This should only be called at operator startup and during unit tests

--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package config

--- a/operator/internal/config/config_test.go
+++ b/operator/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package config

--- a/operator/internal/config/config_test.go
+++ b/operator/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package config
@@ -23,7 +23,7 @@ func TestConfigDefaults(t *testing.T) {
 	asserts.True(conf.VersionCheckEnabled, "VersionCheckEnabled is incorrect")
 	asserts.True(conf.WebhooksEnabled, "WebhooksEnabled is incorrect")
 	asserts.True(conf.WebhookValidationEnabled, "WebhookValidationEnabled is incorrect")
-	asserts.Equal("/verrazzano/install", conf.VerrazzanoInstallDir, "VerrazzanoInstallDir is incorrect")
+	asserts.Equal("/verrazzano/operator/scripts/install", conf.VerrazzanoInstallDir, "VerrazzanoInstallDir is incorrect")
 }
 
 // TestSetConfig tests setting config values

--- a/operator/scripts/install/3-install-verrazzano.sh
+++ b/operator/scripts/install/3-install-verrazzano.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/operator/scripts/install/3-install-verrazzano.sh
+++ b/operator/scripts/install/3-install-verrazzano.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/operator/scripts/install/3-install-verrazzano.sh
+++ b/operator/scripts/install/3-install-verrazzano.sh
@@ -171,10 +171,10 @@ function install_verrazzano()
       --set config.envName=${ENV_NAME} \
       --set config.dnsSuffix=${DNS_SUFFIX} \
       --set config.enableMonitoringStorage=true \
-      --set rancher.rancherURL=https://${RANCHER_HOSTNAME} \
-      --set rancher.rancherUserName="${token_array[0]}" \
-      --set rancher.rancherPassword="${token_array[1]}" \
-      --set rancher.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
+      --set clusterOperator.rancherURL=https://${RANCHER_HOSTNAME} \
+      --set clusterOperator.rancherUserName="${token_array[0]}" \
+      --set clusterOperator.rancherPassword="${token_array[1]}" \
+      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
       --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?

--- a/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
+++ b/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apps/v1

--- a/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
+++ b/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
@@ -33,9 +33,9 @@ spec:
               memory: {{ .Values.verrazzanoOperator.RequestMemory }}
           env:
             - name: rancherURL
-              value: {{ .Values.rancher.rancherURL }}
+              value: {{ .Values.clusterOperator.rancherURL }}
             - name: rancherHost
-              value: {{ .Values.rancher.rancherHostname }}
+              value: {{ .Values.clusterOperator.rancherHostname }}
             - name: USE_SYSTEM_VMI
               value: {{ .Values.appBinding.useSystemVMI | quote }}
             - name: COH_MICRO_IMAGE

--- a/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
+++ b/operator/scripts/install/chart/templates/01-verrazzano-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apps/v1

--- a/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
+++ b/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apps/v1

--- a/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
+++ b/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apps/v1

--- a/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
+++ b/operator/scripts/install/chart/templates/02-verrazzano-cluster-operator.yaml
@@ -25,10 +25,10 @@ spec:
           args:
             - --zap-log-level=info
             - --zap-devel=false
-            - --rancherURL={{ .Values.rancher.rancherURL }}
-            - --rancherUserName={{ .Values.rancher.rancherUserName }}
-            - --rancherPassword={{ .Values.rancher.rancherPassword }}
-            - --rancherHost={{ .Values.rancher.rancherHostname }}
+            - --rancherURL={{ .Values.clusterOperator.rancherURL }}
+            - --rancherUserName={{ .Values.clusterOperator.rancherUserName }}
+            - --rancherPassword={{ .Values.clusterOperator.rancherPassword }}
+            - --rancherHost={{ .Values.clusterOperator.rancherHostname }}
           resources:
             requests:
               memory: {{ .Values.clusterOperator.RequestMemory }}

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -87,17 +87,15 @@ verrazzanoAdmissionController:
   imageVersion: 0.8.0-20201221221835-6c6f18e
   caBundle:
   RequestMemory: 15Mi
+  rancherURL:
+  rancherUserName:
+  rancherPassword:
+  rancherHostname:
 
 console:
   name: verrazzano-console
   imageName: ghcr.io/verrazzano/console
   imageVersion: 0.8.0-20201222142451-75c551d
-
-rancher:
-  rancherURL:
-  rancherUserName:
-  rancherPassword:
-  rancherHostname:
 
 # OCI-related values
 oci:

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano
 

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano
 

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -79,6 +79,10 @@ clusterOperator:
   imageName: ghcr.io/verrazzano/verrazzano-cluster-operator
   imageVersion: 0.8.0-20201218185017-5e9c62f
   RequestMemory: 27Mi
+  rancherURL:
+  rancherUserName:
+  rancherPassword:
+  rancherHostname:
 
 verrazzanoAdmissionController:
   name: verrazzano-validation
@@ -87,10 +91,6 @@ verrazzanoAdmissionController:
   imageVersion: 0.8.0-20201221221835-6c6f18e
   caBundle:
   RequestMemory: 15Mi
-  rancherURL:
-  rancherUserName:
-  rancherPassword:
-  rancherHostname:
 
 console:
   name: verrazzano-console


### PR DESCRIPTION
A recent merge moved the charts on the image which broken upgrade.
Another merge changed rancher helm schema for values that do not have defaults, which also broke upgrade
Fix both issues.