### PR TITLE
Promote new verrazzano-operator image

### DIFF
--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -29,8 +29,8 @@ elasticSearch:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
-  imageVersion: 0.8.0-20210112030707-adbddb2
+  imageName: ghcr.io/verrazzano/verrazzano-operator
+  imageVersion: 0.8.0-20210112141335-3e71377
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.8.0-20201218184638-ae25fcc
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.8.0-20201218185017-e613ee2
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.8.0-20201218184908-e3e3dd3

--- a/operator/scripts/install/chart/values.yaml
+++ b/operator/scripts/install/chart/values.yaml
@@ -29,8 +29,8 @@ elasticSearch:
 
 verrazzanoOperator:
   name: verrazzano-operator
-  imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.8.0-20201223143759-ba517ea
+  imageName: ghcr.io/verrazzano/verrazzano-operator-jenkins
+  imageVersion: 0.8.0-20210112030707-adbddb2
   cohMicroImage: ghcr.io/verrazzano/verrazzano-coh-cluster-operator:0.8.0-20201218184638-ae25fcc
   helidonMicroImage: ghcr.io/verrazzano/verrazzano-helidon-app-operator:0.8.0-20201218185017-e613ee2
   wlsMicroImage: ghcr.io/verrazzano/verrazzano-wko-operator:0.8.0-20201218184908-e3e3dd3


### PR DESCRIPTION
This PR picks up a new version of the verrazzano-operator image, from VZ-1947, which contains a small fix to deduplicate secrets lists in the domain configuration. 