### PR TITLE
Change Istio install for prometheus metrics

### DIFF
--- a/platform-operator/helm_config/overrides/istio-values.yaml
+++ b/platform-operator/helm_config/overrides/istio-values.yaml
@@ -38,5 +38,10 @@ prometheus:
   hub: ghcr.io/verrazzano
   tag: v2.13.1
 
+meshConfig:
+  enablePrometheusMerge: false
+  defaultConfig:
+    proxyMetadata: {}
+
 sidecarInjectorWebhook:
   rewriteAppHTTPProbe: true


### PR DESCRIPTION
# Description

This pull request changes the Istio install to not merge Prometheus metrics.   See https://istio.io/v1.7/docs/ops/integrations/prometheus/ for more details.  Without this change,  Prometheus annotations are overwritten and WLS metrics are not scraped when in the Istio mesh.

Also, unrelated I removed the creation of the admission controller certs since the admission controller is no longer deployed.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
