### PR TITLE
VZ-2227: Add support for rolebindings in multi-cluster project namespaces

### DIFF
--- a/application-operator/test/integ/k8s/resource.go
+++ b/application-operator/test/integ/k8s/resource.go
@@ -44,6 +44,12 @@ func (c Client) DoesClusterRoleBindingExist(name string) bool {
 	return procExistsStatus(err, "ClusterRoleBinding")
 }
 
+// DoesRoleBindingExist returns true if the given RoleBinding exists
+func (c Client) DoesRoleBindingExist(name string, namespace string) bool {
+	_, err := c.clientset.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return procExistsStatus(err, "RoleBinding")
+}
+
 // DoesNamespaceExist returns true if the given Namespace exists
 func (c Client) DoesNamespaceExist(name string) bool {
 	_, err := c.clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})

--- a/application-operator/test/integ/k8s/resource.go
+++ b/application-operator/test/integ/k8s/resource.go
@@ -44,10 +44,19 @@ func (c Client) DoesClusterRoleBindingExist(name string) bool {
 	return procExistsStatus(err, "ClusterRoleBinding")
 }
 
-// DoesRoleBindingExist returns true if the given RoleBinding exists
-func (c Client) DoesRoleBindingExist(name string, namespace string) bool {
-	_, err := c.clientset.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	return procExistsStatus(err, "RoleBinding")
+// DoesRoleBindingContainSubject returns true if the RoleBinding exists and it contains the
+// specified subject
+func (c Client) DoesRoleBindingContainSubject(name, namespace, subjectKind, subjectName string) bool {
+	rb, err := c.clientset.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if exists := procExistsStatus(err, "RoleBinding"); !exists {
+		return false
+	}
+	for _, s := range rb.Subjects {
+		if s.Kind == subjectKind && s.Name == subjectName {
+			return true
+		}
+	}
+	return false
 }
 
 // DoesNamespaceExist returns true if the given Namespace exists

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -210,6 +210,27 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 	})
 })
 
+var _ = ginkgo.Describe("Testing VerrazzanoProject rolebinding generation", func() {
+	ginkgo.It("Apply VerrazzanoProject and validate rolebindings are created", func() {
+		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_sample.yaml")
+		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be created successfully")
+
+		// expect two admin and two monitor rolebindings
+		gomega.Eventually(func() bool {
+			return K8sClient.DoesRoleBindingExist("verrazzano-project-admin", "multiclustertest")
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			return K8sClient.DoesRoleBindingExist("admin", "multiclustertest")
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			return K8sClient.DoesRoleBindingExist("verrazzano-project-monitor", "multiclustertest")
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() bool {
+			return K8sClient.DoesRoleBindingExist("view", "multiclustertest")
+		}, timeout, pollInterval).Should(gomega.BeTrue())
+	})
+})
+
 func appConfigExistsWithFields(namespace string, name string, multiClusterAppConfig *clustersv1alpha1.MultiClusterApplicationConfiguration) bool {
 	fmt.Printf("Looking for OAM app config %v/%v\n", namespace, name)
 	appConfig, err := K8sClient.GetOAMAppConfig(namespace, name)

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_sample.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_sample.yaml
@@ -20,3 +20,11 @@ spec:
             label2: "test2"
           annotations:
             annot2: "test2"
+    security:
+      projectAdminSubjects:
+        - kind: User
+          name: test-user
+      projectMonitorSubjects:
+        - kind: Group
+          name: test-viewers
+

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_update_rolebindings.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_update_rolebindings.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: VerrazzanoProject
+metadata:
+  name: myvzproj
+  namespace: verrazzano-mc
+spec:
+  template:
+    namespaces:
+      - metadata:
+          name: multiclustertest
+          labels:
+            label1: "test1"
+          annotations:
+            annot1: "test1"
+      - metadata:
+          name: some-other-ns
+          labels:
+            label2: "test2"
+          annotations:
+            annot2: "test2"
+    security:
+      projectAdminSubjects:
+        - kind: User
+          name: test-NEW-user
+      projectMonitorSubjects:
+        - kind: Group
+          name: test-NEW-viewers
+


### PR DESCRIPTION
# Description

This PR adds support for rolebindings in multi-cluster project namespaces. The VerrazzanoProject CR supports two optional lists of security subjects, one for admins and one for monitors. If the Project specifies subjects, we create up to four rolebindings per namespace. Admins are bound to the `verrazzano-project-admin` role as well as the cluster `admin` role. Monitor subjects are bound to the `verrazzano-project-monitor` role as well as the cluster `view` role.

I tested this manually by creating admin and managed clusters and applying a VerrazzanoProject YAML containing both admin and monitor subjects. I validated that the rolebindings were created in the project namespaces. For example:

```
$ k get rolebindings -n fred4
NAME                         ROLE                                     AGE
admin                        ClusterRole/admin                        54s
verrazzano-project-admin     ClusterRole/verrazzano-project-admin     55s
verrazzano-project-monitor   ClusterRole/verrazzano-project-monitor   54s
view                         ClusterRole/view                         54s
```

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
