### PR TITLE
fix vmi_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ application-operator/test/integ/integ.coverprofile
 out/
 **/*test-result.xml
 **/*-cluster-dump
+**/*.log

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -49,13 +48,16 @@ func assert(wg *sync.WaitGroup, assertion func()) {
 }
 
 // AssertURLAccessibleAndAuthorized - Assert that a URL is accessible using the provided credentials
-func AssertURLAccessibleAndAuthorized(client *retryablehttp.Client, url string, credentials *UsernamePassword) {
+func AssertURLAccessibleAndAuthorized(client *retryablehttp.Client, url string, credentials *UsernamePassword) bool {
 	req, err := retryablehttp.NewRequest("GET", url, nil)
 	req.SetBasicAuth(credentials.Username, credentials.Password)
 	resp, err := client.Do(req)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "GET %s", url)
+	if err != nil {
+		return false
+	}
 	resp.Body.Close()
-	gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "GET %s", url)
+	Log(Info, fmt.Sprintf("AssertURLAccessibleAndAuthorized %v Response:%v Error:%v", url, resp.StatusCode, err))
+	return resp.StatusCode == http.StatusOK
 }
 
 //PodsRunning checks if all the pods identified by namePrefixes are ready and running


### PR DESCRIPTION
# Description
fix intermittent failures in verify-infra/vmi, kibana and prometheus get 302(redirect) instead of 200(ok)
```
Ex. redirect &{GET https://kibana.vmi.system.xxx/app/kibana Referer:[https://kibana.vmi.system.xxx/]
Ex. redirect &{GET https://prometheus.vmi.system.xxx/graph Referer:[https://prometheus.vmi.system.xxx/]
```

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
