### PR TITLE
Fix the path for config.sh and logging.sh in the install scripts for verrazzano examples

### DIFF
--- a/examples/hello-helidon/install-hello-world.sh
+++ b/examples/hello-helidon/install-hello-world.sh
@@ -6,7 +6,6 @@
 SCRIPT_DIR=$(cd $(dirname $0); pwd -P)
 . $SCRIPT_DIR/../../platform-operator/scripts/install/logging.sh
 . $SCRIPT_DIR/../../platform-operator/scripts/install/config.sh
-pabhat/fix-path-examples
 
 set -euo pipefail
 

--- a/examples/hello-helidon/install-hello-world.sh
+++ b/examples/hello-helidon/install-hello-world.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname $0); pwd -P)

--- a/examples/hello-helidon/install-hello-world.sh
+++ b/examples/hello-helidon/install-hello-world.sh
@@ -4,8 +4,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname $0); pwd -P)
-. $SCRIPT_DIR/../../operator/scripts/install/logging.sh
-. $SCRIPT_DIR/../../operator/scripts/install/config.sh
+. $SCRIPT_DIR/../../platform-operator/scripts/install/logging.sh
+. $SCRIPT_DIR/../../platform-operator/scripts/install/config.sh
+pabhat/fix-path-examples
 
 set -euo pipefail
 

--- a/examples/sock-shop/install-sock-shop.sh
+++ b/examples/sock-shop/install-sock-shop.sh
@@ -4,8 +4,8 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname $0); pwd -P)
-. $SCRIPT_DIR/../../operator/scripts/install/logging.sh
-. $SCRIPT_DIR/../../operator/scripts/install/config.sh
+. $SCRIPT_DIR/../../platform-operator/scripts/install/logging.sh
+. $SCRIPT_DIR/../../platform-operator/scripts/install/config.sh
 
 set -euo pipefail
 

--- a/examples/sock-shop/install-sock-shop.sh
+++ b/examples/sock-shop/install-sock-shop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname $0); pwd -P)


### PR DESCRIPTION
Fixed the path for config.sh and logging.sh in the install scripts of verrazzano examples.