### PR TITLE
Add -v 1 to kind create in integ-test targets to get debug details

### DIFF
--- a/oam-application-operator/Makefile
+++ b/oam-application-operator/Makefile
@@ -204,7 +204,7 @@ ifdef JENKINS_URL
 	./build/scripts/cleanup.sh ${CLUSTER_NAME}
 endif
 	echo 'Create cluster...'
-	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster \
+	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster -v 1 \
 		--name ${CLUSTER_NAME} \
 		--wait 5m \
 		--config=test/kind-config.yaml

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -195,7 +195,7 @@ ifdef JENKINS_URL
 	./build/scripts/cleanup.sh ${CLUSTER_NAME}
 endif
 	echo 'Create cluster...'
-	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster \
+	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster -v 1 \
 		--name ${CLUSTER_NAME} \
 		--wait 5m \
 		--config=test/kind-config.yaml


### PR DESCRIPTION
Add -v 1 to the KIND create in integ-test targets to get debug stack details for the intermittent issues that we are seeing recently. VZ-1934