### PR TITLE
Update generated Prometheus scrape targets to use istio-certs and Update Auth Policy to allow Prometheus to scrape metrics from deployed OAM apps

### DIFF
--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -960,7 +960,7 @@ func MutateLabels(trait *vzapi.MetricsTrait, workload *unstructured.Unstructured
 	return mutated
 }
 
-// schemaScrapeTarget returns the type of scheme (https, http) to use in a scrape target
+// useHTTPSForScrapeTarget returns true if https w istio certs should be used for scrape target. Otherwise return false, use http
 func useHTTPSForScrapeTarget(ctx context.Context, c client.Client, trait *vzapi.MetricsTrait) (bool, error) {
 	if trait.Spec.WorkloadReference.Kind == "VerrazzanoCoherenceWorkload" || trait.Spec.WorkloadReference.Kind == "Coherence" {
 		return false, nil

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -960,7 +960,7 @@ func MutateLabels(trait *vzapi.MetricsTrait, workload *unstructured.Unstructured
 	return mutated
 }
 
-// useHTTPSForScrapeTarget returns true if https w istio certs should be used for scrape target. Otherwise return false, use http
+// useHTTPSForScrapeTarget returns true if https with Istio certs should be used for scrape target. Otherwise return false, use http
 func useHTTPSForScrapeTarget(ctx context.Context, c client.Client, trait *vzapi.MetricsTrait) (bool, error) {
 	if trait.Spec.WorkloadReference.Kind == "VerrazzanoCoherenceWorkload" || trait.Spec.WorkloadReference.Kind == "Coherence" {
 		return false, nil

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -209,6 +209,7 @@ relabel_configs:
   regex: '.*/(.*)$'
   replacement: $1
 `
+
 // prometheusWLSScrapeConfigTemplate configuration for WebLogic prometheus scrape target template
 // Used to add new WebLogic scrape config to a pormetheus configmap
 const prometheusHttpsWLSScrapeConfigTemplate = `job_name: ##JOB_NAME##
@@ -254,7 +255,6 @@ relabel_configs:
   regex: '.*/(.*)$'
   replacement: $1
 `
-
 
 // Reconciler reconciles a MetricsTrait object
 type Reconciler struct {
@@ -877,10 +877,8 @@ func updateStatusIfRequired(status *vzapi.MetricsTraitStatus, results *reconcile
 // mutatePrometheusScrapeConfig mutates the prometheus scrape configuration.
 // Scrap configuration rules will be added, updated, deleted depending on the state of the trait.
 func mutatePrometheusScrapeConfig(trait *vzapi.MetricsTrait, traitDefaults *vzapi.MetricsTraitSpec, prometheusScrapeConfig *gabs.Container, secret *k8score.Secret, workload *unstructured.Unstructured, ctx context.Context, c client.Client) (*gabs.Container, error) {
-	fmt.Println("CDD Mutate Prometheus ScrapeConfig")
 	oldScrapeConfigs := prometheusScrapeConfig.Search(prometheusScrapeConfigsLabel).Children()
 	prometheusScrapeConfig.Array(prometheusScrapeConfigsLabel) // zero out the array of scrape configs
-	fmt.Println("CDD Call Create Scrape Config From Trait")
 	newScrapeJob, newScrapeConfig, err := createScrapeConfigFromTrait(trait, traitDefaults, secret, workload, ctx, c)
 	if err != nil {
 		return prometheusScrapeConfig, err
@@ -962,7 +960,6 @@ func MutateLabels(trait *vzapi.MetricsTrait, workload *unstructured.Unstructured
 	return mutated
 }
 
-
 // schemaScrapeTarget returns the type of scheme (https, http) to use in a scrape target
 func useHttpsForScrapeTarget(ctx context.Context, c client.Client, trait *vzapi.MetricsTrait) (bool, error) {
 	if trait.Spec.WorkloadReference.Kind == "VerrazzanoCoherenceWorkload" || trait.Spec.WorkloadReference.Kind == "Coherence" {
@@ -1001,7 +998,7 @@ func createPrometheusScrapeConfigMapJobName(trait *vzapi.MetricsTrait) (string, 
 // The job name is returned.
 // The YAML container populated from the prometheus scrape config template is returned.
 func createScrapeConfigFromTrait(trait *vzapi.MetricsTrait, traitDefaults *vzapi.MetricsTraitSpec, secret *k8score.Secret, workload *unstructured.Unstructured, ctx context.Context, c client.Client) (string, *gabs.Container, error) {
-	fmt.Println("CDD IN Create Scrape Config From Trait")
+
 	job, err := createPrometheusScrapeConfigMapJobName(trait)
 	if err != nil {
 		return "", nil, err
@@ -1017,8 +1014,7 @@ func createScrapeConfigFromTrait(trait *vzapi.MetricsTrait, traitDefaults *vzapi
 			namespaceHolder: trait.Namespace}
 
 		var configTemplate string
-		https, err  := useHttpsForScrapeTarget(ctx, c, trait)
-		fmt.Printf("CDD use Https = %v and err = %s\n", https, err)
+		https, err := useHttpsForScrapeTarget(ctx, c, trait)
 		if err != nil {
 			return "", nil, err
 		}
@@ -1041,7 +1037,7 @@ func createScrapeConfigFromTrait(trait *vzapi.MetricsTrait, traitDefaults *vzapi
 				configTemplate = prometheusHttpWLSScrapeConfigTemplate
 			}
 		}
-		fmt.Printf("CDD Config Template = %=v\n", https, err)
+
 		// Populate the prometheus scrape config template
 		template := mergeTemplateWithContext(configTemplate, context)
 

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -1671,7 +1671,7 @@ func TestMetricsTraitDeletedForCOHWorkload(t *testing.T) {
 }
 
 // TestUseHTTPSForScrapeTargetFalseConditions tests that false is returned for the following conditions
-// GIVEN a unlabeled istio namespace or a workload of kind VerrazzanoCoherenceWorkload or a workload of kind Coherence
+// GIVEN a unlabeled Istio namespace or a workload of kind VerrazzanoCoherenceWorkload or a workload of kind Coherence
 // WHEN the useHttpsForScrapeTarget method is invoked
 // THEN verify that the false boolean value is returned since all those conditions require an http scrape target
 func TestUseHTTPSForScrapeTargetFalseConditions(t *testing.T) {
@@ -1787,12 +1787,13 @@ func TestUseHTTPSForScrapeTargetFalseConditions(t *testing.T) {
 	https, _ = useHTTPSForScrapeTarget(nil, reconciler.Client, &mtrait)
 	// Expect https to be false for namespaces NOT labeled for istio-injection
 	assert.False(https, "Expected https to be false for namespace NOT labeled for istio injection")
+	mocker.Finish()
 }
 
-// TestUseHTTPSForScrapeTargetTrueCondition tests that true is returned for namespaces marked for istio injection
-// GIVEN a labeled istio namespace
+// TestUseHTTPSForScrapeTargetTrueCondition tests that true is returned for namespaces marked for Istio injection
+// GIVEN a labeled Istio namespace
 // WHEN the useHttpsForScrapeTarget method is invoked
-// THEN verify that the true boolean value is returned since pods in istio namespaces require an https scrape target because of MTLS
+// THEN verify that the true boolean value is returned since pods in Istio namespaces require an https scrape target because of MTLS
 func TestUseHTTPSForScrapeTargetTrueCondition(t *testing.T) {
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
@@ -1898,8 +1899,8 @@ func TestUseHTTPSForScrapeTargetTrueCondition(t *testing.T) {
 	testNamespace.ObjectMeta.Labels = labels
 	https, _ := useHTTPSForScrapeTarget(nil, reconciler.Client, &mtrait)
 	// Expect https to be true for namespaces labeled for istio-injection
-	assert.True(https, "Expected https to be true for namespaces labeled for istio injection")
-
+	assert.True(https, "Expected https to be true for namespaces labeled for Istio injection")
+	mocker.Finish()
 }
 
 // newMetricsTraitReconciler creates a new reconciler for testing

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -1627,48 +1627,7 @@ func TestUseHTTPSForScrapeTargetFalseConditions(t *testing.T) {
 
 	mtrait := vzapi.MetricsTrait{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "VerrazzanoCoherenceWorkload",
-			APIVersion: "",
-		},
-		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: vzapi.MetricsTraitSpec{
-			Port:    nil,
-			Path:    nil,
-			Secret:  nil,
-			Scraper: nil,
-			WorkloadReference: oamrt.TypedReference{
-				APIVersion: "",
-				Kind:       "",
-				Name:       "",
-				UID:        "",
-			},
-		},
-		Status: vzapi.MetricsTraitStatus{
-			ConditionedStatus: oamrt.ConditionedStatus{
-				Conditions: nil,
-			},
-			Resources: nil,
+			Kind: "VerrazzanoCoherenceWorkload",
 		},
 	}
 
@@ -1720,48 +1679,7 @@ func TestUseHTTPSForScrapeTargetTrueCondition(t *testing.T) {
 
 	mtrait := vzapi.MetricsTrait{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "",
-			APIVersion: "",
-		},
-		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: vzapi.MetricsTraitSpec{
-			Port:    nil,
-			Path:    nil,
-			Secret:  nil,
-			Scraper: nil,
-			WorkloadReference: oamrt.TypedReference{
-				APIVersion: "",
-				Kind:       "",
-				Name:       "",
-				UID:        "",
-			},
-		},
-		Status: vzapi.MetricsTraitStatus{
-			ConditionedStatus: oamrt.ConditionedStatus{
-				Conditions: nil,
-			},
-			Resources: nil,
+			Kind: "ContainerizedWorkload",
 		},
 	}
 

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -851,37 +851,10 @@ func TestNoUpdatesRequired(t *testing.T) {
 
 	testNamespace := k8score.Namespace{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: "",
+			Kind: "Namespace",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "test-namespace",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: k8score.NamespaceSpec{
-			Finalizers: nil,
-		},
-		Status: k8score.NamespaceStatus{
-			Phase:      "",
-			Conditions: nil,
+			Name: "test-namespace",
 		},
 	}
 
@@ -1069,37 +1042,10 @@ func TestMetricsTraitCreatedForWLSWorkload(t *testing.T) {
 
 	testNamespace := k8score.Namespace{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: "",
+			Kind: "Namespace",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "test-namespace",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: k8score.NamespaceSpec{
-			Finalizers: nil,
-		},
-		Status: k8score.NamespaceStatus{
-			Phase:      "",
-			Conditions: nil,
+			Name: "test-namespace",
 		},
 	}
 
@@ -1728,37 +1674,10 @@ func TestUseHTTPSForScrapeTargetFalseConditions(t *testing.T) {
 
 	testNamespace := k8score.Namespace{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: "",
+			Kind: "Namespace",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "test-namespace",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: k8score.NamespaceSpec{
-			Finalizers: nil,
-		},
-		Status: k8score.NamespaceStatus{
-			Phase:      "",
-			Conditions: nil,
+			Name: "test-namespace",
 		},
 	}
 
@@ -1848,37 +1767,10 @@ func TestUseHTTPSForScrapeTargetTrueCondition(t *testing.T) {
 
 	testNamespace := k8score.Namespace{
 		TypeMeta: k8smeta.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: "",
+			Kind: "Namespace",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			Name:            "test-namespace",
-			GenerateName:    "",
-			Namespace:       "",
-			SelfLink:        "",
-			UID:             "",
-			ResourceVersion: "",
-			Generation:      0,
-			CreationTimestamp: k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionTimestamp: &k8smeta.Time{
-				Time: time.Time{},
-			},
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: k8score.NamespaceSpec{
-			Finalizers: nil,
-		},
-		Status: k8score.NamespaceStatus{
-			Phase:      "",
-			Conditions: nil,
+			Name: "test-namespace",
 		},
 	}
 

--- a/application-operator/controllers/webhooks/istio_defaulter.go
+++ b/application-operator/controllers/webhooks/istio_defaulter.go
@@ -125,6 +125,7 @@ func (a *IstioWebhook) InjectDecoder(d *admission.Decoder) error {
 func (a *IstioWebhook) createUpdateAuthorizationPolicy(namespace string, serviceAccountName string, ownerRef metav1.OwnerReference) error {
 	podPrincipal := fmt.Sprintf("cluster.local/ns/%s/sa/%s", namespace, serviceAccountName)
 	gwPrincipal := "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+	promPrincipal := "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator"
 
 	// Check if authorization policy exist.  The name of the authorization policy is the owner reference name which happens
 	// to be the appconfig name.
@@ -143,6 +144,7 @@ func (a *IstioWebhook) createUpdateAuthorizationPolicy(namespace string, service
 					Principals: []string{
 						podPrincipal,
 						gwPrincipal,
+						promPrincipal,
 					},
 				},
 			},

--- a/application-operator/controllers/webhooks/istio_defaulter_test.go
+++ b/application-operator/controllers/webhooks/istio_defaulter_test.go
@@ -234,8 +234,9 @@ func TestHandleAppConfigOnwerReference1(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 2)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-appconfig")
 }
 
@@ -312,8 +313,9 @@ func TestHandleAppConfigOnwerReference2(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 2)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa")
 }
 
@@ -390,8 +392,9 @@ func TestHandleAppConfigOnwerReference3(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 2)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa")
 
 	// Create a non-default service account, different than first one we created
@@ -444,8 +447,9 @@ func TestHandleAppConfigOnwerReference3(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 4)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa2")
 }
@@ -523,8 +527,9 @@ func TestHandleAppConfigOnwerReference4(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 2)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa")
 
 	// Create a pod referencing the second service account we created
@@ -568,8 +573,9 @@ func TestHandleAppConfigOnwerReference4(t *testing.T) {
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].Kind, "ApplicationConfiguration")
 	assert.Equal(t, authPolicy.GetOwnerReferences()[0].APIVersion, "core.oam.dev/v1alpha2")
 	assert.Contains(t, authPolicy.Spec.Selector.MatchLabels, IstioAppLabel)
-	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 2)
+	assert.Equal(t, len(authPolicy.Spec.GetRules()[0].From[0].Source.Principals), 3)
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(t, authPolicy.Spec.GetRules()[0].From[0].Source.Principals, "cluster.local/ns/default/sa/test-sa")
 }
 


### PR DESCRIPTION


# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
