### PR TITLE
Increase integ-test timer that waits for platform-operator pod to start

### DIFF
--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -47,11 +47,11 @@ var _ = ginkgo.Describe("verrazzano-install namespace resources ", func() {
 		gomega.Expect(K8sClient.DoesPodExist(platformOperator, installNamespace)).To(gomega.BeTrue(),
 			"The verrazzano-platform-operator pod should exist")
 	})
-	ginkgo.It("is running (within 1m)", func() {
+	ginkgo.It("is running (within 2m)", func() {
 		isPodRunningYet := func() bool {
 			return K8sClient.IsPodRunning(platformOperator, installNamespace)
 		}
-		gomega.Eventually(isPodRunningYet, "1m", "5s").Should(gomega.BeTrue(),
+		gomega.Eventually(isPodRunningYet, "2m", "5s").Should(gomega.BeTrue(),
 			"The verrazzano-platform-operator pod should be in the Running state")
 	})
 })


### PR DESCRIPTION
# Description

The change to use Kubernetes 1.18 image for Kind testing appears to have affected the time required for some pods to start.  When running the integ-test target locally on a Mac the test started failing because 1 minute was not enough time for the platform-operator to start on 1.18 of Kubernetes.

# How has this been tested?

Provide details about how you tested this changed, if necessary
provide instructions to reproduce the testing.

- [x] Tested locally in my own environment
- [ ] Successful acceptance test run on CI server
- [ ] Other (specify)

# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated godoc for all public functions
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [ ] Checked that I correctly spelled trademark and product names
- [ ] Used inclusive language and neutral tone
- [ ] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
