### PR TITLE
Process only locally placed multi cluster resources

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -11,3 +11,9 @@ const VerrazzanoMultiClusterNamespace = "verrazzano-mc"
 
 // MCRegistrationSecret - the name of the secret that contains the cluster registration information
 const MCRegistrationSecret = "verrazzano-cluster"
+
+// AdminKubeconfigData - the field name in MCRegistrationSecret that contains the admin cluster's kubeconfig
+const AdminKubeconfigData = "admin-kubeconfig"
+
+// ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
+const ClusterNameData = "managed-cluster-name"

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -4,20 +4,25 @@
 package clusters
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"io/ioutil"
 	"time"
 
-	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/go-logr/logr"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/yaml"
 )
+
+// MCRegistrationSecretFullName is the full NamespacedName of the cluster registration secret
+var MCRegistrationSecretFullName = types.NamespacedName{
+	Namespace: constants.VerrazzanoSystemNamespace,
+	Name:      constants.MCRegistrationSecret}
 
 // StatusNeedsUpdate determines based on the current state and conditions of a MultiCluster
 // resource, as well as the new state and condition to be set, whether the status update
@@ -76,40 +81,31 @@ func NewScheme() *runtime.Scheme {
 	return scheme
 }
 
-// NewRequest creates a new reconciler request for testing
-// namespace - The namespace to use in the request
-// name - The name to use in the request
-func NewRequest(namespace string, name string) ctrl.Request {
-	return ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
-		},
+// IsPlacedInThisCluster determines whether the given Placement represents placement in the current
+// cluster. Current cluster's identity is determined from the verrazzano-cluster secret
+func IsPlacedInThisCluster(ctx context.Context, rdr client.Reader, placement clustersv1alpha1.Placement) bool {
+	var clusterSecret corev1.Secret
+
+	err := rdr.Get(ctx, MCRegistrationSecretFullName, &clusterSecret)
+	if err != nil {
+		return false
 	}
+	thisCluster := string(clusterSecret.Data[constants.ClusterNameData])
+	for _, placementCluster := range placement.Clusters {
+		if thisCluster == placementCluster.Name {
+			return true
+		}
+	}
+
+	return false
 }
 
-// ReadYaml2Json reads the testdata YAML file at the given path, converts it to JSON and returns
-// a byte slice containing the JSON
-func ReadYaml2Json(filename string) ([]byte, error) {
-	yamlBytes, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read test data file %s: %s", filename, err.Error())
+// IgnoreNotFoundWithLog returns nil if err is a "Not Found" error, and if not, logs an error
+// message that the resource could not be fetched and returns the original error
+func IgnoreNotFoundWithLog(resourceType string, err error, logger logr.Logger) error {
+	if apierrors.IsNotFound(err) {
+		return nil
 	}
-	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall YAML to JSON in file %s: %s", filename, err.Error())
-	}
-	return jsonBytes, nil
-}
-
-// ReadContainerizedWorkload reads the raw workload (typically from an OAM component) into
-// a ContainerizedWorkload object
-func ReadContainerizedWorkload(rawWorkload runtime.RawExtension) (v1alpha2.ContainerizedWorkload, error) {
-	ctrWorkload := v1alpha2.ContainerizedWorkload{}
-	workloadBytes, err := rawWorkload.MarshalJSON()
-	if err != nil {
-		return ctrWorkload, err
-	}
-	err = json.Unmarshal(workloadBytes, &ctrWorkload)
-	return ctrWorkload, err
+	logger.Info("Failed to fetch resource", "type", resourceType, "err", err)
+	return err
 }

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -14,6 +14,7 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,9 @@ func TestReconcileCreateAppConfig(t *testing.T) {
 	// expect a call to fetch the MultiClusterApplicationConfiguration
 	doExpectGetMultiClusterAppConfig(cli, mcAppConfigSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM app config, and return not found error, to test create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -98,7 +102,7 @@ func TestReconcileCreateAppConfig(t *testing.T) {
 	doExpectStatusUpdateSucceeded(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -132,6 +136,9 @@ func TestReconcileUpdateAppConfig(t *testing.T) {
 	// expect a call to fetch the MultiClusterApplicationConfiguration
 	doExpectGetMultiClusterAppConfig(cli, mcAppConfigSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch underlying OAM app config, and return an existing one
 	doExpectGetAppConfigExists(cli, mcAppConfigSample.ObjectMeta, existingOAMAppConfig.Spec)
 
@@ -151,7 +158,7 @@ func TestReconcileUpdateAppConfig(t *testing.T) {
 		Return(nil)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -181,6 +188,9 @@ func TestReconcileCreateAppConfigFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterApplicationConfiguration
 	doExpectGetMultiClusterAppConfig(cli, mcAppConfigSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM app config and return not found error, to simulate create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -198,7 +208,7 @@ func TestReconcileCreateAppConfigFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -229,6 +239,9 @@ func TestReconcileUpdateAppConfigFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterApplicationConfiguration
 	doExpectGetMultiClusterAppConfig(cli, mcAppConfigSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM app config (simulate update case)
 	doExpectGetAppConfigExists(cli, mcAppConfigSample.ObjectMeta, mcAppConfigSample.Spec.Template.Spec)
 
@@ -244,7 +257,74 @@ func TestReconcileUpdateAppConfigFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileResourceNotFound tests the path of reconciling a
+// MultiClusterApplicationConfiguration resource which is non-existent when reconcile is called,
+// possibly because it has been deleted.
+// GIVEN a MultiClusterApplicationConfiguration resource has been deleted
+// WHEN the controller Reconcile function is called
+// THEN expect that no action is taken
+func TestReconcileResourceNotFound(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MultiClusterApplicationConfiguration
+	// and return a not found error
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "clusters.verrazzano.io", Resource: "MultiClusterApplicationConfiguration"}, crName))
+
+	// expect no further action to be taken
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcilePlacementInDifferentCluster tests the path of reconciling a
+// MultiClusterApplicationConfiguration which is placed on a cluster other than the current cluster.
+// We expect this MultiClusterApplicationConfiguration to be ignored, i.e. no OAM app config created
+// GIVEN a MultiClusterApplicationConfiguration resource is created with a placement in different cluster
+// WHEN the controller Reconcile function is called
+// THEN expect that no OAM app config is created
+func TestReconcilePlacementInDifferentCluster(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	mcAppConfigSample, err := getSampleMCAppConfig()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	mcAppConfigSample.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// expect a call to fetch the MultiClusterApplicationConfiguration
+	doExpectGetMultiClusterAppConfig(cli, mcAppConfigSample)
+
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
+	// Expect no further action
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -348,7 +428,7 @@ func getSampleMCAppConfig() (clustersv1alpha1.MultiClusterApplicationConfigurati
 		return mcAppConfig, err
 	}
 
-	rawMCAppConfig, err := clusters.ReadYaml2Json(sampleMCAppConfigFile)
+	rawMCAppConfig, err := clusterstest.ReadYaml2Json(sampleMCAppConfigFile)
 	if err != nil {
 		return mcAppConfig, err
 	}
@@ -363,7 +443,7 @@ func getExistingOAMAppConfig() (v1alpha2.ApplicationConfiguration, error) {
 	if err != nil {
 		return oamAppConfig, err
 	}
-	rawMcAppConfig, err := clusters.ReadYaml2Json(existingAppConfigFile)
+	rawMcAppConfig, err := clusterstest.ReadYaml2Json(existingAppConfigFile)
 	if err != nil {
 		return oamAppConfig, err
 	}

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-multiclusterappconfig.yaml
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-multiclusterappconfig.yaml
@@ -29,4 +29,4 @@ spec:
                   name: http
   placement:
     clusters:
-      - name: managed1
+      - name: cluster1

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -14,6 +14,7 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,9 @@ func TestReconcileCreateComponent(t *testing.T) {
 	// expect a call to fetch the MultiClusterComponent
 	doExpectGetMultiClusterComponent(cli, mcCompSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM component, and return not found error, to test create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -98,7 +102,7 @@ func TestReconcileCreateComponent(t *testing.T) {
 	doExpectStatusUpdateSucceeded(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -132,6 +136,9 @@ func TestReconcileUpdateComponent(t *testing.T) {
 	// expect a call to fetch the MultiClusterComponent
 	doExpectGetMultiClusterComponent(cli, mcCompSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch underlying OAM component, and return an existing component
 	doExpectGetComponentExists(cli, mcCompSample.ObjectMeta, existingOAMComp.Spec)
 
@@ -151,7 +158,7 @@ func TestReconcileUpdateComponent(t *testing.T) {
 		Return(nil)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -180,6 +187,9 @@ func TestReconcileCreateComponentFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterComponent
 	doExpectGetMultiClusterComponent(cli, mcCompSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM component and return not found error, to simulate create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -197,7 +207,7 @@ func TestReconcileCreateComponentFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -226,6 +236,9 @@ func TestReconcileUpdateComponentFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterComponent
 	doExpectGetMultiClusterComponent(cli, mcCompSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing OAM component (simulate update case)
 	doExpectGetComponentExists(cli, mcCompSample.ObjectMeta, mcCompSample.Spec.Template.Spec)
 
@@ -241,7 +254,74 @@ func TestReconcileUpdateComponentFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterComponent which
+// is placed on a cluster other than the current cluster. We expect this MultiClusterComponent to
+// be ignored, and no OAM Component to be created
+// GIVEN a MultiClusterComponent resource is created with a placement in different cluster
+// WHEN the controller Reconcile function is called
+// THEN expect that no OAM Component is created
+func TestReconcilePlacementInDifferentCluster(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	mcCompSample, err := getSampleMCComponent()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	mcCompSample.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// expect a call to fetch the MultiClusterComponent
+	doExpectGetMultiClusterComponent(cli, mcCompSample)
+
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
+	// Expect no further action
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileResourceNotFound tests the path of reconciling a
+// MultiClusterComponent resource which is non-existent when reconcile is called,
+// possibly because it has been deleted.
+// GIVEN a MultiClusterComponent resource has been deleted
+// WHEN the controller Reconcile function is called
+// THEN expect that no action is taken
+func TestReconcileResourceNotFound(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MultiClusterComponent
+	// and return a not found error
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "clusters.verrazzano.io", Resource: "MultiClusterComponent"}, crName))
+
+	// expect no further action to be taken
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -320,9 +400,9 @@ func assertComponentValid(assert *asserts.Assertions, c *v1alpha2.Component, mcC
 
 	// assert some fields on the component spec (e.g. in the case of update, these fields should
 	// be different from the mock pre existing OAM component)
-	expectedContainerizedWorkload, err := clusters.ReadContainerizedWorkload(mcComp.Spec.Template.Spec.Workload)
+	expectedContainerizedWorkload, err := clusterstest.ReadContainerizedWorkload(mcComp.Spec.Template.Spec.Workload)
 	assert.Nil(err)
-	actualContainerizedWorkload, err := clusters.ReadContainerizedWorkload(c.Spec.Workload)
+	actualContainerizedWorkload, err := clusterstest.ReadContainerizedWorkload(c.Spec.Workload)
 	assert.Nil(err)
 	assert.Equal(expectedContainerizedWorkload.Spec.Containers[0].Name, actualContainerizedWorkload.Spec.Containers[0].Name)
 	assert.Equal(expectedContainerizedWorkload.Name, actualContainerizedWorkload.Name)
@@ -342,7 +422,7 @@ func getSampleMCComponent() (clustersv1alpha1.MultiClusterComponent, error) {
 		return mcComp, err
 	}
 
-	rawMcComp, err := clusters.ReadYaml2Json(sampleComponentFile)
+	rawMcComp, err := clusterstest.ReadYaml2Json(sampleComponentFile)
 	if err != nil {
 		return mcComp, err
 	}
@@ -357,7 +437,7 @@ func getExistingOAMComponent() (v1alpha2.Component, error) {
 	if err != nil {
 		return oamComp, err
 	}
-	rawMcComp, err := clusters.ReadYaml2Json(existingComponentFile)
+	rawMcComp, err := clusterstest.ReadYaml2Json(existingComponentFile)
 	if err != nil {
 		return oamComp, err
 	}

--- a/application-operator/controllers/clusters/multiclustercomponent/testdata/hello-multiclustercomponent.yaml
+++ b/application-operator/controllers/clusters/multiclustercomponent/testdata/hello-multiclustercomponent.yaml
@@ -29,4 +29,4 @@ spec:
                   name: http
   placement:
     clusters:
-      - name: managed1
+      - name: cluster1

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -13,6 +13,7 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,9 @@ func TestReconcileCreateConfigMap(t *testing.T) {
 	// expect a call to fetch the MultiClusterConfigMap
 	doExpectGetMultiClusterConfigMap(cli, mcConfigMap)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing K8S ConfigMap, and return not found error, to test create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -98,7 +102,7 @@ func TestReconcileCreateConfigMap(t *testing.T) {
 	doExpectStatusUpdateSucceeded(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -127,6 +131,9 @@ func TestReconcileUpdateConfigMap(t *testing.T) {
 	// expect a call to fetch the MultiClusterConfigMap
 	doExpectGetMultiClusterConfigMap(cli, mcConfigMap)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch underlying K8S ConfigMap, and return an existing ConfigMap
 	doExpectGetConfigMapExists(cli, mcConfigMap.ObjectMeta)
 
@@ -146,7 +153,7 @@ func TestReconcileUpdateConfigMap(t *testing.T) {
 		Return(nil)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -175,6 +182,9 @@ func TestReconcileCreateConfigMapFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterConfigMap
 	doExpectGetMultiClusterConfigMap(cli, mcConfigMap)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing K8S ConfigMap and return not found error, to simulate create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -192,7 +202,7 @@ func TestReconcileCreateConfigMapFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -221,6 +231,9 @@ func TestReconcileUpdateConfigMapFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterConfigMap
 	doExpectGetMultiClusterConfigMap(cli, mcConfigMap)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing K8S ConfigMap (simulate update case)
 	doExpectGetConfigMapExists(cli, mcConfigMap.ObjectMeta)
 
@@ -236,7 +249,74 @@ func TestReconcileUpdateConfigMapFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterConfigMap which
+// is placed on a cluster other than the current cluster. We expect this MultiClusterConfigMap to
+// be ignored, and no K8S ConfigMap to be created
+// GIVEN a MultiClusterConfigMap resource is created with a placement in different cluster
+// WHEN the controller Reconcile function is called
+// THEN expect that no K8S ConfigMap is created
+func TestReconcilePlacementInDifferentCluster(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	mcConfigMap, err := getMCConfigMap(sampleMCConfigMapFile)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	mcConfigMap.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// expect a call to fetch the MultiClusterConfigMap
+	doExpectGetMultiClusterConfigMap(cli, mcConfigMap)
+
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
+	// Expect no further action
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileResourceNotFound tests the path of reconciling a
+// MultiClusterConfigMap resource which is non-existent when reconcile is called,
+// possibly because it has been deleted.
+// GIVEN a MultiClusterConfigMap resource has been deleted
+// WHEN the controller Reconcile function is called
+// THEN expect that no action is taken
+func TestReconcileResourceNotFound(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MultiClusterConfigMap
+	// and return a not found error
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "clusters.verrazzano.io", Resource: "MultiClusterConfigMap"}, crName))
+
+	// expect no further action to be taken
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -331,7 +411,7 @@ func getMCConfigMap(filename string) (clustersv1alpha1.MultiClusterConfigMap, er
 		return mcConfigMap, err
 	}
 
-	rawResource, err := clusters.ReadYaml2Json(sampleConfigMapFile)
+	rawResource, err := clusterstest.ReadYaml2Json(sampleConfigMapFile)
 	if err != nil {
 		return mcConfigMap, err
 	}
@@ -346,7 +426,7 @@ func getExistingConfigMap() (v1.ConfigMap, error) {
 	if err != nil {
 		return configMap, err
 	}
-	rawResource, err := clusters.ReadYaml2Json(existingConfigMapFile)
+	rawResource, err := clusterstest.ReadYaml2Json(existingConfigMapFile)
 	if err != nil {
 		return configMap, err
 	}

--- a/application-operator/controllers/clusters/multiclusterconfigmap/testdata/sample-mcconfigmap.yaml
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/testdata/sample-mcconfigmap.yaml
@@ -24,4 +24,4 @@ spec:
         - arrayVal2
   placement:
     clusters:
-      - name: managed1
+      - name: cluster1

--- a/application-operator/controllers/clusters/multiclusterloggingscope/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterloggingscope/controller_test.go
@@ -14,6 +14,7 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,9 @@ func TestReconcileCreateLoggingScope(t *testing.T) {
 	// expect a call to fetch the MultiClusterLoggingScope
 	doExpectGetMultiClusterLoggingScope(cli, mcLogScopeSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing LoggingScope, and return not found error, to test create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -98,7 +102,7 @@ func TestReconcileCreateLoggingScope(t *testing.T) {
 	doExpectStatusUpdateSucceeded(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -132,6 +136,9 @@ func TestReconcileUpdateLoggingScope(t *testing.T) {
 	// expect a call to fetch the MultiClusterLoggingScope
 	doExpectGetMultiClusterLoggingScope(cli, mcLogScopeSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch underlying LoggingScope, and return an existing LoggingScope
 	doExpectGetLoggingScopeExists(cli, mcLogScopeSample.ObjectMeta, existingLogScope.Spec)
 
@@ -151,7 +158,7 @@ func TestReconcileUpdateLoggingScope(t *testing.T) {
 		Return(nil)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -180,6 +187,9 @@ func TestReconcileCreateLoggingScopeFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterLoggingScope
 	doExpectGetMultiClusterLoggingScope(cli, mcLogScopeSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing LoggingScope and return not found error, to simulate create case
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
@@ -197,7 +207,7 @@ func TestReconcileCreateLoggingScopeFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -226,6 +236,9 @@ func TestReconcileUpdateLoggingScopeFailed(t *testing.T) {
 	// expect a call to fetch the MultiClusterLoggingScope
 	doExpectGetMultiClusterLoggingScope(cli, mcLogScopeSample)
 
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
 	// expect a call to fetch existing LoggingScope (simulate update case)
 	doExpectGetLoggingScopeExists(cli, mcLogScopeSample.ObjectMeta, mcLogScopeSample.Spec.Template.Spec)
 
@@ -241,7 +254,74 @@ func TestReconcileUpdateLoggingScopeFailed(t *testing.T) {
 	doExpectStatusUpdateFailed(cli, mockStatusWriter, assert)
 
 	// create a request and reconcile it
-	request := clusters.NewRequest(namespace, crName)
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterLoggingScope which
+// is placed on a cluster other than the current cluster. We expect this MultiClusterLoggingScope to
+// be ignored, and no LoggingScope to be created
+// GIVEN a MultiClusterLoggingScope resource is created with a placement in different cluster
+// WHEN the controller Reconcile function is called
+// THEN expect that no LoggingScope is created
+func TestReconcilePlacementInDifferentCluster(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	mcLoggingScope, err := getSampleMCLoggingScope()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	mcLoggingScope.Spec.Placement.Clusters[0].Name = "not-my-cluster"
+
+	// expect a call to fetch the MultiClusterLoggingScope
+	doExpectGetMultiClusterLoggingScope(cli, mcLoggingScope)
+
+	// expect a call to fetch the MCRegistration secret
+	clusterstest.DoExpectGetMCRegistrationSecret(cli)
+
+	// Expect no further action
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileResourceNotFound tests the path of reconciling a
+// MultiClusterLoggingScope resource which is non-existent when reconcile is called,
+// possibly because it has been deleted.
+// GIVEN a MultiClusterLoggingScope resource has been deleted
+// WHEN the controller Reconcile function is called
+// THEN expect that no action is taken
+func TestReconcileResourceNotFound(t *testing.T) {
+	assert := asserts.New(t)
+
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MultiClusterLoggingScope
+	// and return a not found error
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "clusters.verrazzano.io", Resource: "MultiClusterLoggingScope"}, crName))
+
+	// expect no further action to be taken
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(namespace, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 
@@ -340,7 +420,7 @@ func getSampleMCLoggingScope() (clustersv1alpha1.MultiClusterLoggingScope, error
 		return mcLogScope, err
 	}
 
-	rawMcLogScope, err := clusters.ReadYaml2Json(sampleLoggingScopeFile)
+	rawMcLogScope, err := clusterstest.ReadYaml2Json(sampleLoggingScopeFile)
 	if err != nil {
 		return mcLogScope, err
 	}
@@ -355,7 +435,7 @@ func getExistingLoggingScope() (v1alpha1.LoggingScope, error) {
 	if err != nil {
 		return logScope, err
 	}
-	rawLogScope, err := clusters.ReadYaml2Json(existingLoggingScopeFile)
+	rawLogScope, err := clusterstest.ReadYaml2Json(existingLoggingScopeFile)
 	if err != nil {
 		return logScope, err
 	}

--- a/application-operator/controllers/clusters/multiclusterloggingscope/testdata/sample-multiclusterloggingscope.yaml
+++ b/application-operator/controllers/clusters/multiclusterloggingscope/testdata/sample-multiclusterloggingscope.yaml
@@ -15,4 +15,4 @@ spec:
       workloadRefs: []
   placement:
     clusters:
-      - name: managed1
+      - name: cluster1

--- a/application-operator/controllers/clusters/test/test_utils.go
+++ b/application-operator/controllers/clusters/test/test_utils.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package clusterstest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/golang/mock/gomock"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/yaml"
+)
+
+// NewRequest creates a new reconciler request for testing
+// namespace - The namespace to use in the request
+// name - The name to use in the request
+func NewRequest(namespace string, name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+// ReadYaml2Json reads the testdata YAML file at the given path, converts it to JSON and returns
+// a byte slice containing the JSON
+func ReadYaml2Json(filename string) ([]byte, error) {
+	yamlBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read test data file %s: %s", filename, err.Error())
+	}
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall YAML to JSON in file %s: %s", filename, err.Error())
+	}
+	return jsonBytes, nil
+}
+
+// ReadContainerizedWorkload reads the raw workload (typically from an OAM component) into
+// a ContainerizedWorkload object
+func ReadContainerizedWorkload(rawWorkload runtime.RawExtension) (v1alpha2.ContainerizedWorkload, error) {
+	ctrWorkload := v1alpha2.ContainerizedWorkload{}
+	workloadBytes, err := rawWorkload.MarshalJSON()
+	if err != nil {
+		return ctrWorkload, err
+	}
+	err = json.Unmarshal(workloadBytes, &ctrWorkload)
+	return ctrWorkload, err
+}
+
+// DoExpectGetMCRegistrationSecret adds an expectation to the given MockClient to expect a Get
+// call for the managed cluster registration secret, and populate it with the cluster-name
+func DoExpectGetMCRegistrationSecret(cli *mocks.MockClient) {
+	// expect a call to fetch the MCRegistrationSecret and return a fake one with a specific cluster name
+	mockRegistrationSecretData := map[string][]byte{constants.ClusterNameData: []byte("cluster1")}
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{
+			Namespace: clusters.MCRegistrationSecretFullName.Namespace,
+			Name:      clusters.MCRegistrationSecretFullName.Name},
+			gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *v1.Secret) error {
+			secret.Data = mockRegistrationSecretData
+			secret.ObjectMeta.Namespace = clusters.MCRegistrationSecretFullName.Namespace
+			secret.ObjectMeta.Name = clusters.MCRegistrationSecretFullName.Name
+			return nil
+		})
+}

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
@@ -158,7 +159,7 @@ func TestReconcileVerrazzanoProject(t *testing.T) {
 			}
 
 			// Make the request
-			request := clusters.NewRequest(tt.fields.vpNamespace, tt.fields.vpName)
+			request := clusterstest.NewRequest(tt.fields.vpNamespace, tt.fields.vpName)
 			reconciler := newVerrazzanoProjectReconciler(mockClient)
 			_, err := reconciler.Reconcile(request)
 

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -20,9 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const adminKubeconfigData = "admin-kubeconfig"
-const clusterNameData = "managed-cluster-name"
-
 // StartAgent - start the agent thread for syncing multi-cluster objects
 func StartAgent(client client.Client, log logr.Logger) {
 	// Wait for the existence of the verrazzano-cluster secret.  It contains the credentials
@@ -45,7 +42,7 @@ func StartAgent(client client.Client, log logr.Logger) {
 	}
 
 	// The cluster secret exists
-	managedClusterName := string(secret.Data[clusterNameData])
+	managedClusterName := string(secret.Data[constants.ClusterNameData])
 	log.Info(fmt.Sprintf("Found secret named %s in namespace %s for cluster named %q", secret.Name, secret.Namespace, managedClusterName))
 
 	// Create the client for accessing the admin cluster
@@ -105,15 +102,15 @@ func (s *Syncer) StartSync() {
 // Validate the cluster secret
 func validateClusterSecret(secret *corev1.Secret) error {
 	// The secret must contain a cluster name
-	_, ok := secret.Data[clusterNameData]
+	_, ok := secret.Data[constants.ClusterNameData]
 	if !ok {
-		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, clusterNameData)
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, constants.ClusterNameData)
 	}
 
 	// The secret must contain a kubeconfig
-	_, ok = secret.Data[adminKubeconfigData]
+	_, ok = secret.Data[constants.AdminKubeconfigData]
 	if !ok {
-		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, adminKubeconfigData)
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, constants.AdminKubeconfigData)
 	}
 
 	return nil
@@ -127,7 +124,7 @@ func getAdminClient(secret *corev1.Secret) (client.Client, error) {
 		return nil, err
 	}
 
-	err = ioutil.WriteFile(tmpFile.Name(), secret.Data[adminKubeconfigData], 0600)
+	err = ioutil.WriteFile(tmpFile.Name(), secret.Data[constants.AdminKubeconfigData], 0600)
 	defer os.Remove(tmpFile.Name())
 	if err != nil {
 		return nil, err

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -322,7 +322,7 @@ func getSampleMCAppConfig(filePath string) (clustersv1alpha1.MultiClusterApplica
 		return mcAppConfig, err
 	}
 
-	rawResource, err := clusters.ReadYaml2Json(sampleAppConfigFile)
+	rawResource, err := clusterstest.ReadYaml2Json(sampleAppConfigFile)
 	if err != nil {
 		return mcAppConfig, err
 	}

--- a/application-operator/mcagent/mcagent_component_test.go
+++ b/application-operator/mcagent/mcagent_component_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -216,7 +216,7 @@ func getSampleMCComponent(filePath string) (clustersv1alpha1.MultiClusterCompone
 		return mcComp, err
 	}
 
-	rawMcComp, err := clusters.ReadYaml2Json(sampleComponentFile)
+	rawMcComp, err := clusterstest.ReadYaml2Json(sampleComponentFile)
 	if err != nil {
 		return mcComp, err
 	}

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -213,7 +213,7 @@ func getSampleMCConfigMap(filePath string) (clustersv1alpha1.MultiClusterConfigM
 		return mcComp, err
 	}
 
-	rawMcComp, err := clusters.ReadYaml2Json(sampleConfigMapFile)
+	rawMcComp, err := clusterstest.ReadYaml2Json(sampleConfigMapFile)
 	if err != nil {
 		return mcComp, err
 	}

--- a/application-operator/mcagent/mcagent_loggingscope_test.go
+++ b/application-operator/mcagent/mcagent_loggingscope_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -214,7 +214,7 @@ func getSampleMCLoggingScope(filePath string) (clustersv1alpha1.MultiClusterLogg
 		return mcLoggingScope, err
 	}
 
-	rawMcComp, err := clusters.ReadYaml2Json(sampleLoggingScopeFile)
+	rawMcComp, err := clusterstest.ReadYaml2Json(sampleLoggingScopeFile)
 	if err != nil {
 		return mcLoggingScope, err
 	}

--- a/application-operator/mcagent/mcagent_secret_test.go
+++ b/application-operator/mcagent/mcagent_secret_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -212,7 +212,7 @@ func getSampleMCSecret(filePath string) (clustersv1alpha1.MultiClusterSecret, er
 		return mcSecret, err
 	}
 
-	rawMcSecret, err := clusters.ReadYaml2Json(sampleSecretFile)
+	rawMcSecret, err := clusterstest.ReadYaml2Json(sampleSecretFile)
 	if err != nil {
 		return mcSecret, err
 	}

--- a/application-operator/test/integ/integ_test.go
+++ b/application-operator/test/integ/integ_test.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/test/integ/k8s"
 	"github.com/verrazzano/verrazzano/application-operator/test/integ/util"
 )
@@ -39,10 +38,10 @@ var _ = BeforeSuite(func() {
 	if err != nil {
 		Fail(fmt.Sprintf("Error creating Kubernetes client to access Verrazzano API objects: %v", err))
 	}
-	_, stderr := util.Kubectl("create ns " + multiclusterTestNamespace)
-	if stderr != "" {
-		Fail(fmt.Sprintf("failed to create namespace %v", multiclusterTestNamespace))
-	}
+
+	// Do set up for multi cluster tests
+	setupMultiClusterTest()
+
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
# Description

Multi cluster controllers process only locally placed multi cluster resources.

Fixes VZ-2115

Cleanup changes:
- MC controllers should also set labels and annotations when mutating resources
- Added deletion test case for MCxxx resources
- Don’t log errors on notfound MCxxx resources - only if some other problem occurred
- separated test utility and non-test utility methods in the clusters package

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
