### PR TITLE
Fix the acceptance test failures run with kind cluster

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -137,6 +137,10 @@ pipeline {
                             cd ${TEST_SCRIPTS_DIR}
                             ./create_kind_cluster.sh "${CLUSTER_NAME}" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG}" "${KUBERNETES_CLUSTER_VERSION}"
 
+                            echo "Install metallb"
+                            cd ${GO_REPO_PATH}/verrazzano
+                            ./tests/e2e/config/scripts/install-metallb.sh
+
                             echo "Create Image Pull Secrets"
                             cd ${GO_REPO_PATH}/verrazzano
                             ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}"

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -292,6 +292,7 @@ pipeline {
             sh """
                 cd ${GO_REPO_PATH}/verrazzano/platform-operator
                 make delete-cluster
+                cd ${WORKSPACE}/verrazzano
                 if [ -f ${POST_DUMP_FAILED_FILE} ]; then
                   echo "Failures seen during dumping of artifacts, treat post as failed"
                   exit 1

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -298,7 +298,7 @@ pipeline {
                     dumpK8sCluster('verrazzano-installation-loop-cluster-dump')
                 }
             }
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**,**/post-uninstall-resources/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
 

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
                     copyArtifacts(projectName: 'verrazzano-create-oke-cluster', selector: lastSuccessful())
                 }
                 sh """
-                    ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${LOOPING_TEST_SCRIPTS_DIR}/pre-install-resources
+                    ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/pre-install-resources
                 """
             }
         }
@@ -276,8 +276,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${LOOPING_TEST_SCRIPTS_DIR}/post-uninstall-resources
-                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${LOOPING_TEST_SCRIPTS_DIR}
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources
                     """
                 }
             }
@@ -298,7 +298,7 @@ pipeline {
                     dumpK8sCluster('verrazzano-installation-loop-cluster-dump')
                 }
             }
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**/*.txt,**/post-uninstall-resources/**/*.txt,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
                 cd ${WORKSPACE}/verrazzano

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -300,6 +300,10 @@ pipeline {
             }
             archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**/*.txt,**/post-uninstall-resources/**/*.txt,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
+            sh """
+                cd ${WORKSPACE}/verrazzano
+            """
+            deleteDir()
         }
 
         failure {

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -298,7 +298,7 @@ pipeline {
                     dumpK8sCluster('verrazzano-installation-loop-cluster-dump')
                 }
             }
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**,**/post-uninstall-resources/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**/*.txt,**/post-uninstall-resources/**/*.txt,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
 

--- a/ci/looping-test/JenkinsfileCreateCluster
+++ b/ci/looping-test/JenkinsfileCreateCluster
@@ -139,7 +139,7 @@ pipeline {
 		
         stage('Create Cluster') {
             steps {
-                sh "TF_VAR_label_prefix=loop-${env.BUILD_NUMBER} TF_VAR_state_name=loop-${env.BUILD_NUMBER}-main ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_label_prefix=loop-${env.BUILD_NUMBER} TF_VAR_state_name=loop-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
 
                 # Create image pull secret for Verrazzano docker images
                 cd ${GO_REPO_PATH}/verrazzano

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
                         # create secret in verrazzano-install ns
                         ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/pre-install-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/pre-install-resources
 
                         echo "Installing yq"
                         GO111MODULE=on go get github.com/mikefarah/yq/v4
@@ -270,8 +270,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/post-uninstall-resources
-                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources
                     """
                 }
             }
@@ -335,7 +335,7 @@ pipeline {
                 }
             }
             sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
-            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/default.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
                 cd ${WORKSPACE}/verrazzano

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
                         # create secret in verrazzano-install ns
                         ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${UNINSTALL_TEST_SCRIPTS_DIR}/pre-install-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/pre-install-resources
 
                         echo "Installing yq"
                         GO111MODULE=on go get github.com/mikefarah/yq/v4
@@ -270,8 +270,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${UNINSTALL_TEST_SCRIPTS_DIR}/post-uninstall-resources
-                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${UNINSTALL_TEST_SCRIPTS_DIR}
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}
                     """
                 }
             }
@@ -335,8 +335,12 @@ pipeline {
                 }
             }
             sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
-            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/pre-install-resources/**/*.txt,**/post-uninstall-resources/**/*.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/pre-install-resources/default.txt,**/post-uninstall-resources/default.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
+            sh """
+                cd ${WORKSPACE}/verrazzano
+            """
+            deleteDir()
         }
 
         failure {

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -335,8 +335,7 @@ pipeline {
                 }
             }
             sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
-
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**,**/post-uninstall-resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -335,7 +335,7 @@ pipeline {
                 }
             }
             sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/pre-install-resources/**,**/post-uninstall-resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/pre-install-resources/**/*.txt,**/post-uninstall-resources/**/*.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
                         # create secret in verrazzano-install ns
                         ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/pre-install-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/pre-install-resources
 
                         echo "Installing yq"
                         GO111MODULE=on go get github.com/mikefarah/yq/v4
@@ -270,8 +270,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/post-uninstall-resources
-                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build
                     """
                 }
             }
@@ -335,7 +335,7 @@ pipeline {
                 }
             }
             sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
-            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/pre-install-resources/default.txt,**/post-uninstall-resources/default.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/default.txt,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
                 cd ${WORKSPACE}/verrazzano

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -18,12 +18,12 @@ check_for_resources() {
   if [ ${status_code:-1} -eq 0 ]; then
     # OCI query succeeded, proceed with value evaluation
     if [ $count -lt $min_required ]; then
-      echo "ERROR: Not enough ${resource_type}s available to run the acceptance tests: ${count}"
+      echo "ERROR: Not enough ${resource_type}s available to create the OKE cluster : ${count}"
       exit 1
     elif [ $count -lt 5 ]; then
-      echo "WARNING: Critically low number of ${resource_type}s available in tenancy: ${count}. Proceeding with acceptance tests."
+      echo "WARNING: Critically low number of ${resource_type}s available in tenancy: ${count}. Proceeding with creating the OKE cluster ..."
     else
-      echo "Sufficient number of ${resource_type}s available for continuing with acceptance tests: ${count}"
+      echo "Sufficient number of ${resource_type}s available for creating the OKE cluster: ${count}"
     fi
   else
     echo "ERROR: Query for available number of ${resource_type}s in tenancy failed."

--- a/tests/e2e/config/scripts/kind-config.yaml
+++ b/tests/e2e/config/scripts/kind-config.yaml
@@ -12,18 +12,3 @@ nodes:
           extraArgs:
             "service-account-issuer": "kubernetes.default.svc"
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-      - |
-        kind: InitConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            node-labels: "ingress-ready=true"
-            authorization-mode: "AlwaysAllow"
-    extraPortMappings:
-      - containerPort: 80
-        hostPort: 80
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 443
-        hostPort: 443
-        listenAddress: "0.0.0.0"
-        protocol: tcp

--- a/tests/e2e/config/scripts/looping-test/get_resources.sh
+++ b/tests/e2e/config/scripts/looping-test/get_resources.sh
@@ -5,7 +5,6 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-#TYPES=$(kubectl api-resources --verbs=list -o name)
 TYPES=`cat $SCRIPT_DIR/types.txt`
 
 if [ -z $1 ] ; then
@@ -13,6 +12,9 @@ if [ -z $1 ] ; then
   exit 1
 fi
 
+namespace=$1
 for type in ${TYPES} ; do
-  kubectl get "${type}" --show-kind -o custom-columns=NAME:.metadata.name,KIND:.kind --ignore-not-found --no-headers -n $1
+  echo "kubectl get ${type} --show-kind -o custom-columns=NAME:.metadata.name,KIND:.kind --ignore-not-found --no-headers -n ${namespace}"
+  kubectl get "${type}" --show-kind -o custom-columns=NAME:.metadata.name,KIND:.kind --ignore-not-found --no-headers -n ${namespace}
+  echo
 done


### PR DESCRIPTION
1. Fix the issue with the newly added Jenkins pipeline to run the ATs with kind clusters (various k8s versions), by installing metallb
2. Archive the output of the script which gathers the resources in default namespace, before installing verrazzano and after uninstalling verrazzano
3. Minor changes to the console output from the script, which creates the OKE cluster

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
