### PR TITLE
Enable Verrazzano to use MC resources after install, without having to register the MC YAML

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -16,6 +16,10 @@ const MCAgentSecret = "verrazzano-cluster-agent"
 // MCRegistrationSecret - the name of the secret that contains the cluster registration information
 const MCRegistrationSecret = "verrazzano-cluster-registration"
 
+// MCLocalRegistrationSecret - the name of the local secret that contains the cluster registration information.
+// Thos is created at Verrazzano install.
+const MCLocalRegistrationSecret = "verrazzano-local-registration"
+
 // AdminKubeconfigData - the field name in MCRegistrationSecret that contains the admin cluster's kubeconfig
 const AdminKubeconfigData = "admin-kubeconfig"
 

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -6,7 +6,6 @@ package clusters
 import (
 	"context"
 	"fmt"
-	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -16,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )

--- a/application-operator/controllers/clusters/cluster_utils_test.go
+++ b/application-operator/controllers/clusters/cluster_utils_test.go
@@ -83,22 +83,39 @@ func TestFetchManagedClusterElasticSearchDetails_DoesNotExist(t *testing.T) {
 // GIVEN The managed cluster registration secret exists
 // WHEN GetClusterName function is called
 // THEN expect the managed-cluster-name from the secret to be returned
-// GIVEN the managed cluster secret does not exist
+// GIVEN the managed cluster secret does not exist but the local resgistration secret does
+// WHEN GetClusterName function is called
+// THEN expect that managed-cluster-name from the local secret to be returned
+// GIVEN the managed cluster secret and the local do not exist
 // WHEN GetClusterName function is called
 // THEN expect that empty string is returned
 func TestGetClusterName(t *testing.T) {
 	mocker := gomock.NewController(t)
 	cli := mocks.NewMockClient(mocker)
 
-	expectMCRegistrationSecret(cli, "mycluster1", 1)
+	expectMCRegistrationSecret(cli, "mycluster1", MCRegistrationSecretFullName.Namespace, 1)
 
 	name := GetClusterName(context.TODO(), cli)
 	asserts.Equal(t, "mycluster1", name)
 
-	// Repeat test for registration secret not found
+	// Repeat test for registration secret not found, then local registration secret should be used
 	cli.EXPECT().
 		Get(gomock.Any(), MCRegistrationSecretFullName, gomock.Not(gomock.Nil())).
 		Return(kerr.NewNotFound(schema.ParseGroupResource("Secret"), MCRegistrationSecretFullName.Name))
+
+	expectMCRegistrationSecret(cli, "mycluster1", MCLocalRegistrationSecretFullName.Namespace, 1)
+
+	name = GetClusterName(context.TODO(), cli)
+	asserts.Equal(t, "mycluster1", name)
+
+	// Repeat test for registration secret and local secret not found
+	cli.EXPECT().
+		Get(gomock.Any(), MCRegistrationSecretFullName, gomock.Not(gomock.Nil())).
+		Return(kerr.NewNotFound(schema.ParseGroupResource("Secret"), MCRegistrationSecretFullName.Name))
+
+	cli.EXPECT().
+		Get(gomock.Any(), MCLocalRegistrationSecretFullName, gomock.Not(gomock.Nil())).
+		Return(kerr.NewNotFound(schema.ParseGroupResource("Secret"), MCLocalRegistrationSecretFullName.Name))
 
 	name = GetClusterName(context.TODO(), cli)
 	asserts.Equal(t, "", name)
@@ -164,7 +181,7 @@ func TestIsPlacedInThisCluster(t *testing.T) {
 	placementWithMyCluster := clustersv1alpha1.Placement{Clusters: []clustersv1alpha1.Cluster{{Name: "othercluster"}, {Name: "mycluster"}}}
 	placementNotMyCluster := clustersv1alpha1.Placement{Clusters: []clustersv1alpha1.Cluster{{Name: "othercluster"}, {Name: "NOTmycluster"}}}
 
-	expectMCRegistrationSecret(cli, "mycluster", 3)
+	expectMCRegistrationSecret(cli, "mycluster", constants.MCRegistrationSecret, 3)
 
 	asserts.True(t, IsPlacedInThisCluster(context.TODO(), cli, placementOnlyMyCluster))
 	asserts.True(t, IsPlacedInThisCluster(context.TODO(), cli, placementWithMyCluster))
@@ -360,7 +377,7 @@ func TestUpdateClusterLevelStatus(t *testing.T) {
 
 }
 
-func expectMCRegistrationSecret(cli *mocks.MockClient, clusterName string, times int) {
+func expectMCRegistrationSecret(cli *mocks.MockClient, clusterName string, secreteName string, times int) {
 	regSecretData := map[string][]byte{constants.ClusterNameData: []byte(clusterName)}
 	cli.EXPECT().
 		Get(gomock.Any(), MCRegistrationSecretFullName, gomock.Not(gomock.Nil())).

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -276,7 +276,7 @@ func configMapExistsMatchingMCConfigMap(namespace, name string, mcConfigMap *clu
 		reflect.DeepEqual(configMap.BinaryData, mcConfigMap.Spec.Template.BinaryData)
 }
 
-func createManagedClusterSecret() {
+func createRegistrationSecret() {
 	createSecret := fmt.Sprintf(
 		"create secret generic %s --from-literal=%s=%s -n %s",
 		constants.MCRegistrationSecret,
@@ -328,5 +328,5 @@ func setupMultiClusterTest() {
 		ginkgo.Fail(fmt.Sprintf("failed to create namespace %v", multiclusterTestNamespace))
 	}
 
-	createManagedClusterSecret()
+	createRegistrationSecret()
 }

--- a/platform-operator/config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/config/crd/bases/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -43,13 +43,6 @@ spec:
             description: VerrazzanoManagedClusterSpec defines the desired state of
               VerrazzanoManagedCluster
             properties:
-              clusterRegistrationSecret:
-                description: The name of the generated secret that contains the kubeconfig
-                  to be used by the cluster agent to connect to admin cluster.  This
-                  secret will also contain other fields needed by the agent, such
-                  as the managed cluster name. This field is managed by a Verrazzano
-                  Kubernetes operator.
-                type: string
               description:
                 description: The description of the managed cluster.
                 type: string

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -28,3 +28,6 @@ const MCRegistrationSecret = "verrazzano-cluster-registration"
 
 // MCClusterRole is the role name for the role used during VMC reconcile
 const MCClusterRole = "verrazzano-managed-cluster"
+
+// MCLocalCluster is the name of the local cluster
+const MCLocalCluster = "local"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -26,6 +26,10 @@ const MCElasticsearchSecret = "verrazzano-cluster-elasticsearch"
 // managed cluster name.
 const MCRegistrationSecret = "verrazzano-cluster-registration"
 
+// MCLocalRegistrationSecret - the name of the local secret that contains the cluster registration information.
+// Thos is created at Verrazzano install.
+const MCLocalRegistrationSecret = "verrazzano-local-registration"
+
 // MCClusterRole is the role name for the role used during VMC reconcile
 const MCClusterRole = "verrazzano-managed-cluster"
 

--- a/platform-operator/controllers/clusters/secret_keys.go
+++ b/platform-operator/controllers/clusters/secret_keys.go
@@ -3,15 +3,29 @@
 
 package clusters
 
+// CaCrtKey is the CA cert key in the system-tls secret
+const CaCrtKey = "ca.crt"
+
+// CaBundleKey is the CA cert key in the Elasticsearch secret
+const CaBundleKey = "ca-bundle"
+
+// KubeconfigKey is the kubeconfig key
 const KubeconfigKey = "admin-kubeconfig"
+
+// ManagedClusterNameKey is the key for the managed cluster name
 const ManagedClusterNameKey = "managed-cluster-name"
 
-const CaCrtKey = "ca.crt"
-const CaBundleKey = "ca-bundle"
+// PasswordKey is the password key
 const PasswordKey = "password"
+
+// UsernameKey is the username key
 const UsernameKey = "username"
+
+// TokenKey is the key for the service account token
 const TokenKey = "token"
 
-const UrlKey = "url"
+// URLKey is the key for a URL
+const URLKey = "url"
 
+// YamlKey is the key for YAML that can be applied using kubectl
 const YamlKey = "yaml"

--- a/platform-operator/controllers/clusters/secret_keys.go
+++ b/platform-operator/controllers/clusters/secret_keys.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package clusters
+
+const KubeconfigKey = "admin-kubeconfig"
+const ManagedClusterNameKey = "managed-cluster-name"
+
+const CaCrtKey = "ca.crt"
+const CaBundleKey = "ca-bundle"
+const PasswordKey = "password"
+const UsernameKey = "username"
+const TokenKey = "token"
+
+const UrlKey = "url"
+
+const YamlKey = "yaml"

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"
@@ -17,11 +17,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
-)
-
-const (
-	kubeconfigKey         = "admin-kubeconfig"
-	managedClusterNameKey = "managed-cluster-name"
 )
 
 // Needed for unit testing
@@ -86,7 +81,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	}
 
 	// Load the kubeconfig struct
-	token := secret.Data["token"]
+	token := secret.Data[TokenKey]
 	b64Cert, err := getB64CAData(config)
 	if err != nil {
 		return err
@@ -137,8 +132,8 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateAgentSecret(vmc *clus
 func (r *VerrazzanoManagedClusterReconciler) mutateAgentSecret(secret *corev1.Secret, kubeconfig string, manageClusterName string) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		kubeconfigKey:         []byte(kubeconfig),
-		managedClusterNameKey: []byte(manageClusterName),
+		KubeconfigKey:         []byte(kubeconfig),
+		ManagedClusterNameKey: []byte(manageClusterName),
 	}
 	return nil
 }

--- a/platform-operator/controllers/clusters/sync_es_secret.go
+++ b/platform-operator/controllers/clusters/sync_es_secret.go
@@ -41,7 +41,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncElasticsearchSecret(vmc *cluste
 	secretData[CaBundleKey] = tlsSecret.Data[CaCrtKey]
 	secretData[UsernameKey] = vzSecret.Data[UsernameKey]
 	secretData[PasswordKey] = vzSecret.Data[PasswordKey]
-	secretData[UrlKey] = []byte(url)
+	secretData[URLKey] = []byte(url)
 
 	// Create/update the Elasticsearch secret
 	_, err = r.createOrUpdateElasticsearchSecret(vmc, secretData)

--- a/platform-operator/controllers/clusters/sync_es_secret.go
+++ b/platform-operator/controllers/clusters/sync_es_secret.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"
@@ -16,12 +16,7 @@ import (
 )
 
 const (
-	caCrtKey    = "ca.crt"
-	caBundleKey = "ca-bundle"
-	passwordKey = "password"
-	usernameKey = "username"
-	urlKey      = "url"
-	vmiIngest   = "vmi-system-es-ingest"
+	vmiIngest = "vmi-system-es-ingest"
 )
 
 // Create a Elasticsearch secret that has the fields needed to send logs from the
@@ -43,10 +38,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncElasticsearchSecret(vmc *cluste
 
 	// Build the secret data
 	secretData := make(map[string][]byte)
-	secretData[caBundleKey] = tlsSecret.Data[caCrtKey]
-	secretData[usernameKey] = vzSecret.Data[usernameKey]
-	secretData[passwordKey] = vzSecret.Data[passwordKey]
-	secretData[urlKey] = []byte(url)
+	secretData[CaBundleKey] = tlsSecret.Data[CaCrtKey]
+	secretData[UsernameKey] = vzSecret.Data[UsernameKey]
+	secretData[PasswordKey] = vzSecret.Data[PasswordKey]
+	secretData[UrlKey] = []byte(url)
 
 	// Create/update the Elasticsearch secret
 	_, err = r.createOrUpdateElasticsearchSecret(vmc, secretData)

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	yamlKey = "yaml"
 	yamlSep = "---\n"
 )
 
@@ -92,7 +91,7 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateManifestSecret(vmc *c
 func (r *VerrazzanoManagedClusterReconciler) mutateManifestSecret(secret *corev1.Secret, yamlData string) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		yamlKey: []byte(yamlData),
+		YamlKey: []byte(yamlData),
 	}
 	return nil
 }

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"
@@ -42,7 +42,7 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateRegistrationSecret(vm
 func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *corev1.Secret, manageClusterName string) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		managedClusterNameKey: []byte(manageClusterName),
+		ManagedClusterNameKey: []byte(manageClusterName),
 	}
 	return nil
 }

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -71,42 +71,42 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 	log.Infof("Syncing the ServiceAccount for VMC %s", vmc.Name)
 	err = r.syncServiceAccount(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the ServiceAccount: %v", err)
+		log.Errorf("Failed to sync the ServiceAccount: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	log.Infof("Syncing the RoleBinding for VMC %s", vmc.Name)
 	err = r.syncManagedRoleBinding(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the RoleBinding: %v", err)
+		log.Errorf("Failed to sync the RoleBinding: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	log.Infof("Syncing the Agent secret for VMC %s", vmc.Name)
 	err = r.syncAgentSecret(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the agent secret: %v", err)
+		log.Errorf("Failed to sync the agent secret: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	log.Infof("Syncing the Registration secret for VMC %s", vmc.Name)
 	err = r.syncRegistrationSecret(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the registration secret: %v", err)
+		log.Errorf("Failed to sync the registration secret: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	log.Infof("Syncing the Elasticsearch secret for VMC %s", vmc.Name)
 	err = r.syncElasticsearchSecret(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the Elasticsearch secret: %v", err)
+		log.Errorf("Failed to sync the Elasticsearch secret: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	log.Infof("Syncing the Manifest secret for VMC %s", vmc.Name)
 	err = r.syncManifestSecret(vmc)
 	if err != nil {
-		log.Infof("Failed to sync the Manifest secret: %v", err)
+		log.Errorf("Failed to sync the Manifest secret: %v", err)
 		return ctrl.Result{}, err
 	}
 

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -342,7 +342,7 @@ func expectSyncElasticsearch(t *testing.T, mock *mocks.MockClient, name string) 
 			asserts.Equalf(userData, string(user), "Incorrect user in Elasticsearch secret ")
 			pw, _ := secret.Data[PasswordKey]
 			asserts.Equalf(passwordData, string(pw), "Incorrect password in Elasticsearch secret ")
-			url, _ := secret.Data[UrlKey]
+			url, _ := secret.Data[URLKey]
 			asserts.Equalf(urlData, string(url), "Incorrect URL in Elasticsearch secret ")
 			return nil
 		})
@@ -386,7 +386,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, name string) {
 				CaCrtKey:    []byte(caData),
 				UsernameKey: []byte(userData),
 				PasswordKey: []byte(passwordData),
-				UrlKey:      []byte(urlData),
+				URLKey:      []byte(urlData),
 			}
 			return nil
 		})

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package controllers
+package clusters
 
 import (
 	"context"
@@ -37,7 +37,6 @@ apiEndpoints:
     bindPort: 6443
 `
 const (
-	tokenKey           = "token"
 	token              = "tokenData"
 	managedClusterData = "cluster1"
 )
@@ -236,7 +235,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: saSecretName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				tokenKey: []byte(token),
+				TokenKey: []byte(token),
 			}
 			return nil
 		})
@@ -276,7 +275,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
 			secret.Data = map[string][]byte{
-				managedClusterNameKey: []byte(managedClusterData),
+				ManagedClusterNameKey: []byte(managedClusterData),
 			}
 			return nil
 		})
@@ -312,8 +311,8 @@ func expectSyncElasticsearch(t *testing.T, mock *mocks.MockClient, name string) 
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				usernameKey: []byte(userData),
-				passwordKey: []byte(passwordData),
+				UsernameKey: []byte(userData),
+				PasswordKey: []byte(passwordData),
 			}
 			return nil
 		})
@@ -323,7 +322,7 @@ func expectSyncElasticsearch(t *testing.T, mock *mocks.MockClient, name string) 
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.SystemTLS}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				caCrtKey: []byte(caData),
+				CaCrtKey: []byte(caData),
 			}
 			return nil
 		})
@@ -337,13 +336,13 @@ func expectSyncElasticsearch(t *testing.T, mock *mocks.MockClient, name string) 
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			ca, _ := secret.Data[caBundleKey]
+			ca, _ := secret.Data[CaBundleKey]
 			asserts.Equalf(caData, string(ca), "Incorrect cadata in Elasticsearch secret ")
-			user, _ := secret.Data[usernameKey]
+			user, _ := secret.Data[UsernameKey]
 			asserts.Equalf(userData, string(user), "Incorrect user in Elasticsearch secret ")
-			pw, _ := secret.Data[passwordKey]
+			pw, _ := secret.Data[PasswordKey]
 			asserts.Equalf(passwordData, string(pw), "Incorrect password in Elasticsearch secret ")
-			url, _ := secret.Data[urlKey]
+			url, _ := secret.Data[UrlKey]
 			asserts.Equalf(urlData, string(url), "Incorrect URL in Elasticsearch secret ")
 			return nil
 		})
@@ -364,7 +363,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetAgentSecretName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				kubeconfigKey: []byte(kubeconfigData),
+				KubeconfigKey: []byte(kubeconfigData),
 			}
 			return nil
 		})
@@ -374,7 +373,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetRegistrationSecretName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				managedClusterNameKey: []byte(clusterName),
+				ManagedClusterNameKey: []byte(clusterName),
 			}
 			return nil
 		})
@@ -384,10 +383,10 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetElasticsearchSecretName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				caCrtKey:    []byte(caData),
-				usernameKey: []byte(userData),
-				passwordKey: []byte(passwordData),
-				urlKey:      []byte(urlData),
+				CaCrtKey:    []byte(caData),
+				UsernameKey: []byte(userData),
+				PasswordKey: []byte(passwordData),
+				UrlKey:      []byte(urlData),
 			}
 			return nil
 		})
@@ -401,7 +400,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, name string) {
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			data, _ := secret.Data[yamlKey]
+			data, _ := secret.Data[YamlKey]
 			asserts.NotZero(len(data), "Expected yaml data in manifest secret")
 			return nil
 		})

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -94,6 +94,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, nil
 	}
 
+	// Sync the local cluster registration secret that allows the use of MCxyz resources on the
+	// admin cluster without needing a VMC.
+	if err := r.syncLocalRegistrationSecret(vz); err != nil {
+		log.Errorf("Failed to sync the local registration secret: %v", err)
+		return reconcile.Result{}, err
+	}
+
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(vz.Status) {
 		// If the version is specified and different than the current version of the installation

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -94,13 +94,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, nil
 	}
 
-	// Sync the local cluster registration secret that allows the use of MCxyz resources on the
-	// admin cluster without needing a VMC.
-	if err := r.syncLocalRegistrationSecret(vz); err != nil {
-		log.Errorf("Failed to sync the local registration secret: %v", err)
-		return reconcile.Result{}, err
-	}
-
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(vz.Status) {
 		// If the version is specified and different than the current version of the installation
@@ -110,6 +103,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		// nothing to do, installation already at target version
 		return ctrl.Result{}, nil
+	}
+
+	// Sync the local cluster registration secret that allows the use of MCxyz resources on the
+	// admin cluster without needing a VMC.
+	if err := r.syncLocalRegistrationSecret(vz); err != nil {
+		log.Errorf("Failed to sync the local registration secret: %v", err)
+		return reconcile.Result{}, err
 	}
 
 	if err := r.createServiceAccount(ctx, log, vz); err != nil {

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verrazzano
+
+import (
+	"context"
+	"fmt"
+	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Create a registration secret in the verrazzano-system namespace, with the managed cluster information.
+// This secret will be used on the admin cluster to get information about itself, like the cluster name,
+// so that the admin cluster can manage multi-cluster resources without the need of a VMC.  In the
+// case of a cluster that is used as a managed cluster, this secret will still be created, but not used, and
+// ultimately replaced when the user applies the managed cluster YAML which has the replacement secret.
+func (r *Reconciler) syncLocalRegistrationSecret(vz *installv1alpha1.Verrazzano) error {
+
+	// If the agent secret exists in verrazzano-system namespace then that means this
+	// is a managed cluster and the user applied the YAML to create all the secrets.
+	// In that case, we do NOT want to create/update this default local secret since
+	// it will override the one created by the YAML
+	var secret corev1.Secret
+	nsn := types.NamespacedName{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.MCAgentSecret,
+	}
+	// get the agent secret and return if it exists
+	err := r.Get(context.TODO(), nsn, &secret)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("Failed fetching the agent secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
+	}
+
+	_, err = r.createOrUpdateLocalRegistrationSecret(vz, constants.MCRegistrationSecret, constants.VerrazzanoSystemNamespace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create or update the secret
+func (r *Reconciler) createOrUpdateLocalRegistrationSecret(vz *installv1alpha1.Verrazzano, name string, namespace string) (controllerutil.OperationResult, error) {
+	var secret corev1.Secret
+	secret.Namespace = namespace
+	secret.Name = name
+
+	return controllerutil.CreateOrUpdate(context.TODO(), r.Client, &secret, func() error {
+		r.mutateLocalRegistrationSecret(&secret)
+		// This SetControllerReference call will trigger garbage collection i.e. the secret
+		// will automatically get deleted when the VerrazzanoManagedCluster is deleted
+		return controllerutil.SetControllerReference(vz, &secret, r.Scheme)
+	})
+}
+
+// Mutate the secret, setting the kubeconfig data
+func (r *Reconciler) mutateLocalRegistrationSecret(secret *corev1.Secret) error {
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		clusters.ManagedClusterNameKey: []byte(constants.MCLocalCluster),
+	}
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -40,7 +40,8 @@ func (r *Reconciler) syncLocalRegistrationSecret(vz *installv1alpha1.Verrazzano)
 		return fmt.Errorf("Failed fetching the agent secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
 	}
 
-	_, err = r.createOrUpdateLocalRegistrationSecret(vz, constants.MCRegistrationSecret, constants.VerrazzanoSystemNamespace)
+	// create the local registration secret
+	_, err = r.createOrUpdateLocalRegistrationSecret(vz, constants.MCLocalRegistrationSecret, constants.VerrazzanoSystemNamespace)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -56,9 +56,9 @@ func (r *Reconciler) createOrUpdateLocalRegistrationSecret(vz *installv1alpha1.V
 
 	return controllerutil.CreateOrUpdate(context.TODO(), r.Client, &secret, func() error {
 		r.mutateLocalRegistrationSecret(&secret)
-		// This SetControllerReference call will trigger garbage collection i.e. the secret
-		// will automatically get deleted when the VerrazzanoManagedCluster is deleted
-		return controllerutil.SetControllerReference(vz, &secret, r.Scheme)
+		// Verrrazzano resource cannot own this secret since it is in a different namespace
+		// The secret will get deleted when verrazzano-system namespace is deleted.
+		return nil
 	})
 }
 

--- a/platform-operator/deploy/operator.yaml
+++ b/platform-operator/deploy/operator.yaml
@@ -3314,13 +3314,6 @@ spec:
             description: VerrazzanoManagedClusterSpec defines the desired state of
               VerrazzanoManagedCluster
             properties:
-              clusterRegistrationSecret:
-                description: The name of the generated secret that contains the kubeconfig
-                  to be used by the cluster agent to connect to admin cluster.  This
-                  secret will also contain other fields needed by the agent, such
-                  as the managed cluster name. This field is managed by a Verrazzano
-                  Kubernetes operator.
-                type: string
               description:
                 description: The description of the managed cluster.
                 type: string


### PR DESCRIPTION
# Description

Enable Verrazzano to use MC resources after install, without having to register the MC YAML.  This is done by creating a local registration secret with the cluster name that is overridden by the MC registration secret once a user applies the YAML.  Also, add to the constants files and make the controllers/clusters package name consistent.

Fixes VZ-2213

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
