### PR TITLE
Do not page on PR issues

### DIFF
--- a/.github/workflows/pagerduty.yml
+++ b/.github/workflows/pagerduty.yml
@@ -8,6 +8,7 @@ on:
     types: [created]
 jobs:
   pagerduty:
+    if: ${{ !github.event.issue.pull_request }}
     env:
       ROUTING_KEY: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
Looking at how to best verify this, the change is to add a conditional to the job which will not execute on PR's

From the github examples:
     https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment