### PR TITLE
Logs of multiple containers in a workload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -417,6 +417,11 @@ pipeline {
                                 runGinkgo('istio/authz')
                             }
                         }
+                        stage('examples logging helidon') {
+                            steps {
+                                runGinkgo('logging/helidon')
+                            }
+                        }
                         stage('examples todo') {
                             steps {
                                 runGinkgo('examples/todo')

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -35,8 +35,8 @@ const (
 	varLogPath         = "/var/log"
 )
 
-// HelidonFluentdContainerConfiguration container specific FLUENTD rules for reading/parsing generic component log files
-const HelidonFluentdContainerConfiguration = `<source>
+// HelidonFluentdContainerConfigurationFormat format for container specific FLUENTD rules for reading/parsing generic component log files
+const HelidonFluentdContainerConfigurationFormat = `<source>
   @type tail
   path "/var/log/containers/#{ENV['WORKLOAD_NAME']}*%s*.log"
   pos_file "/tmp/#{ENV['WORKLOAD_NAME']}-%s.log.pos"
@@ -427,10 +427,10 @@ func replicateVmiSecret(vmiSec *kcore.Secret, namespace, name string) *kcore.Sec
 func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, workloadName string, appContainersNames []string) (err error) {
 
 	helidonFluentdConfiguration := HelidonFluentdConfiguration
+	// add the container specific configuration
 	for _, containerName := range appContainersNames {
-		helidonFluentdConfiguration += fmt.Sprintf(HelidonFluentdContainerConfiguration, containerName, containerName, containerName, containerName, containerName, containerName, containerName)
+		helidonFluentdConfiguration += fmt.Sprintf(HelidonFluentdContainerConfigurationFormat, containerName, containerName, containerName, containerName, containerName, containerName, containerName)
 	}
-
 	// check if configmap exists
 	name := fluentdConfigMapName(workloadName)
 	configMap := &kcore.ConfigMap{}

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -41,7 +41,7 @@ const HelidonFluentdContainerConfigurationFormat = `<source>
   path "/var/log/containers/#{ENV['WORKLOAD_NAME']}*%s*.log"
   pos_file "/tmp/#{ENV['WORKLOAD_NAME']}-%s.log.pos"
   read_from_head true
-  tag %s-%s"
+  tag %s-%s
   # Helidon application messages are expected to look like this:
   # 2020.04.22 16:09:21 INFO org.books.bobby.Main Thread[main,5,main]: http://localhost:8080/books
   <parse>

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -32,20 +32,16 @@ const (
 	volumeVarlog       = "varlog"
 	volumeData         = "datadockercontainers"
 	confVolume         = "fluentd-config-volume"
+	varLogPath         = "/var/log"
 )
 
-// HelidonFluentdConfiguration FLUENTD rules for reading/parsing generic component log files
-const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
-  <match fluent.*>
-    @type stdout
-  </match>
-</label>
-<source>
+// HelidonFluentdContainerConfiguration container specific FLUENTD rules for reading/parsing generic component log files
+const HelidonFluentdContainerConfiguration = `<source>
   @type tail
-  path "/var/log/containers/#{ENV['WORKLOAD_NAME']}*#{ENV['APP_CONTAINER_NAME']}*.log"
-  pos_file "/tmp/#{ENV['WORKLOAD_NAME']}.log.pos"
+  path "/var/log/containers/#{ENV['WORKLOAD_NAME']}*%s*.log"
+  pos_file "/tmp/#{ENV['WORKLOAD_NAME']}-%s.log.pos"
   read_from_head true
-  tag "#{ENV['WORKLOAD_NAME']}"
+  tag "#{ENV['WORKLOAD_NAME']}-%s"
   # Helidon application messages are expected to look like this:
   # 2020.04.22 16:09:21 INFO org.books.bobby.Main Thread[main,5,main]: http://localhost:8080/books
   <parse>
@@ -53,16 +49,45 @@ const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
     <pattern>
       # Docker output
       format json
-      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      time_format %%Y-%%m-%%dT%%H:%%M:%%S.%%NZ
     </pattern>
     <pattern>
       # cri-o output
       format regexp
       expression /^(?<timestamp>(.*?)) (?<stream>stdout|stderr) (?<log>.*)$/
-      time_format %Y-%m-%dT%H:%M:%S.%N%:z
+      time_format %%Y-%%m-%%dT%%H:%%M:%%S.%%N%%:z
     </pattern>
   </parse>
 </source>
+<filter #{ENV['WORKLOAD_NAME']}-%s>
+  @type record_transformer
+  <record>
+    oam.applicationconfiguration.namespace "#{ENV['NAMESPACE']}"
+    oam.applicationconfiguration.name "#{ENV['APP_CONF_NAME']}"
+    oam.component.namespace "#{ENV['NAMESPACE']}"
+    oam.component.name  "#{ENV['COMPONENT_NAME']}"
+    oam.container.name  "%s"
+    verrazzano.cluster.name  "#{ENV['CLUSTER_NAME']}"
+  </record>
+</filter>
+<match #{ENV['WORKLOAD_NAME']}-%s>
+  @type elasticsearch
+  hosts "#{ENV['ELASTICSEARCH_URL']}"
+  ca_file /fluentd/secret/ca-bundle
+  user "#{ENV['ELASTICSEARCH_USER']}"
+  password "#{ENV['ELASTICSEARCH_PASSWORD']}"
+  index_name "#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}-%s"
+  include_timestamp true
+  flush_interval 10s
+</match>
+`
+
+// HelidonFluentdConfiguration FLUENTD rules for reading/parsing generic component log files
+const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
+  <match fluent.*>
+    @type stdout
+  </match>
+</label>
 <filter **>
   @type parser
   key_name log
@@ -84,26 +109,6 @@ const HelidonFluentdConfiguration = `<label @FLUENT_LOG>
 	keep_time_key true
   </parse>
 </filter>
-<filter **>
-  @type record_transformer
-  <record>
-    oam.applicationconfiguration.namespace "#{ENV['NAMESPACE']}"
-    oam.applicationconfiguration.name "#{ENV['APP_CONF_NAME']}"
-    oam.component.namespace "#{ENV['NAMESPACE']}"
-    oam.component.name  "#{ENV['COMPONENT_NAME']}"
-    verrazzano.cluster.name  "#{ENV['CLUSTER_NAME']}"
-  </record>
-</filter>
-<match **>
-  @type elasticsearch
-  hosts "#{ENV['ELASTICSEARCH_URL']}"
-  ca_file /fluentd/secret/ca-bundle
-  user "#{ENV['ELASTICSEARCH_USER']}"
-  password "#{ENV['ELASTICSEARCH_PASSWORD']}"
-  index_name "` + ElasticSearchIndex + `"
-  include_timestamp true
-  flush_interval 10s
-</match>
 `
 
 // HelidonHandler injects FLUENTD sidecar container for generic Kubernetes Deployment
@@ -121,9 +126,12 @@ func (h *HelidonHandler) Apply(ctx context.Context, workload vzapi.QualifiedReso
 	}
 	// Apply logging to the in-memory child Deployment resource.
 	result, err := h.ApplyToDeployment(ctx, workload, scope, deploy)
-	if result != nil || err != nil {
+	if err != nil {
 		h.Log.V(1).Info("Failed to apply logging to Deployment", "Deployment", deploy.Name, "error", err)
 		return result, err
+	}
+	if result != nil {
+		return result, nil
 	}
 	// Store the child Deployment resource.
 	err = h.Update(ctx, deploy)
@@ -136,7 +144,7 @@ func (h *HelidonHandler) Apply(ctx context.Context, workload vzapi.QualifiedReso
 
 // ApplyToDeployment applies a logging scope to an existing in-memory Kubernetes Deployment
 func (h *HelidonHandler) ApplyToDeployment(ctx context.Context, workload vzapi.QualifiedResourceRelation, scope *vzapi.LoggingScope, deploy *kapps.Deployment) (*ctrl.Result, error) {
-	appContainer, fluentdFound := searchContainers(deploy.Spec.Template.Spec.Containers)
+	appContainers, fluentdFound := searchContainers(deploy.Spec.Template.Spec.Containers)
 	h.Log.V(1).Info("Update Deployment", "Deployment", deploy.Name, "fluentdFound", fluentdFound)
 	if fluentdFound {
 		// If the Deployment does contain a FLUENTD container
@@ -145,7 +153,7 @@ func (h *HelidonHandler) ApplyToDeployment(ctx context.Context, workload vzapi.Q
 		duration := time.Duration(rand.IntnRange(5, 10)) * time.Second
 		return &ctrl.Result{Requeue: true, RequeueAfter: duration}, nil
 	}
-	err := h.ensureFluentdConfigMap(ctx, scope.GetNamespace(), workload.Name)
+	err := h.ensureFluentdConfigMap(ctx, scope.GetNamespace(), workload.Name, appContainers)
 	if err != nil {
 		return nil, err
 	}
@@ -159,23 +167,22 @@ func (h *HelidonHandler) ApplyToDeployment(ctx context.Context, workload vzapi.Q
 	}
 	deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, CreateFluentdConfigMapVolume(workload.Name))
 	deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, CreateFluentdSecretVolume(scope.Spec.SecretName))
-	fluentdContainer := CreateFluentdContainer(workload.Namespace, workload.Name, appContainer, scope.Spec.FluentdImage,
-		scope.Spec.SecretName, scope.Spec.ElasticSearchURL, clusters.GetClusterName(context.TODO(), h.Client))
+	fluentdContainer := CreateFluentdContainer(scope.Spec, workload.Namespace, workload.Name, clusters.GetClusterName(context.TODO(), h.Client))
 	deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, fluentdContainer)
 	return nil, nil
 }
 
-func searchContainers(containers []kcore.Container) (string, bool) {
-	var appContainer string
+func searchContainers(containers []kcore.Container) ([]string, bool) {
+	var appContainers []string
 	fluentdFound := false
 	for _, container := range containers {
 		if container.Name == fluentdContainerName {
 			fluentdFound = true
 		} else {
-			appContainer = container.Name
+			appContainers = append(appContainers, container.Name)
 		}
 	}
-	return appContainer, fluentdFound
+	return appContainers, fluentdFound
 }
 
 // Remove removes a logging scope from a Kubernetes Deployment
@@ -245,20 +252,16 @@ func CreateFluentdConfigMap(namespace, name, fluentdConfig string) *kcore.Config
 }
 
 // CreateFluentdContainer creates a FLUENTD sidecar container.
-func CreateFluentdContainer(namespace, workloadName, containerName, fluentdImage, esSecret, esURL string, clusterName string) kcore.Container {
+func CreateFluentdContainer(spec vzapi.LoggingScopeSpec, namespace, workloadName, clusterName string) kcore.Container {
 	container := kcore.Container{
 		Name:            fluentdContainerName,
 		Args:            []string{"-c", "/etc/fluent.conf"},
-		Image:           fluentdImage,
+		Image:           spec.FluentdImage,
 		ImagePullPolicy: kcore.PullIfNotPresent,
 		Env: []kcore.EnvVar{
 			{
 				Name:  "WORKLOAD_NAME",
 				Value: workloadName,
-			},
-			{
-				Name:  "APP_CONTAINER_NAME",
-				Value: containerName,
 			},
 			{
 				Name:  "FLUENTD_CONF",
@@ -290,7 +293,7 @@ func CreateFluentdContainer(namespace, workloadName, containerName, fluentdImage
 			},
 			{
 				Name:  elasticSearchURLEnv,
-				Value: esURL,
+				Value: spec.ElasticSearchURL,
 			},
 			{
 				Name:  "CLUSTER_NAME",
@@ -301,7 +304,7 @@ func CreateFluentdContainer(namespace, workloadName, containerName, fluentdImage
 				ValueFrom: &kcore.EnvVarSource{
 					SecretKeyRef: &kcore.SecretKeySelector{
 						LocalObjectReference: kcore.LocalObjectReference{
-							Name: esSecret,
+							Name: spec.SecretName,
 						},
 						Key: constants.ElasticsearchUsernameData,
 						Optional: func(opt bool) *bool {
@@ -315,7 +318,7 @@ func CreateFluentdContainer(namespace, workloadName, containerName, fluentdImage
 				ValueFrom: &kcore.EnvVarSource{
 					SecretKeyRef: &kcore.SecretKeySelector{
 						LocalObjectReference: kcore.LocalObjectReference{
-							Name: esSecret,
+							Name: spec.SecretName,
 						},
 						Key: constants.ElasticsearchPasswordData,
 						Optional: func(opt bool) *bool {
@@ -338,7 +341,7 @@ func CreateFluentdContainer(namespace, workloadName, containerName, fluentdImage
 				ReadOnly:  true,
 			},
 			{
-				MountPath: "/var/log",
+				MountPath: varLogPath,
 				Name:      volumeVarlog,
 				ReadOnly:  true,
 			},
@@ -421,19 +424,25 @@ func replicateVmiSecret(vmiSec *kcore.Secret, namespace, name string) *kcore.Sec
 	return sec
 }
 
-func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, workloadName string) error {
+func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, workloadName string, appContainersNames []string) (err error) {
+
+	helidonFluentdConfiguration := HelidonFluentdConfiguration
+	for _, containerName := range appContainersNames {
+		helidonFluentdConfiguration += fmt.Sprintf(HelidonFluentdContainerConfiguration, containerName, containerName, containerName, containerName, containerName, containerName, containerName)
+	}
+
 	// check if configmap exists
 	name := fluentdConfigMapName(workloadName)
 	configMap := &kcore.ConfigMap{}
-	err := h.Get(ctx, objKey(namespace, name), configMap)
+	err = h.Get(ctx, objKey(namespace, name), configMap)
 	if kerrs.IsNotFound(err) {
-		if err = h.Create(ctx, CreateFluentdConfigMap(namespace, name, HelidonFluentdConfiguration), &client.CreateOptions{}); err != nil {
-			return err
+		if err = h.Create(ctx, CreateFluentdConfigMap(namespace, name, helidonFluentdConfiguration), &client.CreateOptions{}); err != nil {
+			return
 		}
-		return nil
 	}
-	return err
+	return
 }
+
 func (h *HelidonHandler) deleteFluentdConfigMap(ctx context.Context, namespace, workloadName string) error {
 	name := fluentdConfigMapName(workloadName)
 	configMap := &kcore.ConfigMap{}

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -41,7 +41,7 @@ const HelidonFluentdContainerConfigurationFormat = `<source>
   path "/var/log/containers/#{ENV['WORKLOAD_NAME']}*%s*.log"
   pos_file "/tmp/#{ENV['WORKLOAD_NAME']}-%s.log.pos"
   read_from_head true
-  tag "#{ENV['WORKLOAD_NAME']}-%s"
+  tag %s-%s"
   # Helidon application messages are expected to look like this:
   # 2020.04.22 16:09:21 INFO org.books.bobby.Main Thread[main,5,main]: http://localhost:8080/books
   <parse>
@@ -59,7 +59,7 @@ const HelidonFluentdContainerConfigurationFormat = `<source>
     </pattern>
   </parse>
 </source>
-<filter #{ENV['WORKLOAD_NAME']}-%s>
+<filter %s-%s>
   @type record_transformer
   <record>
     oam.applicationconfiguration.namespace "#{ENV['NAMESPACE']}"
@@ -70,7 +70,7 @@ const HelidonFluentdContainerConfigurationFormat = `<source>
     verrazzano.cluster.name  "#{ENV['CLUSTER_NAME']}"
   </record>
 </filter>
-<match #{ENV['WORKLOAD_NAME']}-%s>
+<match %s-%s>
   @type elasticsearch
   hosts "#{ENV['ELASTICSEARCH_URL']}"
   ca_file /fluentd/secret/ca-bundle
@@ -429,7 +429,7 @@ func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, 
 	helidonFluentdConfiguration := HelidonFluentdConfiguration
 	// add the container specific configuration
 	for _, containerName := range appContainersNames {
-		helidonFluentdConfiguration += fmt.Sprintf(HelidonFluentdContainerConfigurationFormat, containerName, containerName, containerName, containerName, containerName, containerName, containerName)
+		helidonFluentdConfiguration += fmt.Sprintf(HelidonFluentdContainerConfigurationFormat, containerName, containerName, workloadName, containerName, workloadName, containerName, containerName, workloadName, containerName, containerName)
 	}
 	// check if configmap exists
 	name := fluentdConfigMapName(workloadName)

--- a/application-operator/test/templates/helidon_workload_multi_container.yaml
+++ b/application-operator/test/templates/helidon_workload_multi_container.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: oam.verrazzano.io/v1alpha1
+kind: VerrazzanoHelidonWorkload
+metadata:
+  name: ##WORKLOAD_NAME##
+  namespace: ##WORKLOAD_NAMESPACE##
+  labels:
+    app.oam.dev/name: ##APPCONF_NAME##
+    app.oam.dev/component: ##COMPONENT_NAME##
+spec:
+  deploymentTemplate:
+    metadata:
+      name: ##DEPLOYMENT_NAME##
+    podSpec:
+      containers:
+        - name: ##CONTAINER_NAME_1##
+          image: ##CONTAINER_IMAGE_1##
+          ports:
+            - name: ##CONTAINER_PORT_NAME_1##
+              containerPort: ##CONTAINER_PORT_NUMBER_1##
+        - name: ##CONTAINER_NAME_2##
+          image: ##CONTAINER_IMAGE_2##
+          ports:
+            - name: ##CONTAINER_PORT_NAME_2##
+              containerPort: ##CONTAINER_PORT_NUMBER_2##

--- a/application-operator/test/templates/logging_scope.yaml
+++ b/application-operator/test/templates/logging_scope.yaml
@@ -6,9 +6,8 @@ metadata:
   name: ##SCOPE_NAME##
   namespace: ##SCOPE_NAMESPACE##
 spec:
-  elasticSearchHost: ##INJEST_HOST##
-  elasticSearchPort: ##INJEST_PORT##
-  secretName: ##INJEST_SECRET_NAME##
+  elasticSearchURL: ##INGEST_URL##
+  secretName: ##INGEST_SECRET_NAME##
   fluentdImage: ##FLUENTD_IMAGE##
   workloadRefs:
     - apiVersion: ##WORKLOAD_APIVER##

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("Verify Hello Helidon OAM App.", func() {
 	})
 
 	ginkgo.Context("Logging.", func() {
-		indexName := "hello-helidon-hello-helidon-appconf-hello-helidon-component"
+		indexName := "hello-helidon-hello-helidon-appconf-hello-helidon-component-hello-helidon-container"
 
 		// GIVEN an application with logging enabled via a logging scope
 		// WHEN the Elasticsearch index is retrieved

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Verify Spring Boot Application", func() {
 	})
 
 	ginkgo.Context("Logging.", func() {
-		indexName := "springboot-springboot-appconf-springboot-component"
+		indexName := "springboot-springboot-appconf-springboot-component-springboot-container"
 		ginkgo.It("Verify Elasticsearch index exists", func() {
 			gomega.Eventually(func() bool {
 				return pkg.LogIndexFound(indexName)

--- a/tests/e2e/logging/helidon/helidon_logging_suite_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_suite_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package hello_helidon
+package helidon
 
 import (
 	"fmt"

--- a/tests/e2e/logging/helidon/helidon_logging_suite_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_suite_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package hello_helidon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+)
+
+func TestHelidonExample(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("helidon-logging-%d-test-result.xml", config.GinkgoConfig.ParallelNode))
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Helidon Logging Suite", []ginkgo.Reporter{junitReporter})
+}

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package hello_helidon
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	longWaitTimeout     = 10 * time.Minute
+	longPollingInterval = 20 * time.Second
+)
+
+var _ = ginkgo.BeforeSuite(func() {
+	if _, err := pkg.CreateNamespace("helidon-logging", map[string]string{"verrazzano-managed": "true"}); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
+	}
+
+	if err := pkg.CreateOrUpdateResourceFromFile("testdata/logging/helidon/helidon-logging-comp.yaml"); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-logging component resources: %v", err))
+	}
+	if err := pkg.CreateOrUpdateResourceFromFile("testdata/logging/helidon/helidon-logging-app.yaml"); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-logging application resource: %v", err))
+	}
+	if err := pkg.CreateOrUpdateResourceFromFile("testdata/logging/helidon/helidon-logging-logging-scope.yaml"); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-logging application resource: %v", err))
+	}
+
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	// undeploy the application here
+	err := pkg.DeleteResourceFromFile("testdata/logging/helidon/helidon-logging-app.yaml")
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not delete helidon-logging application resource: %v\n", err.Error()))
+	}
+	err = pkg.DeleteResourceFromFile("testdata/logging/helidon/helidon-logging-comp.yaml")
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not delete helidon-logging component resource: %v\n", err.Error()))
+	}
+	err = pkg.DeleteNamespace("helidon-logging")
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Could not delete helidon-logging namespace: %v\n", err.Error()))
+	}
+})
+
+var (
+	expectedPodsHelloHelidon = []string{"hello-helidon-workload"}
+	waitTimeout              = 10 * time.Minute
+	pollingInterval          = 30 * time.Second
+)
+
+const (
+	testNamespace      = "helidon-logging"
+)
+
+var _ = ginkgo.Describe("Verify Hello Helidon OAM App.", func() {
+	// Verify hello-helidon-workload pod is running
+	// GIVEN OAM hello-helidon app is deployed
+	// WHEN the component and appconfig are created
+	// THEN the expected pod must be running in the test namespace
+	ginkgo.Describe("Verify hello-helidon-workload pod is running.", func() {
+		ginkgo.It("and waiting for expected pods must be running", func() {
+			gomega.Eventually(helloHelidonPodsRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+		})
+	})
+
+	// Verify Hello Helidon app is working
+	// GIVEN OAM hello-helidon app is deployed
+	// WHEN the component and appconfig with ingress trait are created
+	// THEN the application endpoint must be accessible
+	ginkgo.Describe("Verify Hello Helidon app is working.", func() {
+		ginkgo.It("Access /greet App Url.", func() {
+			ingress := pkg.Ingress()
+			url := fmt.Sprintf("http://%s/greet", ingress)
+			isEndpointAccessible := func() bool {
+				return appEndpointAccessible(url)
+			}
+			gomega.Eventually(isEndpointAccessible, 15*time.Second, 1*time.Second).Should(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Context("Logging.", func() {
+		indexNameContainer1 := "helidon-logging-hello-helidon-appconf-hello-helidon-component-hello-helidon-container"
+		indexNameContainer2 := "helidon-logging-hello-helidon-appconf-hello-helidon-component-other-container"
+
+		// GIVEN an application with logging enabled via a logging scope
+		// WHEN the Elasticsearch index for hello-helidon-container is retrieved
+		// THEN verify that it is found
+		ginkgo.It("Verify Elasticsearch index for hello-helidon-container exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogIndexFound(indexNameContainer1)
+			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find log index for hello-helidon-container")
+		})
+
+		// GIVEN an application with logging enabled via a logging scope
+		// WHEN the Elasticsearch index for other-container is retrieved
+		// THEN verify that it is found
+		ginkgo.It("Verify Elasticsearch index for other-container exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogIndexFound(indexNameContainer2)
+			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find log index for other-container")
+		})
+
+		// GIVEN an application with logging enabled via a logging scope
+		// WHEN the log records are retrieved from the Elasticsearch index for hello-helidon-container
+		// THEN verify that at least one recent log record is found
+		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound(indexNameContainer1, time.Now().Add(-24*time.Hour), map[string]string{
+					"oam.applicationconfiguration.namespace": "hello-helidon",
+					"oam.applicationconfiguration.name":      "hello-helidon-appconf",
+				  "oam.container.name":                     "hello-helidon-container"})
+			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record for container hello-helidon-container")
+		})
+
+		// GIVEN an application with logging enabled via a logging scope
+		// WHEN the log records are retrieved from the Elasticsearch index for other-container
+		// THEN verify that at least one recent log record is found
+		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound(indexNameContainer2, time.Now().Add(-24*time.Hour), map[string]string{
+					"oam.applicationconfiguration.namespace": "hello-helidon",
+					"oam.applicationconfiguration.name":      "hello-helidon-appconf",
+					"oam.container.name":                     "other-container"})
+			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record for container other-container")
+		})
+	})
+})
+
+func helloHelidonPodsRunning() bool {
+	return pkg.PodsRunning(testNamespace, expectedPodsHelloHelidon)
+}
+
+func appEndpointAccessible(url string) bool {
+	hostname := pkg.GetHostnameFromGateway(testNamespace, "")
+	status, webpage := pkg.GetWebPageWithBasicAuth(url, hostname, "", "")
+	gomega.Expect(status).To(gomega.Equal(http.StatusOK), fmt.Sprintf("GET %v returns status %v expected 200.", url, status))
+	gomega.Expect(strings.Contains(webpage, "Hello World")).To(gomega.Equal(true), fmt.Sprintf("Webpage is NOT Hello World %v", webpage))
+	return true
+}
+

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package hello_helidon
+package helidon
 
 import (
 	"fmt"
@@ -59,7 +59,7 @@ var (
 )
 
 const (
-	testNamespace      = "helidon-logging"
+	testNamespace = "helidon-logging"
 )
 
 var _ = ginkgo.Describe("Verify Hello Helidon OAM App.", func() {
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("Verify Hello Helidon OAM App.", func() {
 				return pkg.LogRecordFound(indexNameContainer1, time.Now().Add(-24*time.Hour), map[string]string{
 					"oam.applicationconfiguration.namespace": "hello-helidon",
 					"oam.applicationconfiguration.name":      "hello-helidon-appconf",
-				  "oam.container.name":                     "hello-helidon-container"})
+					"oam.container.name":                     "hello-helidon-container"})
 			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record for container hello-helidon-container")
 		})
 
@@ -147,4 +147,3 @@ func appEndpointAccessible(url string) bool {
 	gomega.Expect(strings.Contains(webpage, "Hello World")).To(gomega.Equal(true), fmt.Sprintf("Webpage is NOT Hello World %v", webpage))
 	return true
 }
-

--- a/tests/testdata/logging/helidon/helidon-logging-app.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-app.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: hello-helidon-appconf
+  namespace: helidon-logging
+  annotations:
+    version: v1.0.0
+    description: "Hello Helidon application"
+spec:
+  components:
+    - componentName: hello-helidon-component
+      traits:
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: MetricsTrait
+            spec:
+              scraper: verrazzano-system/vmi-system-prometheus-0
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: IngressTrait
+            metadata:
+              name: hello-helidon-ingress
+            spec:
+              rules:
+                - paths:
+                    - path: "/greet"
+                      pathType: Prefix
+      scopes:
+        - scopeRef:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: LoggingScope
+            name: logging-scope

--- a/tests/testdata/logging/helidon/helidon-logging-comp.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-comp.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
+metadata:
+  name: hello-helidon-component
+  namespace: helidon-logging
+spec:
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: hello-helidon-workload
+      namespace: hello-helidon
+      labels:
+        app: hello-helidon
+    spec:
+      containers:
+        - name: hello-helidon-container
+          image: "ghcr.io/verrazzano/example-helidon-greet-app-v1:0.1.12-1-20210218160249-d8db8f3"
+          ports:
+            - containerPort: 8080
+              name: http
+        - name: other-container
+          image: "ghcr.io/oracle/oraclelinux:7-slim"
+          command:
+            - "bin/bash"
+            - "-c"
+            - "while true; do echo $(date) | tee stdout ; sleep 1; done"

--- a/tests/testdata/logging/helidon/helidon-logging-logging-scope.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-logging-scope.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: oam.verrazzano.io/v1alpha1
+kind: LoggingScope
+metadata:
+  name: logging-scope
+  namespace: helidon-logging
+spec:
+  fluentdImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-20201016214205-7f37ac6
+  elasticSearchURL: http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local:9200
+  secretName: verrazzano
+  workloadRefs: []


### PR DESCRIPTION
# Description

Current containerized and helidon workload's fluentd sidecar implementation assumes there is only one application-container in the generated k8s Deployment. OAM ContainerizedWorkload and Deployment allow multiple containers.

Refactor helidon logging: 
- add container name to ElasticSearch index
- add `oam.container.name` to logged fields 
- create source, filter and match in fluentd config for each app container 
- single fluent sidecar container and config map works for all app containers

### Tests
- unit tests for helidon ContainerizedWorkloads and VerrazzanoHelidonWorkload
- update integration test
- add helidon logging acceptance tests

Fixes VZ-2017

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
