### PR TITLE
Restore copyright scanning in this repo

### DIFF
--- a/application-operator/apis/clusters/v1alpha1/multicluster_common_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multicluster_common_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Oracle and/or its affiliates.
+// Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/application-operator/config/rbac/role.yaml
+++ b/application-operator/config/rbac/role.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ignore_copyright_check.txt
+++ b/ignore_copyright_check.txt
@@ -2,10 +2,10 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 platform-operator/scripts/install/config/images
 platform-operator/scripts/install/config/00-crds.patch
-platform-operator/scripts/install/chart/NOTES.txt
+platform-operator/helm_config/charts/verrazzano/NOTES.txt
+platform-operator/helm_config/charts/verrazzano-application-operator/NOTES.txt
 LICENSES-OLCNE.pdf
 coverage.xml
 # The charts and manifests directories contains external (3rd party) Helm charts and manifests
-thirdparty
-
+platform-operator/thirdparty
 application-operator/deploy/application-operator.txt

--- a/tests/e2e/examples/sock-shop/sockshop.go
+++ b/tests/e2e/examples/sock-shop/sockshop.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package sock_shop
 
 import (


### PR DESCRIPTION
The ignore_copyright_check.txt file had a blank line and the copyright scanner seems to have a bug where this causes the entire root directory to be skipped.

This PR removes the blank line and fixes copyright scan errors that were reported. 
