### PR TITLE
VZ-V2044: Update sockshop example to use VerrazzanoCoherenceWorkload

### DIFF
--- a/examples/sock-shop/sock-shop-app.yaml
+++ b/examples/sock-shop/sock-shop-app.yaml
@@ -3,11 +3,11 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: carts-appconf
+  name: sockshop-appconf
   namespace: sockshop
   annotations:
     version: v1.0.0
-    description: "OAM Sock Shop Carts Application"
+    description: "OAM Sock Shop Application"
 spec:
   components:
     - componentName: carts
@@ -31,17 +31,6 @@ spec:
               name: carts-metrics
             spec:
               port: 7001
----
-apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: catalog-appconf
-  namespace: sockshop
-  annotations:
-    version: v1.0.0
-    description: "OAM Sock Shop Catalog Application"
-spec:
-  components:
     - componentName: catalog
       traits:
         - trait:
@@ -63,17 +52,6 @@ spec:
               name: catalog-metrics
             spec:
               port: 7001
----
-apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: orders-appconf
-  namespace: sockshop
-  annotations:
-    version: v1.0.0
-    description: "OAM Sock Shop Orders Application"
-spec:
-  components:
     - componentName: orders
       traits:
         - trait:
@@ -95,17 +73,6 @@ spec:
               name: orders-metrics
             spec:
               port: 7001
----
-apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: payment-appconf
-  namespace: sockshop
-  annotations:
-    version: v1.0.0
-    description: "OAM Sock Shop Payment Application"
-spec:
-  components:
     - componentName: payment
       traits:
         - trait:
@@ -127,17 +94,6 @@ spec:
               name: payment-metrics
             spec:
               port: 7001
----
-apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: shipping-appconf
-  namespace: sockshop
-  annotations:
-    version: v1.0.0
-    description: "OAM Sock Shop Shipping Application"
-spec:
-  components:
     - componentName: shipping
       traits:
         - trait:
@@ -159,17 +115,6 @@ spec:
               name: shipping-metrics
             spec:
               port: 7001
----
-apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: users-appconf
-  namespace: sockshop
-  annotations:
-    version: v1.0.0
-    description: "OAM Sock Shop Shipping Application"
-spec:
-  components:
     - componentName: users
       traits:
         - trait:

--- a/examples/sock-shop/sock-shop-comp.yaml
+++ b/examples/sock-shop/sock-shop-comp.yaml
@@ -8,39 +8,40 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: carts-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Carts
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/carts-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: http
-          port: 7001
-          service:
-            name: carts
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: carts-coh
+        spec:
+          cluster: SockShop
+          role: Carts
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/carts-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: http
+              port: 7001
+              service:
+                name: carts
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -49,39 +50,40 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: catalog-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Catalog
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/catalog-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: http
-          port: 7001
-          service:
-            name: catalogue  # for compatibility with the existing front-end implementation
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: catalog-coh
+        spec:
+          cluster: SockShop
+          role: Catalog
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/catalog-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: http
+              port: 7001
+              service:
+                name: catalogue  # for compatibility with the existing front-end implementation
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -90,39 +92,40 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: orders-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Orders
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/orders-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: http
-          port: 7001
-          service:
-            name: orders
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: orders-coh
+        spec:
+          cluster: SockShop
+          role: Orders
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/orders-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: http
+              port: 7001
+              service:
+                name: orders
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -131,43 +134,44 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: payment-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Payment
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/payment-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: grpc
-          port: 1408
-          service:
-            name: payment
-        - name: http
-          port: 7001
-          service:
-            name: payment-http
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: payment-coh
+        spec:
+          cluster: SockShop
+          role: Payment
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/payment-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: grpc
+              port: 1408
+              service:
+                name: payment
+            - name: http
+              port: 7001
+              service:
+                name: payment-http
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -176,43 +180,44 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: shipping-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Shipping
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/shipping-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: grpc
-          port: 1408
-          service:
-            name: shipping
-        - name: http
-          port: 7001
-          service:
-            name: shipping-http
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: shipping-coh
+        spec:
+          cluster: SockShop
+          role: Shipping
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/shipping-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: grpc
+              port: 1408
+              service:
+                name: shipping
+            - name: http
+              port: 7001
+              service:
+                name: shipping-http
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -221,36 +226,37 @@ metadata:
   namespace: sockshop
 spec:
   workload:
-    apiVersion: coherence.oracle.com/v1
-    kind: Coherence
-    metadata:
-      name: users-coh
-      namespace: sockshop
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoCoherenceWorkload
     spec:
-      cluster: SockShop
-      role: Users
-      replicas: 1
-      image: ghcr.io/helidon-sockshop/users-coherence:2.2.0
-      imagePullPolicy: Always
-      application:
-        type: helidon
-      jvm:
-        args:
-          - "-Dcoherence.k8s.operator.health.wait.dcs=false"
-          - "-Dcoherence.metrics.legacy.names=false"
-        memory:
-          heapSize: 2g
-      coherence:
-        logLevel: 9
-      ports:
-        - name: http
-          port: 7001
-          service:
-            name: user  # for compatibility with the existing front-end implementation
-            port: 80
-          serviceMonitor:
-            enabled: true
-        - name: metrics
-          port: 7001
-          serviceMonitor:
-            enabled: true
+      template:
+        metadata:
+          name: users-coh
+        spec:
+          cluster: SockShop
+          role: Users
+          replicas: 1
+          image: ghcr.io/helidon-sockshop/users-coherence:2.2.0
+          imagePullPolicy: Always
+          application:
+            type: helidon
+          jvm:
+            args:
+              - "-Dcoherence.k8s.operator.health.wait.dcs=false"
+              - "-Dcoherence.metrics.legacy.names=false"
+            memory:
+              heapSize: 2g
+          coherence:
+            logLevel: 9
+          ports:
+            - name: http
+              port: 7001
+              service:
+                name: user  # for compatibility with the existing front-end implementation
+                port: 80
+              serviceMonitor:
+                enabled: true
+            - name: metrics
+              port: 7001
+              serviceMonitor:
+                enabled: true

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_verrazzanocoherenceworkloads.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_verrazzanocoherenceworkloads.yaml
@@ -37,15 +37,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: VerrazzanoCoherenceWorkloadSpec wraps a Coherence resource. The Coherence object must include apiVersion,
-              kind, and spec fields. It may include a metadata field.
+            description: VerrazzanoCoherenceWorkloadSpec wraps a Coherence resource.
+              The Coherence object specified in the template must contain a spec field
+              and it may include a metadata field.
             properties:
-              coherence:
+              template:
                 type: object
-                x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
             required:
-            - coherence
+            - template
             type: object
           status:
             description: VerrazzanoCoherenceWorkloadStatus defines the observed state

--- a/tests/e2e/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/examples/sock-shop/sock_shop_example_test.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -240,7 +241,7 @@ func appMetricsExists() bool {
 
 // appComponentMetricsExists checks whether component related metrics are available
 func appComponentMetricsExists() bool {
-	return metricsExist("vendor_requests_count_total", "app_oam_dev_name", "catalog-appconf")
+	return metricsExist("vendor_requests_count_total", "app_oam_dev_name", "sockshop-appconf")
 }
 
 // appConfigMetricsExists checks whether config metrics are available


### PR DESCRIPTION
I updated the components to use the new VerrazzanoCoherenceWorkload workload. I also updated the app config file so there's a single app config instead of one per component.

I deployed the components and app, verified that all of the pods, etc. come up cleanly, used curl to test the apps, confirmed that metrics, etc. are reporting correctly.
