### PR TITLE
Add support for MulticlusterApplicationConfiguration to cluster agent

### DIFF
--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -6,15 +6,42 @@ package mcagent
 import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Synchronize MultiClusterApplicationConfiguration objects to the local cluster
 func (s *Syncer) syncMCApplicationConfigurationObjects() error {
 	// Get all the MultiClusterApplicationConfiguration objects from the admin cluster
-	allMCApplicationConfigurations := &clustersv1alpha1.MultiClusterApplicationConfigurationList{}
-	err := s.AdminClient.List(s.Context, allMCApplicationConfigurations)
+	allMCApplicationConfigurations := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
+	err := s.AdminClient.List(s.Context, &allMCApplicationConfigurations)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
+	for _, mcAppConfig := range allMCApplicationConfigurations.Items {
+		if s.isThisCluster(mcAppConfig.Spec.Placement) {
+			_, err := s.createOrUpdateMCAppConfig(mcAppConfig)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
+}
+
+func (s *Syncer) createOrUpdateMCAppConfig(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfiguration) (controllerutil.OperationResult, error) {
+	var mcAppConfigNew clustersv1alpha1.MultiClusterApplicationConfiguration
+	mcAppConfigNew.Namespace = mcAppConfig.Namespace
+	mcAppConfigNew.Name = mcAppConfig.Name
+
+	// Create or update on the local cluster
+	return controllerutil.CreateOrUpdate(s.Context, s.MCClient, &mcAppConfigNew, func() error {
+		mutateMCAppConfig(mcAppConfig, &mcAppConfigNew)
+		return nil
+	})
+}
+
+func mutateMCAppConfig(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfiguration, mcAppConfigNew *clustersv1alpha1.MultiClusterApplicationConfiguration) {
+	mcAppConfigNew.Spec.Placement = mcAppConfig.Spec.Placement
+	mcAppConfigNew.Spec.Template = mcAppConfig.Spec.Template
+	mcAppConfigNew.Labels = mcAppConfig.Labels
 }

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -1,0 +1,229 @@
+package mcagent
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	asserts "github.com/stretchr/testify/assert"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const testMCAppConfigName = "unit-mcappconfig"
+const testMCAppConfigNamespace = "unit-mcappconfig-namespace"
+
+var mcAppConfigTestLabels = map[string]string{"label1": "test1"}
+var mcAppConfigTestUpdatedLabels = map[string]string{"label1": "test1updated"}
+
+// TestCreateMCAppConfig tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterApplicationConfiguration objects
+// WHEN the a new object exists
+// THEN ensure that the MultiClusterApplicationConfiguration is created.
+func TestCreateMCAppConfig(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCAppConfig, err := getSampleMCAppConfig("testdata/multicluster-appconfig.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+	}
+
+	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterApplicationConfiguration from the list returned by the admin cluster
+	//                   Return the resource does not exist
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCAppConfigNamespace, Name: testMCAppConfigName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: testMCAppConfigNamespace, Resource: "MultiClusterApplicationConfiguration"}, testMCAppConfigName))
+
+	// Managed Cluster - expect call to create a MultiClusterApplicationConfiguration
+	mcMock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration, opts ...client.CreateOption) error {
+			assert.Equal(testMCAppConfigNamespace, mcAppConfig.Namespace, "mcappconfig namespace did not match")
+			assert.Equal(testMCAppConfigName, mcAppConfig.Name, "mcappconfig name did not match")
+			assert.Equal(mcAppConfigTestLabels, mcAppConfig.Labels, "mcappconfig labels did not match")
+			assert.Equal(testClusterName, mcAppConfig.Spec.Placement.Clusters[0].Name, "mcappconfig does not contain expected placement")
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCApplicationConfigurationObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestUpdateMCAppConfig tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterApplicationConfiguration objects
+// WHEN the object exists
+// THEN ensure that the MultiClusterApplicationConfiguration is updated.
+func TestUpdateMCAppConfig(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCAppConfig, err := getSampleMCAppConfig("testdata/multicluster-appconfig.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+
+	testMCAppConfigUpdate, err := getSampleMCAppConfig("testdata/multicluster-appconfig-update.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+
+	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfigUpdate)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterApplicationConfiguration from the list returned by the admin cluster
+	//                   Return the resource with some values different than what the admin cluster returned
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCAppConfigNamespace, Name: testMCAppConfigName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration) error {
+			testMCAppConfig.DeepCopyInto(mcAppConfig)
+			return nil
+		})
+
+	// Managed Cluster - expect call to update a MultiClusterApplicationConfiguration
+	//                   Verify request had the updated values
+	mcMock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration, opts ...client.UpdateOption) error {
+			assert.Equal(testMCAppConfigNamespace, mcAppConfig.Namespace, "mcappconfig namespace did not match")
+			assert.Equal(testMCAppConfigName, mcAppConfig.Name, "mcappconfig name did not match")
+			assert.Equal(mcAppConfigTestUpdatedLabels, mcAppConfig.Labels, "mcappconfig labels did not match")
+
+			// assert app config metadata annotations updated
+			assert.Equal("Hello application updated", mcAppConfig.Spec.Template.Metadata.Annotations["description"])
+
+			// assert component information in the app config is updated
+			assert.Equal(2, len(mcAppConfig.Spec.Template.Spec.Components))
+			comp0 := mcAppConfig.Spec.Template.Spec.Components[0]
+			comp1 := mcAppConfig.Spec.Template.Spec.Components[1]
+			assert.Equal("hello-component-updated", comp0.ComponentName)
+			assert.Equal("hello-component-extra", comp1.ComponentName)
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCApplicationConfigurationObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestMCAppConfigPlacement tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterApplicationConfiguration objects
+// WHEN an object exists that is not targeted for the cluster
+// THEN ensure that the MultiClusterApplicationConfiguration is not created or updated
+func TestMCAppConfigPlacement(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCAppConfig, err := getSampleMCAppConfig("testdata/multicluster-appconfig.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+	testMCAppConfig.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
+
+	// Expect no calls on managed cluster since the app config was not targeted at this cluster
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCApplicationConfigurationObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// getSampleMCAppConfig creates and returns a sample MultiClusterApplicationConfiguration used in tests
+func getSampleMCAppConfig(filePath string) (clustersv1alpha1.MultiClusterApplicationConfiguration, error) {
+	mcAppConfig := clustersv1alpha1.MultiClusterApplicationConfiguration{}
+	sampleAppConfigFile, err := filepath.Abs(filePath)
+	if err != nil {
+		return mcAppConfig, err
+	}
+
+	rawResource, err := clusters.ReadYaml2Json(sampleAppConfigFile)
+	if err != nil {
+		return mcAppConfig, err
+	}
+
+	err = json.Unmarshal(rawResource, &mcAppConfig)
+	return mcAppConfig, err
+}

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package mcagent
 
 import (

--- a/application-operator/mcagent/mcagent_component.go
+++ b/application-operator/mcagent/mcagent_component.go
@@ -36,7 +36,6 @@ func (s *Syncer) createOrUpdateMCComponent(mcComponent clustersv1alpha1.MultiClu
 	var mcComponentNew clustersv1alpha1.MultiClusterComponent
 	mcComponentNew.Namespace = mcComponent.Namespace
 	mcComponentNew.Name = mcComponent.Name
-	mcComponentNew.Labels = mcComponent.Labels
 
 	// Create or update on the local cluster
 	return controllerutil.CreateOrUpdate(s.Context, s.MCClient, &mcComponentNew, func() error {
@@ -49,4 +48,5 @@ func (s *Syncer) createOrUpdateMCComponent(mcComponent clustersv1alpha1.MultiClu
 func mutateMCComponent(mcComponent clustersv1alpha1.MultiClusterComponent, mcComponentNew *clustersv1alpha1.MultiClusterComponent) {
 	mcComponentNew.Spec.Placement = mcComponent.Spec.Placement
 	mcComponentNew.Spec.Template = mcComponent.Spec.Template
+	mcComponentNew.Labels = mcComponent.Labels
 }

--- a/application-operator/mcagent/mcagent_component_test.go
+++ b/application-operator/mcagent/mcagent_component_test.go
@@ -26,6 +26,7 @@ const testMCComponentName = "unit-mccomp"
 const testMCComponentNamespace = "unit-mccomp-namespace"
 
 var mcComponentTestLabels = map[string]string{"label1": "test1"}
+var mcComponentTestUpdatedLabels = map[string]string{"label1": "test1updated"}
 
 // TestCreateMCComponent tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterComponent objects
@@ -137,7 +138,7 @@ func TestUpdateMCComponent(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcComponent *clustersv1alpha1.MultiClusterComponent, opts ...client.UpdateOption) error {
 			assert.Equal(testMCComponentNamespace, mcComponent.Namespace, "mccomponent namespace did not match")
 			assert.Equal(testMCComponentName, mcComponent.Name, "mccomponent name did not match")
-			assert.Equal(mcComponentTestLabels, mcComponent.Labels, "mccomponent labels did not match")
+			assert.Equal(mcComponentTestUpdatedLabels, mcComponent.Labels, "mccomponent labels did not match")
 			workload := v1alpha2.ContainerizedWorkload{}
 			err := json.Unmarshal(mcComponent.Spec.Template.Spec.Workload.Raw, &workload)
 			assert.NoError(err, "failed to unmarshal the containerized workload")

--- a/application-operator/mcagent/mcagent_secret.go
+++ b/application-operator/mcagent/mcagent_secret.go
@@ -36,7 +36,6 @@ func (s *Syncer) createOrUpdateMCSecret(mcSecret clustersv1alpha1.MultiClusterSe
 	var mcSecretNew clustersv1alpha1.MultiClusterSecret
 	mcSecretNew.Namespace = mcSecret.Namespace
 	mcSecretNew.Name = mcSecret.Name
-	mcSecretNew.Labels = mcSecret.Labels
 
 	// Create or update on the local cluster
 	return controllerutil.CreateOrUpdate(s.Context, s.MCClient, &mcSecretNew, func() error {
@@ -49,4 +48,5 @@ func (s *Syncer) createOrUpdateMCSecret(mcSecret clustersv1alpha1.MultiClusterSe
 func mutateMCSecret(mcSecret clustersv1alpha1.MultiClusterSecret, mcSecretNew *clustersv1alpha1.MultiClusterSecret) {
 	mcSecretNew.Spec.Placement = mcSecret.Spec.Placement
 	mcSecretNew.Spec.Template = mcSecret.Spec.Template
+	mcSecretNew.Labels = mcSecret.Labels
 }

--- a/application-operator/mcagent/mcagent_secret_test.go
+++ b/application-operator/mcagent/mcagent_secret_test.go
@@ -25,7 +25,8 @@ const testClusterName = "managed1"
 const testMCSecretNamespace = "unit-mcsecret-namespace"
 const testMCSecretName = "unit-mcsecret"
 
-var testLabels = map[string]string{"label1": "test1"}
+var mcSecretTestLabels = map[string]string{"label1": "test1"}
+var mcSecretTestUpdatedLabels = map[string]string{"label1": "test1updated"}
 
 // TestCreateMCSecret tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterSecret objects
@@ -67,7 +68,7 @@ func TestCreateMCSecret(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcSecret *clustersv1alpha1.MultiClusterSecret, opts ...client.CreateOption) error {
 			assert.Equal(testMCSecretNamespace, mcSecret.Namespace, "mcsecret namespace did not match")
 			assert.Equal(testMCSecretName, mcSecret.Name, "mcsecret name did not match")
-			assert.Equal(testLabels, mcSecret.Labels, "mcsecret labels did not match")
+			assert.Equal(mcSecretTestLabels, mcSecret.Labels, "mcsecret labels did not match")
 			assert.Equal(testClusterName, mcSecret.Spec.Placement.Clusters[0].Name, "mcsecret does not contain expected placement")
 			assert.Equal([]byte("verrazzano"), mcSecret.Spec.Template.Data["username"], "mcsecret does not contain expected template data")
 			assert.Equal("test-stringdata", mcSecret.Spec.Template.StringData["test"], "mcsecret does not contain expected string data")
@@ -136,7 +137,7 @@ func TestUpdateMCSecret(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcSecret *clustersv1alpha1.MultiClusterSecret, opts ...client.UpdateOption) error {
 			assert.Equal(testMCSecretNamespace, mcSecret.Namespace, "mcsecret namespace did not match")
 			assert.Equal(testMCSecretName, mcSecret.Name, "mcsecret name did not match")
-			assert.Equal(testLabels, mcSecret.Labels, "mcsecret labels did not match")
+			assert.Equal(mcSecretTestUpdatedLabels, mcSecret.Labels, "mcsecret labels did not match")
 			assert.Equal("test-stringdata2", mcSecret.Spec.Template.StringData["test"], "mcsecret does not contain expected string data")
 			assert.Equal([]byte("test"), mcSecret.Spec.Template.Data["username"], "mcsecret does not contain expected data")
 			return nil

--- a/application-operator/mcagent/testdata/multicluster-appconfig-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-appconfig-update.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: MultiClusterApplicationConfiguration
+metadata:
+  name: unit-mcappconfig
+  namespace: unit-mcappconfig-namespace
+  labels:
+    label1: test1updated
+spec:
+  template:
+    metadata:
+      name: hello-app
+      namespace: default
+      annotations:
+        version: v1.0.0
+        description: "Hello application updated"
+    spec:
+      components:
+        - componentName: hello-component-updated
+        - componentName: hello-component-extra
+  placement:
+    clusters:
+      - name: managed1

--- a/application-operator/mcagent/testdata/multicluster-appconfig.yaml
+++ b/application-operator/mcagent/testdata/multicluster-appconfig.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: MultiClusterApplicationConfiguration
+metadata:
+  name: unit-mcappconfig
+  namespace: unit-mcappconfig-namespace
+  labels:
+    label1: test1
+spec:
+  template:
+    metadata:
+      name: hello-app
+      namespace: default
+      annotations:
+        version: v1.0.0
+        description: "Hello application"
+    spec:
+      components:
+        - componentName: hello-component
+  placement:
+    clusters:
+      - name: managed1

--- a/application-operator/mcagent/testdata/multicluster-component-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-component-update.yaml
@@ -7,7 +7,7 @@ metadata:
   name: unit-mccomp
   namespace: unit-mccomp-namespace
   labels:
-    label1: test1
+    label1: test1updated
 spec:
   template:
     spec:

--- a/application-operator/mcagent/testdata/multicluster-secret-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-secret-update.yaml
@@ -7,7 +7,7 @@ metadata:
   name: unit-mcsecret
   namespace: unit-mcsecret-namespace
   labels:
-    label1: test1
+    label1: test1updated
 spec:
   template:
     data:


### PR DESCRIPTION
# Description

Add support for MulticlusterApplicationConfiguration to cluster agent

Fixes VZ-2065

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
