### PR TITLE
Use new Verrazzano Operator image

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.10.0-20210208144209-d62732b
+  imageVersion: 0.10.0-20210216140204-4b137c4
   prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-20201016212958-5b64612
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-20201016212236-05eabe44b


### PR DESCRIPTION
# Description

Use new Verrazzano Operator image that fixes filebeat crash.  See https://github.com/verrazzano/verrazzano-operator/pull/229

Fixes VZ-2148

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
