### PR TITLE
Support creating k8s 1.18 KIND cluster

### DIFF
--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -14,6 +14,8 @@ KIND_IMAGE=""
 create_kind_cluster() {
   if [ ${K8S_VERSION} == 1.17 ]; then
     KIND_IMAGE="v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555"
+  elif [ ${K8S_VERSION} == 1.18 ]; then
+    KIND_IMAGE="v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb"
   elif [ ${K8S_VERSION} == 1.19 ]; then
     KIND_IMAGE="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
   elif [ ${K8S_VERSION} == 1.20 ]; then


### PR DESCRIPTION
# Description

This PR allows creation of KIND cluster v1.18 from Jenkins pipeline verrazzano-new-kind-acceptance-tests and for any other purposes. This is basically reverting the change to tests/e2e/config/scripts/create_kind_cluster.sh, done by https://github.com/verrazzano/verrazzano/pull/710

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
