### PR TITLE
fluentd sidecar of helidon

### DIFF
--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -1,0 +1,402 @@
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package loggingscope
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kapps "k8s.io/api/apps/v1"
+	kcore "k8s.io/api/core/v1"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	helidonWorkloadKey = "core.oam.dev/v1alpha2/ContainerizedWorkload"
+	volumeVarlog       = "varlog"
+	volumeData         = "datadockercontainers"
+	volumeConf         = "fluentd-config-volume"
+)
+
+// HelidonFluentdConfiguration FLUENTD rules for reading/parsing generic component log files
+const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
+  <match fluent.*>
+    @type stdout
+  </match>
+</label>
+<source>
+  @type tail
+  path "/var/log/containers/#{ENV['APPLICATION_NAME']}*#{ENV['APP_CONTAINER_NAME']}*.log"
+  pos_file "/tmp/#{ENV['APPLICATION_NAME']}.log.pos"
+  read_from_head true
+  tag "#{ENV['APPLICATION_NAME']}"
+  # Helidon application messages are expected to look like this:
+  # 2020.04.22 16:09:21 INFO org.books.bobby.Main Thread[main,5,main]: http://localhost:8080/books
+  <parse>
+    @type multi_format
+    <pattern>
+      # Docker output
+      format json
+      time_format %Y-%m-%dT%H:%M:%S.%NZ
+    </pattern>
+    <pattern>
+      # cri-o output
+      format regexp
+      expression /^(?<timestamp>(.*?)) (?<stream>stdout|stderr) (?<log>.*)$/
+      time_format %Y-%m-%dT%H:%M:%S.%N%:z
+    </pattern>
+  </parse>
+</source>
+<filter **>
+  @type parser
+  key_name log
+  <parse>
+    @type grok
+    <grok>
+      name helidon-pattern
+      pattern %{DATESTAMP:timestamp} %{DATA:loglevel} %{DATA:subsystem} %{DATA:thread} %{GREEDYDATA:message}
+    </grok>
+    <grok>
+      name coherence-pattern
+      pattern %{DATESTAMP:timestamp}/%{NUMBER:increment} %{DATA:subsystem} <%{DATA:loglevel}> (%{DATA:thread}): %{GREEDYDATA:message}
+    </grok>
+    <grok>
+      name catchall-pattern
+      pattern %{GREEDYDATA:message}
+    </grok>
+	time_key timestamp
+	keep_time_key true
+  </parse>
+</filter>
+<filter **>
+  @type record_transformer
+  <record>
+    applicationName "#{ENV['APPLICATION_NAME']}"
+  </record>
+</filter>
+<match **>
+  @type elasticsearch
+  host "#{ENV['ELASTICSEARCH_HOST']}"
+  port "#{ENV['ELASTICSEARCH_PORT']}"
+  user "#{ENV['ELASTICSEARCH_USER']}"
+  password "#{ENV['ELASTICSEARCH_PASSWORD']}"
+  index_name "#{ENV['ELASTICSEARCH_APP_INDEX']}"
+  scheme http
+  include_timestamp true
+  flush_interval 10s
+</match>
+`
+
+// HelidonHandler injects FLUENTD sidecar container for generic Kubernetes Deployment
+type HelidonHandler struct {
+	client.Client
+	Log logr.Logger
+}
+
+// Apply applies a logging scope to a Kubernetes Deployment
+func (h *HelidonHandler) Apply(ctx context.Context, workload vzapi.QualifiedResourceRelation, scope *vzapi.LoggingScope) error {
+	deploy, err := h.getDeployment(ctx, workload, scope)
+	if err != nil {
+		h.Log.Error(err, "Failed to fetch Deployment", "Deployment", workload.Name)
+		return err
+	}
+	appContainer, fluentdFound := searchContainers(deploy.Spec.Template.Spec.Containers)
+	if !fluentdFound {
+		err := h.ensureFluentdConfigMap(ctx, scope.GetNamespace(), workload.Name)
+		if err != nil {
+			return err
+		}
+		err = h.ensureEsSecret(ctx, scope.GetNamespace(), scope.Spec.SecretName)
+		if err != nil {
+			return err
+		}
+		volumes := CreateFluentdHostPathVolumes()
+		for _, volume := range volumes {
+			deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, volume)
+		}
+		deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, CreateFluentdConfigMapVolume(workload.Name))
+		fluentdContainer := CreateFluentdContainer(workload.Namespace, workload.Name, appContainer, scope.Spec.FluentdImage, scope.Spec.SecretName, scope.Spec.ElasticSearchHost)
+		deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, fluentdContainer)
+		err = h.Update(ctx, deploy)
+		if err != nil {
+			h.Log.V(1).Info("Update Deployment", "Deployment", deploy.Name, "error", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func searchContainers(containers []kcore.Container) (string, bool) {
+	var appContainer string
+	fluentdFound := false
+	for _, container := range containers {
+		if container.Name == fluentdContainerName {
+			fluentdFound = true
+		} else {
+			appContainer = container.Name
+		}
+	}
+	return appContainer, fluentdFound
+}
+
+// Remove removes a logging scope from a Kubernetes Deployment
+func (h *HelidonHandler) Remove(ctx context.Context, workload vzapi.QualifiedResourceRelation, scope *vzapi.LoggingScope) (bool, error) {
+	deploy, err := h.getDeployment(ctx, workload, scope)
+	if err != nil {
+		h.Log.Error(err, "Failed to fetch Deployment", "Deployment", workload.Name)
+		return kerrs.IsNotFound(err), err
+	}
+	_, fluentdFound := searchContainers(deploy.Spec.Template.Spec.Containers)
+	var errors []string
+	if fluentdFound {
+		err := h.deleteFluentdConfigMap(ctx, scope.GetNamespace(), workload.Name)
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+		existingValumes := deploy.Spec.Template.Spec.Volumes
+		deploy.Spec.Template.Spec.Volumes = []kcore.Volume{}
+		for _, vol := range existingValumes {
+			if vol.Name != volumeVarlog && vol.Name != volumeData && vol.Name != volumeConf {
+				deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, vol)
+			}
+		}
+		existingContainers := deploy.Spec.Template.Spec.Containers
+		deploy.Spec.Template.Spec.Containers = []kcore.Container{}
+		for _, container := range existingContainers {
+			if container.Name != fluentdContainerName {
+				deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, container)
+			}
+		}
+		if err := h.Update(ctx, deploy); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if errors != nil {
+		return false, fmt.Errorf(strings.Join(errors, "\n"))
+	}
+	return true, nil
+}
+
+// getDeployment gets the Kubernetes Deployment
+func (h *HelidonHandler) getDeployment(ctx context.Context, workload vzapi.QualifiedResourceRelation, scope *vzapi.LoggingScope) (*kapps.Deployment, error) {
+	deploy := &kapps.Deployment{}
+	deploy.Namespace = scope.GetNamespace()
+	deploy.Name = workload.Name
+	depKey := client.ObjectKey{Name: workload.Name, Namespace: scope.GetNamespace()}
+	if err := h.Get(ctx, depKey, deploy); err != nil {
+		return nil, err
+	}
+	return deploy, nil
+}
+
+// CreateFluentdConfigMap creates the FLUENTD configmap for a given OAM application
+func CreateFluentdConfigMap(namespace, name, fluentdConfig string) *kcore.ConfigMap {
+	return &kcore.ConfigMap{
+		ObjectMeta: kmeta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: func() map[string]string {
+			var data map[string]string
+			data = make(map[string]string)
+			data[fluentdConfKey] = fluentdConfig
+			return data
+		}(),
+	}
+}
+
+// CreateFluentdContainer creates a FLUENTD sidecar container.
+func CreateFluentdContainer(namespace, appName, containerName, fluentdImage, esSecret, esHost string) kcore.Container {
+	container := kcore.Container{
+		Name:            fluentdContainerName,
+		Args:            []string{"-c", "/etc/fluent.conf"},
+		Image:           fluentdImage,
+		ImagePullPolicy: kcore.PullIfNotPresent,
+		Env: []kcore.EnvVar{
+			{
+				Name:  "APPLICATION_NAME",
+				Value: appName,
+			},
+			{
+				Name:  "APP_CONTAINER_NAME",
+				Value: containerName,
+			},
+			{
+				Name:  "FLUENTD_CONF",
+				Value: fluentdConfKey,
+			},
+			{
+				Name:  "FLUENT_ELASTICSEARCH_SED_DISABLE",
+				Value: "true",
+			},
+			{
+				Name:  "ELASTICSEARCH_APP_INDEX",
+				Value: fmt.Sprintf("%s_%s", namespace, appName),
+			},
+			{
+				Name:  "ELASTICSEARCH_HOST",
+				Value: esHost,
+			},
+			{
+				Name:  "ELASTICSEARCH_PORT",
+				Value: "9200",
+			},
+			{
+				Name: "ELASTICSEARCH_USER",
+				ValueFrom: &kcore.EnvVarSource{
+					SecretKeyRef: &kcore.SecretKeySelector{
+						LocalObjectReference: kcore.LocalObjectReference{
+							Name: esSecret,
+						},
+						Key: "username",
+						Optional: func(opt bool) *bool {
+							return &opt
+						}(true),
+					},
+				},
+			},
+			{
+				Name: "ELASTICSEARCH_PASSWORD",
+				ValueFrom: &kcore.EnvVarSource{
+					SecretKeyRef: &kcore.SecretKeySelector{
+						LocalObjectReference: kcore.LocalObjectReference{
+							Name: esSecret,
+						},
+						Key: "password",
+						Optional: func(opt bool) *bool {
+							return &opt
+						}(true),
+					},
+				},
+			},
+		},
+		VolumeMounts: []kcore.VolumeMount{
+			{
+				MountPath: "/fluentd/etc/fluentd.conf",
+				Name:      volumeConf,
+				SubPath:   fluentdConfKey,
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/var/log",
+				Name:      volumeVarlog,
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/u01/data/docker/containers",
+				Name:      volumeData,
+				ReadOnly:  true,
+			},
+		},
+	}
+
+	return container
+}
+
+// CreateFluentdHostPathVolumes creates hostPath volumes to access container logs.
+func CreateFluentdHostPathVolumes() []kcore.Volume {
+	return []kcore.Volume{
+		{
+			Name: volumeVarlog,
+			VolumeSource: kcore.VolumeSource{
+				HostPath: &kcore.HostPathVolumeSource{
+					Path: "/var/log",
+				},
+			},
+		},
+		{
+			Name: volumeData,
+			VolumeSource: kcore.VolumeSource{
+				HostPath: &kcore.HostPathVolumeSource{
+					Path: "/u01/data/docker/containers",
+				},
+			},
+		},
+	}
+}
+
+// CreateFluentdConfigMapVolume create a config map volume for FLUENTD.
+func CreateFluentdConfigMapVolume(appName string) kcore.Volume {
+	return kcore.Volume{
+		Name: volumeConf,
+		VolumeSource: kcore.VolumeSource{
+			ConfigMap: &kcore.ConfigMapVolumeSource{
+				LocalObjectReference: kcore.LocalObjectReference{
+					Name: fluentdConfigMapName(appName),
+				},
+				DefaultMode: func(mode int32) *int32 {
+					return &mode
+				}(420),
+			},
+		},
+	}
+}
+
+// fluentdConfigMapName returns the name of a components FLUENTD config map
+func fluentdConfigMapName(appName string) string {
+	return fmt.Sprintf("%s-fluentd", appName)
+}
+
+func replicateVmiSecret(vmiSec *kcore.Secret, namespace, name string) *kcore.Secret {
+	sec := &kcore.Secret{
+		ObjectMeta: kmeta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: vmiSec.Data,
+	}
+	return sec
+}
+
+func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, appName string) error {
+	// check if configmap exists
+	name := fluentdConfigMapName(appName)
+	configMap := &kcore.ConfigMap{}
+	err := h.Get(ctx, objKey(namespace, name), configMap)
+	if kerrs.IsNotFound(err) {
+		if err = h.Create(ctx, CreateFluentdConfigMap(namespace, name, HelidonFluentdConfiguration), &client.CreateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
+}
+func (h *HelidonHandler) deleteFluentdConfigMap(ctx context.Context, namespace, appName string) error {
+	name := fluentdConfigMapName(appName)
+	configMap := &kcore.ConfigMap{}
+	err := h.Get(ctx, objKey(namespace, name), configMap)
+	if !kerrs.IsNotFound(err) || err == nil {
+		return h.Delete(ctx, configMap)
+	}
+	return err
+}
+
+func (h *HelidonHandler) ensureEsSecret(ctx context.Context, namespace, name string) error {
+	secret := &kcore.Secret{}
+	err := h.Get(ctx, objKey(namespace, name), secret)
+	if kerrs.IsNotFound(err) {
+		secretKey := client.ObjectKey{Name: "verrazzano", Namespace: "verrazzano-system"}
+		err = h.Get(ctx, secretKey, secret)
+		if err != nil {
+			return err
+		}
+		secret = replicateVmiSecret(secret, namespace, name)
+		if err = h.Create(ctx, secret, &client.CreateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
+}
+
+func objKey(namespace, name string) client.ObjectKey {
+	return client.ObjectKey{Name: name, Namespace: namespace}
+}

--- a/application-operator/controllers/loggingscope/helidon_test.go
+++ b/application-operator/controllers/loggingscope/helidon_test.go
@@ -1,0 +1,268 @@
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package loggingscope
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
+
+	kcore "k8s.io/api/core/v1"
+
+	"github.com/golang/mock/gomock"
+	asserts "github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+
+	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	kapps "k8s.io/api/apps/v1"
+	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TestHelidoHandlerApply tests the creation of the FLUENTD sidecard in the application pod
+// GIVEN an application workload referred in a loggingScope
+// WHEN Apply is called
+// THEN ensure that the expected FLUENTD sidecar container is created
+func TestHelidoHandlerApply(t *testing.T) {
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+	namespace := "hello-ns"
+	appName := "hello-workload"
+	appContainerName := "testApply-app-container"
+	esSecretName := "myEsSecret"
+	workload := workloadOf(namespace, appName)
+	scope := newLoggingScope(namespace, "esHost", esSecretName)
+
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: appName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deploy *kapps.Deployment) error {
+			appContainer := kcore.Container{Name: appContainerName, Image: "test-app-container-image"}
+			deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, appContainer)
+			return nil
+		})
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: fluentdConfigMapName(appName)}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, obj *kcore.ConfigMap) error {
+			return kerrs.NewNotFound(schema.ParseGroupResource("v1.ConfigMap"), fluentdConfigMapName(appName))
+		})
+	mockClient.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, conf *kcore.ConfigMap, opt *client.CreateOptions) error {
+			return nil
+		})
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: esSecretName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, obj *kcore.Secret) error {
+			return kerrs.NewNotFound(schema.ParseGroupResource("v1.ConfigMap"), fluentdConfigMapName(appName))
+		})
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "verrazzano"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *kcore.Secret) error {
+			vmiSecret(sec)
+			return nil
+		})
+	mockClient.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, sec *kcore.Secret, opt *client.CreateOptions) error {
+			return nil
+		})
+	mockClient.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, dep *kapps.Deployment) error {
+			appCon, fluentdFound := searchContainers(dep.Spec.Template.Spec.Containers)
+			asserts.Equal(t, appContainerName, appCon)
+			asserts.True(t, fluentdFound)
+			return nil
+		})
+
+	h := &HelidonHandler{
+		Client: mockClient,
+		Log:    log.NullLogger{},
+	}
+	err := h.Apply(context.Background(), workload, scope)
+	asserts.Nil(t, err)
+}
+
+// TestHelidoHandlerRemove tests the removal of the FLUENTD sidecard in the application pod
+// GIVEN an application workload referred in a loggingScope
+// WHEN Remove is called
+// THEN ensure that the expected FLUENTD sidecar container is removed
+func TestHelidoHandlerRemove(t *testing.T) {
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+	namespace := "hello-ns"
+	appName := "hello-workload"
+	esSecretName := "myEsSecret"
+	appContainerName := "testDelete-app-container"
+	workload := workloadOf(namespace, appName)
+	scope := newLoggingScope(namespace, "esHost", esSecretName)
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: appName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deploy *kapps.Deployment) error {
+			appContainer := kcore.Container{Name: appContainerName, Image: "test-app-container-image"}
+			fluentdContainer := CreateFluentdContainer(workload.Namespace, workload.Name, "appContainer", scope.Spec.FluentdImage, scope.Spec.SecretName, scope.Spec.ElasticSearchHost)
+			deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, appContainer, fluentdContainer)
+			vol := kcore.Volume{
+				Name: "app-volume",
+				VolumeSource: kcore.VolumeSource{
+					HostPath: &kcore.HostPathVolumeSource{
+						Path: "/var/log",
+					},
+				},
+			}
+			deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, vol, CreateFluentdConfigMapVolume(workload.Name))
+			volumes := CreateFluentdHostPathVolumes()
+			for _, volume := range volumes {
+				deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, volume)
+			}
+			return nil
+		})
+
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: fluentdConfigMapName(appName)}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, obj *kcore.ConfigMap) error {
+			return nil
+		})
+	mockClient.EXPECT().
+		Delete(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, conf *kcore.ConfigMap) error {
+			return nil
+		})
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: esSecretName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, obj *kcore.Secret) error {
+			return kerrs.NewNotFound(schema.ParseGroupResource("v1.ConfigMap"), fluentdConfigMapName(appName))
+		})
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "verrazzano"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *kcore.Secret) error {
+			vmiSecret(sec)
+			return nil
+		})
+	mockClient.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, sec *kcore.Secret, opt *client.CreateOptions) error {
+			return nil
+		})
+	mockClient.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, dep *kapps.Deployment) error {
+			appCon, fluentdFound := searchContainers(dep.Spec.Template.Spec.Containers)
+			asserts.Equal(t, appContainerName, appCon)
+			asserts.False(t, fluentdFound)
+			asserts.Equal(t, 1, len(dep.Spec.Template.Spec.Volumes))
+			return nil
+		})
+
+	h := &HelidonHandler{
+		Client: mockClient,
+		Log:    log.NullLogger{},
+	}
+	removed, err := h.Remove(context.Background(), workload, scope)
+	asserts.True(t, removed)
+	asserts.Nil(t, err)
+}
+
+func workloadOf(namespace, appName string) vzapi.QualifiedResourceRelation {
+	return vzapi.QualifiedResourceRelation{
+		APIVersion: "core.oam.dev/v1alpha2",
+		Name:       appName,
+		Namespace:  namespace,
+		Kind:       "ContainerizedWorkload",
+	}
+}
+
+// TestHelidoHandlerApply tests the creation of the FLUENTD sidecard failed with missing deployment
+// GIVEN an application workload referred in a loggingScope
+// WHEN Apply is called
+// THEN ensure that Apply call returns a error
+func TestHelidoHandlerApplyNoDeployment(t *testing.T) {
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+	namespace := "hello-ns"
+	appName := "hello-workload"
+	esSecretName := "myEsSecret"
+	workload := workloadOf(namespace, appName)
+	scope := newLoggingScope(namespace, "esHost", esSecretName)
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: appName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deploy *kapps.Deployment) error {
+			return kerrs.NewNotFound(schema.ParseGroupResource("v1.Deployment"), appName)
+		})
+	h := &HelidonHandler{
+		Client: mockClient,
+		Log:    log.NullLogger{},
+	}
+	err := h.Apply(context.Background(), workload, scope)
+	asserts.NotNil(t, err)
+	asserts.True(t, kerrs.IsNotFound(err))
+}
+
+// TestHelidoHandlerRemoveNoDeployment tests removal of the FLUENTD sidecard failed with missing deployment
+// GIVEN an application workload referred in a loggingScope
+// WHEN Remove is called
+// THEN ensure that Remove call returns a error
+func TestHelidoHandlerRemoveNoDeployment(t *testing.T) {
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+	namespace := "hello-ns"
+	appName := "hello-workload"
+	esSecretName := "myEsSecret"
+	workload := workloadOf(namespace, appName)
+	scope := newLoggingScope(namespace, "esHost", esSecretName)
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: appName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deploy *kapps.Deployment) error {
+			return kerrs.NewNotFound(schema.ParseGroupResource("v1.Deployment"), appName)
+		})
+	h := &HelidonHandler{
+		Client: mockClient,
+		Log:    log.NullLogger{},
+	}
+	removed, err := h.Remove(context.Background(), workload, scope)
+	asserts.NotNil(t, err)
+	asserts.True(t, removed)
+	asserts.True(t, kerrs.IsNotFound(err))
+}
+
+// newLoggingScope creates a test logging scope
+func newLoggingScope(namespace, esHost, esSecret string) *vzapi.LoggingScope {
+	scope := vzapi.LoggingScope{}
+	scope.TypeMeta = kmeta.TypeMeta{APIVersion: vzapi.GroupVersion.Identifier(), Kind: vzapi.LoggingScopeKind}
+	scope.ObjectMeta = kmeta.ObjectMeta{Namespace: namespace, Name: "testScopeName"}
+	scope.Spec.ElasticSearchHost = esHost
+	scope.Spec.ElasticSearchPort = 9200
+	scope.Spec.SecretName = esSecret
+	scope.Spec.FluentdImage = "fluentd/image/location"
+	return &scope
+}
+
+func vmiSecret(sec *kcore.Secret) *kcore.Secret {
+	sec.Name = "verrazzano"
+	sec.Namespace = "verrazzano-system"
+	sec.Data = map[string][]byte{
+		"username": []byte("verrazzano"),
+		"password": []byte(genPassword(10)),
+	}
+	return sec
+}
+
+var passwordChars = []rune("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func genPassword(passSize int) string {
+	rand.Seed(time.Now().UnixNano())
+	var b strings.Builder
+	for i := 0; i < passSize; i++ {
+		b.WriteRune(passwordChars[rand.Intn(len(passwordChars))])
+	}
+	return b.String()
+}

--- a/application-operator/controllers/loggingscope/loggingscope_controller_test.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller_test.go
@@ -5,6 +5,10 @@ package loggingscope
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
@@ -19,8 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strconv"
-	"testing"
 )
 
 const (
@@ -246,7 +248,7 @@ func createTestLoggingScopeRequest() ctrl.Request {
 // newTestReconciler creates a new test reconciler
 func newTestReconciler(client client.Client, scheme *runtime.Scheme, handler Handler) *Reconciler {
 	reconciler := NewReconciler(client, ctrl.Log.WithName("controllers").WithName("LoggingScope"), scheme)
-	reconciler.Handlers[testKind] = handler
+	reconciler.Handlers[fmt.Sprintf("%s/%s", testAPIVersion, testKind)] = handler
 
 	return reconciler
 }

--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -6,6 +6,7 @@ package loggingscope
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	wls "github.com/verrazzano/verrazzano-crd-generator/pkg/apis/weblogic/v8"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
@@ -16,6 +17,7 @@ import (
 
 const (
 	wlsDomainKind     = "Domain"
+	wlsWorkloadKey    = "weblogic.oracle/v8/Domain"
 	storageVolumeName = "weblogic-domain-storage-volume"
 )
 

--- a/application-operator/test/integ/k8s/resource.go
+++ b/application-operator/test/integ/k8s/resource.go
@@ -72,6 +72,25 @@ func (c Client) DoesPodExist(name string, namespace string) bool {
 	return (c.getPod(name, namespace) != nil)
 }
 
+// DoesContainerExist returns true if a container with the given name exists in the pod
+func (c Client) DoesContainerExist(namespace, podName, containerName string) bool {
+	pods, err := c.clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		ginkgo.Fail("Could not get list of pods" + err.Error())
+		return false
+	}
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, podName) {
+			for _, container := range pod.Status.ContainerStatuses {
+				if container.Name == containerName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // IsPodRunning returns true if a Pod with the given prefix is running
 func (c Client) IsPodRunning(name string, namespace string) bool {
 	pod := c.getPod(name, namespace)


### PR DESCRIPTION
* loggingscope adds logging sidecar to generated k8s Deployment of containerized workload (ex. Helidon application) to send logs to system VMI Elasticsearch
* changed the index pattern to include namespace prefix

filed VZ-2016 to refactor OAM logging handlers to share common codes