### PR TITLE
Make Elasticsearch secret be a well known secret name

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -26,6 +26,6 @@ const ElasticsearchHostData = "elasticsearch-host"
 // Elasticsearch endpoint's port number
 const ElasticsearchPortData = "elasticsearch-port"
 
-// ElasticsearchSecretData - the field name in MCRegistrationSecret that contains the name of a
-// secret containing the credentials for the admin cluster's Elasticsearch endpoint
-const ElasticsearchSecretData = "elasticsearch-secret"
+// ElasticsearchSecretName - the name of the secret in the Verrazzano System namespace,
+// that contains credentials and other details for for the admin cluster's Elasticsearch endpoint
+const ElasticsearchSecretName = "verrazzano-cluster-elasticsearch"

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -137,7 +137,7 @@ func FetchManagedClusterElasticSearchDetails(ctx context.Context, rdr client.Rea
 		return ElasticsearchDetails{}
 	}
 	esDetails.Port = uint32(port)
-	esDetails.SecretName = string(clusterSecret.Data[constants.ElasticsearchSecretData])
+	esDetails.SecretName = constants.ElasticsearchSecretName
 	return esDetails
 }
 

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -275,9 +275,9 @@ func TestLoggingScopeDefaulter_DefaultOnManagedCluster(t *testing.T) {
 	// assumed no managed cluster secret found)
 	esDetails := clusters.ElasticsearchDetails{Host: "some-es-host", Port: 9999, SecretName: constants.ElasticsearchSecretName}
 	mcSecret := v1.Secret{Data: map[string][]byte{
-		constants.ClusterNameData:         []byte("managed-cluster1"),
-		constants.ElasticsearchHostData:   []byte(esDetails.Host),
-		constants.ElasticsearchPortData:   []byte(strconv.Itoa(int(esDetails.Port)))}}
+		constants.ClusterNameData:       []byte("managed-cluster1"),
+		constants.ElasticsearchHostData: []byte(esDetails.Host),
+		constants.ElasticsearchPortData: []byte(strconv.Itoa(int(esDetails.Port)))}}
 	doExpectGetManagedClusterSecretFound(cli, mcSecret)
 
 	// Expect get default logging scope

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -273,12 +273,11 @@ func TestLoggingScopeDefaulter_DefaultOnManagedCluster(t *testing.T) {
 
 	// Expect it to get managed cluster secret and return a managed cluster secret (all other tests
 	// assumed no managed cluster secret found)
-	esDetails := clusters.ElasticsearchDetails{Host: "some-es-host", Port: 9999, SecretName: "some-es-secret"}
+	esDetails := clusters.ElasticsearchDetails{Host: "some-es-host", Port: 9999, SecretName: constants.ElasticsearchSecretName}
 	mcSecret := v1.Secret{Data: map[string][]byte{
 		constants.ClusterNameData:         []byte("managed-cluster1"),
 		constants.ElasticsearchHostData:   []byte(esDetails.Host),
-		constants.ElasticsearchPortData:   []byte(strconv.Itoa(int(esDetails.Port))),
-		constants.ElasticsearchSecretData: []byte(esDetails.SecretName)}}
+		constants.ElasticsearchPortData:   []byte(strconv.Itoa(int(esDetails.Port)))}}
 	doExpectGetManagedClusterSecretFound(cli, mcSecret)
 
 	// Expect get default logging scope


### PR DESCRIPTION
# Description

Make Elasticsearch secret be a well known secret name

changes for VZ-2236

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
