### PR TITLE
Clean up generated certificates and secrets during app deletion

### DIFF
--- a/application-operator/controllers/webhooks/appconfig_defaulter.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter.go
@@ -141,6 +141,7 @@ func (a *AppConfigWebhook) cleanupSecret(appConfig *oamv1.ApplicationConfigurati
 	return
 }
 
+// fetchCert gets the cert for the given name; returns nil Certificate if not found
 func fetchCert(ctx context.Context, c client.Reader, name types.NamespacedName) (*certapiv1alpha2.Certificate, error) {
 	var cert certapiv1alpha2.Certificate
 	err := c.Get(ctx, name, &cert)
@@ -155,6 +156,7 @@ func fetchCert(ctx context.Context, c client.Reader, name types.NamespacedName) 
 	return &cert, err
 }
 
+// fetchSecret gets the secret for the given name; returns nil Secret if not found
 func fetchSecret(ctx context.Context, c client.Reader, name types.NamespacedName) (*corev1.Secret, error) {
 	var secret corev1.Secret
 	err := c.Get(ctx, name, &secret)

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -171,7 +171,7 @@ func main() {
 		}
 
 		mgr.GetWebhookServer().CertDir = certDir
-		appconfigWebhook := &webhooks.AppConfigWebhook{Defaulters: []webhooks.AppConfigDefaulter{
+		appconfigWebhook := &webhooks.AppConfigWebhook{Client: mgr.GetClient(), Defaulters: []webhooks.AppConfigDefaulter{
 			&webhooks.MetricsTraitDefaulter{},
 			&webhooks.LoggingScopeDefaulter{Client: mgr.GetClient()},
 		}}


### PR DESCRIPTION
# Description

Clean up generated certificates and secrets during app deletion.

Fixes VZ-2222
#### Summary
- add cleanup to AppConfigWebhook
- add functions to clean up the generated certificates and secrets associated with the app config

#### Tests
- write unit tests to verify AppConfigWebhook behavior on delete
- modify TODO example acceptance test to check for creation of secret on deploy and cleanup on delete


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
