### PR TITLE
VZ-1885.  Patch Elasticsearch

### DIFF
--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -54,8 +54,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
-  imageVersion: 0.8.0-20210107183735-2c0d2c1
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
+  imageVersion: 0.8.0-20210108130006-b5a6f97
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -54,8 +54,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.8.0-20201221212648-684fe83
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
+  imageVersion: 0.8.0-20210107183735-2c0d2c1
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1


### PR DESCRIPTION
Updating the monitoring operator image to work around an issue with the ES rolling upgrade logic in that code.  This fixes ES patching, and we will address rolling upgrade subsequently.