### PR TITLE
Update bobs example tests to test bobby-wls with default logging scope

### DIFF
--- a/examples/bobs-books/bobs-books-app.yaml
+++ b/examples/bobs-books/bobs-books-app.yaml
@@ -39,11 +39,6 @@ spec:
                 - paths:
                     - path: "/bobbys-front-end"
                       pathType: Prefix
-      scopes:
-        - scopeRef:
-            apiVersion: oam.verrazzano.io/v1alpha1
-            kind: LoggingScope
-            name: logging-scope
     - componentName: bobs-orders-wls
       traits:
         - trait:

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -220,40 +220,40 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 		})
 	})
 	ginkgo.Context("WebLogic logging.", func() {
-		indexName := "bobs-books-bobs-books-bobby-wls"
+		bobbyIndexName := "bobs-books-bobs-books-bobby-wls"
 		// GIVEN a WebLogic application with logging enabled via a logging scope
 		// WHEN the Elasticsearch index is retrieved
 		// THEN verify that it is found
 		ginkgo.It("Verify Elasticsearch index exists", func() {
 			gomega.Eventually(func() bool {
-				return pkg.LogIndexFound(indexName)
-			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+indexName)
+				return pkg.LogIndexFound(bobbyIndexName)
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+bobbyIndexName)
 		})
 		// GIVEN a WebLogic application with logging enabled via a logging scope
 		// WHEN the log records are retrieved from the Elasticsearch index
 		// THEN verify that at least one recent log record is found
 		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
 			gomega.Eventually(func() bool {
-				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+				return pkg.LogRecordFound(bobbyIndexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"domainUID":  "bobbys-front-end",
 					"serverName": "bobbys-front-end-adminserver"})
 			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
 		})
-		indexName = "bobs-books-bobs-books-bobs-orders-wls"
+		bobIndexName := "bobs-books-bobs-books-bobs-orders-wls"
 		// GIVEN a WebLogic application with logging enabled via a logging scope
 		// WHEN the Elasticsearch index is retrieved
 		// THEN verify that it is found
 		ginkgo.It("Verify Elasticsearch index exists", func() {
 			gomega.Eventually(func() bool {
-				return pkg.LogIndexFound(indexName)
-			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+indexName)
+				return pkg.LogIndexFound(bobIndexName)
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+bobIndexName)
 		})
 		// GIVEN a WebLogic application with logging enabled via a logging scope
 		// WHEN the log records are retrieved from the Elasticsearch index
 		// THEN verify that at least one recent log record is found
 		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
 			gomega.Eventually(func() bool {
-				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+				return pkg.LogRecordFound(bobIndexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"domainUID":  "bobs-bookstore",
 					"serverName": "bobs-bookstore-adminserver"})
 			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -239,6 +239,25 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 					"serverName": "bobbys-front-end-adminserver"})
 			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
 		})
+		indexName = "bobs-books-bobs-books-bobs-orders-wls"
+		// GIVEN a WebLogic application with logging enabled via a logging scope
+		// WHEN the Elasticsearch index is retrieved
+		// THEN verify that it is found
+		ginkgo.It("Verify Elasticsearch index exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogIndexFound(indexName)
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find log index "+indexName)
+		})
+		// GIVEN a WebLogic application with logging enabled via a logging scope
+		// WHEN the log records are retrieved from the Elasticsearch index
+		// THEN verify that at least one recent log record is found
+		ginkgo.It("Verify recent Elasticsearch log record exists", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+					"domainUID":  "bobs-bookstore",
+					"serverName": "bobs-bookstore-adminserver"})
+			}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Expected to find a recent log record")
+		})
 	})
 	ginkgo.Context("Coherence logging.", func() {
 		indexName := "bobs-books-bobs-books-robert-coh"


### PR DESCRIPTION
# Description

Updating tests to verify that the issues described in VZ-2099 & VZ-2147 are no longer a problem.

#### Summary
- Remove explicit logging scope on `bobby-wls` in `bobs-books-app` so that it will use the default logging scope.  Verified by existing case in `bobs-books-test`
- Update `WebLogic logging` test in `bobs-books-test` to also check for records under index `bobs-books-bobs-books-bobs-orders-wls`


Fixes VZ-2099 & VZ-2147

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
