### PR TITLE
use nodeport instead of lb address to access rancher during install

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -277,7 +277,7 @@ function wait_for_rancher_agent_to_exist {
 }
 
 function patch_rancher_agents() {
-    local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME})
+    local rancher_in_cluster_host=$(get_rancher_in_cluster_host)
 
     if [ ${RANCHER_HOSTNAME} != ${rancher_in_cluster_host} ]; then
         local patch_data='{"spec":{"template":{"spec":{"hostAliases":[{"hostnames":["'"${RANCHER_HOSTNAME}"'"],"ip":"'"${rancher_in_cluster_host}"'"}]}}}}'

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -226,7 +226,6 @@ function install_rancher()
 
 function set_rancher_server_url
 {
-    local rancher_server_url="https://${RANCHER_HOSTNAME}"
     echo "Get Rancher admin password."
     rancher_admin_password=$(kubectl get secret --namespace cattle-system rancher-admin-secret -o jsonpath={.data.password})
     if [ $? -ne 0 ]; then
@@ -249,12 +248,12 @@ function set_rancher_server_url
       echo "Failed to get valid Rancher access token. Continuing without setting Rancher server URL."
       return 0
     fi
-    echo "Set Rancher server URL to ${rancher_server_url}"
-    curl_args=("${rancher_server_url}/v3/settings/server-url" $(get_rancher_resolve ${RANCHER_HOSTNAME}) \
+    echo "Set Rancher server URL to https://${RANCHER_HOSTNAME}"
+    curl_args=("https://${RANCHER_HOSTNAME}:$(get_nginx_nodeport)/v3/settings/server-url" $(get_rancher_resolve ${RANCHER_HOSTNAME}) \
           -H 'content-type: application/json' \
           -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" \
           -X PUT \
-          --data-binary '{"name":"server-url","value":"'${rancher_server_url}'"}' \
+          --data-binary '{"name":"server-url","value":"'https://${RANCHER_HOSTNAME}'"}' \
           --insecure)
     call_curl 200 http_response http_status curl_args || true
     if [ ${http_status:--1} -ne 200 ]; then

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -277,7 +277,7 @@ function wait_for_rancher_agent_to_exist {
 }
 
 function patch_rancher_agents() {
-    local rancher_in_cluster_host=$(get_rancher_in_cluster_host)
+    local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME})
 
     if [ ${RANCHER_HOSTNAME} != ${rancher_in_cluster_host} ]; then
         local patch_data='{"spec":{"template":{"spec":{"hostAliases":[{"hostnames":["'"${RANCHER_HOSTNAME}"'"],"ip":"'"${rancher_in_cluster_host}"'"}]}}}}'

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -175,7 +175,7 @@ function install_verrazzano()
       --set clusterOperator.rancherURL=https://${RANCHER_HOSTNAME} \
       --set clusterOperator.rancherUserName="${token_array[0]}" \
       --set clusterOperator.rancherPassword="${token_array[1]}" \
-      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host) \
+      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
       --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -175,7 +175,7 @@ function install_verrazzano()
       --set clusterOperator.rancherURL=https://${RANCHER_HOSTNAME} \
       --set clusterOperator.rancherUserName="${token_array[0]}" \
       --set clusterOperator.rancherPassword="${token_array[1]}" \
-      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
+      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host) \
       --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?

--- a/platform-operator/scripts/install/common.sh
+++ b/platform-operator/scripts/install/common.sh
@@ -63,7 +63,7 @@ function get_rancher_access_token {
     ARGS=(-k --connect-timeout 30 $(get_rancher_resolve ${rancher_hostname}) \
     -d '{"Username":"admin", "Password":"'$rancher_password'"}' \
     -H "Content-Type: application/json" \
-    -X POST https://$rancher_hostname/v3-public/localProviders/local?action=login)
+    -X POST https://$rancher_hostname:$(get_nginx_nodeport)/v3-public/localProviders/local?action=login)
     echo "--------------------------$(get_rancher_resolve ${rancher_hostname})"
     call_curl 201 response http_code ARGS
     if [ $? -eq 0 ]; then
@@ -95,7 +95,7 @@ function get_rancher_access_token {
     -d '{"type":"token", "description":"automation"}' \
     -H "Content-Type: application/json"
     -H "Authorization: Bearer ${rancher_admin_token}" \
-    -X POST https://$rancher_hostname/v3/token )
+    -X POST https://$rancher_hostname:$(get_nginx_nodeport)/v3/token )
     call_curl 201 response http_code ARGS
     if [ $? -eq 0 ]; then
       rancher_access_token=$(echo $response | jq -r '.token')

--- a/platform-operator/scripts/install/common.sh
+++ b/platform-operator/scripts/install/common.sh
@@ -64,6 +64,7 @@ function get_rancher_access_token {
     -d '{"Username":"admin", "Password":"'$rancher_password'"}' \
     -H "Content-Type: application/json" \
     -X POST https://$rancher_hostname/v3-public/localProviders/local?action=login)
+    echo "--------------------------$(get_rancher_resolve ${rancher_hostname})"
     call_curl 201 response http_code ARGS
     if [ $? -eq 0 ]; then
       rancher_admin_token=$(echo $response | jq -r '.token')

--- a/platform-operator/scripts/install/common.sh
+++ b/platform-operator/scripts/install/common.sh
@@ -64,7 +64,6 @@ function get_rancher_access_token {
     -d '{"Username":"admin", "Password":"'$rancher_password'"}' \
     -H "Content-Type: application/json" \
     -X POST https://$rancher_hostname:$(get_nginx_nodeport)/v3-public/localProviders/local?action=login)
-    echo "--------------------------$(get_rancher_resolve ${rancher_hostname})"
     call_curl 201 response http_code ARGS
     if [ $? -eq 0 ]; then
       rancher_admin_token=$(echo $response | jq -r '.token')

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -294,10 +294,10 @@ function get_acme_environment() {
 }
 
 # rancher needs to be accessed by the scripts running in-cluster
-# --resolve rancher.my-env.127.0.0.1.xip.io:443:nginx_host_ip:nginx_node_port
+# --resolve rancher.my-env.127.0.0.1.xip.io:nginx_node_port:nginx_host_ip
 function get_rancher_resolve() {
   local rancher_hostname=$1
-  local resolve="--resolve ${rancher_hostname}:443:$(get_nginx_hostip):$(get_nginx_nodeport)"
+  local resolve="--resolve ${rancher_hostname}:$(get_nginx_nodeport):$(get_nginx_hostip)"
   echo ${resolve}
 }
 

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -297,13 +297,18 @@ function get_acme_environment() {
 # --resolve rancher.my-env.127.0.0.1.xip.io:443:nginx_host_ip:nginx_node_port
 function get_rancher_resolve() {
   local rancher_hostname=$1
-  local rancher_in_cluster_host=$(get_rancher_in_cluster_host)
-  local resolve="--resolve ${rancher_hostname}:443:${rancher_in_cluster_host}:$(get_nginx_nodeport)"
+  local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME})
+  local resolve="--resolve ${rancher_hostname}:443:$(get_nginx_hostip):$(get_nginx_nodeport)"
   echo ${resolve}
 }
 
 function get_rancher_in_cluster_host() {
-  echo $(get_nginx_hostip)
+  local rancher_hostname=$1
+  local rancher_in_cluster_host=${rancher_hostname}
+  if [ $(get_config_value ".ingress.type") == "NodePort" ]; then
+    rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller -o jsonpath='{.items[0].status.hostIP}')
+  fi
+  echo ${rancher_in_cluster_host}
 }
 
 function get_nginx_hostip() {

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -297,7 +297,6 @@ function get_acme_environment() {
 # --resolve rancher.my-env.127.0.0.1.xip.io:443:nginx_host_ip:nginx_node_port
 function get_rancher_resolve() {
   local rancher_hostname=$1
-  local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME})
   local resolve="--resolve ${rancher_hostname}:443:$(get_nginx_hostip):$(get_nginx_nodeport)"
   echo ${resolve}
 }

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -294,24 +294,16 @@ function get_acme_environment() {
 }
 
 # rancher needs to be accessed by the scripts running in-cluster
-# in case of NodePort, 127.0.0.1 is not accessible
-# --resolve rancher.my-env.127.0.0.1.xip.io:443:nginx_container_ip
+# --resolve rancher.my-env.127.0.0.1.xip.io:443:nginx_container_ip:443
 function get_rancher_resolve() {
   local rancher_hostname=$1
-  local rancher_in_cluster_host=$(get_rancher_in_cluster_host ${rancher_hostname})
-  local resolve=""
-  if [ ${rancher_hostname} != ${rancher_in_cluster_host} ]; then
-    resolve="--resolve ${rancher_hostname}:443:${rancher_in_cluster_host}"
-  fi
+  local rancher_in_cluster_host=$(get_rancher_in_cluster_host)
+  local resolve="--resolve ${rancher_hostname}:443:${rancher_in_cluster_host}:443"
   echo ${resolve}
 }
 
 function get_rancher_in_cluster_host() {
-  local rancher_hostname=$1
-  local rancher_in_cluster_host=${rancher_hostname}
-  if [ $(get_config_value ".ingress.type") == "NodePort" ]; then
-    rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller -o jsonpath='{.items[0].status.hostIP}')
-  fi
+  local rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller -o jsonpath='{.items[0].status.hostIP}')
   echo ${rancher_in_cluster_host}
 }
 

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -305,7 +305,7 @@ function get_rancher_in_cluster_host() {
   local rancher_hostname=$1
   local rancher_in_cluster_host=${rancher_hostname}
   if [ $(get_config_value ".ingress.type") == "NodePort" ]; then
-    rancher_in_cluster_host=$(kubectl -n ingress-nginx get pods --selector app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller -o jsonpath='{.items[0].status.hostIP}')
+    rancher_in_cluster_host=$(get_nginx_hostip)
   fi
   echo ${rancher_in_cluster_host}
 }


### PR DESCRIPTION
# Description

Use nodeport instead of lb address to access rancher during install.  This way, installer will not access public endpoint, hence no DNS resolution needed.

Manually tested with OKE magicdns and OKE OCIDNS as well.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
