### PR TITLE
remove k8s_user related settings for impersonation

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -122,9 +122,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: {{ .Values.api.consoleUserGroup }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: {{ .Values.api.consoleUser }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -233,10 +230,10 @@ data:
       ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
-    logJsonMessage(ngx.INFO, "Check for k8s_user in jwt token.")
-    if ( not (jwt_obj.payload) or not (jwt_obj.payload.k8s_user)) then
+    logJsonMessage(ngx.INFO, "Check for sub in jwt token.")
+    if ( not (jwt_obj.payload) or not (jwt_obj.payload.sub)) then
       ngx.status = 401
-      logJsonMessage(ngx.ERR, "No k8s_user asscoiated with user.")
+      logJsonMessage(ngx.ERR, "No sub asscoiated with user.")
       ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -261,7 +258,7 @@ data:
     for i,group in pairs(jwt_obj.payload.groups) do
       ngx.req.set_header("Impersonate-Group", group)
     end
-    ngx.req.set_header("Impersonate-User", jwt_obj.payload.k8s_user)
+    ngx.req.set_header("Impersonate-User", jwt_obj.payload.sub)
   nginx.conf: |
     #user  nobody;
     worker_processes  1;

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -226,14 +226,14 @@ data:
     logJsonMessage(ngx.INFO, "Check for groups in jwt token.")
     if ( not (jwt_obj.payload) or not (jwt_obj.payload.groups)) then
       ngx.status = 401
-      logJsonMessage(ngx.ERR, "No groups asscoiated with user.")
+      logJsonMessage(ngx.ERR, "No groups associated with user.")
       ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     logJsonMessage(ngx.INFO, "Check for sub in jwt token.")
     if ( not (jwt_obj.payload) or not (jwt_obj.payload.sub)) then
       ngx.status = 401
-      logJsonMessage(ngx.ERR, "No sub asscoiated with user.")
+      logJsonMessage(ngx.ERR, "No sub associated with user.")
       ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -90,7 +90,6 @@ api:
   port: 8775
   clusterRole: console
   consoleUserGroup: console-users
-  consoleUser: console-user
 
 # OCI-related values
 oci:

--- a/platform-operator/scripts/install/config/keycloak.json
+++ b/platform-operator/scripts/install/config/keycloak.json
@@ -401,12 +401,7 @@
       "realm-management" : [ "manage-users" ]
     },
     "notBefore" : 0,
-    "groups" : [ "console-users" ],
-    "attributes": {
-      "k8s_user": [
-        "console-user"
-      ]
-    }
+    "groups" : [ "console-users" ]
   }, {
     "id" : "ca205b69-e8a8-45c9-88b1-ea9c1b072152",
     "createdTimestamp" : 1564417839778,
@@ -524,21 +519,6 @@
             "access.token.claim": "true",
             "claim.name": "groups",
             "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "c93fc5e2-729c-4d55-875b-2f9dd15155c4",
-          "name": "k8s-user",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "k8s_user",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "k8s_user",
-            "jsonType.label": "String"
           }
         }
       ],


### PR DESCRIPTION
# Description

The existing implementation of verrazzano-api requires a user for impersonation and that user was being read from `k8s_user` attribute of keycloak user. As per review from @wmhopkins it was decided that we might not require this attribute and the `sub` field from jwt token may directly be used for impersonation and there is no need to assign the concerned clusterrole to users individually as long as the group being impersonated is bound to that role. This was tested and found to be working fine. Hence this PR to remove the keycloak settings and role assignments/impersonation settings which are no longer required.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
