### PR TITLE
uptake operators that access rancher by nodeport instead of public address

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/01-verrazzano-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/01-verrazzano-operator.yaml
@@ -36,6 +36,8 @@ spec:
               value: {{ .Values.clusterOperator.rancherURL }}
             - name: rancherHost
               value: {{ .Values.clusterOperator.rancherHostname }}
+            - name: rancherPort
+              value: {{ .Values.clusterOperator.rancherHostPort | quote }}
             - name: USE_SYSTEM_VMI
               value: {{ .Values.appBinding.useSystemVMI | quote }}
             - name: PROMETHEUS_PUSHER_IMAGE

--- a/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-cluster-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-cluster-operator.yaml
@@ -29,6 +29,7 @@ spec:
             - --rancherUserName={{ .Values.clusterOperator.rancherUserName }}
             - --rancherPassword={{ .Values.clusterOperator.rancherPassword }}
             - --rancherHost={{ .Values.clusterOperator.rancherHostname }}
+            - --rancherPort={{ .Values.clusterOperator.rancherHostPort }}
           resources:
             requests:
               memory: {{ .Values.clusterOperator.RequestMemory }}

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.10.0-20210216140204-4b137c4
+  imageVersion: 0.10.0-20210216212736-d777dad
   prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-20201016212958-5b64612
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-20201016212236-05eabe44b
@@ -70,12 +70,13 @@ monitoringOperator:
 clusterOperator:
   name: verrazzano-cluster-operator
   imageName: ghcr.io/verrazzano/verrazzano-cluster-operator
-  imageVersion: 0.9.0-20210121214611-0810b05
+  imageVersion: 0.10.0-20210216220118-e1c14d1
   RequestMemory: 27Mi
   rancherURL:
   rancherUserName:
   rancherPassword:
   rancherHostname:
+  rancherHostPort:
 
 console:
   name: verrazzano-console

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -175,7 +175,8 @@ function install_verrazzano()
       --set clusterOperator.rancherURL=https://${RANCHER_HOSTNAME} \
       --set clusterOperator.rancherUserName="${token_array[0]}" \
       --set clusterOperator.rancherPassword="${token_array[1]}" \
-      --set clusterOperator.rancherHostname=$(get_rancher_in_cluster_host ${RANCHER_HOSTNAME}) \
+      --set clusterOperator.rancherHostname=$(get_nginx_hostip) \
+      --set clusterOperator.rancherHostPort=$(get_nginx_nodeport) \
       --set verrazzanoAdmissionController.caBundle="$(kubectl -n ${VERRAZZANO_NS} get secret verrazzano-validation -o json | jq -r '.data."ca.crt"' | base64 --decode)" \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -16,9 +16,7 @@ import (
 var waitTimeout = 15 * time.Minute
 var pollingInterval = 30 * time.Second
 var expectedPodsCattleSystem = []string{
-	"rancher",
-	"cattle-node-agent",
-	"cattle-cluster-agent"}
+	"rancher"}
 
 var expectedPodsKeycloak = []string{
 	"mysql",


### PR DESCRIPTION

# Description

Uptake new cluster-opeartor and varrazzano-operator that accress rancher by nodeport instead of public address.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
