### PR TITLE
Ignore an issue with deletion of rancher local cluster during Verrazzano uninstall

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -31,10 +31,15 @@ function initializing_uninstall {
 
   if [ "${RANCHER_ACCESS_TOKEN}" ]; then
     log "Updating ${rancher_cluster_url}"
-    status=$(curl -o /dev/null -s -w "%{http_code}\n" $(get_rancher_resolve ${rancher_hostname}) -X DELETE -H "Accept: application/json" -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" --insecure "${rancher_cluster_url}")
-    if [ "$status" != 200 ] && [ "$status" != 404 ] ; then
-      return 1
+    local temp_output="/tmp/delete_cluster.out"
+    status=$(curl -o ${temp_output} -s -w "%{http_code}\n" $(get_rancher_resolve ${rancher_hostname}) -X DELETE -H "Accept: application/json" -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" --insecure "${rancher_cluster_url}")
+    if [ "$status" != 200 ] ; then
+      local cluster_delete_output=$(cat $temp_output)
+      log "${cluster_delete_output}"
+      rm "$temp_output"
+      return 0
     fi
+
     local max_retries=30
     local retries=0
     while true ; do
@@ -48,7 +53,7 @@ function initializing_uninstall {
       fi
       ((retries+=1))
       if [ "$retries" -ge "$max_retries" ] ; then
-        return 1
+        return 0
       fi
     done
   fi


### PR DESCRIPTION
# Description
In this PR, a change is made to uninstall scripts to continue with the installation in case of an issue in deleting the rancher local cluster. The uninstall relies on 2-uninstall-system-components.sh to remove the resources in the cattle-system namespace using helm uninstall. Also this change makes the stderror available in the console log, when resetting the rancher password fails.

During the testing, it is noticed that the pods cattle-node-agent and cattle-agent fail to come up on verrazzano reinstall after a failure to delete the local cluster in the previous uninstall at times, which I would like to track separately, outside of this issue.

During the testing, it is noticed that the pods cattle-node-agent and cattle-agent don't come up on verrazzano reinstall after a failure to delete the local cluster in the previous uninstall. The uninstall log 

With the testing done so far, the issue did not occur with v1.17.13, happened intermittently with v.1.18.10. The support matrix for Rancher 2.4.3 (which is used by Verrazzano) indicates that the version is not certified with k8s versions 1.18, 1.19 and 1.20.  
I can see the following warning and error in the rancher logs

"[2021-03-17 15:30:38 UTC] 2021/03/17 15:24:53 [WARNING] failed to create or update driverMetadata: driverMetadata: unable to find default k8s version in current k8s v1.18.x [v1.15.11-rancher1-3 v1.16.9-rancher1-1 v1.17.5-rancher1-1], Fallback to refresh from local file path /var/lib/rancher-data/driver-metadata/data.json"

I don't know whether the issue with v.1.18.10 will go away on upgrading the rancher or it is just coincidence

Fixes VZ-2192

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
