### PR TITLE
Add verrazzano required labels to namespaces created via a VerrazzanoProject

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -36,8 +36,12 @@ const ElasticsearchPasswordData = "password"
 
 // LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"
+
+// LabelVerrazzanoManagedDefault - default value for LabelVerrazzanoManaged
 const LabelVerrazzanoManagedDefault = "true"
 
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
+
+// LabelIstioInjectionDefault - default value for LabelIstioInjection
 const LabelIstioInjectionDefault = "enabled"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -36,6 +36,8 @@ const ElasticsearchPasswordData = "password"
 
 // LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"
+const LabelVerrazzanoManagedDefault = "true"
 
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
+const LabelIstioInjectionDefault = "enabled"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -34,5 +34,8 @@ const ElasticsearchUsernameData = "username"
 // cluster's Elasticsearch password
 const ElasticsearchPasswordData = "password"
 
-// LabelVerrazzanoManaged - constant for a kubernetes label that is applied by Verrazzano
+// LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"
+
+// LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
+const LabelIstioInjection = "istio-injection"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -33,3 +33,6 @@ const ElasticsearchUsernameData = "username"
 // ElasticsearchPasswordData - the field name in ElasticsearchSecret that contains the admin
 // cluster's Elasticsearch password
 const ElasticsearchPasswordData = "password"
+
+// LabelVerrazzanoManaged - constant for a kubernetes label that is applied by Verrazzano
+const LabelVerrazzanoManaged = "verrazzano-managed"

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -80,5 +80,13 @@ func (r *Reconciler) mutateNamespace(nsTemplate clustersv1alpha1.NamespaceTempla
 	if namespace.Labels == nil {
 		namespace.Labels = map[string]string{}
 	}
+
+	// Apply the standard Verrazzano labels
 	namespace.Labels[constants.LabelVerrazzanoManaged] = "true"
+	namespace.Labels[constants.LabelIstioInjection] = "enabled"
+
+	// Apply user specified labels, which may override standard Verrazzano labels
+	for label, value := range nsTemplate.Metadata.Labels {
+		namespace.Labels[label] = value
+	}
 }

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -77,5 +77,8 @@ func (r *Reconciler) mutateNamespace(nsTemplate clustersv1alpha1.NamespaceTempla
 	namespace.Spec = nsTemplate.Spec
 
 	// Add verrazzano generated labels if not already present
+	if namespace.Labels == nil {
+		namespace.Labels = map[string]string{}
+	}
 	namespace.Labels[constants.LabelVerrazzanoManaged] = "true"
 }

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -72,7 +72,6 @@ func (r *Reconciler) createOrUpdateNamespaces(ctx context.Context, vp clustersv1
 }
 
 func (r *Reconciler) mutateNamespace(nsTemplate clustersv1alpha1.NamespaceTemplate, namespace *corev1.Namespace) {
-	namespace.Labels = nsTemplate.Metadata.Labels
 	namespace.Annotations = nsTemplate.Metadata.Annotations
 	namespace.Spec = nsTemplate.Spec
 
@@ -82,8 +81,8 @@ func (r *Reconciler) mutateNamespace(nsTemplate clustersv1alpha1.NamespaceTempla
 	}
 
 	// Apply the standard Verrazzano labels
-	namespace.Labels[constants.LabelVerrazzanoManaged] = "true"
-	namespace.Labels[constants.LabelIstioInjection] = "enabled"
+	namespace.Labels[constants.LabelVerrazzanoManaged] = constants.LabelVerrazzanoManagedDefault
+	namespace.Labels[constants.LabelIstioInjection] = constants.LabelIstioInjectionDefault
 
 	// Apply user specified labels, which may override standard Verrazzano labels
 	for label, value := range nsTemplate.Metadata.Labels {

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -6,17 +6,15 @@ package verrazzanoproject
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/go-logr/logr"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 )
 
 // Reconciler reconciles a VerrazzanoProject object

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -75,4 +75,7 @@ func (r *Reconciler) mutateNamespace(nsTemplate clustersv1alpha1.NamespaceTempla
 	namespace.Labels = nsTemplate.Metadata.Labels
 	namespace.Annotations = nsTemplate.Metadata.Annotations
 	namespace.Spec = nsTemplate.Spec
+
+	// Add verrazzano generated labels if not already present
+	namespace.Labels[constants.LabelVerrazzanoManaged] = "true"
 }

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -36,10 +36,10 @@ var existingNS = clustersv1alpha1.NamespaceTemplate{
 	},
 }
 
+// Omit labels on this namespace to handle test case of starting with an empty label
 var newNS = clustersv1alpha1.NamespaceTemplate{
 	Metadata: metav1.ObjectMeta{
-		Name:   "newNS",
-		Labels: testLabels,
+		Name: "newNS",
 	},
 }
 

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -162,6 +162,8 @@ func TestReconcileVerrazzanoProject(t *testing.T) {
 								assert.Equal(tt.fields.nsList[0].Metadata.Labels, namespace.Labels, "namespace labels did not match")
 								_, labelExists := namespace.Labels[constants.LabelVerrazzanoManaged]
 								assert.True(labelExists, fmt.Sprintf("the label %s does not exist", constants.LabelVerrazzanoManaged))
+								_, labelExists = namespace.Labels[constants.LabelIstioInjection]
+								assert.True(labelExists, fmt.Sprintf("the label %s does not exist", constants.LabelIstioInjection))
 								return nil
 							})
 					} else {

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -160,6 +160,8 @@ func TestReconcileVerrazzanoProject(t *testing.T) {
 							DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
 								assert.Equal(tt.fields.nsList[0].Metadata.Name, namespace.Name, "namespace name did not match")
 								assert.Equal(tt.fields.nsList[0].Metadata.Labels, namespace.Labels, "namespace labels did not match")
+								_, labelExists := namespace.Labels[constants.LabelVerrazzanoManaged]
+								assert.True(labelExists, fmt.Sprintf("the label %s does not exist", constants.LabelVerrazzanoManaged))
 								return nil
 							})
 					} else {

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -153,6 +153,15 @@ func TestReconcileVerrazzanoProject(t *testing.T) {
 							DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 								return nil
 							})
+
+						// expect call to update the namespace
+						mockClient.EXPECT().
+							Update(gomock.Any(), gomock.Any()).
+							DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+								assert.Equal(tt.fields.nsList[0].Metadata.Name, namespace.Name, "namespace name did not match")
+								assert.Equal(tt.fields.nsList[0].Metadata.Labels, namespace.Labels, "namespace labels did not match")
+								return nil
+							})
 					} else {
 						// expect call to get a namespace that returns namespace not found
 						mockClient.EXPECT().

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -159,7 +159,6 @@ func TestReconcileVerrazzanoProject(t *testing.T) {
 							Update(gomock.Any(), gomock.Any()).
 							DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
 								assert.Equal(tt.fields.nsList[0].Metadata.Name, namespace.Name, "namespace name did not match")
-								assert.Equal(tt.fields.nsList[0].Metadata.Labels, namespace.Labels, "namespace labels did not match")
 								_, labelExists := namespace.Labels[constants.LabelVerrazzanoManaged]
 								assert.True(labelExists, fmt.Sprintf("the label %s does not exist", constants.LabelVerrazzanoManaged))
 								_, labelExists = namespace.Labels[constants.LabelIstioInjection]

--- a/application-operator/test/integ/k8s/resource.go
+++ b/application-operator/test/integ/k8s/resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 
@@ -180,6 +181,11 @@ func (c Client) GetMultiClusterSecret(namespace, name string) (*clustersv1alpha1
 // GetSecret gets the specified K8S secret
 func (c Client) GetSecret(namespace, name string) (*corev1.Secret, error) {
 	return c.clientset.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// GetSecret gets the specified K8S namespace
+func (c Client) GetNamespace(name string) (*corev1.Namespace, error) {
+	return c.clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 // GetMultiClusterComponent gets the specified MultiClusterComponent

--- a/application-operator/test/integ/k8s/resource.go
+++ b/application-operator/test/integ/k8s/resource.go
@@ -7,15 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-
 	"strings"
 
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
-
 	"github.com/onsi/ginkgo"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,7 +180,7 @@ func (c Client) GetSecret(namespace, name string) (*corev1.Secret, error) {
 	return c.clientset.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// GetSecret gets the specified K8S namespace
+// GetNamespace gets the specified K8S namespace
 func (c Client) GetNamespace(name string) (*corev1.Namespace, error) {
 	return c.clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -159,6 +159,21 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject validation", func() {
 	})
 })
 
+var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func() {
+	ginkgo.It("Apply VerrazzanoProject with default namespace labels", func() {
+		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_namespace_default_labels.yaml")
+		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be created successfully")
+		gomega.Eventually(func() bool {
+			namespace, err := K8sClient.GetNamespace("test-namespace-1")
+			return appConfigExistsWithFields(multiclusterTestNamespace, "mymcappconf", mcAppConfig)
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+	})
+	ginkgo.It("Apply VerrazzanoProject with default namespace labels", func() {
+		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml")
+		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be updated successfully")
+	})
+})
+
 func appConfigExistsWithFields(namespace string, name string, multiClusterAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration) bool {
 	fmt.Printf("Looking for OAM app config %v/%v\n", namespace, name)
 	appConfig, err := K8sClient.GetOAMAppConfig(namespace, name)

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -173,6 +173,16 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 			}
 			return false
 		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			namespace, err := K8sClient.GetNamespace("test-namespace-2")
+			if err == nil {
+				return namespace.Labels[constants.LabelIstioInjection] == constants.LabelIstioInjectionDefault &&
+					namespace.Labels[constants.LabelVerrazzanoManaged] == constants.LabelVerrazzanoManagedDefault &&
+					namespace.Labels["label2"] == "test2" &&
+					len(namespace.Labels) == 3
+			}
+			return false
+		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 	ginkgo.It("Apply VerrazzanoProject to override default verrazzano labels", func() {
 		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml")
@@ -183,6 +193,16 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 				return namespace.Labels[constants.LabelIstioInjection] == "disabled" &&
 					namespace.Labels[constants.LabelVerrazzanoManaged] == "false" &&
 					namespace.Labels["label1"] == "test1" &&
+					len(namespace.Labels) == 3
+			}
+			return false
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			namespace, err := K8sClient.GetNamespace("test-namespace-2")
+			if err == nil {
+				return namespace.Labels[constants.LabelIstioInjection] == constants.LabelIstioInjectionDefault &&
+					namespace.Labels[constants.LabelVerrazzanoManaged] == constants.LabelVerrazzanoManagedDefault &&
+					namespace.Labels["label2"] == "test2" &&
 					len(namespace.Labels) == 3
 			}
 			return false

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -167,7 +167,9 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 			namespace, err := K8sClient.GetNamespace("test-namespace-1")
 			if err == nil {
 				return namespace.Labels[constants.LabelIstioInjection] == constants.LabelIstioInjectionDefault &&
-					namespace.Labels[constants.LabelVerrazzanoManaged] == constants.LabelVerrazzanoManagedDefault
+					namespace.Labels[constants.LabelVerrazzanoManaged] == constants.LabelVerrazzanoManagedDefault &&
+					namespace.Labels["label1"] == "test1" &&
+					len(namespace.Labels) == 3
 			}
 			return false
 		}, timeout, pollInterval).Should(gomega.BeTrue())
@@ -179,7 +181,9 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 			namespace, err := K8sClient.GetNamespace("test-namespace-1")
 			if err == nil {
 				return namespace.Labels[constants.LabelIstioInjection] == "disabled" &&
-					namespace.Labels[constants.LabelVerrazzanoManaged] == "false"
+					namespace.Labels[constants.LabelVerrazzanoManaged] == "false" &&
+					namespace.Labels["label1"] == "test1" &&
+					len(namespace.Labels) == 3
 			}
 			return false
 		}, timeout, pollInterval).Should(gomega.BeTrue())

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_default_labels.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_default_labels.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: VerrazzanoProject
+metadata:
+  name: test-namespaces
+  namespace: verrazzano-mc
+spec:
+  template:
+    namespaces:
+      - metadata:
+          name: test-namespace-1
+          labels:
+            label1: "test1"
+          annotations:
+            annot1: "test1"
+      - metadata:
+          name: test-namespace-2
+          labels:
+            label2: "test2"
+          annotations:
+            annot2: "test2"

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: VerrazzanoProject
+metadata:
+  name: test-namespaces
+  namespace: verrazzano-mc
+spec:
+  template:
+    namespaces:
+      - metadata:
+          name: test-namespace-1
+          labels:
+            label1: "test1"
+            istio-injection: "disabled"
+            verrazzano-managed: "false"
+          annotations:
+            annot1: "test1"
+      - metadata:
+          name: test-namespace-2
+          labels:
+            label2: "test2"
+          annotations:
+            annot2: "test2"


### PR DESCRIPTION
# Description

Apply the verrazzano required labels to namespaces that are created or updated for a VerrazzanoProject.  Each namespace will get the following labels applied:

- verrazzno-managed: true
- istio-injection: enabled

However, if a user specifies these labels in the VerrazzanoProject resource, the customer supplied value wins.

Fixes VZ-2226

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
