### PR TITLE
Uptake OAM Kubernetes Runtime image built from source by Oracle

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -210,7 +210,7 @@ CLUSTER_NAME = verrazzano
 VERRAZZANO_NS = verrazzano-system
 DEPLOY = deploy
 OPERATOR_SETUP = test/operatorsetup
-OAM_RUNTIME_IMAGE="ghcr.io/verrazzano/oam-kubernetes-runtime:v0.3.0"
+OAM_RUNTIME_IMAGE="ghcr.io/verrazzano/oam-kubernetes-runtime:0.0-test"
 
 # These exports are needed for the install.sh
 export KUBECONFIG=${HOME}/.kube/config

--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -210,7 +210,7 @@ CLUSTER_NAME = verrazzano
 VERRAZZANO_NS = verrazzano-system
 DEPLOY = deploy
 OPERATOR_SETUP = test/operatorsetup
-OAM_RUNTIME_IMAGE="ghcr.io/verrazzano/oam-kubernetes-runtime:0.0-test"
+OAM_RUNTIME_IMAGE="ghcr.io/verrazzano/oam-kubernetes-runtime:v0.3.0-20210222205541-9e8d4fb"
 
 # These exports are needed for the install.sh
 export KUBECONFIG=${HOME}/.kube/config

--- a/platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml
+++ b/platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: ghcr.io/verrazzano/oam-kubernetes-runtime
-  tag: v0.3.0
+  tag: 0.0-test

--- a/platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml
+++ b/platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: ghcr.io/verrazzano/oam-kubernetes-runtime
-  tag: 0.0-test
+  tag: v0.3.0-20210222205541-9e8d4fb


### PR DESCRIPTION
# Description

This PR uptakes the OAM Kubernetes Runtime image built from source by Oracle.  This image uses Oracle Linux 7 slim as the base image, and has some updated dependencies.

Fixes VZ-1470

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
