### PR TITLE
remove printing out operator.yaml in Jenkins logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -361,7 +361,6 @@ pipeline {
                             fi
 
                             # Install the verrazzano-platform-operator
-                            cat /tmp/operator.yaml
                             kubectl apply -f /tmp/operator.yaml
 
                             # make sure ns exists

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -161,7 +161,6 @@ pipeline {
                                 echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"
                                 ./tests/e2e/config/scripts/process_operator_yaml.sh platform-operator "${VERRAZZANO_OPERATOR_IMAGE}"
                             fi
-                            cat /tmp/operator.yaml
                             kubectl apply -f /tmp/operator.yaml
 
                             # make sure ns exists

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -188,7 +188,6 @@ pipeline {
                         fi
 
                         # Install the verrazzano-platform-operator
-                        cat /tmp/operator.yaml
                         kubectl apply -f /tmp/operator.yaml
 
                         # make sure ns exists

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -433,7 +433,6 @@ pipeline {
                                                 fi
 
                                                 # Install the verrazzano-platform-operator
-                                                cat /tmp/operator.yaml
                                                 kubectl apply -f /tmp/operator.yaml
 
                                                 # make sure ns exists

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -177,7 +177,6 @@ pipeline {
                         echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"
                         ${WORKSPACE}/tests/e2e/config/scripts/process_operator_yaml.sh . "${VERRAZZANO_OPERATOR_IMAGE}"
                     fi
-                    cat /tmp/operator.yaml
                     kubectl apply -f /tmp/operator.yaml
                     # make sure ns exists
                     ${WORKSPACE}/tests/e2e/config/scripts/check_verrazzano_ns_exists.sh verrazzano-install

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -190,7 +190,6 @@ pipeline {
                         fi
 
                         # Install the verrazzano-platform-operator
-                        cat /tmp/operator.yaml
                         kubectl apply -f /tmp/operator.yaml
 
                         # make sure ns exists


### PR DESCRIPTION
# Description

Just to remove the content of the operator.yaml from Jenkins logs to make it more readable.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
