### PR TITLE
Use consistent logging in platform-operator

### DIFF
--- a/platform-operator/controllers/component/component.go
+++ b/platform-operator/controllers/component/component.go
@@ -4,6 +4,7 @@
 package component
 
 import (
+	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -13,5 +14,5 @@ type Component interface {
 	Name() string
 
 	// Upgrade will upgrade the Verrazzano component specified in the CR.Version field
-	Upgrade(client clipkg.Client, namespace string) error
+	Upgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string) error
 }

--- a/platform-operator/controllers/component/helm_component_test.go
+++ b/platform-operator/controllers/component/helm_component_test.go
@@ -6,11 +6,13 @@ package component
 import (
 	"errors"
 	"fmt"
+	"os/exec"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
-	"os/exec"
+	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 )
 
 // helmFakeRunner is used to test helm without actually running an OS exec command
@@ -50,12 +52,12 @@ func TestUpgrade(t *testing.T) {
 	defer helm.SetDefaultRunner()
 	setUpgradeFunc(fakeUpgrade)
 	defer setDefaultUpgradeFunc()
-	err := comp.Upgrade(nil, "")
+	err := comp.Upgrade(zap.S(), nil, "")
 	assert.NoError(err, "Upgrade returned an error")
 }
 
 // fakeUpgrade verifies that the correct parameter values are passed to upgrade
-func fakeUpgrade(releaseName string, namespace string, chartDir string, overwriteYaml string) (stdout []byte, stderr []byte, err error) {
+func fakeUpgrade(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, overwriteYaml string) (stdout []byte, stderr []byte, err error) {
 	if releaseName != "release1" {
 		return []byte("error"), []byte(""), errors.New("Invalid release name")
 	}
@@ -76,7 +78,7 @@ func (r helmFakeRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err er
 	return []byte("success"), []byte(""), nil
 }
 
-func fakePreUpgrade(client clipkg.Client, release string, namespace string, chartDir string) error {
+func fakePreUpgrade(log *zap.SugaredLogger, client clipkg.Client, release string, namespace string, chartDir string) error {
 	if release != "release1" {
 		return fmt.Errorf("Incorrect release name %s", release)
 	}

--- a/platform-operator/controllers/component/istio.go
+++ b/platform-operator/controllers/component/istio.go
@@ -4,10 +4,9 @@
 package component
 
 import (
-	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -17,15 +16,13 @@ var deleteJobFunc = k8s.DeleteJob
 // PreUpgrade deletes the Istio Helm install job that may have been left over
 // from the previous install.  This must be done or the helm install will fail because the Istio
 // Helm post-hook won't be able to create the job
-func PreUpgrade(client clipkg.Client, _ string, namespace string, chartDir string) error {
-	var log = ctrl.Log.WithName("upgrade")
-
+func PreUpgrade(log *zap.SugaredLogger, client clipkg.Client, _ string, namespace string, chartDir string) error {
 	chart, err := helm.GetChartInfo(chartDir)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("Unable to get the chart from %s", chartDir))
+		log.Errorf("Unable to get the chart from %s: %v", chartDir, err)
 		return err
 	}
 	jobName := "istio-security-post-install-" + chart.Version
-	log.Info(fmt.Sprintf("Deleting Istio Helm post-install job %s", jobName))
+	log.Infof("Deleting Istio Helm post-install job %s", jobName)
 	return deleteJobFunc(client, jobName, namespace)
 }

--- a/platform-operator/controllers/component/istio_test.go
+++ b/platform-operator/controllers/component/istio_test.go
@@ -5,10 +5,12 @@ package component
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TestPreUpgrade tests the Istio preUpgrade function
@@ -20,7 +22,7 @@ func TestPreUpgrade(t *testing.T) {
 	deleteJobFunc = fakeDeleteJob
 
 	chartDir, _ := filepath.Abs("./testdata")
-	err := PreUpgrade(nil, "", "ns", chartDir)
+	err := PreUpgrade(zap.S(), nil, "", "ns", chartDir)
 	assert.NoError(err, "PreUpgrade returned an error")
 }
 

--- a/platform-operator/controllers/component/verrazzano.go
+++ b/platform-operator/controllers/component/verrazzano.go
@@ -5,6 +5,8 @@ package component
 
 import (
 	"path/filepath"
+
+	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -38,8 +40,8 @@ func (v Verrazzano) Name() string {
 // Upgrade is done by using the helm chart upgrade command.   This command will apply the latest chart
 // that is included in the operator image, while retaining any helm value overrides that were applied during
 // install.
-func (v Verrazzano) Upgrade(_ clipkg.Client, namespace string) error {
-	_, _, err := helm.Upgrade(vzReleaseName, resolveNamespace(namespace), VzChartDir(), "")
+func (v Verrazzano) Upgrade(log *zap.SugaredLogger, _ clipkg.Client, namespace string) error {
+	_, _, err := helm.Upgrade(log, vzReleaseName, resolveNamespace(namespace), VzChartDir(), "")
 	return err
 }
 

--- a/platform-operator/controllers/component/verrazzano_test.go
+++ b/platform-operator/controllers/component/verrazzano_test.go
@@ -4,11 +4,12 @@
 package component
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
 	"os/exec"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
+	"go.uber.org/zap"
 )
 
 // fakeRunner is used to test helm without actually running an OS exec command
@@ -35,7 +36,7 @@ func TestVzUpgrade(t *testing.T) {
 	vz := Verrazzano{}
 	helm.SetCmdRunner(fakeRunner{})
 	defer helm.SetDefaultRunner()
-	err := vz.Upgrade(nil, "")
+	err := vz.Upgrade(zap.S(), nil, "")
 	assert.NoError(err, "Upgrade returned an error")
 }
 

--- a/platform-operator/controllers/controller.go
+++ b/platform-operator/controllers/controller.go
@@ -65,7 +65,7 @@ func (r *VerrazzanoReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		}
 
 		// Error getting the verrazzano resource - don't requeue.
-		log.Error(err, "Failed to fetch verrazzano resource")
+		log.Errorf("Failed to fetch verrazzano resource: %v", err)
 		return reconcile.Result{}, err
 	}
 
@@ -476,7 +476,7 @@ func (r *VerrazzanoReconciler) setUninstallCondition(log *zap.SugaredLogger, job
 		// Update the job
 		err := r.Status().Update(context.TODO(), job)
 		if err != nil {
-			log.Error(err, "Failed to update uninstall job owner references")
+			log.Errorf("Failed to update uninstall job owner references: %v", err)
 			return err
 		}
 

--- a/platform-operator/controllers/upgrade.go
+++ b/platform-operator/controllers/upgrade.go
@@ -44,9 +44,9 @@ func (r *VerrazzanoReconciler) reconcileUpgrade(log *zap.SugaredLogger, req ctrl
 			log.Info("Dry run enabled, skipping upgrade")
 			break
 		}
-		err := comp.Upgrade(r, cr.Namespace)
+		err := comp.Upgrade(log, r, cr.Namespace)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("Error upgrading component %s", comp.Name()))
+			log.Errorf("Error upgrading component %s: %v", comp.Name(), err)
 			msg := fmt.Sprintf("Error upgrading component %s - %s\".  Error is %s", comp.Name(),
 				fmtGeneration(cr.Generation), err.Error())
 			err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeFailed)

--- a/platform-operator/internal/util/helm/helmcli_test.go
+++ b/platform-operator/internal/util/helm/helmcli_test.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +43,7 @@ func TestUpgrade(t *testing.T) {
 	SetCmdRunner(goodRunner{t: t})
 	defer SetDefaultRunner()
 
-	stdout, stderr, err := Upgrade(release, ns, chartdir, overrideYaml)
+	stdout, stderr, err := Upgrade(zap.S(), release, ns, chartdir, overrideYaml)
 	assert.NoError(err, "Upgrade returned an error")
 	assert.Len(stderr, 0, "Upgrade stderr should be empty")
 	assert.NotZero(stdout, "Upgrade stdout should not be empty")
@@ -56,7 +58,7 @@ func TestUpgradeFail(t *testing.T) {
 	SetCmdRunner(badRunner{t: t})
 	defer SetDefaultRunner()
 
-	stdout, stderr, err := Upgrade(release, ns, "", "")
+	stdout, stderr, err := Upgrade(zap.S(), release, ns, "", "")
 	assert.Error(err, "Upgrade should have returned an error")
 	assert.Len(stdout, 0, "Upgrade stdout should be empty")
 	assert.NotZero(stderr, "Upgrade stderr should not be empty")


### PR DESCRIPTION
This pull request changes the logging to consistently use the zap SugaredLogger and to use the same logger created in the Verrazzano controllers Reconcile function throughout the code.  All platform-operator log messages now contain the same fields: level, timestamp, caller, message and resource fields.