### PR TITLE
Remove delete of fluentd configmap

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -341,9 +341,6 @@ func addJvmArgs(coherenceSpec map[string]interface{}) {
 func (r *Reconciler) handleDelete(ctx context.Context, log logr.Logger, workload *vzapi.VerrazzanoCoherenceWorkload, coherence *unstructured.Unstructured) (bool, error) {
 	if !workload.ObjectMeta.DeletionTimestamp.IsZero() {
 		if controllers.StringSliceContainsString(workload.ObjectMeta.Finalizers, finalizer) {
-			log.Info("Deleting logging-related resources (if needed)")
-			r.deleteLogging(ctx, log, workload.ObjectMeta.Namespace)
-
 			log.Info("Deleting Coherence CR")
 			if err := r.Delete(ctx, coherence); err != nil {
 				return true, err
@@ -369,20 +366,4 @@ func (r *Reconciler) handleDelete(ctx context.Context, log logr.Logger, workload
 	}
 
 	return false, nil
-}
-
-// deleteLogging cleans up any logging resources that we created when processing a
-// LoggingScope on resource creation
-func (r *Reconciler) deleteLogging(ctx context.Context, log logr.Logger, namespace string) {
-	// this struct is empty as we're just using this to delete the FLUENTD config map - also if
-	// there was no logging scope for this component, this will just be a no-op
-	fluentdPod := &loggingscope.FluentdPod{}
-	fluentdManager := &loggingscope.Fluentd{
-		Context: ctx,
-		Log:     log,
-		Client:  r.Client,
-	}
-	resource := vzapi.QualifiedResourceRelation{Namespace: namespace}
-
-	fluentdManager.Remove(nil, resource, fluentdPod)
 }

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -320,8 +320,7 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 }
 
 // TestReconcileDeleteResources tests the happy path of reconciling a VerrazzanoCoherenceWorkload when
-// the workload is being deleted. We delete resources that were created for FLUENTD as well as
-// the Coherence CR we created.
+// the workload is being deleted.
 // GIVEN a VerrazzanoCoherenceWorkload resource is being deleted
 // WHEN the controller Reconcile function is called
 // THEN expect delete calls for resources we created
@@ -342,21 +341,6 @@ func TestReconcileDeleteResources(t *testing.T) {
 			workload.ObjectMeta.Finalizers = []string{finalizer}
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoCoherenceWorkload"
-			return nil
-		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// one item in the list is enough to cause the FLUENTD code to try delete the config map
-			configMaps := list.(*unstructured.UnstructuredList)
-			configMaps.Items = []unstructured.Unstructured{{}}
-			return nil
-		})
-	// expect a call to delete the FLUENTD config map
-	cli.EXPECT().
-		Delete(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.DeleteOption) error {
 			return nil
 		})
 	// expect a call to delete the Coherence CR


### PR DESCRIPTION
There is a problem with the way we manage fluentd configmaps for our OAM components. We create a single configmap in the namespace and all pods refer to the one configmap. When deleting an app config, if the configmap is deleted and one or more pods happen to restart, they fail to come up because they cannot mount the configmap, resulting in the pods being in a bad state.

For now, I'm removing the code from the VerrazzanoCoherenceWorkload controller that deletes the configmap. This means the configmap will not get deleted but at least all of the statefulsets, pods, etc. will get cleaned up and the namespace won't be blocked from being deleted.

We need to come up with a long-term solution for this problem. Maybe create a separate configmap per component? I think there still may be a race condition even if we do that though. Definitely needs more thought.
