### PR TITLE
Watch for changes in the registration secret

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -166,14 +166,14 @@ export VERRAZZANO_APP_OP_IMAGE=${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 .PHONY: setup-cluster
 setup-cluster: create-cluster
 	echo 'Load Docker image for the OAM runtime...'
-	docker pull ${OAM_RUNTIME_IMAGE}
-	kind load docker-image --name ${CLUSTER_NAME} ${OAM_RUNTIME_IMAGE}
+	time docker pull ${OAM_RUNTIME_IMAGE}
+	time kind load docker-image --name ${CLUSTER_NAME} ${OAM_RUNTIME_IMAGE}
 
 	echo 'Load Docker image for the Verrazzano application operator...'
-	kind load docker-image --name ${CLUSTER_NAME} ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+	time kind load docker-image --name ${CLUSTER_NAME} ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 
 	echo 'Install OAM runtime and Verrazzano application operator...'
-	installer/install.sh || (echo 'Application operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d ${CLUSTER_DUMP_LOCATION}; exit 1)
+	time installer/install.sh || (echo 'Application operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d ${CLUSTER_DUMP_LOCATION}; exit 1)
 
 .PHONY: integ-test
 integ-test: setup-cluster

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -3,6 +3,9 @@
 
 package constants
 
+// VerrazzanoClustersGroup - clusters group
+const VerrazzanoClustersGroup = "clusters.verrazzano.io"
+
 // VerrazzanoSystemNamespace is the system namespace for verrazzano
 const VerrazzanoSystemNamespace = "verrazzano-system"
 

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -10,11 +10,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
-
 	"github.com/go-logr/logr"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -72,7 +71,7 @@ func (s *Syncer) ProcessAgentThread() error {
 	// The cluster secret exists - log the cluster name only if it changes
 	managedClusterName := string(secret.Data[constants.ClusterNameData])
 	if managedClusterName != s.ManagedClusterName {
-		s.Log.Info(fmt.Sprintf("Found secret named %s in namespace %s for cluster named %q", secret.Name, secret.Namespace, managedClusterName))
+		s.Log.Info(fmt.Sprintf("Found secret named %s in namespace %s, cluster name changed from %q to %q", secret.Name, secret.Namespace, s.ManagedClusterName, managedClusterName))
 		s.ManagedClusterName = managedClusterName
 	}
 

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -60,11 +60,10 @@ func (s *Syncer) ProcessAgentThread() error {
 			s.AgentSecretFound = false
 		}
 		return nil
-	} else {
-		err := validateAgentSecret(&secret)
-		if err != nil {
-			return fmt.Errorf("secret validation failed: %v", err)
-		}
+	}
+	err = validateAgentSecret(&secret)
+	if err != nil {
+		return fmt.Errorf("secret validation failed: %v", err)
 	}
 
 	// Remember the secret had been found in order to notice if it gets deleted

--- a/application-operator/mcagent/mcagent_common.go
+++ b/application-operator/mcagent/mcagent_common.go
@@ -13,11 +13,13 @@ import (
 
 // Syncer contains context for synchronize operations
 type Syncer struct {
-	AdminClient        client.Client
-	LocalClient        client.Client
-	Log                logr.Logger
-	ManagedClusterName string
-	Context            context.Context
+	AdminClient           client.Client
+	LocalClient           client.Client
+	Log                   logr.Logger
+	ManagedClusterName    string
+	Context               context.Context
+	AgentSecretFound      bool
+	SecretResourceVersion string
 
 	// List of namespaces to watch for multi-cluster objects.
 	ProjectNamespaces []string

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -23,8 +23,9 @@ import (
 
 var validSecret = corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      constants.MCAgentSecret,
-		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:            constants.MCAgentSecret,
+		Namespace:       constants.VerrazzanoSystemNamespace,
+		ResourceVersion: "version1",
 	},
 	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), constants.AdminKubeconfigData: []byte("kubeconfig")},
 }
@@ -51,6 +52,7 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.ObjectMeta = validSecret.ObjectMeta
 			secret.Data = validSecret.Data
+			secret.ResourceVersion = validSecret.ResourceVersion
 			return nil
 		})
 
@@ -75,6 +77,7 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 	adminMocker.Finish()
 	mcMocker.Finish()
 	assert.NoError(err)
+	assert.Equal(validSecret.ResourceVersion, s.SecretResourceVersion)
 }
 
 // TestProcessAgentThreadSecretDeleted tests agent thread when the registration secret is deleted

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -23,9 +23,8 @@ import (
 
 var validSecret = corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:            constants.MCAgentSecret,
-		Namespace:       constants.VerrazzanoSystemNamespace,
-		ResourceVersion: "version1",
+		Name:      constants.MCAgentSecret,
+		Namespace: constants.VerrazzanoSystemNamespace,
 	},
 	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), constants.AdminKubeconfigData: []byte("kubeconfig")},
 }
@@ -52,7 +51,6 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.ObjectMeta = validSecret.ObjectMeta
 			secret.Data = validSecret.Data
-			secret.ResourceVersion = validSecret.ResourceVersion
 			return nil
 		})
 

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -5,15 +5,35 @@ package mcagent
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestProcessAgentThread(t *testing.T) {
+var validSecret = corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      constants.MCAgentSecret,
+		Namespace: constants.VerrazzanoSystemNamespace,
+	},
+	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), constants.AdminKubeconfigData: []byte("kubeconfig")},
+}
+
+// TestProcessAgentThreadNoProjects tests agent thread when no projects exist
+// GIVEN a request to process the agent loop
+// WHEN the a new VerrazzanoProjects resources exists
+// THEN ensure that there are no calls to sync any multi-cluste resources
+func TestProcessAgentThreadNoProjects(t *testing.T) {
 	assert := asserts.New(t)
 	log := ctrl.Log.WithName("test")
 
@@ -25,6 +45,22 @@ func TestProcessAgentThread(t *testing.T) {
 	adminMocker := gomock.NewController(t)
 	adminMock := mocks.NewMockClient(adminMocker)
 
+	// Managed Cluster - expect call to get the cluster registration secret.
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.MCAgentSecret}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.ObjectMeta = validSecret.ObjectMeta
+			secret.Data = validSecret.Data
+			return nil
+		})
+
+	// Admin Cluster - expect call to list VerrazzanoProject objects - return an empty list
+	adminMock.EXPECT().
+		List(gomock.Any(), &clustersv1alpha1.VerrazzanoProjectList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, list *clustersv1alpha1.VerrazzanoProjectList, opts ...*client.ListOptions) error {
+			return fmt.Errorf("no project resources found %s", exec.ErrNotFound)
+		})
+
 	// Make the request
 	s := &Syncer{
 		AdminClient:        adminMock,
@@ -32,6 +68,48 @@ func TestProcessAgentThread(t *testing.T) {
 		Log:                log,
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
+	}
+	err := s.ProcessAgentThread()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+}
+
+// TestProcessAgentThreadSecretDeleted tests agent thread when the registration secret is deleted
+// GIVEN a request to process the agent loop
+// WHEN the registration secret has been deleted
+// THEN ensure that there are no calls to get VerrazzanoProject resources
+func TestProcessAgentThreadSecretDeleted(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Managed Cluster - expect call to get the cluster registration secret.
+	mcMock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.MCAgentSecret}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			return fmt.Errorf("no project resources found %s", exec.ErrNotFound)
+		})
+
+	// Do not expect any further calls because the registration secret no longer exists
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		LocalClient:        mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+		AgentSecretFound:   true,
 	}
 	err := s.ProcessAgentThread()
 

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mcagent
+
+import "testing"
+
+func TestProcessAgentThread(t *testing.T) {
+}

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -118,5 +118,26 @@ func TestProcessAgentThreadSecretDeleted(t *testing.T) {
 	adminMocker.Finish()
 	mcMocker.Finish()
 	assert.NoError(err)
+}
 
+// TestValidateSecret tests secret validation function
+func TestValidateSecret(t *testing.T) {
+	assert := asserts.New(t)
+
+	// Valid secret
+	err := validateAgentSecret(&validSecret)
+	assert.NoError(err)
+
+	// A secret without a cluster name
+	invalidSecret := validSecret
+	invalidSecret.Data = map[string][]byte{constants.AdminKubeconfigData: []byte("kubeconfig")}
+	err = validateAgentSecret(&invalidSecret)
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", constants.ClusterNameData))
+
+	// A secret without a kubeconfig
+	invalidSecret.Data = map[string][]byte{constants.ClusterNameData: []byte("cluster1")}
+	err = validateAgentSecret(&invalidSecret)
+	assert.Error(err)
+	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", constants.AdminKubeconfigData))
 }

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -3,7 +3,41 @@
 
 package mcagent
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	asserts "github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
 
 func TestProcessAgentThread(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Managed cluster mocks
+	mcMocker := gomock.NewController(t)
+	mcMock := mocks.NewMockClient(mcMocker)
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminMock,
+		LocalClient:        mcMock,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err := s.ProcessAgentThread()
+
+	// Validate the results
+	adminMocker.Finish()
+	mcMocker.Finish()
+	assert.NoError(err)
+
 }

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -358,7 +358,7 @@ func setupMultiClusterTest() {
 		return K8sClient.IsPodRunning(applicationOperator, constants.VerrazzanoSystemNamespace)
 	}
 	gomega.Eventually(isPodRunningYet, "2m", "5s").Should(gomega.BeTrue(),
-		fmt.Sprintf("The %s pod should be in the Running state", constants.VerrazzanoSystemNamespace))
+		fmt.Sprintf("The pod %s in namespace %s should be in the Running state", applicationOperator, constants.VerrazzanoSystemNamespace))
 
 	_, stderr := util.Kubectl("create ns " + constants.VerrazzanoMultiClusterNamespace)
 	if stderr != "" {

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -321,7 +321,7 @@ func configMapExistsMatchingMCConfigMap(namespace, name string, mcConfigMap *clu
 func createRegistrationSecret() {
 	createSecret := fmt.Sprintf(
 		"create secret generic %s --from-literal=%s=%s -n %s",
-		constants.MCRegistrationSecret,
+		constants.MCAgentSecret,
 		constants.ClusterNameData,
 		managedClusterName,
 		constants.VerrazzanoSystemNamespace)

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -321,7 +321,7 @@ func configMapExistsMatchingMCConfigMap(namespace, name string, mcConfigMap *clu
 func createRegistrationSecret() {
 	createSecret := fmt.Sprintf(
 		"create secret generic %s --from-literal=%s=%s -n %s",
-		constants.MCAgentSecret,
+		constants.MCRegistrationSecret,
 		constants.ClusterNameData,
 		managedClusterName,
 		constants.VerrazzanoSystemNamespace)


### PR DESCRIPTION
# Description

Watch for changes in the registration secret.  

- If secret is deleted stop syncing multi-cluster objects
- If the secret changes, re-establish the connection to the admin cluster with the new values

Fixes VZ-2228

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
