### PR TITLE
add additional permissions based on examples to console clusterrole

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -67,6 +67,7 @@ rules:
   - loggingscopes
   - metricstraits
   - verrazzanocoherenceworkloads
+  - verrazzanoweblogicworkloads
   verbs:
   - get
   - list

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -11,6 +11,8 @@ rules:
   - ""
   resources:
   - namespaces
+  - configmaps
+  - services
   verbs:
   - get
   - list
@@ -63,6 +65,8 @@ rules:
   resources:
   - ingresstraits
   - loggingscopes
+  - metricstraits
+  - verrazzanocoherenceworkloads
   verbs:
   - get
   - list
@@ -74,6 +78,7 @@ rules:
   - applicationconfigurations
   - containerizedworkloads
   - healthscopes
+  - manualscalertraits
   verbs:
   - get
   - list
@@ -83,6 +88,22 @@ rules:
   resources:
   - verrazzanomanagedclusters
   - verrazzanomonitoringinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coherence.oracle.com
+  resources:
+  - coherences
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - weblogic.oracle
+  resources:
+  - domains
   verbs:
   - get
   - list

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -80,7 +80,7 @@ clusterOperator:
 console:
   name: verrazzano-console
   imageName: ghcr.io/verrazzano/console
-  imageVersion: 0.10.0-20210210142813-e472bf6
+  imageVersion: 0.10.0-20210212141431-71fa098
 
 api:
   name: verrazzano-api


### PR DESCRIPTION
# Description

The example apps create several resources as components/workloads which were not listed in permissions in the clusterrole created for console. This change adds those.

Fixes issue with displaying example apps in console

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
