### PR TITLE
Only synchronize multi-cluster objects from namespaces specified by VerrazzanoProject resources

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -197,7 +197,7 @@ endif
 #
 .PHONY: unit-test
 unit-test: go-install
-	$(GO) test -v ./apis/... ./controllers/... ./internal/...
+	$(GO) test -v ./apis/... ./controllers/... ./internal/... ./mcagent/...
 
 .PHONY: coverage
 coverage: unit-test

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -59,6 +59,7 @@ func StartAgent(client client.Client, log logr.Logger) {
 		Log:                log,
 		ManagedClusterName: managedClusterName,
 		Context:            context.TODO(),
+		ProjectNamespaces:  map[string]bool{},
 	}
 
 	// Start syncing multi-cluster objects
@@ -75,26 +76,31 @@ func (s *Syncer) StartSync() {
 		if err != nil {
 			s.Log.Error(err, "Error syncing VerrazzanoProject objects")
 		}
-		err = s.syncMCSecretObjects()
-		if err != nil {
-			s.Log.Error(err, "Error syncing MultiClusterSecret objects")
+
+		// Synchronize objects one namespace at a time
+		for namespace, _ := range s.ProjectNamespaces {
+			err = s.syncMCSecretObjects(namespace)
+			if err != nil {
+				s.Log.Error(err, "Error syncing MultiClusterSecret objects")
+			}
+			err = s.syncMCConfigMapObjects(namespace)
+			if err != nil {
+				s.Log.Error(err, "Error syncing MultiClusterConfigMap objects")
+			}
+			err = s.syncMCLoggingScopeObjects(namespace)
+			if err != nil {
+				s.Log.Error(err, "Error syncing MultiClusterLoggingScope objects")
+			}
+			err = s.syncMCComponentObjects(namespace)
+			if err != nil {
+				s.Log.Error(err, "Error syncing MultiClusterComponent objects")
+			}
+			err = s.syncMCApplicationConfigurationObjects(namespace)
+			if err != nil {
+				s.Log.Error(err, "Error syncing MultiClusterApplicationConfiguration objects")
+			}
 		}
-		err = s.syncMCConfigMapObjects()
-		if err != nil {
-			s.Log.Error(err, "Error syncing MultiClusterConfigMap objects")
-		}
-		err = s.syncMCLoggingScopeObjects()
-		if err != nil {
-			s.Log.Error(err, "Error syncing MultiClusterLoggingScope objects")
-		}
-		err = s.syncMCComponentObjects()
-		if err != nil {
-			s.Log.Error(err, "Error syncing MultiClusterComponent objects")
-		}
-		err = s.syncMCApplicationConfigurationObjects()
-		if err != nil {
-			s.Log.Error(err, "Error syncing MultiClusterApplicationConfiguration objects")
-		}
+
 		time.Sleep(1 * time.Minute)
 	}
 }

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -59,7 +59,7 @@ func StartAgent(client client.Client, log logr.Logger) {
 		Log:                log,
 		ManagedClusterName: managedClusterName,
 		Context:            context.TODO(),
-		ProjectNamespaces:  map[string]bool{},
+		ProjectNamespaces:  []string{},
 	}
 
 	// Start syncing multi-cluster objects
@@ -78,7 +78,7 @@ func (s *Syncer) StartSync() {
 		}
 
 		// Synchronize objects one namespace at a time
-		for namespace := range s.ProjectNamespaces {
+		for _, namespace := range s.ProjectNamespaces {
 			err = s.syncMCSecretObjects(namespace)
 			if err != nil {
 				s.Log.Error(err, "Error syncing MultiClusterSecret objects")

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -78,7 +78,7 @@ func (s *Syncer) StartSync() {
 		}
 
 		// Synchronize objects one namespace at a time
-		for namespace, _ := range s.ProjectNamespaces {
+		for namespace := range s.ProjectNamespaces {
 			err = s.syncMCSecretObjects(namespace)
 			if err != nil {
 				s.Log.Error(err, "Error syncing MultiClusterSecret objects")

--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -13,10 +13,11 @@ import (
 )
 
 // Synchronize MultiClusterApplicationConfiguration objects to the local cluster
-func (s *Syncer) syncMCApplicationConfigurationObjects() error {
+func (s *Syncer) syncMCApplicationConfigurationObjects(namespace string) error {
 	// Get all the MultiClusterApplicationConfiguration objects from the admin cluster
 	allAdminMCAppConfigs := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
-	err := s.AdminClient.List(s.Context, &allAdminMCAppConfigs)
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := s.AdminClient.List(s.Context, &allAdminMCAppConfigs, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -36,7 +37,7 @@ func (s *Syncer) syncMCApplicationConfigurationObjects() error {
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
 	allLocalMCAppConfigs := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
-	err = s.LocalClient.List(s.Context, &allLocalMCAppConfigs)
+	err = s.LocalClient.List(s.Context, &allLocalMCAppConfigs, listOptions)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterApplicationConfiguration on local cluster")
 		return nil

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -90,7 +90,7 @@ func TestCreateMCAppConfig(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCApplicationConfigurationObjects()
+	err = s.syncMCApplicationConfigurationObjects(testMCAppConfigNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -175,7 +175,7 @@ func TestUpdateMCAppConfig(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCApplicationConfigurationObjects()
+	err = s.syncMCApplicationConfigurationObjects(testMCAppConfigNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -249,7 +249,7 @@ func TestDeleteMCAppConfig(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCApplicationConfigurationObjects()
+	err = s.syncMCApplicationConfigurationObjects(testMCAppConfigNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -302,7 +302,7 @@ func TestMCAppConfigPlacement(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCApplicationConfigurationObjects()
+	err = s.syncMCApplicationConfigurationObjects(testMCAppConfigNamespace)
 
 	// Validate the results
 	adminMocker.Finish()

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -52,7 +52,8 @@ func TestCreateMCAppConfig(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})
@@ -77,7 +78,8 @@ func TestCreateMCAppConfig(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})
@@ -124,7 +126,8 @@ func TestUpdateMCAppConfig(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfigUpdate)
 			return nil
 		})
@@ -162,7 +165,8 @@ func TestUpdateMCAppConfig(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})
@@ -213,7 +217,8 @@ func TestDeleteMCAppConfig(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})
@@ -230,7 +235,8 @@ func TestDeleteMCAppConfig(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list including an orphaned object
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfigOrphan)
 			return nil
@@ -281,7 +287,8 @@ func TestMCAppConfigPlacement(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterApplicationConfiguration objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})
@@ -289,7 +296,8 @@ func TestMCAppConfigPlacement(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterApplicationConfiguration objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterApplicationConfigurationList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcAppConfigList *clustersv1alpha1.MultiClusterApplicationConfigurationList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCAppConfigNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcAppConfigList.Items = append(mcAppConfigList.Items, testMCAppConfig)
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_common.go
+++ b/application-operator/mcagent/mcagent_common.go
@@ -19,10 +19,8 @@ type Syncer struct {
 	ManagedClusterName string
 	Context            context.Context
 
-	// List of namespaces to watch for multi-cluster objects.  Using a map
-	// as a more efficient means of checking for duplicates.  The value in the
-	// map is ignored.
-	ProjectNamespaces map[string]bool
+	// List of namespaces to watch for multi-cluster objects.
+	ProjectNamespaces []string
 }
 
 // Check if the placement is for this cluster

--- a/application-operator/mcagent/mcagent_common.go
+++ b/application-operator/mcagent/mcagent_common.go
@@ -18,6 +18,11 @@ type Syncer struct {
 	Log                logr.Logger
 	ManagedClusterName string
 	Context            context.Context
+
+	// List of namespaces to watch for multi-cluster objects.  Using a map
+	// as a more efficient means of checking for duplicates.  The value in the
+	// map is ignored.
+	ProjectNamespaces map[string]bool
 }
 
 // Check if the placement is for this cluster

--- a/application-operator/mcagent/mcagent_component.go
+++ b/application-operator/mcagent/mcagent_component.go
@@ -13,10 +13,11 @@ import (
 )
 
 // Synchronize MultiClusterComponent objects to the local cluster
-func (s *Syncer) syncMCComponentObjects() error {
+func (s *Syncer) syncMCComponentObjects(namespace string) error {
 	// Get all the MultiClusterComponent objects from the admin cluster
 	allAdminMCComponents := clustersv1alpha1.MultiClusterComponentList{}
-	err := s.AdminClient.List(s.Context, &allAdminMCComponents)
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := s.AdminClient.List(s.Context, &allAdminMCComponents, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -38,7 +39,7 @@ func (s *Syncer) syncMCComponentObjects() error {
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
 	allLocalMCComponents := clustersv1alpha1.MultiClusterComponentList{}
-	err = s.LocalClient.List(s.Context, &allLocalMCComponents)
+	err = s.LocalClient.List(s.Context, &allLocalMCComponents, listOptions)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterComponent on local cluster")
 		return nil

--- a/application-operator/mcagent/mcagent_component_test.go
+++ b/application-operator/mcagent/mcagent_component_test.go
@@ -53,7 +53,8 @@ func TestCreateMCComponent(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterComponent objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})
@@ -78,7 +79,8 @@ func TestCreateMCComponent(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterComponent objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})
@@ -125,7 +127,8 @@ func TestUpdateMCComponent(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterComponent objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponentUpdate)
 			return nil
 		})
@@ -158,7 +161,8 @@ func TestUpdateMCComponent(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterComponent objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})
@@ -209,7 +213,8 @@ func TestDeleteMCComponent(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterComponent objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})
@@ -226,7 +231,8 @@ func TestDeleteMCComponent(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterComponent objects - return list including an orphaned object
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponentOrphan)
 			return nil
@@ -277,7 +283,8 @@ func TestMCComponentPlacement(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterComponent objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})
@@ -285,7 +292,8 @@ func TestMCComponentPlacement(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterComponent objects - return same list as admin
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterComponentList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcComponentList *clustersv1alpha1.MultiClusterComponentList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCComponentNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcComponentList.Items = append(mcComponentList.Items, testMCComponent)
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_component_test.go
+++ b/application-operator/mcagent/mcagent_component_test.go
@@ -91,7 +91,7 @@ func TestCreateMCComponent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCComponentObjects()
+	err = s.syncMCComponentObjects(testMCComponentNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -171,7 +171,7 @@ func TestUpdateMCComponent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCComponentObjects()
+	err = s.syncMCComponentObjects(testMCComponentNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -245,7 +245,7 @@ func TestDeleteMCComponent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCComponentObjects()
+	err = s.syncMCComponentObjects(testMCComponentNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -298,7 +298,7 @@ func TestMCComponentPlacement(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCComponentObjects()
+	err = s.syncMCComponentObjects(testMCComponentNamespace)
 
 	// Validate the results
 	adminMocker.Finish()

--- a/application-operator/mcagent/mcagent_configmap.go
+++ b/application-operator/mcagent/mcagent_configmap.go
@@ -13,10 +13,11 @@ import (
 )
 
 // Synchronize MultiClusterConfigMap objects to the local cluster
-func (s *Syncer) syncMCConfigMapObjects() error {
+func (s *Syncer) syncMCConfigMapObjects(namespace string) error {
 	// Get all the MultiClusterConfigMap objects from the admin cluster
 	allAdminMCConfigMaps := clustersv1alpha1.MultiClusterConfigMapList{}
-	err := s.AdminClient.List(s.Context, &allAdminMCConfigMaps)
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := s.AdminClient.List(s.Context, &allAdminMCConfigMaps, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -38,7 +39,7 @@ func (s *Syncer) syncMCConfigMapObjects() error {
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
 	allLocalMCConfigMaps := clustersv1alpha1.MultiClusterConfigMapList{}
-	err = s.LocalClient.List(s.Context, &allLocalMCConfigMaps)
+	err = s.LocalClient.List(s.Context, &allLocalMCConfigMaps, listOptions)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterConfigMap on local cluster")
 		return nil

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -91,7 +91,7 @@ func TestCreateMCConfigMap(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCConfigMapObjects()
+	err = s.syncMCConfigMapObjects(testMCConfigMapNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -168,7 +168,7 @@ func TestUpdateMCConfigMap(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCConfigMapObjects()
+	err = s.syncMCConfigMapObjects(testMCConfigMapNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -242,7 +242,7 @@ func TestDeleteMCConfigMap(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCConfigMapObjects()
+	err = s.syncMCConfigMapObjects(testMCConfigMapNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -295,7 +295,7 @@ func TestMCConfigMapPlacement(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCConfigMapObjects()
+	err = s.syncMCConfigMapObjects(testMCConfigMapNamespace)
 
 	// Validate the results
 	adminMocker.Finish()

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -52,7 +52,8 @@ func TestCreateMCConfigMap(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
@@ -78,7 +79,8 @@ func TestCreateMCConfigMap(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
@@ -126,7 +128,8 @@ func TestUpdateMCConfigMap(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMapUpdate)
 			return nil
 		})
@@ -155,7 +158,8 @@ func TestUpdateMCConfigMap(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
@@ -206,7 +210,8 @@ func TestDeleteMCConfigMap(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
@@ -223,7 +228,8 @@ func TestDeleteMCConfigMap(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return list including an orphaned object
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMapOrphan)
 			return nil
@@ -274,7 +280,8 @@ func TestMCConfigMapPlacement(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterConfigMap objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mCConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mCConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mCConfigMapList.Items = append(mCConfigMapList.Items, testMCConfigMap)
 			return nil
 		})
@@ -282,7 +289,8 @@ func TestMCConfigMapPlacement(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterConfigMap objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterConfigMapList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcConfigMapList *clustersv1alpha1.MultiClusterConfigMapList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCConfigMapNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcConfigMapList.Items = append(mcConfigMapList.Items, testMCConfigMap)
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_loggingscope.go
+++ b/application-operator/mcagent/mcagent_loggingscope.go
@@ -13,10 +13,11 @@ import (
 )
 
 // Synchronize MultiClusterLoggingScope objects to the local cluster
-func (s *Syncer) syncMCLoggingScopeObjects() error {
+func (s *Syncer) syncMCLoggingScopeObjects(namespace string) error {
 	// Get all the MultiClusterLoggingScope objects from the admin cluster
 	allAdminMCLoggingScopes := clustersv1alpha1.MultiClusterLoggingScopeList{}
-	err := s.AdminClient.List(s.Context, &allAdminMCLoggingScopes)
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := s.AdminClient.List(s.Context, &allAdminMCLoggingScopes, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -38,7 +39,7 @@ func (s *Syncer) syncMCLoggingScopeObjects() error {
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
 	allLocalMCLoggingScopes := clustersv1alpha1.MultiClusterLoggingScopeList{}
-	err = s.LocalClient.List(s.Context, &allLocalMCLoggingScopes)
+	err = s.LocalClient.List(s.Context, &allLocalMCLoggingScopes, listOptions)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterLoggingScope on local cluster")
 		return nil

--- a/application-operator/mcagent/mcagent_loggingscope_test.go
+++ b/application-operator/mcagent/mcagent_loggingscope_test.go
@@ -52,7 +52,8 @@ func TestCreateMCLoggingScope(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})
@@ -79,7 +80,8 @@ func TestCreateMCLoggingScope(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})
@@ -126,7 +128,8 @@ func TestUpdateMCLoggingScope(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScopeUpdate)
 			return nil
 		})
@@ -156,7 +159,8 @@ func TestUpdateMCLoggingScope(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})
@@ -207,7 +211,8 @@ func TestDeleteMCLoggingScope(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})
@@ -224,7 +229,8 @@ func TestDeleteMCLoggingScope(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return list including an orphaned object
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScopeOrphan)
 			return nil
@@ -275,7 +281,8 @@ func TestMCLoggingScopePlacement(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterLoggingScope objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})
@@ -283,7 +290,8 @@ func TestMCLoggingScopePlacement(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterLoggingScope objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterLoggingScopeList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcLoggingScopeList *clustersv1alpha1.MultiClusterLoggingScopeList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCLoggingScopeNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcLoggingScopeList.Items = append(mcLoggingScopeList.Items, testMCLoggingScope)
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_loggingscope_test.go
+++ b/application-operator/mcagent/mcagent_loggingscope_test.go
@@ -92,7 +92,7 @@ func TestCreateMCLoggingScope(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCLoggingScopeObjects()
+	err = s.syncMCLoggingScopeObjects(testMCLoggingScopeNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -169,7 +169,7 @@ func TestUpdateMCLoggingScope(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCLoggingScopeObjects()
+	err = s.syncMCLoggingScopeObjects(testMCLoggingScopeNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -243,7 +243,7 @@ func TestDeleteMCLoggingScope(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCLoggingScopeObjects()
+	err = s.syncMCLoggingScopeObjects(testMCLoggingScopeNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -296,7 +296,7 @@ func TestMCLoggingScopePlacement(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCLoggingScopeObjects()
+	err = s.syncMCLoggingScopeObjects(testMCLoggingScopeNamespace)
 
 	// Validate the results
 	adminMocker.Finish()

--- a/application-operator/mcagent/mcagent_project.go
+++ b/application-operator/mcagent/mcagent_project.go
@@ -8,6 +8,7 @@ import (
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,7 +25,7 @@ func (s *Syncer) syncVerrazzanoProjects() error {
 	}
 
 	// Rebuild the list of namespaces to watch for multi-cluster objects.
-	namespaces := map[string]bool{}
+	var namespaces []string
 
 	// Write each of the records in verrazzano-mc namespace
 	for _, vp := range allProjects.Items {
@@ -38,10 +39,10 @@ func (s *Syncer) syncVerrazzanoProjects() error {
 				// Add the project namespaces to the list of namespaces to watch.
 				// Check for duplicates values, even though they should never exist.
 				for _, namespace := range vp.Spec.Namespaces {
-					if _, exists := namespaces[namespace]; exists {
+					if controllers.StringSliceContainsString(namespaces, namespace) {
 						s.Log.Info(fmt.Sprintf("the namespace %s in project %s is a duplicate", namespace, vp.Name))
 					} else {
-						namespaces[namespace] = true
+						namespaces = append(namespaces, namespace)
 					}
 				}
 			}

--- a/application-operator/mcagent/mcagent_project_test.go
+++ b/application-operator/mcagent/mcagent_project_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/verrazzano/verrazzano/application-operator/controllers"
+
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
@@ -64,7 +66,7 @@ func TestSyncer_syncVerrazzanoProjects(t *testing.T) {
 			fields{
 				"random-namespace",
 				"vpInRandomNamespace",
-				newNamespaces,
+				[]string{},
 			},
 			false,
 		},
@@ -149,6 +151,12 @@ func TestSyncer_syncVerrazzanoProjects(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("syncVerrazzanoProjects() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Validate the namespace list that resulted from processing the VerrazzanoProject objects
+			assert.Equal(len(tt.fields.nsNames), len(s.ProjectNamespaces), "number of expected namespaces did not match")
+			for _, namespace := range tt.fields.nsNames {
+				assert.True(controllers.StringSliceContainsString(s.ProjectNamespaces, namespace), "expected namespace not being watched")
 			}
 		})
 	}

--- a/application-operator/mcagent/mcagent_secret.go
+++ b/application-operator/mcagent/mcagent_secret.go
@@ -13,10 +13,10 @@ import (
 )
 
 // Synchronize MultiClusterSecret objects to the local cluster
-func (s *Syncer) syncMCSecretObjects() error {
+func (s *Syncer) syncMCSecretObjects(namespace string) error {
 	// Get all the MultiClusterSecret objects from the admin cluster
 	allAdminMCSecrets := clustersv1alpha1.MultiClusterSecretList{}
-	listOptions := &client.ListOptions{}
+	listOptions := &client.ListOptions{Namespace: namespace}
 	err := s.AdminClient.List(s.Context, &allAdminMCSecrets, listOptions)
 	if err != nil {
 		return client.IgnoreNotFound(err)
@@ -39,7 +39,7 @@ func (s *Syncer) syncMCSecretObjects() error {
 	// local cluster and compare to the list received from the admin cluster.
 	// The admin cluster is the source of truth.
 	allLocalMCSecrets := clustersv1alpha1.MultiClusterSecretList{}
-	err = s.LocalClient.List(s.Context, &allLocalMCSecrets)
+	err = s.LocalClient.List(s.Context, &allLocalMCSecrets, listOptions)
 	if err != nil {
 		s.Log.Error(err, "failed to list MultiClusterSecret on local cluster")
 		return nil

--- a/application-operator/mcagent/mcagent_secret_test.go
+++ b/application-operator/mcagent/mcagent_secret_test.go
@@ -51,7 +51,8 @@ func TestCreateMCSecret(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterSecret objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -78,7 +79,8 @@ func TestCreateMCSecret(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -124,7 +126,8 @@ func TestUpdateMCSecret(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterSecret objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecretUpdate)
 			return nil
 		})
@@ -154,7 +157,8 @@ func TestUpdateMCSecret(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -199,7 +203,8 @@ func TestMCSecretPlacement(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterSecret objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -207,7 +212,8 @@ func TestMCSecretPlacement(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterSecret objects - return same list as admin cluster
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -258,7 +264,8 @@ func TestDeleteMCSecret(t *testing.T) {
 	// Admin Cluster - expect call to list MultiClusterSecret objects - return list with one object
 	adminMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			return nil
 		})
@@ -275,7 +282,8 @@ func TestDeleteMCSecret(t *testing.T) {
 	// Managed Cluster - expect call to list MultiClusterSecret objects - return list including an orphaned object
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.MultiClusterSecretList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, opts ...*client.ListOptions) error {
+		DoAndReturn(func(ctx context.Context, mcSecretList *clustersv1alpha1.MultiClusterSecretList, listOptions *client.ListOptions) error {
+			assert.Equal(testMCSecretNamespace, listOptions.Namespace, "list request did not have expected namespace")
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecret)
 			mcSecretList.Items = append(mcSecretList.Items, testMCSecretOrphan)
 			return nil

--- a/application-operator/mcagent/mcagent_secret_test.go
+++ b/application-operator/mcagent/mcagent_secret_test.go
@@ -91,7 +91,7 @@ func TestCreateMCSecret(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCSecretObjects()
+	err = s.syncMCSecretObjects(testMCSecretNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -167,7 +167,7 @@ func TestUpdateMCSecret(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCSecretObjects()
+	err = s.syncMCSecretObjects(testMCSecretNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -220,7 +220,7 @@ func TestMCSecretPlacement(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCSecretObjects()
+	err = s.syncMCSecretObjects(testMCSecretNamespace)
 
 	// Validate the results
 	adminMocker.Finish()
@@ -294,7 +294,7 @@ func TestDeleteMCSecret(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncMCApplicationConfigurationObjects()
+	err = s.syncMCSecretObjects(testMCSecretNamespace)
 
 	// Validate the results
 	adminMocker.Finish()


### PR DESCRIPTION
# Description

Refine the multi-cluster agent to only synchronize objects that are contained in namespaces specified by VerrazzanoProject resources.
- Each time VP resources are synced the list of namespaces to watch is rebuilt
- If a namespace gets from a VP, the agent will stop watching the namespace and leave it's content intact

Also fixed a problem where the `mcagent` unit tests were not being run

Fixes VZ-2209

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
