### PR TITLE
Update Verrazzano acceptance test to use Kind with metallb

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,6 +336,10 @@ pipeline {
                             cd ${GO_REPO_PATH}/verrazzano/platform-operator
                             make create-cluster
 
+                            echo "Install metallb"
+                            cd ${GO_REPO_PATH}/verrazzano
+                            ./tests/e2e/config/scripts/install-metallb.sh
+
                             echo "Create Image Pull Secrets"
                             cd ${GO_REPO_PATH}/verrazzano
                             ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}"

--- a/platform-operator/test/kind-config.yaml
+++ b/platform-operator/test/kind-config.yaml
@@ -12,18 +12,3 @@ nodes:
           extraArgs:
             "service-account-issuer": "kubernetes.default.svc"
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-      - |
-        kind: InitConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            node-labels: "ingress-ready=true"
-            authorization-mode: "AlwaysAllow"
-    extraPortMappings:
-      - containerPort: 80
-        hostPort: 80
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 443
-        hostPort: 443
-        listenAddress: "0.0.0.0"
-        protocol: tcp

--- a/tests/e2e/config/scripts/install-metallb.sh
+++ b/tests/e2e/config/scripts/install-metallb.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+set -e
+
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+kubectl apply -f - <<-EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: my-ip-space
+      protocol: layer2
+      addresses:
+      - 172.18.0.230-172.18.0.250
+EOF

--- a/tests/e2e/config/scripts/install-metallb.sh
+++ b/tests/e2e/config/scripts/install-metallb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -6,20 +6,4 @@ kind: Verrazzano
 metadata:
   name: my-verrazzano
 spec:
-  components:
-    ingress:
-      type: NodePort
-      nginxInstallArgs:
-        - name: controller.kind
-          value: DaemonSet
-        - name: controller.hostPort.enabled
-          value: "true"
-        - name: controller.nodeSelector.ingress-ready
-          value: "true"
-          setString: true
-        - name: controller.tolerations[0].key
-          value: node-role.kubernetes.io/master
-        - name: controller.tolerations[0].operator
-          value: Equal
-        - name: controller.tolerations[0].effect
-          value: NoSchedule
+  profile: dev

--- a/tests/e2e/pkg/environment.go
+++ b/tests/e2e/pkg/environment.go
@@ -32,17 +32,17 @@ func Ingress() string {
 	}
 
 	if clusterType == CLUSTER_TYPE_KIND {
-		return kindIngress()
+		return loadBalancerIngress()
 	} else if clusterType == CLUSTER_TYPE_OLCNE {
-		return olcneIngress()
+		return externalLoadBalancerIngress()
 	} else {
-		return okeIngress()
+		return loadBalancerIngress()
 	}
 }
 
-// kindIngress returns the ingress address from a KIND cluster
-func kindIngress() string {
-	fmt.Println("Obtaining KIND control plane address info ...")
+// nodePortIngress returns the ingress node port address
+func nodePortIngress() string {
+	fmt.Println("Obtaining node address info ...")
 	addrHost := ""
 	var addrPort int32
 
@@ -54,26 +54,27 @@ func kindIngress() string {
 	}
 
 	ingressgateway := findIstioIngressGatewaySvc(false)
-	fmt.Println("ingressgateway for KIND cluster is ", ingressgateway)
+	fmt.Println("ingressgateway for cluster is ", ingressgateway)
 	for _, eachPort := range ingressgateway.Spec.Ports {
 		if eachPort.Port == 80 {
-			fmt.Printf("KIND cluster - found ingressgateway port %d with nodeport %d, name %s\n", eachPort.Port, eachPort.NodePort, eachPort.Name)
+			fmt.Printf("cluster - found ingressgateway port %d with nodeport %d, name %s\n", eachPort.Port, eachPort.NodePort, eachPort.Name)
+			fmt.Printf("cluster - found ingressgateway port %d with nodeport %d, name %s\n", eachPort.Port, eachPort.NodePort, eachPort.Name)
 			addrPort = eachPort.NodePort
 		}
 	}
 
 	if addrHost == "" {
-		fmt.Println("KIND control plane address is empty")
+		fmt.Println("node address is empty")
 		return ""
 	} else {
 		ingressAddr := fmt.Sprintf("%s:%d", addrHost, addrPort)
-		fmt.Printf("KIND ingress address is %s\n", ingressAddr)
+		fmt.Printf("ingress address is %s\n", ingressAddr)
 		return ingressAddr
 	}
 }
 
-// okeIngress returns the ingress address from an OKE cluster
-func okeIngress() string {
+// loadBalancerIngress returns the ingress load balancer address
+func loadBalancerIngress() string {
 	fmt.Println("Obtaining ingressgateway info ...")
 	ingressgateway := findIstioIngressGatewaySvc(true)
 	for i := range ingressgateway.Status.LoadBalancer.Ingress {
@@ -90,9 +91,9 @@ func okeIngress() string {
 	return ""
 }
 
-// olcneIngress returns the ingress address from an OLCNE cluster
-func olcneIngress() string {
-	fmt.Println("Obtaining OLCNE ingressgateway info ...")
+// externalLoadBalancerIngress returns the ingress external load balancer address
+func externalLoadBalancerIngress() string {
+	fmt.Println("Obtaining ingressgateway info ...")
 	// Test a service for a dynamic address (.status.loadBalancer.ingress[0].ip),
 	// 	if that's not present then use .spec.externalIPs[0]
 	lb_ingressgateway := findIstioIngressGatewaySvc(true)

--- a/tests/e2e/pkg/vmi.go
+++ b/tests/e2e/pkg/vmi.go
@@ -75,7 +75,7 @@ func getHttpClientWIthCABundle(caData []byte) *http.Client {
 		tr.Proxy = http.ProxyURL(tURLProxy)
 	}
 
-	ipResolve := getManagementClusterNodeIP()
+	ipResolve := getNginxNodeIP()
 	if ipResolve != "" {
 		dialer := &net.Dialer{
 			Timeout:   30 * time.Second,
@@ -94,8 +94,8 @@ func getHttpClientWIthCABundle(caData []byte) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
-// If testing against KIND, returns the control-plane node ip ; "" otherwise
-func getManagementClusterNodeIP() string {
+// Returns the nginx controller node ip
+func getNginxNodeIP() string {
 	pods := ListPods("ingress-nginx")
 	for i := range pods.Items {
 		pod := pods.Items[i]

--- a/tests/e2e/pkg/vmi.go
+++ b/tests/e2e/pkg/vmi.go
@@ -75,7 +75,7 @@ func getHttpClientWIthCABundle(caData []byte) *http.Client {
 		tr.Proxy = http.ProxyURL(tURLProxy)
 	}
 
-	ipResolve := getNginxNodeIP()
+	ipResolve := getNginxControllerNodeIP()
 	if ipResolve != "" {
 		dialer := &net.Dialer{
 			Timeout:   30 * time.Second,
@@ -95,7 +95,7 @@ func getHttpClientWIthCABundle(caData []byte) *http.Client {
 }
 
 // Returns the nginx controller node ip
-func getNginxNodeIP() string {
+func getNginxControllerNodeIP() string {
 	pods := ListPods("ingress-nginx")
 	for i := range pods.Items {
 		pod := pods.Items[i]

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -193,7 +193,7 @@ func getHTTPClientWIthCABundle(caData []byte) *http.Client {
 		tr.Proxy = http.ProxyURL(tURLProxy)
 	}
 
-	ipResolve := getNodeIP()
+	ipResolve := getNginxNodeIP()
 	if ipResolve != "" {
 		dialer := &net.Dialer{
 			Timeout:   30 * time.Second,
@@ -251,8 +251,8 @@ func doGetCACertFromSecret(secretName string, namespace string) []byte {
 	return certSecret.Data["ca.crt"]
 }
 
-// Returns the control-plane node ip
-func getNodeIP() string {
+// Returns the nginx controller node ip
+func getNginxNodeIP() string {
 	clientset := GetKubernetesClientset()
 	pods, err := clientset.CoreV1().Pods("ingress-nginx").List(context.TODO(), metav1.ListOptions{})
 	if err == nil {

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -28,9 +28,6 @@ const (
 	// EnvName - default environment name
 	EnvName = "default"
 
-	// DnsZone - default DNS zone
-	DnsZone = "127.0.0.1.xip.io"
-
 	// NumRetries - maximum number of retries
 	NumRetries = 7
 

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -4,17 +4,24 @@
 package web_test
 
 import (
+	"context"
+	"fmt"
 	"time"
+
+	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-var serverUrl = "https://verrazzano." + pkg.EnvName + "." + pkg.DnsZone
-
 var _ = ginkgo.Describe("Verrazzano Web UI",
 	func() {
+		ingress, _ := pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-console-ingress", v1.GetOptions{})
+		var ingressRules []v1beta1.IngressRule = ingress.Spec.Rules
+		serverUrl := fmt.Sprintf("https://%s/", ingressRules[0].Host)
+
 		pkg.Log(pkg.Info, "The Web UI's URL is "+serverUrl)
 
 		ginkgo.It("can be accessed", func() {


### PR DESCRIPTION
# Description

In Verrazzano build pipeline, update acceptance test to use metallb to replace nodeport for nginx and istio ingress access in KinD.

Fixes VZ-2146

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
