### PR TITLE
Don't call ginkgo.Fail() in web.go doReq()

### DIFF
--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -176,7 +176,11 @@ func doReq(url, method string, contentType string, hostHeader string, username s
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		Log(Error, err.Error())
-		ginkgo.Fail(fmt.Sprintf("Could not %s %s ", req.Method, url))
+		// do not call Fail() here - this is not necessarily a permanent failure and
+		// we should not call Fail() inside a func that is called from an Eventually()
+		// a later retry may be successful - for example the endpoint may not be available
+		// since the pod has not reached ready state yet
+		return resp.StatusCode, ""
 	}
 	defer resp.Body.Close()
 	html, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Signed-off-by: Mark Nelson <mark.x.nelson@oracle.com>

# Description

This PR changes the behavior of doReq() so that it does not call ginkgo.Fail() when a requests "fails" in a way that may not be permanent, but could be just due to the requested resource not yet being available, for example when the pod serving the request has not yet reached the ready/running state.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
