### PR TITLE
VZ-2031: uninstall hangs when oam applications are running

### DIFF
--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -85,8 +85,9 @@ func TestMetricsTraitCreatedForContainerizedWorkload(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:      "test-deployment-name",
-			Namespace: "test-namespace",
+			Name:              "test-deployment-name",
+			Namespace:         "test-namespace",
+			CreationTimestamp: k8smeta.Now(),
 			OwnerReferences: []k8smeta.OwnerReference{{
 				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
 				Kind:       oamcore.ContainerizedWorkloadKind,
@@ -233,8 +234,9 @@ func TestMetricsTraitCreatedForVerrazzanoWorkload(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:      "test-deployment-name",
-			Namespace: "test-namespace",
+			Name:              "test-deployment-name",
+			Namespace:         "test-namespace",
+			CreationTimestamp: k8smeta.Now(),
 			OwnerReferences: []k8smeta.OwnerReference{{
 				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
 				Kind:       oamcore.ContainerizedWorkloadKind,
@@ -495,6 +497,110 @@ func TestMetricsTraitDeletedForContainerizedWorkload(t *testing.T) {
 	assert.GreaterOrEqual(result.RequeueAfter.Seconds(), 45.0)
 }
 
+// TestMetricsTraitDeletedForContainerizedWorkload tests deletion of a metrics trait related to a containerized workload.
+// GIVEN a metrics trait with a non-zero deletion time
+// GIVEN the related deployment resource no longer exists
+// WHEN the metrics trait Reconcile method is invoked
+// THEN verify that metrics trait finalizer is removed
+// AND verify that the scraper configmap is cleanup up
+// AND verify that the scraper pod is restarted
+// AND verify that the finalizer is removed
+func TestMetricsTraitDeletedForContainerizedWorkloadWhenDeploymentDeleted(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	//mockStatus := mocks.NewMockStatusWriter(mocker)
+	var err error
+
+	params := map[string]string{
+		"##OAM_APP_NAME##":         "test-oam-app-name",
+		"##OAM_COMP_NAME##":        "test-oam-comp-name",
+		"##TRAIT_NAME##":           "test-trait-name",
+		"##TRAIT_NAMESPACE##":      "test-namespace",
+		"##WORKLOAD_APIVER##":      "core.oam.dev/v1alpha2",
+		"##WORKLOAD_KIND##":        "ContainerizedWorkload",
+		"##WORKLOAD_NAME##":        "test-workload-name",
+		"##PROMETHEUS_NAME##":      "vmi-system-prometheus-0",
+		"##PROMETHEUS_NAMESPACE##": "verrazzano-system",
+		"##DEPLOYMENT_NAMESPACE##": "test-namespace",
+		"##DEPLOYMENT_NAME##":      "test-workload-name",
+	}
+
+	// Expect a call to get the deleted trait resource.
+	mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.MetricsTrait) error {
+		assert.Equal("test-namespace", name.Namespace)
+		assert.Equal("test-trait-name", name.Name)
+		assert.NoError(updateObjectFromYAMLTemplate(trait, "test/templates/containerized_workload_metrics_trait_deleted.yaml", params))
+		return nil
+	})
+	// Expect a call to get the child deployment resource
+	// Do not modify the provided Deployment object to simulate it no longer existing.
+	mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).DoAndReturn(func(ctx context.Context, name types.NamespacedName, obj *k8sapps.Deployment) error {
+		assert.Equal("test-namespace", name.Namespace)
+		assert.Equal("test-workload-name", name.Name)
+		assert.True(obj.CreationTimestamp.IsZero(), "Expected creationTimestamp to be zero.")
+		return nil
+	})
+	// Expect a call to get the prometheus deployment.
+	mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, deployment *k8sapps.Deployment) error {
+		assert.Equal("verrazzano-system", name.Namespace)
+		assert.Equal("vmi-system-prometheus-0", name.Name)
+		assert.NoError(updateObjectFromYAMLTemplate(deployment, "test/templates/prometheus_deployment.yaml", params))
+		return nil
+	})
+	// Expect a call to get the prometheus configmap.
+	mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, configmap *k8score.ConfigMap) error {
+		assert.Equal("verrazzano-system", name.Namespace)
+		assert.Equal("vmi-system-prometheus-0", name.Name)
+		assert.NoError(updateObjectFromYAMLTemplate(configmap, "test/templates/prometheus_configmap.yaml", params))
+		return nil
+	})
+	// Expect a call to update the prometheus configmap
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, obj *k8score.ConfigMap) error {
+		assert.Equal("verrazzano-system", obj.Namespace)
+		assert.Equal("vmi-system-prometheus-0", obj.Name)
+		return nil
+	})
+	// Expect a call to list the prometheus replicasets
+	mock.EXPECT().List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+		assert.Equal("ReplicaSet", list.GetKind())
+		pod := k8score.Pod{}
+		assert.NoError(updateObjectFromYAMLTemplate(&pod, "test/templates/prometheus_replicaset.yaml", params))
+		return appendAsUnstructured(list, pod)
+	})
+	// Expect a call to list the prometheus pods
+	mock.EXPECT().List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+		assert.Equal("Pod", list.GetKind())
+		pod := k8score.Pod{}
+		assert.NoError(updateObjectFromYAMLTemplate(&pod, "test/templates/prometheus_pod.yaml", params))
+		return appendAsUnstructured(list, pod)
+	})
+	// Expect a call to delete the prometheus pods
+	mock.EXPECT().Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, uns *unstructured.Unstructured, opts ...client.DeleteOption) error {
+		assert.Equal("verrazzano-system", uns.GetNamespace())
+		assert.Equal("vmi-system-prometheus-0", uns.GetName())
+		return nil
+	})
+	// Expect a call to update the metrics trait to remove the finalizer
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, obj *vzapi.MetricsTrait) error {
+		assert.Equal("test-namespace", obj.Namespace)
+		assert.Equal("test-trait-name", obj.Name)
+		assert.Len(obj.Finalizers, 0)
+		return nil
+	})
+
+	// Create and make the request
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test-namespace", Name: "test-trait-name"}}
+	reconciler := newMetricsTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.GreaterOrEqual(result.RequeueAfter.Seconds(), 45.0)
+}
+
 // TestFetchTraitError tests a failure to fetch the trait during reconcile.
 // GIVEN a valid new metrics trait
 // WHEN the the metrics trait Reconcile method is invoked
@@ -591,8 +697,9 @@ func TestDeploymentUpdateError(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:      "test-deployment-name",
-			Namespace: "test-namespace",
+			Name:              "test-deployment-name",
+			Namespace:         "test-namespace",
+			CreationTimestamp: k8smeta.Now(),
 			OwnerReferences: []k8smeta.OwnerReference{{
 				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
 				Kind:       oamcore.ContainerizedWorkloadKind,
@@ -721,8 +828,9 @@ func TestNoUpdatesRequired(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:      "test-deployment-name",
-			Namespace: "test-namespace",
+			Name:              "test-deployment-name",
+			Namespace:         "test-namespace",
+			CreationTimestamp: k8smeta.Now(),
 			OwnerReferences: []k8smeta.OwnerReference{{
 				APIVersion: oamcore.SchemeGroupVersion.Identifier(),
 				Kind:       oamcore.ContainerizedWorkloadKind,
@@ -1229,8 +1337,9 @@ func TestMetricsTraitCreatedForCOHWorkload(t *testing.T) {
 			Kind:       "StatefulSet",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:      "test-stateful-set-name",
-			Namespace: "test-namespace",
+			Name:              "test-stateful-set-name",
+			Namespace:         "test-namespace",
+			CreationTimestamp: k8smeta.Now(),
 			OwnerReferences: []k8smeta.OwnerReference{{
 				APIVersion: "coherence.oracle.com/v1",
 				Kind:       "Coherence",

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
@@ -9,6 +9,6 @@ global:
 # NOTE: The image value gets set in the override file verrazzano-application-operator-values.yaml
 # during the platform operator docker image build.
 image:
-imagePullPolicy: Always
+imagePullPolicy: IfNotPresent
 
 requestMemory: 72Mi

--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -52,4 +52,16 @@ function initializing_uninstall {
   fi
 }
 
+# Delete all of the OAM ApplicationConfiguration resources in all namespaces.
+function delete_oam_applications_configurations {
+  delete_k8s_resource_from_all_namespaces applicationconfigurations.core.oam.dev
+}
+
+# Delete all of the OAM Component resources in all namespaces.
+function delete_oam_components {
+  delete_k8s_resource_from_all_namespaces components.core.oam.dev
+}
+
 action "Initializing Uninstall" initializing_uninstall || exit 1
+action "Deleting OAM application configurations" delete_oam_applications_configurations || exit 1
+action "Deleting OAM components" delete_oam_components || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -90,8 +90,9 @@ function delete_rancher() {
   while [ "$crd_content" ]
   do
     # remove finalizers from crds
+    # Ignore patch failures and attempt to delete the resources anyway.
     patch_k8s_resources crds ":metadata.name,:spec.group" "Could not remove finalizers from CustomResourceDefinitions in Rancher" '/coreos.com|cattle.io/ {print $1}' '{"metadata":{"finalizers":null}}' \
-      || return $? # return on pipefail
+      || true
 
     # delete crds
     # This process is backgrounded in order to timeout due to finalizers hanging

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -13,6 +13,8 @@ UNINSTALL_DIR=$SCRIPT_DIR/..
 
 set -o pipefail
 
+VERRAZZANO_NS=verrazzano-system
+
 function delete_verrazzano() {
   # delete helm installation of Verrazzano
   log "Deleting Verrazzano"
@@ -62,45 +64,51 @@ function delete_verrazzano() {
 
 function delete_oam_operator {
   log "Uninstall the OAM Kubernetes operator"
-  helm uninstall oam-kubernetes-runtime --namespace "${VERRAZZANO_NS}" || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to uninstall the OAM Kubernetes operator."
+  if helm status oam-kubernetes-runtime --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
+    if ! helm uninstall oam-kubernetes-runtime --namespace "${VERRAZZANO_NS}" ; then
+      error "Failed to uninstall the OAM Kubernetes operator."
+    fi
   fi
 
   log "Delete the OAM Kubernetes operator roles"
-  kubectl delete clusterrolebinding cluster-admin-binding-oam || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to delete the OAM Kubernetes operator roles."
+  if kubectl get clusterrolebinding cluster-admin-binding-oam ; then
+    if ! kubectl delete clusterrolebinding cluster-admin-binding-oam ; then
+      error "Failed to delete the OAM Kubernetes operator roles."
+    fi
   fi
 }
 
 function delete_application_operator {
   log "Uninstall the Verrazzano Kubernetes application operator"
-  helm uninstall verrazzano-application-operator --namespace "${VERRAZZANO_NS}" || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to uninstall the Verrazzano Kubernetes application operator."
+  if helm status verrazzano-application-operator --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
+    if ! helm uninstall verrazzano-application-operator --namespace "${VERRAZZANO_NS}" ; then
+      error "Failed to uninstall the Verrazzano Kubernetes application operator."
+    fi
   fi
 }
 
 function delete_weblogic_operator {
   log "Uninstall the WebLogic Kubernetes operator"
-  helm uninstall weblogic-operator --namespace "${VERRAZZANO_NS}" || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to uninstall the WebLogic Kubernetes operator."
+  if helm status uninstall weblogic-operator --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
+    if ! helm uninstall weblogic-operator --namespace "${VERRAZZANO_NS}" ; then
+      error "Failed to uninstall the WebLogic Kubernetes operator."
+    fi
   fi
 
   log "Delete the WebLogic Kubernetes operator service account"
-  kubectl delete serviceaccount -n "${VERRAZZANO_NS}" weblogic-operator-sa || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to delete the WebLogic Kubernetes operator service account."
+  if kubectl get serviceaccount -n "${VERRAZZANO_NS}" weblogic-operator-sa > /dev/null 2>&1 ; then
+    if ! kubectl delete serviceaccount -n "${VERRAZZANO_NS}" weblogic-operator-sa ; then
+      error "Failed to delete the WebLogic Kubernetes operator service account."
+    fi
   fi
 }
 
 function delete_coherence_operator {
   log "Uninstall the Coherence Kubernetes operator"
-  helm uninstall coherence-operator --namespace "${VERRAZZANO_NS}" || return $?
-  if [ $? -ne 0 ]; then
-    error "Failed to uninstall the Coherence Kubernetes operator."
+  if helm status uninstall coherence-operator --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
+    if ! helm uninstall coherence-operator --namespace "${VERRAZZANO_NS}" ; then
+      error "Failed to uninstall the Coherence Kubernetes operator."
+    fi
   fi
 }
 

--- a/platform-operator/scripts/uninstall/uninstall-utils.sh
+++ b/platform-operator/scripts/uninstall/uninstall-utils.sh
@@ -4,7 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
-INSTALL_DIR=$SCRIPT_DIR/../../install
+INSTALL_DIR=$SCRIPT_DIR/../install
 
 . $INSTALL_DIR/common.sh
 

--- a/platform-operator/scripts/uninstall/uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-verrazzano.sh
@@ -45,10 +45,6 @@ if [ "$FORCE" = false ] ; then
   done
 fi
 
-action "Retrieving Verrazzano Applications" check_applications || exit 1
-echo -ne "$APPLICATION_RESOURCES" >&4
-prompt_delete_applications || exit 1
-
 section "Uninstalling Verrazzano Applications"
 $SCRIPT_DIR/uninstall-steps/0-uninstall-applications.sh || exit 1
 section "Uninstalling Keycloak..."

--- a/platform-operator/scripts/uninstall/uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-verrazzano.sh
@@ -5,10 +5,9 @@
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 INSTALL_DIR=$SCRIPT_DIR/../install
-UNINSTALL_DIR=$SCRIPT_DIR/..
 
 . $INSTALL_DIR/common.sh
-. $UNINSTALL_DIR/uninstall-utils.sh
+. $SCRIPT_DIR/uninstall-utils.sh
 
 set -o pipefail
 


### PR DESCRIPTION
# Description

Improves the resiliency of Verrazzano uninstall.  Fixes N things in particular.
1. Fixes issues in metrics trait controller that prevented finalizer removal if a related resource was deleted before the trait.
2. Removes all OAM apps as part of uninstall.
3. Improves resiliency of Rancher CRD cleanup.
4. Checks for existence of OAM components before attempting to delete them. 
5. Uses the correct namespace when deleting OAM components.

Fixes VZ-2031

# How has this been tested?

In KinD cluster did repeated (>20) apply/delete of OAM apps. 
Also did repeated install/uninstall of Verrazzano with OAM apps left deployed.

- [x] Tested locally in my own environment
- [ ] Successful acceptance test run on CI server
- [x] Other (specify).  
# Checklist 

As the author of this PR, I have:

- [x] Checked my code follows the style guidelines, ran `go fmt`
- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated godoc for all public functions
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate
- [x] Checked that I correctly spelled trademark and product names
- [x] Used inclusive language and neutral tone
- [x] Not included any sensitive information or hardcoded credentials

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
