### PR TITLE
RBAC Acceptance Tests for new verrazzano cluster roles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -407,6 +407,11 @@ pipeline {
                                 runGinkgo('istio/authz')
                             }
                         }
+                        stage('examples role based access') {
+                            steps {
+                                runGinkgo('security/rbac')
+                            }
+                        }
                         stage('examples logging helidon') {
                             steps {
                                 runGinkgo('logging/helidon')

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -527,6 +527,9 @@ func CreateRoleBinding(userOCID string, namespace string, rolebindingname string
 		},
 	}
 
+	// Get the Kubernetes clientset
+	clientset := GetKubernetesClientset()
+
 	_, err := clientset.RbacV1().RoleBindings(namespace).Create(context.TODO(), &rb, metav1.CreateOptions{})
 	if err != nil {
 		Log(Info, fmt.Sprintf("Failed to create role binding: %v", err))
@@ -559,6 +562,7 @@ func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
 func CanI(userOCID string, namespace string, verb string, resource string) (bool, string) {
 	return CanIGroup(userOCID, namespace, verb, resource, "")
 }
+
 func CanIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string) {
 
 	canI := &v1beta1.SelfSubjectAccessReview{

--- a/tests/e2e/security/rbac/rbac_suite_test.go
+++ b/tests/e2e/security/rbac/rbac_suite_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rbac_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+)
+
+func TestSecurityRBACExample(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("security-RBAC-%d-test-result.xml", config.GinkgoConfig.ParallelNode))
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Verrazzano Role Based Access Suite", []ginkgo.Reporter{junitReporter})
+}

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -22,25 +22,25 @@ var (
 
 const (
 	verrazzanoSystemNS = "verrazzano-system"
-	fooNamespace       = "foo"
+	rbacTestNamespace  = "rbactest"
 	v80ProjectAdmin    = "ocid1.user.oc1..aaaaaaaallodotxfvg0g1antsyq3gonyyhblya66kiqjnp2kogonykvjwi19"
 	v80ProjectMonitor  = "ocid1.user.oc1..aaaaaaaallodotxfvg0yank33sq3gonyghblya66kiqjnp2kogonykvjwi19"
 )
 
 var _ = ginkgo.BeforeSuite(func() {
 	pkg.Log(pkg.Info, "Create namespace")
-	if _, err := pkg.CreateNamespace(fooNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
+	if _, err := pkg.CreateNamespace(rbacTestNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
 	}
 })
 
 var _ = ginkgo.AfterSuite(func() {
 	pkg.Log(pkg.Info, "Delete namespace")
-	if err := pkg.DeleteNamespace(fooNamespace); err != nil {
+	if err := pkg.DeleteNamespace(rbacTestNamespace); err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
 	}
 	gomega.Eventually(func() bool {
-		ns, err := pkg.GetNamespace(fooNamespace)
+		ns, err := pkg.GetNamespace(rbacTestNamespace)
 		return ns == nil && err != nil && errors.IsNotFound(err)
 	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
 })
@@ -48,23 +48,23 @@ var _ = ginkgo.AfterSuite(func() {
 var _ = ginkgo.Describe("Test RBAC Permission", func() {
 	ginkgo.Context("for user with role verrazzano-project-admin", func() {
 
-		ginkgo.It("Fail getting Pods in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace Foo?  No")
-			if allowed, reason := pkg.CanI(v80ProjectAdmin, fooNamespace, "list", "pods"); allowed != false {
+		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
 		ginkgo.It("Create RoleBinding Admin for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-admin")
-			if err := pkg.CreateRoleBinding(v80ProjectAdmin, fooNamespace, "admin-binding", "admin"); err != nil {
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "admin-binding", "admin"); err != nil {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
 
-		ginkgo.It("Succeed getting Pods in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace foo?  no")
-			if allowed, reason := pkg.CanI(v80ProjectAdmin, fooNamespace, "list", "pods"); allowed == false {
+		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
@@ -76,65 +76,65 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail list ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail create OAM Component in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail list OAM Component in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "components", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
 		ginkgo.It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin")
-			if err := pkg.CreateRoleBinding(v80ProjectAdmin, fooNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin"); err != nil {
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin"); err != nil {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
 
-		ginkgo.It("Succeed create ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Succeed list ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Succeed create OAM Components in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "components", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Succeed list OAM Components in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "components", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
@@ -145,23 +145,23 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 var _ = ginkgo.Describe("Test RBAC Permission", func() {
 	ginkgo.Context("for user with role verrazzano-project-monitor", func() {
 
-		ginkgo.It("Fail getting Pods in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace Foo?  No")
-			if allowed, reason := pkg.CanI(v80ProjectMonitor, fooNamespace, "list", "pods"); allowed != false {
+		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
 		ginkgo.It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-monitor")
-			if err := pkg.CreateRoleBinding(v80ProjectMonitor, fooNamespace, "monitor-binding", "admin"); err != nil {
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "monitor-binding", "admin"); err != nil {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
 
-		ginkgo.It("Succeed getting Pods in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace foo?  no")
-			if allowed, reason := pkg.CanI(v80ProjectMonitor, fooNamespace, "list", "pods"); allowed == false {
+		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
@@ -173,65 +173,65 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail list ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail create OAM Component in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail list OAM Component in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "components", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
 		ginkgo.It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor")
-			if err := pkg.CreateRoleBinding(v80ProjectMonitor, fooNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor"); err != nil {
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor"); err != nil {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Succeed list ApplicationConfiguration in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Fail create OAM Components in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})
 
-		ginkgo.It("Succeed list OAM Components in namespace foo", func() {
-			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "components", "core.oam.dev"); allowed == false {
+		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 			}
 		})

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rbac_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+var (
+	expectedPodsOperator = []string{"verrazzano-application-operator"}
+	expectedPodsOam      = []string{"oam-kubernetes-runtime"}
+	waitTimeout          = 10 * time.Minute
+	pollingInterval      = 30 * time.Second
+)
+
+const (
+	verrazzanoSystemNS = "verrazzano-system"
+	fooNamespace       = "foo"
+	v80ProjectAdmin    = "ocid1.user.oc1..aaaaaaaallodotxfvg0g1antsyq3gonyyhblya66kiqjnp2kogonykvjwi19"
+	v80ProjectMonitor  = "ocid1.user.oc1..aaaaaaaallodotxfvg0yank33sq3gonyghblya66kiqjnp2kogonykvjwi19"
+)
+
+var _ = ginkgo.BeforeSuite(func() {
+	pkg.Log(pkg.Info, "Create namespace")
+	if _, err := pkg.CreateNamespace(fooNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
+	}
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	pkg.Log(pkg.Info, "Delete namespace")
+	if err := pkg.DeleteNamespace(fooNamespace); err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
+	}
+	gomega.Eventually(func() bool {
+		ns, err := pkg.GetNamespace(fooNamespace)
+		return ns == nil && err != nil && errors.IsNotFound(err)
+	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+})
+
+var _ = ginkgo.Describe("Test RBAC Permission", func() {
+	ginkgo.Context("for user with role verrazzano-project-admin", func() {
+
+		ginkgo.It("Fail getting Pods in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace Foo?  No")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, fooNamespace, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding Admin for verrazzano-project-admin", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-admin")
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, fooNamespace, "admin-binding", "admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed getting Pods in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace foo?  no")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, fooNamespace, "list", "pods"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Component in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list OAM Component in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin")
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, fooNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed create ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed create OAM Components in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "create", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list OAM Components in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, fooNamespace, "list", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+	})
+})
+
+var _ = ginkgo.Describe("Test RBAC Permission", func() {
+	ginkgo.Context("for user with role verrazzano-project-monitor", func() {
+
+		ginkgo.It("Fail getting Pods in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace Foo?  No")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, fooNamespace, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-monitor")
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, fooNamespace, "monitor-binding", "admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed getting Pods in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace foo?  no")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, fooNamespace, "list", "pods"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Component in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list OAM Component in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor")
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, fooNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Components in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace foo?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list OAM Components in namespace foo", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace foo?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, fooNamespace, "list", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+	})
+})


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Create an Acceptance Test suite for RBAC based on new roles, verrazzano-prooject-admin and verrazzano-project-monitor.
Add helper functions CanI, CanIGroup where the api group is specified and CreateClusterRoleBinding
Verify that users with these rules can and cannot do what the roles grant

# Checklist 

As the author of this PR, I have:

- [x ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
