### PR TITLE
Remove verrazzano-monitoring-instance-api image from Verrazzano 

### DIFF
--- a/examples/hello-helidon/README.md
+++ b/examples/hello-helidon/README.md
@@ -116,7 +116,6 @@ the deployed Hello World Helidon application.  Accessing them may require the fo
     $ kubectl get ing -n verrazzano-system
     NAME                         CLASS    HOSTS                                                    ADDRESS          PORTS     AGE
     verrazzano-console-ingress   <none>   verrazzano.default.140.238.94.217.xip.io                 140.238.94.217   80, 443   7d2h
-    vmi-system-api               <none>   api.vmi.system.default.140.238.94.217.xip.io             140.238.94.217   80, 443   7d2h
     vmi-system-es-ingest         <none>   elasticsearch.vmi.system.default.140.238.94.217.xip.io   140.238.94.217   80, 443   7d2h
     vmi-system-grafana           <none>   grafana.vmi.system.default.140.238.94.217.xip.io         140.238.94.217   80, 443   7d2h
     vmi-system-kibana            <none>   kibana.vmi.system.default.140.238.94.217.xip.io          140.238.94.217   80, 443   7d2h

--- a/examples/sock-shop/README.md
+++ b/examples/sock-shop/README.md
@@ -147,7 +147,6 @@ the deployed Sock Shop application.  Accessing them may require the following:
     $ kubectl get ing -n verrazzano-system
     NAME                         CLASS    HOSTS                                                    ADDRESS          PORTS     AGE
     verrazzano-console-ingress   <none>   verrazzano.default.140.238.94.217.xip.io                 140.238.94.217   80, 443   7d2h
-    vmi-system-api               <none>   api.vmi.system.default.140.238.94.217.xip.io             140.238.94.217   80, 443   7d2h
     vmi-system-es-ingest         <none>   elasticsearch.vmi.system.default.140.238.94.217.xip.io   140.238.94.217   80, 443   7d2h
     vmi-system-grafana           <none>   grafana.vmi.system.default.140.238.94.217.xip.io         140.238.94.217   80, 443   7d2h
     vmi-system-kibana            <none>   kibana.vmi.system.default.140.238.94.217.xip.io          140.238.94.217   80, 443   7d2h

--- a/examples/springboot-app/README.md
+++ b/examples/springboot-app/README.md
@@ -95,7 +95,6 @@ Install Verrazzano following the [installation instructions](https://verrazzano.
    $ kubectl get ingress -n verrazzano-system
    NAME                         CLASS    HOSTS                                                     ADDRESS           PORTS     AGE
    verrazzano-console-ingress   <none>   verrazzano.default.140.141.142.143.xip.io                 140.141.142.143   80, 443   7d2h
-   vmi-system-api               <none>   api.vmi.system.default.140.141.142.143.xip.io             140.141.142.143   80, 443   7d2h
    vmi-system-es-ingest         <none>   elasticsearch.vmi.system.default.140.141.142.143.xip.io   140.141.142.143   80, 443   7d2h
    vmi-system-grafana           <none>   grafana.vmi.system.default.140.141.142.143.xip.io         140.141.142.143   80, 443   7d2h
    vmi-system-kibana            <none>   kibana.vmi.system.default.140.141.142.143.xip.io          140.141.142.143   80, 443   7d2h

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -131,7 +131,6 @@ The ToDo List application deployment artifacts are contained in the Verrazzano p
    $ kubectl get ingress -n verrazzano-system
    NAME                         CLASS    HOSTS                                                     ADDRESS           PORTS     AGE
    verrazzano-console-ingress   <none>   verrazzano.default.140.141.142.143.xip.io                 140.141.142.143   80, 443   7d2h
-   vmi-system-api               <none>   api.vmi.system.default.140.141.142.143.xip.io             140.141.142.143   80, 443   7d2h
    vmi-system-es-ingest         <none>   elasticsearch.vmi.system.default.140.141.142.143.xip.io   140.141.142.143   80, 443   7d2h
    vmi-system-grafana           <none>   grafana.vmi.system.default.140.141.142.143.xip.io         140.141.142.143   80, 443   7d2h
    vmi-system-kibana            <none>   kibana.vmi.system.default.140.141.142.143.xip.io          140.141.142.143   80, 443   7d2h

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -115,8 +115,6 @@ type VolumeClaimSpecTemplate struct {
 type InstanceInfo struct {
 	// ConsoleURL The Console URL for this Verrazzano installation
 	ConsoleURL *string `json:"consoleUrl,omitempty"`
-	// SystemURL The System API URL for this Verrazzano installation
-	SystemURL *string `json:"systemApi,omitempty"`
 	// KeyCloakURL The KeyCloak URL for this Verrazzano installation
 	KeyCloakURL *string `json:"keyCloakUrl,omitempty"`
 	// RancherURL The Rancher URL for this Verrazzano installation

--- a/platform-operator/apis/verrazzano/v1alpha1/zz_generated.deepcopy.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/zz_generated.deepcopy.go
@@ -284,11 +284,6 @@ func (in *InstanceInfo) DeepCopyInto(out *InstanceInfo) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.SystemURL != nil {
-		in, out := &in.SystemURL, &out.SystemURL
-		*out = new(string)
-		**out = **in
-	}
 	if in.KeyCloakURL != nil {
 		in, out := &in.KeyCloakURL, &out.KeyCloakURL
 		*out = new(string)

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -3085,10 +3085,6 @@ spec:
                   rancherUrl:
                     description: RancherURL The Rancher URL for this Verrazzano installation
                     type: string
-                  systemApi:
-                    description: SystemURL The System API URL for this Verrazzano
-                      installation
-                    type: string
                 type: object
               state:
                 description: State of the Verrazzano custom resource

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,7 +61,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.13.0-20210326120907-a9e1ee8
+  imageVersion: 0.13.0-20210331140418-91b4bf6
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
@@ -76,7 +76,6 @@ monitoringOperator:
   esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.13.0-20210326120907-a9e1ee8
   esInitImage: ghcr.io/oracle/oraclelinux:7.8
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-20201130145840-7717e73
-  monitoringInstanceApiImage: "noimage"
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   oidcProxyImage: ghcr.io/verrazzano/nginx-ingress-controller:0.32-20210122132046-a84f6166a

--- a/platform-operator/internal/vzinstance/verrazzano_instance.go
+++ b/platform-operator/internal/vzinstance/verrazzano_instance.go
@@ -30,7 +30,6 @@ func GetInstanceInfo(client client.Client) *v1alpha1.InstanceInfo {
 
 	instanceInfo := &v1alpha1.InstanceInfo{
 		ConsoleURL:    getSystemIngressURL(client, ingressList.Items, systemNamespace, "verrazzano-console-ingress"),
-		SystemURL:     getSystemIngressURL(client, ingressList.Items, systemNamespace, "vmi-system-api"),
 		RancherURL:    getSystemIngressURL(client, ingressList.Items, "cattle-system", "rancher"),
 		KeyCloakURL:   getSystemIngressURL(client, ingressList.Items, "keycloak", "keycloak"),
 		ElasticURL:    getSystemIngressURL(client, ingressList.Items, systemNamespace, "vmi-system-es-ingest"),

--- a/platform-operator/internal/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/internal/vzinstance/verrazzano_instance_test.go
@@ -98,14 +98,6 @@ func TestGetInstanceInfo(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: systemNamespace, Name: "vmi-system-api"},
-					Spec: extv1beta1.IngressSpec{
-						Rules: []extv1beta1.IngressRule{
-							{Host: apiURL},
-						},
-					},
-				},
 			}
 			return nil
 		})
@@ -120,7 +112,6 @@ func TestGetInstanceInfo(t *testing.T) {
 	assert.Equal(t, "https://"+grafanaURL, *instanceInfo.GrafanaURL)
 	assert.Equal(t, "https://"+kibanaURL, *instanceInfo.KibanaURL)
 	assert.Equal(t, "https://"+promURL, *instanceInfo.PrometheusURL)
-	assert.Equal(t, "https://"+apiURL, *instanceInfo.SystemURL)
 }
 
 // TestGetInstanceInfoManagedCluster tests GetInstanceInfo method
@@ -179,14 +170,6 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: systemNamespace, Name: "vmi-system-api"},
-					Spec: extv1beta1.IngressSpec{
-						Rules: []extv1beta1.IngressRule{
-							{Host: apiURL},
-						},
-					},
-				},
 			}
 			return nil
 		})
@@ -201,7 +184,6 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 	assert.Nil(t, instanceInfo.GrafanaURL)
 	assert.Nil(t, instanceInfo.KibanaURL)
 	assert.Equal(t, "https://"+promURL, *instanceInfo.PrometheusURL)
-	assert.Equal(t, "https://"+apiURL, *instanceInfo.SystemURL)
 }
 
 // TestGetInstanceInfoManagedCluster tests GetInstanceInfo method

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -158,11 +158,6 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 					},
 				)
 			})
-
-		ginkgo.It("The pod vmi-system-api is not there",
-			func() {
-				gomega.Expect(vzComponentPresent("vmi-system-api", "verrazzano-system")).To(gomega.Equal(false))
-			})
 	})
 
 func nsListContains(list []v1.Namespace, target string) bool {


### PR DESCRIPTION
# Description

Changes to allow for the removal of the verrazzano-monitoring-instance-api image completely from Verrazzano platform-operator/helm_config/charts/verrazzano/values.yaml.

- remove `verrazzano-monitoring-instance-api` image from helm_config `values.yaml`
- update VMO image
- remove System API URL from `verrazzano_types.go`
- remove systemApi from `crds/install.verrazzano.io_verrazzanos.yaml` and `verrazzano_instance.go`
- clean-up of README in examples to remove references to ingress `vmi-system-api`
- clean up test test cases

Fixes VZ-2452

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
