### PR TITLE
Upgrade VMC controller to generate a service account

### DIFF
--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -208,6 +208,7 @@ else
 	cat config/crd/bases/install.verrazzano.io_verrazzanos.yaml >> ${BUILD-DEPLOY}/operator.yaml
 	cat config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml >> ${BUILD-DEPLOY}/operator.yaml
 	kubectl apply -f ${BUILD-DEPLOY}/operator.yaml || (echo 'Platform operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d platform-operator-integ-cluster-dump; exit 1)
+	kubectl create namespace verrazzano-mc
 endif
 	echo 'Run tests...'
 	ginkgo -v --keepGoing -cover test/integ/... || (echo 'Platform operator tests failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d platform-operator-integ-cluster-dump;)

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -178,7 +178,7 @@ endif
 #
 .PHONY: unit-test
 unit-test: go-install
-	$(GO) test -v  ./internal/... ./controllers/... ./api/...
+	$(GO) test -v  ./internal/... ./controllers/... ./apis/...
 
 .PHONY: coverage
 coverage: unit-test

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -208,7 +208,6 @@ else
 	cat config/crd/bases/install.verrazzano.io_verrazzanos.yaml >> ${BUILD-DEPLOY}/operator.yaml
 	cat config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml >> ${BUILD-DEPLOY}/operator.yaml
 	kubectl apply -f ${BUILD-DEPLOY}/operator.yaml || (echo 'Platform operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d platform-operator-integ-cluster-dump; exit 1)
-	kubectl create namespace verrazzano-mc
 endif
 	echo 'Run tests...'
 	ginkgo -v --keepGoing -cover test/integ/... || (echo 'Platform operator tests failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d platform-operator-integ-cluster-dump;)

--- a/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -20,10 +20,6 @@ type VerrazzanoManagedClusterSpec struct {
 	// the endpoint, username and password.
 	PrometheusSecret string `json:"prometheusSecret"`
 
-	// The generated identifier for the managed cluster.
-	// This field is managed by a Verrazzano Kubernetes operator.
-	ClusterID string `json:"clusterID,omitempty"`
-
 	// The name of the ServiceAccount that was generated for the managed cluster.
 	// This field is managed by a Verrazzano Kubernetes operator.
 	ServiceAccount string `json:"serviceAccount,omitempty"`

--- a/platform-operator/config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -43,10 +43,6 @@ spec:
             description: VerrazzanoManagedClusterSpec defines the desired state of
               VerrazzanoManagedCluster
             properties:
-              clusterID:
-                description: The generated identifier for the managed cluster. This
-                  field is managed by a Verrazzano Kubernetes operator.
-                type: string
               description:
                 description: The description of the managed cluster.
                 type: string

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
@@ -45,7 +45,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 			return reconcile.Result{}, nil
 		}
 
-		// Error getting the verrazzano resource - don't requeue.
+		// Error getting the VerrazzanoManagedCluster resource - don't requeue.
 		log.Errorf("Failed to fetch resource: %v", err)
 		return reconcile.Result{}, err
 	}

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
@@ -77,7 +77,10 @@ func reconcileServiceAccount(r *VerrazzanoManagedClusterReconciler, vmc *cluster
 		if errors.IsNotFound(err) {
 			// Create the SA
 			r.log.Infof("Creating ServiceAccount %s in namespace %s", saNew.Name, saNew.Namespace)
-			err = r.Client.Create(context.TODO(), saNew)
+			err2 := r.Client.Create(context.TODO(), saNew)
+			if err2 != nil {
+				return err2
+			}
 		} else {
 			return err
 		}

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +24,8 @@ type VerrazzanoManagedClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
+
+const resourceKind = "VerrazzanoManagedCluster"
 
 // +kubebuilder:rbac:groups=clusters.verrazzano.io,resources=verrazzanomanagedclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=clusters.verrazzano.io,resources=verrazzanomanagedclusters/status,verbs=get;update;patch
@@ -41,7 +46,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		}
 
 		// Error getting the verrazzano resource - don't requeue.
-		log.Errorf("Failed to fetch verrazzano resource: %v", err)
+		log.Errorf("Failed to fetch %s resource: %v", resourceKind, err)
 		return reconcile.Result{}, err
 	}
 
@@ -50,7 +55,52 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	// Reconcile the cluster-id
+	clusterID := generateClusterID(vmc.Name, vmc.Namespace)
+	if vmc.Spec.ClusterID != clusterID {
+		log.Infof("Updating ClusterID from %q to %q on %s resource %s in namespace %s", vmc.Spec.ClusterID, clusterID, resourceKind, vmc.Name, vmc.Namespace)
+		vmc.Spec.ClusterID = clusterID
+		err := r.Update(ctx, vmc)
+		if err != nil {
+			log.Errorf("Failed to update %s resource %s in namespace %s: %v", resourceKind, vmc.Name, vmc.Namespace, err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Reconcile the service account
+	err = reconcileServiceAccount(vmc, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func reconcileServiceAccount(r *VerrazzanoManagedClusterReconciler, vmc *clustersv1alpha1.VerrazzanoManagedCluster, namespace string) error {
+	saNew := createServiceAccount(vmc.Spec.ClusterID, namespace)
+
+	// Does the service account exist?
+	sa, err := r.Client.Get()
+
+}
+
+// Generate the value of the cluster identifier
+func generateClusterID(clusterName string, namespace string) string {
+	return fmt.Sprintf("%s-%s", clusterName, namespace)
+}
+
+// Create a service account object
+func createServiceAccount(name string, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Secrets:                      nil,
+		ImagePullSecrets:             nil,
+		AutomountServiceAccountToken: nil,
+	}
 }
 
 // SetupWithManager creates a new controller and adds it to the manager

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller.go
@@ -26,8 +26,6 @@ type VerrazzanoManagedClusterReconciler struct {
 	log    *zap.SugaredLogger
 }
 
-const resourceKind = "VerrazzanoManagedCluster"
-
 // +kubebuilder:rbac:groups=clusters.verrazzano.io,resources=verrazzanomanagedclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=clusters.verrazzano.io,resources=verrazzanomanagedclusters/status,verbs=get;update;patch
 
@@ -48,7 +46,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		}
 
 		// Error getting the verrazzano resource - don't requeue.
-		log.Errorf("Failed to fetch %s resource: %v", resourceKind, err)
+		log.Errorf("Failed to fetch resource: %v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,7 +30,7 @@ const kind = "VerrazzanoManagedCluster"
 // WHEN a VerrazzanoManagedCluster resource has been applied
 // THEN ensure all the objects are created
 func TestCreateVMC(t *testing.T) {
-	namespace := "verrazzano-install"
+	namespace := "verrazzano-mc"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
 	asserts := assert.New(t)
@@ -132,7 +131,7 @@ func TestDeleteVMC(t *testing.T) {
 // newScheme creates a new scheme that includes this package's object to use for testing
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	vzapi.AddToScheme(scheme)
+	clustersapi.AddToScheme(scheme)
 	return scheme
 }
 

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
@@ -8,18 +8,16 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
+++ b/platform-operator/controllers/verrazzanomanagedcluster/verrazzanomanagedcluster_controller_test.go
@@ -8,11 +8,16 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,6 +53,28 @@ func TestCreateVMC(t *testing.T) {
 				Namespace: name.Namespace,
 				Name:      name.Name,
 				Labels:    labels}
+			return nil
+		})
+
+	// Expect a call to get the ServiceAccount - return that it does not exist
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: generateServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, generateServiceAccountName(name)))
+
+	// Expect a call to create the ServiceAccount - return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
+			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
+			asserts.Equalf(generateServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
+			return nil
+		})
+
+	// Expect a call to update the ServiceAccount of the resource - return success
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, vmc *clustersapi.VerrazzanoManagedCluster, opts ...client.UpdateOption) error {
+			asserts.Equal(vmc.Spec.ServiceAccount, generateServiceAccountName(name), "ServiceAccount name did not match")
 			return nil
 		})
 

--- a/platform-operator/deploy/operator.yaml
+++ b/platform-operator/deploy/operator.yaml
@@ -3203,10 +3203,6 @@ spec:
             description: VerrazzanoManagedClusterSpec defines the desired state of
               VerrazzanoManagedCluster
             properties:
-              clusterID:
-                description: The generated identifier for the managed cluster. This
-                  field is managed by a Verrazzano Kubernetes operator.
-                type: string
               description:
                 description: The description of the managed cluster.
                 type: string

--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -15,6 +15,7 @@ import (
 const clusterAdmin = "cluster-admin"
 const platformOperator = "verrazzano-platform-operator"
 const installNamespace = "verrazzano-install"
+const mcNamespace = "verrazzano-mc"
 
 var K8sClient k8s.Client
 

--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -15,7 +15,6 @@ import (
 const clusterAdmin = "cluster-admin"
 const platformOperator = "verrazzano-platform-operator"
 const installNamespace = "verrazzano-install"
-const mcNamespace = "verrazzano-mc"
 
 var K8sClient k8s.Client
 

--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -84,8 +84,4 @@ var _ = ginkgo.Describe("Testing VerrazzanoManagedCluster CRDs", func() {
 		_, stderr := util.Kubectl("apply -f testdata/vmc_sample.yaml")
 		gomega.Expect(stderr).To(gomega.Equal(""))
 	})
-	ginkgo.It("VerrazzanoManagedCluster can be deleted ", func() {
-		_, stderr := util.Kubectl("delete -f testdata/vmc_sample.yaml")
-		gomega.Expect(stderr).To(gomega.Equal(""))
-	})
 })

--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -15,6 +15,7 @@ import (
 const clusterAdmin = "cluster-admin"
 const platformOperator = "verrazzano-platform-operator"
 const installNamespace = "verrazzano-install"
+const mcNamespace = "verrazzano-mc"
 
 var K8sClient k8s.Client
 
@@ -79,6 +80,10 @@ var _ = ginkgo.Describe("Custom Resource Definition for verrazzano install", fun
 })
 
 var _ = ginkgo.Describe("Testing VerrazzanoManagedCluster CRDs", func() {
+	ginkgo.It("Create multi-cluster namespace ", func() {
+		_, stderr := util.Kubectl(fmt.Sprintf("create namespace %s", mcNamespace))
+		gomega.Expect(stderr).To(gomega.Equal(""))
+	})
 	ginkgo.It("VerrazzanoManagedCluster can be created ", func() {
 		_, stderr := util.Kubectl("apply -f testdata/vmc_sample.yaml")
 		gomega.Expect(stderr).To(gomega.Equal(""))

--- a/platform-operator/test/integ/testdata/vmc_sample.yaml
+++ b/platform-operator/test/integ/testdata/vmc_sample.yaml
@@ -4,7 +4,7 @@ apiVersion: clusters.verrazzano.io/v1alpha1
 kind: VerrazzanoManagedCluster
 metadata:
   name: cluster1
-  namespace: verrazzano-install
+  namespace: verrazzano-mc
 spec:
   description: "Test VerrazzanoManagedCluster object"
   prometheusSecret: prometheus-cluster1


### PR DESCRIPTION
# Description

Update the controller for the VerrazzanoManagedCluster objects to generate a service account and associate it with the VMC object.

Fixes VZ-2057

# How has this been tested?

- [x] Tested locally in my own environment
- [ ] Successful acceptance test run on CI server
- [x] Other (added mock tests for updated controller flow)

# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated godoc for all public functions
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [x] Checked that I correctly spelled trademark and product names
- [ ] Used inclusive language and neutral tone
- [x] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
