### PR TITLE
Complete the implementation of deleting Mcxxxx resources

### DIFF
--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -69,9 +69,10 @@ func mutateMCAppConfig(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfi
 	mcAppConfigNew.Labels = mcAppConfig.Labels
 }
 
+// appConfigListContains returns boolean indicating if the list contains the object with the specified name and namespace
 func appConfigListContains(mcAdminList *clustersv1alpha1.MultiClusterApplicationConfigurationList, name string, namespace string) bool {
-	for _, mcAppConfig := range mcAdminList.Items {
-		if mcAppConfig.Name == name && mcAppConfig.Namespace == namespace {
+	for _, item := range mcAdminList.Items {
+		if item.Name == name && item.Namespace == namespace {
 			return true
 		}
 	}

--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -15,12 +15,12 @@ import (
 // Synchronize MultiClusterApplicationConfiguration objects to the local cluster
 func (s *Syncer) syncMCApplicationConfigurationObjects() error {
 	// Get all the MultiClusterApplicationConfiguration objects from the admin cluster
-	allMCApplicationConfigurations := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
-	err := s.AdminClient.List(s.Context, &allMCApplicationConfigurations)
+	allAdminMCAppConfigs := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
+	err := s.AdminClient.List(s.Context, &allAdminMCAppConfigs)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	for _, mcAppConfig := range allMCApplicationConfigurations.Items {
+	for _, mcAppConfig := range allAdminMCAppConfigs.Items {
 		if s.isThisCluster(mcAppConfig.Spec.Placement) {
 			_, err := s.createOrUpdateMCAppConfig(mcAppConfig)
 			s.Log.Error(err, "Error syncing MultiClusterApplicationConfiguration object",
@@ -32,15 +32,15 @@ func (s *Syncer) syncMCApplicationConfigurationObjects() error {
 	// Get the list of MultiClusterApplicationConfiguration resources on the
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
-	localMCApplicationConfiguration := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
-	err = s.LocalClient.List(s.Context, &localMCApplicationConfiguration)
+	allLocalMCAppConfigs := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
+	err = s.LocalClient.List(s.Context, &allLocalMCAppConfigs)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterApplicationConfiguration on local cluster")
 		return nil
 	}
-	for _, mcAppConfig := range localMCApplicationConfiguration.Items {
+	for _, mcAppConfig := range allLocalMCAppConfigs.Items {
 		// Delete each MultiClusterApplicationConfiguration object that is not on the admin cluster
-		if !listContains(&allMCApplicationConfigurations, mcAppConfig.Name, mcAppConfig.Namespace) {
+		if !appConfigListContains(&allAdminMCAppConfigs, mcAppConfig.Name, mcAppConfig.Namespace) {
 			err := s.LocalClient.Delete(s.Context, &mcAppConfig)
 			if err != nil {
 				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterApplicationConfiguration with name %q and namespace %q", mcAppConfig.Name, mcAppConfig.Namespace))
@@ -69,7 +69,7 @@ func mutateMCAppConfig(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfi
 	mcAppConfigNew.Labels = mcAppConfig.Labels
 }
 
-func listContains(mcAdminList *clustersv1alpha1.MultiClusterApplicationConfigurationList, name string, namespace string) bool {
+func appConfigListContains(mcAdminList *clustersv1alpha1.MultiClusterApplicationConfigurationList, name string, namespace string) bool {
 	for _, mcAppConfig := range mcAdminList.Items {
 		if mcAppConfig.Name == name && mcAppConfig.Namespace == namespace {
 			return true

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -238,12 +238,8 @@ func TestDeleteMCAppConfig(t *testing.T) {
 
 	// Managed Cluster - expect a call to delete a MultiClusterApplicationConfiguration object
 	mcMock.EXPECT().
-		Delete(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration, opts ...*client.ListOptions) error {
-			assert.Equal(testMCAppConfigOrphan.Name, mcAppConfig.Name, "unexpected object being deleted")
-			assert.Equal(testMCAppConfigOrphan.Namespace, mcAppConfig.Namespace, "unexpected object being deleted")
-			return nil
-		})
+		Delete(gomock.Any(), gomock.Eq(&testMCAppConfigOrphan), gomock.Any()).
+		Return(nil)
 
 	// Make the request
 	s := &Syncer{

--- a/application-operator/mcagent/mcagent_component.go
+++ b/application-operator/mcagent/mcagent_component.go
@@ -4,6 +4,8 @@
 package mcagent
 
 import (
+	"fmt"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,38 @@ import (
 // Synchronize MultiClusterComponent objects to the local cluster
 func (s *Syncer) syncMCComponentObjects() error {
 	// Get all the MultiClusterComponent objects from the admin cluster
-	allMCComponents := clustersv1alpha1.MultiClusterComponentList{}
-	err := s.AdminClient.List(s.Context, &allMCComponents)
+	allAdminMCComponents := clustersv1alpha1.MultiClusterComponentList{}
+	err := s.AdminClient.List(s.Context, &allAdminMCComponents)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
 	// Write each of the records that are targeted to this cluster
-	for _, mcComponent := range allMCComponents.Items {
+	for _, mcComponent := range allAdminMCComponents.Items {
 		if s.isThisCluster(mcComponent.Spec.Placement) {
 			_, err := s.createOrUpdateMCComponent(mcComponent)
 			s.Log.Error(err, "Error syncing MultiClusterComponent object",
 				types.NamespacedName{Namespace: mcComponent.Namespace, Name: mcComponent.Name})
+		}
+	}
+
+	// Delete orphaned MultiClusterComponent resources.
+	// Get the list of MultiClusterComponent resources on the
+	// local cluster and compare to the list received from the admin cluster.
+	// The admin cluster is the source of truth.
+	allLocalMCComponents := clustersv1alpha1.MultiClusterComponentList{}
+	err = s.LocalClient.List(s.Context, &allLocalMCComponents)
+	if err != nil {
+		s.Log.Error(err, "failed to list MultiClusterComponent on local cluster")
+		return nil
+	}
+	for _, mcComponent := range allLocalMCComponents.Items {
+		// Delete each MultiClusterComponent object that is not on the admin cluster
+		if !componentListContains(&allAdminMCComponents, mcComponent.Name, mcComponent.Namespace) {
+			err := s.LocalClient.Delete(s.Context, &mcComponent)
+			if err != nil {
+				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterComponent with name %q and namespace %q", mcComponent.Name, mcComponent.Namespace))
+			}
 		}
 	}
 
@@ -49,4 +71,13 @@ func mutateMCComponent(mcComponent clustersv1alpha1.MultiClusterComponent, mcCom
 	mcComponentNew.Spec.Placement = mcComponent.Spec.Placement
 	mcComponentNew.Spec.Template = mcComponent.Spec.Template
 	mcComponentNew.Labels = mcComponent.Labels
+}
+
+func componentListContains(mcAdminList *clustersv1alpha1.MultiClusterComponentList, name string, namespace string) bool {
+	for _, mcComponent := range mcAdminList.Items {
+		if mcComponent.Name == name && mcComponent.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/application-operator/mcagent/mcagent_component.go
+++ b/application-operator/mcagent/mcagent_component.go
@@ -73,9 +73,10 @@ func mutateMCComponent(mcComponent clustersv1alpha1.MultiClusterComponent, mcCom
 	mcComponentNew.Labels = mcComponent.Labels
 }
 
+// componentListContains returns boolean indicating if the list contains the object with the specified name and namespace
 func componentListContains(mcAdminList *clustersv1alpha1.MultiClusterComponentList, name string, namespace string) bool {
-	for _, mcComponent := range mcAdminList.Items {
-		if mcComponent.Name == name && mcComponent.Namespace == namespace {
+	for _, item := range mcAdminList.Items {
+		if item.Name == name && item.Namespace == namespace {
 			return true
 		}
 	}

--- a/application-operator/mcagent/mcagent_configmap.go
+++ b/application-operator/mcagent/mcagent_configmap.go
@@ -4,6 +4,8 @@
 package mcagent
 
 import (
+	"fmt"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,38 @@ import (
 // Synchronize MultiClusterConfigMap objects to the local cluster
 func (s *Syncer) syncMCConfigMapObjects() error {
 	// Get all the MultiClusterConfigMap objects from the admin cluster
-	allMCConfigMaps := clustersv1alpha1.MultiClusterConfigMapList{}
-	err := s.AdminClient.List(s.Context, &allMCConfigMaps)
+	allAdminMCConfigMaps := clustersv1alpha1.MultiClusterConfigMapList{}
+	err := s.AdminClient.List(s.Context, &allAdminMCConfigMaps)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
 	// Write each of the records that are targeted to this cluster
-	for _, mcConfigMap := range allMCConfigMaps.Items {
+	for _, mcConfigMap := range allAdminMCConfigMaps.Items {
 		if s.isThisCluster(mcConfigMap.Spec.Placement) {
 			_, err := s.createOrUpdateMCConfigMap(mcConfigMap)
 			s.Log.Error(err, "Error syncing MultiClusterConfigMap object",
 				types.NamespacedName{Namespace: mcConfigMap.Namespace, Name: mcConfigMap.Name})
+		}
+	}
+
+	// Delete orphaned MultiClusterConfigMap resources.
+	// Get the list of MultiClusterConfigMap resources on the
+	// local cluster and compare to the list received from the admin cluster.
+	// The admin cluster is the source of truth.
+	allLocalMCConfigMaps := clustersv1alpha1.MultiClusterConfigMapList{}
+	err = s.LocalClient.List(s.Context, &allLocalMCConfigMaps)
+	if err != nil {
+		s.Log.Error(err, "failed to list MultiClusterConfigMap on local cluster")
+		return nil
+	}
+	for _, mcConfigMap := range allLocalMCConfigMaps.Items {
+		// Delete each MultiClusterConfigMap object that is not on the admin cluster
+		if !configMapListContains(&allAdminMCConfigMaps, mcConfigMap.Name, mcConfigMap.Namespace) {
+			err := s.LocalClient.Delete(s.Context, &mcConfigMap)
+			if err != nil {
+				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterConfigMap with name %q and namespace %q", mcConfigMap.Name, mcConfigMap.Namespace))
+			}
 		}
 	}
 
@@ -49,4 +71,14 @@ func mutateMCConfigMap(mcConfigMap clustersv1alpha1.MultiClusterConfigMap, mcCon
 	mcConfigMapNew.Spec.Placement = mcConfigMap.Spec.Placement
 	mcConfigMapNew.Spec.Template = mcConfigMap.Spec.Template
 	mcConfigMapNew.Labels = mcConfigMap.Labels
+}
+
+// configMapListContains returns boolean indicating if the list contains the object with the specified name and namespace
+func configMapListContains(mcAdminList *clustersv1alpha1.MultiClusterConfigMapList, name string, namespace string) bool {
+	for _, item := range mcAdminList.Items {
+		if item.Name == name && item.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -176,6 +176,80 @@ func TestUpdateMCConfigMap(t *testing.T) {
 	assert.NoError(err)
 }
 
+// TestDeleteMCConfigMap tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterConfigMap objects
+// WHEN the object exists on the local cluster but not on the admin cluster
+// THEN ensure that the MultiClusterConfigMap is deleted.
+func TestDeleteMCConfigMap(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCConfigMap, err := getSampleMCConfigMap("testdata/multicluster-configmap.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+	}
+	testMCConfigMapOrphan, err := getSampleMCConfigMap("testdata/multicluster-configmap.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterConfigMap")
+	}
+	testMCConfigMapOrphan.Name = "orphaned-resource"
+
+	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterConfigMap from the list returned by the admin cluster
+	//                   Return the resource
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCConfigMapNamespace, Name: testMCConfigMapName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap) error {
+			testMCConfigMap.DeepCopyInto(mcConfigMap)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return list including an orphaned object
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMapOrphan)
+			return nil
+		})
+
+	// Managed Cluster - expect a call to delete a MultiClusterConfigMap object
+	mcMock.EXPECT().
+		Delete(gomock.Any(), gomock.Eq(&testMCConfigMapOrphan), gomock.Any()).
+		Return(nil)
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		LocalClient:        mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCConfigMapObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
 // TestMCConfigMapPlacement tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterConfigMap objects
 // WHEN the a object exists that is not targeted for the cluster

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -75,6 +75,14 @@ func TestCreateMCConfigMap(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -144,6 +152,14 @@ func TestUpdateMCConfigMap(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -186,6 +202,14 @@ func TestMCConfigMapPlacement(t *testing.T) {
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, mCConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
 			mCConfigMapList.Items = append(mCConfigMapList.Items, testMCConfigMap)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
 

--- a/application-operator/mcagent/mcagent_loggingscope.go
+++ b/application-operator/mcagent/mcagent_loggingscope.go
@@ -4,6 +4,8 @@
 package mcagent
 
 import (
+	"fmt"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,18 +15,38 @@ import (
 // Synchronize MultiClusterLoggingScope objects to the local cluster
 func (s *Syncer) syncMCLoggingScopeObjects() error {
 	// Get all the MultiClusterLoggingScope objects from the admin cluster
-	allMCLoggingScopes := clustersv1alpha1.MultiClusterLoggingScopeList{}
-	err := s.AdminClient.List(s.Context, &allMCLoggingScopes)
+	allAdminMCLoggingScopes := clustersv1alpha1.MultiClusterLoggingScopeList{}
+	err := s.AdminClient.List(s.Context, &allAdminMCLoggingScopes)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
 	// Write each of the records that are targeted to this cluster
-	for _, mcLoggingScope := range allMCLoggingScopes.Items {
+	for _, mcLoggingScope := range allAdminMCLoggingScopes.Items {
 		if s.isThisCluster(mcLoggingScope.Spec.Placement) {
 			_, err := s.createOrUpdateMCLoggingScope(mcLoggingScope)
 			s.Log.Error(err, "Error syncing MultiClusterLoggingScope object",
 				types.NamespacedName{Namespace: mcLoggingScope.Namespace, Name: mcLoggingScope.Name})
+		}
+	}
+
+	// Delete orphaned MultiClusterLoggingScope resources.
+	// Get the list of MultiClusterLoggingScope resources on the
+	// local cluster and compare to the list received from the admin cluster.
+	// The admin cluster is the source of truth.
+	allLocalMCLoggingScopes := clustersv1alpha1.MultiClusterLoggingScopeList{}
+	err = s.LocalClient.List(s.Context, &allLocalMCLoggingScopes)
+	if err != nil {
+		s.Log.Error(err, "failed to list MultiClusterLoggingScope on local cluster")
+		return nil
+	}
+	for _, mcLoggingScope := range allLocalMCLoggingScopes.Items {
+		// Delete each MultiClusterLoggingScope object that is not on the admin cluster
+		if !loggingScopeListContains(&allAdminMCLoggingScopes, mcLoggingScope.Name, mcLoggingScope.Namespace) {
+			err := s.LocalClient.Delete(s.Context, &mcLoggingScope)
+			if err != nil {
+				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterLoggingScope with name %q and namespace %q", mcLoggingScope.Name, mcLoggingScope.Namespace))
+			}
 		}
 	}
 
@@ -49,4 +71,14 @@ func mutateMCLoggingScope(mcLoggingScope clustersv1alpha1.MultiClusterLoggingSco
 	mcLoggingScopeNew.Spec.Placement = mcLoggingScope.Spec.Placement
 	mcLoggingScopeNew.Spec.Template = mcLoggingScope.Spec.Template
 	mcLoggingScopeNew.Labels = mcLoggingScope.Labels
+}
+
+// loggingScopeListContains returns boolean indicating if the list contains the object with the specified name and namespace
+func loggingScopeListContains(mcAdminList *clustersv1alpha1.MultiClusterLoggingScopeList, name string, namespace string) bool {
+	for _, item := range mcAdminList.Items {
+		if item.Name == name && item.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/application-operator/mcagent/mcagent_loggingscope_test.go
+++ b/application-operator/mcagent/mcagent_loggingscope_test.go
@@ -76,6 +76,14 @@ func TestCreateMCLoggingScope(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -145,6 +153,88 @@ func TestUpdateMCLoggingScope(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
+			return nil
+		})
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		LocalClient:        mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncMCLoggingScopeObjects()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestDeleteMCLoggingScope tests the synchronization method for the following use case.
+// GIVEN a request to sync MultiClusterLoggingScope objects
+// WHEN the object exists on the local cluster but not on the admin cluster
+// THEN ensure that the MultiClusterLoggingScope is deleted.
+func TestDeleteMCLoggingScope(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Test data
+	testMCLoggingScope, err := getSampleMCLoggingScope("testdata/multicluster-loggingscope.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterLoggingScope")
+	}
+	testMCLoggingScopeOrphan, err := getSampleMCLoggingScope("testdata/multicluster-loggingscope.yaml")
+	if err != nil {
+		assert.NoError(err, "failed to read sample data for MultiClusterLoggingScope")
+	}
+	testMCLoggingScopeOrphan.Name = "orphaned-resource"
+
+	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
+			return nil
+		})
+
+	// Managed Cluster - expect call to get a MultiClusterLoggingScope from the list returned by the admin cluster
+	//                   Return the resource
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testMCLoggingScopeNamespace, Name: testMCLoggingScopeName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, mcLoggingScope *clustersv1alpha1.MultiClusterLoggingScope) error {
+			testMCLoggingScope.DeepCopyInto(mcLoggingScope)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return list including an orphaned object
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScopeOrphan)
+			return nil
+		})
+
+	// Managed Cluster - expect a call to delete a MultiClusterLoggingScope object
+	mcMock.EXPECT().
+		Delete(gomock.Any(), gomock.Eq(&testMCLoggingScopeOrphan), gomock.Any()).
+		Return(nil)
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -184,6 +274,14 @@ func TestMCLoggingScopePlacement(t *testing.T) {
 
 	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
 	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
+	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)

--- a/application-operator/mcagent/mcagent_project_test.go
+++ b/application-operator/mcagent/mcagent_project_test.go
@@ -11,20 +11,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/verrazzano/verrazzano/application-operator/constants"
-
-	"sigs.k8s.io/yaml"
-
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 // TestSyncer_syncVerrazzanoProjects tests the synchronization method for the following use case.

--- a/application-operator/mcagent/mcagent_secret.go
+++ b/application-operator/mcagent/mcagent_secret.go
@@ -4,6 +4,8 @@
 package mcagent
 
 import (
+	"fmt"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,21 +15,42 @@ import (
 // Synchronize MultiClusterSecret objects to the local cluster
 func (s *Syncer) syncMCSecretObjects() error {
 	// Get all the MultiClusterSecret objects from the admin cluster
-	allMCSecrets := clustersv1alpha1.MultiClusterSecretList{}
+	allAdminMCSecrets := clustersv1alpha1.MultiClusterSecretList{}
 	listOptions := &client.ListOptions{}
-	err := s.AdminClient.List(s.Context, &allMCSecrets, listOptions)
+	err := s.AdminClient.List(s.Context, &allAdminMCSecrets, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
 	// Write each of the records that are targeted to this cluster
-	for _, mcSecret := range allMCSecrets.Items {
+	for _, mcSecret := range allAdminMCSecrets.Items {
 		if s.isThisCluster(mcSecret.Spec.Placement) {
 			_, err := s.createOrUpdateMCSecret(mcSecret)
 			s.Log.Error(err, "Error syncing MultiClusterSecret object",
 				types.NamespacedName{Namespace: mcSecret.Namespace, Name: mcSecret.Name})
 		}
 	}
+
+	// Delete orphaned MultiClusterSecret resources.
+	// Get the list of MultiClusterSecret resources on the
+	// local cluster and compare to the list received from the admin cluster.
+	// The admin cluster is the source of truth.
+	allLocalMCSecrets := clustersv1alpha1.MultiClusterSecretList{}
+	err = s.LocalClient.List(s.Context, &allLocalMCSecrets)
+	if err != nil {
+		s.Log.Error(err, "failed to list MultiClusterSecret on local cluster")
+		return nil
+	}
+	for _, mcSecret := range allLocalMCSecrets.Items {
+		// Delete each MultiClusterSecret object that is not on the admin cluster
+		if !secretListContains(&allAdminMCSecrets, mcSecret.Name, mcSecret.Namespace) {
+			err := s.LocalClient.Delete(s.Context, &mcSecret)
+			if err != nil {
+				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterSecret with name %q and namespace %q", mcSecret.Name, mcSecret.Namespace))
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -49,4 +72,14 @@ func mutateMCSecret(mcSecret clustersv1alpha1.MultiClusterSecret, mcSecretNew *c
 	mcSecretNew.Spec.Placement = mcSecret.Spec.Placement
 	mcSecretNew.Spec.Template = mcSecret.Spec.Template
 	mcSecretNew.Labels = mcSecret.Labels
+}
+
+// secretListContains returns boolean indicating if the list contains the object with the specified name and namespace
+func secretListContains(mcAdminList *clustersv1alpha1.MultiClusterSecretList, name string, namespace string) bool {
+	for _, item := range mcAdminList.Items {
+		if item.Name == name && item.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/application-operator/mcagent/mcagent_secret_test.go
+++ b/application-operator/mcagent/mcagent_secret_test.go
@@ -75,6 +75,14 @@ func TestCreateMCSecret(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -143,6 +151,14 @@ func TestUpdateMCSecret(t *testing.T) {
 			return nil
 		})
 
+	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
+	mcMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
+			return nil
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -182,6 +198,14 @@ func TestMCSecretPlacement(t *testing.T) {
 
 	// Admin Cluster - expect call to list MultiClusterSecret objects - return list with one object
 	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
+			return nil
+		})
+
+	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
+	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)


### PR DESCRIPTION
# Description

Complete the implementation of deleting Mcxxxx resources on managed clusters when they have been deleted on the admin cluster.

Fixes VZ-2170

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
