### PR TITLE
Don't set upstream value in coredns config map

### DIFF
--- a/platform-operator/scripts/install/config/coredns-template.yaml
+++ b/platform-operator/scripts/install/config/coredns-template.yaml
@@ -13,7 +13,6 @@ data:
          ready
          kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            upstream
             fallthrough in-addr.arpa ip6.arpa
          }
          prometheus :9153


### PR DESCRIPTION
# Description

This pull request fixes the verrazzano-new-kind-acceptance-tests which are failing on Kubernetes 1.19 and 1.20.
The failure was due to a deprecated value being set in the coredns configmap in the kube-system namespace during the Istio install.

Fixes VZ-2396

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
