### PR TITLE
VZ-2044: Additional support for VerrazzanoCoherenceWorkload

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -184,6 +184,144 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 	assert.Equal(time.Duration(0), result.RequeueAfter)
 }
 
+// TestSuccessfullyCreateNewIngressForVerrazzanoWorkload tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that applies to a Verrazzano workload type
+// WHEN the trait exists but the ingress does not
+// THEN ensure that the workload is unwrapped and the trait is created.
+func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "VerrazzanoCoherenceWorkload",
+				Name:       "test-workload-name"}
+			return nil
+		})
+
+	containedName := "test-contained-workload-name"
+	containedResource := map[string]interface{}{
+		"apiVersion": "coherence.oracle.com/v1",
+		"kind":       "Coherence",
+		"metadata": map[string]interface{}{
+			"name": containedName,
+		},
+	}
+
+	// Expect a call to get the Verrazzano Coherence workload resource
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
+			workload.SetAPIVersion("oam.verrazzano.io/v1alpha1")
+			workload.SetKind("VerrazzanoCoherenceWorkload")
+			workload.SetNamespace(name.Namespace)
+			workload.SetName(name.Name)
+			unstructured.SetNestedMap(workload.Object, containedResource, "spec", "coherence")
+			return nil
+		})
+	// Expect a call to get the contained Coherence resource
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: containedName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
+			workload.SetUnstructuredContent(containedResource)
+			workload.SetNamespace(name.Namespace)
+			workload.SetUID("test-workload-uid")
+			return nil
+		})
+	// Expect a call to get the containerized workload resource definition
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "coherences.coherence.oracle.com"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
+			workloadDef.Namespace = name.Namespace
+			workloadDef.Name = name.Name
+			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
+				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
+				{APIVersion: "v1", Kind: "Service", Selector: nil},
+			}
+			return nil
+		})
+	// Expect a call to list the child Deployment resources of the Coherence workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("Deployment", list.GetKind())
+			return nil
+		})
+	// Expect a call to list the child Service resources of the Coherence workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("Service", list.GetKind())
+			return appendAsUnstructured(list, v1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "core.oam.dev/v1alpha2",
+						Kind:       "ContainerizedWorkload",
+						Name:       "test-workload-name",
+						UID:        "test-workload-uid",
+					}}}})
+		})
+	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-gw"}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-trait-name-rule-0-gw"))
+	// Expect a call to create the ingress resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclinet.Gateway, opts ...client.CreateOption) error {
+			return nil
+		})
+	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
+	// Expect a call to create the ingress resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, virtualservice *istioclinet.VirtualService, opts ...client.CreateOption) error {
+			return nil
+		})
+	// Expect a call to get the status writer and return a mock.
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	// Expect a call to update the status of the ingress trait.
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 2)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest("test-space", "test-trait-name")
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
 // TestFailureToGetWorkload tests the Reconcile method for the following use case.
 // GIVEN a request to reconcile an ingress trait resource
 // WHEN the workload related to the trait cannot be found

--- a/application-operator/controllers/loggingscope/loggingscope_controller.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller.go
@@ -22,6 +22,7 @@ import (
 	oamv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 )
 
 const (
@@ -81,7 +82,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 		handler := r.Handlers[handlerKey(resource)]
 		if handler == nil {
-			log.Error(nil, "Unknown Resource Kind encountered in Logging Scope Controller", "resource", resource)
+			// if this is one of our wrapper resources, we expect to not find a handler since logging is
+			// added at resource creation time
+			if vznav.IsVerrazzanoWorkloadKind(workload) {
+				log.Info("Skipping logging scope processing for Verrazzano workload kind", "resource", resource)
+			} else {
+				log.Error(nil, "Unknown Resource Kind encountered in Logging Scope Controller", "resource", resource)
+			}
 			continue
 		}
 		err = handler.Apply(ctx, resource, scope)

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -10,10 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
@@ -186,6 +187,175 @@ func TestMetricsTraitCreatedForContainerizedWorkload(t *testing.T) {
 			port, ok := deployment.Spec.Template.Annotations["verrazzano.io/metricsPort"]
 			assert.True(ok)
 			assert.Equal("8080", port)
+			return nil
+		})
+	// Expect a call to get the status writer
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	// Expect a call to update the status of the trait status
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.MetricsTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			return nil
+		})
+
+	// Create and make the request
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test-namespace", Name: "test-trait-name"}}
+
+	reconciler := newMetricsTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestMetricsTraitCreatedForVerrazzanoWorkload tests the creation of a metrics trait related to a Verrazzano workload.
+// The Verrazzano workload contains the real workload so we need to unwrap it.
+// GIVEN a metrics trait that has been created
+// AND the metrics trait is related to a Verrazzano workload
+// WHEN the metrics trait Reconcile method is invoked
+// THEN the contained workload should be unwrapped
+// AND verify that metrics trait finalizer is added
+// AND verify that pod annotations are updated
+// AND verify that the scraper configmap is updated
+// AND verify that the scraper pod is restarted
+func TestMetricsTraitCreatedForVerrazzanoWorkload(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	testDeployment := k8sapps.Deployment{
+		TypeMeta: k8smeta.TypeMeta{
+			APIVersion: k8sapps.SchemeGroupVersion.Identifier(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name:      "test-deployment-name",
+			Namespace: "test-namespace",
+			OwnerReferences: []k8smeta.OwnerReference{{
+				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
+				Kind:       oamcore.ContainerizedWorkloadKind,
+				Name:       "test-workload-name",
+				UID:        "test-workload-uid"}}}}
+	// Expect a call to get the trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-namespace", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.MetricsTrait) error {
+			trait.TypeMeta = k8smeta.TypeMeta{
+				APIVersion: vzapi.GroupVersion.Identifier(),
+				Kind:       vzapi.MetricsTraitKind}
+			trait.ObjectMeta = k8smeta.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
+				Kind:       oamcore.ContainerizedWorkloadKind,
+				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.MetricsTrait) error {
+			assert.Equal("test-namespace", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("metricstrait.finalizers.verrazzano.io", trait.Finalizers[0])
+			return nil
+		})
+
+	containedName := "test-contained-workload-name"
+	containedResource := map[string]interface{}{
+		"apiVersion": "coherence.oracle.com/v1",
+		"kind":       "Coherence",
+		"metadata": map[string]interface{}{
+			"name": containedName,
+		},
+	}
+
+	// Expect a call to get the Verrazzano workload resource
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-namespace", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
+			workload.SetAPIVersion("oam.verrazzano.io/v1alpha1")
+			workload.SetKind("VerrazzanoCoherenceWorkload")
+			workload.SetNamespace(name.Namespace)
+			workload.SetName(name.Name)
+			unstructured.SetNestedMap(workload.Object, containedResource, "spec", "coherence")
+			workload.SetUID("test-workload-uid")
+			return nil
+		})
+	// Expect a call to get the contained Coherence resource
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-namespace", Name: containedName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
+			workload.SetUnstructuredContent(containedResource)
+			workload.SetNamespace(name.Namespace)
+			workload.SetUID("test-workload-uid")
+			return nil
+		})
+	// Expect a call to get the prometheus configuration.
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deployment *k8sapps.Deployment) error {
+			assert.Equal("istio-system", name.Namespace)
+			assert.Equal("prometheus", name.Name)
+			deployment.APIVersion = k8sapps.SchemeGroupVersion.Identifier()
+			deployment.Kind = deploymentKind
+			deployment.Namespace = name.Namespace
+			deployment.Name = name.Name
+			return nil
+		})
+	// Expect a call to get the Coherence workload resource definition
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "coherences.coherence.oracle.com"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *oamcore.WorkloadDefinition) error {
+			workloadDef.Namespace = name.Namespace
+			workloadDef.Name = name.Name
+			workloadDef.Spec.ChildResourceKinds = []oamcore.ChildResourceKind{
+				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
+				{APIVersion: "v1", Kind: "Service", Selector: nil},
+			}
+			return nil
+		})
+	// Expect a call to list the child Deployment resources of the Coherence workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("Deployment", list.GetKind())
+			return appendAsUnstructured(list, testDeployment)
+		})
+	// Expect a call to list the child Service resources of the Coherence workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("Service", list.GetKind())
+			return nil
+		})
+	// Expect a call to get the deployment definition
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-namespace", Name: "test-deployment-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, deployment *k8sapps.Deployment) error {
+			deployment.ObjectMeta = testDeployment.ObjectMeta
+			deployment.Spec = testDeployment.Spec
+			return nil
+		})
+	// Expect a call to update the prometheus config
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, deployment *k8sapps.Deployment, opts ...client.UpdateOption) error {
+			scrape, ok := deployment.Spec.Template.Annotations["verrazzano.io/metricsEnabled"]
+			assert.True(ok)
+			assert.Equal("true", scrape)
+			target, ok := deployment.Spec.Template.Annotations["verrazzano.io/metricsPath"]
+			assert.True(ok)
+			assert.Equal("/metrics", target)
+			port, ok := deployment.Spec.Template.Annotations["verrazzano.io/metricsPort"]
+			assert.True(ok)
+			assert.Equal("9612", port)
 			return nil
 		})
 	// Expect a call to get the status writer

--- a/application-operator/controllers/navigation/trait_test.go
+++ b/application-operator/controllers/navigation/trait_test.go
@@ -6,6 +6,8 @@ package navigation
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
@@ -18,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 )
 
 // TestFetchTrait tests various usages of FetchTrait
@@ -135,4 +136,59 @@ func TestFetchWorkloadFromTrait(t *testing.T) {
 	assert.Nil(uns)
 	assert.Error(err)
 	assert.Equal("test-error", err.Error())
+
+	// GIVEN a trait with a reference to a Verrazzano workload type
+	// WHEN the workload is fetched via the trait
+	// THEN verify that the contained workload is unwrapped and returned
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	workloadAPIVersion := "oam.verrazzano.io/v1alpha1"
+	workloadKind := "VerrazzanoCoherenceWorkload"
+
+	containedAPIVersion := "oam.verrazzano.io/v1alpha1"
+	containedKind := "VerrazzanoCoherenceWorkload"
+	containedName := "unit-test-resource"
+
+	containedResource := map[string]interface{}{
+		"apiVersion": containedAPIVersion,
+		"kind":       containedKind,
+		"metadata": map[string]interface{}{
+			"name": containedName,
+		},
+	}
+
+	trait = &vzapi.IngressTrait{
+		TypeMeta:   metav1.TypeMeta{Kind: "IngressTrait", APIVersion: "oam.verrazzano.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-trait-name", Namespace: "test-trait-namespace"},
+		Spec: vzapi.IngressTraitSpec{WorkloadReference: oamrt.TypedReference{
+			APIVersion: workloadAPIVersion, Kind: workloadKind, Name: "test-workload-name"}}}
+
+	// expect a call to fetch the referenced workload
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "test-trait-namespace", Name: "test-workload-name"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *unstructured.Unstructured) error {
+			obj.SetNamespace(key.Namespace)
+			obj.SetName(key.Name)
+			obj.SetAPIVersion(workloadAPIVersion)
+			obj.SetKind(workloadKind)
+			unstructured.SetNestedMap(obj.Object, containedResource, "spec", "coherence")
+			return nil
+		})
+	// expect a call to fetch the contained workload that is wrapped by the Verrazzano workload
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "test-trait-namespace", Name: containedName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *unstructured.Unstructured) error {
+			obj.SetUnstructuredContent(containedResource)
+			return nil
+		})
+
+	uns, err = FetchWorkloadFromTrait(ctx, cli, ctrl.Log, trait)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.NotNil(uns)
+	assert.Equal(containedAPIVersion, uns.GetAPIVersion())
+	assert.Equal(containedKind, uns.GetKind())
+	assert.Equal(containedName, uns.GetName())
 }

--- a/application-operator/controllers/navigation/workload_test.go
+++ b/application-operator/controllers/navigation/workload_test.go
@@ -6,6 +6,7 @@ package navigation
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -16,9 +17,11 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	k8sapps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -349,4 +352,219 @@ func TestLoggingScopeFromWorkloadLabels(t *testing.T) {
 	mocker.Finish()
 	assert.True(k8serrors.IsNotFound(err))
 	assert.Nil(loggingScope)
+}
+
+// TestIsVerrazzanoWorkloadKind tests the IsVerrazzanoWorkloadKind function.
+func TestIsVerrazzanoWorkloadKind(t *testing.T) {
+	assert := asserts.New(t)
+
+	// GIVEN a Verrazzano workload
+	// WHEN a call is made to check if the workload is a Verrazzano workload kind
+	// THEN expect the call to return true
+	workloadKind := "VerrazzanoCoherenceWorkload"
+
+	u := &unstructured.Unstructured{}
+	u.SetKind(workloadKind)
+
+	assert.True(IsVerrazzanoWorkloadKind(u))
+
+	// GIVEN a non-Verrazzano workload
+	// WHEN a call is made to check if the workload is a Verrazzano workload kind
+	// THEN expect the call to return false
+	workloadKind = "ContainerizedWorkload"
+
+	u = &unstructured.Unstructured{}
+	u.SetKind(workloadKind)
+
+	assert.False(IsVerrazzanoWorkloadKind(u))
+}
+
+// TestGetContainedWorkloadVersionKindName tests the GetContainedWorkloadVersionKindName function.
+func TestGetContainedWorkloadVersionKindName(t *testing.T) {
+	assert := asserts.New(t)
+
+	// GIVEN a Verrazzano workload containing another workload
+	// WHEN a call is made to get the api version, kind, and name of the contained workload
+	// THEN the api version, kind, and name are returned
+	workloadAPIVersion := "oam.verrazzano.io/v1alpha1"
+	workloadKind := "VerrazzanoCoherenceWorkload"
+
+	containedAPIVersion := "oam.verrazzano.io/v1alpha1"
+	containedKind := "VerrazzanoCoherenceWorkload"
+	containedName := "unit-test-resource"
+
+	containedResource := map[string]interface{}{
+		"apiVersion": containedAPIVersion,
+		"kind":       containedKind,
+		"metadata": map[string]interface{}{
+			"name": containedName,
+		},
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+	unstructured.SetNestedMap(u.Object, containedResource, "spec", "coherence")
+
+	apiVersion, kind, name, err := GetContainedWorkloadVersionKindName(u)
+
+	assert.Nil(err)
+	assert.Equal(containedAPIVersion, apiVersion)
+	assert.Equal(containedKind, kind)
+	assert.Equal(containedName, name)
+
+	// GIVEN a Verrazzano workload containing another workload where the Verrazzano workload is of an unknown kind
+	// WHEN a call is made to get the api version, kind, and name of the contained workload
+	// THEN an error is returned
+	workloadKind = "VerrazzanoBogusWorkload"
+
+	u = &unstructured.Unstructured{}
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+
+	apiVersion, kind, name, err = GetContainedWorkloadVersionKindName(u)
+
+	assert.Error(err)
+	assert.True(strings.HasPrefix(err.Error(), "Unable to find spec property for workload type"))
+	assert.Empty(apiVersion)
+	assert.Empty(kind)
+	assert.Empty(name)
+
+	// GIVEN a Verrazzano workload containing another workload missing the apiVersion field
+	// WHEN a call is made to get the api version, kind, and name of the contained workload
+	// THEN an error is returned
+	workloadAPIVersion = "oam.verrazzano.io/v1alpha1"
+	workloadKind = "VerrazzanoCoherenceWorkload"
+
+	containedResource = map[string]interface{}{}
+
+	u = &unstructured.Unstructured{}
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+	unstructured.SetNestedMap(u.Object, containedResource, "spec", "coherence")
+
+	apiVersion, kind, name, err = GetContainedWorkloadVersionKindName(u)
+
+	assert.Error(err)
+	assert.True(strings.HasPrefix(err.Error(), "Unable to find api version"))
+	assert.Empty(apiVersion)
+	assert.Empty(kind)
+	assert.Empty(name)
+
+	// GIVEN a Verrazzano workload containing another workload missing the kind field
+	// WHEN a call is made to get the api version, kind, and name of the contained workload
+	// THEN an error is returned
+	workloadAPIVersion = "oam.verrazzano.io/v1alpha1"
+	workloadKind = "VerrazzanoCoherenceWorkload"
+
+	containedResource = map[string]interface{}{
+		"apiVersion": containedAPIVersion,
+	}
+
+	u = &unstructured.Unstructured{}
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+	unstructured.SetNestedMap(u.Object, containedResource, "spec", "coherence")
+
+	apiVersion, kind, name, err = GetContainedWorkloadVersionKindName(u)
+
+	assert.Error(err)
+	assert.True(strings.HasPrefix(err.Error(), "Unable to find kind"))
+	assert.Empty(apiVersion)
+	assert.Empty(kind)
+	assert.Empty(name)
+
+	// GIVEN a Verrazzano workload containing another workload missing the metadata name field
+	// WHEN a call is made to get the api version, kind, and name of the contained workload
+	// THEN an error is returned
+	workloadAPIVersion = "oam.verrazzano.io/v1alpha1"
+	workloadKind = "VerrazzanoCoherenceWorkload"
+
+	containedResource = map[string]interface{}{
+		"apiVersion": containedAPIVersion,
+		"kind":       containedKind,
+	}
+
+	u = &unstructured.Unstructured{}
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+	unstructured.SetNestedMap(u.Object, containedResource, "spec", "coherence")
+
+	apiVersion, kind, name, err = GetContainedWorkloadVersionKindName(u)
+
+	assert.Error(err)
+	assert.True(strings.HasPrefix(err.Error(), "Unable to find metadata name"))
+	assert.Empty(apiVersion)
+	assert.Empty(kind)
+	assert.Empty(name)
+}
+
+// TestFetchContainedWorkload tests the FetchContainedWorkload function.
+func TestFetchContainedWorkload(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller
+	var cli *mocks.MockClient
+	var ctx = context.TODO()
+
+	namespace := "unit-test-namespace"
+	workloadAPIVersion := "oam.verrazzano.io/v1alpha1"
+	workloadKind := "VerrazzanoCoherenceWorkload"
+
+	containedAPIVersion := "coherence.oracle.com/v1"
+	containedKind := "Coherence"
+	containedName := "unit-test-resource"
+
+	containedResource := map[string]interface{}{
+		"apiVersion": containedAPIVersion,
+		"kind":       containedKind,
+		"metadata": map[string]interface{}{
+			"name": containedName,
+		},
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetNamespace(namespace)
+	u.SetAPIVersion(workloadAPIVersion)
+	u.SetKind(workloadKind)
+	unstructured.SetNestedMap(u.Object, containedResource, "spec", "coherence")
+
+	// GIVEN a Verrazzano workload containing another workload
+	// WHEN a call is made to fetch the contained workload and there is an error
+	// THEN validate that the call returns an error
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// expect a call to get the contained resource, return an error
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: containedName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, contained *unstructured.Unstructured) error {
+			return errors.NewNotFound(schema.GroupResource{}, "Unable to fetch resource")
+		})
+
+	contained, err := FetchContainedWorkload(ctx, cli, u)
+
+	assert.True(errors.IsNotFound(err))
+	assert.Nil(contained)
+
+	// GIVEN a Verrazzano workload containing another workload
+	// WHEN a call is made to fetch the contained workload
+	// THEN the call returns the contained workload
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// expect a call to get the contained resource, return it as unstructured
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: containedName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, contained *unstructured.Unstructured) error {
+			contained.SetUnstructuredContent(containedResource)
+			return nil
+		})
+
+	contained, err = FetchContainedWorkload(ctx, cli, u)
+
+	assert.Nil(err)
+	assert.Equal(containedAPIVersion, contained.GetAPIVersion())
+	assert.Equal(containedKind, contained.GetKind())
+	assert.Equal(containedName, contained.GetName())
 }


### PR DESCRIPTION
I'm breaking this ticket into multiple PRs to try to make them easier to review rather than submitting a single, bigger PR. This PR continues support for VerrazzanoCoherenceWorkload.

Specifically, this PR updates the ingress and metrics traits so that they are Verrazzano workload aware. When fetching the workload for the trait, if the workload is a Verrazzano workload type, we unwrap the contained workload before fetching the workload definition and children. Most of the code here is in additional unit tests.

**Note**: Based on the late-breaking decision to remove the kind and API version from the wrapped CRs, I will have to make corresponding CRD and implementation changes. I'm not going to do that yet, I'll submit a separate PR for those changes.
