### PR TITLE
RBAC Acceptance Tests for new verrazzano cluster roles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -407,6 +407,11 @@ pipeline {
                                 runGinkgo('istio/authz')
                             }
                         }
+                        stage('examples role based access') {
+                            steps {
+                                runGinkgo('security/rbac')
+                            }
+                        }
                         stage('examples logging helidon') {
                             steps {
                                 runGinkgo('logging/helidon')

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -6,7 +6,6 @@ package pkg
 import (
 	"context"
 	"fmt"
-	"k8s.io/api/authorization/v1beta1"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	vmcClient "github.com/verrazzano/verrazzano/platform-operator/clients/clusters/clientset/versioned"
 	vpoClient "github.com/verrazzano/verrazzano/platform-operator/clients/verrazzano/clientset/versioned"
 
+	"k8s.io/api/authorization/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/onsi/ginkgo"
@@ -539,6 +539,19 @@ func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
 	return configMap
 }
 
+/*
+The following code adds http headers to the kubernetes client invocations.  This is done to emulate the functionality of
+kubectl auth can-i ...
+
+WrapTransport is configured to point to the function
+WrapTransport will be invoked for custom HTTP behavior after the underlying transport is initialized
+(either the transport created from TLSClientConfig, Transport, or http.DefaultTransport).
+The config may layer other RoundTrippers on top of the returned RoundTripper.
+
+WrapperFunc wraps an http.RoundTripper when a new transport is created for a client, allowing per connection behavior to be injected.
+
+RoundTripper is an interface representing the ability to execute a single HTTP transaction, obtaining the Response for a given Request.
+*/
 // headerAdder is an http.RoundTripper that adds additional headers to the request
 type headerAdder struct {
 	headers map[string][]string

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -36,22 +36,6 @@ import (
 
 const dockerconfigjsonTemplate string = "{\"auths\":{\"%v\":{\"username\":\"%v\",\"password\":\"%v\",\"auth\":\"%v\"}}}"
 
-// headerAdder is an http.RoundTripper that adds additional headers to the request
-type headerAdder struct {
-	headers map[string][]string
-
-	rt http.RoundTripper
-}
-
-func (h *headerAdder) RoundTrip(req *http.Request) (*http.Response, error) {
-	for k, vv := range h.headers {
-		for _, v := range vv {
-			req.Header.Add(k, v)
-		}
-	}
-	return h.rt.RoundTrip(req)
-}
-
 // GetKubeConfig will get the kubeconfig from the environment variable KUBECONFIG, if set, or else from $HOME/.kube/config
 func GetKubeConfig() *restclient.Config {
 	kubeconfig := ""
@@ -553,6 +537,22 @@ func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
 		ginkgo.Fail(fmt.Sprintf("Failed to get Config Map %v from namespace %v:  Error = %v ", configMapName, namespace, err))
 	}
 	return configMap
+}
+
+// headerAdder is an http.RoundTripper that adds additional headers to the request
+type headerAdder struct {
+	headers map[string][]string
+
+	rt http.RoundTripper
+}
+
+func (h *headerAdder) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, vv := range h.headers {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	return h.rt.RoundTrip(req)
 }
 
 func CanI(userOCID string, namespace string, verb string, resource string) (bool, string) {

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -569,10 +569,10 @@ func (h *headerAdder) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func CanI(userOCID string, namespace string, verb string, resource string) (bool, string) {
-	return CanIGroup(userOCID, namespace, verb, resource, "")
+	return CanIForAPIGroup(userOCID, namespace, verb, resource, "")
 }
 
-func CanIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string) {
+func CanIForAPIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string) {
 
 	canI := &v1beta1.SelfSubjectAccessReview{
 		TypeMeta: metav1.TypeMeta{

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -6,6 +6,8 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"k8s.io/api/authorization/v1beta1"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +35,22 @@ import (
 )
 
 const dockerconfigjsonTemplate string = "{\"auths\":{\"%v\":{\"username\":\"%v\",\"password\":\"%v\",\"auth\":\"%v\"}}}"
+
+// headerAdder is an http.RoundTripper that adds additional headers to the request
+type headerAdder struct {
+	headers map[string][]string
+
+	rt http.RoundTripper
+}
+
+func (h *headerAdder) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, vv := range h.headers {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	return h.rt.RoundTrip(req)
+}
 
 // GetKubeConfig will get the kubeconfig from the environment variable KUBECONFIG, if set, or else from $HOME/.kube/config
 func GetKubeConfig() *restclient.Config {
@@ -479,6 +497,43 @@ func DoesRoleBindingContainSubject(namespace, name, subjectKind, subjectName str
 	return false
 }
 
+func CreateRoleBinding(userOCID string, namespace string, rolebindingname string, clusterrolename string) error {
+
+	subject1 := rbacv1.Subject{
+		Kind:      "User",
+		APIGroup:  "rbac.authorization.k8s.io",
+		Name:      userOCID,
+		Namespace: "",
+	}
+	subjects := []rbacv1.Subject{0: subject1}
+
+	rb := rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rolebindingname,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterrolename,
+		},
+	}
+
+	// Get the Kubernetes clientset
+	clientset := GetKubernetesClientset()
+
+	_, err := clientset.RbacV1().RoleBindings(namespace).Create(context.TODO(), &rb, metav1.CreateOptions{})
+	if err != nil {
+		Log(Info, fmt.Sprintf("Failed to create role binding: %v", err))
+	}
+
+	return err
+}
+
 // GetIstioClientset returns the clientset object for Istio
 func GetIstioClientset() *istioClient.Clientset {
 	cs, err := istioClient.NewForConfig(GetKubeConfig())
@@ -498,4 +553,55 @@ func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
 		ginkgo.Fail(fmt.Sprintf("Failed to get Config Map %v from namespace %v:  Error = %v ", configMapName, namespace, err))
 	}
 	return configMap
+}
+
+func CanI(userOCID string, namespace string, verb string, resource string) (bool, string) {
+	return CanIGroup(userOCID, namespace, verb, resource, "")
+}
+
+func CanIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string) {
+
+	canI := &v1beta1.SelfSubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SelfSubjectAccessReview",
+			APIVersion: "authorization.k8s.io/v1",
+		},
+		Spec: v1beta1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &v1beta1.ResourceAttributes{
+				Namespace:   namespace,
+				Verb:        verb,
+				Group:       group,
+				Version:     "",
+				Resource:    resource,
+				Subresource: "",
+				Name:        "",
+			},
+		},
+	}
+
+	config := GetKubeConfig()
+
+	wt := config.WrapTransport // Config might already have a transport wrapper
+	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if wt != nil {
+			rt = wt(rt)
+		}
+		return &headerAdder{
+			headers: map[string][]string{"Impersonate-User": {userOCID}},
+			rt:      rt,
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		ginkgo.Fail("Could not get Kubernetes clientset")
+	}
+
+	auth, err := clientset.AuthorizationV1beta1().SelfSubjectAccessReviews().Create(context.TODO(), canI, metav1.CreateOptions{})
+	if err != nil {
+		Log(Info, fmt.Sprintf("Failed to check perms: %v", err))
+	}
+
+	return auth.Status.Allowed, auth.Status.Reason
+
 }

--- a/tests/e2e/security/rbac/rbac_suite_test.go
+++ b/tests/e2e/security/rbac/rbac_suite_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rbac_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+)
+
+func TestSecurityRBACExample(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("security-RBAC-%d-test-result.xml", config.GinkgoConfig.ParallelNode))
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Verrazzano Role Based Access Suite", []ginkgo.Reporter{junitReporter})
+}

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rbac_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+var (
+	expectedPodsOperator = []string{"verrazzano-application-operator"}
+	expectedPodsOam      = []string{"oam-kubernetes-runtime"}
+	waitTimeout          = 10 * time.Minute
+	pollingInterval      = 30 * time.Second
+)
+
+const (
+	verrazzanoSystemNS = "verrazzano-system"
+	rbacTestNamespace  = "rbactest"
+	v80ProjectAdmin    = "ocid1.user.oc1..aaaaaaaallodotxfvg0g1antsyq3gonyyhblya66kiqjnp2kogonykvjwi19"
+	v80ProjectMonitor  = "ocid1.user.oc1..aaaaaaaallodotxfvg0yank33sq3gonyghblya66kiqjnp2kogonykvjwi19"
+)
+
+var _ = ginkgo.BeforeSuite(func() {
+	pkg.Log(pkg.Info, "Create namespace")
+	if _, err := pkg.CreateNamespace(rbacTestNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
+	}
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	pkg.Log(pkg.Info, "Delete namespace")
+	if err := pkg.DeleteNamespace(rbacTestNamespace); err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
+	}
+	gomega.Eventually(func() bool {
+		ns, err := pkg.GetNamespace(rbacTestNamespace)
+		return ns == nil && err != nil && errors.IsNotFound(err)
+	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+})
+
+var _ = ginkgo.Describe("Test RBAC Permission", func() {
+	ginkgo.Context("for user with role verrazzano-project-admin", func() {
+
+		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding Admin for verrazzano-project-admin", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-admin")
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "admin-binding", "admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
+			if allowed, reason := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin")
+			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+	})
+})
+
+var _ = ginkgo.Describe("Test RBAC Permission", func() {
+	ginkgo.Context("for user with role verrazzano-project-monitor", func() {
+
+		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-monitor")
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "monitor-binding", "admin"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
+			if allowed, reason := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
+			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor")
+			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor"); err != nil {
+				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
+			}
+		})
+
+		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
+			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
+				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
+			}
+		})
+
+	})
+})

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -51,97 +51,84 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Create RoleBinding Admin for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-admin")
-			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "admin-binding", "admin"); err != nil {
-				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
-			}
+			err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "admin-binding", "admin")
+			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Admin RoleBinding creation failed: reason = %s", err))
 		})
 
 		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			if allowed, reason := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin")
-			if err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin"); err != nil {
-				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
-			}
+			err := pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin")
+			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: VerrazzanoProjectAdmin RoleBinding creation failed: reason = %s", err))
 		})
 
 		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 	})
@@ -152,97 +139,84 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-monitor")
-			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "monitor-binding", "admin"); err != nil {
-				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
-			}
+			err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "monitor-binding", "admin")
+			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Admin RoleBinding creation failed: reason = %s", err))
 		})
 
 		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			if allowed, reason := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor")
-			if err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor"); err != nil {
-				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
-			}
+			err := pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor")
+			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: VerrazzanoProjectAdmin RoleBinding creation failed: reason = %s", err))
 		})
 
 		time.Sleep(sleepDuration)
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev"); allowed != false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			if allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev"); allowed == false {
-				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-			}
+			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 	})

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -25,6 +25,8 @@ const (
 	rbacTestNamespace  = "rbactest"
 	v80ProjectAdmin    = "ocid1.user.oc1..aaaaaaaallodotxfvg0g1antsyq3gonyyhblya66kiqjnp2kogonykvjwi19"
 	v80ProjectMonitor  = "ocid1.user.oc1..aaaaaaaallodotxfvg0yank33sq3gonyghblya66kiqjnp2kogonykvjwi19"
+	// The tests can run so fast against a Kind cluster that a pause is put in after rolebindings are created for test stability
+	sleepNumMS = 500 * time.Millisecond
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -61,6 +63,8 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
+
+		time.Sleep(sleepNumMS)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
@@ -111,6 +115,8 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
+		time.Sleep(sleepNumMS)
+
 		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
 			if allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev"); allowed == false {
@@ -158,6 +164,8 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
+
+		time.Sleep(sleepNumMS)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
@@ -207,6 +215,8 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 				ginkgo.Fail(fmt.Sprintf("FAIL: RoleBinding creation failed: reason = %s", err))
 			}
 		})
+
+		time.Sleep(sleepNumMS)
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -77,25 +77,25 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
@@ -109,25 +109,25 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
@@ -165,25 +165,25 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
@@ -197,25 +197,25 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			allowed, reason := pkg.CanIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 			gomega.Expect(allowed).To(gomega.BeTrue(), fmt.Sprintf("FAIL: Did Not Pass Authorization on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 		})
 

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 		})
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
 			if allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 		})
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
-			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  no")
+			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
 			if allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods"); allowed == false {
 				ginkgo.Fail(fmt.Sprintf("FAIL: Did Not Pass Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 			}

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -5,12 +5,11 @@ package rbac_test
 
 import (
 	"fmt"
+	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
-
-	"github.com/onsi/ginkgo"
 )
 
 var (

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -26,7 +26,7 @@ const (
 	v80ProjectAdmin    = "ocid1.user.oc1..aaaaaaaallodotxfvg0g1antsyq3gonyyhblya66kiqjnp2kogonykvjwi19"
 	v80ProjectMonitor  = "ocid1.user.oc1..aaaaaaaallodotxfvg0yank33sq3gonyghblya66kiqjnp2kogonykvjwi19"
 	// The tests can run so fast against a Kind cluster that a pause is put in after rolebindings are created for test stability
-	sleepNumMS = 500 * time.Millisecond
+	sleepDuration = 500 * time.Millisecond
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		time.Sleep(sleepNumMS)
+		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		time.Sleep(sleepNumMS)
+		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		time.Sleep(sleepNumMS)
+		time.Sleep(sleepDuration)
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 			}
 		})
 
-		time.Sleep(sleepNumMS)
+		time.Sleep(sleepDuration)
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Create an Acceptance Test suite for RBAC based on new roles, verrazzano-project-admin and verrazzano-project-monitor.
Add helper functions CanI, CanIGroup where the api group is specified and CreateClusterRoleBinding
Verify that users with these rules can and cannot do what the roles grant

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
