### PR TITLE
VZ-2173.  Fix copyright year in required files, and make the year-check the default.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 .git

--- a/.github/workflows/pagerduty.yml
+++ b/.github/workflows/pagerduty.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: pagerduty-trigger
 on:

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -61,8 +61,6 @@ pipeline {
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // Needed by ToDoList example test
         DATABASE_PSW = credentials('todo-mysql-password') // Needed by ToDoList example test
-
-        COPYRIGHT_SCAN_TARGET = "${env.BRANCH_NAME == 'master' ? 'copyright-check' : 'copyright-check-branch'}"
     }
 
     stages {
@@ -139,7 +137,7 @@ pipeline {
                     git diff --name-only "@{2001-01-01}" "@{now}"
                     git diff origin/master --name-only
                     git log --since=01-01-2021 --name-only --oneline --pretty="format:" | sort -u
-                    time make ${COPYRIGHT_SCAN_TARGET}
+                    time make copyright-check
                 """
             }
         }

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -138,6 +138,7 @@ pipeline {
                     git branch
                     git diff --name-only "@{2001-01-01}" "@{now}"
                     git diff origin/master --name-only
+                    git log --since=01-01-2021 --name-only --oneline --pretty="format:" | sort -u
                     time make ${COPYRIGHT_SCAN_TARGET}
                 """
             }

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ copyright-check-year: copyright-test
 	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
 
 .PHONY: copyright-check
-copyright-check: copyright-check-year
-	go run tools/copyright/copyright.go --verbose .
+copyright-check: copyright-test
+	go run tools/copyright/copyright.go --verbose --enforce-current .
 
 .PHONY: copyright-check-local
 copyright-check-local: copyright-test

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,12 @@ test-platform-operator-install-logs:
 copyright-test:
 	(cd tools/copyright; go test .)
 
+.PHONY: copyright-check-year
+copyright-check-year:
+	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-2021 --name-only --oneline --pretty="format:" | sort -u)
+
 .PHONY: copyright-check
-copyright-check: copyright-test
+copyright-check: copyright-check-year
 	go run tools/copyright/copyright.go --verbose .
 
 .PHONY: copyright-check-local

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ copyright-test:
 	(cd tools/copyright; go test .)
 
 .PHONY: copyright-check-year
-copyright-check-year:
-	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-2021 --name-only --oneline --pretty="format:" | sort -u)
+copyright-check-year: copyright-test
+	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
 
 .PHONY: copyright-check
 copyright-check: copyright-check-year

--- a/platform-operator/apis/verrazzano/v1alpha1/groupversion_info.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 // Package v1alpha1 contains API Schema definitions for the install v1alpha1 API group

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/platform-operator/build/scripts/copy-junit-output.sh
+++ b/platform-operator/build/scripts/copy-junit-output.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 find . -name \*test-result.xml -exec cp {} $1 \;

--- a/platform-operator/build/scripts/coverage.sh
+++ b/platform-operator/build/scripts/coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Code coverage generation

--- a/platform-operator/config/crd/kustomization.yaml
+++ b/platform-operator/config/crd/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # This kustomization.yaml is not intended to be run by itself,

--- a/platform-operator/config/samples/install-default.yaml
+++ b/platform-operator/config/samples/install-default.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/platform-operator/config/samples/install-oci.yaml
+++ b/platform-operator/config/samples/install-oci.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/platform-operator/config/samples/install-olcne.yaml
+++ b/platform-operator/config/samples/install-olcne.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/platform-operator/config/scripts/kubeconfig-template
+++ b/platform-operator/config/scripts/kubeconfig-template
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: v1

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/controllers/verrazzano/installjob/configmap.go
+++ b/platform-operator/controllers/verrazzano/installjob/configmap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/controllers/verrazzano/installjob/configmap_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/configmap_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/controllers/verrazzano/installjob/serviceaccount.go
+++ b/platform-operator/controllers/verrazzano/installjob/serviceaccount.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/controllers/verrazzano/installjob/serviceaccount_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/serviceaccount_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package installjob

--- a/platform-operator/helm_config/charts/verrazzano/.helmignore
+++ b/platform-operator/helm_config/charts/verrazzano/.helmignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 test
 *.txt

--- a/platform-operator/helm_config/charts/verrazzano/crds/verrazzano.io_verrazzanomanagedclusters_crd.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/crds/verrazzano.io_verrazzanomanagedclusters_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---

--- a/platform-operator/helm_config/charts/verrazzano/crds/verrazzano.io_verrazzanomonitoringinstances_crd.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/crds/verrazzano.io_verrazzanomonitoringinstances_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: v1
 kind: Secret

--- a/platform-operator/helm_config/charts/verrazzano/values.dev.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.dev.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano
 

--- a/platform-operator/helm_config/charts/verrazzano/values.prod.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.prod.yaml
@@ -1,3 +1,3 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano

--- a/platform-operator/internal/util/log/log.go
+++ b/platform-operator/internal/util/log/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package log

--- a/platform-operator/internal/util/log/log_test.go
+++ b/platform-operator/internal/util/log/log_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package log

--- a/platform-operator/internal/util/os/exec.go
+++ b/platform-operator/internal/util/os/exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package os

--- a/platform-operator/internal/util/os/exec_test.go
+++ b/platform-operator/internal/util/os/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package os

--- a/platform-operator/internal/util/semver/semver.go
+++ b/platform-operator/internal/util/semver/semver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package semver

--- a/platform-operator/internal/util/semver/semver_test.go
+++ b/platform-operator/internal/util/semver/semver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package semver

--- a/platform-operator/mocks/controller_mock.go
+++ b/platform-operator/mocks/controller_mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 

--- a/platform-operator/scripts/install/config/coredns-template.yaml
+++ b/platform-operator/scripts/install/config/coredns-template.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: v1
 kind: ConfigMap

--- a/platform-operator/scripts/install/config/istio_intermediate_ca_config.txt
+++ b/platform-operator/scripts/install/config/istio_intermediate_ca_config.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 [ req ]
 distinguished_name  = req_distinguished_name

--- a/platform-operator/scripts/install/config/istio_root_ca_config.txt
+++ b/platform-operator/scripts/install/config/istio_root_ca_config.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 [ ca ]
 default_ca = CA_default

--- a/platform-operator/scripts/install/config/verrazzano_admission_controller_ca_config.txt
+++ b/platform-operator/scripts/install/config/verrazzano_admission_controller_ca_config.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 [ req ]

--- a/platform-operator/scripts/install/config/verrazzano_admission_controller_cert_config.txt
+++ b/platform-operator/scripts/install/config/verrazzano_admission_controller_cert_config.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 [req]

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/install/install-oke.sh
+++ b/platform-operator/scripts/install/install-oke.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/install/k8s-dump-objects.sh
+++ b/platform-operator/scripts/install/k8s-dump-objects.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/install/logging.sh
+++ b/platform-operator/scripts/install/logging.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/uninstall/uninstall-steps/4-uninstall-keycloak.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/4-uninstall-keycloak.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/test/integ/integ_suite_test.go
+++ b/platform-operator/test/integ/integ_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package integ_test

--- a/platform-operator/test/integ/k8s/client.go
+++ b/platform-operator/test/integ/k8s/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package k8s

--- a/platform-operator/test/integ/k8s/resource.go
+++ b/platform-operator/test/integ/k8s/resource.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package k8s

--- a/platform-operator/test/integ/util/utils.go
+++ b/platform-operator/test/integ/util/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package util

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -299,13 +300,25 @@ func printScanReport() {
 
 	if len(filesWithErrors) > 0 {
 		fmt.Printf("\nThe following files have errors:\n")
-		for path, errors := range filesWithErrors {
+
+		// Sort the keys so the files are grouped lexicographically in the output,
+		// instead of randomized by just walking the map
+		keys := make([]string, 0, len(filesWithErrors))
+		for key := range filesWithErrors {
+			if len(key) > 0 {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			errors := filesWithErrors[key]
 			buff := new(bytes.Buffer)
 			writer := csv.NewWriter(buff)
 			writer.Write(errors)
 			writer.Flush()
 
-			fmt.Printf("\tFile: %s, Errors: %s\n", path, buff.String())
+			fmt.Printf("\tFile: %s, Errors: %s\n", key, buff.String())
 		}
 
 		fmt.Println("\nExamples of valid comments:")


### PR DESCRIPTION
# Description

Add the current year to the files that need it, and make the year-check the default on copyright scans since we've updated every file in the repo this year already.  We can revisit at the end of the year.

Fixes VZ-2173.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
