### PR TITLE
Mgilbode/webhook san take2

### DIFF
--- a/platform-operator/internal/certificate/certificate.go
+++ b/platform-operator/internal/certificate/certificate.go
@@ -79,6 +79,7 @@ func CreateWebhookCertificates(certDir string) (*bytes.Buffer, error) {
 
 	// server cert config
 	cert := &x509.Certificate{
+		DNSNames:     []string{commonName},
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,

--- a/platform-operator/internal/certificate/certificate_test.go
+++ b/platform-operator/internal/certificate/certificate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certificate
@@ -6,6 +6,8 @@ package certificate
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,8 +34,23 @@ func TestCreateWebhookCertificates(t *testing.T) {
 	caBundle, err := CreateWebhookCertificates(dir)
 	assert.Nil(err, "error should not be returned setting up certificates")
 	assert.NotNil(caBundle, "CA bundle should be returned")
-	assert.FileExists(fmt.Sprintf("%s/%s", dir, "tls.crt"), "expected tls.crt file not found")
-	assert.FileExists(fmt.Sprintf("%s/%s", dir, "tls.key"), "expected tls.key file not found")
+
+	crtFile := fmt.Sprintf("%s/%s", dir, "tls.crt")
+	keyFile := fmt.Sprintf("%s/%s", dir, "tls.key")
+	assert.FileExists(crtFile, dir, "tls.crt", "expected tls.crt file not found")
+	assert.FileExists(keyFile, dir, "tls.key", "expected tls.key file not found")
+
+	crtBytes, err := ioutil.ReadFile(crtFile)
+	if assert.NoError(err) {
+		block, _ := pem.Decode(crtBytes)
+		assert.NotEmptyf(block, "failed to decode PEM block containing public key")
+		assert.Equal("CERTIFICATE", block.Type)
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if assert.NoError(err) {
+			assert.NotEmpty(cert.DNSNames, "Certificate DNSNames SAN field should not be empty")
+			assert.Equal("verrazzano-platform-operator.verrazzano-install.svc", cert.DNSNames[0])
+		}
+	}
 }
 
 // TestCreateWebhookCertificatesFail tests that the certificates needed for webhooks are not created


### PR DESCRIPTION
# Description

Fixes VZ-2076 - adds SAN to webhook server cert to work w/ more recent versions of kubernetes

# How has this been tested?

Provide details about how you tested this changed, if necessary
provide instructions to reproduce the testing.

- [] Tested locally in my own environment
- [x] Successful acceptance test run on CI server
- [ ] Other (specify)

# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated godoc for all public functions
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [ ] Checked that I correctly spelled trademark and product names
- [ ] Used inclusive language and neutral tone
- [ ] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
