### PR TITLE
Support managed cluster when defaulting logging scope

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -217,8 +217,8 @@ export KUBECONFIG=${HOME}/.kube/config
 export VERRAZZANO_KUBECONFIG=${HOME}/.kube/config
 export VERRAZZANO_APP_OP_IMAGE=${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 
-.PHONY: integ-test
-integ-test: create-cluster
+.PHONY: setup-cluster
+setup-cluster: create-cluster
 	echo 'Load Docker image for the OAM runtime...'
 	docker pull ${OAM_RUNTIME_IMAGE}
 	kind load docker-image --name ${CLUSTER_NAME} ${OAM_RUNTIME_IMAGE}
@@ -229,6 +229,8 @@ integ-test: create-cluster
 	echo 'Install OAM runtime and Verrazzano application operator...'
 	installer/install.sh || (echo 'Application operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d ${CLUSTER_DUMP_LOCATION}; exit 1)
 
+.PHONY: integ-test
+integ-test: setup-cluster
 	echo 'Run tests...'
 	ginkgo -v --keepGoing -cover test/integ/... || (echo 'Application operator tests failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d ${CLUSTER_DUMP_LOCATION}; exit 1)
 

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -17,3 +17,15 @@ const AdminKubeconfigData = "admin-kubeconfig"
 
 // ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
 const ClusterNameData = "managed-cluster-name"
+
+// ElasticsearchHostData - the field name in MCRegistrationSecret that contains the admin cluster's
+// Elasticsearch endpoint's host name
+const ElasticsearchHostData = "elasticsearch-host"
+
+// ElasticsearchPortData - the field name in MCRegistrationSecret that contains the admin cluster's
+// Elasticsearch endpoint's port number
+const ElasticsearchPortData = "elasticsearch-port"
+
+// ElasticsearchSecretData - the field name in MCRegistrationSecret that contains the name of a
+// secret containing the credentials for the admin cluster's Elasticsearch endpoint
+const ElasticsearchSecretData = "elasticsearch-secret"

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -122,10 +122,10 @@ func IgnoreNotFoundWithLog(resourceType string, err error, logger logr.Logger) e
 // FetchManagedClusterElasticSearchDetails fetches Elasticsearch details to use for system and
 // application logs on this managed cluster. If this cluster is NOT a managed cluster (i.e. does not
 // have the managed cluster secret), an empty ElasticsearchDetails will be returned
-func FetchManagedClusterElasticSearchDetails(todo context.Context, rdr client.Reader, logger logr.Logger) ElasticsearchDetails {
+func FetchManagedClusterElasticSearchDetails(ctx context.Context, rdr client.Reader, logger logr.Logger) ElasticsearchDetails {
 	esDetails := ElasticsearchDetails{}
 	clusterSecret := corev1.Secret{}
-	err := fetchClusterSecret(context.TODO(), rdr, &clusterSecret)
+	err := fetchClusterSecret(ctx, rdr, &clusterSecret)
 	if err != nil {
 		return esDetails
 	}

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -6,6 +6,7 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -23,6 +24,14 @@ import (
 var MCRegistrationSecretFullName = types.NamespacedName{
 	Namespace: constants.VerrazzanoSystemNamespace,
 	Name:      constants.MCRegistrationSecret}
+
+// ElasticsearchDetails represents all the details needed
+// to determine how to connect to an Elasticsearch instance
+type ElasticsearchDetails struct {
+	Host       string
+	Port       uint32
+	SecretName string
+}
 
 // StatusNeedsUpdate determines based on the current state and conditions of a MultiCluster
 // resource, as well as the new state and condition to be set, whether the status update
@@ -86,7 +95,7 @@ func NewScheme() *runtime.Scheme {
 func IsPlacedInThisCluster(ctx context.Context, rdr client.Reader, placement clustersv1alpha1.Placement) bool {
 	var clusterSecret corev1.Secret
 
-	err := rdr.Get(ctx, MCRegistrationSecretFullName, &clusterSecret)
+	err := fetchClusterSecret(ctx, rdr, &clusterSecret)
 	if err != nil {
 		return false
 	}
@@ -108,4 +117,30 @@ func IgnoreNotFoundWithLog(resourceType string, err error, logger logr.Logger) e
 	}
 	logger.Info("Failed to fetch resource", "type", resourceType, "err", err)
 	return err
+}
+
+// FetchManagedClusterElasticSearchDetails fetches Elasticsearch details to use for system and
+// application logs on this managed cluster. If this cluster is NOT a managed cluster (i.e. does not
+// have the managed cluster secret), an empty ElasticsearchDetails will be returned
+func FetchManagedClusterElasticSearchDetails(todo context.Context, rdr client.Reader, logger logr.Logger) ElasticsearchDetails {
+	esDetails := ElasticsearchDetails{}
+	clusterSecret := corev1.Secret{}
+	err := fetchClusterSecret(context.TODO(), rdr, &clusterSecret)
+	if err != nil {
+		return esDetails
+	}
+	esDetails.Host = string(clusterSecret.Data[constants.ElasticsearchHostData])
+	port, err := strconv.Atoi(string(clusterSecret.Data[constants.ElasticsearchPortData]))
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("Invalid value for %s in cluster secret %s",
+			constants.ElasticsearchPortData, MCRegistrationSecretFullName.Name))
+		return ElasticsearchDetails{}
+	}
+	esDetails.Port = uint32(port)
+	esDetails.SecretName = string(clusterSecret.Data[constants.ElasticsearchSecretData])
+	return esDetails
+}
+
+func fetchClusterSecret(ctx context.Context, rdr client.Reader, clusterSecret *corev1.Secret) error {
+	return rdr.Get(ctx, MCRegistrationSecretFullName, clusterSecret)
 }

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -10,19 +10,25 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"strconv"
 	"testing"
 )
 
 // NotFoundError indicates an error caused by a StatusNotFound status
 type NotFoundError struct {
 }
+
+var emptyEsDetails = clusters.ElasticsearchDetails{}
 
 func (s NotFoundError) Error() string {
 	return "StatusNotFound"
@@ -63,11 +69,18 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	// THEN Default should create the default logging scope and add it to the component of the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// First expect it to check for a managed cluster secret
+	doExpectGetManagedClusterSecretNotFound(cli)
+
+	// Expect get existing logging scope (non-existent)
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			return NotFoundError{}
 		})
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
+
+	// Expect create logging scope
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -78,6 +91,8 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	// THEN Default should leave the existing logging scope on the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// Expect get default logging scope and since it exists, expect no other calls
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			return NotFoundError{}
@@ -89,13 +104,17 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	// THEN Default should delete the default logging scope and leave the existing logging scope on the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// Expect get default logging scope
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			scope.Name = "default-hello-app-logging-scope"
 			scope.Labels = map[string]string{"default.logging.scope": "true"}
 			return nil
 		})
-	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
+
+	// Expect default logging scope delete
+	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return nil
 		})
@@ -107,6 +126,8 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	//   on the others in the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// Expect get default logging scope and since it exists, expect no other calls
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			scope.Name = "default-hello-app-logging-scope"
@@ -122,11 +143,18 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	//   set the default logging scope on the others in the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// Expect it to get managed cluster secret
+	doExpectGetManagedClusterSecretNotFound(cli)
+
+	// Expect get default logging scope
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			return NotFoundError{}
 		})
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
+
+	// Expect create default logging scope
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -139,11 +167,18 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	//   on all of the components in the appconfig
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
+
+	// Expect it to get managed cluster secret
+	doExpectGetManagedClusterSecretNotFound(cli)
+
+	// Expect get default logging scope
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
 			return NotFoundError{}
 		})
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
+
+	// Expect create default logging scope
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -179,7 +214,7 @@ func TestLoggingScopeDefaulter_Cleanup(t *testing.T) {
 			scope.Labels = map[string]string{"default.logging.scope": "true"}
 			return nil
 		})
-	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return nil
 		})
@@ -192,6 +227,71 @@ func TestLoggingScopeDefaulter_Cleanup(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 	testLoggingScopeDefaulterCleanup(t, cli, "hello-conf.yaml", true)
+	mocker.Finish()
+}
+
+// TestCreateDefaultLoggingScope tests the behavior of CreateDefaultLoggingScope
+// GIVEN a managed cluster with Elasticsearch details specified
+// WHEN CreateDefaultLoggingScope is called with those ElasticsearchDetails
+// THEN it should create a default LoggingScope with the provided details
+func TestCreateDefaultLoggingScope(t *testing.T) {
+	scopeName := "default-hello-app-logging-scope"
+	namespacedName := types.NamespacedName{Name: scopeName, Namespace: "default"}
+
+	// WHEN CreateDefaultLoggingScope is called with empty ES details
+	// it should use the default values in the created logging scope
+	scope := CreateDefaultLoggingScope(namespacedName, emptyEsDetails)
+	asserts.Equal(t, defaultElasticSearchHost, scope.Spec.ElasticSearchHost)
+	asserts.Equal(t, defaultElasticSearchPort, scope.Spec.ElasticSearchPort)
+	asserts.Equal(t, defaultSecretName, scope.Spec.SecretName)
+
+	// WHEN CreateDefaultLoggingScope is called with non-empty ES details
+	// it should use the values provided instead of the defaults
+	esDetails := clusters.ElasticsearchDetails{Host: "some-other-es", Port: 9999, SecretName: "some-other-secret"}
+	scope = CreateDefaultLoggingScope(namespacedName, esDetails)
+	asserts.Equal(t, esDetails.Host, scope.Spec.ElasticSearchHost)
+	asserts.Equal(t, esDetails.Port, scope.Spec.ElasticSearchPort)
+	asserts.Equal(t, esDetails.SecretName, scope.Spec.SecretName)
+}
+
+// TestLoggingScopeDefaulter_DefaultManagedCluster tests adding a default LoggingScope to an
+// appconfig in a managed cluster (in this case the default logging scope should refer to the admin
+// cluster's Elasticsearch endpoint and secret)
+// GIVEN a AppConfigDefaulter and an appconfig in a managed cluster,
+// WHEN Default is called with an appconfig
+// THEN it should add a default LoggingScope to the appconfig which refers to the admin cluster ES
+func TestLoggingScopeDefaulter_DefaultOnManagedCluster(t *testing.T) {
+	var cli *mocks.MockClient
+	var mocker *gomock.Controller
+
+	scopeName := "default-hello-app-logging-scope"
+	namespacedName := types.NamespacedName{Name: scopeName, Namespace: "default"}
+
+	// The appconfig has one component with no scopes and the default scope does not exist
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// Expect it to get managed cluster secret and return a managed cluster secret (all other tests
+	// assumed no managed cluster secret found)
+	esDetails := clusters.ElasticsearchDetails{Host: "some-es-host", Port: 9999, SecretName: "some-es-secret"}
+	mcSecret := v1.Secret{Data: map[string][]byte{
+		constants.ClusterNameData:         []byte("managed-cluster1"),
+		constants.ElasticsearchHostData:   []byte(esDetails.Host),
+		constants.ElasticsearchPortData:   []byte(strconv.Itoa(int(esDetails.Port))),
+		constants.ElasticsearchSecretData: []byte(esDetails.SecretName)}}
+	doExpectGetManagedClusterSecretFound(cli, mcSecret)
+
+	// Expect get default logging scope
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
+			return NotFoundError{}
+		})
+
+	// Expect create logging scope with the esDetails specified in the managedClusterSecret (instead of the defaults)
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, esDetails)), gomock.Not(gomock.Nil())).
+		Return(nil)
+
+	testLoggingScopeDefaulterDefault(t, cli, "hello-conf.yaml", map[string]string{"hello-component": scopeName}, false)
 	mocker.Finish()
 }
 
@@ -235,4 +335,19 @@ func testLoggingScopeDefaulterCleanup(t *testing.T, cli client.Client, configPat
 	if err != nil {
 		t.Fatalf("Error in defaulter.Default %v", err)
 	}
+}
+
+func doExpectGetManagedClusterSecretNotFound(cli *mocks.MockClient) {
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			return NotFoundError{}
+		})
+}
+
+func doExpectGetManagedClusterSecretFound(cli *mocks.MockClient, managedClusterSecret v1.Secret) {
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			secret.Data = managedClusterSecret.Data
+			return nil
+		})
 }


### PR DESCRIPTION
# Description

logging_scope_defaulter supports managed clusters where the default is supposed to Elasticsearch on the admin cluster. The Elasticsearch connection information is specified in the managed cluster registration secret.

Partially fixes VZ-2236

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
