### PR TITLE
Add Subject Alternate Name (SAN) - DNSNames to validating webhook of application-operator

### DIFF
--- a/application-operator/internal/certificates/certificates.go
+++ b/application-operator/internal/certificates/certificates.go
@@ -46,11 +46,11 @@ func SetupCertificates(certDir string) (*bytes.Buffer, error) {
 
 	// CA config
 	ca := &x509.Certificate{
+		DNSNames:     []string{commonName},
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
-		DNSNames:              []string{commonName},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(1, 0, 0),
 		IsCA:                  true,
@@ -85,6 +85,7 @@ func SetupCertificates(certDir string) (*bytes.Buffer, error) {
 
 	// server cert config
 	cert := &x509.Certificate{
+		DNSNames:     []string{commonName},
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,

--- a/application-operator/internal/certificates/certificates.go
+++ b/application-operator/internal/certificates/certificates.go
@@ -46,11 +46,11 @@ func SetupCertificates(certDir string) (*bytes.Buffer, error) {
 
 	// CA config
 	ca := &x509.Certificate{
-		DNSNames:     []string{commonName},
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
+		DNSNames:     []string{commonName},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(1, 0, 0),
 		IsCA:                  true,

--- a/application-operator/internal/certificates/certificates.go
+++ b/application-operator/internal/certificates/certificates.go
@@ -50,7 +50,7 @@ func SetupCertificates(certDir string) (*bytes.Buffer, error) {
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
-		DNSNames:     []string{commonName},
+		DNSNames:              []string{commonName},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(1, 0, 0),
 		IsCA:                  true,


### PR DESCRIPTION
This PR adds Subject Alternate Name (SAN) value DNSNames to validating webhook of application-operator, to fix the issue observed with OAM examples when run with KIND cluster v1.18 and 1.19. The creation of application resources fail with an exception like 

`Failed to create ToDo List application resource: failed to create or update resource: Internal error occurred: failed calling webhook "verrazzano-application-appconfig-defaulter.verrazzano.io": Post "
https://verrazzano-application-operator.verrazzano-system.svc:443/appconfig-defaulter?timeout=30s
": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`

This change fixes VZ-2207

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
