### PR TITLE
VZ-2190: Set owner ref in workload wrapper controllers

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -69,8 +69,6 @@ multiline_flush_interval 20s
   include_timestamp true
 </match>
 `
-
-const finalizer = "verrazzanocoherenceworkload.finalizers.verrazzano.io"
 
 const specField = "spec"
 const jvmField = "jvm"
@@ -145,11 +143,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	u.SetAPIVersion(apiVersion)
 	u.SetKind(kind)
 
-	// clean up resources that we've created on delete
-	if isDeleting, err := r.handleDelete(ctx, log, workload, u); isDeleting {
-		return reconcile.Result{}, err
-	}
-
 	// mutate the Coherence resource, copy labels, add logging, etc.
 	if err = copyLabels(log, workload.ObjectMeta.GetLabels(), u); err != nil {
 		return reconcile.Result{}, err
@@ -171,6 +164,12 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// set istio injection annotation to false for Coherence pods
 	if err = r.disableIstioInjection(log, u); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// set controller reference so the Coherence CR gets deleted when the workload is deleted
+	if err = controllerutil.SetControllerReference(workload, u, r.Scheme); err != nil {
+		log.Error(err, "Unable to set controller ref")
 		return reconcile.Result{}, err
 	}
 
@@ -378,36 +377,4 @@ func addJvmArgs(coherenceSpec map[string]interface{}) {
 		args = append(args, additionalJvmArgs...)
 	}
 	jvm[argsField] = args
-}
-
-// handleDelete handles delete processing - we delete the Coherence CR when our VerrazzanoCoherenceWorkload is deleted.
-// returns true if our workload is being deleted, false otherwise
-func (r *Reconciler) handleDelete(ctx context.Context, log logr.Logger, workload *vzapi.VerrazzanoCoherenceWorkload, coherence *unstructured.Unstructured) (bool, error) {
-	if !workload.ObjectMeta.DeletionTimestamp.IsZero() {
-		if controllers.StringSliceContainsString(workload.ObjectMeta.Finalizers, finalizer) {
-			log.Info("Deleting Coherence CR")
-			if err := r.Delete(ctx, coherence); err != nil {
-				return true, err
-			}
-
-			workload.ObjectMeta.Finalizers = controllers.RemoveStringFromStringSlice(workload.ObjectMeta.Finalizers, finalizer)
-			if err := r.Update(ctx, workload); err != nil {
-				// just log and keep going
-				r.Log.Info("Unable to remove finalizer from workload", "error", err)
-			}
-		}
-
-		return true, nil
-	}
-
-	// not deleting, so add our finalizer and update the workload if it's not already in the list
-	if !controllers.StringSliceContainsString(workload.ObjectMeta.Finalizers, finalizer) {
-		workload.ObjectMeta.Finalizers = append(workload.ObjectMeta.Finalizers, finalizer)
-		if err := r.Update(ctx, workload); err != nil {
-			// just log and keep going
-			r.Log.Info("Unable to add finalizer to workload", "error", err)
-		}
-	}
-
-	return false, nil
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	corev1 "k8s.io/api/core/v1"
@@ -20,10 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-const finalizer = "verrazzanoweblogicworkload.finalizers.verrazzano.io"
 
 const specField = "spec"
 
@@ -90,17 +88,18 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	u.SetAPIVersion(apiVersion)
 	u.SetKind(kind)
 
-	// clean up resources that we've created on delete
-	if isDeleting, err := r.handleDelete(ctx, log, workload, u); isDeleting {
-		return reconcile.Result{}, err
-	}
-
 	// mutate the WebLogic domain resource, copy labels, add logging, etc.
 	if err = copyLabels(log, workload.ObjectMeta.GetLabels(), u); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err = r.addLogging(ctx, log, req.NamespacedName.Namespace, workload.ObjectMeta.Labels, u); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// set controller reference so the WebLogic domain CR gets deleted when the workload is deleted
+	if err = controllerutil.SetControllerReference(workload, u, r.Scheme); err != nil {
+		log.Error(err, "Unable to set controller ref")
 		return reconcile.Result{}, err
 	}
 
@@ -241,39 +240,4 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace 
 	}
 
 	return nil
-}
-
-// handleDelete handles delete processing - we delete the WebLogic domain CR when our VerrazzanoWebLogicWorkload is deleted.
-// returns true if our workload is being deleted, false otherwise
-func (r *Reconciler) handleDelete(ctx context.Context, log logr.Logger, workload *vzapi.VerrazzanoWebLogicWorkload, weblogic *unstructured.Unstructured) (bool, error) {
-	if !workload.ObjectMeta.DeletionTimestamp.IsZero() {
-		if controllers.StringSliceContainsString(workload.ObjectMeta.Finalizers, finalizer) {
-			log.Info("Deleting WebLogic domain CR")
-			if err := r.Delete(ctx, weblogic); err != nil {
-				// ignore not found, still need to remove the finalizer
-				if !k8serrors.IsNotFound(err) {
-					return true, err
-				}
-			}
-
-			workload.ObjectMeta.Finalizers = controllers.RemoveStringFromStringSlice(workload.ObjectMeta.Finalizers, finalizer)
-			if err := r.Update(ctx, workload); err != nil {
-				// just log and keep going
-				r.Log.Info("Unable to remove finalizer from workload", "error", err)
-			}
-		}
-
-		return true, nil
-	}
-
-	// not deleting, so add our finalizer and update the workload if it's not already in the list
-	if !controllers.StringSliceContainsString(workload.ObjectMeta.Finalizers, finalizer) {
-		workload.ObjectMeta.Finalizers = append(workload.ObjectMeta.Finalizers, finalizer)
-		if err := r.Update(ctx, workload); err != nil {
-			// just log and keep going
-			r.Log.Info("Unable to add finalizer to workload", "error", err)
-		}
-	}
-
-	return false, nil
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -6,7 +6,6 @@ package wlsworkload
 import (
 	"context"
 	"testing"
-	"time"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
@@ -18,7 +17,6 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,13 +87,6 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 			workload.Kind = "VerrazzanoWebLogicWorkload"
 			return nil
 		})
-	// expect a call to add a finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(workload.ObjectMeta.Finalizers[0], finalizer)
-			return nil
-		})
 	// expect a call to fetch the oam application configuration
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
@@ -154,13 +145,6 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
-			return nil
-		})
-	// expect a call to add a finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(workload.ObjectMeta.Finalizers[0], finalizer)
 			return nil
 		})
 	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)
@@ -248,13 +232,6 @@ func TestReconcileAlreadyExists(t *testing.T) {
 			workload.Kind = "VerrazzanoWebLogicWorkload"
 			return nil
 		})
-	// expect a call to add a finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(workload.ObjectMeta.Finalizers[0], finalizer)
-			return nil
-		})
 	// expect a call to fetch the oam application configuration
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
@@ -306,13 +283,6 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
-			return nil
-		})
-	// expect a call to add a finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(workload.ObjectMeta.Finalizers[0], finalizer)
 			return nil
 		})
 	// expect a call to fetch the oam application configuration
@@ -399,54 +369,6 @@ func TestReconcileFetchWorkloadError(t *testing.T) {
 	assert.Equal(false, result.Requeue)
 }
 
-// TestReconcileDeleteResources tests the happy path of reconciling a VerrazzanoWebLogicWorkload when
-// the workload is being deleted.
-// GIVEN a VerrazzanoWebLogicWorkload resource is being deleted
-// WHEN the controller Reconcile function is called
-// THEN expect delete calls for resources we created
-func TestReconcileDeleteResources(t *testing.T) {
-	assert := asserts.New(t)
-
-	var mocker *gomock.Controller = gomock.NewController(t)
-	var cli *mocks.MockClient = mocks.NewMockClient(mocker)
-
-	// expect a call to fetch the VerrazzanoWebLogicWorkload - set the deletion timestamp to trigger the
-	// delete workflow
-	cli.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			json := `{"metadata":{"name":"unit-test-cluster"},"spec":{"replicas":3}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(json)}
-			workload.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-			workload.ObjectMeta.Finalizers = []string{finalizer}
-			workload.APIVersion = vzapi.GroupVersion.String()
-			workload.Kind = "VerrazzanoWebLogicWorkload"
-			return nil
-		})
-	// expect a call to delete the WebLogic domain CR
-	cli.EXPECT().
-		Delete(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.DeleteOption) error {
-			return nil
-		})
-	// expect a call to update the workload to remove the finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(0, len(workload.ObjectMeta.Finalizers))
-			return nil
-		})
-
-	// create a request and reconcile it
-	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
-	reconciler := newReconciler(cli)
-	result, err := reconciler.Reconcile(request)
-
-	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
-}
-
 // TestCopyLabelsFailure tests reconciling a VerrazzanoWebLogicWorkload and we are
 // not able to copy labels to the WebLogic domain CR.
 // GIVEN a VerrazzanoWebLogicWorkload resource
@@ -466,7 +388,6 @@ func TestCopyLabelsFailure(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
 			json := `{"metadata":{"name":"unit-test-cluster"},"spec":27}`
 			workload.Spec.Template = runtime.RawExtension{Raw: []byte(json)}
-			workload.ObjectMeta.Finalizers = []string{finalizer}
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
 			return nil
@@ -507,13 +428,6 @@ func TestAddLoggingFailure(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
-			return nil
-		})
-	// expect a call to add a finalizer
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
-			assert.Equal(workload.ObjectMeta.Finalizers[0], finalizer)
 			return nil
 		})
 	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)


### PR DESCRIPTION
# Description

When I initially implemented the VerrazzanoWebLogicWorkload and VerrazzanoCoherenceWorkload controllers, I didn't know `SetOwnerReference` was a thing. This PR updates the controllers to call `SetOwnerReference` and removes all of the explicit delete handling code.

I tested by running the sockshop and todo-list examples and confirmed that when the OAM application YAML is deleted, all of the resources are cleanup up correctly.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
