### PR TITLE
Fix bug in copyright checker

### DIFF
--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -219,6 +219,9 @@ func runScan(args []string) int {
 		}
 	}
 	printScanReport()
+	if len(filesWithErrors) > 0 {
+		return 1
+	}
 	return 0
 }
 

--- a/tools/copyright/copyright_test.go
+++ b/tools/copyright/copyright_test.go
@@ -15,7 +15,7 @@ import (
 func TestRunScan(t *testing.T) {
 	verbose = true
 	ec := runScan([]string{"test"})
-	assert.Equal(t, 0, ec)
+	assert.Equal(t, 1, ec)
 	assert.Equal(t, uint(6), numFilesAnalyzed)
 	assert.Equal(t, 5, len(filesWithErrors))
 	assert.Equal(t, uint(1), numFilesSkipped)


### PR DESCRIPTION

# Description

Fix a bug in the copyright checker, not returning non-zero error code when errors exist.

Fixes VZ-2173

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
