### PR TITLE
fix fluentd to use auth-enabled elastic entry

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -163,6 +163,7 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 	loggingScopeName := "unit-test-logging-scope"
 	fluentdImage := "unit-test-image:latest"
 	loggingSecretName := "logging-secret"
+	esURL := "http://es-odic"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
 	// expect a call to fetch the OAM application configuration (and the component has an attached logging scope)
@@ -202,6 +203,7 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
 			loggingScope.Spec.FluentdImage = fluentdImage
 			loggingScope.Spec.SecretName = loggingSecretName
+			loggingScope.Spec.ElasticSearchURL = esURL
 			return nil
 		})
 	// expect a call to list the FLUENTD config maps
@@ -292,6 +294,7 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 	fluentdImage := "unit-test-image:latest"
 	existingJvmArg := "-Dcoherence.test=unit-test"
 	loggingSecretName := "logging-secret"
+	esURL := "http://es-odic"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
 	// expect a call to fetch the OAM application configuration (and the component has an attached logging scope)
@@ -331,6 +334,7 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
 			loggingScope.Spec.FluentdImage = fluentdImage
 			loggingScope.Spec.SecretName = loggingSecretName
+			loggingScope.Spec.ElasticSearchURL = esURL
 			return nil
 		})
 	// expect a call to list the FLUENTD config maps

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -157,7 +157,7 @@ func (h *HelidonHandler) ApplyToDeployment(ctx context.Context, workload vzapi.Q
 	if err != nil {
 		return nil, err
 	}
-	err = ensureLoggingSecret(ctx, h, scope.GetNamespace(), scope.Spec.SecretName)
+	err = ensureLoggingSecret(ctx, h, scope.GetNamespace(), &scope.Spec)
 	if err != nil {
 		return nil, err
 	}

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -151,6 +151,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	loggingScopeName := "unit-test-logging-scope"
 	fluentdImage := "unit-test-image:latest"
 	loggingSecretName := "logging-secret"
+	esURL := "http://es-odic"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -180,6 +181,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
 			loggingScope.Spec.FluentdImage = fluentdImage
 			loggingScope.Spec.SecretName = loggingSecretName
+			loggingScope.Spec.ElasticSearchURL = esURL
 			return nil
 		})
 	// expect a call to list the FLUENTD config maps


### PR DESCRIPTION
# Description

Fix fluentd to use verrazzano secret to connect to auth-enabled oidc elasticsearch entry

Fixes VZ-2247

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
