### PR TITLE
Put fluentdImage back in Bob's Books logging scope

### DIFF
--- a/examples/bobs-books/bobs-books-logging-scope.yaml
+++ b/examples/bobs-books/bobs-books-logging-scope.yaml
@@ -7,6 +7,7 @@ metadata:
   name: logging-scope
   namespace: bobs-books
 spec:
+  fluentdImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.10.4-20201016214205-7f37ac6
   elasticSearchURL: http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local:9200
   secretName: verrazzano
   workloadRefs: []


### PR DESCRIPTION
# Description

The changes to make logging scope fields optional included a change to the Bob's Books example to remove the Fluentd image, as a test to prove that it gets defaulted properly. Unfortunately the hackathon participants pull the examples from master so this breaks against the latest release.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
