### PR TITLE
VZ-2101: Bump Coherence Operator to 3.1.3

### DIFF
--- a/application-operator/installer/scripts/3-install-coh-operator.sh
+++ b/application-operator/installer/scripts/3-install-coh-operator.sh
@@ -24,7 +24,7 @@ function install_coh_operator {
   fi
 
   log "Install the Coherence Kubernetes operator"
-  helm install --namespace verrazzano-system coherence coherence/coherence-operator --version 3.1.1 --wait
+  helm install --namespace verrazzano-system coherence coherence/coherence-operator --version 3.1.3 --wait
   if [ $? -ne 0 ]; then
     error "Failed to install the Coherence Kubernetes operator."
     return 1

--- a/application-operator/test/templates/coherence_workload_statefulset.yaml
+++ b/application-operator/test/templates/coherence_workload_statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               value: "true"
             - name: COH_METRICS_PORT
               value: "9612"
-          image: fixme-deployment-example:3.1.1
+          image: fixme-deployment-example:3.1.3
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5
@@ -182,7 +182,7 @@ spec:
               value: /coherence-operator/utils
             - name: COH_CLUSTER_NAME
               value: example-cluster
-          image: ghcr.io/oracle/coherence-operator:3.1.1-utils
+          image: ghcr.io/oracle/coherence-operator:3.1.3-utils
           imagePullPolicy: IfNotPresent
           name: coherence-k8s-utils
           resources: {}

--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-image: ghcr.io/oracle/coherence-operator:3.1.1
+image: ghcr.io/oracle/coherence-operator:3.1.3
 defaultCoherenceImage: ghcr.io/oracle/coherence-ce:20.06.1

--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -107,7 +107,7 @@ The `coherence-operator` folder was created by running the following commands:
 
 ```
 export COHERENCE_OPERATOR_CHART_REPO=https://oracle.github.io/coherence-operator/charts
-export COHERENCE_OPERATOR_CHART_VERSION=3.1.1
+export COHERENCE_OPERATOR_CHART_VERSION=3.1.3
 rm -rf coherence-operator
 helm repo add coherence ${COHERENCE_OPERATOR_CHART_REPO}
 helm repo update

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -1,12 +1,12 @@
-# Copyright 2020, Oracle Corporation and/or its affiliates.
+# Copyright 2020, 2021, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.1.1
-appVersion: 3.1.1
+version: 3.1.3
+appVersion: 3.1.3
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -1,9 +1,9 @@
-# Copyright 2020 Oracle Corporation and/or its affiliates.
+# Copyright 2020, 2021, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
 # image is the Coherence Operator image
-image: "ghcr.io/oracle/coherence-operator:3.1.1"
+image: "ghcr.io/oracle/coherence-operator:3.1.3"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
@@ -11,7 +11,7 @@ defaultCoherenceImage: "oraclecoherence/coherence-ce:20.06.1"
 
 # defaultCoherenceUtilsImage is the Coherence Operator utils image that will be used when running
 # Coherence Pods. This image version should typically match the Operator version.
-defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.1.1-utils"
+defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.1.3-utils"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.


### PR DESCRIPTION
# Description

Upgrading the Coherence Operator from 3.1.1 to 3.1.3. I tested by installing Verrazzano on a local test cluster and went through the Coherence examples to make sure there were no regressions.

I also looked at public-facing docs to see if there were any references to the version of the Coherence Operator and did not find any.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
