### PR TITLE
Revert "Add validating webhook to prevent VMC creation when Verrazzano not installed"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ vendor
 .idea
 **/*.iml
 platform-operator/pkg/assets
-platform-operator/build/deploy
 bin
 platform-operator/bin
 dist

--- a/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
+++ b/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -45,10 +45,6 @@ func (v *VerrazzanoManagedCluster) ValidateCreate() error {
 		return fmt.Errorf("Namespace for the resource must be %s", constants.VerrazzanoMultiClusterNamespace)
 	}
 	client, err := getClientFunc()
-	if err != nil {
-		return err
-	}
-	err = v.validateVerrazzanoInstalled(client)
 	if err != nil {
 		return err
 	}
@@ -100,7 +96,6 @@ func newScheme() *runtime.Scheme {
 	scheme.AddKnownTypes(schema.GroupVersion{
 		Version: "v1",
 	}, &corev1.Secret{}, &corev1.ConfigMap{})
-	scheme.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.VerrazzanoList{}, &v1alpha1.Verrazzano{})
 	return scheme
 }
 
@@ -143,23 +138,4 @@ func (v VerrazzanoManagedCluster) validateConfigMap(client client.Client) error 
 		return fmt.Errorf("Data with key %q contains invalid url %q in the ConfigMap %s namespace %s", constants.ServerDataKey, cm.Data[constants.ServerDataKey], constants.AdminClusterConfigMapName, constants.VerrazzanoMultiClusterNamespace)
 	}
 	return nil
-}
-
-// validateVerrazzanoInstalled enforces that a Verrazzano installation successfully completed
-func (v VerrazzanoManagedCluster) validateVerrazzanoInstalled(client client.Client) error {
-	// Get the Verrazzano resource
-	verrazzano := v1alpha1.VerrazzanoList{}
-	err := client.List(context.TODO(), &verrazzano)
-	if err != nil || len(verrazzano.Items) == 0 {
-		return fmt.Errorf("Verrazzano must be installed")
-	}
-
-	// Verify the state is install complete
-	for _, cond := range verrazzano.Items[0].Status.Conditions {
-		if cond.Type == v1alpha1.InstallComplete {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("the Verrazzano install must successfully complete (run the command %q to view the install status)", "kubectl get verrazzano -A")
 }

--- a/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook_test.go
+++ b/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook_test.go
@@ -7,32 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-// List of Verrazzano resources that have status InstallComplete
-var verrazzanoList = &v1alpha1.VerrazzanoList{
-	Items: []v1alpha1.Verrazzano{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-verrazzano",
-				Namespace: "default",
-			},
-			Status: v1alpha1.VerrazzanoStatus{
-				Conditions: []v1alpha1.Condition{
-					{
-						Type: v1alpha1.InstallComplete,
-					},
-				},
-			},
-		},
-	},
-}
 
 // TestCreateWithSecretAndConfigMap tests the validation of a valid VerrazzanoManagedCluster secret and valid verrazzano-admin-cluster configmap
 // GIVEN a call validate VerrazzanoManagedCluster
@@ -43,8 +24,7 @@ func TestCreateWithSecretAndConfigMap(t *testing.T) {
 
 	// fake client needed to get secret
 	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(),
-			verrazzanoList,
+		return fake.NewFakeClientWithScheme(k8scheme.Scheme,
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,
@@ -75,7 +55,6 @@ func TestCreateWithSecretAndConfigMap(t *testing.T) {
 		},
 	}
 	err := vz.ValidateCreate()
-
 	assert.NoError(t, err, "Error validating VerrazzanoMultiCluster resource")
 }
 
@@ -88,8 +67,7 @@ func TestCreateNoConfigMap(t *testing.T) {
 
 	// fake client needed to get secret
 	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(),
-			verrazzanoList,
+		return fake.NewFakeClientWithScheme(k8scheme.Scheme,
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,
@@ -124,8 +102,7 @@ func TestCreateWithSecretConfigMapMissingServer(t *testing.T) {
 
 	// fake client needed to get secret
 	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(),
-			verrazzanoList,
+		return fake.NewFakeClientWithScheme(k8scheme.Scheme,
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,
@@ -163,7 +140,7 @@ func TestCreateWithSecretConfigMapMissingServer(t *testing.T) {
 // THEN the validation should fail
 func TestCreateMissingSecretName(t *testing.T) {
 	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(), verrazzanoList), nil
+		return fake.NewFakeClientWithScheme(k8scheme.Scheme), nil
 	}
 	defer func() { getClientFunc = getClient }()
 	vz := VerrazzanoManagedCluster{
@@ -185,7 +162,7 @@ func TestCreateMissingSecretName(t *testing.T) {
 func TestCreateMissingSecret(t *testing.T) {
 	const secretName = "mySecret"
 	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(), verrazzanoList), nil
+		return fake.NewFakeClientWithScheme(newScheme()), nil
 	}
 	defer func() { getClientFunc = getClient }()
 
@@ -202,53 +179,4 @@ func TestCreateMissingSecret(t *testing.T) {
 	err := vz.ValidateCreate()
 	assert.EqualError(t, err, "The Prometheus secret mySecret does not exist in namespace verrazzano-mc",
 		"Expected correct error message for missing secret")
-}
-
-// TestCreateVerrazzanoNotInstalled tests the validation of a Verrazzano being installed
-// GIVEN a call validate VerrazzanoManagedCluster
-// WHEN the a Verrazzano install has not completed
-// THEN the validation should fail
-func TestCreateVerrazzanoNotInstalled(t *testing.T) {
-	const secretName = "mySecret"
-
-	var notInstalledList = &v1alpha1.VerrazzanoList{
-		Items: []v1alpha1.Verrazzano{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-verrazzano",
-					Namespace: "default",
-				},
-				Status: v1alpha1.VerrazzanoStatus{
-					Conditions: []v1alpha1.Condition{
-						{
-							Type: v1alpha1.InstallStarted,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// fake client needed to validate create
-	getClientFunc = func() (client.Client, error) {
-		return fake.NewFakeClientWithScheme(newScheme(),
-			notInstalledList,
-		), nil
-	}
-	defer func() { getClientFunc = getClient }()
-
-	// VMC to be validated
-	vz := VerrazzanoManagedCluster{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testMC",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
-		},
-		Spec: VerrazzanoManagedClusterSpec{
-			PrometheusSecret: secretName,
-		},
-	}
-	err := vz.ValidateCreate()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "the Verrazzano install must successfully complete")
 }

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -319,7 +319,7 @@ func TestDeleteVMC(t *testing.T) {
 
 	// Expect a call to get the prometheus configmap and return one with two entries, including this cluster
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "vmi-system-prometheus-config"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "vmi-system-prometheus-config"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			// setup a scaled down existing scrape config entry for cluster1
 			configMap.Data = map[string]string{

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -6,7 +6,6 @@ package component
 import (
 	"path/filepath"
 
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 )
 
@@ -98,28 +97,28 @@ func GetComponents() []Component {
 		helmComponent{
 			releaseName:             "coherence-operator",
 			chartDir:                filepath.Join(thirdPartyChartsDir, "coherence-operator"),
-			chartNamespace:          constants.VerrazzanoSystemNamespace,
+			chartNamespace:          "verrazzano-system",
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "coherence-values.yaml"),
 		},
 		helmComponent{
 			releaseName:             "weblogic-operator",
 			chartDir:                filepath.Join(thirdPartyChartsDir, "weblogic-operator"),
-			chartNamespace:          constants.VerrazzanoSystemNamespace,
+			chartNamespace:          "verrazzano-system",
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "weblogic-values.yaml"),
 		},
 		helmComponent{
 			releaseName:             "oam-kubernetes-runtime",
 			chartDir:                filepath.Join(thirdPartyChartsDir, "oam-kubernetes-runtime"),
-			chartNamespace:          constants.VerrazzanoSystemNamespace,
+			chartNamespace:          "verrazzano-system",
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "oam-kubernetes-runtime-values.yaml"),
 		},
 		helmComponent{
 			releaseName:             "verrazzano-application-operator",
 			chartDir:                filepath.Join(vzChartsDir, "verrazzano-application-operator"),
-			chartNamespace:          constants.VerrazzanoSystemNamespace,
+			chartNamespace:          "verrazzano-system",
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "verrazzano-application-operator-values.yaml"),
 		},

--- a/platform-operator/controllers/verrazzano/component/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano.go
@@ -6,15 +6,15 @@ package component
 import (
 	"path/filepath"
 
-	"github.com/verrazzano/verrazzano/application-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
 	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
 )
 
 const vzReleaseName = "verrazzano"
-const vzDefaultNamespace = constants.VerrazzanoSystemNamespace
+const vzDefaultNamespace = "verrazzano-system"
 
 // Verrazzano struct needed to implement interface
 type Verrazzano struct {

--- a/platform-operator/controllers/verrazzano/component/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/helm"
 	"go.uber.org/zap"
 )
@@ -32,6 +31,7 @@ func TestVzName(t *testing.T) {
 //  WHEN I call Upgrade
 //  THEN the Verrazzano upgrade returns success
 func TestVzUpgrade(t *testing.T) {
+	const defNs = "verrazzano-system"
 	assert := assert.New(t)
 	vz := Verrazzano{}
 	helm.SetCmdRunner(fakeRunner{})
@@ -45,7 +45,7 @@ func TestVzUpgrade(t *testing.T) {
 //  WHEN I call resolveNamespace
 //  THEN the Verrazzano namespace name is correctly resolved
 func TestVzResolveNamespace(t *testing.T) {
-	const defNs = constants.VerrazzanoSystemNamespace
+	const defNs = "verrazzano-system"
 	assert := assert.New(t)
 	ns := resolveNamespace("")
 	assert.Equal(defNs, ns, "Wrong namespace resolved for verrazzano when using empty namespace")

--- a/platform-operator/test/integ/integ_test.go
+++ b/platform-operator/test/integ/integ_test.go
@@ -22,6 +22,7 @@ const clusterAdmin = "cluster-admin"
 const platformOperator = "verrazzano-platform-operator"
 const managedGeneratedName1 = "verrazzano-cluster-cluster1"
 const installNamespace = "verrazzano-install"
+const vzMcNamespace = "verrazzano-mc"
 const prometheusSecret = "prometheus-cluster1"
 const vmiESIngest = "vmi-system-es-ingest"
 const hostdata = "testhost"
@@ -34,25 +35,6 @@ var _ = ginkgo.BeforeSuite(func() {
 	K8sClient, err = k8s.NewClient(util.GetKubeconfig())
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Error creating Kubernetes client to access Verrazzano API objects: %v", err))
-	}
-
-	// Platform operator pod is eventually running
-	isPodRunningYet := func() bool {
-		return K8sClient.IsPodRunning(platformOperator, installNamespace)
-	}
-	gomega.Eventually(isPodRunningYet, "2m", "5s").Should(gomega.BeTrue(),
-		"The verrazzano-platform-operator pod should be in the Running state")
-
-	// Create multi-cluster namespace
-	if !K8sClient.DoesNamespaceExist(constants.VerrazzanoMultiClusterNamespace) {
-		err = K8sClient.EnsureNamespace(constants.VerrazzanoMultiClusterNamespace)
-		gomega.Expect(err).To(gomega.BeNil())
-	}
-
-	// Create verrazzano-system namespace
-	if !K8sClient.DoesNamespaceExist(constants.VerrazzanoSystemNamespace) {
-		err = K8sClient.EnsureNamespace(constants.VerrazzanoSystemNamespace)
-		gomega.Expect(err).To(gomega.BeNil())
 	}
 })
 
@@ -108,9 +90,22 @@ var _ = ginkgo.Describe("Custom Resource Definition for verrazzano install", fun
 	})
 })
 
-// TODO: Move these tests to the end-to-end acceptance test suite.  They have become impractical to run for an integration test.
-/*
 var _ = ginkgo.Describe("Testing VMC creation and auto secret generation", func() {
+	ginkgo.It("Platform operator pod is eventually running", func() {
+		isPodRunningYet := func() bool {
+			return K8sClient.IsPodRunning(platformOperator, installNamespace)
+		}
+		gomega.Eventually(isPodRunningYet, "2m", "5s").Should(gomega.BeTrue(),
+			"The verrazzano-platform-operator pod should be in the Running state")
+	})
+	ginkgo.It("Create multi-cluster namespace ", func() {
+		err := K8sClient.EnsureNamespace(vzMcNamespace)
+		gomega.Expect(err).To(gomega.BeNil())
+	})
+	ginkgo.It("Create verrazzano-system namespace ", func() {
+		err := K8sClient.EnsureNamespace(constants.VerrazzanoSystemNamespace)
+		gomega.Expect(err).To(gomega.BeNil())
+	})
 	ginkgo.It("Missing secret name validation ", func() {
 		_, stderr := util.Kubectl("apply -f testdata/vmc_missing_secret_name.yaml")
 		gomega.Expect(stderr).To(gomega.ContainSubstring("missing required field \"prometheusSecret\""))
@@ -118,16 +113,16 @@ var _ = ginkgo.Describe("Testing VMC creation and auto secret generation", func(
 	ginkgo.It("Missing secret validation ", func() {
 		_, stderr := util.Kubectl("apply -f testdata/vmc_sample.yaml")
 		gomega.Expect(stderr).To(gomega.ContainSubstring(
-			fmt.Sprintf(fmt.Sprintf("The Prometheus secret %s does not exist in namespace %s", prometheusSecret, constants.VerrazzanoMultiClusterNamespace))))
+			fmt.Sprintf(fmt.Sprintf("The Prometheus secret %s does not exist in namespace %s", prometheusSecret, vzMcNamespace))))
 	})
 	ginkgo.It("Create Prometheus secret ", func() {
 		_, stderr := util.Kubectl(
-			fmt.Sprintf("create secret generic %s -n %s --from-literal=password=mypw --from-literal=username=myuser", prometheusSecret, constants.VerrazzanoMultiClusterNamespace))
+			fmt.Sprintf("create secret generic %s -n %s --from-literal=password=mypw --from-literal=username=myuser", prometheusSecret, vzMcNamespace))
 		gomega.Expect(stderr).To(gomega.Equal(""))
 	})
 	ginkgo.It("Create verrazzano-admin-cluster configmap ", func() {
 		_, stderr := util.Kubectl(
-			fmt.Sprintf("create cm %s -n %s --from-literal=server=http://testUrl", adminClusterConfigMap, constants.VerrazzanoMultiClusterNamespace))
+			fmt.Sprintf("create cm %s -n %s --from-literal=server=http://testUrl", adminClusterConfigMap, vzMcNamespace))
 		gomega.Expect(stderr).To(gomega.Equal(""))
 	})
 	ginkgo.It("Create Verrazzano secret needed to create ES secret ", func() {
@@ -155,7 +150,7 @@ var _ = ginkgo.Describe("Testing VMC creation and auto secret generation", func(
 	})
 	ginkgo.It("ServiceAccount exists ", func() {
 		serviceAccountExists := func() bool {
-			return K8sClient.DoesServiceAccountExist(managedGeneratedName1, constants.VerrazzanoMultiClusterNamespace)
+			return K8sClient.DoesServiceAccountExist(managedGeneratedName1, vzMcNamespace)
 		}
 		gomega.Eventually(serviceAccountExists, "30s", "5s").Should(gomega.BeTrue(),
 			"The ServiceAccount should exist")
@@ -169,57 +164,36 @@ var _ = ginkgo.Describe("Testing VMC creation and auto secret generation", func(
 	})
 	ginkgo.It("Registration secret exists ", func() {
 		secretExists := func() bool {
-			return K8sClient.DoesSecretExist(vzclusters.GetRegistrationSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+			return K8sClient.DoesSecretExist(vzclusters.GetRegistrationSecretName(managedClusterName), vzMcNamespace)
 		}
 		gomega.Eventually(secretExists, "30s", "5s").Should(gomega.BeTrue(),
-			fmt.Sprintf("The registration Secret %s should exist in %s", vzclusters.GetRegistrationSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace))
+			fmt.Sprintf("The registration Secret %s should exist in %s", vzclusters.GetRegistrationSecretName(managedClusterName), vzMcNamespace))
 	})
 	ginkgo.It("Agent secret exists ", func() {
 		secretExists := func() bool {
-			return K8sClient.DoesSecretExist(vzclusters.GetAgentSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+			return K8sClient.DoesSecretExist(vzclusters.GetAgentSecretName(managedClusterName), vzMcNamespace)
 		}
 		gomega.Eventually(secretExists, "60s", "5s").Should(gomega.BeTrue(),
-			fmt.Sprintf("The agent Secret %s should exist in %s", vzclusters.GetAgentSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace))
+			fmt.Sprintf("The agent Secret %s should exist in %s", vzclusters.GetAgentSecretName(managedClusterName), vzMcNamespace))
 	})
 	ginkgo.It("Manifest secret exists ", func() {
 		secretExists := func() bool {
-			return K8sClient.DoesSecretExist(vzclusters.GetManifestSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+			return K8sClient.DoesSecretExist(vzclusters.GetManifestSecretName(managedClusterName), vzMcNamespace)
 		}
 		gomega.Eventually(secretExists, "30s", "5s").Should(gomega.BeTrue(),
-			fmt.Sprintf("The manigest Secret %s should exist in %s", vzclusters.GetManifestSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace))
+			fmt.Sprintf("The manigest Secret %s should exist in %s", vzclusters.GetManifestSecretName(managedClusterName), vzMcNamespace))
 	})
 	ginkgo.It("Checking the VMC related secrets ", func() {
 		verifyAgentSecret()
 		verifyRegistrationSecret()
 		verifyManifestSecret()
 	})
-	ginkgo.It("Cleanup test", func() {
-		ginkgo.It("VerrazzanoManagedCluster can be deleted ", func() {
-			_, stderr := util.Kubectl("delete -f testdata/vmc_sample.yaml")
-			gomega.Expect(stderr).To(gomega.Equal(""))
-		})
-		ginkgo.It("ServiceAccount deleted ", func() {
-			serviceAccountExists := func() bool {
-				return K8sClient.DoesServiceAccountExist(managedGeneratedName1, constants.VerrazzanoMultiClusterNamespace)
-			}
-			gomega.Eventually(serviceAccountExists, "30s", "5s").Should(gomega.BeFalse(),
-				"The ServiceAccount should notexist")
-		})
-		ginkgo.It("ClusterRoleBinding deleted ", func() {
-			bindingExists := func() bool {
-				return K8sClient.DoesClusterRoleBindingExist(managedGeneratedName1)
-			}
-			gomega.Eventually(bindingExists, "30s", "5s").Should(gomega.BeFalse(),
-				"The ClusterRoleBinding should not exist")
-		})
-	})
 })
-*/
 
 // Verify the agent secret
 func verifyAgentSecret() {
 	// Get the agent secret
-	secret, err := K8sClient.GetSecret(vzclusters.GetAgentSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+	secret, err := K8sClient.GetSecret(vzclusters.GetAgentSecretName(managedClusterName), vzMcNamespace)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Unable to get registration secret %s: %v", vzclusters.GetAgentSecretName(managedClusterName), err))
 	}
@@ -240,7 +214,7 @@ func verifyAgentSecret() {
 // Verify the registration secret
 func verifyRegistrationSecret() {
 	// Get the registration secret
-	secret, err := K8sClient.GetSecret(vzclusters.GetRegistrationSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+	secret, err := K8sClient.GetSecret(vzclusters.GetRegistrationSecretName(managedClusterName), vzMcNamespace)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Unable to get registration secret %s: %v", vzclusters.GetRegistrationSecretName(managedClusterName), err))
 	}
@@ -254,7 +228,7 @@ func verifyRegistrationSecret() {
 
 // Verify the manifest secrets
 func verifyManifestSecret() {
-	secret, err := K8sClient.GetSecret(vzclusters.GetManifestSecretName(managedClusterName), constants.VerrazzanoMultiClusterNamespace)
+	secret, err := K8sClient.GetSecret(vzclusters.GetManifestSecretName(managedClusterName), vzMcNamespace)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Unable to get cluster secret %s that contains kubeconfig: %v", vzclusters.GetManifestSecretName(managedClusterName), err))
 	}


### PR DESCRIPTION
Reverts verrazzano/verrazzano#852

This change is causing a failure in the new multi-cluster acceptance test suite.  Reverting to investigate.