### PR TITLE
Remove triggering AT with k8s version 1.18 from the stable master build

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
     parameters {
         string (name: 'VERRAZZANO_BRANCH',
-                        defaultValue: 'develop',
-                        description: 'Branch or tag or commit to clone and checkout, of the Verrazzano repo',
+                        defaultValue: 'master',
+                        description: 'Branch to clone and checkout the Verrazzano repo',
                         trim: true)
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
@@ -314,7 +314,7 @@ pipeline {
             subject: "Verrazzano: ${env.JOB_NAME} - Failed",
             body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
             script {
-                if (env.BRANCH_NAME == "master" || env.BRANCH_NAME == "develop") {
+                if (env.BRANCH_NAME == "master") {
                     pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
                     slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                 }

--- a/ci/kind/JenkinsfileBuildTrigger
+++ b/ci/kind/JenkinsfileBuildTrigger
@@ -21,7 +21,7 @@ pipeline {
     }
 
     environment {
-        KUBERNETES_VERSION = '1.17,1.18,1.19,1.20'
+        KUBERNETES_VERSION = '1.17,1.19,1.20'
     }
 
     stages {
@@ -29,7 +29,7 @@ pipeline {
             steps {
                 script {
                     for (kversion in env.KUBERNETES_VERSION.tokenize(',')) {
-                        build job: 'verrazzano-new-kind-acceptance-tests/develop',
+                        build job: 'verrazzano-new-kind-acceptance-tests/master',
                             parameters: [
                                 string(name: 'VERRAZZANO_BRANCH', value: params.VERRAZZANO_BRANCH),
                                 string(name: 'KUBERNETES_CLUSTER_VERSION', value: kversion)

--- a/ci/kind/JenkinsfileBuildTrigger
+++ b/ci/kind/JenkinsfileBuildTrigger
@@ -15,8 +15,8 @@ pipeline {
 
     parameters {
         string (name: 'VERRAZZANO_BRANCH',
-                        defaultValue: 'develop',
-                        description: 'Branch or tag or commit to clone and checkout, of the Verrazzano repo',
+                        defaultValue: 'master',
+                        description: 'Branch to clone and checkout the Verrazzano repo',
                         trim: true)
     }
 

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -28,8 +28,8 @@ pipeline {
 
     parameters {
         string (name: 'VERRAZZANO_BRANCH',
-                defaultValue: 'develop',
-                description: 'Branch or tag or commit to clone and checkout, of the Verrazzano repo',
+                defaultValue: 'master',
+                description: 'Branch to clone and checkout the Verrazzano repo',
                 trim: true)
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
@@ -321,7 +321,7 @@ pipeline {
                 subject: "Verrazzano: ${env.JOB_NAME} - Failed",
                 body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
                 script {
-                    if (env.BRANCH_NAME == "master" || env.BRANCH_NAME == "develop") {
+                    if (env.BRANCH_NAME == "master") {
                         pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
                         slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                     }
@@ -359,7 +359,7 @@ pipeline {
         //    script {
         //        if (!abort) {
         //             def failures = failureCount as String
-        //             build job: 'verrazzano-new-installation-loop/develop',
+        //             build job: 'verrazzano-new-installation-loop/master',
         //                parameters: [
         //                        string(name: 'VERRAZZANO_BRANCH', value: params.VERRAZZANO_BRANCH),
         //                        string(name: 'OKE_NODE_POOL', value: params.OKE_NODE_POOL),

--- a/ci/looping-test/JenkinsfileCreateCluster
+++ b/ci/looping-test/JenkinsfileCreateCluster
@@ -24,8 +24,8 @@ pipeline {
 
     parameters {
         string (name: 'VERRAZZANO_BRANCH',
-                defaultValue: 'develop',
-                description: 'Branch or tag or commit to clone and checkout, of the Verrazzano repo',
+                defaultValue: 'master',
+                description: 'Branch to clone and checkout the Verrazzano repo',
                 trim: true)
         choice (description: 'OKE node pool configuration', name: 'OKE_NODE_POOL',
             // 1st choice is the default value
@@ -168,7 +168,7 @@ pipeline {
             subject: "Verrazzano: ${env.JOB_NAME} - Failed",
             body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
             script {
-                if (env.BRANCH_NAME == "master" || env.BRANCH_NAME == "develop") {
+                if (env.BRANCH_NAME == "master") {
                     pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
                     slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                 }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
 
     parameters {
         string (name: 'VERRAZZANO_BRANCH',
-                defaultValue: 'develop',
-                description: 'Branch or tag or commit to clone and checkout, of the Verrazzano repo',
+                defaultValue: 'master',
+                description: 'Branch to clone and checkout the Verrazzano repo',
                 trim: true)
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
@@ -354,7 +354,7 @@ pipeline {
                 subject: "Verrazzano: ${env.JOB_NAME} - Failed",
                 body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
                 script {
-                    if (env.BRANCH_NAME == "master" || env.BRANCH_NAME == "develop") {
+                    if (env.BRANCH_NAME == "master") {
                         pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
                         slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                     }

--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -14,8 +14,6 @@ KIND_IMAGE=""
 create_kind_cluster() {
   if [ ${K8S_VERSION} == 1.17 ]; then
     KIND_IMAGE="v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555"
-  elif [ ${K8S_VERSION} == 1.18 ]; then
-    KIND_IMAGE="v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb"
   elif [ ${K8S_VERSION} == 1.19 ]; then
     KIND_IMAGE="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
   elif [ ${K8S_VERSION} == 1.20 ]; then


### PR DESCRIPTION
# Description

This PR removes triggering AT with k8s version 1.18 from verrazzano-triggered-acceptance-tests, which is already done by the top level Jenkinsfile (which runs by default). Also the references to 'develop' branch is replaced with 'master' as appropriate.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
