### PR TITLE
VZ-2370: Fix VerrazzanoWebLogicWorkload and VerrazzanoCoherenceWorkload to handle workload updates

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -190,13 +190,20 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
+	// make a copy of the Coherence spec since u.Object will get overwritten in CreateOrUpdate
+	// if the Coherence CR exists
+	specCopy, _, err := unstructured.NestedFieldCopy(u.Object, specField)
+	if err != nil {
+		log.Error(err, "Unable to make a copy of the Coherence spec")
+	}
+
 	// write out the Coherence resource
-	if err = r.Client.Create(ctx, u); err != nil {
-		if !k8serrors.IsAlreadyExists(err) {
-			return reconcile.Result{}, err
-		}
-		log.Info("Coherence CR already exists, ignoring error on create")
-		return reconcile.Result{}, nil
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, u, func() error {
+		return unstructured.SetNestedField(u.Object, specCopy, specField)
+	})
+	if err != nil {
+		log.Error(err, "Error creating or updating Coherence CR")
+		return reconcile.Result{}, err
 	}
 
 	// Get the namespace resource that the VerrazzanoCoherenceWorkload resource is deployed to
@@ -209,7 +216,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	log.Info("Successfully created Verrazzano Coherence workload")
+	log.Info("Successfully reconciled Verrazzano Coherence workload")
 	return reconcile.Result{}, nil
 }
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -195,6 +195,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	specCopy, _, err := unstructured.NestedFieldCopy(u.Object, specField)
 	if err != nil {
 		log.Error(err, "Unable to make a copy of the Coherence spec")
+		return reconcile.Result{}, err
 	}
 
 	// write out the Coherence resource

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -131,6 +131,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	specCopy, _, err := unstructured.NestedFieldCopy(u.Object, specField)
 	if err != nil {
 		log.Error(err, "Unable to make a copy of the WebLogic spec")
+		return reconcile.Result{}, err
 	}
 
 	// write out the WebLogic resource

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -126,13 +126,20 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// write out the WebLogic domain resource
-	if err = r.Client.Create(ctx, u); err != nil {
-		if !k8serrors.IsAlreadyExists(err) {
-			return reconcile.Result{}, err
-		}
-		log.Info("WebLogic domain CR already exists, ignoring error on create")
-		return reconcile.Result{}, nil
+	// make a copy of the WebLogic spec since u.Object will get overwritten in CreateOrUpdate
+	// if the WebLogic CR exists
+	specCopy, _, err := unstructured.NestedFieldCopy(u.Object, specField)
+	if err != nil {
+		log.Error(err, "Unable to make a copy of the WebLogic spec")
+	}
+
+	// write out the WebLogic resource
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, u, func() error {
+		return unstructured.SetNestedField(u.Object, specCopy, specField)
+	})
+	if err != nil {
+		log.Error(err, "Error creating or updating WebLogic CR")
+		return reconcile.Result{}, err
 	}
 
 	if err = r.createDestinationRule(ctx, log, namespace.Name, namespace.Labels, workload.ObjectMeta.Labels); err != nil {


### PR DESCRIPTION
# Description

Prior to these changes, the VerrazzanoWebLogicWorkload and VerrazzanoCoherenceWorkload components did not support updating. Once the underlying WebLogic domain and Coherence resources were created, they could not be updated. This PR fixes that so that the component specs can be updated and applied and the controllers will update the specs in the WebLogic domain and Coherence resources.

I tested this manually by deploying the Sock Shop example, updated the "replicas" from 1 to 3, applied the component YAML, and verified that the Coherence pods scaled up. I ran a similar test with the ToDo example and updated the VerrazzanoWebLogicWorkloads.

Fixes VZ-2370

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
