### PR TITLE
VZ-2047: More implementation of the VerrazzanoWebLogicWorkload controller

### DIFF
--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -24,8 +24,8 @@ const (
 	storageVolumeMountPath = scratchVolMountPath
 )
 
-// FLUENTD parsing rules for WLS
-const wlsFluentdParsingRules = `<match fluent.**>
+// WlsFluentdParsingRules defines the FLUENTD parsing rules for WLS
+const WlsFluentdParsingRules = `<match fluent.**>
   @type null
 </match>
 <source>
@@ -93,7 +93,7 @@ const wlsFluentdParsingRules = `<match fluent.**>
 </match>
 `
 
-var getFluentdManager = getFluentd
+var getFluentdManager = GetFluentd
 
 // wlsHandler handles FLUENTD integration for WLS domains
 type wlsHandler struct {
@@ -113,7 +113,7 @@ func (h *wlsHandler) Apply(ctx context.Context, resource vzapi.QualifiedResource
 		return nil, err
 	}
 	serverPod := domain.Spec.ServerPod
-	fluentdPod := toFluentdPod(serverPod, resource, buildWLSLogPath(name))
+	fluentdPod := toFluentdPod(serverPod, resource, BuildWLSLogPath(name))
 	updated, err := getFluentdManager(ctx, h.Log, h).Apply(scope, resource, fluentdPod)
 
 	if updated && err == nil {
@@ -122,7 +122,7 @@ func (h *wlsHandler) Apply(ctx context.Context, resource vzapi.QualifiedResource
 		serverPod.VolumeMounts = fluentdPod.VolumeMounts
 		domain.Spec.ServerPod = serverPod
 		domain.Spec.Configuration.Istio.Enabled = false
-		domain.Spec.LogHome = buildWLSLogHome(name)
+		domain.Spec.LogHome = BuildWLSLogHome(name)
 		domain.Spec.LogHomeEnabled = true
 
 		err = h.Update(ctx, &domain)
@@ -155,12 +155,12 @@ func (h *wlsHandler) Remove(ctx context.Context, resource vzapi.QualifiedResourc
 	return removeVerified, err
 }
 
-// getFluentd creates an instance of FluentManager
-func getFluentd(ctx context.Context, log logr.Logger, client k8sclient.Client) FluentdManager {
+// GetFluentd creates an instance of FluentManager
+func GetFluentd(ctx context.Context, log logr.Logger, client k8sclient.Client) FluentdManager {
 	return &Fluentd{Context: ctx,
 		Log:                    log,
 		Client:                 client,
-		ParseRules:             wlsFluentdParsingRules,
+		ParseRules:             WlsFluentdParsingRules,
 		StorageVolumeName:      storageVolumeName,
 		StorageVolumeMountPath: storageVolumeMountPath,
 	}
@@ -205,12 +205,12 @@ func getWlsSpecificContainerEnv(workload vzapi.QualifiedResourceRelation) []v1.E
 	}
 }
 
-// buildWLSLogPath builds a log path given a resource name
-func buildWLSLogPath(name string) string {
+// BuildWLSLogPath builds a log path given a resource name
+func BuildWLSLogPath(name string) string {
 	return fmt.Sprintf("%s/logs/%s/$(SERVER_NAME).log", scratchVolMountPath, name)
 }
 
-// buildWLSLogHome builds a log home give a resource name
-func buildWLSLogHome(name string) string {
+// BuildWLSLogHome builds a log home give a resource name
+func BuildWLSLogHome(name string) string {
 	return fmt.Sprintf("%s/logs/%s", scratchVolMountPath, name)
 }

--- a/application-operator/controllers/loggingscope/wls_test.go
+++ b/application-operator/controllers/loggingscope/wls_test.go
@@ -45,7 +45,7 @@ func TestApply(t *testing.T) {
 	scope := createTestLoggingScope(true)
 
 	wlsDomain := createWlsDomain(resource)
-	fluentdPod := toFluentdPod(wlsDomain.Spec.ServerPod, resource, buildWLSLogPath(resource.Name))
+	fluentdPod := toFluentdPod(wlsDomain.Spec.ServerPod, resource, BuildWLSLogPath(resource.Name))
 
 	mockClient.EXPECT().
 		Get(context.Background(), types.NamespacedName{Name: testResourceName, Namespace: testNamespace}, &wlsDomain).

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -5,13 +5,30 @@ package wlsworkload
 
 import (
 	"context"
+	"errors"
 
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
+	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// this struct allows us to extract information from the unstructured WebLogic spec
+// so we can interface with the FLUENTD code
+type containersMountsVolumes struct {
+	Containers   []corev1.Container
+	Volumes      []corev1.Volume
+	VolumeMounts []corev1.VolumeMount
+}
 
 // Reconciler reconciles a VerrazzanoWebLogicWorkload object
 type Reconciler struct {
@@ -32,9 +49,179 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
+	ctx := context.Background()
 	log := r.Log.WithValues("verrazzanoweblogicworkload", req.NamespacedName)
 	log.Info("Reconciling verrazzano weblogic workload")
 
-	return ctrl.Result{}, nil
+	// fetch the workload and unwrap the WebLogic resource
+	workload, err := r.fetchWorkload(ctx, req.NamespacedName)
+	if err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	u, err := vznav.ConvertRawExtensionToUnstructured(&workload.Spec.Template)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// make sure the namespace is set to the namespace of the component
+	if err = unstructured.SetNestedField(u.Object, req.NamespacedName.Namespace, "metadata", "namespace"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// the embedded resource doesn't have an API version or kind, so add them
+	gvk := vznav.APIVersionAndKindToContainedGVK(workload.APIVersion, workload.Kind)
+	if gvk == nil {
+		return reconcile.Result{}, errors.New("unable to determine contained GroupVersionKind for workload")
+	}
+
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+
+	// mutate the WebLogic domain resource, copy labels, add logging, etc.
+	if err = copyLabels(log, workload.ObjectMeta.GetLabels(), u); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err = r.addLogging(ctx, log, req.NamespacedName.Namespace, workload.ObjectMeta.Labels, u); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// write out the WebLogic domain resource
+	if err = r.Client.Create(ctx, u); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return reconcile.Result{}, err
+		}
+		log.Info("WebLogic domain CR already exists, ignoring error on create")
+		return reconcile.Result{}, nil
+	}
+
+	log.Info("Successfully created WebLogic domain")
+	return reconcile.Result{}, nil
+}
+
+// fetchWorkload fetches the VerrazzanoWebLogicWorkload data given a namespaced name
+func (r *Reconciler) fetchWorkload(ctx context.Context, name types.NamespacedName) (*vzapi.VerrazzanoWebLogicWorkload, error) {
+	var workload vzapi.VerrazzanoWebLogicWorkload
+	if err := r.Get(ctx, name, &workload); err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("VerrazzanoWebLogicWorkload has been deleted", "name", name)
+		} else {
+			r.Log.Error(err, "Failed to fetch VerrazzanoWebLogicWorkload", "name", name)
+		}
+		return nil, err
+	}
+
+	return &workload, nil
+}
+
+// copyLabels copies specific labels from the Verrazzano workload to the contained WebLogic resource
+func copyLabels(log logr.Logger, workloadLabels map[string]string, weblogic *unstructured.Unstructured) error {
+	// the WebLogic domain spec/serverPod/labels field has labels that get propagated to the pods
+	labels, found, _ := unstructured.NestedStringMap(weblogic.Object, "spec", "serverPod", "labels")
+	if !found {
+		labels = map[string]string{}
+	}
+
+	// copy the oam component and app name labels
+	if componentName, ok := workloadLabels[oam.LabelAppComponent]; ok {
+		labels[oam.LabelAppComponent] = componentName
+	}
+
+	if appName, ok := workloadLabels[oam.LabelAppName]; ok {
+		labels[oam.LabelAppName] = appName
+	}
+
+	err := unstructured.SetNestedStringMap(weblogic.Object, labels, "spec", "serverPod", "labels")
+	if err != nil {
+		log.Error(err, "Unable to set labels in spec serverPod")
+		return err
+	}
+
+	return nil
+}
+
+// addLogging adds a FLUENTD sidecar and updates the WebLogic spec if there is an associated LoggingScope
+func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, weblogic *unstructured.Unstructured) error {
+	loggingScope, err := vznav.LoggingScopeFromWorkloadLabels(ctx, r.Client, namespace, labels)
+	if err != nil {
+		return err
+	}
+
+	if loggingScope == nil {
+		log.Info("No logging scope found for workload, nothing to do")
+		return nil
+	}
+
+	// extract just enough of the WebLogic data into concrete types so we can merge with
+	// the FLUENTD data
+	var extracted containersMountsVolumes
+	if serverPod, found, _ := unstructured.NestedMap(weblogic.Object, "spec", "serverPod"); found {
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(serverPod, &extracted); err != nil {
+			return errors.New("unable to extract containers, volumes, and volume mounts from WebLogic spec")
+		}
+	}
+
+	name, found, _ := unstructured.NestedString(weblogic.Object, "metadata", "name")
+	if !found {
+		return errors.New("expected to find metadata name in WebLogic spec")
+	}
+
+	// fluentdPod starts with what's in the spec and we add in the FLUENTD things when Apply is
+	// called on the fluentdManager
+	fluentdPod := &loggingscope.FluentdPod{
+		Containers:   extracted.Containers,
+		Volumes:      extracted.Volumes,
+		VolumeMounts: extracted.VolumeMounts,
+		LogPath:      loggingscope.BuildWLSLogPath(name),
+	}
+	fluentdManager := loggingscope.GetFluentd(ctx, r.Log, r.Client)
+
+	// fluentdManager.Apply wants a QRR but it only cares about the namespace (at least for
+	// this use case)
+	resource := vzapi.QualifiedResourceRelation{Namespace: namespace}
+
+	// note that this call has the side effect of creating a FLUENTD config map if one
+	// does not already exist in the namespace
+	if _, err = fluentdManager.Apply(loggingScope, resource, fluentdPod); err != nil {
+		return err
+	}
+
+	// convert the containers, volumes, and mounts in fluentdPod to unstructured and set
+	// the values in the spec
+	fluentdPodUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(fluentdPod)
+	if err != nil {
+		return err
+	}
+
+	err = unstructured.SetNestedSlice(weblogic.Object, fluentdPodUnstructured["containers"].([]interface{}), "spec", "serverPod", "containers")
+	if err != nil {
+		log.Error(err, "Unable to set serverPod containers")
+		return err
+	}
+	err = unstructured.SetNestedSlice(weblogic.Object, fluentdPodUnstructured["volumes"].([]interface{}), "spec", "serverPod", "volumes")
+	if err != nil {
+		log.Error(err, "Unable to set serverPod volumes")
+		return err
+	}
+	err = unstructured.SetNestedField(weblogic.Object, fluentdPodUnstructured["volumeMounts"].([]interface{}), "spec", "serverPod", "volumeMounts")
+	if err != nil {
+		log.Error(err, "Unable to set serverPod volumeMounts")
+		return err
+	}
+
+	// logHome and logHomeEnabled fields need to be set to turn on logging
+	err = unstructured.SetNestedField(weblogic.Object, loggingscope.BuildWLSLogHome(name), "spec", "logHome")
+	if err != nil {
+		log.Error(err, "Unable to set logHome")
+		return err
+	}
+	err = unstructured.SetNestedField(weblogic.Object, true, "spec", "logHomeEnabled")
+	if err != nil {
+		log.Error(err, "Unable to set logHomeEnabled")
+		return err
+	}
+
+	return nil
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -4,16 +4,32 @@
 package wlsworkload
 
 import (
+	"context"
 	"testing"
 
+	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const namespace = "unit-test-namespace"
+const weblogicAPIVersion = "weblogic.oracle/v8"
+const weblogicKind = "Domain"
 
 // TestReconcilerSetupWithManager test the creation of the VerrazzanoWebLogicWorkload reconciler.
 // GIVEN a controller implementation
@@ -43,4 +59,341 @@ func TestReconcilerSetupWithManager(t *testing.T) {
 	err = reconciler.SetupWithManager(mgr)
 	mocker.Finish()
 	assert.NoError(err)
+}
+
+// TestReconcileCreateWebLogicDomain tests the basic happy path of reconciling a VerrazzanoWebLogicWorkload. We
+// expect to write out a WebLogic domain CR but we aren't adding logging or any other scopes or traits.
+// GIVEN a VerrazzanoWebLogicWorkload resource is created
+// WHEN the controller Reconcile function is called
+// THEN expect a WebLogic domain CR to be written
+func TestReconcileCreateWebLogicDomain(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.GroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			return nil
+		})
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to create the WebLogic domain CR
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+
+			// make sure the OAM component and app name labels were copied
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "serverPod", "labels")
+			assert.Equal(labels, specLabels)
+			return nil
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileCreateWebLogicDomainWithLogging tests the happy path of reconciling a VerrazzanoWebLogicWorkload
+// with an attached logging scope. We expect to write out a WebLogic domain CR with the FLUENTD sidecar and
+// associated volumes and mounts.
+// GIVEN a VerrazzanoWebLogicWorkload resource is created with a logging scope
+// WHEN the controller Reconcile function is called
+// THEN expect a WebLogic domain CR to be written with logging extras.
+func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	loggingScopeName := "unit-test-logging-scope"
+	fluentdImage := "unit-test-image:latest"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.GroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			return nil
+		})
+	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+			loggingScope.Spec.FluentdImage = fluentdImage
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
+			return nil
+		})
+	// expect a call to create the WebLogic domain CR
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+
+			// make sure the OAM component and app name labels were copied
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "serverPod", "labels")
+			assert.Equal(labels, specLabels)
+
+			// make sure the FLUENTD sidecar was added
+			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
+			assert.Equal(1, len(containers))
+			assert.Equal(fluentdImage, containers[0].(map[string]interface{})["image"])
+			return nil
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileAlreadyExists tests reconciling a VerrazzanoWebLogicWorkload when the WebLogic
+// domain CR already exists. We ignore the error and return success.
+// GIVEN a VerrazzanoWebLogicWorkload resource
+// WHEN the controller Reconcile function is called and the WebLogic domain CR already exists
+// THEN ignore the error on create and return success
+func TestReconcileAlreadyExists(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.GroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			return nil
+		})
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to create the WebLogic domain CR and return an AlreadyExists error
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+			return k8serrors.NewAlreadyExists(k8sschema.GroupResource{}, "")
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileErrorOnCreate tests reconciling a VerrazzanoWebLogicWorkload and an
+// error occurs attempting to create the WebLogic domain CR.
+// GIVEN a VerrazzanoWebLogicWorkload resource is created
+// WHEN the controller Reconcile function is called and there is an error creating the WebLogic domain CR
+// THEN expect an error to be returned
+func TestReconcileErrorOnCreate(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.GroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			return nil
+		})
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to create the WebLogic domain CR and return an AlreadyExists error
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+			return k8serrors.NewBadRequest("an error has occurred")
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Error(err)
+	assert.Equal("an error has occurred", err.Error())
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileWorkloadNotFound tests reconciling a VerrazzanoWebLogicWorkload when the workload
+// cannot be fetched. This happens when the workload has been deleted by the OAM runtime.
+// GIVEN a VerrazzanoWebLogicWorkload resource has been deleted
+// WHEN the controller Reconcile function is called and we attempt to fetch the workload
+// THEN return success from the controller as there is nothing more to do
+func TestReconcileWorkloadNotFound(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileFetchWorkloadError tests reconciling a VerrazzanoWebLogicWorkload when the workload
+// cannot be fetched due to an unexpected error.
+// GIVEN a VerrazzanoWebLogicWorkload resource has been created
+// WHEN the controller Reconcile function is called and we attempt to fetch the workload and get an error
+// THEN return the error
+func TestReconcileFetchWorkloadError(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller = gomock.NewController(t)
+	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			return k8serrors.NewBadRequest("an error has occurred")
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Equal("an error has occurred", err.Error())
+	assert.Equal(false, result.Requeue)
+}
+
+// newScheme creates a new scheme that includes this package's object to use for testing
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	vzapi.AddToScheme(scheme)
+	return scheme
+}
+
+// newReconciler creates a new reconciler for testing
+// c - The K8s client to inject into the reconciler
+func newReconciler(c client.Client) Reconciler {
+	return Reconciler{
+		Client: c,
+		Log:    ctrl.Log.WithName("test"),
+		Scheme: newScheme(),
+	}
+}
+
+// newRequest creates a new reconciler request for testing
+// namespace - The namespace to use in the request
+// name - The name to use in the request
+func newRequest(namespace string, name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
 }


### PR DESCRIPTION
# Description

This PR continues the implementation of the VerrazzanoWebLogicWorkload controller. It includes most of the core functionality, including logging. I think support for deleting resources is the only chunk left and that will come in the next PR.

Code coverage on the controller is only at 76%. Most of the uncovered lines are error conditions that are not easily tested. I will increase the coverage % in the next PR.

Note that nothing is actually using this new workload type yet. The last PR will switch the examples over to use this workload.

# How has this been tested?

Provide details about how you tested this changed, if necessary
provide instructions to reproduce the testing.

- [x] Tested locally in my own environment
- [x] Successful acceptance test run on CI server
- [ ] Other (specify)

# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated godoc for all public functions
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [x] Checked that I correctly spelled trademark and product names
- [x] Used inclusive language and neutral tone
- [x] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
