### PR TITLE
VZ-1878. Patch cert-manager

### DIFF
--- a/operator/internal/component/component.go
+++ b/operator/internal/component/component.go
@@ -29,14 +29,14 @@ func GetComponents() []Component {
 			releaseName:             "external-dns",
 			chartDir:                filepath.Join(config.Get().ThirdpartyChartsDir, "external-dns"),
 			chartNamespace:          "cert-manager",
-			allowsNamespaceOverride: true,
+			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(componentDir, "external-dns-values.yaml"),
 		},
 		helmComponent{
 			releaseName:             "cert-manager",
 			chartDir:                filepath.Join(config.Get().ThirdpartyChartsDir, "cert-manager"),
 			chartNamespace:          "cert-manager",
-			allowsNamespaceOverride: true,
+			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(componentDir, "cert-manager-values.yaml"),
 		},
 	}

--- a/operator/internal/component/component.go
+++ b/operator/internal/component/component.go
@@ -32,5 +32,12 @@ func GetComponents() []Component {
 			allowsNamespaceOverride: true,
 			valuesFile:              filepath.Join(componentDir, "external-dns-values.yaml"),
 		},
+		helmComponent{
+			releaseName:             "cert-manager",
+			chartDir:                filepath.Join(config.Get().ThirdpartyChartsDir, "cert-manager"),
+			chartNamespace:          "cert-manager",
+			allowsNamespaceOverride: true,
+			valuesFile:              filepath.Join(componentDir, "cert-manager-values.yaml"),
+		},
 	}
 }

--- a/operator/internal/component/component_test.go
+++ b/operator/internal/component/component_test.go
@@ -16,7 +16,7 @@ import (
 func TestGetComponents(t *testing.T) {
 	assert := assert.New(t)
 	comps := GetComponents()
-	assert.Len(comps, 3, "Wrong number of components")
+	assert.Len(comps, 4, "Wrong number of components")
 	assert.Equal(comps[0].Name(), "verrazzano")
 	assert.Equal(comps[1].Name(), "ingress-nginx")
 	assert.Equal(comps[2].Name(), "external-dns")

--- a/operator/internal/component/helm_component.go
+++ b/operator/internal/component/helm_component.go
@@ -18,9 +18,9 @@ type helmComponent struct {
 	// chartNamespace is the namespace passed to the helm command
 	chartNamespace string
 
-	// allowsNamespaceOverride bool indicates that the namespace can be overridden
+	// ignoreNamespaceOverride bool indicates that the namespace can be overridden
 	// by the namespace param passed to Upgrade
-	allowsNamespaceOverride bool
+	ignoreNamespaceOverride bool
 
 	// valuesFile is the helm chart values override file
 	valuesFile string
@@ -45,7 +45,7 @@ func (h helmComponent) Name() string {
 // install.
 func (h helmComponent) Upgrade(ns string) error {
 	namespace := ns
-	if h.allowsNamespaceOverride {
+	if h.ignoreNamespaceOverride {
 		namespace = h.chartNamespace
 	}
 	_, _, err := upgradeFunc(h.releaseName, namespace, h.chartDir, h.valuesFile)

--- a/operator/internal/component/helm_component_test.go
+++ b/operator/internal/component/helm_component_test.go
@@ -39,7 +39,7 @@ func TestUpgrade(t *testing.T) {
 		releaseName:             "release1",
 		chartDir:                "chartDir",
 		chartNamespace:          "chartNS",
-		allowsNamespaceOverride: true,
+		ignoreNamespaceOverride: true,
 		valuesFile:              "valuesFile",
 	}
 

--- a/operator/scripts/install/2-install-system-components.sh
+++ b/operator/scripts/install/2-install-system-components.sh
@@ -129,14 +129,7 @@ function install_cert_manager()
     helm upgrade cert-manager ${CERT_MANAGER_CHART_DIR} \
         --install \
         --namespace cert-manager \
-        --set image.repository=$CERT_MANAGER_IMAGE \
-        --set image.tag=$CERT_MANAGER_TAG \
-        --set extraArgs[0]=--acme-http01-solver-image=$CERT_MANAGER_SOLVER_IMAGE:$CERT_MANAGER_SOLVER_TAG \
-        --set cainjector.enabled=false \
-        --set webhook.enabled=false \
-        --set webhook.injectAPIServerCA=false \
-        --set ingressShim.defaultIssuerName=verrazzano-cluster-issuer \
-        --set ingressShim.defaultIssuerKind=ClusterIssuer \
+        -f $SCRIPT_DIR/components/cert-manager-values.yaml \
         ${EXTRA_CERT_MANAGER_ARGUMENTS} \
         --wait \
         || return $?

--- a/operator/scripts/install/common.sh
+++ b/operator/scripts/install/common.sh
@@ -220,11 +220,6 @@ command -v curl >/dev/null 2>&1 || {
 GLOBAL_HUB_REPO=ghcr.io/verrazzano
 GLOBAL_IMAGE_PULL_SECRET=verrazzano-container-registry
 
-CERT_MANAGER_IMAGE=ghcr.io/verrazzano/cert-manager-controller
-CERT_MANAGER_TAG=0.13.1-20201016205232-4c8f3fe38
-CERT_MANAGER_SOLVER_IMAGE=ghcr.io/verrazzano/cert-manager-acmesolver
-CERT_MANAGER_SOLVER_TAG=0.13.1-20201016205234-4c8f3fe38
-
 GRAFANA_REPO=ghcr.io/verrazzano/grafana
 GRAFANA_TAG=v6.4.4
 

--- a/operator/scripts/install/components/cert-manager-values.yaml
+++ b/operator/scripts/install/components/cert-manager-values.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+#local EXTRA_CERT_MANAGER_ARGUMENTS=""
+#if [ "$CERT_ISSUER_TYPE" == "ca" ]; then
+#EXTRA_CERT_MANAGER_ARGUMENTS="--set clusterResourceNamespace=$(get_config_value ".certificates.ca.clusterResourceNamespace")"
+#fi
+#
+#helm upgrade cert-manager ${CERT_MANAGER_CHART_DIR} \
+#--install \
+#--namespace cert-manager \
+#--set image.repository=$CERT_MANAGER_IMAGE \
+#--set image.tag=$CERT_MANAGER_TAG \
+#--set extraArgs[0]=--acme-http01-solver-image=$CERT_MANAGER_SOLVER_IMAGE:$CERT_MANAGER_SOLVER_TAG \
+#--set cainjector.enabled=false \
+#--set webhook.enabled=false \
+#--set webhook.injectAPIServerCA=false \
+#--set ingressShim.defaultIssuerName=verrazzano-cluster-issuer \
+#--set ingressShim.defaultIssuerKind=ClusterIssuer \
+#${EXTRA_CERT_MANAGER_ARGUMENTS} \
+#--wait \
+#|| return $?
+#
+
+#  CERT_MANAGER_IMAGE=ghcr.io/verrazzano/cert-manager-controller
+#  CERT_MANAGER_TAG=0.13.1-20201016205232-4c8f3fe38
+#  CERT_MANAGER_SOLVER_IMAGE=ghcr.io/verrazzano/cert-manager-acmesolver
+#  CERT_MANAGER_SOLVER_TAG=0.13.1-20201016205234-4c8f3fe38
+
+image:
+  repository: ghcr.io/verrazzano/cert-manager-controller
+  tag: 0.13.1-20201016205232-4c8f3fe38
+
+webhook:
+  enabled: false
+  injectAPIServerCA: false
+
+cainjector:
+  enabled: false
+
+ingressShim:
+  defaultIssuerName: verrazzano-cluster-issuer
+  defaultIssuerKind: ClusterIssuer
+
+extraArgs:
+  - --acme-http01-solver-image=ghcr.io/verrazzano/cert-manager-acmesolver:0.13.1-20201016205234-4c8f3fe38

--- a/operator/scripts/install/components/cert-manager-values.yaml
+++ b/operator/scripts/install/components/cert-manager-values.yaml
@@ -1,32 +1,6 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-#local EXTRA_CERT_MANAGER_ARGUMENTS=""
-#if [ "$CERT_ISSUER_TYPE" == "ca" ]; then
-#EXTRA_CERT_MANAGER_ARGUMENTS="--set clusterResourceNamespace=$(get_config_value ".certificates.ca.clusterResourceNamespace")"
-#fi
-#
-#helm upgrade cert-manager ${CERT_MANAGER_CHART_DIR} \
-#--install \
-#--namespace cert-manager \
-#--set image.repository=$CERT_MANAGER_IMAGE \
-#--set image.tag=$CERT_MANAGER_TAG \
-#--set extraArgs[0]=--acme-http01-solver-image=$CERT_MANAGER_SOLVER_IMAGE:$CERT_MANAGER_SOLVER_TAG \
-#--set cainjector.enabled=false \
-#--set webhook.enabled=false \
-#--set webhook.injectAPIServerCA=false \
-#--set ingressShim.defaultIssuerName=verrazzano-cluster-issuer \
-#--set ingressShim.defaultIssuerKind=ClusterIssuer \
-#${EXTRA_CERT_MANAGER_ARGUMENTS} \
-#--wait \
-#|| return $?
-#
-
-#  CERT_MANAGER_IMAGE=ghcr.io/verrazzano/cert-manager-controller
-#  CERT_MANAGER_TAG=0.13.1-20201016205232-4c8f3fe38
-#  CERT_MANAGER_SOLVER_IMAGE=ghcr.io/verrazzano/cert-manager-acmesolver
-#  CERT_MANAGER_SOLVER_TAG=0.13.1-20201016205234-4c8f3fe38
-
 image:
   repository: ghcr.io/verrazzano/cert-manager-controller
   tag: 0.13.1-20201016205232-4c8f3fe38


### PR DESCRIPTION
Enable patch-level upgrades for cert-manager.

AT: https://build.verrazzano.io/blue/organizations/jenkins/verrazzano-kind-acceptance-tests/detail/mcico%2Fvz-1878-patch-certmgr/1/pipeline