### PR TITLE
VZ-2189: Fix ES logging when app has multiple workload types

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -70,9 +70,13 @@ multiline_flush_interval 20s
 </match>
 `
 
-const specField = "spec"
-const jvmField = "jvm"
-const argsField = "args"
+const (
+	specField = "spec"
+	jvmField  = "jvm"
+	argsField = "args"
+
+	workloadType = "coherence"
+)
 
 var specLabelsFields = []string{specField, "labels"}
 var specAnnotationsFields = []string{specField, "annotations"}
@@ -281,6 +285,7 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace 
 		ParseRules:             fluentdParsingRules,
 		StorageVolumeName:      "logs",
 		StorageVolumeMountPath: "/logs",
+		WorkloadType:           workloadType,
 	}
 
 	// fluentdManager.Apply wants a QRR but it only cares about the namespace (at least for
@@ -330,7 +335,7 @@ func moveConfigMapVolume(log logr.Logger, fluentdPod *loggingscope.FluentdPod, c
 			fluentdVolMount = container.VolumeMounts[0]
 			// Coherence needs the vol mount to match the config map name, so fix it, need
 			// to see if we can just change name set by the FLUENTD code
-			fluentdVolMount.Name = "fluentd-config"
+			fluentdVolMount.Name = "fluentd-config" + "-" + workloadType
 			fluentdPod.Containers[0].VolumeMounts = nil
 			break
 		}

--- a/application-operator/controllers/loggingscope/fluentd_test.go
+++ b/application-operator/controllers/loggingscope/fluentd_test.go
@@ -30,6 +30,8 @@ const (
 	testESHostUpdate   = "es-host-update"
 	testESPortUpdate   = "1111"
 	testESSecretUpdate = "test-secret-update"
+
+	testWorkLoadType = "test-workload"
 )
 
 // TestFluentdApply tests the creation of all FLUENTD resources in the system for a resource
@@ -44,14 +46,14 @@ func TestFluentdApply(t *testing.T) {
 	resource := createTestResourceRelation()
 	fluentdPod := createTestFluentdPod()
 
-	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath}
+	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath, testWorkLoadType}
 
 	// simulate config map not existing
 	mockClient.EXPECT().
-		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName}).
+		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
 		DoAndReturn(func(ctx context.Context, resources *unstructured.UnstructuredList, inNamespace client.InNamespace, fields client.MatchingFields) error {
 			asserts.Equal(t, client.InNamespace(testNamespace), inNamespace)
-			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName}, fields)
+			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}, fields)
 			asserts.Equal(t, configMapAPIVersion, resources.GetAPIVersion())
 			asserts.Equal(t, configMapKind, resources.GetKind())
 			return nil
@@ -89,14 +91,14 @@ func TestFluentdApplyForUpdate(t *testing.T) {
 	resource := createTestResourceRelation()
 	fluentdPod := createTestFluentdPodForUpdate()
 
-	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath}
+	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath, testWorkLoadType}
 
 	// simulate config map existing
 	mockClient.EXPECT().
-		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName}).
+		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
 		DoAndReturn(func(ctx context.Context, resources *unstructured.UnstructuredList, inNamespace client.InNamespace, fields client.MatchingFields) error {
 			asserts.Equal(t, client.InNamespace(testNamespace), inNamespace)
-			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName}, fields)
+			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}, fields)
 			asserts.Equal(t, configMapAPIVersion, resources.GetAPIVersion())
 			asserts.Equal(t, configMapKind, resources.GetKind())
 
@@ -125,7 +127,7 @@ func TestFluentdRemove(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mockClient := mocks.NewMockClient(mocker)
 
-	fluentd := &Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath}
+	fluentd := &Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath, testWorkLoadType}
 	scope := createTestLoggingScope(true)
 	resource := createTestResourceRelation()
 	fluentdPod := createTestFluentdPod()
@@ -133,10 +135,10 @@ func TestFluentdRemove(t *testing.T) {
 
 	// simulate config map existing
 	mockClient.EXPECT().
-		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName}).
+		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
 		DoAndReturn(func(ctx context.Context, resources *unstructured.UnstructuredList, inNamespace client.InNamespace, fields client.MatchingFields) error {
 			asserts.Equal(t, client.InNamespace(testNamespace), inNamespace)
-			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName}, fields)
+			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}, fields)
 			asserts.Equal(t, configMapAPIVersion, resources.GetAPIVersion())
 			asserts.Equal(t, configMapKind, resources.GetKind())
 

--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -22,6 +22,7 @@ const (
 	wlsWorkloadKey         = "weblogic.oracle/v8/Domain"
 	storageVolumeName      = "weblogic-domain-storage-volume"
 	storageVolumeMountPath = scratchVolMountPath
+	workloadType           = "weblogic"
 )
 
 // WlsFluentdParsingRules defines the FLUENTD parsing rules for WLS
@@ -163,6 +164,7 @@ func GetFluentd(ctx context.Context, log logr.Logger, client k8sclient.Client) F
 		ParseRules:             WlsFluentdParsingRules,
 		StorageVolumeName:      storageVolumeName,
 		StorageVolumeMountPath: storageVolumeMountPath,
+		WorkloadType:           workloadType,
 	}
 }
 

--- a/tests/e2e/examples/bobs-books/bobs_books_test.go
+++ b/tests/e2e/examples/bobs-books/bobs_books_test.go
@@ -214,27 +214,45 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 			)
 		})
 	})
-	// disabling this test until we can fix the bug caused by the fact that we write a single FLUENTD configmap
-	// which causes a Coherence configmap to get loaded by WebLogic pods depending on timing of writing the configmap
-	// ginkgo.Context("Logging.", func() {
-	// 	indexName := "bobs-books-bobby-front-end-bobby-wls"
-	// 	// GIVEN a WebLogic application with logging enabled via a logging scope
-	// 	// WHEN the Elasticsearch index is retrieved
-	// 	// THEN verify that it is found
-	// 	ginkgo.It("Verify Elasticsearch index exists", func() {
-	// 		gomega.Eventually(func() bool {
-	// 			return pkg.LogIndexFound(indexName)
-	// 		}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index for bobs-books")
-	// 	})
-	// 	// GIVEN a WebLogic application with logging enabled via a logging scope
-	// 	// WHEN the log records are retrieved from the Elasticsearch index
-	// 	// THEN verify that at least one recent log record is found
-	// 	ginkgo.It("Verify recent Elasticsearch log record exists", func() {
-	// 		gomega.Eventually(func() bool {
-	// 			return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-	// 				"domainUID":  "bobbys-front-end",
-	// 				"serverName": "bobbys-front-end-adminserver"})
-	// 		}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
-	// 	})
-	// })
+	ginkgo.Context("WebLogic logging.", func() {
+		indexName := "bobs-books-bobs-books-bobby-wls"
+		// GIVEN a WebLogic application with logging enabled via a logging scope
+		// WHEN the Elasticsearch index is retrieved
+		// THEN verify that it is found
+		ginkgo.It("Verify Elasticsearch index exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogIndexFound(indexName)
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+indexName)
+		})
+		// GIVEN a WebLogic application with logging enabled via a logging scope
+		// WHEN the log records are retrieved from the Elasticsearch index
+		// THEN verify that at least one recent log record is found
+		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+					"domainUID":  "bobbys-front-end",
+					"serverName": "bobbys-front-end-adminserver"})
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
+		})
+	})
+	ginkgo.Context("Coherence logging.", func() {
+		indexName := "bobs-books-bobs-books-robert-coh"
+		// GIVEN a Coherence application with logging enabled via a logging scope
+		// WHEN the Elasticsearch index is retrieved
+		// THEN verify that it is found
+		ginkgo.It("Verify Elasticsearch index exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogIndexFound(indexName)
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+indexName)
+		})
+		// GIVEN a Coherence application with logging enabled via a logging scope
+		// WHEN the log records are retrieved from the Elasticsearch index
+		// THEN verify that at least one recent log record is found
+		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+					"cluster": "roberts-coherence"})
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
+		})
+	})
 })


### PR DESCRIPTION
# Description

This is a short/medium-term fix for ES logging when an application is compromised of multiple workload types. Previously we created a single shared fluentd configmap for all pods regardless of workload type. This change results in a separate configmap per workload type.

I tested by running multiple examples and looking in Kibana to make sure I saw logs for all pods. For Bob's Books, I confirmed that both WebLogic and Coherence logs were sent. I also added another test to the Bob's Books test suite to look for Coherence log records in addition to WebLogic log records.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
