### PR TITLE
Add support for syncing MultiClusterConfigMap 

### DIFF
--- a/application-operator/mcagent/mcagent_configmap.go
+++ b/application-operator/mcagent/mcagent_configmap.go
@@ -36,7 +36,6 @@ func (s *Syncer) createOrUpdateMCConfigMap(mcConfigMap clustersv1alpha1.MultiClu
 	var mcConfigMapNew clustersv1alpha1.MultiClusterConfigMap
 	mcConfigMapNew.Namespace = mcConfigMap.Namespace
 	mcConfigMapNew.Name = mcConfigMap.Name
-	mcConfigMapNew.Labels = mcConfigMap.Labels
 
 	// Create or update on the local cluster
 	return controllerutil.CreateOrUpdate(s.Context, s.MCClient, &mcConfigMapNew, func() error {
@@ -49,4 +48,5 @@ func (s *Syncer) createOrUpdateMCConfigMap(mcConfigMap clustersv1alpha1.MultiClu
 func mutateMCConfigMap(mcConfigMap clustersv1alpha1.MultiClusterConfigMap, mcConfigMapNew *clustersv1alpha1.MultiClusterConfigMap) {
 	mcConfigMapNew.Spec.Placement = mcConfigMap.Spec.Placement
 	mcConfigMapNew.Spec.Template = mcConfigMap.Spec.Template
+	mcConfigMapNew.Labels = mcConfigMap.Labels
 }

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mcagent
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	asserts "github.com/stretchr/testify/assert"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const testMCConfigMapName = "unit-mccm"
+const testMCConfigMapNamespace = "unit-mccm-namespace"
+
+var mcConfigMapTestLabels = map[string]string{"label1": "test1"}
+
+// TestCreateMCConfigMap tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterConfigMap objects
+// WHEN the a new object exists
+// THEN ensure that the MultiClusterConfigMap is created.
+func TestCreateMCConfigMap(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCConfigMap, err := getSampleMCConfigMap("testdata/multicluster-configmap.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+	}
+
+	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterConfigMap from the list returned by the admin cluster
+	//                   Return the resource does not exist
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCConfigMapNamespace, Name: testMCConfigMapName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: testMCConfigMapNamespace, Resource: "MultiClusterConfigMap"}, testMCConfigMapName))
+
+	// Managed Cluster - expect call to create a MultiClusterConfigMap
+	mcMock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(testMCConfigMapNamespace, mcConfigMap.Namespace, "mcConfigMap namespace did not match")
+			assert.Equal(testMCConfigMapName, mcConfigMap.Name, "mcConfigMap name did not match")
+			assert.Equal(mcConfigMapTestLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
+			assert.Equal(testClusterName, mcConfigMap.Spec.Placement.Clusters[0].Name, "mcConfigMap does not contain expected placement")
+			assert.Equal("simplevalue", mcConfigMap.Spec.Template.Data["simple.key"])
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCConfigMapObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestUpdateMCConfigMap tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterConfigMap objects
+// WHEN the a object exists
+// THEN ensure that the MultiClusterConfigMap is updated.
+func TestUpdateMCConfigMap(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+	//mcMockStatusWriter := mocks.NewMockStatusWriter(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCConfigMap, err := getSampleMCConfigMap("testdata/multicluster-configmap.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+
+	testMCConfigMapUpdate, err := getSampleMCConfigMap("testdata/multicluster-configmap-update.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+
+	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMapUpdate)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterConfigMap from the list returned by the admin cluster
+	//                   Return the resource with some values different than what the admin cluster returned
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCConfigMapNamespace, Name: testMCConfigMapName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap) error {
+			testMCConfigMap.DeepCopyInto(mcConfigMap)
+			return nil
+		})
+
+	// Managed Cluster - expect call to update a MultiClusterConfigMap
+	//                   Verify request had the updated values
+	mcMock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap, opts ...client.UpdateOption) error {
+			assert.Equal(testMCConfigMapNamespace, mcConfigMap.Namespace, "mcConfigMap namespace did not match")
+			assert.Equal(testMCConfigMapName, mcConfigMap.Name, "mcConfigMap name did not match")
+			assert.Equal(mcConfigMapTestLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
+			assert.Equal("simplevalue2", mcConfigMap.Spec.Template.Data["simple.key"])
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCConfigMapObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestMCConfigMapPlacement tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterConfigMap objects
+// WHEN the a object exists that is not targeted for the cluster
+// THEN ensure that the MultiClusterConfigMap is not created or updated
+func TestMCConfigMapPlacement(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCConfigMap, err := getSampleMCConfigMap("testdata/multicluster-configmap.yaml")
+	assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+	testMCConfigMap.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mCConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mCConfigMapList.Items = append(mCConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		MCClient:           mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCConfigMapObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// getSampleMCConfigMap creates and returns a sample MultiClusterConfigMap used in tests
+func getSampleMCConfigMap(filePath string) (clustersv1alpha1.MultiClusterConfigMap, error) {
+	mcComp := clustersv1alpha1.MultiClusterConfigMap{}
+	sampleConfigMapFile, err := filepath.Abs(filePath)
+	if err != nil {
+		return mcComp, err
+	}
+
+	rawMcComp, err := clusters.ReadYaml2Json(sampleConfigMapFile)
+	if err != nil {
+		return mcComp, err
+	}
+
+	err = json.Unmarshal(rawMcComp, &mcComp)
+	return mcComp, err
+}

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -25,6 +25,7 @@ const testMCConfigMapName = "unit-mccm"
 const testMCConfigMapNamespace = "unit-mccm-namespace"
 
 var mcConfigMapTestLabels = map[string]string{"label1": "test1"}
+var mcConfigMapTestUpdatedLabels = map[string]string{"label1": "test1updated"}
 
 // TestCreateMCConfigMap tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterConfigMap objects
@@ -138,7 +139,7 @@ func TestUpdateMCConfigMap(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap, opts ...client.UpdateOption) error {
 			assert.Equal(testMCConfigMapNamespace, mcConfigMap.Namespace, "mcConfigMap namespace did not match")
 			assert.Equal(testMCConfigMapName, mcConfigMap.Name, "mcConfigMap name did not match")
-			assert.Equal(mcConfigMapTestLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
+			assert.Equal(mcConfigMapTestUpdatedLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
 			assert.Equal("simplevalue2", mcConfigMap.Spec.Template.Data["simple.key"])
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_loggingscope.go
+++ b/application-operator/mcagent/mcagent_loggingscope.go
@@ -36,7 +36,6 @@ func (s *Syncer) createOrUpdateMCLoggingScope(mcLoggingScope clustersv1alpha1.Mu
 	var mcLoggingScopeNew clustersv1alpha1.MultiClusterLoggingScope
 	mcLoggingScopeNew.Namespace = mcLoggingScope.Namespace
 	mcLoggingScopeNew.Name = mcLoggingScope.Name
-	mcLoggingScopeNew.Labels = mcLoggingScope.Labels
 
 	// Create or update on the local cluster
 	return controllerutil.CreateOrUpdate(s.Context, s.MCClient, &mcLoggingScopeNew, func() error {
@@ -49,4 +48,5 @@ func (s *Syncer) createOrUpdateMCLoggingScope(mcLoggingScope clustersv1alpha1.Mu
 func mutateMCLoggingScope(mcLoggingScope clustersv1alpha1.MultiClusterLoggingScope, mcLoggingScopeNew *clustersv1alpha1.MultiClusterLoggingScope) {
 	mcLoggingScopeNew.Spec.Placement = mcLoggingScope.Spec.Placement
 	mcLoggingScopeNew.Spec.Template = mcLoggingScope.Spec.Template
+	mcLoggingScopeNew.Labels = mcLoggingScope.Labels
 }

--- a/application-operator/mcagent/mcagent_loggingscope_test.go
+++ b/application-operator/mcagent/mcagent_loggingscope_test.go
@@ -25,6 +25,7 @@ const testMCLoggingScopeName = "unit-mclogscope"
 const testMCLoggingScopeNamespace = "unit-mclogscope-namespace"
 
 var mcLoggingScopeTestLabels = map[string]string{"label1": "test1"}
+var mcLoggingScopeTestUpdatedLabels = map[string]string{"label1": "test1updated"}
 
 // TestCreateMCLoggingScope tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterLoggingScope objects
@@ -138,7 +139,7 @@ func TestUpdateMCLoggingScope(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcLoggingScope *clustersv1alpha1.MultiClusterLoggingScope, opts ...client.UpdateOption) error {
 			assert.Equal(testMCLoggingScopeNamespace, mcLoggingScope.Namespace, "mcloggingscope namespace did not match")
 			assert.Equal(testMCLoggingScopeName, mcLoggingScope.Name, "mcloggingscope name did not match")
-			assert.Equal(mcLoggingScopeTestLabels, mcLoggingScope.Labels, "mcloggingscope labels did not match")
+			assert.Equal(mcLoggingScopeTestUpdatedLabels, mcLoggingScope.Labels, "mcloggingscope labels did not match")
 			assert.Equal("logScopeSecret2", mcLoggingScope.Spec.Template.Spec.SecretName, "mcloggingscope does not contain expected secret")
 			assert.Equal("myLocalEsHost2", mcLoggingScope.Spec.Template.Spec.ElasticSearchHost, "mcloggingscope does not contain expected elasticSearchHost")
 			return nil

--- a/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
@@ -6,7 +6,7 @@ metadata:
   name: unit-mccm
   namespace: unit-mccm-namespace
   labels:
-    label1: test1
+    label1: test1updated
 spec:
   template:
     metadata:

--- a/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: MultiClusterConfigMap
+metadata:
+  name: unit-mccm
+  namespace: unit-mccm-namespace
+  labels:
+    label1: test1
+spec:
+  template:
+    metadata:
+      name: myconfigmap
+      namespace: myns
+    data:
+      simple.key: "simplevalue2"
+      json.key: |
+        {
+          "testStrKey": "testValue",
+          "testNumKey": 3
+        }
+      yaml.key: |
+        testYamlKey1: testValue1
+        testArrayKey:
+        - arrayVal1
+        - arrayVal2
+  placement:
+    clusters:
+      - name: managed1

--- a/application-operator/mcagent/testdata/multicluster-configmap.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: MultiClusterConfigMap
+metadata:
+  name: unit-mccm
+  namespace: unit-mccm-namespace
+  labels:
+    label1: test1
+spec:
+  template:
+    metadata:
+      name: myconfigmap
+      namespace: myns
+    data:
+      simple.key: "simplevalue"
+      json.key: |
+        {
+          "testStrKey": "testValue",
+          "testNumKey": 3
+        }
+      yaml.key: |
+        testYamlKey1: testValue1
+        testArrayKey:
+        - arrayVal1
+        - arrayVal2
+  placement:
+    clusters:
+      - name: managed1

--- a/application-operator/mcagent/testdata/multicluster-loggingscope-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-loggingscope-update.yaml
@@ -6,7 +6,7 @@ metadata:
   name: unit-mclogscope
   namespace: unit-mclogscope-namespace
   labels:
-    label1: test1
+    label1: test1updated
 spec:
   template:
     spec:


### PR DESCRIPTION
# Description

This is a continuation of the work for VZ-2065.  This PR adds support for syncing MultiClusterConfigMap objects.  Also fixes a problem of updates to labels not being handled properly.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
