### PR TITLE
VZ-2108: Make all logging scope fields optional

### DIFF
--- a/application-operator/apis/oam/v1alpha1/loggingscope_types.go
+++ b/application-operator/apis/oam/v1alpha1/loggingscope_types.go
@@ -16,13 +16,13 @@ const LoggingScopeKind string = "LoggingScope"
 // LoggingScopeSpec defines the desired state of LoggingScope
 type LoggingScopeSpec struct {
 	// The fluentd image
-	FluentdImage string `json:"fluentdImage"`
+	FluentdImage string `json:"fluentdImage,omitempty"`
 
-	// URL for ElasticSearch
-	ElasticSearchURL string `json:"elasticSearchURL"`
+	// URL for Elasticsearch
+	ElasticSearchURL string `json:"elasticSearchURL,omitempty"`
 
-	// Name of secret with ElasticSearch credentials
-	SecretName string `json:"secretName"`
+	// Name of secret with Elasticsearch credentials
+	SecretName string `json:"secretName,omitempty"`
 
 	// WorkloadReferences to the workloads this scope applies to.
 	WorkloadReferences []runtimev1alpha1.TypedReference `json:"workloadRefs"`

--- a/application-operator/config/crd/bases/clusters.verrazzano.io_multiclusterloggingscopes.yaml
+++ b/application-operator/config/crd/bases/clusters.verrazzano.io_multiclusterloggingscopes.yaml
@@ -71,13 +71,13 @@ spec:
                     description: LoggingScopeSpec defines the desired state of LoggingScope
                     properties:
                       elasticSearchURL:
-                        description: URL for ElasticSearch
+                        description: URL for Elasticsearch
                         type: string
                       fluentdImage:
                         description: The fluentd image
                         type: string
                       secretName:
-                        description: Name of secret with ElasticSearch credentials
+                        description: Name of secret with Elasticsearch credentials
                         type: string
                       workloadRefs:
                         description: WorkloadReferences to the workloads this scope

--- a/application-operator/config/crd/bases/clusters.verrazzano.io_multiclusterloggingscopes.yaml
+++ b/application-operator/config/crd/bases/clusters.verrazzano.io_multiclusterloggingscopes.yaml
@@ -107,9 +107,6 @@ spec:
                           type: object
                         type: array
                     required:
-                    - elasticSearchURL
-                    - fluentdImage
-                    - secretName
                     - workloadRefs
                     type: object
                 type: object

--- a/application-operator/config/crd/bases/oam.verrazzano.io_loggingscopes.yaml
+++ b/application-operator/config/crd/bases/oam.verrazzano.io_loggingscopes.yaml
@@ -74,9 +74,6 @@ spec:
                   type: object
                 type: array
             required:
-            - elasticSearchURL
-            - fluentdImage
-            - secretName
             - workloadRefs
             type: object
           status:

--- a/application-operator/config/crd/bases/oam.verrazzano.io_loggingscopes.yaml
+++ b/application-operator/config/crd/bases/oam.verrazzano.io_loggingscopes.yaml
@@ -39,13 +39,13 @@ spec:
             description: LoggingScopeSpec defines the desired state of LoggingScope
             properties:
               elasticSearchURL:
-                description: URL for ElasticSearch
+                description: URL for Elasticsearch
                 type: string
               fluentdImage:
                 description: The fluentd image
                 type: string
               secretName:
-                description: Name of secret with ElasticSearch credentials
+                description: Name of secret with Elasticsearch credentials
                 type: string
               workloadRefs:
                 description: WorkloadReferences to the workloads this scope applies

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -124,7 +124,7 @@ func IgnoreNotFoundWithLog(resourceType string, err error, logger logr.Logger) e
 // FetchManagedClusterElasticSearchDetails fetches Elasticsearch details to use for system and
 // application logs on this managed cluster. If this cluster is NOT a managed cluster (i.e. does not
 // have the managed cluster secret), an empty ElasticsearchDetails will be returned
-func FetchManagedClusterElasticSearchDetails(ctx context.Context, rdr client.Reader, logger logr.Logger) ElasticsearchDetails {
+func FetchManagedClusterElasticSearchDetails(ctx context.Context, rdr client.Reader) ElasticsearchDetails {
 	esDetails := ElasticsearchDetails{}
 	esSecret := corev1.Secret{}
 	err := fetchElasticsearchSecret(ctx, rdr, &esSecret)

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -276,7 +276,7 @@ func (r *Reconciler) disableIstioInjection(log logr.Logger, u *unstructured.Unst
 
 // addLogging adds a FLUENTD sidecar and updates the Coherence spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, coherenceSpec map[string]interface{}) error {
-	loggingScope, err := vznav.LoggingScopeFromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -276,7 +276,7 @@ func (r *Reconciler) disableIstioInjection(log logr.Logger, u *unstructured.Unst
 
 // addLogging adds a FLUENTD sidecar and updates the Coherence spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, coherenceSpec map[string]interface{}) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -276,7 +276,7 @@ func (r *Reconciler) disableIstioInjection(log logr.Logger, u *unstructured.Unst
 
 // addLogging adds a FLUENTD sidecar and updates the Coherence spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, coherenceSpec map[string]interface{}) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
+	loggingScope, err := loggingscope.FetchLoggingScopeFromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -276,7 +276,7 @@ func mergeMapOverrideWithDest(src, dst map[string]string) map[string]string {
 
 // addLogging adds a FLUENTD sidecar and configmap and updates the Deployment
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, deployment *appsv1.Deployment) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
+	loggingScope, err := loggingscope.FetchLoggingScopeFromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -276,7 +276,7 @@ func mergeMapOverrideWithDest(src, dst map[string]string) map[string]string {
 
 // addLogging adds a FLUENTD sidecar and configmap and updates the Deployment
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, deployment *appsv1.Deployment) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
-	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -277,7 +276,7 @@ func mergeMapOverrideWithDest(src, dst map[string]string) map[string]string {
 
 // addLogging adds a FLUENTD sidecar and configmap and updates the Deployment
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, deployment *appsv1.Deployment) error {
-	loggingScope, err := vznav.LoggingScopeFromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -6,12 +6,13 @@ package helidonworkload
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
 	"reflect"
 
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
+	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/application-operator/controllers/loggingscope/loggingscope_controller.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller.go
@@ -22,6 +22,7 @@ import (
 	oamv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 )
 
@@ -72,6 +73,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if scope == nil || err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
+
+	applyDefaults(r.Client, scope)
 
 	var errors []string
 	var resources []vzapi.QualifiedResourceRelation
@@ -206,5 +209,56 @@ func toResource(workload *unstructured.Unstructured) vzapi.QualifiedResourceRela
 		Name:       workload.GetName(),
 		Namespace:  workload.GetNamespace(),
 		Kind:       workload.GetKind(),
+	}
+}
+
+// FromWorkloadLabels returns the LoggingScope object associated with the workload or nil if
+// there is no associated logging scope. The workload lookup is done using the OAM labels from the workload metadata.
+func FromWorkloadLabels(ctx context.Context, cli client.Reader, namespace string, labels map[string]string) (*vzapi.LoggingScope, error) {
+	component, err := vznav.ComponentFromWorkloadLabels(ctx, cli, namespace, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch the first logging scope - do we need to handle multiple logging scopes?
+	for _, s := range component.Scopes {
+		if s.ScopeReference.Kind == vzapi.LoggingScopeKind {
+			scope := vzapi.LoggingScope{}
+			name := types.NamespacedName{
+				Namespace: namespace,
+				Name:      s.ScopeReference.Name,
+			}
+			err = cli.Get(ctx, name, &scope)
+			if err != nil {
+				return nil, err
+			}
+
+			applyDefaults(cli, &scope)
+			return &scope, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// applyDefaults fills in any empty fields in the logging scope - also handle the case
+// where we are running in a managed cluster
+func applyDefaults(cli client.Reader, scope *vzapi.LoggingScope) {
+	if scope.Spec.ElasticSearchURL == "" && scope.Spec.SecretName == "" {
+		// if we're running in a managed cluster, use the multicluster ES URL and secret, and if we're
+		// not the fields will be empty and we will set these fields to defaults below
+		elasticSearchDetails := clusters.FetchManagedClusterElasticSearchDetails(context.TODO(), cli)
+		scope.Spec.ElasticSearchURL = elasticSearchDetails.URL
+		scope.Spec.SecretName = elasticSearchDetails.SecretName
+	}
+
+	if scope.Spec.FluentdImage == "" {
+		scope.Spec.FluentdImage = DefaultFluentdImage
+	}
+	if scope.Spec.ElasticSearchURL == "" {
+		scope.Spec.ElasticSearchURL = DefaultElasticSearchURL
+	}
+	if scope.Spec.SecretName == "" {
+		scope.Spec.SecretName = DefaultSecretName
 	}
 }

--- a/application-operator/controllers/loggingscope/loggingscope_controller.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller.go
@@ -212,9 +212,9 @@ func toResource(workload *unstructured.Unstructured) vzapi.QualifiedResourceRela
 	}
 }
 
-// FromWorkloadLabels returns the LoggingScope object associated with the workload or nil if
+// FetchLoggingScopeFromWorkloadLabels returns the LoggingScope object associated with the workload or nil if
 // there is no associated logging scope. The workload lookup is done using the OAM labels from the workload metadata.
-func FromWorkloadLabels(ctx context.Context, cli client.Reader, log logr.Logger, namespace string, labels map[string]string) (*vzapi.LoggingScope, error) {
+func FetchLoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader, log logr.Logger, namespace string, labels map[string]string) (*vzapi.LoggingScope, error) {
 	component, err := vznav.ComponentFromWorkloadLabels(ctx, cli, namespace, labels)
 	if err != nil {
 		return nil, err

--- a/application-operator/controllers/loggingscope/loggingscope_controller_test.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller_test.go
@@ -390,7 +390,7 @@ func TestFetchLoggingScopeWithDefaults(t *testing.T) {
 			return nil
 		})
 	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
@@ -435,7 +435,7 @@ func TestApplyDefaults(t *testing.T) {
 	}
 
 	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
@@ -464,7 +464,7 @@ func TestApplyDefaults(t *testing.T) {
 	}
 
 	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
@@ -557,7 +557,7 @@ func TestApplyDefaultsForManagedCluster(t *testing.T) {
 		constants.ElasticsearchURLData: []byte(adminClusterESURL)}}
 
 	// logging scope URL and secret are empty so expect a call to get the cluster secret
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
 			secret.Data = mcSecret.Data
 			return nil

--- a/application-operator/controllers/loggingscope/loggingscope_controller_test.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller_test.go
@@ -270,7 +270,7 @@ func TestFromWorkloadLabels(t *testing.T) {
 			return nil
 		})
 
-	loggingScope, err := FromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
 
 	mocker.Finish()
 	assert.NoError(err)
@@ -306,7 +306,7 @@ func TestFromWorkloadLabels(t *testing.T) {
 			return nil
 		})
 
-	loggingScope, err = FromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
 
 	mocker.Finish()
 	assert.NoError(err)
@@ -338,7 +338,7 @@ func TestFromWorkloadLabels(t *testing.T) {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
 
-	loggingScope, err = FromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
 
 	mocker.Finish()
 	assert.True(k8serrors.IsNotFound(err))
@@ -395,7 +395,7 @@ func TestFetchLoggingScopeWithDefaults(t *testing.T) {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
 
-	loggingScope, err := FromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
 
 	mocker.Finish()
 	assert.NoError(err)

--- a/application-operator/controllers/loggingscope/loggingscope_controller_test.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller_test.go
@@ -10,13 +10,19 @@ import (
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -237,6 +243,336 @@ func TestLoggingScopeReconcileRemoveAndForget(t *testing.T) {
 	asserts.Nil(t, err)
 
 	mocker.Finish()
+}
+
+// TestFromWorkloadLabels tests the FromWorkloadLabels function.
+func TestFromWorkloadLabels(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker *gomock.Controller
+	var cli *mocks.MockClient
+	var ctx = context.TODO()
+
+	// GIVEN workload labels
+	// WHEN an attempt is made to get the logging scopes from the app component but there are no scopes
+	// THEN expect no error and a nil logging scope is returned
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: "unit-test-app-config"}
+
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: "unit-test-app-config"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+
+	loggingScope, err := FromWorkloadLabels(ctx, cli, "unit-test-namespace", labels)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Nil(loggingScope)
+
+	// GIVEN workload labels
+	// WHEN an attempt is made to get the logging scopes from the app component and there is a logging scope
+	// THEN expect no error and a logging scope is returned
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+	loggingScopeName := "unit-test-logging-scope"
+	fluentdImage := "unit-test-image:latest"
+	esURL := "localhost"
+	esSecretName := "unit-test-secret"
+
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: "unit-test-app-config"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+			loggingScope.Spec.FluentdImage = fluentdImage
+			loggingScope.Spec.ElasticSearchURL = esURL
+			loggingScope.Spec.SecretName = esSecretName
+			return nil
+		})
+
+	loggingScope, err = FromWorkloadLabels(ctx, cli, "unit-test-namespace", labels)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.NotNil(loggingScope)
+	assert.Equal(fluentdImage, loggingScope.Spec.FluentdImage)
+	assert.Equal(esURL, loggingScope.Spec.ElasticSearchURL)
+	assert.Equal(esSecretName, loggingScope.Spec.SecretName)
+
+	// GIVEN workload labels
+	// WHEN an attempt is made to get the logging scopes from the app component and we cannot fetch the logging scope details
+	// THEN expect a NotFound error is returned
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: "unit-test-app-config"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+
+	loggingScope, err = FromWorkloadLabels(ctx, cli, "unit-test-namespace", labels)
+
+	mocker.Finish()
+	assert.True(k8serrors.IsNotFound(err))
+	assert.Nil(loggingScope)
+}
+
+// TestFetchLoggingScopeWithDefaults tests that defaults are correctly applied when
+// fetching a logging scope
+func TestFetchLoggingScopeWithDefaults(t *testing.T) {
+	assert := asserts.New(t)
+
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+
+	DefaultFluentdImage = "default-unit-test-image:latest"
+
+	var mocker *gomock.Controller
+	var cli *mocks.MockClient
+	var ctx = context.TODO()
+
+	loggingScopeName := "unit-test-logging-scope"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: "unit-test-app-config"}
+
+	// GIVEN workload labels
+	// WHEN an attempt is made to get the logging scopes from the app component and there is a logging scope
+	// AND the logging scope has no spec fields populated
+	// THEN expect no error and a logging scope with populated defaults is returned
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: "unit-test-app-config"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+			return nil
+		})
+	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+
+	loggingScope, err := FromWorkloadLabels(ctx, cli, "unit-test-namespace", labels)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.NotNil(loggingScope)
+	assert.Equal(DefaultFluentdImage, loggingScope.Spec.FluentdImage)
+	assert.Equal(DefaultElasticSearchURL, loggingScope.Spec.ElasticSearchURL)
+	assert.Equal(DefaultSecretName, loggingScope.Spec.SecretName)
+}
+
+// TestApplyDefaults tests various combinations of applied defaults
+func TestApplyDefaults(t *testing.T) {
+
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+
+	DefaultFluentdImage = "default-unit-test-image:latest"
+
+	var mocker *gomock.Controller
+	var cli *mocks.MockClient
+
+	// GIVEN a logging scope with no spec fields populated
+	// WHEN we apply defaults
+	// THEN the logging scope spec fields are populated with all of the default values
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	loggingScope := &vzapi.LoggingScope{}
+	expected := &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     DefaultFluentdImage,
+			ElasticSearchURL: DefaultElasticSearchURL,
+			SecretName:       DefaultSecretName,
+		},
+	}
+
+	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+
+	assertApplyDefaults(cli, expected, loggingScope, t)
+	mocker.Finish()
+
+	// GIVEN a logging scope with just the fluentd image in the spec
+	// WHEN we apply defaults
+	// THEN the remaining logging scope spec fields are populated with default values
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	fluentdImage := "unit-test-image:1.0"
+	loggingScope = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage: fluentdImage,
+		},
+	}
+	expected = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     fluentdImage,
+			ElasticSearchURL: DefaultElasticSearchURL,
+			SecretName:       DefaultSecretName,
+		},
+	}
+
+	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+
+	assertApplyDefaults(cli, expected, loggingScope, t)
+	mocker.Finish()
+
+	// GIVEN a logging scope with the fluentd image and ES URL in the spec
+	// WHEN we apply defaults
+	// THEN the remaining logging scope spec fields are populated with default values
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	esURL := "localhost:9200"
+	loggingScope = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     fluentdImage,
+			ElasticSearchURL: esURL,
+		},
+	}
+	expected = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     fluentdImage,
+			ElasticSearchURL: esURL,
+			SecretName:       DefaultSecretName,
+		},
+	}
+	assertApplyDefaults(cli, expected, loggingScope, t)
+	mocker.Finish()
+
+	// GIVEN a logging scope with all spec fields populated
+	// WHEN we apply defaults
+	// THEN none of the spec fields
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	esSecretName := "sssshhhhhhh"
+	loggingScope = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     fluentdImage,
+			ElasticSearchURL: esURL,
+			SecretName:       esSecretName,
+		},
+	}
+	expected = &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     fluentdImage,
+			ElasticSearchURL: esURL,
+			SecretName:       esSecretName,
+		},
+	}
+	assertApplyDefaults(cli, expected, loggingScope, t)
+	mocker.Finish()
+}
+
+// TestApplyDefaultsForManagedCluster tests applying defaults when the
+// logging scope is in a multi-cluster managed cluster
+func TestApplyDefaultsForManagedCluster(t *testing.T) {
+
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+
+	DefaultFluentdImage = "default-unit-test-image:latest"
+
+	var mocker *gomock.Controller
+	var cli *mocks.MockClient
+
+	// GIVEN a logging scope with no spec fields populated
+	// WHEN we apply defaults
+	// THEN the logging scope spec fields are populated with all of the default values
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	adminClusterESURL := "http://some-es-host:9999"
+
+	loggingScope := &vzapi.LoggingScope{}
+	expected := &vzapi.LoggingScope{
+		Spec: vzapi.LoggingScopeSpec{
+			FluentdImage:     DefaultFluentdImage,
+			ElasticSearchURL: adminClusterESURL,
+			SecretName:       constants.ElasticsearchSecretName,
+		},
+	}
+
+	mcSecret := v1.Secret{Data: map[string][]byte{
+		constants.ClusterNameData:      []byte("managed-cluster1"),
+		constants.ElasticsearchURLData: []byte(adminClusterESURL)}}
+
+	// logging scope URL and secret are empty so expect a call to get the cluster secret
+	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
+			secret.Data = mcSecret.Data
+			return nil
+		})
+
+	assertApplyDefaults(cli, expected, loggingScope, t)
+	mocker.Finish()
+}
+
+// assertApplyDefaults applies defaults to the passed in actual logging scope and
+// asserts that it is equal to the expected logging scope
+func assertApplyDefaults(cli client.Reader, expected, actual *vzapi.LoggingScope, t *testing.T) {
+	assert := asserts.New(t)
+	applyDefaults(cli, actual)
+	assert.Equal(expected, actual)
 }
 
 // createTestLoggingScopeRequest creates a test logging scope reconcile request

--- a/application-operator/controllers/navigation/workload.go
+++ b/application-operator/controllers/navigation/workload.go
@@ -104,33 +104,6 @@ func ComponentFromWorkloadLabels(ctx context.Context, cli client.Reader, namespa
 	return nil, errors.New("Unable to find application component for workload")
 }
 
-// LoggingScopeFromWorkloadLabels returns the LoggingScope object associated with the workload or nil if
-// there is no associated logging scope. The workload lookup is done using the OAM labels from the workload metadata.
-func LoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader, namespace string, labels map[string]string) (*vzapi.LoggingScope, error) {
-	component, err := ComponentFromWorkloadLabels(ctx, cli, namespace, labels)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch the first logging scope - do we need to handle multiple logging scopes?
-	for _, s := range component.Scopes {
-		if s.ScopeReference.Kind == vzapi.LoggingScopeKind {
-			scope := vzapi.LoggingScope{}
-			name := types.NamespacedName{
-				Namespace: namespace,
-				Name:      s.ScopeReference.Name,
-			}
-			err = cli.Get(ctx, name, &scope)
-			if err != nil {
-				return nil, err
-			}
-			return &scope, nil
-		}
-	}
-
-	return nil, nil
-}
-
 // MetricsTraitFromWorkloadLabels returns the MetricsTrait object associated with the workload or nil if
 // there is no associated metrics trait for the workload. If there is an associated metrics trait and the lookup of the
 // trait fails, an error is returned and the reconcile should be retried.

--- a/application-operator/controllers/webhooks/logging_scope_defaulter.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter.go
@@ -60,7 +60,7 @@ func (d *LoggingScopeDefaulter) Cleanup(appConfig *oamv1.ApplicationConfiguratio
 	return
 }
 
-// CreateDefaultLoggingScope creates the default logging scope for the given namespace
+// createDefaultLoggingScope creates the default logging scope for the given namespace
 func createDefaultLoggingScope(name types.NamespacedName) *vzapi.LoggingScope {
 	scope := &vzapi.LoggingScope{
 		ObjectMeta: metav1.ObjectMeta{

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -68,12 +68,6 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 
-<<<<<<< HEAD
-	// First expect it to check for a managed cluster Elasticsearch secret
-	doExpectGetManagedClusterElasticsearchSecretNotFound(cli)
-
-=======
->>>>>>> 7aae8a19... Default all logging scope fields if they are not specified
 	// Expect get existing logging scope (non-existent)
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -5,22 +5,21 @@ package webhooks
 
 import (
 	"context"
+	"net/http"
+	"testing"
+
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"testing"
 )
 
 // NotFoundError indicates an error caused by a StatusNotFound status
@@ -69,9 +68,12 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 
+<<<<<<< HEAD
 	// First expect it to check for a managed cluster Elasticsearch secret
 	doExpectGetManagedClusterElasticsearchSecretNotFound(cli)
 
+=======
+>>>>>>> 7aae8a19... Default all logging scope fields if they are not specified
 	// Expect get existing logging scope (non-existent)
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
@@ -79,7 +81,7 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 		})
 
 	// Expect create logging scope
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(createDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -113,7 +115,7 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 		})
 
 	// Expect default logging scope delete
-	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(createDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return nil
 		})
@@ -143,9 +145,6 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 
-	// Expect it to get managed cluster secret
-	doExpectGetManagedClusterElasticsearchSecretNotFound(cli)
-
 	// Expect get default logging scope
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
@@ -153,7 +152,7 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 		})
 
 	// Expect create default logging scope
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(createDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -167,9 +166,6 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 
-	// Expect it to get managed cluster secret
-	doExpectGetManagedClusterElasticsearchSecretNotFound(cli)
-
 	// Expect get default logging scope
 	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
@@ -177,7 +173,7 @@ func TestLoggingScopeDefaulter_Default(t *testing.T) {
 		})
 
 	// Expect create default logging scope
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(createDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return nil
 		})
@@ -213,7 +209,7 @@ func TestLoggingScopeDefaulter_Cleanup(t *testing.T) {
 			scope.Labels = map[string]string{"default.logging.scope": "true"}
 			return nil
 		})
-	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, emptyEsDetails)), gomock.Not(gomock.Nil())).
+	cli.EXPECT().Delete(gomock.Eq(context.TODO()), gomock.Eq(createDefaultLoggingScope(namespacedName)), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return nil
 		})
@@ -226,69 +222,6 @@ func TestLoggingScopeDefaulter_Cleanup(t *testing.T) {
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 	testLoggingScopeDefaulterCleanup(t, cli, "hello-conf.yaml", true)
-	mocker.Finish()
-}
-
-// TestCreateDefaultLoggingScope tests the behavior of CreateDefaultLoggingScope
-// GIVEN a managed cluster with Elasticsearch details specified
-// WHEN CreateDefaultLoggingScope is called with those ElasticsearchDetails
-// THEN it should create a default LoggingScope with the provided details
-func TestCreateDefaultLoggingScope(t *testing.T) {
-	scopeName := "default-hello-app-logging-scope"
-	namespacedName := types.NamespacedName{Name: scopeName, Namespace: "default"}
-
-	// WHEN CreateDefaultLoggingScope is called with empty ES details
-	// it should use the default values in the created logging scope
-	scope := CreateDefaultLoggingScope(namespacedName, emptyEsDetails)
-	asserts.Equal(t, defaultElasticSearchURL, scope.Spec.ElasticSearchURL)
-	asserts.Equal(t, defaultSecretName, scope.Spec.SecretName)
-
-	// WHEN CreateDefaultLoggingScope is called with non-empty ES details
-	// it should use the values provided instead of the defaults
-	esDetails := clusters.ElasticsearchDetails{URL: "http://some-other-es:9999", SecretName: "some-other-secret"}
-	scope = CreateDefaultLoggingScope(namespacedName, esDetails)
-	asserts.Equal(t, esDetails.URL, scope.Spec.ElasticSearchURL)
-	asserts.Equal(t, esDetails.SecretName, scope.Spec.SecretName)
-}
-
-// TestLoggingScopeDefaulter_DefaultManagedCluster tests adding a default LoggingScope to an
-// appconfig in a managed cluster (in this case the default logging scope should refer to the admin
-// cluster's Elasticsearch endpoint and secret)
-// GIVEN a AppConfigDefaulter and an appconfig in a managed cluster,
-// WHEN Default is called with an appconfig
-// THEN it should add a default LoggingScope to the appconfig which refers to the admin cluster ES
-func TestLoggingScopeDefaulter_DefaultOnManagedCluster(t *testing.T) {
-	var cli *mocks.MockClient
-	var mocker *gomock.Controller
-
-	scopeName := "default-hello-app-logging-scope"
-	namespacedName := types.NamespacedName{Name: scopeName, Namespace: "default"}
-
-	// The appconfig has one component with no scopes and the default scope does not exist
-	mocker = gomock.NewController(t)
-	cli = mocks.NewMockClient(mocker)
-
-	// Expect it to get managed cluster Elasticsearch secret and return a valid one (all other tests
-	// assumed no managed cluster Elasticsearch secret found)
-	esDetails := clusters.ElasticsearchDetails{URL: "http://some-es-host:9999", SecretName: constants.ElasticsearchSecretName}
-	mcElasticsearchSecret := v1.Secret{Data: map[string][]byte{
-		constants.ElasticsearchURLData:      []byte(esDetails.URL),
-		constants.ElasticsearchUsernameData: []byte("someUser"),
-		constants.ElasticsearchPasswordData: []byte("somePass"),
-	}}
-	doExpectGetManagedClusterElasticsearchSecretFound(cli, mcElasticsearchSecret)
-
-	// Expect get default logging scope
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(namespacedName), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, key client.ObjectKey, scope *vzapi.LoggingScope) error {
-			return NotFoundError{}
-		})
-
-	// Expect create logging scope with the esDetails specified in the managedClusterSecret (instead of the defaults)
-	cli.EXPECT().Create(gomock.Eq(context.TODO()), gomock.Eq(CreateDefaultLoggingScope(namespacedName, esDetails)), gomock.Not(gomock.Nil())).
-		Return(nil)
-
-	testLoggingScopeDefaulterDefault(t, cli, "hello-conf.yaml", map[string]string{"hello-component": scopeName}, false)
 	mocker.Finish()
 }
 
@@ -332,19 +265,4 @@ func testLoggingScopeDefaulterCleanup(t *testing.T, cli client.Client, configPat
 	if err != nil {
 		t.Fatalf("Error in defaulter.Default %v", err)
 	}
-}
-
-func doExpectGetManagedClusterElasticsearchSecretNotFound(cli *mocks.MockClient) {
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
-			return NotFoundError{}
-		})
-}
-
-func doExpectGetManagedClusterElasticsearchSecretFound(cli *mocks.MockClient, managedClusterSecret v1.Secret) {
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCElasticsearchSecretFullName), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
-			secret.Data = managedClusterSecret.Data
-			return nil
-		})
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -186,7 +186,7 @@ func copyLabels(log logr.Logger, workloadLabels map[string]string, weblogic *uns
 
 // addLogging adds a FLUENTD sidecar and updates the WebLogic spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, weblogic *unstructured.Unstructured) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -186,7 +186,7 @@ func copyLabels(log logr.Logger, workloadLabels map[string]string, weblogic *uns
 
 // addLogging adds a FLUENTD sidecar and updates the WebLogic spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, weblogic *unstructured.Unstructured) error {
-	loggingScope, err := vznav.LoggingScopeFromWorkloadLabels(ctx, r.Client, namespace, labels)
+	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -186,7 +186,7 @@ func copyLabels(log logr.Logger, workloadLabels map[string]string, weblogic *uns
 
 // addLogging adds a FLUENTD sidecar and updates the WebLogic spec if there is an associated LoggingScope
 func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, weblogic *unstructured.Unstructured) error {
-	loggingScope, err := loggingscope.FromWorkloadLabels(ctx, r.Client, log, namespace, labels)
+	loggingScope, err := loggingscope.FetchLoggingScopeFromWorkloadLabels(ctx, r.Client, log, namespace, labels)
 	if err != nil {
 		return err
 	}

--- a/application-operator/deploy/verrazzano.yaml_template
+++ b/application-operator/deploy/verrazzano.yaml_template
@@ -73,6 +73,8 @@ spec:
           env:
             - name: VERRAZZANO_KUBECONFIG
               value: /home/verrazzano/kubeconfig
+            - name: DEFAULT_FLUENTD_IMAGE
+              value: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-20201016214205-7f37ac6
           resources:
             requests:
               memory: 72Mi

--- a/examples/bobs-books/bobs-books-logging-scope.yaml
+++ b/examples/bobs-books/bobs-books-logging-scope.yaml
@@ -7,7 +7,6 @@ metadata:
   name: logging-scope
   namespace: bobs-books
 spec:
-  fluentdImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-20201016214205-7f37ac6
   elasticSearchURL: http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local:9200
   secretName: verrazzano
   workloadRefs: []

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
@@ -71,13 +71,13 @@ spec:
                     description: LoggingScopeSpec defines the desired state of LoggingScope
                     properties:
                       elasticSearchURL:
-                        description: URL for ElasticSearch
+                        description: URL for Elasticsearch
                         type: string
                       fluentdImage:
                         description: The fluentd image
                         type: string
                       secretName:
-                        description: Name of secret with ElasticSearch credentials
+                        description: Name of secret with Elasticsearch credentials
                         type: string
                       workloadRefs:
                         description: WorkloadReferences to the workloads this scope

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
@@ -107,9 +107,6 @@ spec:
                           type: object
                         type: array
                     required:
-                    - elasticSearchURL
-                    - fluentdImage
-                    - secretName
                     - workloadRefs
                     type: object
                 type: object

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_loggingscopes.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_loggingscopes.yaml
@@ -74,9 +74,6 @@ spec:
                   type: object
                 type: array
             required:
-            - elasticSearchURL
-            - fluentdImage
-            - secretName
             - workloadRefs
             type: object
           status:

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_loggingscopes.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_loggingscopes.yaml
@@ -39,13 +39,13 @@ spec:
             description: LoggingScopeSpec defines the desired state of LoggingScope
             properties:
               elasticSearchURL:
-                description: URL for ElasticSearch
+                description: URL for Elasticsearch
                 type: string
               fluentdImage:
                 description: The fluentd image
                 type: string
               secretName:
-                description: Name of secret with ElasticSearch credentials
+                description: Name of secret with Elasticsearch credentials
                 type: string
               workloadRefs:
                 description: WorkloadReferences to the workloads this scope applies

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -78,6 +78,9 @@ spec:
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/certs
+          env:
+            - name: DEFAULT_FLUENTD_IMAGE
+              value: {{ .Values.fluentdImage }}
       volumes:
         - name: webhook-certs
           emptyDir: {}

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
@@ -12,3 +12,5 @@ image:
 imagePullPolicy: IfNotPresent
 
 requestMemory: 72Mi
+
+fluentdImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-20201016214205-7f37ac6


### PR DESCRIPTION
# Description

All logging scope fields are now optional, except for the workload refs field, because the OAM operator cannot handle a logging scope missing workload refs. The Fluentd image now comes from an environment variable set on the Verrazzano application operator, which is configured by the installer. The Elasticsearch URL and the secret name defaults are still hard-coded (that may change in the future).

Notes:

- I moved the function to fetch the logging scope given labels out of the workload functions file and into the logging scope file. The function has grown in scope, beyond just a simple workload utility function. As a result, the linter complained that the name should drop "LoggingScope" from the front to prevent stuttering when prefixed with the package.
- The defaults apply to multi-cluster logging scopes as well, so now instead of setting MC logging properties on the default logging scope, they can apply to user-defined logging scopes.


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
