### PR TITLE
enable filebeat test in verify-infra/vmi

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.12.0-20210303213135-b763444
+  imageVersion: 0.12.0-20210227194926-ba090ba
   prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-20201016212958-5b64612
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-20201016212236-05eabe44b

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -30,7 +30,7 @@ elasticSearch:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.12.0-20210227194926-ba090ba
+  imageVersion: 0.12.0-20210303213135-b763444
   prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-20201016212958-5b64612
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-20201016212236-05eabe44b

--- a/tests/e2e/pkg/elasticsearch.go
+++ b/tests/e2e/pkg/elasticsearch.go
@@ -96,8 +96,11 @@ func LogRecordFound(indexName string, after time.Time, fields map[string]string)
 		timestamp := Jq(hit, "_source", "@timestamp")
 		t, err := time.Parse(ISO8601Layout, timestamp.(string))
 		if err != nil {
-			Log(Error, fmt.Sprintf("Failed to parse timestamp: %s", timestamp))
-			return false
+			t, err = time.Parse(time.RFC3339Nano, timestamp.(string))
+			if err != nil {
+				Log(Error, fmt.Sprintf("Failed to parse timestamp: %s", timestamp))
+				return false
+			}
 		}
 		if t.After(after) {
 			Log(Info, fmt.Sprintf("Found recent record: %s", timestamp))

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -113,13 +113,12 @@ var _ = ginkgo.Describe("VMI", func() {
 		)
 	})
 
-	ginkgo.PIt("Elasticsearch filebeat Index should be accessible", func() {
+	ginkgo.It("Elasticsearch filebeat Index should be accessible", func() {
 		gomega.Eventually(func() bool {
 			return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
 				time.Now().Add(-24*time.Hour),
 				map[string]string{
-					"kubernetes.namespace":      "verrazzano-system",
-					"kubernetes.container.name": "verrazzano-application-operator"})
+					"beat.version":      "6.8.3"})
 		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
 	})
 

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/vmi"
@@ -115,39 +114,13 @@ var _ = ginkgo.Describe("VMI", func() {
 	})
 
 	ginkgo.PIt("Elasticsearch filebeat Index should be accessible", func() {
-		var filebeatIndexName string
-		var filebeatIndex interface{}
-
 		gomega.Eventually(func() bool {
-			for name, esIndex := range elastic.GetIndices() {
-				if strings.Contains(name, "filebeat") {
-					filebeatIndexName = name
-					filebeatIndex = esIndex
-					return true
-				}
-			}
-			return false
-		}, 5 * time.Minute, 10 * time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat index")
-
-		gomega.Expect(filebeatIndexName).NotTo(gomega.Equal(""), "Found filebeatIndex")
-		dynamicTemplates := jq(filebeatIndex, "mappings", "dynamic_templates").([]interface{})
-		var messageField interface{}
-		for _, dynamicTemp := range dynamicTemplates {
-			found := dynamicTemp.(map[string]interface{})["message_field"]
-			if found != nil {
-				messageField = found
-			}
-		}
-		messagePath := jq(messageField, "path_match")
-		gomega.Expect(messagePath).To(gomega.Equal("log.message"), "log message path")
-		messageType := jq(messageField, "mapping", "type")
-		gomega.Expect(messageType).To(gomega.Equal("text"), "log message type")
-
-		gomega.Eventually(func() bool {
-			return pkg.LogRecordFound(filebeatIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-				"kubernetes.namespace":  "verrazzano-system",
-				"kubernetes.container.name": "verrazzano-monitoring-operator"})
-		}, 5 * time.Minute, 10 * time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
+			return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
+				time.Now().Add(-24*time.Hour),
+				map[string]string{
+					"kubernetes.namespace":      "verrazzano-system",
+					"kubernetes.container.name": "verrazzano-application-operator"})
+		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
 	})
 
 	ginkgo.It("Kibana endpoint should be accessible", func() {

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("VMI", func() {
 
 	ginkgo.It("Elasticsearch filebeat Index should be accessible", func() {
 		gomega.Eventually(func() bool {
-			return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
+			return pkg.LogRecordFound("vmo-local-filebeat-"+time.Now().Format("2006.01.02"),
 				time.Now().Add(-24*time.Hour),
 				map[string]string{
 					"beat.version":      "6.8.3"})

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -122,6 +122,15 @@ var _ = ginkgo.Describe("VMI", func() {
 		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
 	})
 
+	ginkgo.It("Elasticsearch journalbeat Index should be accessible", func() {
+		gomega.Eventually(func() bool {
+			return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
+				time.Now().Add(-24*time.Hour),
+				map[string]string{
+					"beat.version":      "6.8.3"})
+		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a journalbeat log record")
+	})
+
 	ginkgo.It("Kibana endpoint should be accessible", func() {
 		assertIngressURL("vmi-system-kibana")
 	})


### PR DESCRIPTION
# Description

Upgrade verrazzano-operator to fix filebeat on KinD; re-enable the filebeat test; add journalbeat test.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
