### PR TITLE
Fix bug copying labels in VerrazzanoCoherenceWorkload

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -5,7 +5,6 @@ package cohworkload
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -83,8 +82,7 @@ func TestReconcileCreateCoherence(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-coherence-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoCoherenceWorkload) error {
-			labelsJSON, _ := json.Marshal(labels)
-			coherenceJSON := `{"metadata":{"name":"unit-test-cluster","labels":` + string(labelsJSON) + `},"spec":{"replicas":3}}`
+			coherenceJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"replicas":3}}`
 			workload.Spec.Template = runtime.RawExtension{Raw: []byte(coherenceJSON)}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
@@ -114,7 +112,8 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Equal(coherenceKind, u.GetKind())
 
 			// make sure the OAM component and app name labels were copied
-			assert.Equal(labels, u.GetLabels())
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "labels")
+			assert.Equal(labels, specLabels)
 
 			// make sure sidecar.istio.io/inject annotation was added
 			annotations, _, _ := unstructured.NestedStringMap(u.Object, "spec", "annotations")

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -33,6 +33,8 @@ const namespace = "unit-test-namespace"
 const coherenceAPIVersion = "coherence.oracle.com/v1"
 const coherenceKind = "Coherence"
 
+var specJvmArgsFields = []string{specField, jvmField, argsField}
+
 // TestReconcilerSetupWithManager test the creation of the logging scope reconciler.
 // GIVEN a controller implementation
 // WHEN the controller is created
@@ -112,11 +114,11 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Equal(coherenceKind, u.GetKind())
 
 			// make sure the OAM component and app name labels were copied
-			specLabels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "labels")
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, specLabelsFields...)
 			assert.Equal(labels, specLabels)
 
 			// make sure sidecar.istio.io/inject annotation was added
-			annotations, _, _ := unstructured.NestedStringMap(u.Object, "spec", "annotations")
+			annotations, _, _ := unstructured.NestedStringMap(u.Object, specAnnotationsFields...)
 			assert.Equal(annotations, map[string]string{"sidecar.istio.io/inject": "false"})
 			return nil
 		})
@@ -206,15 +208,15 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 			assert.Equal(coherenceKind, u.GetKind())
 
 			// make sure JVM args were added
-			jvmArgs, _, _ := unstructured.NestedSlice(u.Object, "spec", "jvm", "args")
+			jvmArgs, _, _ := unstructured.NestedSlice(u.Object, specJvmArgsFields...)
 			assert.Equal(additionalJvmArgs, jvmArgs)
 
 			// make sure side car was added
-			sideCars, _, _ := unstructured.NestedSlice(u.Object, "spec", "sideCars")
+			sideCars, _, _ := unstructured.NestedSlice(u.Object, specField, "sideCars")
 			assert.Equal(1, len(sideCars))
 
 			// make sure sidecar.istio.io/inject annotation was added
-			annotations, _, _ := unstructured.NestedStringMap(u.Object, "spec", "annotations")
+			annotations, _, _ := unstructured.NestedStringMap(u.Object, specAnnotationsFields...)
 			assert.Equal(annotations, map[string]string{"sidecar.istio.io/inject": "false"})
 			return nil
 		})
@@ -306,16 +308,16 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 			assert.Equal(coherenceKind, u.GetKind())
 
 			// make sure JVM args were added and that the existing arg is still present
-			jvmArgs, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "jvm", "args")
+			jvmArgs, _, _ := unstructured.NestedStringSlice(u.Object, specJvmArgsFields...)
 			assert.Equal(len(additionalJvmArgs)+1, len(jvmArgs))
 			assert.True(controllers.StringSliceContainsString(jvmArgs, existingJvmArg))
 
 			// make sure side car was added
-			sideCars, _, _ := unstructured.NestedSlice(u.Object, "spec", "sideCars")
+			sideCars, _, _ := unstructured.NestedSlice(u.Object, specField, "sideCars")
 			assert.Equal(1, len(sideCars))
 
 			// make sure sidecar.istio.io/inject annotation was added
-			annotations, _, _ := unstructured.NestedStringMap(u.Object, "spec", "annotations")
+			annotations, _, _ := unstructured.NestedStringMap(u.Object, specAnnotationsFields...)
 			assert.Equal(annotations, map[string]string{"sidecar.istio.io/inject": "false"})
 			return nil
 		})


### PR DESCRIPTION
# Description

Fix bug, the VerrazzanoCoherenceWorkload controller was copying labels into the Coherence CR metadata labels. It needs to copy them into the `spec/labels` field instead.

# How has this been tested?

Ran sockshop example, dumped the Coherence CR and confirmed the labels were in the correct location. Dumped the resulting Coherence pods and verified that the labels were present in the metadata labels section.

- [x] Tested locally in my own environment
- [ ] Successful acceptance test run on CI server
- [ ] Other (specify)

# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated godoc for all public functions
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [x] Checked that I correctly spelled trademark and product names
- [x] Used inclusive language and neutral tone
- [x] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
