### PR TITLE
conditionally set ca_file in fluentd conf

### DIFF
--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const fluentdParsingRules = `<match fluent.**>
+const cohFluentdParsingRules = `<match fluent.**>
 @type null
 </match>
 
@@ -68,8 +68,7 @@ multiline_flush_interval 20s
 
 <match coherence-cluster>
   @type elasticsearch
-  hosts "#{ENV['ELASTICSEARCH_URL']}"
-  ca_file /fluentd/secret/ca-bundle
+  hosts "#{ENV['ELASTICSEARCH_URL']}"{{ .CAFile}}
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
   index_name "` + loggingscope.ElasticSearchIndex + `"
@@ -354,7 +353,7 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, workload *
 		Context:                ctx,
 		Log:                    log,
 		Client:                 r.Client,
-		ParseRules:             fluentdParsingRules,
+		ParseRules:             cohFluentdParsingRules,
 		StorageVolumeName:      "logs",
 		StorageVolumeMountPath: "/logs",
 		WorkloadType:           workloadType,

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -6,6 +6,7 @@ package cohworkload
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -233,21 +234,7 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(fluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
-	// expect a call to get the Elasticsearch  secret in app namespace - return not found
+	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
 		Get(gomock.Any(), testLoggingSecretFullName, gomock.Not(gomock.Nil())).
@@ -262,6 +249,20 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(cohFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 	// expect a call to attempt to get the Coherence CR - return not found
@@ -384,21 +385,7 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(fluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
-	// expect a call to get the Elasticsearch  secret in app namespace - return not found
+	// expect a call to get the elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
 		Get(gomock.Any(), testLoggingSecretFullName, gomock.Not(gomock.Nil())).
@@ -413,6 +400,20 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(cohFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 	// expect a call to attempt to get the Coherence CR
@@ -549,20 +550,6 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(fluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
 	// expect a call to get the Elasticsearch  secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -578,6 +565,20 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(cohFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 	// expect a call to attempt to get the Coherence CR
@@ -774,20 +775,6 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(fluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
 	// expect a call to get the Elasticsearch  secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -803,6 +790,20 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(cohFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 	// expect a call to attempt to get the Coherence CR - return not found
@@ -1157,5 +1158,33 @@ func newRequest(namespace string, name string) ctrl.Request {
 			Namespace: namespace,
 			Name:      name,
 		},
+	}
+}
+
+func Test_getFluentdConfiguration(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiresCABundle bool
+		containsCAFile   bool
+	}{
+		{
+			name:             "without ca-bundle",
+			requiresCABundle: false,
+			containsCAFile:   false,
+		},
+		{
+			name:             "with ca-bundle",
+			requiresCABundle: true,
+			containsCAFile:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := loggingscope.GetFluentdConfiguration(cohFluentdParsingRules, tt.requiresCABundle)
+			got := strings.Contains(conf, loggingscope.CAFileConfig)
+			if got != tt.containsCAFile {
+				t.Errorf("getFluentdConfiguration() containsCAFile = %v, want %v", got, tt.containsCAFile)
+			}
+		})
 	}
 }

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -325,17 +325,6 @@ func TestReconcileCreateVerrazzanoHelidonWorkloadWithLoggingScope(t *testing.T) 
 		Return(k8serrors.NewNotFound(k8sschema.GroupResource{Group: "", Resource: "configmap"}, "fluentd-config-helidon-test-deployment")).
 		Times(1)
 
-	// expect a call to create a Configmap
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(testNamespace, config.Namespace)
-			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
-			assert.Len(config.Data, 1)
-			assert.Contains(config.Data["fluentd.conf"], "label")
-			return nil
-		}).Times(1)
-
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -353,6 +342,18 @@ func TestReconcileCreateVerrazzanoHelidonWorkloadWithLoggingScope(t *testing.T) 
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})
+
+	// expect a call to create a Configmap
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(testNamespace, config.Namespace)
+			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
+			assert.Len(config.Data, 1)
+			assert.Contains(config.Data["fluentd.conf"], "label")
+			return nil
+		}).Times(1)
+
 	// expect a call to create the Deployment
 	cli.EXPECT().
 		Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -498,16 +499,6 @@ func TestReconcileCreateVerrazzanoHelidonWorkloadWithMultipleContainersAndLoggin
 		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "fluentd-config-helidon-test-deployment"}, gomock.Not(gomock.Nil())).
 		Return(k8serrors.NewNotFound(k8sschema.GroupResource{Group: "", Resource: "configmap"}, "fluentd-config-helidon-test-deployment")).
 		Times(1)
-	// expect a call to create a Configmap
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(testNamespace, config.Namespace)
-			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
-			assert.Len(config.Data, 1)
-			assert.Contains(config.Data["fluentd.conf"], "label")
-			return nil
-		}).Times(1)
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -525,6 +516,17 @@ func TestReconcileCreateVerrazzanoHelidonWorkloadWithMultipleContainersAndLoggin
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})
+	// expect a call to create a Configmap
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(testNamespace, config.Namespace)
+			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
+			assert.Len(config.Data, 1)
+			assert.Contains(config.Data["fluentd.conf"], "label")
+			return nil
+		}).Times(1)
+
 	// expect a call to create the Deployment
 	cli.EXPECT().
 		Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -694,17 +696,6 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		Return(k8serrors.NewNotFound(k8sschema.GroupResource{Group: "", Resource: "configmap"}, "fluentd-config-helidon-test-deployment")).
 		Times(1)
 
-	// expect a call to create a Configmap
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(testNamespace, config.Namespace)
-			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
-			assert.Len(config.Data, 1)
-			assert.Contains(config.Data["fluentd.conf"], "label")
-			return nil
-		}).Times(1)
-
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -722,6 +713,17 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})
+	// expect a call to create a Configmap
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(testNamespace, config.Namespace)
+			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
+			assert.Len(config.Data, 1)
+			assert.Contains(config.Data["fluentd.conf"], "label")
+			return nil
+		}).Times(1)
+
 	// expect a call to create the Deployment
 	cli.EXPECT().
 		Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -881,17 +883,6 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		Return(k8serrors.NewNotFound(k8sschema.GroupResource{Group: "", Resource: "configmap"}, "fluentd-config-helidon-test-deployment")).
 		Times(1)
 
-	// expect a call to create a Configmap
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(testNamespace, config.Namespace)
-			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
-			assert.Len(config.Data, 1)
-			assert.Contains(config.Data["fluentd.conf"], "label")
-			return nil
-		}).Times(1)
-
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -909,6 +900,18 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})
+
+	// expect a call to create a Configmap
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, config *v1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(testNamespace, config.Namespace)
+			assert.Equal("fluentd-config-helidon-test-deployment", config.Name)
+			assert.Len(config.Data, 1)
+			assert.Contains(config.Data["fluentd.conf"], "label")
+			return nil
+		}).Times(1)
+
 	// expect a call to create the Deployment
 	cli.EXPECT().
 		Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -4,9 +4,11 @@
 package loggingscope
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"text/template"
 
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
@@ -35,6 +37,8 @@ const (
 
 	secretVolume    = "secret-volume"
 	secretMountPath = "/fluentd/secret"
+
+	CAFileConfig = "\n  ca_file /fluentd/secret/ca-bundle"
 )
 
 // ElasticSearchIndex defines the common index pattern
@@ -86,12 +90,14 @@ type FluentdPod struct {
 func (f *Fluentd) Apply(scope *vzapi.LoggingScope, resource vzapi.QualifiedResourceRelation, fluentdPod *FluentdPod) (bool, error) {
 	upToDate := f.isFluentdContainerUpToDate(fluentdPod.Containers, scope)
 	if !upToDate {
-		err := f.ensureFluentdConfigMapExists(resource.Namespace)
+		requiresCABundle, err := ensureLoggingSecret(f.Context, f, resource.Namespace, scope.Spec.SecretName)
 		if err != nil {
 			return false, err
 		}
-
-		ensureLoggingSecret(f.Context, f, resource.Namespace, scope.Spec.SecretName)
+		err = f.ensureFluentdConfigMapExists(resource.Namespace, scope, requiresCABundle)
+		if err != nil {
+			return false, err
+		}
 		f.ensureFluentdVolumes(fluentdPod, scope)
 		f.ensureFluentdVolumeMountExists(fluentdPod)
 		f.ensureFluentdContainer(fluentdPod, scope, resource.Namespace)
@@ -103,7 +109,7 @@ func (f *Fluentd) Apply(scope *vzapi.LoggingScope, resource vzapi.QualifiedResou
 // Remove removes FLUENTD container, configmap, volumes and volume mounts.
 // Returns whether the remove action has been verified so that the caller knows when it is safe to forget the association.
 func (f *Fluentd) Remove(scope *vzapi.LoggingScope, resource vzapi.QualifiedResourceRelation, fluentdPod *FluentdPod) bool {
-	configMapVerified := f.removeFluentdConfigMap(resource.Namespace)
+	configMapVerified := f.removeFluentdConfigMap(resource.Namespace, scope)
 	volumesVerified := f.removeFluentdVolumes(fluentdPod)
 	mountsVerified := f.removeFluentdVolumeMounts(fluentdPod)
 	containersVerified := f.removeFluentdContainer(fluentdPod)
@@ -194,7 +200,7 @@ func (f *Fluentd) ensureFluentdVolumeMountExists(fluentdPod *FluentdPod) {
 
 // ensureFluentdConfigMapExists ensures that the FLUENTD configmap exists. If it already exists, there is nothing
 // to do. If it doesn't exist, create it.
-func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
+func (f *Fluentd) ensureFluentdConfigMapExists(namespace string, scope *vzapi.LoggingScope, requiresCABundle bool) error {
 	// check if configmap exists
 	configMapExists, err := resourceExists(f.Context, f, configMapAPIVersion, configMapKind, configMapName+"-"+f.WorkloadType, namespace)
 	if err != nil {
@@ -202,7 +208,7 @@ func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
 	}
 
 	if !configMapExists {
-		if err = f.Create(f.Context, f.createFluentdConfigMap(namespace), &k8sclient.CreateOptions{}); err != nil {
+		if err = f.Create(f.Context, f.createFluentdConfigMap(namespace, requiresCABundle), &k8sclient.CreateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -210,7 +216,7 @@ func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
 }
 
 // createFluentdConfigMap creates the FLUENTD configmap per given namespace.
-func (f *Fluentd) createFluentdConfigMap(namespace string) *corev1.ConfigMap {
+func (f *Fluentd) createFluentdConfigMap(namespace string, requiresCABundle bool) *v1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName + "-" + f.WorkloadType,
@@ -218,10 +224,33 @@ func (f *Fluentd) createFluentdConfigMap(namespace string) *corev1.ConfigMap {
 		},
 		Data: func() map[string]string {
 			var data = make(map[string]string)
-			data[fluentdConfKey] = f.ParseRules
+			data[fluentdConfKey] = GetFluentdConfiguration(f.ParseRules, requiresCABundle)
 			return data
 		}(),
 	}
+}
+
+func GetFluentdConfiguration(templateConfig string, requiresCABundle bool) string {
+	tmpl, err := template.New("fluentdContainer").Parse(templateConfig)
+	if err != nil {
+		return ""
+	}
+
+	caFile := ""
+	if requiresCABundle {
+		caFile = CAFileConfig
+	}
+	data := struct {
+		CAFile string
+	}{caFile}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return ""
+	}
+
+	return buf.String()
 }
 
 // removeFluentdContainer removes FLUENTD container
@@ -284,11 +313,12 @@ func (f *Fluentd) removeFluentdVolumes(fluentdPod *FluentdPod) bool {
 }
 
 // removeFluentdConfigMap removes the FLUENTD configmap
-func (f *Fluentd) removeFluentdConfigMap(namespace string) bool {
+func (f *Fluentd) removeFluentdConfigMap(namespace string, scope *vzapi.LoggingScope) bool {
 	configMapExists, err := resourceExists(f.Context, f, configMapAPIVersion, configMapKind, configMapName+"-"+f.WorkloadType, namespace)
 
 	if configMapExists {
-		_ = f.Delete(f.Context, f.createFluentdConfigMap(namespace), &k8sclient.DeleteOptions{})
+		// TODO what if the ca_file doesn't match
+		_ = f.Delete(f.Context, f.createFluentdConfigMap(namespace, false), &k8sclient.DeleteOptions{})
 	}
 	// return true when we confirm that the configmap has been successfully deleted
 	return !(configMapExists) && err == nil
@@ -512,7 +542,8 @@ func resourceExists(ctx context.Context, r k8sclient.Reader, apiVersion, kind, n
 	return len(resources.Items) != 0, err
 }
 
-func ensureLoggingSecret(ctx context.Context, cli k8sclient.Client, namespace, name string) error {
+func ensureLoggingSecret(ctx context.Context, cli k8sclient.Client, namespace, name string) (bool, error) {
+	requiresCABundle := false
 	secret := &corev1.Secret{}
 	err := cli.Get(ctx, objKey(namespace, name), secret)
 	if kerrs.IsNotFound(err) {
@@ -527,9 +558,12 @@ func ensureLoggingSecret(ctx context.Context, cli k8sclient.Client, namespace, n
 		// as a volume in fluentd. In certain cases (e.g. admin server using local Elasticsearch),
 		// the secret is not required to have contents. In other cases, where user explicitly
 		// specifies a secret on the logging scope, they should have already created it in the app NS
-		return createEmptySecretForFluentdVolume(ctx, cli, namespace, name)
+		return false, createEmptySecretForFluentdVolume(ctx, cli, namespace, name)
 	}
-	return err
+	if len(secret.Data[constants.ElasticsearchCABundleData]) > 0 {
+		requiresCABundle = true
+	}
+	return requiresCABundle, err
 }
 
 func createEmptySecretForFluentdVolume(ctx context.Context, cli k8sclient.Client, namespace string, name string) error {
@@ -543,26 +577,30 @@ func createEmptySecretForFluentdVolume(ctx context.Context, cli k8sclient.Client
 }
 
 // copies the logging related data from managed cluster secret to the given namespace/name IF it exists
-func copyManagedClusterLoggingSecret(ctx context.Context, cli k8sclient.Client, namespace string, name string) error {
+func copyManagedClusterLoggingSecret(ctx context.Context, cli k8sclient.Client, namespace string, name string) (bool, error) {
+	requiresCABundle := false
 	if name != clusters.MCRegistrationSecretFullName.Name {
 		// The managed cluster ES secret is not the one specified on the logging scope
 		// nothing to copy
-		return nil
+		return requiresCABundle, nil
 	}
 	secret := &corev1.Secret{}
 	err := cli.Get(ctx, clusters.MCRegistrationSecretFullName, secret)
 	if kerrs.IsNotFound(err) {
 		// Not a managed cluster, nothing to copyLoggingData
-		return nil
+		return requiresCABundle, nil
 	}
 	if err != nil {
-		return err
+		return requiresCABundle, err
+	}
+	if len(secret.Data[constants.ElasticsearchCABundleData]) > 0 {
+		requiresCABundle = true
 	}
 	err = cli.Create(ctx, copyLoggingData(secret, namespace, name), &k8sclient.CreateOptions{})
 	if kerrs.IsAlreadyExists(err) {
-		return nil
+		return requiresCABundle, nil
 	}
-	return err
+	return requiresCABundle, err
 }
 
 // copies the logging related data from one secret to another

--- a/application-operator/controllers/loggingscope/fluentd_test.go
+++ b/application-operator/controllers/loggingscope/fluentd_test.go
@@ -50,6 +50,23 @@ func TestFluentdApply(t *testing.T) {
 
 	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath, testWorkLoadType}
 
+	// simulate Elasticsearch secret not existing
+	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: scope.Spec.SecretName}
+	mockClient.EXPECT().
+		Get(fluentd.Context, testLoggingSecretFullName, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.ParseGroupResource("v1.Secret"), scope.Spec.SecretName))
+
+	// expect empty Elasticsearch secret created in app namespace
+	mockClient.EXPECT().
+		Create(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, sec *v1.Secret, options *client.CreateOptions) error {
+			asserts.Equal(t, testNamespace, sec.Namespace)
+			asserts.Equal(t, scope.Spec.SecretName, sec.Name)
+			asserts.Nil(t, sec.Data)
+			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+
 	// simulate config map not existing
 	mockClient.EXPECT().
 		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
@@ -64,24 +81,7 @@ func TestFluentdApply(t *testing.T) {
 	mockClient.EXPECT().
 		Create(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, configMap *v1.ConfigMap, options *client.CreateOptions) error {
-			asserts.Equal(t, *fluentd.createFluentdConfigMap(testNamespace), *configMap)
-			asserts.Equal(t, client.CreateOptions{}, *options)
-			return nil
-		})
-
-	// simulate Elasticsearch secret not existing
-	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: scope.Spec.SecretName}
-	mockClient.EXPECT().
-		Get(fluentd.Context, testLoggingSecretFullName, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.ParseGroupResource("v1.Secret"), scope.Spec.SecretName))
-
-	// expect empty Elasticsearch secret created in app namespace
-	mockClient.EXPECT().
-		Create(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, sec *v1.Secret, options *client.CreateOptions) error {
-			asserts.Equal(t, testNamespace, sec.Namespace)
-			asserts.Equal(t, scope.Spec.SecretName, sec.Name)
-			asserts.Nil(t, sec.Data)
+			asserts.Equal(t, *fluentd.createFluentdConfigMap(testNamespace, false), *configMap)
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})
@@ -181,7 +181,7 @@ func TestFluentdRemove(t *testing.T) {
 	mockClient.EXPECT().
 		Delete(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, configmap *v1.ConfigMap, options *client.DeleteOptions) error {
-			asserts.True(t, reflect.DeepEqual(fluentd.createFluentdConfigMap(testNamespace), configmap))
+			asserts.True(t, reflect.DeepEqual(fluentd.createFluentdConfigMap(testNamespace, false), configmap))
 			asserts.Equal(t, client.DeleteOptions{}, *options)
 
 			return nil
@@ -213,25 +213,6 @@ func TestFluentdApply_ManagedClusterElasticsearch(t *testing.T) {
 
 	fluentd := Fluentd{mockClient, ctrl.Log, context.Background(), testParseRules, testStorageName, scratchVolMountPath, testWorkLoadType}
 
-	// simulate config map not existing
-	mockClient.EXPECT().
-		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
-		DoAndReturn(func(ctx context.Context, resources *unstructured.UnstructuredList, inNamespace client.InNamespace, fields client.MatchingFields) error {
-			asserts.Equal(t, client.InNamespace(testNamespace), inNamespace)
-			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}, fields)
-			asserts.Equal(t, configMapAPIVersion, resources.GetAPIVersion())
-			asserts.Equal(t, configMapKind, resources.GetKind())
-			return nil
-		})
-
-	mockClient.EXPECT().
-		Create(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, configMap *v1.ConfigMap, options *client.CreateOptions) error {
-			asserts.Equal(t, *fluentd.createFluentdConfigMap(testNamespace), *configMap)
-			asserts.Equal(t, client.CreateOptions{}, *options)
-			return nil
-		})
-
 	// simulate Elasticsearch secret not existing in app NS
 	testLoggingSecretFullName := types.NamespacedName{Namespace: testNamespace, Name: scope.Spec.SecretName}
 	mockClient.EXPECT().
@@ -258,6 +239,25 @@ func TestFluentdApply_ManagedClusterElasticsearch(t *testing.T) {
 			asserts.Equal(t, testNamespace, sec.Namespace)
 			asserts.Equal(t, managedClusterLoggingSecretKey.Name, sec.Name)
 			asserts.Equal(t, expectedData, sec.Data)
+			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+
+	// simulate config map not existing
+	mockClient.EXPECT().
+		List(fluentd.Context, gomock.Not(gomock.Nil()), client.InNamespace(testNamespace), client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}).
+		DoAndReturn(func(ctx context.Context, resources *unstructured.UnstructuredList, inNamespace client.InNamespace, fields client.MatchingFields) error {
+			asserts.Equal(t, client.InNamespace(testNamespace), inNamespace)
+			asserts.Equal(t, client.MatchingFields{"metadata.name": configMapName + "-" + testWorkLoadType}, fields)
+			asserts.Equal(t, configMapAPIVersion, resources.GetAPIVersion())
+			asserts.Equal(t, configMapKind, resources.GetKind())
+			return nil
+		})
+
+	mockClient.EXPECT().
+		Create(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, configMap *v1.ConfigMap, options *client.CreateOptions) error {
+			asserts.Equal(t, *fluentd.createFluentdConfigMap(testNamespace, false), *configMap)
 			asserts.Equal(t, client.CreateOptions{}, *options)
 			return nil
 		})

--- a/application-operator/controllers/loggingscope/helidon.go
+++ b/application-operator/controllers/loggingscope/helidon.go
@@ -72,8 +72,7 @@ const helidonFluentdContainerConfigurationTemplate = `<source>
 </filter>
 <match {{ .WorkloadName}}-{{ .ContainerName}}>
   @type elasticsearch
-  hosts "#{ENV['ELASTICSEARCH_URL']}"
-  ca_file /fluentd/secret/ca-bundle
+  hosts "#{ENV['ELASTICSEARCH_URL']}"{{ .CAFile}}
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
   index_name "#{ENV['NAMESPACE']}-#{ENV['APP_CONF_NAME']}-#{ENV['COMPONENT_NAME']}-{{ .ContainerName}}"
@@ -153,11 +152,11 @@ func (h *HelidonHandler) ApplyToDeployment(ctx context.Context, workload vzapi.Q
 		duration := time.Duration(rand.IntnRange(5, 10)) * time.Second
 		return &ctrl.Result{Requeue: true, RequeueAfter: duration}, nil
 	}
-	err := h.ensureFluentdConfigMap(ctx, scope.GetNamespace(), workload.Name, appContainers)
+	requiresCABundle, err := ensureLoggingSecret(ctx, h, scope.GetNamespace(), scope.Spec.SecretName)
 	if err != nil {
 		return nil, err
 	}
-	err = ensureLoggingSecret(ctx, h, scope.GetNamespace(), scope.Spec.SecretName)
+	err = h.ensureFluentdConfigMap(ctx, scope, workload.Name, appContainers, requiresCABundle)
 	if err != nil {
 		return nil, err
 	}
@@ -420,38 +419,51 @@ func fluentdConfigMapName(workloadName string) string {
 	return fmt.Sprintf("fluentd-config-helidon-%s", workloadName)
 }
 
-func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, namespace, workloadName string, appContainersNames []string) error {
+func (h *HelidonHandler) ensureFluentdConfigMap(ctx context.Context, scope *vzapi.LoggingScope, workloadName string, appContainersNames []string, requiresCABundle bool) error {
+	// check if configmap exists
+	name := fluentdConfigMapName(workloadName)
+	configMap := &kcore.ConfigMap{}
+	err := h.Get(ctx, objKey(scope.Namespace, name), configMap)
+	if kerrs.IsNotFound(err) {
+		conf, err := getFluentdConfigurationForHelidon(workloadName, appContainersNames, requiresCABundle)
+		if err != nil {
+			return err
+		}
 
-	helidonFluentdConfiguration := HelidonFluentdConfiguration
+		if err = h.Create(ctx, CreateFluentdConfigMap(scope.Namespace, name, conf), &client.CreateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getFluentdConfigurationForHelidon(workloadName string, appContainersNames []string, requiresCABundle bool) (string, error) {
+	fluentdConfiguration := HelidonFluentdConfiguration
 	// add the container specific configuration
+	caFile := ""
+	if requiresCABundle {
+		caFile = CAFileConfig
+	}
 	for _, containerName := range appContainersNames {
 		tmpl, err := template.New("fluentdContainer").Parse(helidonFluentdContainerConfigurationTemplate)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		data := struct {
 			WorkloadName  string
 			ContainerName string
-		}{workloadName, containerName}
+			CAFile        string
+		}{workloadName, containerName, caFile}
 
 		var buf bytes.Buffer
 		err = tmpl.Execute(&buf, data)
 		if err != nil {
-			return err
+			return "", err
 		}
-		helidonFluentdConfiguration += buf.String()
+		fluentdConfiguration += buf.String()
 	}
-	// check if configmap exists
-	name := fluentdConfigMapName(workloadName)
-	configMap := &kcore.ConfigMap{}
-	err := h.Get(ctx, objKey(namespace, name), configMap)
-	if kerrs.IsNotFound(err) {
-		if err = h.Create(ctx, CreateFluentdConfigMap(namespace, name, helidonFluentdConfiguration), &client.CreateOptions{}); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fluentdConfiguration, nil
 }
 
 func (h *HelidonHandler) deleteFluentdConfigMap(ctx context.Context, namespace, workloadName string) error {

--- a/application-operator/controllers/loggingscope/wls.go
+++ b/application-operator/controllers/loggingscope/wls.go
@@ -83,8 +83,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 </filter>
 <match **>
   @type elasticsearch
-  hosts "#{ENV['ELASTICSEARCH_URL']}"
-  ca_file /fluentd/secret/ca-bundle
+  hosts "#{ENV['ELASTICSEARCH_URL']}"{{ .CAFile}}
   user "#{ENV['ELASTICSEARCH_USER']}"
   password "#{ENV['ELASTICSEARCH_PASSWORD']}"
   index_name "` + ElasticSearchIndex + `"

--- a/application-operator/controllers/loggingscope/wls_test.go
+++ b/application-operator/controllers/loggingscope/wls_test.go
@@ -5,6 +5,7 @@ package loggingscope
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -178,4 +179,32 @@ func updateServerPod(serverPod *wls.ServerPod) {
 	serverPod.Containers = append(serverPod.Containers, v1.Container{})
 	serverPod.Volumes = append(serverPod.Volumes, v1.Volume{})
 	serverPod.VolumeMounts = append(serverPod.VolumeMounts, v1.VolumeMount{})
+}
+
+func Test_getFluentdConfiguration(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiresCABundle bool
+		containsCAFile   bool
+	}{
+		{
+			name:             "without ca-bundle",
+			requiresCABundle: false,
+			containsCAFile:   false,
+		},
+		{
+			name:             "with ca-bundle",
+			requiresCABundle: true,
+			containsCAFile:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := GetFluentdConfiguration(WlsFluentdParsingRules, tt.requiresCABundle)
+			got := strings.Contains(conf, CAFileConfig)
+			if got != tt.containsCAFile {
+				t.Errorf("getFluentdConfiguration() containsCAFile = %v, want %v", got, tt.containsCAFile)
+			}
+		})
+	}
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -5,6 +5,7 @@ package wlsworkload
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -217,13 +218,6 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			// return no resources
 			return nil
 		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -242,6 +236,13 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			return nil
 		})
 
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(loggingscope.WlsFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
+			return nil
+		})
 	// expect a call to get the namespace for the domain
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: "", Name: namespace}), gomock.Not(gomock.Nil())).
@@ -348,20 +349,6 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -377,6 +364,20 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(loggingscope.WlsFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 
@@ -507,20 +508,6 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 			loggingScope.Spec.SecretName = loggingSecretName
 			return nil
 		})
-	// expect a call to list the FLUENTD config maps
-	cli.EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			// return no resources
-			return nil
-		})
-	// no config maps found, so expect a call to create a config map with our parsing rules
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			assert.Equal(loggingscope.WlsFluentdParsingRules, configMap.Data["fluentd.conf"])
-			return nil
-		})
 	// expect a call to get the Elasticsearch secret in app namespace - return not found
 	testLoggingSecretFullName := types.NamespacedName{Namespace: namespace, Name: loggingSecretName}
 	cli.EXPECT().
@@ -536,6 +523,20 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 			asserts.Equal(t, loggingSecretName, sec.Name)
 			asserts.Nil(t, sec.Data)
 			asserts.Equal(t, client.CreateOptions{}, *options)
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(loggingscope.WlsFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
 			return nil
 		})
 


### PR DESCRIPTION
# Description

When ca-bundle is empty, do not set ca_file is the fluentd conf.  It applies to the fluentd sidecar in helidon, wls, and coh apps.

Fixes VZ-2447

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
