### PR TITLE
Changes to Weblogic workload controller for istio

### DIFF
--- a/application-operator/controllers/webhooks/istio_defaulter.go
+++ b/application-operator/controllers/webhooks/istio_defaulter.go
@@ -240,7 +240,7 @@ func (a *IstioWebhook) createServiceAccount(namespace string, ownerRef metav1.Ow
 	return serviceAccount.Name, nil
 }
 
-// flatten traverses a nested array of owner references and returns a single array of owner references.
+// flattenOwnerReferences traverses a nested array of owner references and returns a single array of owner references.
 func (a *IstioWebhook) flattenOwnerReferences(list []metav1.OwnerReference, namespace string, ownerRefs []metav1.OwnerReference) ([]metav1.OwnerReference, error) {
 	for _, ownerRef := range ownerRefs {
 		list = append(list, ownerRef)

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -267,27 +267,13 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace 
 	return nil
 }
 
-// updateIstioEnabled sets the domain resource configuration.istio.enabled value based
-// on the namespace label istio-injection
-func updateIstioEnabled(labels map[string]string, u *unstructured.Unstructured) error {
-	istioEnabled := false
-	for key, value := range labels {
-		if key == "istio-injection" && value == "enabled" {
-			istioEnabled = true
-		}
-	}
-
-	return unstructured.SetNestedField(u.Object, istioEnabled, specConfigurationIstioEnabledFields...)
-}
-
 // createOrUpdateDestinationRule creates or updates an Istio destinationRule required by WebLogic servers.
 // The destinationRule is only created when the namespace has the label istio-injection=enabled.
 func (r *Reconciler) createOrUpdateDestinationRule(ctx context.Context, namespace string, namespaceLabels map[string]string, workloadLabels map[string]string) error {
 	istioEnabled := false
-	for key, value := range namespaceLabels {
-		if key == "istio-injection" && value == "enabled" {
-			istioEnabled = true
-		}
+	value, ok := namespaceLabels["istio-injection"]
+	if ok && value == "enabled" {
+		istioEnabled = true
 	}
 
 	if !istioEnabled {
@@ -338,4 +324,16 @@ func (r *Reconciler) mutateDestinationRule(destinationRule *istioclient.Destinat
 	}
 
 	return nil
+}
+
+// updateIstioEnabled sets the domain resource configuration.istio.enabled value based
+// on the namespace label istio-injection
+func updateIstioEnabled(labels map[string]string, u *unstructured.Unstructured) error {
+	istioEnabled := false
+	value, ok := labels["istio-injection"]
+	if ok && value == "enabled" {
+		istioEnabled = true
+	}
+
+	return unstructured.SetNestedField(u.Object, istioEnabled, specConfigurationIstioEnabledFields...)
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -493,7 +493,6 @@ func TestAddLoggingFailure(t *testing.T) {
 // THEN the domain resource to spec.configuration.istio.enabled is set to true
 func TestIstioEnabled(t *testing.T) {
 	assert := asserts.New(t)
-	reconciler := Reconciler{}
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -508,7 +507,7 @@ func TestIstioEnabled(t *testing.T) {
 			"kind": "Domain",
 		},
 	}
-	err := reconciler.istioEnabled(namespace, u)
+	err := istioEnabled(namespace, u)
 	assert.NoError(err, "Unexpected error setting istio enabled")
 	specIstioEnabled, _, _ := unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
 	assert.Equal(specIstioEnabled, true)
@@ -519,7 +518,6 @@ func TestIstioEnabled(t *testing.T) {
 // THEN the domain resource to spec.configuration.istio.enabled is set to false
 func TestIstioDisabled(t *testing.T) {
 	assert := asserts.New(t)
-	reconciler := Reconciler{}
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -534,7 +532,7 @@ func TestIstioDisabled(t *testing.T) {
 			"kind": "Domain",
 		},
 	}
-	err := reconciler.istioEnabled(namespace, u)
+	err := istioEnabled(namespace, u)
 	assert.NoError(err, "Unexpected error setting istio enabled")
 	specIstioEnabled, _, _ := unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
 	assert.Equal(specIstioEnabled, false)
@@ -549,7 +547,7 @@ func TestIstioDisabled(t *testing.T) {
 			"kind": "Domain",
 		},
 	}
-	err = reconciler.istioEnabled(namespace, u)
+	err = istioEnabled(namespace, u)
 	assert.NoError(err, "Unexpected error setting istio enabled")
 	specIstioEnabled, _, _ = unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
 	assert.Equal(specIstioEnabled, false)

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -488,68 +487,36 @@ func TestAddLoggingFailure(t *testing.T) {
 }
 
 // TestIstioEnabled tests that domain resource spec.configuration.istio.enabled is set correctly.
-// GIVEN a namespace with the label istio-injection equals enabled
-// WHEN the label istio-injection equals enabled
+// GIVEN istio-injection is disabled
 // THEN the domain resource to spec.configuration.istio.enabled is set to true
 func TestIstioEnabled(t *testing.T) {
 	assert := asserts.New(t)
 
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			Labels: map[string]string{
-				"istio-injection": "enabled",
-			},
-		},
-	}
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind": "Domain",
 		},
 	}
-	err := istioEnabled(namespace, u)
+	err := updateIstioEnabled(true, u)
 	assert.NoError(err, "Unexpected error setting istio enabled")
 	specIstioEnabled, _, _ := unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
 	assert.Equal(specIstioEnabled, true)
 }
 
 // TestIstioDisabled tests that domain resource spec.configuration.istio.enabled is set correctly.
-// GIVEN a namespace with the label istio-injection not set or set to disable
+// GIVEN istio-injection is disabled
 // THEN the domain resource to spec.configuration.istio.enabled is set to false
 func TestIstioDisabled(t *testing.T) {
 	assert := asserts.New(t)
 
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			Labels: map[string]string{
-				"istio-injection": "disabled",
-			},
-		},
-	}
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind": "Domain",
 		},
 	}
-	err := istioEnabled(namespace, u)
+	err := updateIstioEnabled(false, u)
 	assert.NoError(err, "Unexpected error setting istio enabled")
 	specIstioEnabled, _, _ := unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
-	assert.Equal(specIstioEnabled, false)
-
-	namespace = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
-	}
-	u = &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind": "Domain",
-		},
-	}
-	err = istioEnabled(namespace, u)
-	assert.NoError(err, "Unexpected error setting istio enabled")
-	specIstioEnabled, _, _ = unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
 	assert.Equal(specIstioEnabled, false)
 }
 

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -178,8 +178,6 @@ spec:
           clusters:
             - clusterName: cluster-1
           configuration:
-            istio:
-              enabled: false
             introspectorJobActiveDeadlineSeconds: 300
             model:
               runtimeEncryptionSecret: bobbys-front-end-runtime-encrypt-secret
@@ -400,8 +398,6 @@ spec:
           clusters:
             - clusterName: cluster-1
           configuration:
-            istio:
-              enabled: false
             introspectorJobActiveDeadlineSeconds: 300
             model:
               configMap: bobs-bookstore-wdt-config-map

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -27,8 +27,6 @@ spec:
           webLogicCredentialsSecret:
             name: tododomain-weblogic-credentials
           configuration:
-            istio:
-              enabled: false
             introspectorJobActiveDeadlineSeconds: 900
             model:
               configMap: tododomain-jdbc-config

--- a/tools/copyright/go.mod
+++ b/tools/copyright/go.mod
@@ -2,6 +2,4 @@ module github.com/verrazzano/verrazzano/tools/copyright
 
 go 1.15
 
-require (
-        github.com/stretchr/testify v1.5.1
-)
+require github.com/stretchr/testify v1.5.1


### PR DESCRIPTION
# Description

This pull request contains Istio related changes to the Weblogic workload controller.
The changes are:
1. Automatically set the domain resource spec.configuration.istio.enabled value.  If the namespace of the domain has Istio enabled then set the value to true otherwise set the value to false.
2. Create an istio destination rule for the WebLogic servers when the namespace is Istio enabled.
3. Remove the setting of spec.configuration.istio.enabled from the examples - todo-list and bobs-books.


Fixes VZ-2114

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
