### PR TITLE
Support multi-cluster delete of application configuration objects

### DIFF
--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -237,7 +237,13 @@ func TestDeleteMCAppConfig(t *testing.T) {
 		})
 
 	// Managed Cluster - expect a call to delete a MultiClusterApplicationConfiguration object
-	mcMock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mcMock.EXPECT().
+		Delete(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration, opts ...*client.ListOptions) error {
+			assert.Equal(testMCAppConfigOrphan.Name, mcAppConfig.Name, "unexpected object being deleted")
+			assert.Equal(testMCAppConfigOrphan.Namespace, mcAppConfig.Namespace, "unexpected object being deleted")
+			return nil
+		})
 
 	// Make the request
 	s := &Syncer{

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -74,6 +74,14 @@ func TestCreateMCAppConfig(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -151,6 +159,86 @@ func TestUpdateMCAppConfig(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		LocalClient:        mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCApplicationConfigurationObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestDeleteMCAppConfig tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterApplicationConfiguration objects
+// WHEN the object exists on the local cluster but not on the admin cluster
+// THEN ensure that the MultiClusterApplicationConfiguration is deleted.
+func TestDeleteMCAppConfig(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCAppConfig, err := getSampleMCAppConfig("testdata/multicluster-appconfig.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+	}
+	testMCAppConfigOrphan, err := getSampleMCAppConfig("testdata/multicluster-appconfig.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterApplicationConfiguration")
+	}
+	testMCAppConfigOrphan.Name = "orphaned-resource"
+
+	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterApplicationConfiguration from the list returned by the admin cluster
+	//                   Return the resource
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCAppConfigNamespace, Name: testMCAppConfigName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration) error {
+			testMCAppConfig.DeepCopyInto(mcAppConfig)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list including an orphaned object
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfigOrphan)
+			return nil
+		})
+
+	// Managed Cluster - expect a call to delete a MultiClusterApplicationConfiguration object
+	mcMock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -196,7 +284,13 @@ func TestMCAppConfigPlacement(t *testing.T) {
 			return nil
 		})
 
-	// Expect no calls on managed cluster since the app config was not targeted at this cluster
+	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
+			return nil
+		})
 
 	// Make the request
 	s := &Syncer{


### PR DESCRIPTION
# Description

This is the initial PR for adding support to the multi-cluster agent to delete local multi-cluster objects that have deleted on the admin cluster.  Once this PR is approved, a follow-up PR will implement the delete for the rest of the MC resources.

Fixes VZ-2170

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
