### PR TITLE
Update uninstall and loop scripts to list k8s resources

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -5,6 +5,7 @@ def DOCKER_IMAGE_TAG
 
 def abort = false
 def failureCount = 0
+def skip_stage = 'false'
 
 pipeline {
     options {
@@ -93,6 +94,8 @@ pipeline {
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
         LOOPING_TEST_SCRIPTS_DIR = "${TEST_SCRIPTS_DIR}/looping-test"
         INSTALL_CONFIG_FILE = "${GO_REPO_PATH}/verrazzano/platform-operator/config/samples/install-default.yaml"
+        WEBLOGIC_PSW = credentials('weblogic-example-domain-password')
+        DATABASE_PSW = credentials('todo-mysql-password')
     }
 
     stages {
@@ -180,6 +183,7 @@ pipeline {
                 OCI_OS_BUCKET="verrazzano-builds"
             }
             steps {
+                listNamepacesAndPods('before installing Verrazzano')
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
                         cd ${GO_REPO_PATH}/verrazzano
@@ -191,13 +195,6 @@ pipeline {
                             echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"
                             env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
                         fi
-
-                        echo "Listing all namespaces"
-                        kubectl get namespace
-                        echo "-----------------------------------------------------"
-                        echo "Listing all pods in all namespaces"
-                        kubectl get pods --all-namespaces
-                        echo "-----------------------------------------------------"
 
                         # Install the verrazzano-platform-operator
                         kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
@@ -252,6 +249,12 @@ pipeline {
                     dumpVerrazzanoApplicationOperatorLogs()
                     dumpOamKubernetesRuntimeLogs()
                     dumpVerrazzanoApiLogs()
+                    listNamepacesAndPods('after Verrazzano install')
+                }
+                failure {
+                    script {
+                        skip_stage = 'true'
+                    }
                 }
             }
         }
@@ -261,14 +264,12 @@ pipeline {
             environment {
                 TEST_ENV = "OKE"
             }
+            when {
+                expression { skip_stage == 'false' }
+            }
             steps {
-                sh """
-                    echo "Listing all pods in all namespaces before running verify-install"
-                    kubectl get pods --all-namespaces
-                    echo "-----------------------------------------------------"
-                """
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    runGinkgoRandomize('verify-install')
+                    runGinkgo('examples/todo')
                 }
             }
             post {
@@ -329,17 +330,12 @@ pipeline {
             archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
-                echo "Listing all namespaces"
-                kubectl get namespace
-                echo "-----------------------------------------------------"
-                echo "Listing all pods in all namespaces"
-                kubectl get pods --all-namespaces
-                echo "-----------------------------------------------------"
                 if [ -f ${POST_DUMP_FAILED_FILE} ]; then
                     echo "Failures seen during dumping of artifacts, treat post as failed"
                     exit 1
                 fi
             """
+            listNamepacesAndPods('after uninstalling Verrazzano')
         }
 
         failure {
@@ -413,11 +409,11 @@ pipeline {
     }
 }
 
-def runGinkgoRandomize(testSuitePath) {
+def runGinkgo(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor ${testSuitePath}/...
+            ginkgo -v -keepGoing --noColor ${testSuitePath}/...
         """
     }
 }
@@ -501,5 +497,14 @@ def dumpVerrazzanoApiLogs() {
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
         export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-api.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-api-*" -m "verrazzano api" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def listNamepacesAndPods(customMessage) {
+    sh """
+        echo "Listing all the namespaces and pods the namespaces ${customMessage}"
+        kubectl get namespaces
+        kubectl get all --all-namespaces
+        echo "-----------------------------------------------------"
     """
 }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -91,9 +91,8 @@ pipeline {
         LOOPING_TEST_SCRIPTS_DIR = "${TEST_SCRIPTS_DIR}/looping-test"
         UNINSTALL_TEST_SCRIPTS_DIR = "${TEST_SCRIPTS_DIR}/uninstall-test"
         INSTALL_CONFIG_FILE = "${GO_REPO_PATH}/verrazzano/platform-operator/config/samples/install-default.yaml"
-
-        WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // Needed by ToDoList example test
-        DATABASE_PSW = credentials('todo-mysql-password') // Needed by ToDoList example test
+        WEBLOGIC_PSW = credentials('weblogic-example-domain-password')
+        DATABASE_PSW = credentials('todo-mysql-password')
     }
 
     stages {
@@ -176,6 +175,7 @@ pipeline {
                 OCI_OS_BUCKET="verrazzano-builds"
             }
             steps {
+                listNamepacesAndPods('before installing Verrazzano')
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
                         # Create image pull secret for Verrazzano docker images
@@ -246,6 +246,7 @@ pipeline {
                     dumpVerrazzanoApplicationOperatorLogs('install')
                     dumpOamKubernetesRuntimeLogs('install')
                     dumpVerrazzanoApiLogs('install')
+                    listNamepacesAndPods('after Verrazzano install')
                 }
             }
         }
@@ -256,8 +257,12 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    // Enable Bob's Books demo later
                     runGinkgo('examples/todo')
+                }
+            }
+            post {
+                failure {
+                    dumpK8sCluster('verrazzano-uninstall-after-test-dump')
                 }
             }
         }
@@ -298,6 +303,7 @@ pipeline {
 
         stage("Reinstall Verrazzano") {
             steps {
+                listNamepacesAndPods('before reinstalling Verrazzano')
                 sh """
                     # sleep for a period to ensure async deletion of verrazzano components from uninstall above has completed
                     sleep 90
@@ -330,6 +336,7 @@ pipeline {
                     dumpVerrazzanoApplicationOperatorLogs('reinstall')
                     dumpOamKubernetesRuntimeLogs('reinstall')
                     dumpVerrazzanoApiLogs('reinstall')
+                    listNamepacesAndPods('after reinstalling Verrazzano')
                 }
             }
         }
@@ -340,7 +347,6 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    // Enable Bob's Books demo later
                     runGinkgo('examples/todo')
                 }
             }
@@ -353,20 +359,13 @@ pipeline {
                     dumpK8sCluster('verrazzano-uninstall-test-dump')
                 }
             }
-            sh """
-                echo "Listing all namespaces"
-                kubectl get namespace
-                echo "------------------------------------------"
-                echo "Listing all pods in all namespaces"
-                kubectl get pods --all-namespaces
-            """
-            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
         failure {
             script {
                 dumpK8sCluster('verrazzano-uninstall-test-dump')
-                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*verrazzano-uninstall-test-dump/**', allowEmptyArchive: true
+                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
                 mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
                 subject: "Verrazzano: ${env.JOB_NAME} - Failed",
                 body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
@@ -473,5 +472,14 @@ def dumpVerrazzanoApiLogs(logDirectory) {
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
         export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-api.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-api-*" -m "verrazzano api" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def listNamepacesAndPods(customMessage) {
+    sh """
+        echo "Listing all the namespaces and pods the namespaces ${customMessage}."
+        kubectl get namespaces
+        kubectl get all --all-namespaces
+        echo "-----------------------------------------------------"
     """
 }


### PR DESCRIPTION
# Description

This PR contains minor changes to list k8s resources, in Jenkins scripts used by uninstall tests and install-uninstall loop. The change skips certain stages when the previous stage fails, when applicable. As part of this change, the loop test is modified to run examples/todo, as we have an intermittent issue where some of the pods in cattle-system won't come up after reinstall. The issue will be investigated separately.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
