### PR TITLE
VZ-2044: Update Coherence ES index

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -62,7 +62,7 @@ multiline_flush_interval 20s
   port "#{ENV['ELASTICSEARCH_PORT']}"
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
-  index_name "oam-#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}"
+  index_name "` + loggingscope.ElasticSearchIndex + `"
   scheme http
   key_name timestamp 
   types timestamp:time

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
@@ -48,6 +49,10 @@ multiline_flush_interval 20s
  role "#{ENV['COH_ROLE']}"
  host "#{ENV['HOSTNAME']}"
  pod-uid "#{ENV['COH_POD_UID']}"
+ oam.applicationconfiguration.namespace "#{ENV['NAMESPACE']}"
+ oam.applicationconfiguration.name "#{ENV['APP_CONF_NAME']}"
+ oam.component.namespace "#{ENV['NAMESPACE']}"
+ oam.component.name  "#{ENV['COMPONENT_NAME']}"
 </record>
 </filter>
 
@@ -57,7 +62,7 @@ multiline_flush_interval 20s
   port "#{ENV['ELASTICSEARCH_PORT']}"
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
-  index_name "#{ENV['COH_CLUSTER_NAME']}"
+  index_name "oam-#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}"
   scheme http
   key_name timestamp 
   types timestamp:time
@@ -126,7 +131,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// mutate the Coherence spec, add logging, etc.
+	// mutate the Coherence resource, copy labels, add logging, etc.
+	copyLabels(workload.ObjectMeta.GetLabels(), u)
+
 	spec, found, _ := unstructured.NestedMap(u.Object, "spec")
 	if !found {
 		return reconcile.Result{}, errors.New("Embedded Coherence resource is missing the required 'spec' field")
@@ -167,6 +174,22 @@ func (r *Reconciler) fetchWorkload(ctx context.Context, name types.NamespacedNam
 	}
 
 	return &workload, nil
+}
+
+// copyLabels copies specific labels from the Verrazzano workload to the contained Coherence resource
+func copyLabels(workloadLabels map[string]string, coherence *unstructured.Unstructured) {
+	labels := map[string]string{}
+
+	// copy the oam component and app name labels
+	if componentName, ok := workloadLabels[oam.LabelAppComponent]; ok {
+		labels[oam.LabelAppComponent] = componentName
+	}
+
+	if appName, ok := workloadLabels[oam.LabelAppName]; ok {
+		labels[oam.LabelAppName] = appName
+	}
+
+	coherence.SetLabels(labels)
 }
 
 // addLogging adds a FLUENTD sidecar and updates the Coherence spec if there is an associated LoggingScope

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -5,6 +5,7 @@ package cohworkload
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -80,8 +81,9 @@ func TestReconcileCreateCoherence(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-coherence-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoCoherenceWorkload) error {
-			json := `{"apiVersion":"coherence.oracle.com/v1","kind":"Coherence","metadata":{"name":"unit-test-cluster"},"spec":{"replicas":3}}`
-			workload.Spec.Coherence = runtime.RawExtension{Raw: []byte(json)}
+			labelsJSON, _ := json.Marshal(labels)
+			coherenceJSON := `{"apiVersion":"coherence.oracle.com/v1","kind":"Coherence","metadata":{"name":"unit-test-cluster","labels":` + string(labelsJSON) + `},"spec":{"replicas":3}}`
+			workload.Spec.Coherence = runtime.RawExtension{Raw: []byte(coherenceJSON)}
 			workload.ObjectMeta.Labels = labels
 			return nil
 		})
@@ -106,6 +108,9 @@ func TestReconcileCreateCoherence(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
 			assert.Equal("coherence.oracle.com/v1", u.GetAPIVersion())
 			assert.Equal("Coherence", u.GetKind())
+
+			// make sure the oam component and app name labels were copied
+			assert.Equal(labels, u.GetLabels())
 			return nil
 		})
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -109,7 +109,7 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Equal("coherence.oracle.com/v1", u.GetAPIVersion())
 			assert.Equal("Coherence", u.GetKind())
 
-			// make sure the oam component and app name labels were copied
+			// make sure the OAM component and app name labels were copied
 			assert.Equal(labels, u.GetLabels())
 			return nil
 		})

--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -31,6 +31,9 @@ const (
 	elasticSearchPwdField  = "ELASTICSEARCH_PASSWORD"
 )
 
+// ElasticSearchIndex defines the common index pattern
+const ElasticSearchIndex = "#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}"
+
 // FluentdManager is a general interface to interact with FLUENTD related resources
 type FluentdManager interface {
 	Apply(scope *vzapi.LoggingScope, resource vzapi.QualifiedResourceRelation, fluentdPod *FluentdPod) (bool, error)

--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -67,7 +68,7 @@ func (f *Fluentd) Apply(scope *vzapi.LoggingScope, resource vzapi.QualifiedResou
 
 		f.ensureFluentdVolumes(fluentdPod)
 		f.ensureFluentdVolumeMountExists(fluentdPod)
-		f.ensureFluentdContainer(fluentdPod, scope)
+		f.ensureFluentdContainer(fluentdPod, scope, resource.Namespace)
 		return true, nil
 	}
 	return false, nil
@@ -87,7 +88,7 @@ func (f *Fluentd) Remove(scope *vzapi.LoggingScope, resource vzapi.QualifiedReso
 // ensureFluentdContainer ensures that the FLUENTD container is in the expected state. If a FLUENTD container already
 // exists, replace it with a container created with the current scope information. If no FLUENTD container already
 // exists, create one and add it to the FluentdPod.
-func (f *Fluentd) ensureFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.LoggingScope) {
+func (f *Fluentd) ensureFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.LoggingScope, namespace string) {
 	containers := fluentdPod.Containers
 	fluentdContainerIndex := -1
 	// iterate over existing containers looking for FLUENTD container
@@ -98,7 +99,7 @@ func (f *Fluentd) ensureFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.Lo
 			break
 		}
 	}
-	fluentdContainer := f.createFluentdContainer(fluentdPod, scope)
+	fluentdContainer := f.createFluentdContainer(fluentdPod, scope, namespace)
 	if fluentdContainerIndex != -1 {
 		// the index is still the initial -1 so we didn't find an existing FLUENTD container so we replace it
 		containers[fluentdContainerIndex] = fluentdContainer
@@ -306,7 +307,7 @@ func (f *Fluentd) isFluentdContainerUpToDate(containers []v1.Container, scope *v
 }
 
 // createFluentdContainer creates the FLUENTD container
-func (f *Fluentd) createFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.LoggingScope) corev1.Container {
+func (f *Fluentd) createFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.LoggingScope, namespace string) corev1.Container {
 	container := corev1.Container{
 		Name:            "fluentd",
 		Args:            []string{"-c", "/etc/fluent.conf"},
@@ -358,6 +359,26 @@ func (f *Fluentd) createFluentdContainer(fluentdPod *FluentdPod, scope *vzapi.Lo
 						Optional: func(opt bool) *bool {
 							return &opt
 						}(true),
+					},
+				},
+			},
+			{
+				Name:  "NAMESPACE",
+				Value: namespace,
+			},
+			{
+				Name: "APP_CONF_NAME",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.labels['" + oam.LabelAppName + "']",
+					},
+				},
+			},
+			{
+				Name: "COMPONENT_NAME",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.labels['" + oam.LabelAppComponent + "']",
 					},
 				},
 			},

--- a/application-operator/controllers/loggingscope/fluentd_test.go
+++ b/application-operator/controllers/loggingscope/fluentd_test.go
@@ -129,7 +129,7 @@ func TestFluentdRemove(t *testing.T) {
 	scope := createTestLoggingScope(true)
 	resource := createTestResourceRelation()
 	fluentdPod := createTestFluentdPod()
-	addFluentdArtifactsToFluentdPod(fluentd, fluentdPod, scope)
+	addFluentdArtifactsToFluentdPod(fluentd, fluentdPod, scope, resource.Namespace)
 
 	// simulate config map existing
 	mockClient.EXPECT().
@@ -187,10 +187,10 @@ func createTestFluentdPodForUpdate() *FluentdPod {
 }
 
 // addFluentdArtifactsToFluentdPod adds FLUENTD artifacts to a FluentdPod
-func addFluentdArtifactsToFluentdPod(fluentd *Fluentd, fluentdPod *FluentdPod, scope *v1alpha1.LoggingScope) {
+func addFluentdArtifactsToFluentdPod(fluentd *Fluentd, fluentdPod *FluentdPod, scope *v1alpha1.LoggingScope, namespace string) {
 	fluentd.ensureFluentdVolumes(fluentdPod)
 	fluentdPod.VolumeMounts = append(fluentdPod.VolumeMounts, fluentd.createFluentdVolumeMount())
-	fluentdPod.Containers = append(fluentdPod.Containers, fluentd.createFluentdContainer(fluentdPod, scope))
+	fluentdPod.Containers = append(fluentdPod.Containers, fluentd.createFluentdContainer(fluentdPod, scope, namespace))
 }
 
 // testAssertFluentdPodForApply asserts FluentdPod state for Apply

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -91,7 +91,7 @@ const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
   port "#{ENV['ELASTICSEARCH_PORT']}"
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
-  index_name "oam-#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}"
+  index_name "` + ElasticSearchIndex + `"
   scheme http
   include_timestamp true
   flush_interval 10s

--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -200,26 +200,6 @@ func getWlsSpecificContainerEnv(workload vzapi.QualifiedResourceRelation) []v1.E
 				},
 			},
 		},
-		{
-			Name:  "NAMESPACE",
-			Value: workload.Namespace,
-		},
-		{
-			Name: "APP_CONF_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: "metadata.labels['app.oam.dev/name']",
-				},
-			},
-		},
-		{
-			Name: "COMPONENT_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: "metadata.labels['app.oam.dev/component']",
-				},
-			},
-		},
 	}
 }
 

--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -83,7 +83,7 @@ const wlsFluentdParsingRules = `<match fluent.**>
   port "#{ENV['ELASTICSEARCH_PORT']}"
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
-  index_name "oam-#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}"
+  index_name "` + ElasticSearchIndex + `"
   scheme http
   key_name timestamp 
   types timestamp:time

--- a/tests/e2e/examples/todo-list/todo_list_test.go
+++ b/tests/e2e/examples/todo-list/todo_list_test.go
@@ -92,7 +92,7 @@ func undeployToDoListExample() {
 	if err := pkg.DeleteNamespace("todo-list"); err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete namespace: %v", err))
 	}
-	gomega.Eventually(func () bool {
+	gomega.Eventually(func() bool {
 		ns, err := pkg.GetNamespace("todo-list")
 		return ns == nil && err != nil && errors.IsNotFound(err)
 	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("Verify ToDo List example application.", func() {
 		// WHEN the running pods are checked
 		// THEN the adminserver and mysql pods should be found running
 		ginkgo.It("Verify 'tododomain-adminserver' and 'mysql' pods are running", func() {
-			gomega.Eventually(func () bool {
+			gomega.Eventually(func() bool {
 				return pkg.PodsRunning("todo-list", []string{"mysql", "tododomain-adminserver"})
 			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 		})
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("Verify ToDo List example application.", func() {
 	//})
 
 	ginkgo.Context("Logging.", func() {
-		indexName := "oam-todo-list--"
+		indexName := "todo-list--"
 
 		// GIVEN a WebLogic application with logging enabled via a logging scope
 		// WHEN the Elasticsearch index is retrieved


### PR DESCRIPTION
This PR updates the Coherence ES index to match the work that GZ recently did for WLS. The index uses the pattern `oam-#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}` so that users can more easily search logs for their applications.

The work in the VerrazzanoCoherenceWorkload controller was simply to update the fluentd rules and also to copy the OAM app and component name labels into the Coherence CR that the controller writes out.

I also moved 3 fluentd container environment variables out of `wls.go` into `fluentd.go` as they will be needed by all workload types.