### PR TITLE
VZ-2173.  Move and update copyright scanner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,6 +202,10 @@ pipeline {
                     make go-ineffassign
                     cd ${GO_REPO_PATH}/verrazzano/application-operator
                     make go-ineffassign
+
+                    echo "copyright scan"
+                    cd ${GO_REPO_PATH}/verrazzano
+                    time make copyright-check
                 """
 
                 dir('platform-operator'){
@@ -212,10 +216,6 @@ pipeline {
                     echo "Third party license check application-operator"
                     thirdpartyCheck()
                 }
-                sh """
-                    echo "copyright"
-                """
-                copyrightScan "${WORKSPACE}"
             }
         }
 

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -1,0 +1,285 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+//
+// This is temporary, to experiment with the Git settings in the Jenkins pipelines
+
+def DOCKER_IMAGE_TAG
+def SKIP_ACCEPTANCE_TESTS = false
+
+pipeline {
+    options {
+        skipDefaultCheckout true
+    }
+
+    agent {
+       docker {
+            image "${RUNNER_DOCKER_IMAGE}"
+            args "${RUNNER_DOCKER_ARGS}"
+            registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
+            registryCredentialsId 'ocir-pull-and-push-account'
+            label "VM.Standard2.8"
+        }
+    }
+
+    parameters {
+        booleanParam (description: 'Whether to kick off acceptance test run at the end of this build', name: 'RUN_ACCEPTANCE_TESTS', defaultValue: true)
+        booleanParam (description: 'Whether to run example tests', name: 'RUN_EXAMPLE_TESTS', defaultValue: true)
+        booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
+    }
+
+    environment {
+        DOCKER_PLATFORM_CI_IMAGE_NAME = 'verrazzano-platform-operator-jenkins'
+        DOCKER_PLATFORM_PUBLISH_IMAGE_NAME = 'verrazzano-platform-operator'
+        DOCKER_PLATFORM_IMAGE_NAME = "${env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master' ? env.DOCKER_PLATFORM_PUBLISH_IMAGE_NAME : env.DOCKER_PLATFORM_CI_IMAGE_NAME}"
+        DOCKER_OAM_CI_IMAGE_NAME = 'verrazzano-application-operator-jenkins'
+        DOCKER_OAM_PUBLISH_IMAGE_NAME = 'verrazzano-application-operator'
+        DOCKER_OAM_IMAGE_NAME = "${env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master' ? env.DOCKER_OAM_PUBLISH_IMAGE_NAME : env.DOCKER_OAM_CI_IMAGE_NAME}"
+        CREATE_LATEST_TAG = "${env.BRANCH_NAME == 'master' ? '1' : '0'}"
+        GOPATH = '/home/opc/go'
+        GO_REPO_PATH = "${GOPATH}/src/github.com/verrazzano"
+        DOCKER_CREDS = credentials('github-packages-credentials-rw')
+        DOCKER_EMAIL = credentials('github-packages-email')
+        DOCKER_REPO = 'ghcr.io'
+        DOCKER_NAMESPACE = 'verrazzano'
+        NETRC_FILE = credentials('netrc')
+        GITHUB_API_TOKEN = credentials('github-api-token-release-assets')
+        GITHUB_RELEASE_USERID = credentials('github-userid-release')
+        GITHUB_RELEASE_EMAIL = credentials('github-email-release')
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
+
+        CLUSTER_NAME = 'verrazzano'
+        POST_DUMP_FAILED_FILE = "${WORKSPACE}/post_dump_failed_file.tmp"
+        TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
+        KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
+        VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        OCR_CREDS = credentials('ocr-pull-and-push-account')
+        OCR_REPO = 'container-registry.oracle.com'
+        IMAGE_PULL_SECRET = 'verrazzano-container-registry'
+        INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
+        INSTALL_PROFILE = "dev"
+        VZ_ENVIRONMENT_NAME = "default"
+
+        WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // Needed by ToDoList example test
+        DATABASE_PSW = credentials('todo-mysql-password') // Needed by ToDoList example test
+
+        COPYRIGHT_SCAN_TARGET = "${env.BRANCH_NAME == 'master' ? 'copyright-check' : 'copyright-check-branch'}"
+    }
+
+    stages {
+        stage('Clean workspace and checkout') {
+            steps {
+                sh """
+                    echo "${NODE_LABELS}"
+                """
+
+                script {
+                    checkout scm
+                }
+                sh """
+                    cp -f "${NETRC_FILE}" $HOME/.netrc
+                    chmod 600 $HOME/.netrc
+                """
+
+                script {
+	            try {
+		        sh """
+                            echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+		        """
+		    } catch(error) {
+		        echo "docker login failed, retrying after sleep"
+		        retry(4) {
+			    sleep(30)
+			    sh """
+                                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+			    """
+		        }
+		    }
+	        }
+                script {
+	            try {
+		        sh """
+                            echo "${OCR_CREDS_PSW}" | docker login -u ${OCR_CREDS_USR} ${OCR_REPO} --password-stdin
+		        """
+		    } catch(error) {
+		        echo "OCR docker login failed, retrying after sleep"
+		        retry(4) {
+			    sleep(30)
+			    sh """
+                                echo "${OCR_CREDS_PSW}" | docker login -u ${OCR_CREDS_USR} ${OCR_REPO} --password-stdin
+			    """
+		        }
+		    }
+	        }
+                sh """
+                    rm -rf ${GO_REPO_PATH}/verrazzano
+                    mkdir -p ${GO_REPO_PATH}/verrazzano
+                    tar cf - . | (cd ${GO_REPO_PATH}/verrazzano/ ; tar xf -)
+                """
+
+                script {
+                    def props = readProperties file: '.verrazzano-development-version'
+                    VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+                    SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short HEAD").trim()
+                    DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
+                }
+            }
+        }
+
+//                    cd ${GO_REPO_PATH}/verrazzano
+
+        stage('Quality and Compliance Checks') {
+            when { not { buildingTag() } }
+            steps {
+                sh """
+                    echo "copyright scan"
+                    echo "working directory"
+                    pwd
+                    git branch
+                    git diff --name-only "@{2001-01-01}" "@{now}"
+                    git diff origin/master --name-only
+                    time make ${COPYRIGHT_SCAN_TARGET}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                    dumpVerrazzanoSystemPods()
+                    dumpCattleSystemPods()
+                    dumpNginxIngressControllerLogs()
+                    dumpVerrazzanoPlatformOperatorLogs()
+                    dumpVerrazzanoApplicationOperatorLogs()
+                    dumpOamKubernetesRuntimeLogs()
+                    dumpVerrazzanoApiLogs()
+                }
+            }
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*cluster-dump/**', allowEmptyArchive: true
+            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+
+            sh """
+                cd ${GO_REPO_PATH}/verrazzano/platform-operator
+                make delete-cluster
+                if [ -f ${POST_DUMP_FAILED_FILE} ]; then
+                  echo "Failures seen during dumping of artifacts, treat post as failed"
+                  exit 1
+                fi
+            """
+            deleteDir()
+        }
+        failure {
+            mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
+            subject: "Verrazzano: ${env.JOB_NAME} - Failed",
+            body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
+            script {
+                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME == "verrazzano/develop") {
+                    pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
+                    slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                }
+            }
+        }
+    }
+}
+
+def runGinkgoRandomize(testSuitePath) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor ${testSuitePath}/...
+        """
+    }
+}
+
+def runGinkgo(testSuitePath) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -v -keepGoing --noColor ${testSuitePath}/...
+        """
+    }
+}
+
+def dumpK8sCluster(dumpDirectory) {
+    sh """
+        ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory}
+    """
+}
+
+def dumpVerrazzanoSystemPods() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/platform-operator
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-pods.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -m "verrazzano system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-certs.log"
+        ./scripts/install/k8s-dump-objects.sh -o cert -n verrazzano-system -m "verrazzano system certs" || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-kibana.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-kibana-*" -m "verrazzano system kibana log" -l -c kibana || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-es-master.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-es-master-*" -m "verrazzano system kibana log" -l -c es-master || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def dumpCattleSystemPods() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/platform-operator
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/cattle-system-pods.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -m "cattle system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/rancher.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -r "rancher-*" -m "Rancher logs" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def dumpNginxIngressControllerLogs() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/platform-operator
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/nginx-ingress-controller.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n ingress-nginx -r "nginx-ingress-controller-*" -m "Nginx Ingress Controller" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def dumpVerrazzanoPlatformOperatorLogs() {
+    sh """
+        ## dump out verrazzano-platform-operator logs
+        mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
+        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        echo "verrazzano-platform-operator logs dumped to verrazzano-platform-operator-pod.log"
+        echo "verrazzano-platform-operator pod description dumped to verrazzano-platform-operator-pod.out"
+        echo "------------------------------------------"
+    """
+}
+
+def dumpVerrazzanoApplicationOperatorLogs() {
+    sh """
+        ## dump out verrazzano-application-operator logs
+        mkdir -p ${WORKSPACE}/verrazzano-application-operator/logs
+        kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        echo "verrazzano-application-operator logs dumped to verrazzano-application-operator-pod.log"
+        echo "verrazzano-application-operator pod description dumped to verrazzano-application-operator-pod.out"
+        echo "------------------------------------------"
+    """
+}
+
+def dumpOamKubernetesRuntimeLogs() {
+    sh """
+        ## dump out oam-kubernetes-runtime logs
+        mkdir -p ${WORKSPACE}/oam-kubernetes-runtime/logs
+        kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/oam-kubernetes-runtime/logs/oam-kubernetes-runtime-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/verrazzano-application-operator/logs/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        echo "verrazzano-application-operator logs dumped to oam-kubernetes-runtime-pod.log"
+        echo "verrazzano-application-operator pod description dumped to oam-kubernetes-runtime-pod.out"
+        echo "------------------------------------------"
+    """
+}
+
+def dumpVerrazzanoApiLogs() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/platform-operator
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-api.log"
+        ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-api-*" -m "verrazzano api" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}

--- a/ignore_copyright_check.txt
+++ b/ignore_copyright_check.txt
@@ -11,3 +11,4 @@ platform-operator/thirdparty
 application-operator/deploy/application-operator.txt
 tests/e2e/config/scripts/terraform/cluster/required-env-vars
 tests/e2e/config/scripts/looping-test/types.txt
+tools/copyright/test

--- a/tools/copyright/README.md
+++ b/tools/copyright/README.md
@@ -1,0 +1,138 @@
+# Copyright Scanner
+
+This tool enforces that all required files have the necessary copyright and license 
+statements near the beginning of the file.
+
+## Usage
+
+```shell
+go run copyright.go [options] path [path ... ]
+
+Options:
+--enforce-current   Enforce that files provided to the tool have the current year in the copyright
+--verbose           Verbose output
+```
+
+## Running the Scanner
+
+The tool can be run simply by invoking it with a list of files or directory paths.
+
+For example, to check all files in the Verrazzano repo, you can run it as follows:
+
+```shell
+$ cd ${VERRAZZANO_ROOT}
+$ go run copyright.go .
+Files to ignore: [platform-operator/scripts/install/config/00-crds.patch platform-operator/helm_config/charts/verrazzano/NOTES.txt platform-operator/helm_config/charts/verrazzano-application-operator/NOTES.txt LICENSES-OLCNE.pdf application-operator/deploy/application-operator.txt tests/e2e/config/scripts/terraform/cluster/required-env-vars tests/e2e/config/scripts/looping-test/types.txt .DS_Store]
+Directories to ignore: [platform-operator/thirdparty .idea]
+
+Copyright scanning target .
+
+Results of scan:
+	Files analyzed: 547
+	Files with error: 0
+	Files skipped: 50
+	Directories skipped: 9
+```
+
+Adding `--verbose` will spit out more details.  For example:
+
+```shell
+$ go run tools/copyright/copyright.go --verbose platform-operator/scripts 
+Files to ignore: [platform-operator/scripts/install/config/00-crds.patch platform-operator/helm_config/charts/verrazzano/NOTES.txt platform-operator/helm_config/charts/verrazzano-application-operator/NOTES.txt LICENSES-OLCNE.pdf application-operator/deploy/application-operator.txt tests/e2e/config/scripts/terraform/cluster/required-env-vars tests/e2e/config/scripts/looping-test/types.txt]
+Directories to ignore: [platform-operator/thirdparty]
+
+Copyright scanning target platform-operator/scripts
+Scanning platform-operator/scripts/install/1-install-istio.sh
+Scanning platform-operator/scripts/install/2-install-system-components.sh
+Scanning platform-operator/scripts/install/3-install-verrazzano.sh
+Scanning platform-operator/scripts/install/4-install-keycloak.sh
+Scanning platform-operator/scripts/install/common.sh
+Skipping file platform-operator/scripts/install/config/00-crds.patch
+Skipping file platform-operator/scripts/install/config/config_defaults.json
+Skipping file platform-operator/scripts/install/config/config_kind.json
+Skipping file platform-operator/scripts/install/config/config_oci.json
+Skipping file platform-operator/scripts/install/config/config_olcne.json
+Scanning platform-operator/scripts/install/config/coredns-template.yaml
+Scanning platform-operator/scripts/install/config/istio_intermediate_ca_config.txt
+Scanning platform-operator/scripts/install/config/istio_root_ca_config.txt
+Skipping file platform-operator/scripts/install/config/keycloak.json
+Scanning platform-operator/scripts/install/config/verrazzano_admission_controller_ca_config.txt
+Scanning platform-operator/scripts/install/config/verrazzano_admission_controller_cert_config.txt
+Scanning platform-operator/scripts/install/config.sh
+Scanning platform-operator/scripts/install/create_oci_config_secret.sh
+Scanning platform-operator/scripts/install/install-oke.sh
+Scanning platform-operator/scripts/install/k8s-dump-objects.sh
+Scanning platform-operator/scripts/install/logging.sh
+Skipping file platform-operator/scripts/uninstall/README.md
+Skipping file platform-operator/scripts/uninstall/build/logs/uninstall-verrazzano.sh.log
+Scanning platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+Scanning platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+Scanning platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+Scanning platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+Scanning platform-operator/scripts/uninstall/uninstall-steps/4-uninstall-keycloak.sh
+Skipping file platform-operator/scripts/uninstall/uninstall-steps/build/logs/1-uninstall-istio.sh.log
+Skipping file platform-operator/scripts/uninstall/uninstall-steps/build/logs/2-uninstall-system-components.sh.log
+Skipping file platform-operator/scripts/uninstall/uninstall-steps/build/logs/3-uninstall-verrazzano.sh.log
+Skipping file platform-operator/scripts/uninstall/uninstall-steps/build/logs/4-uninstall-keycloak.sh.log
+Scanning platform-operator/scripts/uninstall/uninstall-utils.sh
+Scanning platform-operator/scripts/uninstall/uninstall-verrazzano.sh
+
+Results of scan:
+	Files analyzed: 22
+	Files with error: 0
+	Files skipped: 12
+	Directories skipped: 0
+```
+## Scanning Locally Modified Files
+
+While doing local development, in addition to adding copyright/license statements to new files, the copyright statements 
+in existing files may need to be updated to add the current year.  
+
+You can use the scanner to check if the files modified locally have the correct copyright/license information,
+including the current year, using the `--enforce-current` option.
+
+The following example uses the `git status --short` command to obtain a set of locally modified files and validate the
+copyright/licsense information:
+
+```shell
+$ go run tools/copyright/copyright.go --verbose --enforce-current  $(git status --short | cut -c 4-)
+Enforcing current year in copyright string
+Files to ignore: [platform-operator/scripts/install/config/00-crds.patch platform-operator/helm_config/charts/verrazzano/NOTES.txt platform-operator/helm_config/charts/verrazzano-application-operator/NOTES.txt LICENSES-OLCNE.pdf application-operator/deploy/application-operator.txt tests/e2e/config/scripts/terraform/cluster/required-env-vars tests/e2e/config/scripts/looping-test/types.txt .DS_Store]
+Directories to ignore: [platform-operator/thirdparty .idea]
+
+Copyright scanning target ignore_copyright_check.txt
+Copyright scanning target tools/copyright/README.md
+Copyright scanning target .DS_Store
+Copyright scanning target platform-operator/run-vpo.sh
+
+Results of scan:
+	Files analyzed: 2
+	Files with error: 0
+	Files skipped: 2
+	Directories skipped: 0
+```
+
+## Scanning Files Changed in a Branch
+
+In combination with Git, you can use the tool to scan for files modified between branches.
+
+The following example compares the current working branch against master to get the set of modified files and feeds it
+to the scanner, and also checks for the current year in the copyright:
+
+```shell
+$ go run tools/copyright/copyright.go --enforce-current $(git diff --name-only origin/master) 
+Enforcing current year in copyright string
+Files to ignore: [platform-operator/scripts/install/config/00-crds.patch platform-operator/helm_config/charts/verrazzano/NOTES.txt platform-operator/helm_config/charts/verrazzano-application-operator/NOTES.txt LICENSES-OLCNE.pdf application-operator/deploy/application-operator.txt tests/e2e/config/scripts/terraform/cluster/required-env-vars tests/e2e/config/scripts/looping-test/types.txt .DS_Store]
+Directories to ignore: [platform-operator/thirdparty .idea]
+
+Copyright scanning target Jenkinsfile
+Copyright scanning target Makefile
+Copyright scanning target tools/copyright/README.md
+Copyright scanning target tools/copyright/copyright.go
+
+Results of scan:
+	Files analyzed: 3
+	Files with error: 0
+	Files skipped: 1
+	Directories skipped: 0
+```

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -1,0 +1,423 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This program will accept a list of files and directories and scan all of the files found therin to make sure that
+// they have the correct Oracle copyright header and UPL license headers.
+//
+// Internally, we manage a list of file extensions and relative file/directory names to ignore.  We also load a list
+// of ignore paths from the working directory of the program containing a list of paths relative to that working dir
+// to explicitly ignore.
+
+const (
+	// ignoreFileDefaultName is the name of the special file that contains a list of files to ignore
+	ignoreFileDefaultName = "ignore_copyright_check.txt"
+
+	// maxLines is the maximum number of lines to read in a file before giving up
+	maxLines = 5
+)
+
+var (
+	// filesToSkip is a list of well-known filenames to skip while scanning, relative to the directory being scanned
+	filesToSkip = []string{
+		".gitlab-ci.yml",
+		"go.mod",
+		"go.sum",
+		"LICENSE",
+		"LICENSE.txt",
+		"THIRD_PARTY_LICENSES.txt",
+		"coverage.html",
+		"clair-scanner",
+	}
+
+	// directoriesToShip is a list of well-known (sub)directories to skip while scanning, relative to the working
+	// directory being scanned
+	directoriesToSkip = []string{
+		".git",
+		"out",
+		"bin",
+		".settings",
+		"thirdparty_licenses",
+		"vendor",
+		"_output",
+		"_gen", "target",
+		"node_modules",
+	}
+
+	// extensionsToSkip is a list of well-known file extensions that we will skip while scanning, including
+	// binary files and file types that do not support comments (like json)
+	extensionsToSkip = []string{
+		".json",
+		".png",
+		".csv",
+		".ico",
+		".md",
+		".jpeg",
+		".jpg",
+		".log",
+		"-test-result.xml",
+		".woff",
+		".woff2",
+		".ttf",
+		".min.js",
+		".min.css",
+		".map",
+		".cov",
+		".iml",
+	}
+
+	// copyrightRegex is the regular expression for recognizing correctly formatted copyright statements
+	// Explanation of the regular expression
+	// -------------------------------------
+	// ^                           matches start of the line
+	// (#|\/\/|<!--|\/\*)          matches either a # character, or two / characters or the literal string "<!--", or "/*"
+	// Copyright                   matches the literal string " Copyright "
+	// \([cC]\)                    matches "(c)" or "(C)"
+	// ([1-2][0-9][0-9][0-9], )    matches a year in the range 1000-2999 followed by a comma and a space
+	// ?([1-2][0-9][0-9][0-9], )   matches an OPTIONAL second year in the range 1000-2999 followed by a comma and a space
+	// Oracle ... affiliates       matches that literal string
+	// (\.|\. -->|\. \*\/|\. --%>) matches "." or ". -->" or ". */"
+	// $                           matches the end of the line
+	// the correct copyright line looks like this:
+	// Copyright (c) 2020, Oracle and/or its affiliates.
+	copyrightRegex = regexp.MustCompile(`^(#|\/\/|<!--|\/\*|<%--) Copyright \([cC]\) ([1-2][0-9][0-9][0-9], )?([1-2][0-9][0-9][0-9], )Oracle and\/or its affiliates(\.|\. -->|\. \*\/|\. --%>)$`)
+
+	// uplRegex is the regular express for recognizing correctly formatted UPL license headers
+	// Explanation of the regular expression
+	// -------------------------------------
+	// ^                           matches start of the line
+	// (#|\/\/|<!--|\/\*|<%--)     matches either a # character, or two / characters or the literal string "<!--", "/*" or "<%--"
+	// Licensed ... licenses\\/upl matches that literal string
+	// (\.|\. -->|\. \*\/|\. --%>) matches "." or ". -->" or ". */" or ". --%>"
+	// $                           matches the end of the line
+	// the correct copyright line looks like this:
+	// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+	uplRegex = regexp.MustCompile(`^(#|\/\/|<!--|\/\*|<%--) Licensed under the Universal Permissive License v 1\.0 as shown at https:\/\/oss\.oracle\.com\/licenses\/upl(\.|\. -->|\. \*\/|\. --%>)$`)
+
+	// filesWithErrors Map to track files that failed the check with their error messages
+	filesWithErrors map[string][]string
+
+	// numFilesAnalyzed Total number of files analyzed
+	numFilesAnalyzed uint = 0
+
+	// numFilesSkipped Total number of files skipped
+	numFilesSkipped uint = 0
+
+	// numDirectoriesSkipped Total number of directories skipped
+	numDirectoriesSkipped uint = 0
+
+	// filesToIgnore Files to ignore
+	filesToIgnore = []string{}
+
+	// directoriesToIgnore Directories to ignore
+	directoriesToIgnore = []string{}
+
+	// enforceCurrentYear Enforce that the current year is present in the copyright string (for modified files checks)
+	enforceCurrentYear = false
+
+	// currentYear Holds the current year string if we are enforcing that
+	currentYear string
+
+	// verbose If true enables verbose output
+	verbose = false
+)
+
+func main() {
+
+	help := false
+
+	flag.BoolVar(&enforceCurrentYear, "enforce-current", false, "Enforce the current year is present")
+	flag.BoolVar(&verbose, "verbose", false, "Verbose output")
+	flag.BoolVar(&help, "help", false, "Display usage help")
+	flag.Parse()
+
+	if help {
+		printUsage()
+		os.Exit(0)
+	}
+
+	os.Exit(runScan(flag.Args()))
+}
+
+// runScan Execute the scan against the provided targets
+func runScan(args []string) int {
+
+	if len(args) < 1 {
+		fmt.Printf("\nNo pathnames provided for scan, exiting.\n")
+		printUsage()
+		return 1
+	}
+
+	year, _, _ := time.Now().Date()
+	currentYear = strconv.Itoa(year) + ", "
+
+	if enforceCurrentYear {
+		fmt.Println("Enforcing current year in copyright string")
+	}
+
+	if err := loadIgnoreFile(); err != nil {
+		fmt.Printf("Error updating ingore files list: %v\n", err)
+		return 1
+	}
+
+	filesWithErrors = make(map[string][]string, 10)
+
+	// Arguments are a list of directories and/or files.  Iterate through each one and
+	// - if it's a file,scan it
+	// - if it's a dir, walk it and scan it recursively
+	for _, arg := range args {
+		fmt.Println(fmt.Sprintf("Scanning target %s", arg))
+		argInfo, err := os.Stat(arg)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Printf("WARNING: %s does not exist, skipping\n", arg)
+				continue
+			}
+			fmt.Printf("Error getting file info for %s: %v", arg, err.Error())
+			return 1
+		}
+		if argInfo.IsDir() {
+			err = filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					if skipOrIgnoreDir(info.Name(), path) {
+						if verbose {
+							fmt.Printf("Skipping directory %s and all its contents\n", path)
+						}
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				err = checkFile(path, info)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+		} else {
+			err = checkFile(arg, argInfo)
+		}
+		if err != nil {
+			fmt.Printf("Error processing %s: %v", arg, err.Error())
+			return 1
+		}
+	}
+	printScanReport()
+	return 0
+}
+
+// checkFile Scans the specified file if it does not match the ignore criteria
+func checkFile(path string, info os.FileInfo) error {
+	// Ignore the file if
+	// - the extension matches one in the global set of ignored extensions
+	// - the name matches one in the global set of ignored relative file names
+	// - it is in the global ignores list read from disk
+	if skipFile(path, info) {
+		numFilesSkipped++
+		if verbose {
+			fmt.Println(fmt.Sprintf("Skipping file %s", path))
+		}
+		return nil
+	}
+
+	fileErrors, err := checkCopyrightAndLicense(path)
+	if err != nil {
+		return err
+	}
+	numFilesAnalyzed++
+	if verbose {
+		fmt.Printf("Scanning %s\n", path)
+	}
+	if len(fileErrors) > 0 {
+		filesWithErrors[path] = fileErrors
+	}
+	return nil
+}
+
+// checkCopyrightAndLicense returns true if the file has a valid/correct copyright notice
+func checkCopyrightAndLicense(path string) (fileErrors []string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return fileErrors, err
+	}
+	reader := bufio.NewScanner(file)
+	reader.Split(bufio.ScanLines)
+	defer file.Close()
+
+	foundCopyright := false
+	foundLicense := false
+
+	linesRead := 0
+	for reader.Scan() && linesRead < maxLines {
+		line := reader.Text()
+		if copyrightRegex.MatchString(line) {
+			foundCopyright = true
+			if enforceCurrentYear && !strings.Contains(line, currentYear) {
+				fileErrors = append(fileErrors, "Copyright does not contain current year")
+			}
+		}
+		if uplRegex.MatchString(line) {
+			foundLicense = true
+		}
+		if foundCopyright && foundLicense {
+			break
+		}
+		linesRead++
+	}
+	if !foundCopyright {
+		fileErrors = append(fileErrors, "Copyright not found")
+	}
+	if !foundLicense {
+		fileErrors = append(fileErrors, "License not found")
+	}
+	return fileErrors, nil
+}
+
+// printScanReport Dump the scan to stdout
+func printScanReport() {
+	fmt.Printf("\nResults of scan:\n\tFiles analyzed: %d\n\tFiles with error: %d\n\tFiles skipped: %d\n\tDirectories skipped: %d\n",
+		numFilesAnalyzed, len(filesWithErrors), numFilesSkipped, numDirectoriesSkipped)
+
+	if len(filesWithErrors) > 0 {
+		fmt.Printf("\nThe following files have errors:\n")
+		for path, errors := range filesWithErrors {
+			buff := new(bytes.Buffer)
+			writer := csv.NewWriter(buff)
+			writer.Write(errors)
+			writer.Flush()
+
+			fmt.Printf("\tFile: %s, Errors: %s\n", path, buff.String())
+		}
+
+		fmt.Println("\nExamples of valid comments:")
+		fmt.Println("With forward slash (Java-style):")
+		fmt.Println("// Copyright (c) 2021, Oracle and/or its affiliates.")
+		fmt.Println("// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.")
+		fmt.Println("With dash (For SQL files for example):")
+		fmt.Println("-- Copyright (c) 2021, Oracle and/or its affiliates.")
+		fmt.Println("-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.")
+		fmt.Println("XML comments:")
+		fmt.Println("<!-- Copyright (c) 2021, Oracle and/or its affiliates. -->")
+		fmt.Println("<!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->")
+		fmt.Println("With #:")
+		fmt.Println("# Copyright (c) 2021, Oracle and/or its affiliates.")
+		fmt.Println("# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.")
+	}
+}
+
+// loadIgnoreFile Loads the set of user-specified ignore files/paths
+func loadIgnoreFile() error {
+	ignoreFileName := os.Getenv("COPYRIGHT_INGOREFILE_PATH")
+	if len(ignoreFileName) == 0 {
+		ignoreFileName = ignoreFileDefaultName
+	}
+
+	ignoreFile, err := os.Open(ignoreFileName)
+	if err != nil {
+		return err
+	}
+	reader := bufio.NewScanner(ignoreFile)
+	reader.Split(bufio.ScanLines)
+	defer ignoreFile.Close()
+
+	// ignoreFileList Contents of ignore file
+	ignoreFileList := []string{}
+
+	for reader.Scan() {
+		line := strings.TrimSpace(reader.Text())
+		// skip empty lines - otherwise the code below will end up skipping entire
+		if len(line) == 0 {
+			continue
+		}
+		// ignore lines starting with "#"
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		ignoreFileList = append(ignoreFileList, line)
+	}
+
+	for _, ignoreLine := range ignoreFileList {
+		info, err := os.Stat(ignoreLine)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			// if the path points to an existing directory, add it to directories to ignore
+			directoriesToIgnore = append(directoriesToIgnore, ignoreLine)
+		} else {
+			filesToIgnore = append(filesToIgnore, ignoreLine)
+		}
+	}
+
+	fmt.Printf("Files to ignore: %v\n", filesToIgnore)
+	fmt.Printf("Directories to ignore: %v\n", directoriesToIgnore)
+	fmt.Println()
+	return nil
+}
+
+// skipOrIgnoreDir Returns true if a directory matches the skip or ignore lists
+func skipOrIgnoreDir(relativeName string, path string) bool {
+	if contains(directoriesToSkip, relativeName) || contains(directoriesToIgnore, path) {
+		numDirectoriesSkipped++
+		return true
+	}
+	return false
+}
+
+// skipFile Returns true if the file should be ignored/skipped
+func skipFile(pathToFile string, info os.FileInfo) bool {
+	return contains(filesToSkip, info.Name()) ||
+		contains(extensionsToSkip, filepath.Ext(info.Name())) ||
+		contains(filesToIgnore, pathToFile) ||
+		isFileOnIgnoredPath(pathToFile)
+}
+
+// isFileOnIgnoredPath Returns true if the file is under one of the dirs specified in the ignore file
+func isFileOnIgnoredPath(filepath string) bool {
+	for index, _ := range directoriesToIgnore {
+		if strings.Contains(filepath, directoriesToIgnore[index]) {
+			return true
+		}
+	}
+	return false
+}
+
+// contains Search a list of strings for a value
+func contains(strings []string, value string) bool {
+	for i, _ := range strings {
+		if value == strings[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// printUsage Prints the help for this program
+func printUsage() {
+	usageString := `
+
+go run copyright.go [options] path1 [path2 path3 ...]
+
+Options:
+	--enforce-current   Enforce that files provided to the tool have the current year in the copyright
+	--verbose           Verbose output
+
+`
+	fmt.Println(usageString)
+}

--- a/tools/copyright/copyright_test.go
+++ b/tools/copyright/copyright_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+// TestRunScan Tests the main scan driver function
+// GIVEN a call to runScan
+// WHEN with a directory to scan
+// THEN the scan results are as expected
+func TestRunScan(t *testing.T) {
+	verbose = true
+	ec := runScan([]string{"test"})
+	assert.Equal(t, 0, ec)
+	assert.Equal(t, uint(6), numFilesAnalyzed)
+	assert.Equal(t, 5, len(filesWithErrors))
+	assert.Equal(t, uint(1), numFilesSkipped)
+	assert.Equal(t, uint(1), numDirectoriesSkipped)
+}
+
+// TestRunScanNoArgs Tests the main scan driver function
+// GIVEN a call to runScan
+// WHEN no args are provided
+// THEN a non-zero code is returned
+func TestRunScanNoArgs(t *testing.T) {
+	assert.Equal(t, 1, runScan([]string{}))
+}
+
+// TestRunScanNoArgs Tests the main scan driver function
+// GIVEN a call to runScan
+// WHEN a non-existent path is provided
+// THEN a zero error code is returned (the path is ignored)
+func TestRunScanPathDoesNotExist(t *testing.T) {
+	assert.Equal(t, 0, runScan([]string{"foo"}))
+}
+
+// TestContains test the contains() utility fn
+// GIVEN a list of strings
+// WHEN contains is called with valid and invalid strings
+// THEN true is returned when the item is present, false otherwise
+func TestContains(t *testing.T) {
+	assert.True(t, contains([]string{"foo", "bar", "thud"}, "foo"))
+	assert.True(t, contains([]string{"foo", "bar", "thud"}, "bar"))
+	assert.True(t, contains([]string{"foo", "bar", "thud"}, "thud"))
+	assert.False(t, contains([]string{"foo", "bar", "thud"}, "thwack"))
+	assert.False(t, contains([]string{}, "foo"))
+	assert.False(t, contains([]string{"foo", "bar", "thud"}, ""))
+}
+
+// TestPrintScanReport Keep code coverage happy if we need to
+func TestPrintScanReport(t *testing.T) {
+	filesWithErrors = make(map[string][]string, 10)
+	filesWithErrors["test1"] = []string{"Some kind of error"}
+	printScanReport()
+	printUsage()
+}
+
+// TestSkipOrIgnoreDir tests the skip/ignore dir logic
+// GIVEN a call to skipOrIgnoreDir
+// WHEN paths are passed that do and do not match the skip criteria
+// THEN true is returned if the dir is to be skipped, false otherwise
+func TestSkipOrIgnoreDir(t *testing.T) {
+
+	saveIgnores := directoriesToIgnore
+	defer func() {
+		directoriesToIgnore = saveIgnores
+	}()
+
+	directoriesToIgnore = append(directoriesToIgnore, "someDirToIgnore")
+	skippedCountBefore := numDirectoriesSkipped
+	assert.True(t, skipOrIgnoreDir(directoriesToSkip[0], "foo"))
+	assert.True(t, skipOrIgnoreDir("foo", directoriesToIgnore[0]))
+	assert.False(t, skipOrIgnoreDir("foo", "bar"))
+	assert.Equal(t, skippedCountBefore+2, numDirectoriesSkipped)
+}
+
+// TestSkipOrIgnoreDir tests the skip/ignore dir logic
+// GIVEN a call to skipOrIgnoreDir
+// WHEN paths are passed that do and do not match the skip criteria
+// THEN true is returned if the dir is to be skipped, false otherwise
+func TestLoadIgnoreFile(t *testing.T) {
+
+	defer os.Unsetenv("COPYRIGHT_INGOREFILE_PATH")
+
+	os.Setenv("COPYRIGHT_INGOREFILE_PATH", "./thud.txt")
+	err := loadIgnoreFile()
+	assert.NotNil(t, err)
+
+	os.Setenv("COPYRIGHT_INGOREFILE_PATH", "./"+ignoreFileDefaultName)
+	err = loadIgnoreFile()
+	assert.Nil(t, err)
+	assert.True(t, len(directoriesToIgnore) > 0)
+	assert.True(t, len(filesToIgnore) > 0)
+}
+
+// TestCheckFileNoLicense tests checkFile with a file with no license string
+// GIVEN a call to checkFile
+// WHEN with a file with valid license and copyright info
+// THEN No errors are reported
+func TestCheckFile(t *testing.T) {
+	runCheckFileTest(t, "test/include/good.txt", false)
+}
+
+// TestCheckFileNoLicense tests checkFile with a file with no license string
+// GIVEN a call to checkFile
+// WHEN with a file with no license string
+// THEN Errors are reported
+func TestCheckFileNoLicense(t *testing.T) {
+	runCheckFileTest(t, "test/include/nolicense.txt", true)
+}
+
+// TestCheckFileNoCopyright tests checkFile with a file with no license string
+// GIVEN a call to checkFile
+// WHEN with a file with no copyright string
+// THEN Errors are reported
+func TestCheckFileNoCopyright(t *testing.T) {
+	runCheckFileTest(t, "test/include/nocopyright.txt", true)
+}
+
+// TestCheckFileBadCopyright tests checkFile with a file
+// GIVEN a call to checkFile
+// WHEN with a file with a bad copyright string
+// THEN Errors are reported
+func TestCheckFileBadCopyright(t *testing.T) {
+	runCheckFileTest(t, "test/include/badcopyright.txt", true)
+}
+
+// TestCheckFileBadLicense tests checkFile with a file
+// GIVEN a call to checkFile
+// WHEN with a file with a bad license string
+// THEN Errors are reported
+func TestCheckFileBadLicense(t *testing.T) {
+	runCheckFileTest(t, "test/include/badlicense.txt", true)
+}
+
+// TestCheckFileBuriedInfo tests checkFile with a file
+// GIVEN a call to checkFile
+// WHEN with a file with valid license/copyright info buried too far down (over 5 lines)
+// THEN Errors are reported
+func TestCheckFileBuriedInfo(t *testing.T) {
+	runCheckFileTest(t, "test/include/buried.txt", true)
+}
+
+// TestCheckFileFileOnIgnoreList tests checkFile with a file
+// GIVEN a call to checkFile
+// WHEN with a file on the ignore list
+// THEN No errors are reported and the skip count increments
+func TestCheckFileFileOnIgnoreList(t *testing.T) {
+	loadIgnoreFile()
+	defer func() {
+		filesToIgnore = []string{}
+		directoriesToIgnore = []string{}
+	}()
+	beforeTestSkippedCount := numFilesSkipped
+	runCheckFileTest(t, "test/include/ignore.txt", false)
+	assert.Equal(t, beforeTestSkippedCount+1, numFilesSkipped)
+}
+
+func runCheckFileTest(t *testing.T, fileName string, expectErrors bool) {
+	filesWithErrors = make(map[string][]string, 10)
+	verbose = true
+
+	numErrors := 0
+	if expectErrors {
+		numErrors = 1
+	}
+
+	info, err := os.Stat(fileName)
+	assert.Nil(t, err)
+	assert.Nil(t, checkFile(fileName, info))
+	assert.True(t, len(filesWithErrors) == numErrors)
+	_, ok := filesWithErrors[fileName]
+	assert.Equal(t, expectErrors, ok)
+	printScanReport()
+}

--- a/tools/copyright/go.mod
+++ b/tools/copyright/go.mod
@@ -1,0 +1,7 @@
+module github.com/verrazzano/verrazzano/tools/copyright
+
+go 1.15
+
+require (
+        github.com/stretchr/testify v1.5.1
+)

--- a/tools/copyright/go.sum
+++ b/tools/copyright/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/copyright/ignore_copyright_check.txt
+++ b/tools/copyright/ignore_copyright_check.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# For unit test purposes
+#
+test/ignore
+test/include/ignore.txt

--- a/tools/copyright/test/ignore/someFile.txt
+++ b/tools/copyright/test/ignore/someFile.txt
@@ -1,0 +1,1 @@
+// Should be ignored

--- a/tools/copyright/test/include/badcopyright.txt
+++ b/tools/copyright/test/include/badcopyright.txt
@@ -1,0 +1,2 @@
+// (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/tools/copyright/test/include/badlicense.txt
+++ b/tools/copyright/test/include/badlicense.txt
@@ -1,0 +1,2 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/tools/copyright/test/include/buried.txt
+++ b/tools/copyright/test/include/buried.txt
@@ -1,0 +1,13 @@
+// Test that the check will fail if the lines are too far down in the file
+
+some text
+more text
+other stuff
+
+
+
+
+
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/tools/copyright/test/include/good.txt
+++ b/tools/copyright/test/include/good.txt
@@ -1,0 +1,2 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/tools/copyright/test/include/ignore.txt
+++ b/tools/copyright/test/include/ignore.txt
@@ -1,0 +1,1 @@
+// Should be ignored

--- a/tools/copyright/test/include/nocopyright.txt
+++ b/tools/copyright/test/include/nocopyright.txt
@@ -1,0 +1,1 @@
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/tools/copyright/test/include/nolicense.txt
+++ b/tools/copyright/test/include/nolicense.txt
@@ -1,0 +1,1 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.


### PR DESCRIPTION
# Description

Moves the copyright scanner from the internal repository and re-implements it in Go.  Also adds the ability to scan files explicitly.  
- You can provide a list of files and dirs to scan, which enables us to pass in just a set of modified files to check
- Error output now lists what checks failed for each file
- Added a verbose flag
- Added the ability to enforce the current year is in the copyright string; useful for checking modified files in a branch
- Updated the Makefile to add targets to check only the files that have changed locally in a branch, or files that have been changed in a branch (compared with master at present)
- Updated the Jenkinsfile to use the scanner
- Will use the branch-diff/current-year target later once resolve some issues with using `git log`/`git diff` in Jenkins

Fixes VZ-2173.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
