### PR TITLE
Fix VMC unit test failure and coverage.sh failure reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,13 +206,16 @@ pipeline {
                 sh """
                     cd ${GO_REPO_PATH}/verrazzano
                     make -B coverage
-                    cp coverage.html ${WORKSPACE}
-                    cp coverage.xml ${WORKSPACE}
-                    build/copy-junit-output.sh ${WORKSPACE}
                 """
             }
             post {
                 always {
+                    sh """
+                        cd ${GO_REPO_PATH}/verrazzano
+                        cp coverage.html ${WORKSPACE}
+                        cp coverage.xml ${WORKSPACE}
+                        build/copy-junit-output.sh ${WORKSPACE}
+                    """
                     archiveArtifacts artifacts: '**/coverage.html', allowEmptyArchive: true
                     junit testResults: '**/*test-result.xml', allowEmptyResults: true
                     cobertura(coberturaReportFile: 'coverage.xml',

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -13,6 +13,8 @@ go test -coverpkg=./... -coverprofile ./coverage.raw.cov $(go list ./... | \
   grep -Ev github.com/verrazzano/verrazzano/tools | \
   grep -Ev github.com/verrazzano/verrazzano/tests)
 
+TEST_STATUS=$?
+
 cat ./coverage.raw.cov | grep -v "zz_generated.deepcopy" | grep -v "mocks" > coverage.cov
 
 # Display the global code coverage.  This generates the total number the badge uses
@@ -29,3 +31,5 @@ if [ "$1" == "html" ]; then
         fi
     fi
 fi
+
+exit $TEST_STATUS

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -436,7 +436,7 @@ func TestCreateVMCSyncSvcAccountFailed(t *testing.T) {
 
 	// Validate the results - there should have been an error returned for failing to sync svc account
 	mocker.Finish()
-	asserts.NotNil(err)
+	asserts.Nil(err)
 	asserts.Contains(err.Error(), "failing syncServiceAccount")
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -436,7 +436,7 @@ func TestCreateVMCSyncSvcAccountFailed(t *testing.T) {
 
 	// Validate the results - there should have been an error returned for failing to sync svc account
 	mocker.Finish()
-	asserts.Nil(err)
+	asserts.NotNil(err)
 	asserts.Contains(err.Error(), "failing syncServiceAccount")
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -434,10 +434,10 @@ func TestCreateVMCSyncSvcAccountFailed(t *testing.T) {
 	reconciler := newVMCReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
-	// Validate the results - there should not have been an error returned - we already expect the
-	// status to be updated with a Ready=false condition
+	// Validate the results - there should have been an error returned for failing to sync svc account
 	mocker.Finish()
-	asserts.Nil(err)
+	asserts.NotNil(err)
+	asserts.Contains(err.Error(), "failing syncServiceAccount")
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
 }
@@ -471,10 +471,10 @@ func TestCreateVMCSyncRoleBindingFailed(t *testing.T) {
 	reconciler := newVMCReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
-	// Validate the results - there should not have been an error returned - we already expect the
-	// status to be updated with a Ready=false condition
+	// Validate the results - there should have been an error returned
 	mocker.Finish()
-	asserts.Nil(err)
+	asserts.NotNil(err)
+	asserts.Contains(err.Error(), "failing syncRoleBinding")
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
 }


### PR DESCRIPTION
# Description

Fix VMC unit test failure and modify the coverage.sh script to report test failures in its exit status so that the Jenkins stage will fail on unit test failures

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
