### PR TITLE
Archive cluster dump on failures from uninstall pipeline

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -192,6 +192,13 @@ pipeline {
                             env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
                         fi
 
+                        echo "Listing all namespaces"
+                        kubectl get namespace
+                        echo "-----------------------------------------------------"
+                        echo "Listing all pods in all namespaces"
+                        kubectl get pods --all-namespaces
+                        echo "-----------------------------------------------------"
+
                         # Install the verrazzano-platform-operator
                         kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
 
@@ -313,6 +320,12 @@ pipeline {
             archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
+                echo "Listing all namespaces"
+                kubectl get namespace
+                echo "-----------------------------------------------------"
+                echo "Listing all pods in all namespaces"
+                kubectl get pods --all-namespaces
+                echo "-----------------------------------------------------"
                 if [ -f ${POST_DUMP_FAILED_FILE} ]; then
                     echo "Failures seen during dumping of artifacts, treat post as failed"
                     exit 1
@@ -322,6 +335,13 @@ pipeline {
 
         failure {
             dumpK8sCluster('verrazzano-installation-loop-cluster-dump')
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-installation-loop-cluster-dump/**', allowEmptyArchive: true
+            sh """
+                if [ -f ${POST_DUMP_FAILED_FILE} ]; then
+                    echo "Failures seen during dumping of artifacts, treat post as failed"
+                    exit 1
+                fi
+            """
             script {
                 failureCount = params.failureCount as Integer
                 failureCount++

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -343,17 +343,20 @@ pipeline {
                     dumpK8sCluster('verrazzano-uninstall-test-dump')
                 }
             }
-            sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
+            sh """
+                echo "Listing all namespaces"
+                kubectl get namespace
+                echo "------------------------------------------"
+                echo "Listing all pods in all namespaces"
+                kubectl get pods --all-namespaces
+            """
             archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
-            sh """
-                cd ${WORKSPACE}/verrazzano
-            """
-            deleteDir()
         }
-
         failure {
             script {
+                dumpK8sCluster('verrazzano-uninstall-test-dump')
+                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
                 mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
                 subject: "Verrazzano: ${env.JOB_NAME} - Failed",
                 body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
@@ -364,6 +367,10 @@ pipeline {
                     }
                 }
             }
+        }
+        cleanup {
+            sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
+            deleteDir()
         }
     }
 }


### PR DESCRIPTION
# Description

This change fixes the issue with archiving the cluster dumps on failure, from the Jenkins script used by uninstall test and install-uninstall loop test. The Jenkins scripts are updated to list all the namespaces and list the pods in all the namespaces, for easier reference, even though the cluster dump might provide the same information.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
