### PR TITLE
VZ-2334.  Update verify-infra and verify-install for profiles, MC AT pipeline

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
                 choices: [ "v1.18.10", "v1.17.13" ])
-        choice (name: 'KUBERNETES_CLUSTER_VERSION',
+        choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
                 choices: [ "1.18", "1.17" ])
@@ -49,8 +49,14 @@ pipeline {
                         defaultValue: 'NONE',
                         description: 'Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the latest operator.yaml published to the Verrazzano Object Store will be used',
                         trim: true)
-        string name: "ADMIN_CLUSTER_PROFILE", defaultValue: 'dev', description: 'Verrazzano Admin Cluster install profile name',  trim: true
-        string name: "MANAGED_CLUSTER_PROFILE", defaultValue: 'managed-cluster', description: 'Verrazzano Managed Cluster install profile name', trim: true
+        choice (name: 'ADMIN_CLUSTER_PROFILE',
+                description: 'Verrazzano Admin Cluster install profile name',
+                // 1st choice is the default value
+                choices: [ "dev", "prod" ])
+        choice (name: 'MANAGED_CLUSTER_PROFILE',
+                description: 'Verrazzano Managed Cluster install profile name',
+                // 1st choice is the default value
+                choices: [ "managed-cluster", "dev", "prod" ])
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
     }
 
@@ -305,18 +311,18 @@ pipeline {
                 }
                 stage ('Verify Install') {
                     // NOTE: The stages are executed in parallel, however the tests themselves are executed against
-                    //       each cluster in sequence.  But we should be able to parallelize even that
+                    //       each cluster in sequence.  But we should parallizing those also, if we can.
                     parallel {
                         stage ('multicluster/verify-install') {
                             steps {
                                 runGinkgoRandomize('multicluster/verify-install')
                             }
                         }
-                        //stage('verify-install') {
-                        //    steps {
-                        //        runGinkgoRandomize('verify-install')
-                        //    }
-                        //}
+                        stage('verify-install') {
+                            steps {
+                                runGinkgoRandomize('verify-install')
+                            }
+                        }
                         stage('verify-infra restapi') {
                             steps {
                                 runGinkgoRandomize('verify-infra/restapi')
@@ -327,11 +333,11 @@ pipeline {
                                 runGinkgoRandomize('verify-infra/oam')
                             }
                         }
-                        //stage('verify-infra vmi') {
-                        //    steps {
-                        //        runGinkgoRandomize('verify-infra/vmi')
-                        //    }
-                        //}
+                        stage('verify-infra vmi') {
+                            steps {
+                                runGinkgoRandomize('verify-infra/vmi')
+                            }
+                        }
                     }
                     post {
                         always {
@@ -448,7 +454,7 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 echo "Create Kind cluster \$1"
                 cd ${TEST_SCRIPTS_DIR}
-                ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KUBERNETES_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork"
+                ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork"
                 echo "Install metallb"
                 cd ${GO_REPO_PATH}/verrazzano
                 ./tests/e2e/config/scripts/install-metallb.sh $metallbAddressRange
@@ -465,6 +471,9 @@ def installVerrazzano(count, verrazzanoConfig) {
             sh """
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 cd ${GO_REPO_PATH}/verrazzano
+
+                # Display the kubectl and cluster versions
+                kubectl version
 
                 echo "Create Image Pull Secrets"
                 ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}"
@@ -514,22 +523,17 @@ def runGinkgoRandomize(testSuitePath) {
 def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript) {
     script {
         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-        def envName = "default"
         for(int count=1; count<=clusterCount; count++) {
             def destinationPath = "${env.KUBECONFIG_DIR}/${count}/${installerFileName}"
             def installProfile = env.MANAGED_CLUSTER_PROFILE
+            // Installs using OCI DNS require a unique domain per cluster
+            // - also, the env name must be <= 10 chars for some reason.
+            def envName = "mgd${count-1}"
             if (count == 1) {
+                // Cluster "1" is always the admin cluster, use the chosen profile for the VZ install
+                // with the env name "admin"
                 installProfile = env.ADMIN_CLUSTER_PROFILE
-            }
-            if (params.TEST_ENV == 'ocidns_oke') {
-                // Installs using OCI DNS require a unique domain per cluster, so to distinguish
-                // we use different environmentName values for each cluster; also, the env
-                // name must be <= 10 chars for some reason.
-                if (count == 1) {
-                    envName = "admin"
-                } else {
-                    envName = "mgd${count-1}"
-                }
+                envName = "admin"
             }
             sh """
                 mkdir -p "${KUBECONFIG_DIR}/${count}"

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -236,7 +236,7 @@ func GetVMOClientset() *vmoclient.Clientset {
 func GetPlatformOperatorClientset() *vpoClient.Clientset {
 	client, err := vpoClient.NewForConfig(GetKubeConfig())
 	if err != nil {
-		ginkgo.Fail("Could not get Verrazzano Monitoring Operator clientset")
+		ginkgo.Fail("Could not get Verrazzano Platform Operator clientset")
 	}
 	return client
 }

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	// EnvName - default environment name
-	EnvName = "default"
+	// DefaultEnvName - default environment name
+	DefaultEnvName = "default"
 
 	// Username - the username of the verrazzano admin user
 	Username               = "verrazzano"
@@ -237,14 +237,22 @@ func getHTTPClientWIthCABundle(caData []byte) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
+func getEnvName() string {
+	installedEnvName := GetVerrazzanoInstallResource().Spec.EnvironmentName
+	if len(installedEnvName) == 0 {
+		return DefaultEnvName
+	}
+	return installedEnvName
+}
+
 // getVerrazzanoCACert returns the verrazzano CA cert
 func getVerrazzanoCACert() []byte {
-	return doGetCACertFromSecret(EnvName+"-secret", "verrazzano-system")
+	return doGetCACertFromSecret(getEnvName()+"-secret", "verrazzano-system")
 }
 
 // getKeycloakCACert returns the keycloak CA cert
 func getKeycloakCACert() []byte {
-	return doGetCACertFromSecret(EnvName+"-secret", "keycloak")
+	return doGetCACertFromSecret(getEnvName()+"-secret", "keycloak")
 }
 
 // getSystemVMICACert returns the system vmi CA cert

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/clients/verrazzano/clientset/versioned/typed/verrazzano/v1alpha1"
 	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"strings"
 	"time"
@@ -25,6 +28,20 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func vmiPersistentVolumes() (map[string]*corev1.PersistentVolumeClaim, error) {
+	pvcs, err := pkg.GetKubernetesClientset().CoreV1().PersistentVolumeClaims("verrazzano-system").List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	volumeClaims := make(map[string]*corev1.PersistentVolumeClaim)
+
+	for _, pvc := range pvcs.Items {
+		volumeClaims[pvc.Name] = &pvc
+	}
+	return volumeClaims, nil
+}
 
 func vmiIngressURLs() (map[string]string, error) {
 	ingressList, err := pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").List(context.TODO(), v1.ListOptions{})
@@ -53,10 +70,22 @@ func verrazzanoMonitoringInstanceCRD() (*apiextensionsv1beta1.CustomResourceDefi
 	return crd, nil
 }
 
+func verrazzanoInstallerCRD() (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	crd, err := pkg.APIExtensionsClientSet().CustomResourceDefinitions().Get(context.TODO(), "verrazzanos.install.verrazzano.io", v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return crd, nil
+}
+
 var (
-	creds                  *pkg.UsernamePassword
-	vmiCRD                 *apiextensionsv1beta1.CustomResourceDefinition
+	creds  *pkg.UsernamePassword
+	vmiCRD *apiextensionsv1beta1.CustomResourceDefinition
+	vzCRD  *apiextensionsv1beta1.CustomResourceDefinition
+	//installCR              *v1alpha1.Verrazzano
+	vzClient               installv1alpha1.VerrazzanoInterface
 	ingressURLs            map[string]string
+	volumeClaims           map[string]*corev1.PersistentVolumeClaim
 	elastic                *vmi.Elastic
 	waitTimeout            = 5 * time.Minute
 	pollingInterval        = 5 * time.Second
@@ -66,9 +95,20 @@ var (
 
 var _ = ginkgo.BeforeSuite(func() {
 	var err error
+
+	vzCRD, err = verrazzanoInstallerCRD()
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Error retrieving system VMI CRD: %v", err))
+	}
+
 	ingressURLs, err = vmiIngressURLs()
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Error retrieving system VMI ingress URLs: %v", err))
+	}
+
+	volumeClaims, err = vmiPersistentVolumes()
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Error retrieving persistent volumes for verrazzano-system: %v", err))
 	}
 
 	vmiCRD, err = verrazzanoMonitoringInstanceCRD()
@@ -84,91 +124,151 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.Describe("VMI", func() {
+
 	ginkgo.It("api server should be accessible", func() {
-		assertIngressURL("vmi-system-api")
+		assertURLByIngressName("vmi-system-api")
 	})
 
-	ginkgo.It("Elasticsearch endpoint should be accessible", func() {
-		elasticPodsRunning := func() bool {
-			return pkg.PodsRunning("verrazzano-system", []string{"vmi-system-es-master"})
-		}
-		gomega.Eventually(elasticPodsRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "pods did not all show up")
-		gomega.Eventually(elasticTLSSecret, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "tls-secret did not show up")
-		//gomega.Eventually(elasticCertificate, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "certificate did not show up")
-		gomega.Eventually(elasticIngress, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "ingress did not show up")
-		assertOidcIngress("vmi-system-es-ingest")
-		pkg.Concurrently(
-			func() {
-				gomega.Eventually(elasticConnected, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "never connected")
-			},
-			func() {
-				gomega.Eventually(elasticIndicesCreated, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "indices never created")
-			},
-		)
-	})
+	isManagedClusterProfile := pkg.IsManagedClusterProfile()
+	if isManagedClusterProfile {
+		ginkgo.It("Elasticsearch should NOT be present", func() {
+			// Verify ES not present
+			gomega.Expect(pkg.PodsNotRunning("verrazzano-system", []string{"vmi-system-es"})).To(gomega.BeTrue())
+			gomega.Expect(elasticTLSSecret()).To(gomega.BeTrue())
+			gomega.Expect(elastic.CheckIngress()).To(gomega.BeFalse())
+			gomega.Expect(ingressURLs).NotTo(gomega.HaveKey("vmi-system-es-ingest"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
 
-	ginkgo.It("Elasticsearch filebeat Index should be accessible", func() {
-		gomega.Eventually(func() bool {
-			return pkg.LogRecordFound("vmo-local-filebeat-"+time.Now().Format("2006.01.02"),
-				time.Now().Add(-24*time.Hour),
-				map[string]string{
-					"beat.version": "6.8.3"})
-		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
-	})
+			// Verify Kibana not present
+			gomega.Expect(pkg.PodsNotRunning("verrazzano-system", []string{"vmi-system-kibana"})).To(gomega.BeTrue())
+			gomega.Expect(ingressURLs).NotTo(gomega.HaveKey("vmi-system-kibana"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
 
-	ginkgo.It("Elasticsearch journalbeat Index should be accessible", func() {
-		gomega.Eventually(func() bool {
-			return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
-				time.Now().Add(-24*time.Hour),
-				map[string]string{
-					"beat.version": "6.8.3"})
-		}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a journalbeat log record")
-	})
+			// Verify Grafana not present
+			gomega.Expect(pkg.PodsNotRunning("verrazzano-system", []string{"vmi-system-grafana"})).To(gomega.BeTrue())
+			gomega.Expect(ingressURLs).NotTo(gomega.HaveKey("vmi-system-grafana"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
+		})
+	} else {
+		ginkgo.It("Elasticsearch endpoint should be accessible", func() {
+			elasticPodsRunning := func() bool {
+				return pkg.PodsRunning("verrazzano-system", []string{"vmi-system-es-master"})
+			}
+			gomega.Eventually(elasticPodsRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "pods did not all show up")
+			gomega.Eventually(elasticTLSSecret, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "tls-secret did not show up")
+			//gomega.Eventually(elasticCertificate, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "certificate did not show up")
+			gomega.Eventually(elasticIngress, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "ingress did not show up")
+			gomega.Expect(ingressURLs).To(gomega.HaveKey("vmi-system-es-ingest"), "Ingress vmi-system-es-ingest not found")
+			assertOidcIngressByName("vmi-system-es-ingest")
+			pkg.Concurrently(
+				func() {
+					gomega.Eventually(elasticConnected, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "never connected")
+				},
+				func() {
+					gomega.Eventually(elasticIndicesCreated, elasticWaitTimeout, elasticPollingInterval).Should(gomega.BeTrue(), "indices never created")
+				},
+			)
+		})
 
-	ginkgo.It("Kibana endpoint should be accessible", func() {
-		kibanaPodsRunning := func() bool {
-			return pkg.PodsRunning("verrazzano-system", []string{"vmi-system-kibana"})
-		}
-		gomega.Eventually(kibanaPodsRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "kibana pods did not all show up")
-		assertOidcIngress("vmi-system-kibana")
-	})
+		ginkgo.It("Elasticsearch filebeat Index should be accessible", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound("vmo-local-filebeat-"+time.Now().Format("2006.01.02"),
+					time.Now().Add(-24*time.Hour),
+					map[string]string{
+						"beat.version": "6.8.3"})
+			}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a filebeat log record")
+		})
 
-	ginkgo.It("Prometheus endpoint should be accessible", func() {
-		assertOidcIngress("vmi-system-prometheus")
-	})
+		ginkgo.It("Elasticsearch journalbeat Index should be accessible", func() {
+			gomega.Eventually(func() bool {
+				return pkg.LogRecordFound("vmo-local-journalbeat-"+time.Now().Format("2006.01.02"),
+					time.Now().Add(-24*time.Hour),
+					map[string]string{
+						"beat.version": "6.8.3"})
+			}, 5*time.Minute, 10*time.Second).Should(gomega.BeTrue(), "Expected to find a journalbeat log record")
+		})
+
+		ginkgo.It("Kibana endpoint should be accessible", func() {
+			kibanaPodsRunning := func() bool {
+				return pkg.PodsRunning("verrazzano-system", []string{"vmi-system-kibana"})
+			}
+			gomega.Eventually(kibanaPodsRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "kibana pods did not all show up")
+			gomega.Expect(ingressURLs).To(gomega.HaveKey("vmi-system-kibana"), "Ingress vmi-system-kibana not found")
+			assertOidcIngressByName("vmi-system-kibana")
+		})
+
+		ginkgo.It("Prometheus endpoint should be accessible", func() {
+			assertOidcIngressByName("vmi-system-prometheus")
+		})
+
+		ginkgo.It("Prometheus push gateway should be accessible", func() {
+			assertURLByIngressName("vmi-system-prometheus-gw")
+		})
+
+		ginkgo.It("Grafana endpoint should be accessible", func() {
+			gomega.Expect(ingressURLs).To(gomega.HaveKey("vmi-system-grafana"), "Ingress vmi-system-grafana not found")
+			assertOidcIngressByName("vmi-system-grafana")
+		})
+
+		ginkgo.It("Default dashboard should be installed in System Grafana for shared VMI", func() {
+			pkg.Concurrently(
+				func() { assertDashboard("Host%20Metrics") },
+				func() { assertDashboard("WebLogic%20Server%20Dashboard") },
+				func() { assertDashboard("Coherence%20Elastic%20Data%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Persistence%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Cache%20Details%20Dashboard") },
+				func() { assertDashboard("Coherence%20Members%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Kubernetes%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Dashboard%20Main") },
+				func() { assertDashboard("Coherence%20Caches%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Service%20Details%20Dashboard") },
+				func() { assertDashboard("Coherence%20Proxy%20Servers%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Federation%20Details%20Dashboard") },
+				func() { assertDashboard("Coherence%20Federation%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Services%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20HTTP%20Servers%20Summary%20Dashboard") },
+				func() { assertDashboard("Coherence%20Proxy%20Server%20Detail%20Dashboard") },
+				func() { assertDashboard("Coherence%20Alerts%20Dashboard") },
+				func() { assertDashboard("Coherence%20Member%20Details%20Dashboard") },
+				func() { assertDashboard("Coherence%20Machines%20Summary%20Dashboard") },
+			)
+		})
+	}
 
 	ginkgo.It("Prometheus push gateway should be accessible", func() {
-		assertIngressURL("vmi-system-prometheus-gw")
+		assertURLByIngressName("vmi-system-prometheus-gw")
 	})
 
-	ginkgo.It("Grafana endpoint should be accessible", func() {
-		assertOidcIngress("vmi-system-grafana")
+	ginkgo.It("Verify the instance info endpoint URLs", func() {
+		assertInstanceInfoURLs()
 	})
 
-	ginkgo.It("Default dashboard should be installed in System Grafana for shared VMI", func() {
-		pkg.Concurrently(
-			func() { assertDashboard("Host%20Metrics") },
-			func() { assertDashboard("WebLogic%20Server%20Dashboard") },
-			func() { assertDashboard("Coherence%20Elastic%20Data%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Persistence%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Cache%20Details%20Dashboard") },
-			func() { assertDashboard("Coherence%20Members%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Kubernetes%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Dashboard%20Main") },
-			func() { assertDashboard("Coherence%20Caches%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Service%20Details%20Dashboard") },
-			func() { assertDashboard("Coherence%20Proxy%20Servers%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Federation%20Details%20Dashboard") },
-			func() { assertDashboard("Coherence%20Federation%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Services%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20HTTP%20Servers%20Summary%20Dashboard") },
-			func() { assertDashboard("Coherence%20Proxy%20Server%20Detail%20Dashboard") },
-			func() { assertDashboard("Coherence%20Alerts%20Dashboard") },
-			func() { assertDashboard("Coherence%20Member%20Details%20Dashboard") },
-			func() { assertDashboard("Coherence%20Machines%20Summary%20Dashboard") },
-		)
-	})
+	size := "50Gi"
+	if pkg.IsDevProfile() {
+		ginkgo.It("Check persistent volumes for dev profile", func() {
+			gomega.Expect(len(volumeClaims)).To(gomega.Equal(0))
+		})
+	} else if isManagedClusterProfile {
+		ginkgo.It("Check persistent volumes for managed cluster profile", func() {
+			gomega.Expect(len(volumeClaims)).To(gomega.Equal(1))
+			assertPersistentVolume("vmi-system-prometheus", size)
+		})
+	} else if pkg.IsProdProfile() {
+		ginkgo.It("Check persistent volumes for prod cluster profile", func() {
+			gomega.Expect(len(volumeClaims)).To(gomega.Equal(7))
+			assertPersistentVolume("vmi-system-prometheus", size)
+			assertPersistentVolume("vmi-system-grafana", size)
+			assertPersistentVolume("elasticsearch-master-vmi-system-es-master-0", size)
+			assertPersistentVolume("elasticsearch-master-vmi-system-es-master-1", size)
+			assertPersistentVolume("elasticsearch-master-vmi-system-es-master-2", size)
+			assertPersistentVolume("vmi-system-es-data", size)
+			assertPersistentVolume("vmi-system-es-data-1", size)
+		})
+	}
 })
+
+func assertPersistentVolume(key string, size string) {
+	gomega.Expect(volumeClaims).To(gomega.HaveKey(key))
+	pvc := volumeClaims[key]
+	gomega.Expect(pvc.Spec.Resources.Requests.Storage().String()).To(gomega.Equal(size))
+}
 
 func jq(node interface{}, path ...string) interface{} {
 	for _, p := range path {
@@ -177,10 +277,14 @@ func jq(node interface{}, path ...string) interface{} {
 	return node
 }
 
-func assertIngressURL(key string) {
+func assertURLByIngressName(key string) {
 	gomega.Expect(ingressURLs).To(gomega.HaveKey(key), fmt.Sprintf("Ingress %s not found", key))
-	assertUnAuthorized := assertURLAccessibleAndUnauthorized(ingressURLs[key])
-	assertAuthorized := assertURLAccessibleAndAuthorized(ingressURLs[key])
+	assertIngressURL(ingressURLs[key])
+}
+
+func assertIngressURL(url string) {
+	assertUnAuthorized := assertURLAccessibleAndUnauthorized(url)
+	assertAuthorized := assertURLAccessibleAndAuthorized(url)
 	pkg.Concurrently(
 		func() {
 			gomega.Eventually(assertUnAuthorized, waitTimeout, pollingInterval).Should(gomega.BeTrue())
@@ -234,15 +338,21 @@ func assertOauthURLAccessibleAndUnauthorized(url string) bool {
 		return false
 	}
 	location, _ := resp.Location()
+	gomega.Expect(location).NotTo(gomega.BeNil())
 	pkg.Log(pkg.Info, fmt.Sprintf("oidcUnauthorized %v StatusCode:%v host:%v", url, resp.StatusCode, location.Host))
 	return resp.StatusCode == 302 && strings.Contains(location.Host, "keycloak")
 }
 
-func assertOidcIngress(key string) {
+func assertOidcIngressByName(key string) {
 	gomega.Expect(ingressURLs).To(gomega.HaveKey(key), fmt.Sprintf("Ingress %s not found", key))
-	assertUnAuthorized := assertOauthURLAccessibleAndUnauthorized(ingressURLs[key])
-	assertBasicAuth := assertURLAccessibleAndAuthorized(ingressURLs[key])
-	assertBearerAuth := assertBearerAuthorized(ingressURLs[key])
+	url := ingressURLs[key]
+	assertOidcIngress(url)
+}
+
+func assertOidcIngress(url string) {
+	assertUnAuthorized := assertOauthURLAccessibleAndUnauthorized(url)
+	assertBasicAuth := assertURLAccessibleAndAuthorized(url)
+	assertBearerAuth := assertBearerAuthorized(url)
 	pkg.Concurrently(
 		func() {
 			gomega.Eventually(assertUnAuthorized, waitTimeout, pollingInterval).Should(gomega.BeTrue())
@@ -314,4 +424,35 @@ func assertDashboard(url string) {
 		return true
 	}
 	gomega.Eventually(searchDashboard, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+}
+
+func assertInstanceInfoURLs() {
+	cr := pkg.GetVerrazzanoInstallResource()
+	instanceInfo := cr.Status.VerrazzanoInstance
+	switch cr.Spec.Profile {
+	case v1alpha1.ManagedCluster:
+		gomega.Expect(instanceInfo.GrafanaURL).To(gomega.BeNil())
+		gomega.Expect(instanceInfo.ElasticURL).To(gomega.BeNil())
+		gomega.Expect(instanceInfo.KibanaURL).To(gomega.BeNil())
+	default:
+		gomega.Expect(instanceInfo.GrafanaURL).NotTo(gomega.BeNil())
+		gomega.Expect(instanceInfo.ElasticURL).NotTo(gomega.BeNil())
+		gomega.Expect(instanceInfo.KibanaURL).NotTo(gomega.BeNil())
+		if instanceInfo.ElasticURL != nil {
+			assertOidcIngress(*instanceInfo.ElasticURL)
+		}
+		if instanceInfo.KibanaURL != nil {
+			assertOidcIngress(*instanceInfo.KibanaURL)
+		}
+		if instanceInfo.GrafanaURL != nil {
+			assertOidcIngress(*instanceInfo.GrafanaURL)
+		}
+	}
+	gomega.Expect(instanceInfo.PrometheusURL).NotTo(gomega.BeNil())
+	if instanceInfo.PrometheusURL != nil {
+		assertOidcIngress(*instanceInfo.PrometheusURL)
+	}
+	if instanceInfo.SystemURL != nil {
+		assertIngressURL(*instanceInfo.SystemURL)
+	}
 }

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -98,7 +98,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	vzCRD, err = verrazzanoInstallerCRD()
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Error retrieving system VMI CRD: %v", err))
+		ginkgo.Fail(fmt.Sprintf("Error retrieving Verrazzano Installer CRD: %v", err))
 	}
 
 	ingressURLs, err = vmiIngressURLs()

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -29,14 +29,11 @@ var expectedPodsIngressNginx = []string{
 	"ingress-controller-ingress-nginx-controller",
 	"ingress-controller-ingress-nginx-defaultbackend"}
 
-var expectedPodsVerrazzanoSystemMinimal = []string{
+var expectedNonVMIPodsVerrazzanoSystem = []string{
 	"verrazzano-console",
 	"verrazzano-monitoring-operator",
 	"verrazzano-operator",
-	"vmi-system-api",
-	"vmi-system-es-master",
-	"vmi-system-grafana",
-	"vmi-system-kibana"}
+}
 
 // comment out while debugging so it does not break master
 //"vmi-system-prometheus",
@@ -121,6 +118,21 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 			ginkgoExt.Entry("includes rancher-agent", "cattle-cluster-agent", true),
 		)
 
+		isManagedClusterProfile := pkg.IsManagedClusterProfile()
+		isProdProfile := pkg.IsProdProfile()
+		ginkgoExt.DescribeTable("deployed VMI components",
+			func(name string, expected bool) {
+				gomega.Expect(vzComponentPresent(name, "verrazzano-system")).To(gomega.Equal(expected))
+			},
+			ginkgoExt.Entry("includes prometheus", "vmi-system-prometheus", true),
+			ginkgoExt.Entry("includes prometheus-gw", "vmi-system-prometheus-gw", true),
+			ginkgoExt.Entry("includes es-ingest", "vmi-system-es-ingest", isProdProfile),
+			ginkgoExt.Entry("includes es-data", "vmi-system-es-data", isProdProfile),
+			ginkgoExt.Entry("includes es-master", "vmi-system-es-master", !isManagedClusterProfile),
+			ginkgoExt.Entry("includes es-kibana", "vmi-system-kibana", !isManagedClusterProfile),
+			ginkgoExt.Entry("includes es-grafana", "vmi-system-grafana", !isManagedClusterProfile),
+		)
+
 		ginkgo.It("Expected pods are running",
 			func() {
 				pkg.Concurrently(
@@ -141,7 +153,7 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 							Should(gomega.BeTrue())
 					},
 					func() {
-						gomega.Eventually(pkg.PodsRunning("verrazzano-system", expectedPodsVerrazzanoSystemMinimal), waitTimeout, pollingInterval).
+						gomega.Eventually(pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem), waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
 					},
 				)


### PR DESCRIPTION

# Description

Update the verify-infra and verify-install ATs and include them in the MC AT pipelne.  Also cleans up a few things in the MC Pipeline Jenkinsfile.

- Check for VMI endpoints based on profile
- Check for VMI persistent volume configurations based on profile
- Also account in tests for cases where envName is not "default"
- enable the verify-infra and verify-install tests for the MC pipeline
- Jenkinsfile, rename KinD cluster version parameter, and spit out the cluster version before installing VZ
- Jenkinsfile, make profile parameters dropdown lists
- Jenkinsfile, go back to using the same env names in the VZ install CR regardless of cluster type

Fixes VZ-2334

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
