### PR TITLE
Tvlatas/misc tool

### DIFF
--- a/tools/analysis/Makefile
+++ b/tools/analysis/Makefile
@@ -107,10 +107,6 @@ endif
 unit-test: go-install
 	$(GO) test -v  ./...
 
-.PHONY: coverage
-coverage: unit-test
-	./build/scripts/coverage.sh html
-
 .PHONY: push-tag
 push-tag:
 	PUBLISH_TAG="${DOCKER_IMAGE_TAG}"; \


### PR DESCRIPTION
# Description

This removes the coverage target from the analysis tool makefile to get rid if make warning.
It also adds in a cluster dump script update that will dump individual config maps into the corresponding namespace directories

# Checklist 

As the author of this PR, I have:

- [ X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
