### PR TITLE
VZ-2011: use a more generic namespace label selector for oam based weblogic workloads

### DIFF
--- a/oam-application-operator/examples/bobs-books/README.md
+++ b/oam-application-operator/examples/bobs-books/README.md
@@ -28,10 +28,10 @@ Alternatively, you can specify the credentials in environment variables: `GHCR_U
 
 ## Detailed Steps Description
 
-1. Create the namespace and apply the `verrazzano-domain` label.
+1. Create the namespace and apply the `verrazzano-managed` label.
     ```
     kubectl create namespace bobs-books
-    kubectl label namespaces bobs-books verrazzano-domain=true
+    kubectl label namespaces bobs-books verrazzano-managed=true
     ```
 
 1. Create a secret for the Oracle Container Registry using your credentials.

--- a/oam-application-operator/examples/bobs-books/install-bobs-books.sh
+++ b/oam-application-operator/examples/bobs-books/install-bobs-books.sh
@@ -13,7 +13,7 @@ OCR_PASS="${4:-$OCR_PASS}"
 GHCR_SERVER="ghcr.io"
 OCR_SERVER="container-registry.oracle.com"
 NAMESPACE="bobs-books"
-NAMESPACE_LABEL="verrazzano-domain"
+NAMESPACE_LABEL="verrazzano-managed"
 GHCR_SECRET="github-packages"
 OCR_SECRET="ocr"
 

--- a/oam-application-operator/examples/todo/README.md
+++ b/oam-application-operator/examples/todo/README.md
@@ -11,7 +11,7 @@ ToDo List is a demo application which contains a WebLogic component and an Ingre
 1. Create a namespace for the ToDo example.  Mark it as a domain namespace for the WebLogic operator that was deployed in the verrazzano-application-operator install above.
    ```
    kubectl create namespace todo
-   kubectl label namespace todo verrazzano-domain=true
+   kubectl label namespace todo verrazzano-managed=true
    ```
 
 1. Create a `docker-registry` secret to enable pulling the ToDo example image.

--- a/oam-application-operator/examples/todo/install-todo.sh
+++ b/oam-application-operator/examples/todo/install-todo.sh
@@ -49,7 +49,7 @@ status=$(kubectl get namespace ${NAMESPACE} -o jsonpath="{.status.phase}" 2> /de
 if [ "${status}" == "Active" ]; then
   echo "Found namespace ${NAMESPACE}."
   echo "Ensuring namespace label exists."
-  kubectl label --overwrite namespace ${NAMESPACE} verrazzano-domain=true
+  kubectl label --overwrite namespace ${NAMESPACE} verrazzano-managed=true
   if [ $? -ne 0 ]; then
       echo "ERROR: Failed to label namespace ${NAMESPACE}, exiting."
       exit 1
@@ -61,7 +61,7 @@ else
       echo "ERROR: Failed to create namespace ${NAMESPACE}, exiting."
       exit 1
   fi
-  kubectl label namespace ${NAMESPACE} verrazzano-domain=true
+  kubectl label namespace ${NAMESPACE} verrazzano-managed=true
   if [ $? -ne 0 ]; then
       echo "ERROR: Failed to label namespace ${NAMESPACE}, exiting."
       exit 1

--- a/oam-application-operator/installer/scripts/2-install-wls-operator.sh
+++ b/oam-application-operator/installer/scripts/2-install-wls-operator.sh
@@ -31,7 +31,7 @@ function install_wls_operator {
   fi
 
   log "Install WebLogic Kubernetes operator"
-  helm install weblogic-operator $TMP_DIR/weblogic-kubernetes-operator/kubernetes/charts/weblogic-operator --namespace verrazzano-system --set image=oracle/weblogic-kubernetes-operator:3.1.0 --set serviceAccount=weblogic-operator-sa --set domainNamespaceSelectionStrategy=LabelSelector --set domainNamespaceLabelSelector=verrazzano-domain --set enableClusterRoleBinding=true --wait
+  helm install weblogic-operator $TMP_DIR/weblogic-kubernetes-operator/kubernetes/charts/weblogic-operator --namespace verrazzano-system --set image=oracle/weblogic-kubernetes-operator:3.1.0 --set serviceAccount=weblogic-operator-sa --set domainNamespaceSelectionStrategy=LabelSelector --set domainNamespaceLabelSelector=verrazzano-maanged --set enableClusterRoleBinding=true --wait
   if [ $? -ne 0 ]; then
     error "Failed to install WebLogic Kubernetes operator."
     return 1

--- a/operator/scripts/install/3-install-verrazzano.sh
+++ b/operator/scripts/install/3-install-verrazzano.sh
@@ -249,7 +249,7 @@ function install_weblogic_operator {
     --set image="${WEBLOGIC_OPERATOR_IMAGE_REPO}:${WEBLOGIC_OPERATOR_IMAGE_TAG}" \
     --set serviceAccount=weblogic-operator-sa \
     --set domainNamespaceSelectionStrategy=LabelSelector \
-    --set domainNamespaceLabelSelector=verrazzano-domain \
+    --set domainNamespaceLabelSelector=verrazzano-managed \
     --set enableClusterRoleBinding=true \
     || return $?
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Changes the namespace label the WebLogic operator watches to detect Domain CRs from `verrazzano-domain` to `verrazzano-managed`.  This is more future proof as this namespace label can then be used for other Verrazzano features that might apply for a given namespace.