### PR TITLE
Allow users to control when OAM application is upgraded to latest Verrazzano

### DIFF
--- a/application-operator/apis/oam/v1alpha1/verrazzanocoherenceworkload_types.go
+++ b/application-operator/apis/oam/v1alpha1/verrazzanocoherenceworkload_types.go
@@ -17,11 +17,14 @@ type VerrazzanoCoherenceWorkloadSpec struct {
 
 // VerrazzanoCoherenceWorkloadStatus defines the observed state of VerrazzanoCoherenceWorkload
 type VerrazzanoCoherenceWorkloadStatus struct {
+	// CurrentUpgradeVersion is the version that was specified when the application was last upgraded with Verrazzano
+	CurrentUpgradeVersion string `json:"currentUpgradeVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // VerrazzanoCoherenceWorkload is the Schema for the verrazzanocoherenceworkloads API
+// +kubebuilder:subresource:status
 type VerrazzanoCoherenceWorkload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/application-operator/apis/oam/v1alpha1/verrazzanohelidonworkload_types.go
+++ b/application-operator/apis/oam/v1alpha1/verrazzanohelidonworkload_types.go
@@ -32,6 +32,9 @@ type VerrazzanoHelidonWorkloadStatus struct {
 
 	// Resources managed by this workload.
 	Resources []QualifiedResourceRelation `json:"resources,omitempty"`
+
+	// CurrentUpgradeVersion is the version that was specified when the application was last upgraded with Verrazzano
+	CurrentUpgradeVersion string `json:"currentUpgradeVersion,omitempty"`
 }
 
 // VerrazzanoHelidonWorkload is the Schema for verrazzanohelidonworkloads API

--- a/application-operator/apis/oam/v1alpha1/verrazzanoweblogicworkload_types.go
+++ b/application-operator/apis/oam/v1alpha1/verrazzanoweblogicworkload_types.go
@@ -17,11 +17,14 @@ type VerrazzanoWebLogicWorkloadSpec struct {
 
 // VerrazzanoWebLogicWorkloadStatus defines the observed state of VerrazzanoWebLogicWorkload
 type VerrazzanoWebLogicWorkloadStatus struct {
+	// CurrentUpgradeVersion is the version that was specified when the application was last upgraded with Verrazzano
+	CurrentUpgradeVersion string `json:"currentUpgradeVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // VerrazzanoWebLogicWorkload is the Schema for the verrazzanoweblogicworkloads API
+// +kubebuilder:subresource:status
 type VerrazzanoWebLogicWorkload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -64,3 +64,11 @@ const StatusUpdateChannelBufferSize = 50
 // StatusUpdateBatchSize - the number of status update messages the multi cluster agent should
 // process each time it wakes up
 const StatusUpdateBatchSize = 10
+
+// LabelUpgradeVersion - label which allows users to indicate that a running app should be upgraded to latest version of
+// Verrazzano. When an application is deployed, the value of this label is set on workload.Status.CurrentUpgradeVersion.
+// When reconciling, if the value provided in the label is different than the value in the workload status, the application
+// will be 'upgraded' to use the resources provided by current version of Verrazzano. If any of these resources have
+// changed since the application was deployed, the application will pick up the latest values and be restarted. If the
+// label value matches the value in the workload status, all Verrazzano provided resources will remain unchanged.
+const LabelUpgradeVersion = "upgrade-version"

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -12,11 +12,14 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	istionet "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,7 +169,25 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, errors.New("Embedded Coherence resource is missing the required 'spec' field")
 	}
 
-	if err = r.addLogging(ctx, log, req.NamespacedName.Namespace, workload.ObjectMeta.Labels, spec); err != nil {
+	// Attempt to get the existing Coherence StatefulSet. This is used in the case where we don't want to update any resources
+	// which are defined by Verrazzano such as the Fluentd image used by logging. In this case we obtain the previous
+	// Fluentd image and set that on the new Coherence StatefulSet.
+	var existingCoherence v1.StatefulSet
+	coherenceKey := types.NamespacedName{Name: u.GetName(), Namespace: workload.Namespace}
+	if err := r.Get(ctx, coherenceKey, &existingCoherence); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Info("No existing Coherence StatefulSet found")
+		} else {
+			log.Error(err, "An error occurred trying to obtain an existing Coherence StatefulSet")
+			return reconcile.Result{}, err
+		}
+	}
+	// upgradeApp indicates whether the user has indicated that it is ok to update the application to use the latest
+	// resource values from Verrazzano. An example of this is the Fluentd image used by logging.
+	upgradeApp := controllers.IsWorkloadMarkedForUpgrade(workload.Labels, workload.Status.CurrentUpgradeVersion)
+
+	// Add the Fluentd sidecar container required for logging to the Coherence StatefulSet
+	if err = r.addLogging(ctx, log, workload, upgradeApp, spec, &existingCoherence); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -217,6 +238,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
+	if err = r.updateUpgradeVersionInStatus(ctx, workload); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	log.Info("Successfully reconciled Verrazzano Coherence workload")
 	return reconcile.Result{}, nil
 }
@@ -252,6 +277,10 @@ func copyLabels(log logr.Logger, workloadLabels map[string]string, coherence *un
 		labels[oam.LabelAppName] = appName
 	}
 
+	if upgradeVersion, ok := workloadLabels[constants.LabelUpgradeVersion]; ok {
+		labels[constants.LabelUpgradeVersion] = upgradeVersion
+	}
+
 	err := unstructured.SetNestedStringMap(coherence.Object, labels, specLabelsFields...)
 	if err != nil {
 		log.Error(err, "Unable to set labels in spec")
@@ -283,8 +312,20 @@ func (r *Reconciler) disableIstioInjection(log logr.Logger, u *unstructured.Unst
 }
 
 // addLogging adds a FLUENTD sidecar and updates the Coherence spec if there is an associated LoggingScope
-func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace string, labels map[string]string, coherenceSpec map[string]interface{}) error {
-	loggingScope, err := loggingscope.FetchLoggingScopeFromWorkloadLabels(ctx, r.Client, log, namespace, labels)
+func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, workload *vzapi.VerrazzanoCoherenceWorkload, upgradeApp bool, coherenceSpec map[string]interface{}, existingCoherence *v1.StatefulSet) error {
+	// If the Coherence StatefulSet already exists and we don't want to update the Fluentd image, obtain the Fluentd image from the
+	// current Coherence StatefulSet
+	var existingFluentdImage string
+	if !upgradeApp {
+		for _, container := range existingCoherence.Spec.Template.Spec.Containers {
+			if container.Name == loggingscope.FluentdContainerName {
+				existingFluentdImage = container.Image
+				break
+			}
+		}
+	}
+
+	loggingScope, err := loggingscope.FetchLoggingScopeFromWorkloadLabels(ctx, r.Client, log, workload.Namespace, workload.Labels, existingFluentdImage)
 	if err != nil {
 		return err
 	}
@@ -321,7 +362,7 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, namespace 
 
 	// fluentdManager.Apply wants a QRR but it only cares about the namespace (at least for
 	// this use case)
-	resource := vzapi.QualifiedResourceRelation{Namespace: namespace}
+	resource := vzapi.QualifiedResourceRelation{Namespace: workload.Namespace}
 
 	// note that this call has the side effect of creating a FLUENTD config map if one
 	// does not already exist in the namespace
@@ -536,5 +577,13 @@ func (r *Reconciler) mutateDestinationRule(destinationRule *istioclient.Destinat
 		return err
 	}
 
+	return nil
+}
+
+func (r *Reconciler) updateUpgradeVersionInStatus(ctx context.Context, workload *vzapi.VerrazzanoCoherenceWorkload) error {
+	if workload.Labels[constants.LabelUpgradeVersion] != workload.Status.CurrentUpgradeVersion {
+		workload.Status.CurrentUpgradeVersion = workload.Labels[constants.LabelUpgradeVersion]
+		return r.Status().Update(ctx, workload)
+	}
 	return nil
 }

--- a/application-operator/controllers/controller_utils.go
+++ b/application-operator/controllers/controller_utils.go
@@ -3,7 +3,11 @@
 
 package controllers
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+)
 
 // StringSliceContainsString determines if a string is found in a string slice.
 // slice is the string slice to search. May be nil.
@@ -44,4 +48,13 @@ func ConvertAPIVersionToGroupAndVersion(apiVersion string) (string, string) {
 		return "", parts[0]
 	}
 	return parts[0], parts[1]
+}
+
+// IsWorkloadMarkedForUpgrade checks to see if a workload needs to be upgraded to the latest
+// Verrazzano version. Verrazzano defines some resources which are used by applications and when Verrazzano is upgraded,
+// a user can mark an application to indicate that it should use the latest resources defined by Verrazzano.
+// A response of 'true' indicates that reconcile should use the latest resources defined by Verrazzano and a response
+// of 'false' indicates that the application should continue to use the current values.
+func IsWorkloadMarkedForUpgrade(labels map[string]string, previousUpgrade string) bool {
+	return labels[constants.LabelUpgradeVersion] != previousUpgrade
 }

--- a/application-operator/controllers/controller_utils_test.go
+++ b/application-operator/controllers/controller_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	asserts "github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 )
 
 // Test_stringSliceContainsString tests metrics trait utility function stringSliceContainsString
@@ -94,4 +95,21 @@ func TestConvertAPIVersionToGroupAndVersion(t *testing.T) {
 	g, v = ConvertAPIVersionToGroupAndVersion("version")
 	assert.Equal("", g)
 	assert.Equal("version", v)
+}
+
+// TestIsWorkloadMarkedForUpgrade tests IsWorkloadMarkedForUpgrade to ensure that it returns the correct response
+// based on a map of labels and a current version.
+func TestIsWorkloadMarkedForUpgrade(t *testing.T) {
+	assert := asserts.New(t)
+	labels := map[string]string{"foo": "bar", constants.LabelUpgradeVersion: "12345"}
+
+	// GIVEN a current upgrade version that matches the corresponding label
+	// WHEN IsWorkloadMarkedForUpgrade is called
+	// THEN false is returned
+	assert.False(IsWorkloadMarkedForUpgrade(labels, "12345"))
+
+	// GIVEN a current upgrade version that doesn't match the corresponding label
+	// WHEN IsWorkloadMarkedForUpgrade is called
+	// THEN true is returned
+	assert.True(IsWorkloadMarkedForUpgrade(labels, "99999"))
 }

--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
+	FluentdContainerName = "fluentd"
 	fluentdConfKey       = "fluentd.conf"
 	fluentdConfMountPath = "/fluentd/etc/fluentd.conf"
-	fluentdContainerName = "fluentd"
 	configMapName        = "fluentd-config"
 	scratchVolMountPath  = "/scratch"
 
@@ -229,7 +229,7 @@ func (f *Fluentd) removeFluentdContainer(fluentdPod *FluentdPod) bool {
 	containers := fluentdPod.Containers
 	fluentdContainerIndex := -1
 	for i, container := range containers {
-		if container.Name == fluentdContainerName {
+		if container.Name == FluentdContainerName {
 			fluentdContainerIndex = i
 			break
 		}
@@ -297,7 +297,7 @@ func (f *Fluentd) removeFluentdConfigMap(namespace string) bool {
 // isFluentdContainerUpToDate is used to determine if the FLUENTD container is in the current expected state
 func (f *Fluentd) isFluentdContainerUpToDate(containers []v1.Container, scope *vzapi.LoggingScope) bool {
 	for _, container := range containers {
-		if container.Name != fluentdContainerName {
+		if container.Name != FluentdContainerName {
 			continue
 		}
 		diffExists := false

--- a/application-operator/controllers/loggingscope/fluentd_test.go
+++ b/application-operator/controllers/loggingscope/fluentd_test.go
@@ -287,7 +287,7 @@ func createTestFluentdPod() *FluentdPod {
 // createTestFluendPodForUpdate creates a test FluentdPod to be used in testing update
 func createTestFluentdPodForUpdate() *FluentdPod {
 	env := createFluentdESEnv()
-	fluentdContainer := v1.Container{Name: fluentdContainerName, Env: env}
+	fluentdContainer := v1.Container{Name: FluentdContainerName, Env: env}
 	fluentdPod := &FluentdPod{
 		Containers:   []v1.Container{{Name: "test-container"}, fluentdContainer},
 		Volumes:      []v1.Volume{{Name: "test-volume"}},
@@ -312,7 +312,7 @@ func testAssertFluentdPodForApply(t *testing.T, fluentdPod *FluentdPod, loggingS
 	asserts.Len(t, containers, 2)
 	success := false
 	for _, container := range containers {
-		if container.Name == fluentdContainerName {
+		if container.Name == FluentdContainerName {
 			env := container.Env
 			for _, envVar := range env {
 				switch name := envVar.Name; name {
@@ -343,7 +343,7 @@ func testAssertFluentdPodForApplyUpdate(t *testing.T, fluentdPod *FluentdPod) {
 	asserts.Len(t, containers, 2)
 	success := false
 	for _, container := range containers {
-		if container.Name == fluentdContainerName {
+		if container.Name == FluentdContainerName {
 			env := container.Env
 			for _, envVar := range env {
 				switch name := envVar.Name; name {

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -174,7 +174,7 @@ func searchContainers(containers []kcore.Container) ([]string, bool) {
 	var appContainers []string
 	fluentdFound := false
 	for _, container := range containers {
-		if container.Name == fluentdContainerName {
+		if container.Name == FluentdContainerName {
 			fluentdFound = true
 		} else {
 			appContainers = append(appContainers, container.Name)
@@ -207,7 +207,7 @@ func (h *HelidonHandler) Remove(ctx context.Context, workload vzapi.QualifiedRes
 		existingContainers := deploy.Spec.Template.Spec.Containers
 		deploy.Spec.Template.Spec.Containers = []kcore.Container{}
 		for _, container := range existingContainers {
-			if container.Name != fluentdContainerName {
+			if container.Name != FluentdContainerName {
 				deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, container)
 			}
 		}
@@ -251,7 +251,7 @@ func CreateFluentdConfigMap(namespace, name, fluentdConfig string) *kcore.Config
 // CreateFluentdContainer creates a FLUENTD sidecar container.
 func CreateFluentdContainer(spec vzapi.LoggingScopeSpec, namespace, workloadName string) kcore.Container {
 	container := kcore.Container{
-		Name:            fluentdContainerName,
+		Name:            FluentdContainerName,
 		Args:            []string{"-c", "/etc/fluent.conf"},
 		Image:           spec.FluentdImage,
 		ImagePullPolicy: kcore.PullIfNotPresent,

--- a/application-operator/controllers/loggingscope/loggingscope_controller.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller.go
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	applyDefaults(r.Client, log, scope)
+	applyDefaults(r.Client, log, scope, "")
 
 	var errors []string
 	var resources []vzapi.QualifiedResourceRelation
@@ -214,7 +214,7 @@ func toResource(workload *unstructured.Unstructured) vzapi.QualifiedResourceRela
 
 // FetchLoggingScopeFromWorkloadLabels returns the LoggingScope object associated with the workload or nil if
 // there is no associated logging scope. The workload lookup is done using the OAM labels from the workload metadata.
-func FetchLoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader, log logr.Logger, namespace string, labels map[string]string) (*vzapi.LoggingScope, error) {
+func FetchLoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader, log logr.Logger, namespace string, labels map[string]string, fluentdImageOrverride string) (*vzapi.LoggingScope, error) {
 	component, err := vznav.ComponentFromWorkloadLabels(ctx, cli, namespace, labels)
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func FetchLoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader,
 				return nil, err
 			}
 
-			applyDefaults(cli, log, &scope)
+			applyDefaults(cli, log, &scope, fluentdImageOrverride)
 			return &scope, nil
 		}
 	}
@@ -243,7 +243,7 @@ func FetchLoggingScopeFromWorkloadLabels(ctx context.Context, cli client.Reader,
 
 // applyDefaults fills in any empty fields in the logging scope - also handle the case
 // where we are running in a managed cluster
-func applyDefaults(cli client.Reader, log logr.Logger, scope *vzapi.LoggingScope) {
+func applyDefaults(cli client.Reader, log logr.Logger, scope *vzapi.LoggingScope, fluentdImageOrverride string) {
 	if scope.Spec.ElasticSearchURL == "" && scope.Spec.SecretName == "" {
 		// if we're running in a managed cluster, use the multicluster ES URL and secret, and if we're
 		// not the fields will be empty and we will set these fields to defaults below
@@ -257,7 +257,9 @@ func applyDefaults(cli client.Reader, log logr.Logger, scope *vzapi.LoggingScope
 		}
 	}
 
-	if scope.Spec.FluentdImage == "" {
+	if len(fluentdImageOrverride) != 0 {
+		scope.Spec.FluentdImage = fluentdImageOrverride
+	} else {
 		scope.Spec.FluentdImage = DefaultFluentdImage
 	}
 	if scope.Spec.ElasticSearchURL == "" {

--- a/application-operator/controllers/loggingscope/loggingscope_controller_test.go
+++ b/application-operator/controllers/loggingscope/loggingscope_controller_test.go
@@ -31,12 +31,13 @@ import (
 )
 
 const (
-	testKind       = "test-type"
-	workloadUID    = "test-workload-uid"
-	workloadName   = "test-workload-name"
-	testNamespace  = "test-namespace"
-	testAPIVersion = "testv1"
-	testScopeName  = "test-scope-name"
+	testKind         = "test-type"
+	workloadUID      = "test-workload-uid"
+	workloadName     = "test-workload-name"
+	testNamespace    = "test-namespace"
+	testAPIVersion   = "testv1"
+	testScopeName    = "test-scope-name"
+	testFluentdImage = "test-image:latest"
 )
 
 // TestReconcilerSetupWithManager test the creation of the logging scope reconciler.
@@ -89,6 +90,13 @@ func TestLoggingScopeReconcileApply(t *testing.T) {
 	updatedScope := createTestLoggingScope(true)
 	updatedScope.Status = testStatus
 
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+	DefaultFluentdImage = testFluentdImage
+
 	mockClient.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testScopeName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, scope *vzapi.LoggingScope) error {
@@ -130,6 +138,13 @@ func TestLoggingScopeReconcileRemove(t *testing.T) {
 		APIVersion: testAPIVersion, Kind: testKind, Name: workloadName, Namespace: testNamespace,
 	}}}
 	testScope.Status = testStatus
+
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+	DefaultFluentdImage = testFluentdImage
 
 	// lookup scope
 	mockClient.EXPECT().
@@ -178,6 +193,13 @@ func TestLoggingScopeReconcileBothApplyAndRemove(t *testing.T) {
 	updatedScope := createTestLoggingScope(true)
 	updatedScope.Status = updatedStatus
 
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+	DefaultFluentdImage = testFluentdImage
+
 	mockClient.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testScopeName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, scope *vzapi.LoggingScope) error {
@@ -223,6 +245,13 @@ func TestLoggingScopeReconcileRemoveAndForget(t *testing.T) {
 	testScope.Status = testStatus
 	updatedScope := createTestLoggingScope(false)
 
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+	DefaultFluentdImage = testFluentdImage
+
 	// lookup scope
 	mockClient.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testScopeName}, gomock.Not(gomock.Nil())).
@@ -253,6 +282,14 @@ func TestFromWorkloadLabels(t *testing.T) {
 	var cli *mocks.MockClient
 	var ctx = context.TODO()
 
+	// set the logging scope default FLUENTD image for this test and then put it back when we're done
+	oldDefaultFluentdImage := DefaultFluentdImage
+	defer func() {
+		DefaultFluentdImage = oldDefaultFluentdImage
+	}()
+
+	DefaultFluentdImage = testFluentdImage
+
 	// GIVEN workload labels
 	// WHEN an attempt is made to get the logging scopes from the app component but there are no scopes
 	// THEN expect no error and a nil logging scope is returned
@@ -270,19 +307,19 @@ func TestFromWorkloadLabels(t *testing.T) {
 			return nil
 		})
 
-	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels, "")
 
 	mocker.Finish()
 	assert.NoError(err)
 	assert.Nil(loggingScope)
 
-	// GIVEN workload labels
+	// GIVEN workload labels and a Fluentd image override
 	// WHEN an attempt is made to get the logging scopes from the app component and there is a logging scope
-	// THEN expect no error and a logging scope is returned
+	// THEN expect no error and a logging scope is returned with the provided Fluentd image
 	mocker = gomock.NewController(t)
 	cli = mocks.NewMockClient(mocker)
 	loggingScopeName := "unit-test-logging-scope"
-	fluentdImage := "unit-test-image:latest"
+	fluentdImageOverride := "unit-test-image:latest"
 	esURL := "localhost"
 	loggingSecretName := "unit-test-secret"
 
@@ -300,18 +337,51 @@ func TestFromWorkloadLabels(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: loggingScopeName}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
-			loggingScope.Spec.FluentdImage = fluentdImage
 			loggingScope.Spec.ElasticSearchURL = esURL
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
 
-	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels, fluentdImageOverride)
 
 	mocker.Finish()
 	assert.NoError(err)
 	assert.NotNil(loggingScope)
-	assert.Equal(fluentdImage, loggingScope.Spec.FluentdImage)
+	assert.Equal(fluentdImageOverride, loggingScope.Spec.FluentdImage)
+	assert.Equal(esURL, loggingScope.Spec.ElasticSearchURL)
+	assert.Equal(loggingSecretName, loggingScope.Spec.SecretName)
+
+	// GIVEN workload labels and no Fluentd image override
+	// WHEN an attempt is made to get the logging scopes from the app component and there is a logging scope
+	// THEN expect no error and a logging scope is returned with the default Fluentd image
+	mocker = gomock.NewController(t)
+	cli = mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the oam application configuration
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: "unit-test-app-config"}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq(client.ObjectKey{Namespace: "unit-test-namespace", Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+			loggingScope.Spec.ElasticSearchURL = esURL
+			loggingScope.Spec.SecretName = loggingSecretName
+			return nil
+		})
+
+	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels, "")
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.NotNil(loggingScope)
+	assert.Equal(testFluentdImage, loggingScope.Spec.FluentdImage)
 	assert.Equal(esURL, loggingScope.Spec.ElasticSearchURL)
 	assert.Equal(loggingSecretName, loggingScope.Spec.SecretName)
 
@@ -338,7 +408,7 @@ func TestFromWorkloadLabels(t *testing.T) {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
 
-	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err = FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels, "")
 
 	mocker.Finish()
 	assert.True(k8serrors.IsNotFound(err))
@@ -356,7 +426,7 @@ func TestFetchLoggingScopeWithDefaults(t *testing.T) {
 		DefaultFluentdImage = oldDefaultFluentdImage
 	}()
 
-	DefaultFluentdImage = "default-unit-test-image:latest"
+	DefaultFluentdImage = testFluentdImage
 
 	var mocker *gomock.Controller
 	var cli *mocks.MockClient
@@ -395,12 +465,12 @@ func TestFetchLoggingScopeWithDefaults(t *testing.T) {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
 		})
 
-	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels)
+	loggingScope, err := FetchLoggingScopeFromWorkloadLabels(ctx, cli, ctrl.Log.WithName("test"), "unit-test-namespace", labels, "")
 
 	mocker.Finish()
 	assert.NoError(err)
 	assert.NotNil(loggingScope)
-	assert.Equal(DefaultFluentdImage, loggingScope.Spec.FluentdImage)
+	assert.Equal(testFluentdImage, loggingScope.Spec.FluentdImage)
 	assert.Equal(DefaultElasticSearchURL, loggingScope.Spec.ElasticSearchURL)
 	assert.Equal(DefaultSecretName, loggingScope.Spec.SecretName)
 }
@@ -414,7 +484,7 @@ func TestApplyDefaults(t *testing.T) {
 		DefaultFluentdImage = oldDefaultFluentdImage
 	}()
 
-	DefaultFluentdImage = "default-unit-test-image:latest"
+	DefaultFluentdImage = testFluentdImage
 
 	var mocker *gomock.Controller
 	var cli *mocks.MockClient
@@ -428,7 +498,7 @@ func TestApplyDefaults(t *testing.T) {
 	loggingScope := &vzapi.LoggingScope{}
 	expected := &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     DefaultFluentdImage,
+			FluentdImage:     testFluentdImage,
 			ElasticSearchURL: DefaultElasticSearchURL,
 			SecretName:       DefaultSecretName,
 		},
@@ -443,36 +513,7 @@ func TestApplyDefaults(t *testing.T) {
 	assertApplyDefaults(cli, expected, loggingScope, t)
 	mocker.Finish()
 
-	// GIVEN a logging scope with just the fluentd image in the spec
-	// WHEN we apply defaults
-	// THEN the remaining logging scope spec fields are populated with default values
-	mocker = gomock.NewController(t)
-	cli = mocks.NewMockClient(mocker)
-
-	fluentdImage := "unit-test-image:1.0"
-	loggingScope = &vzapi.LoggingScope{
-		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage: fluentdImage,
-		},
-	}
-	expected = &vzapi.LoggingScope{
-		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     fluentdImage,
-			ElasticSearchURL: DefaultElasticSearchURL,
-			SecretName:       DefaultSecretName,
-		},
-	}
-
-	// logging scope URL and secret are empty so expect a call to get the cluster secret, return NotFound
-	cli.EXPECT().Get(gomock.Eq(context.TODO()), gomock.Eq(clusters.MCRegistrationSecretFullName), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *v1.Secret) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
-		})
-
-	assertApplyDefaults(cli, expected, loggingScope, t)
-	mocker.Finish()
-
-	// GIVEN a logging scope with the fluentd image and ES URL in the spec
+	// GIVEN a logging scope with the Elasticsearch URL in the spec
 	// WHEN we apply defaults
 	// THEN the remaining logging scope spec fields are populated with default values
 	mocker = gomock.NewController(t)
@@ -481,13 +522,12 @@ func TestApplyDefaults(t *testing.T) {
 	esURL := "localhost:9200"
 	loggingScope = &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     fluentdImage,
 			ElasticSearchURL: esURL,
 		},
 	}
 	expected = &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     fluentdImage,
+			FluentdImage:     testFluentdImage,
 			ElasticSearchURL: esURL,
 			SecretName:       DefaultSecretName,
 		},
@@ -504,14 +544,13 @@ func TestApplyDefaults(t *testing.T) {
 	loggingSecretName := "sssshhhhhhh"
 	loggingScope = &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     fluentdImage,
 			ElasticSearchURL: esURL,
 			SecretName:       loggingSecretName,
 		},
 	}
 	expected = &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     fluentdImage,
+			FluentdImage:     testFluentdImage,
 			ElasticSearchURL: esURL,
 			SecretName:       loggingSecretName,
 		},
@@ -530,7 +569,7 @@ func TestApplyDefaultsForManagedCluster(t *testing.T) {
 		DefaultFluentdImage = oldDefaultFluentdImage
 	}()
 
-	DefaultFluentdImage = "default-unit-test-image:latest"
+	DefaultFluentdImage = testFluentdImage
 
 	var mocker *gomock.Controller
 	var cli *mocks.MockClient
@@ -547,7 +586,7 @@ func TestApplyDefaultsForManagedCluster(t *testing.T) {
 	loggingScope := &vzapi.LoggingScope{}
 	expected := &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     DefaultFluentdImage,
+			FluentdImage:     testFluentdImage,
 			ElasticSearchURL: adminClusterESURL,
 			SecretName:       constants.MCRegistrationSecret,
 		},
@@ -577,7 +616,7 @@ func TestApplyDefaultsForManagedCluster(t *testing.T) {
 	loggingScope = &vzapi.LoggingScope{}
 	expected = &vzapi.LoggingScope{
 		Spec: vzapi.LoggingScopeSpec{
-			FluentdImage:     DefaultFluentdImage,
+			FluentdImage:     testFluentdImage,
 			ElasticSearchURL: DefaultElasticSearchURL,
 			SecretName:       DefaultSecretName,
 		},
@@ -602,7 +641,7 @@ func TestApplyDefaultsForManagedCluster(t *testing.T) {
 // asserts that it is equal to the expected logging scope
 func assertApplyDefaults(cli client.Reader, expected, actual *vzapi.LoggingScope, t *testing.T) {
 	assert := asserts.New(t)
-	applyDefaults(cli, ctrl.Log.WithName("test"), actual)
+	applyDefaults(cli, ctrl.Log.WithName("test"), actual, "")
 	assert.Equal(expected, actual)
 }
 
@@ -642,7 +681,7 @@ func createTestLoggingScope(includeWorkload bool) *vzapi.LoggingScope {
 		Name:      testScopeName}
 	scope.Spec.ElasticSearchURL = testESURL
 	scope.Spec.SecretName = testESSecret
-	scope.Spec.FluentdImage = "fluentd/image/location"
+	scope.Spec.FluentdImage = testFluentdImage
 	if includeWorkload {
 		scope.Spec.WorkloadReferences = []oamrt.TypedReference{{
 			APIVersion: oamcore.SchemeGroupVersion.Identifier(),

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -5,7 +5,6 @@ package wlsworkload
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -15,6 +14,8 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	wls "github.com/verrazzano/verrazzano/application-operator/apis/weblogic/v8"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingscope"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
@@ -84,6 +85,12 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 	componentName := "unit-test-component"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
@@ -93,6 +100,7 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
 			return nil
 		})
 	// expect a call to fetch the oam application configuration
@@ -161,6 +169,17 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	loggingSecretName := "logging-secret"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
+	// set the Fluentd image which is obtained via env then reset at end of test
+	initialDefaultFluentdImage := loggingscope.DefaultFluentdImage
+	loggingscope.DefaultFluentdImage = fluentdImage
+	defer func() { loggingscope.DefaultFluentdImage = initialDefaultFluentdImage }()
+
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
@@ -170,6 +189,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
 			return nil
 		})
 	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)
@@ -186,7 +206,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: loggingScopeName}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
-			loggingScope.Spec.FluentdImage = fluentdImage
+
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
@@ -204,14 +224,14 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
 			return nil
 		})
-	// expect a call to get the elasticsearch secret in app namespace - return not found
+	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
 		Get(gomock.Any(), testLoggingSecretFullName, gomock.Not(gomock.Nil())).
 		Return(k8serrors.NewNotFound(schema.ParseGroupResource("v1.Secret"), loggingSecretName))
 
-	// expect a call to create an empty elasticsearch secret in app namespace (default behavior, so
-	// that fluentd volume mount works)
+	// expect a call to create an empty Elasticsearch secret in app namespace (default behavior, so
+	// that Fluentd volume mount works)
 	cli.EXPECT().
 		Create(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, sec *corev1.Secret, options *client.CreateOptions) error {
@@ -262,12 +282,168 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	assert.Equal(false, result.Requeue)
 }
 
-// TestReconcileUpdateCR tests reconciling a VerrazzanoWebLogicWorkload when the WebLogic
-// CR already exists. We expect the CR to be updated.
-// GIVEN a VerrazzanoWebLogicWorkload resource is updated
-// WHEN the controller Reconcile function is called and the WebLogic CR already exists
-// THEN the WebLogic CR is updated
-func TestReconcileUpdateCR(t *testing.T) {
+// TestReconcileAlreadyExistsUpgrade tests reconciling a VerrazzanoWebLogicWorkload when the WebLogic
+// domain CR already exists and the upgrade version specified in the labels differs from the current upgrade version.
+// This should result in the latest Fluentd image being pulled from the env.
+// GIVEN a VerrazzanoWebLogicWorkload resource
+// WHEN the controller Reconcile function is called and the WebLogic domain CR already exists and the upgrade version differs
+// THEN the Fluentd image should be retrieved from the env and the new update version should be set on the workload status
+func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	loggingScopeName := "unit-test-logging-scope"
+	fluentdImage := "unit-test-image:latest"
+	loggingSecretName := "logging-secret"
+	newUpgradeVersion := "new-upgrade"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName, constants.LabelUpgradeVersion: newUpgradeVersion}
+
+	// set the Fluentd image which is obtained via env then reset at end of test
+	initialDefaultFluentdImage := loggingscope.DefaultFluentdImage
+	loggingscope.DefaultFluentdImage = fluentdImage
+	defer func() { loggingscope.DefaultFluentdImage = initialDefaultFluentdImage }()
+
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			// return nil error to simulate domain existing
+			return nil
+		})
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.GroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
+			// set the previous upgrade value to be different than what is specified in the associated label
+			// to tell Verrazzano to get the Fluentd image from the env
+			workload.Status.CurrentUpgradeVersion = "oldVersion"
+			return nil
+		})
+	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
+			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
+			return nil
+		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+
+			loggingScope.Spec.SecretName = loggingSecretName
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
+			return nil
+		})
+	// expect a call to get the Elasticsearch secret in app namespace - return not found
+	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
+	cli.EXPECT().
+		Get(gomock.Any(), testLoggingSecretFullName, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.ParseGroupResource("v1.Secret"), loggingSecretName))
+
+	// expect a call to create an empty Elasticsearch secret in app namespace (default behavior, so
+	// that Fluentd volume mount works)
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, sec *corev1.Secret, options *client.CreateOptions) error {
+			asserts.Equal(t, namespace, sec.Namespace)
+			asserts.Equal(t, loggingSecretName, sec.Name)
+			asserts.Nil(t, sec.Data)
+			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+
+	// expect a call to get the namespace for the domain
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: "", Name: namespace}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to attempt to get the Coherence CR
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, u *unstructured.Unstructured) error {
+			// set the old Fluentd image on the returned obj
+			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
+			unstructured.SetNestedField(containers[0].(map[string]interface{}), "unit-test-image:existing", "image")
+			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
+			// return nil error because Coherence StatefulSet exists
+			return nil
+		})
+	// expect a call to create the WebLogic domain CR
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+
+			// make sure the OAM component and app name labels were copied
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, specServerPodLabelsFields...)
+			assert.Equal(2, len(specLabels))
+			assert.Equal("unit-test-component", specLabels["app.oam.dev/component"])
+			assert.Equal("unit-test-app-config", specLabels["app.oam.dev/name"])
+
+			// make sure the FLUENTD sidecar was added
+			containers, _, _ := unstructured.NestedSlice(u.Object, specServerPodContainersFields...)
+			assert.Equal(1, len(containers))
+			assert.Equal(fluentdImage, containers[0].(map[string]interface{})["image"])
+			return nil
+		})
+
+	// expect a call to status update
+	cli.EXPECT().Status().Return(mockStatus).AnyTimes()
+	// expect a call to update the status upgrade version
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			assert.Equal(newUpgradeVersion, workload.Status.CurrentUpgradeVersion)
+			return nil
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileAlreadyExistsNoUpgrade tests reconciling a VerrazzanoWebLogicWorkload when the WebLogic
+// domain CR already exists and the upgrade version specified in the labels matches the current upgrade version.
+// This should result in the previous Fluentd image being used.
+// GIVEN a VerrazzanoWebLogicWorkload resource
+// WHEN the controller Reconcile function is called and the WebLogic domain CR already exists and the upgrade version matches
+// THEN the previous Fluentd image should be used again
+func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -275,56 +451,113 @@ func TestReconcileUpdateCR(t *testing.T) {
 
 	appConfigName := "unit-test-app-config"
 	componentName := "unit-test-component"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+	loggingScopeName := "unit-test-logging-scope"
+	fluentdImage := "unit-test-image:latest"
+	existingFluentdImage := "unit-test-image:existing"
+	loggingSecretName := "logging-secret"
+	previousUpgradeVersion := "new-upgrade"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName, constants.LabelUpgradeVersion: previousUpgradeVersion}
 
-	// simulate the "replicas" field changing to 3
-	replicasFromWorkload := int64(3)
+	// existing domain containers
+	containers := []corev1.Container{{Name: loggingscope.FluentdContainerName, Image: existingFluentdImage}}
 
+	// set the Fluentd image which is obtained via env then reset at end of test
+	initialDefaultFluentdImage := loggingscope.DefaultFluentdImage
+	loggingscope.DefaultFluentdImage = fluentdImage
+	defer func() { loggingscope.DefaultFluentdImage = initialDefaultFluentdImage }()
+
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
+			domain.Spec.ServerPod.Containers = containers
+			// return nil error to simulate domain existing
+			return nil
+		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"replicas":` + fmt.Sprint(replicasFromWorkload) + `}}`
+			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
 			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
+			// set the previous upgrade value to match what is specified in the associated label
+			// to tell Verrazzano to get the Fluentd image from existing domain
+			workload.Status.CurrentUpgradeVersion = previousUpgradeVersion
 			return nil
 		})
-	// expect a call to fetch the oam application configuration
+	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, appConfig *oamcore.ApplicationConfiguration) error {
 			component := oamcore.ApplicationConfigurationComponent{ComponentName: componentName}
+			loggingScope := oamcore.ComponentScope{ScopeReference: oamrt.TypedReference{Kind: vzapi.LoggingScopeKind, Name: loggingScopeName}}
+			component.Scopes = []oamcore.ComponentScope{loggingScope}
 			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{component}
 			return nil
 		})
+	// expect a call to fetch the logging scope
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: namespace, Name: loggingScopeName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, loggingScope *vzapi.LoggingScope) error {
+
+			loggingScope.Spec.SecretName = loggingSecretName
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
+			return nil
+		})
+	// expect a call to get the Elasticsearch secret in app namespace - return not found
+	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
+	cli.EXPECT().
+		Get(gomock.Any(), testLoggingSecretFullName, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.ParseGroupResource("v1.Secret"), loggingSecretName))
+
+	// expect a call to create an empty Elasticsearch secret in app namespace (default behavior, so
+	// that Fluentd volume mount works)
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, sec *corev1.Secret, options *client.CreateOptions) error {
+			asserts.Equal(t, namespace, sec.Namespace)
+			asserts.Equal(t, loggingSecretName, sec.Name)
+			asserts.Nil(t, sec.Data)
+			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+
 	// expect a call to get the namespace for the domain
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: "", Name: namespace}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to attempt to get the WebLogic CR and return an existing resource
+	// expect a call to attempt to get the Coherence CR
 	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, key client.ObjectKey, u *unstructured.Unstructured) error {
-			// note this resource has a "replicas" field currently set to 1
-			spec := map[string]interface{}{"replicas": int64(1)}
-			return unstructured.SetNestedField(u.Object, spec, specField)
-		})
-	// expect a call to update the WebLogic domain CR
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
-			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
-			assert.Equal(weblogicKind, u.GetKind())
-
-			// make sure the replicas field is set to the correct value (from our workload spec)
-			spec, _, _ := unstructured.NestedMap(u.Object, specField)
-			assert.Equal(replicasFromWorkload, spec["replicas"])
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, u *unstructured.Unstructured) error {
+			// set the old Fluentd image on the returned obj
+			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
+			unstructured.SetNestedField(containers[0].(map[string]interface{}), existingFluentdImage, "image")
+			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
+			// return nil error because Coherence StatefulSet exists
 			return nil
 		})
+
+	// Call to Update() is not expected since nothing changed
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
@@ -351,6 +584,12 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 	componentName := "unit-test-component"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
@@ -360,6 +599,7 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
 			return nil
 		})
 	// expect a call to fetch the oam application configuration
@@ -508,6 +748,12 @@ func TestAddLoggingFailure(t *testing.T) {
 	loggingScopeName := "unit-test-logging-scope"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
 
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
@@ -517,6 +763,7 @@ func TestAddLoggingFailure(t *testing.T) {
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.GroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
 			return nil
 		})
 	// expect a call to fetch the oam application configuration (and the component has an attached logging scope)


### PR DESCRIPTION

# Description

Introduces a new label which users can set to upgrade their applications to use the latest installed version of Verrazzano. When a user upgrades Verrazzano, they may not want to immediately restart their applications and uptake any Verrazzano resource changes. When a user is ready to upgrade their application and uptake the latest Verrazzano provided resources, the user can set the label value to a different value in their application configuration. If the label value differs from the value stored in the workload status which was the last used value, then the application will be upgraded to the latest Verrazzano version. The label can be any valid string such as a simple counter or a timestamp.
`  labels:
    upgrade-version: "1616527520"`

Fixes VZ-1996

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
