### PR TITLE
Agent Updates VMC status with LastAgentConnectTime

### DIFF
--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 )
 
 var (
@@ -61,6 +62,7 @@ func init() {
 
 	_ = clustersv1alpha1.AddToScheme(scheme)
 	_ = certapiv1alpha2.AddToScheme(scheme)
+	_ = platformopclusters.AddToScheme(scheme)
 }
 
 const defaultScraperName = "verrazzano-system/vmi-system-prometheus-0"

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/wlsworkload"
 	"github.com/verrazzano/verrazzano/application-operator/internal/certificates"
 	"github.com/verrazzano/verrazzano/application-operator/mcagent"
+	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	istioclinet "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +42,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 )
 
 var (

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/wlsworkload"
 	"github.com/verrazzano/verrazzano/application-operator/internal/certificates"
 	"github.com/verrazzano/verrazzano/application-operator/mcagent"
-	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	istioclinet "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,7 +61,6 @@ func init() {
 
 	_ = clustersv1alpha1.AddToScheme(scheme)
 	_ = certapiv1alpha2.AddToScheme(scheme)
-	_ = platformopclusters.AddToScheme(scheme)
 }
 
 const defaultScraperName = "verrazzano-system/vmi-system-prometheus-0"

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"time"
 
+	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/go-logr/logr"
@@ -105,9 +107,29 @@ func (s *Syncer) ProcessAgentThread() error {
 		s.SecretResourceVersion = secret.ResourceVersion
 	}
 
+	// Update the status of our VMC on the admin cluster to record the last time we connected
+	err = s.updateVMCStatus()
+	if err != nil {
+		// we couldn't update status of the VMC - but we should keep going with the rest of the work
+		s.Log.Error(err, "Failed to update VMC status on admin cluster")
+	}
+
 	// Sync multi-cluster objects
 	s.SyncMultiClusterResources()
 	return nil
+}
+
+func (s *Syncer) updateVMCStatus() error {
+	vmcName := client.ObjectKey{Name: s.ManagedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace}
+	vmc := platformopclusters.VerrazzanoManagedCluster{}
+	err := s.AdminClient.Get(s.Context, vmcName, &vmc)
+	if err != nil {
+		return err
+	}
+	vmc.Status.LastAgentConnectTime = metav1.Now()
+
+	// update status of VMC
+	return s.AdminClient.Status().Update(s.Context, &vmc)
 }
 
 // SyncMultiClusterResources - sync multi-cluster objects

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -204,6 +204,7 @@ func getAdminClient(secret *corev1.Secret) (client.Client, error) {
 	}
 	scheme := runtime.NewScheme()
 	_ = clustersv1alpha1.AddToScheme(scheme)
+	_ = platformopclusters.AddToScheme(scheme)
 
 	clientset, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -62,7 +62,7 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 
 	// Admin Cluster - expect a get followed by status update on VMC to record last agent connect time
 	vmcName := types.NamespacedName{Name: string(validSecret.Data[constants.ClusterNameData]), Namespace: constants.VerrazzanoMultiClusterNamespace}
-	expectAdminVMCStatusUpdate(adminMock, vmcName, adminStatusMock, assert)
+	expectAdminVMCStatusUpdateSuccess(adminMock, vmcName, adminStatusMock, assert)
 
 	// Admin Cluster - expect call to list VerrazzanoProject objects - return an empty list
 	adminMock.EXPECT().
@@ -93,26 +93,6 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 	mcMocker.Finish()
 	assert.NoError(err)
 	assert.Equal(validSecret.ResourceVersion, s.SecretResourceVersion)
-}
-
-func expectAdminVMCStatusUpdate(adminMock *mocks.MockClient, vmcName types.NamespacedName, adminStatusMock *mocks.MockStatusWriter, assert *asserts.Assertions) {
-	adminMock.EXPECT().
-		Get(gomock.Any(), vmcName, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, vmc *platformopclusters.VerrazzanoManagedCluster) error {
-			vmc.Name = vmcName.Name
-			vmc.Namespace = vmcName.Namespace
-			return nil
-		})
-	adminMock.EXPECT().Status().Return(adminStatusMock)
-	adminStatusMock.EXPECT().
-		Update(gomock.Any(), gomock.AssignableToTypeOf(&platformopclusters.VerrazzanoManagedCluster{})).
-		DoAndReturn(func(ctx context.Context, vmc *platformopclusters.VerrazzanoManagedCluster) error {
-			assert.Equal(vmcName.Namespace, vmc.Namespace)
-			assert.Equal(vmcName.Name, vmc.Name)
-			assert.NotNil(vmc.Status)
-			assert.NotNil(vmc.Status.LastAgentConnectTime)
-			return nil
-		})
 }
 
 // TestProcessAgentThreadSecretDeleted tests agent thread when the registration secret is deleted
@@ -429,4 +409,64 @@ func Test_discardStatusMessages(t *testing.T) {
 	discardStatusMessages(statusUpdateChan)
 
 	asserts.Equal(t, 0, len(statusUpdateChan))
+}
+
+func expectAdminVMCStatusUpdateFailure(adminMock *mocks.MockClient, vmcName types.NamespacedName, adminStatusMock *mocks.MockStatusWriter, assert *asserts.Assertions) {
+	adminMock.EXPECT().
+		Get(gomock.Any(), vmcName, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "clusters.verrazzano.io", Resource: "VerrazzanoManagedCluster"}, vmcName.Name))
+}
+
+func expectAdminVMCStatusUpdateSuccess(adminMock *mocks.MockClient, vmcName types.NamespacedName, adminStatusMock *mocks.MockStatusWriter, assert *asserts.Assertions) {
+	adminMock.EXPECT().
+		Get(gomock.Any(), vmcName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, vmc *platformopclusters.VerrazzanoManagedCluster) error {
+			vmc.Name = vmcName.Name
+			vmc.Namespace = vmcName.Namespace
+			return nil
+		})
+	adminMock.EXPECT().Status().Return(adminStatusMock)
+	adminStatusMock.EXPECT().
+		Update(gomock.Any(), gomock.AssignableToTypeOf(&platformopclusters.VerrazzanoManagedCluster{})).
+		DoAndReturn(func(ctx context.Context, vmc *platformopclusters.VerrazzanoManagedCluster) error {
+			assert.Equal(vmcName.Namespace, vmc.Namespace)
+			assert.Equal(vmcName.Name, vmc.Name)
+			assert.NotNil(vmc.Status)
+			assert.NotNil(vmc.Status.LastAgentConnectTime)
+			return nil
+		})
+}
+
+// TestSyncer_updateVMCStatus tests updateVMCStatus method
+// GIVEN updateVMCStatus is called
+// WHEN the status update of VMC on admin cluster succeeds
+// THEN updateVMCStatus returns nil error
+// GIVEN updateVMCStatus is called
+// WHEN the status update of VMC on admin cluster fails
+// THEN updateVMCStatus returns a non-nil error
+func TestSyncer_updateVMCStatus(t *testing.T) {
+	assert := asserts.New(t)
+	log := ctrl.Log.WithName("test")
+
+	// Admin cluster mocks
+	adminMocker := gomock.NewController(t)
+	adminMock := mocks.NewMockClient(adminMocker)
+	adminStatusMock := mocks.NewMockStatusWriter(adminMocker)
+
+	s := &Syncer{
+		AdminClient:        adminMock,
+		Log:                log,
+		ManagedClusterName: "my-test-cluster",
+	}
+	vmcName := types.NamespacedName{Name: s.ManagedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace}
+
+	// Mock the success of status updates and assert that updateVMCStatus returns nil error
+	expectAdminVMCStatusUpdateSuccess(adminMock, vmcName, adminStatusMock, assert)
+	assert.Nil(s.updateVMCStatus())
+
+	// Mock the failure of status updates and assert that updateVMCStatus returns non-nil error
+	expectAdminVMCStatusUpdateFailure(adminMock, vmcName, adminStatusMock, assert)
+	assert.NotNil(s.updateVMCStatus())
+
+	adminMocker.Finish()
 }

--- a/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -31,6 +31,9 @@ type VerrazzanoManagedClusterSpec struct {
 
 // VerrazzanoManagedClusterStatus defines the observed state of VerrazzanoManagedCluster
 type VerrazzanoManagedClusterStatus struct {
+	// Last time the agent from this managed cluster connected to the admin cluster.
+	// +optional
+	LastAgentConnectTime metav1.Time `json:"lastAgentConnectTime,omitempty"`
 }
 
 // VerrazzanoManagedCluster is the Schema for the Verrazzanomanagedclusters API

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -67,6 +67,12 @@ spec:
           status:
             description: VerrazzanoManagedClusterStatus defines the observed state
               of VerrazzanoManagedCluster
+            properties:
+              lastAgentConnectTime:
+                description: Last time the agent from this managed cluster connected
+                  to the admin cluster.
+                format: date-time
+                type: string
             type: object
         type: object
     served: true

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
       - multiclusterloggingscopes
       - multiclustersecrets
       - verrazzanoprojects
+      - verrazzanomanagedclusters
     verbs:
       - get
       - list

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
       - multiclusterloggingscopes/status
       - multiclustersecrets/status
       - verrazzanoprojects/status
+      - verrazzanomanagedclusters/status
     verbs:
       - get
       - list


### PR DESCRIPTION
# Description

Managed cluster agent updates VMC status on admin cluster to indicate last connection time.

Fixes: VZ-2266

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
