### PR TITLE
Fix problem where istio-proxy container not in ready state

### DIFF
--- a/platform-operator/helm_config/overrides/istio-values.yaml
+++ b/platform-operator/helm_config/overrides/istio-values.yaml
@@ -15,29 +15,13 @@ global:
     enabled: true
   controlPlaneSecurityEnabled: true
   enableHelmTest: false
+  istioNamespace: istio-system
 
 gateways:
   istio-egressgateway:
     env:
       # Needed to route traffic via egress gateway if desired.
       ISTIO_META_REQUESTED_NETWORK_VIEW: "external"
-  istio-ingressgateway:
-    ports:
-      - port: 15021
-        targetPort: 15021
-        name: status-port
-      - port: 80
-        targetPort: 8080
-        name: http2
-        nodePort: 31380
-      - port: 443
-        targetPort: 8443
-        name: https
-        nodePort: 31390
-        # This is the port where sni routing happens
-      - port: 15443
-        targetPort: 15443
-        name: tls
 
 istiocoredns:
   enabled: true
@@ -53,3 +37,6 @@ grafana:
 prometheus:
   hub: ghcr.io/verrazzano
   tag: v2.13.1
+
+sidecarInjectorWebhook:
+  rewriteAppHTTPProbe: true


### PR DESCRIPTION
This pull request fixes a problem where the istio-proxy sidercar was not getting to a ready state because a readiness probe was failing.  The fix was to include additional settings during istio install.  Also, removed explicitly setting of ingressgateway ports which were not needed.