### PR TITLE
update beats config upon multi-cluster registration change

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -10,16 +10,21 @@ import (
 	"os"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	"github.com/go-logr/logr"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const managedClusterNameEnvName = "MANAGED_CLUSTER_NAME"
 
 // StartAgent - start the agent thread for syncing multi-cluster objects
 func StartAgent(client client.Client, log logr.Logger) {
@@ -33,6 +38,7 @@ func StartAgent(client client.Client, log logr.Logger) {
 		Log:                   log,
 		Context:               context.TODO(),
 		ProjectNamespaces:     []string{},
+		ManagedClusterName:    "",
 		AgentSecretFound:      false,
 		SecretResourceVersion: "",
 	}
@@ -43,6 +49,7 @@ func StartAgent(client client.Client, log logr.Logger) {
 		if err != nil {
 			s.Log.Error(err, "error processing multi-cluster resources")
 		}
+		s.configureBeats()
 		time.Sleep(60 * time.Second)
 	}
 }
@@ -57,6 +64,7 @@ func (s *Syncer) ProcessAgentThread() error {
 		if clusters.IgnoreNotFoundWithLog("secret", err, s.Log) == nil && s.AgentSecretFound {
 			s.Log.Info(fmt.Sprintf("the secret %s in namespace %s was deleted", constants.MCAgentSecret, constants.VerrazzanoSystemNamespace))
 			s.AgentSecretFound = false
+			s.ManagedClusterName = ""
 		}
 		return nil
 	}
@@ -166,4 +174,49 @@ func getAdminClient(secret *corev1.Secret) (client.Client, error) {
 	}
 
 	return clientset, nil
+}
+
+// reconfigure beats by restarting Verrazzano Operator deployment if ManagedClusterName has been changed
+func (s *Syncer) configureBeats() {
+	// Get the verrazzano-operator deployment
+	deploymentName := types.NamespacedName{Name: "verrazzano-operator", Namespace: constants.VerrazzanoSystemNamespace}
+	deployment := appsv1.Deployment{}
+	err := s.LocalClient.Get(context.TODO(), deploymentName, &deployment)
+	if err == nil {
+		if len(deployment.Spec.Template.Spec.Containers) > 0 {
+			clusterNameEnv := getClusterNameEnvValue(deployment.Spec.Template.Spec.Containers[0].Env)
+			if clusterNameEnv != s.ManagedClusterName {
+				s.Log.Info(fmt.Sprintf("Restarting the deployment %s, cluster name changed from %q to %q", deploymentName, clusterNameEnv, s.ManagedClusterName))
+				controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &deployment, func() error {
+					deployment.Spec.Template.Spec.Containers[0].Env = updateClusterNameEnvValue(deployment.Spec.Template.Spec.Containers[0].Env, s.ManagedClusterName)
+					return nil
+				})
+			}
+		} else {
+			s.Log.Info(fmt.Sprintf("No container defined in the deployment %s", deploymentName))
+		}
+	} else {
+		s.Log.Info(fmt.Sprintf("Failed to find the deployment %s, %s", deploymentName, err.Error()))
+	}
+}
+
+// get the value for env var MANAGED_CLUSTER_NAME
+func getClusterNameEnvValue(envs []corev1.EnvVar) string {
+	for _, env := range envs {
+		if env.Name == managedClusterNameEnvName {
+			return env.Value
+		}
+	}
+	return ""
+}
+
+// update the value for env var MANAGED_CLUSTER_NAME
+func updateClusterNameEnvValue(envs []corev1.EnvVar, newValue string) []corev1.EnvVar {
+	for i, env := range envs {
+		if env.Name == managedClusterNameEnvName {
+			envs[i].Value = newValue
+			return envs
+		}
+	}
+	return append(envs, corev1.EnvVar{Name: managedClusterNameEnvName, Value: newValue})
 }

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -183,9 +183,11 @@ func (s *Syncer) configureBeats() {
 	err := s.LocalClient.Get(context.TODO(), deploymentName, &deployment)
 	if err != nil {
 		s.Log.Info(fmt.Sprintf("Failed to find the deployment %s, %s", deploymentName, err.Error()))
+		return
 	}
 	if len(deployment.Spec.Template.Spec.Containers) < 1 {
 		s.Log.Info(fmt.Sprintf("No container defined in the deployment %s", deploymentName))
+		return
 	}
 
 	// get the cluster name

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -24,6 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ENV VAR for managed cluster name in verrazzano operator
+const managedClusterNameEnvName = "MANAGED_CLUSTER_NAME"
+
+// ENV VAR for elasticsearch secret version in verrazzano operator
+const elasticsearchSecretVersionEnvName = "ES_SECRET_VERSION"
+
 // StartAgent - start the agent thread for syncing multi-cluster objects
 func StartAgent(client client.Client, log logr.Logger) {
 	// Wait for the existence of the verrazzano-cluster-agent secret.  It contains the credentials
@@ -171,9 +177,6 @@ func getAdminClient(secret *corev1.Secret) (client.Client, error) {
 
 	return clientset, nil
 }
-
-const managedClusterNameEnvName = "MANAGED_CLUSTER_NAME"
-const elasticsearchSecretVersionEnvName = "ES_SECRET_VERSION"
 
 // reconfigure beats by restarting Verrazzano Operator deployment if ManagedClusterName has been changed
 func (s *Syncer) configureBeats() {

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -194,7 +194,7 @@ func (s *Syncer) configureBeats() {
 					return
 				}
 			} else {
-				managedClusterName = regSecret.ClusterName
+				managedClusterName = string(regSecret.Data[constants.ClusterNameData])
 			}
 			clusterNameEnv := getEnvValue(deployment.Spec.Template.Spec.Containers[0].Env, managedClusterNameEnvName)
 			toUpdate = clusterNameEnv != managedClusterName

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -218,6 +218,7 @@ func (s *Syncer) configureBeats() {
 			// CreateOrUpdate updates the deployment if cluster name or es secret version changed
 			if toUpdate {
 				controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &deployment, func() error {
+					s.Log.Info(fmt.Sprintf("Update the deployment %s, cluster name from %q to %q, elasticsearch secret version from %q to %q", deploymentName, clusterNameEnv, managedClusterName, esSecertVersionEnv, esSecretVersion))
 					deployment.Spec.Template.Spec.Containers[0].Env = updateEnvValue(updateEnvValue(deployment.Spec.Template.Spec.Containers[0].Env, managedClusterNameEnvName, managedClusterName), elasticsearchSecretVersionEnvName, esSecretVersion)
 					return nil
 				})

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -316,7 +316,7 @@ func TestSyncer_configureBeats(t *testing.T) {
 				DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 					secret.Name = constants.MCRegistrationSecret
 					secret.Namespace = constants.VerrazzanoSystemNamespace
-					secret.ClusterName = newClusterName
+					secret.Data = map[string][]byte{constants.ClusterNameData: []byte(newClusterName)}
 					return nil
 				})
 

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -152,6 +152,10 @@ func TestValidateSecret(t *testing.T) {
 	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", constants.AdminKubeconfigData))
 }
 
+// Test_getEnvValue tests getEnvValue
+// GIVEN a request for a specified ENV name
+// WHEN the env array contains such an env
+// THEN returns the env value, empty string if not found
 func Test_getEnvValue(t *testing.T) {
 	testEnvs := []corev1.EnvVar{}
 	asserts.Equal(t, "", getEnvValue(testEnvs, managedClusterNameEnvName), "expected cluster name")
@@ -175,6 +179,10 @@ func Test_getEnvValue(t *testing.T) {
 	asserts.Equal(t, "cluster1", getEnvValue(testEnvs, managedClusterNameEnvName), "expected cluster name")
 }
 
+// Test_getEnvValue tests updateEnvValue
+// GIVEN a request for a specified ENV name/value
+// WHEN the env array contains such an env
+// THEN updates its value, append the env name/value if not found
 func Test_updateEnvValue(t *testing.T) {
 	testEnvs := []corev1.EnvVar{}
 	newValue := "cluster2"
@@ -229,6 +237,10 @@ func getTestDeploymentSpec(clusterName, esSecretVersion string) appsv1.Deploymen
 	}
 }
 
+// TestSyncer_configureBeats tests configuring beats by updating verrazzano operator deployment
+// GIVEN a request to configure the beats
+// WHEN the cluster name in registration secret has been changed or the elasticsearch secret has been updated
+// THEN ensure that verrazzano operator deployment is updated
 func TestSyncer_configureBeats(t *testing.T) {
 	type fields struct {
 		oldClusterName     string

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -49,7 +49,7 @@ kibana:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.12.0-20210303213135-b763444
+  imageVersion: 0.12.0-20210309234804-464b776
   prometheusPusherImage: ghcr.io/verrazzano/prometheus-pusher:1.0.1-20201016212958-5b64612
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   filebeatImage: ghcr.io/verrazzano/filebeat:6.8.3-20201016212236-05eabe44b


### PR DESCRIPTION
# Description

When the registration is updated (new reg, un-reg, cluster name updates), re-configure the beats by restarting the verrazzano operator. 

Fixes VZ-2168

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
