### PR TITLE
Fix IngressTrait_Controller has wrong name for Gateway and Virtual Se…

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -378,7 +378,7 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 		return r.mutateGateway(gateway, trait, rule, secretName)
 	})
 
-	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: trait.Name, Role: "gateway"}
+	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: name, Role: "gateway"}
 	status.Relations = append(status.Relations, ref)
 	status.Results = append(status.Results, res)
 	status.Errors = append(status.Errors, err)
@@ -471,7 +471,7 @@ func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vz
 		return r.mutateVirtualService(virtualService, trait, rule, service, gateway)
 	})
 
-	ref := vzapi.QualifiedResourceRelation{APIVersion: virtualServiceAPIVersion, Kind: virtualServiceKind, Name: trait.Name, Role: "virtualservice"}
+	ref := vzapi.QualifiedResourceRelation{APIVersion: virtualServiceAPIVersion, Kind: virtualServiceKind, Name: name, Role: "virtualservice"}
 	status.Relations = append(status.Relations, ref)
 	status.Results = append(status.Results, res)
 	status.Errors = append(status.Errors, err)


### PR DESCRIPTION
…rvice resources

# Description

There was a bug in the IngressTrait controller where the gateway and virtual services published to the ingress trait cr was using the name of the trait itself.  It has been fixed to use the respective gateway and virtual service name


# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
