### PR TITLE
Application configuration deletion failure prevents namespace deletion

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -185,18 +185,9 @@ var _ = Describe("Sock Shop Application", func() {
 
 // undeploys the application, components, and namespace
 var _ = AfterSuite(func() {
-	// undeploy the application here
-	err := pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-app.yaml")
+	err := undeploySockShopApplication()
 	if err != nil {
-		Fail(fmt.Sprintf("Could not delete sock shop applications: %v\n", err.Error()))
-	}
-	err = pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-comp.yaml")
-	if err != nil {
-		Fail(fmt.Sprintf("Could not delete sock shop components: %v\n", err.Error()))
-	}
-	err = pkg.DeleteNamespace("sockshop")
-	if err != nil {
-		Fail(fmt.Sprintf("Could not delete sock shop namespace: %v\n", err.Error()))
+		Fail(fmt.Sprintf("Could not undeploy sock shop application: %v\n", err.Error()))
 	}
 })
 

--- a/tests/e2e/examples/socks/sockshop.go
+++ b/tests/e2e/examples/socks/sockshop.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 
@@ -248,4 +250,17 @@ func (s *SockShop) GetOrders(hostname string) {
 	status, orders := s.Get(ordersURL)
 	gomega.Expect(status).To(gomega.Equal(201), fmt.Sprintf("Get %v returns status %v expected 201", ordersURL, status))
 	pkg.Log(Info, fmt.Sprintf("Orders: %v have been retrieved", orders))
+}
+
+// undeploySockShopApplication undeploys the sock shop application
+func undeploySockShopApplication() error {
+	err := pkg.DeleteNamespace("sockshop")
+	if err != nil {
+		return err
+	}
+	gomega.Eventually(func() bool {
+		ns, err := pkg.GetNamespace("sockshop")
+		return ns == nil && err != nil && errors.IsNotFound(err)
+	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+	return nil
 }


### PR DESCRIPTION
# Description

Attempts to delete a namespace containing an Verrazzano OAM based application (e.g. sock shop) are failing. In this use case an attempt is being made to delete the namespace without previously deleting the application.

This occurs when the application uses the default logging scope and the namespace is terminated without deleting the app config first.  When the namespace is deleted, the resources in that namespace are cleaned up including the default logging scope.  During that process the application config defaulter webhook is triggered with an UPDATE notification.  The webhook determines that a default logging scope is required for the app config, so it attempts to create a new one.  Obviously this should be skipped in the case where the namespace is being terminated.

This PR adds code to the app config defaulter webhook to fetch the namespace and check to see if it's terminating.  If terminating then skip the code to create a new default logging scope.

#### Tests
- Update existing unit tests to expect call to get namespace and add case with a terminating namespace.
- Alter the sockshop example tests to uninstall the example by deleting the namespace without deleting the app config and asserting that the namespace is actually deleted. 

Fixes VZ-2332

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
