### PR TITLE
MC test fix: Wait for namespace to exist on set up

### DIFF
--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -43,6 +43,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	if err := pkg.CreateOrUpdateResourceFromFile("examples/multicluster/hello-helidon/verrazzano-project.yaml"); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create hello-helidon project resource: %v", err))
 	}
+
+	// wait for the namespace to be created on the admin cluster before applying components and app config
+	gomega.Eventually(namespaceExists, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+
 	if err := pkg.CreateOrUpdateResourceFromFile("examples/multicluster/hello-helidon/mc-hello-helidon-comp.yaml"); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create multi-cluster hello-helidon component resources: %v", err))
 	}
@@ -361,6 +365,11 @@ func componentWorkloadExists() bool {
 		Resource: "verrazzanohelidonworkloads",
 	}
 	return resourceExists(gvr, testNamespace, workloadName)
+}
+
+func namespaceExists() bool {
+	_, err := pkg.GetNamespace(testNamespace)
+	return err == nil
 }
 
 func helloHelidonPodsRunning() bool {


### PR DESCRIPTION
I noticed a few intermittent MC AT test failures in the hello-helidon example test because the beforeSuite setup was applying the MC component and app config YAML right after creating the VerrazzanoProject, and if the VP creation hasn't had time to create the namespace on the admin cluster, applying the components and app config can fail.

This PR adds a wait for the namespace to exist on the admin cluster before applying the YAML files.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
