### PR TITLE
Fix compute bound controller loop when writing a failed status

### DIFF
--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -42,9 +42,6 @@ type ElasticsearchDetails struct {
 // needs to be done
 func StatusNeedsUpdate(curConditions []clustersv1alpha1.Condition, curState clustersv1alpha1.StateType,
 	newCondition clustersv1alpha1.Condition, newState clustersv1alpha1.StateType) bool {
-	if newState == clustersv1alpha1.Failed {
-		return true
-	}
 	if newState != curState {
 		return true
 	}
@@ -54,6 +51,7 @@ func StatusNeedsUpdate(curConditions []clustersv1alpha1.Condition, curState clus
 			existingCond.Message == newCondition.Message &&
 			existingCond.Type == newCondition.Type {
 			foundStatus = true
+			break
 		}
 	}
 	return !foundStatus

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
@@ -89,7 +89,7 @@ func (r *Reconciler) mutateAppConfig(mcAppConfig clustersv1alpha1.MultiClusterAp
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {
 	condition, state := clusters.GetConditionAndStateFromResult(err, opResult, "OAM Application Configuration")
-	if clusters.StatusNeedsUpdate(mcAppConfig.Status.Conditions, state, condition, state) {
+	if clusters.StatusNeedsUpdate(mcAppConfig.Status.Conditions, mcAppConfig.Status.State, condition, state) {
 		mcAppConfig.Status.State = state
 		mcAppConfig.Status.Conditions = append(mcAppConfig.Status.Conditions, condition)
 		return reconcile.Result{}, r.Status().Update(ctx, mcAppConfig)

--- a/application-operator/controllers/clusters/multiclustercomponent/controller.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller.go
@@ -83,7 +83,7 @@ func (r *Reconciler) mutateComponent(mcComp clustersv1alpha1.MultiClusterCompone
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcComp *clustersv1alpha1.MultiClusterComponent, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {
 	condition, state := clusters.GetConditionAndStateFromResult(err, opResult, "OAM Component")
-	if clusters.StatusNeedsUpdate(mcComp.Status.Conditions, state, condition, state) {
+	if clusters.StatusNeedsUpdate(mcComp.Status.Conditions, mcComp.Status.State, condition, state) {
 		mcComp.Status.State = state
 		mcComp.Status.Conditions = append(mcComp.Status.Conditions, condition)
 		return reconcile.Result{}, r.Status().Update(ctx, mcComp)

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -89,7 +89,7 @@ func (r *Reconciler) mutateConfigMap(mcConfigMap clustersv1alpha1.MultiClusterCo
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {
 	condition, state := clusters.GetConditionAndStateFromResult(err, opResult, "ConfigMap")
-	if clusters.StatusNeedsUpdate(mcConfigMap.Status.Conditions, state, condition, state) {
+	if clusters.StatusNeedsUpdate(mcConfigMap.Status.Conditions, mcConfigMap.Status.State, condition, state) {
 		mcConfigMap.Status.State = state
 		mcConfigMap.Status.Conditions = append(mcConfigMap.Status.Conditions, condition)
 		return reconcile.Result{}, r.Status().Update(ctx, mcConfigMap)

--- a/application-operator/controllers/clusters/multiclusterloggingscope/controller.go
+++ b/application-operator/controllers/clusters/multiclusterloggingscope/controller.go
@@ -82,7 +82,7 @@ func (r *Reconciler) mutateLoggingScope(mcLogScope clustersv1alpha1.MultiCluster
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcLogScope *clustersv1alpha1.MultiClusterLoggingScope, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {
 	condition, state := clusters.GetConditionAndStateFromResult(err, opResult, "LoggingScope")
-	if clusters.StatusNeedsUpdate(mcLogScope.Status.Conditions, state, condition, state) {
+	if clusters.StatusNeedsUpdate(mcLogScope.Status.Conditions, mcLogScope.Status.State, condition, state) {
 		mcLogScope.Status.State = state
 		mcLogScope.Status.Conditions = append(mcLogScope.Status.Conditions, condition)
 		return reconcile.Result{}, r.Status().Update(ctx, mcLogScope)

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -53,7 +53,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcSecret *clustersv1alpha1.MultiClusterSecret, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {
 	condition, state := clusters.GetConditionAndStateFromResult(err, opResult, "Secret")
-	if clusters.StatusNeedsUpdate(mcSecret.Status.Conditions, state, condition, state) {
+	if clusters.StatusNeedsUpdate(mcSecret.Status.Conditions, mcSecret.Status.State, condition, state) {
 		mcSecret.Status.State = state
 		mcSecret.Status.Conditions = append(mcSecret.Status.Conditions, condition)
 		return reconcile.Result{}, r.Status().Update(ctx, mcSecret)

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -23,6 +23,7 @@ const (
 	timeout                   = 2 * time.Minute
 	pollInterval              = 40 * time.Millisecond
 	applicationOperator       = "verrazzano-application-operator"
+	duration                  = 1 * time.Minute
 )
 
 var (
@@ -90,10 +91,8 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "invalid-mccm")
 			return err == nil && mcConfigMap.Status.State == clustersv1alpha1.Failed
 		}, timeout, pollInterval).Should(gomega.BeTrue())
-		gomega.Eventually(func() bool {
+		gomega.Consistently(func() bool {
 			// Verify the controller is not updating the status more than once with the failure.
-			// Re-read the resource to see if any status updates occurred since the last read.
-			time.Sleep(10 * time.Second)
 			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "invalid-mccm")
 			count := 0
 			if err == nil {
@@ -104,7 +103,7 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 				}
 			}
 			return err == nil && count == 1
-		}, timeout, pollInterval).Should(gomega.BeTrue())
+		}, duration, pollInterval).Should(gomega.BeTrue())
 	})
 })
 

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -90,6 +90,21 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "invalid-mccm")
 			return err == nil && mcConfigMap.Status.State == clustersv1alpha1.Failed
 		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			// Verify the controller is not updating the status more than once with the failure.
+			// Re-read the resource to see if any status updates occurred since the last read.
+			time.Sleep(10 * time.Second)
+			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "invalid-mccm")
+			count := 0
+			if err == nil {
+				for _, condition := range mcConfigMap.Status.Conditions {
+					if condition.Type == clustersv1alpha1.DeployFailed {
+						count++
+					}
+				}
+			}
+			return err == nil && count == 1
+		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 })
 


### PR DESCRIPTION
# Description

This PR fixes a problem where the controllers for MCxxxxx resources would go into a compute bound reconcile loop writing the status field of a resource.  This would occur when the resource embedded in the Mcxxxx envelope could not be created.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
