### PR TITLE
VZ-1343, VZ-2348.  Install/uninstall issues

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -268,13 +268,13 @@ pipeline {
                 expression { skip_stage == 'false' }
             }
             parallel {
-                /*stage('verify-install') {
+                stage('verify-install') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             runGinkgo('verify-install')
                         }
                     }
-                }*/
+                }
                 stage('verify-infra restapi') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -296,16 +296,6 @@ pipeline {
                         }
                     }
                 }
-                /* Disabling these for now, they take about 3x as long as the other tests, and the others are good
-                   enough to establish that the install is working
-                stage('Verify examples/todo') {
-                    steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            runGinkgo('examples/todo')
-                        }
-                    }
-                }
-                */
             }
             post {
                 failure {

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -429,7 +429,7 @@ pipeline {
             script {
                 if (!abort) {
                     def failures = failureCount as String
-                    build job: 'verrazzano-install-loop/master',
+                    build job: env.JOB_NAME,  // Use the current Job so it stays in-branch
                         parameters: [
                             string(name: 'VERRAZZANO_BRANCH', value: params.VERRAZZANO_BRANCH),
                             string(name: 'OKE_NODE_POOL', value: params.OKE_NODE_POOL),

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -296,6 +296,8 @@ pipeline {
                         }
                     }
                 }
+                /* Disabling these for now, they take about 3x as long as the other tests, and the others are good
+                   enough to establish that the install is working
                 stage('Verify examples/todo') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -303,6 +305,7 @@ pipeline {
                         }
                     }
                 }
+                */
             }
             post {
                 failure {

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -260,7 +260,6 @@ pipeline {
             }
         }
 
-
         stage('Verify Install') {
             environment {
                 TEST_ENV = "OKE"
@@ -268,9 +267,41 @@ pipeline {
             when {
                 expression { skip_stage == 'false' }
             }
-            steps {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    runGinkgo('examples/todo')
+            parallel {
+                stage('verify-install') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            runGinkgo('verify-install')
+                        }
+                    }
+                }
+                stage('verify-infra restapi') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            runGinkgo('verify-infra/restapi')
+                        }
+                    }
+                }
+                stage('verify-infra oam') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            runGinkgo('verify-infra/oam')
+                        }
+                    }
+                }
+                stage('verify-infra vmi') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            runGinkgo('verify-infra/vmi')
+                        }
+                    }
+                }
+                stage('Verify examples/todo') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            runGinkgo('examples/todo')
+                        }
+                    }
                 }
             }
             post {
@@ -279,7 +310,6 @@ pipeline {
                 }
             }
         }
-
         stage('Uninstall Verrazzano') {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -435,7 +435,8 @@ pipeline {
                             string(name: 'OKE_NODE_POOL', value: params.OKE_NODE_POOL),
                             string(name: 'OKE_CLUSTER_VERSION', value: params.OKE_CLUSTER_VERSION),
                             string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                            string(name: 'failureCount', value: failures)
+                            string(name: 'failureCount', value: failures),
+                            booleanParam(name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', value: params.DUMP_K8S_CLUSTER_ON_SUCCESS)
                         ], wait: false
                 }
             }

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -363,7 +363,7 @@ pipeline {
                 }
 
                 // kick off another cluster build after initial attempt to reuse cluster (failureCount = 1)
-                if (failureCount > 1 && env.JOB_NAME == "verrazzano-install-loop/master") {
+                if (failureCount > 0) {
                     try {
                         build job: 'verrazzano-create-oke-cluster',
                             parameters: [
@@ -372,10 +372,10 @@ pipeline {
                                 string(name: 'OKE_CLUSTER_VERSION', value: params.OKE_CLUSTER_VERSION),
                             ], wait: true
                         failureCount = 0
-                        pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\nPlease investigate the cause of the failure, then clean up the cluster and associated resources when you are done. The OKE cluster to inspect will be the one associated with the previous successful build of project create-oke-cluster")
+                        //pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\nPlease investigate the cause of the failure, then clean up the cluster and associated resources when you are done. The OKE cluster to inspect will be the one associated with the previous successful build of project create-oke-cluster")
                     } catch (Exception e) {
                         abort = true
-                        slackSend ( message: "Loop test interrupted due to cluster build failure - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                        //slackSend ( message: "Loop test interrupted due to cluster build failure - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                     }
                 }
             }
@@ -393,13 +393,14 @@ pipeline {
         cleanup {
             deleteDir()
             script {
-                if (!abort && env.JOB_NAME == "verrazzano-install-loop/master") {
+                if (!abort) {
                     def failures = failureCount as String
                     build job: 'verrazzano-install-loop/master',
                         parameters: [
                             string(name: 'VERRAZZANO_BRANCH', value: params.VERRAZZANO_BRANCH),
                             string(name: 'OKE_NODE_POOL', value: params.OKE_NODE_POOL),
                             string(name: 'OKE_CLUSTER_VERSION', value: params.OKE_CLUSTER_VERSION),
+                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                             string(name: 'failureCount', value: failures)
                         ], wait: false
                 }

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -363,7 +363,7 @@ pipeline {
                 }
 
                 // kick off another cluster build after initial attempt to reuse cluster (failureCount = 1)
-                if (failureCount > 0) {
+                if (failureCount > 1) {
                     try {
                         build job: 'verrazzano-create-oke-cluster',
                             parameters: [
@@ -372,10 +372,14 @@ pipeline {
                                 string(name: 'OKE_CLUSTER_VERSION', value: params.OKE_CLUSTER_VERSION),
                             ], wait: true
                         failureCount = 0
-                        //pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\nPlease investigate the cause of the failure, then clean up the cluster and associated resources when you are done. The OKE cluster to inspect will be the one associated with the previous successful build of project create-oke-cluster")
+                        if (env.JOB_NAME == "verrazzano-install-loop/master") {
+                            pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\nPlease investigate the cause of the failure, then clean up the cluster and associated resources when you are done. The OKE cluster to inspect will be the one associated with the previous successful build of project create-oke-cluster")
+                        }
                     } catch (Exception e) {
                         abort = true
-                        //slackSend ( message: "Loop test interrupted due to cluster build failure - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                        if (env.JOB_NAME == "verrazzano-install-loop/master") {
+                            slackSend ( message: "Loop test interrupted due to cluster build failure - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                        }
                     }
                 }
             }

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -268,13 +268,13 @@ pipeline {
                 expression { skip_stage == 'false' }
             }
             parallel {
-                stage('verify-install') {
+                /*stage('verify-install') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             runGinkgo('verify-install')
                         }
                     }
-                }
+                }*/
                 stage('verify-infra restapi') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -72,6 +72,11 @@ function setup_cluster_issuer() {
         fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist"
     fi
 
+    acmeURL="https://acme-v02.api.letsencrypt.org/directory"
+    if [ "$(get_acme_environment)" != "production" ]; then
+      acmeURL="https://acme-staging-v02.api.letsencrypt.org/directory"
+    fi
+
     kubectl apply -f <(echo "
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -80,7 +85,7 @@ metadata:
 spec:
   acme:
     email: $EMAIL_ADDRESS
-    server: "https://acme-v02.api.letsencrypt.org/directory"
+    server: "${acmeURL}"
     privateKeySecretRef:
       name: verrazzano-cert-acme-secret
     solvers:

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -74,6 +74,7 @@ function setup_cluster_issuer() {
 
     acmeURL="https://acme-v02.api.letsencrypt.org/directory"
     if [ "$(get_acme_environment)" != "production" ]; then
+      log "Non-production case, using the ACME staging environment"
       acmeURL="https://acme-staging-v02.api.letsencrypt.org/directory"
     fi
 

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -219,7 +219,7 @@ function install_rancher()
     kubectl -n cattle-system rollout status -w deploy/rancher || return $?
 
     log "Ensure default Rancher admin user is present"
-    STDERROR_FILE="/tmp/rancher_ensureadminuser.err"
+    STDERROR_FILE="${TMP_DIR}/rancher_ensureadminuser.err"
     kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- ensure-default-admin 2>$STDERROR_FILE
     RANCHER_ADMIN_USERNAME=$(kubectl get users -l authz.management.cattle.io/bootstrapping=admin-user -o jsonpath={'.items[].username'})
     if [ -z "${RANCHER_ADMIN_USERNAME}" ]; then
@@ -233,7 +233,7 @@ function install_rancher()
     fi
 
     log "Reset Rancher admin password and create secrets"
-    STDERROR_FILE="/tmp/rancher_resetpwd.err"
+    STDERROR_FILE="${TMP_DIR}/rancher_resetpwd.err"
     local max_retries=5
     local retries=0
     while true ; do

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -122,8 +122,8 @@ function install_verrazzano()
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?
 
-  log "Waiting for pods in ${VERRAZZANO_NS} to be reach Ready state"
-  kubectl  wait --for=condition=Ready pod -n verrazzano-system --all=true
+  log "Waiting for the verrazzano-operator pod in ${VERRAZZANO_NS} to reach Ready state"
+  kubectl  wait -l app=verrazzano-operator --for=condition=Ready pod -n verrazzano-system
 
   log "Verifying that needed secrets are created"
   retries=0

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -126,6 +126,9 @@ function install_verrazzano()
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?
 
+  log "Waiting for pods in ${VERRAZZANO_NS} to be reach Ready state"
+  kubectl  wait --for=condition=Ready pod -n verrazzano-system --all=true
+
   log "Verifying that needed secrets are created"
   retries=0
   until [ "$retries" -ge 60 ]

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -103,11 +103,7 @@ function install_verrazzano()
     EXTRA_V8O_ARGUMENTS="${EXTRA_V8O_ARGUMENTS} --set global.imagePullSecrets[0]=${GLOBAL_IMAGE_PULL_SECRET}"
   fi
 
-  local profile=$(get_config_value '.profile')
-  if [ -z "$profile" ]; then
-    error "The value .profile must be set in the config file"
-    exit 1
-  fi
+  local profile=$(get_install_profile)
   if [ ! -f "${VZ_CHARTS_DIR}/verrazzano/values.${profile}.yaml" ]; then
     error "The file ${VZ_CHARTS_DIR}/verrazzano/values.${profile}.yaml does not exist"
     exit 1

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -296,14 +296,7 @@ function get_install_profile() {
 
 function get_acme_environment() {
   if [ -z "$(get_config_value ".certificates.acme.environment")" ]; then
-    # Ideally we would handle this by just setting helm chart values, but the Rancher override
-    # and VZ ClusterIssuer resource are done here in the scripts, so switch off the profile value
-    # if the environment is not explicitly specified
-    if [ "$(get_install_profile)" != "dev" ]; then
-      echo "production"
-    else
-      echo "staging"
-    fi
+    echo "production"
   else
     get_config_value ".certificates.acme.environment"
   fi

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -299,7 +299,7 @@ function get_acme_environment() {
     # Ideally we would handle this by just setting helm chart values, but the Rancher override
     # and VZ ClusterIssuer resource are done here in the scripts, so switch off the profile value
     # if the environment is not explicitly specified
-    if [ "$(get_profile)" != "dev" ]; then
+    if [ "$(get_install_profile)" != "dev" ]; then
       echo "production"
     else
       echo "staging"

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -284,9 +284,26 @@ function get_verrazzano_ports_spec() {
   echo $ports_spec
 }
 
+function get_install_profile() {
+  local profile=$(get_config_value '.profile')
+  if [ -z "${profile}" ]; then
+    error "The value .profile must be set in the config file"
+    exit 1
+  else
+    echo "${profile}"
+  fi
+}
+
 function get_acme_environment() {
   if [ -z "$(get_config_value ".certificates.acme.environment")" ]; then
-    echo "production"
+    # Ideally we would handle this by just setting helm chart values, but the Rancher override
+    # and VZ ClusterIssuer resource are done here in the scripts, so switch off the profile value
+    # if the environment is not explicitly specified
+    if [ "$(get_profile)" != "dev" ]; then
+      echo "production"
+    else
+      echo "staging"
+    fi
   else
     get_config_value ".certificates.acme.environment"
   fi

--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -57,13 +57,7 @@ function initializing_uninstall {
         break
       fi
     done
-
-    # Occasionally the 'local' Rancher cluster object is stuck with a dangling finalizer, remove it so
-    # we don't orphan the cluster info between installs
-    log "Remove any dangling finalizers from the 'local' Rancher cluster object"
-    kubectl patch cluster local -n kube-system -p '{"metadata":{"finalizers":null}}' --type=merge || true
   fi
-
   return 0
 }
 

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -76,6 +76,12 @@ function delete_cert_manager() {
 }
 
 function delete_rancher() {
+  # Occasionally the 'local' Rancher cluster object is stuck with a dangling finalizer, remove it so
+  # we don't orphan the cluster info between installs
+  log "Remove any dangling finalizers from the 'local' Rancher cluster object"
+  kubectl patch cluster local -n kube-system -p '{"metadata":{"finalizers":null}}' --type=merge || true
+  kubectl wait --for=delete -n kube-system cluster/local --timeout=2m || true
+
   # Deleting rancher components
   log "Deleting rancher"
   helm ls -A \


### PR DESCRIPTION
Resolve some lingering issues around install/uninstall

- Have install wait for pods in verrazzano-system to reach Ready state before looking for secrets
- Uninstall should be more resilient around Rancher `local` cluster object removal, and general not prevent the uninstall from continuing
- On uninstall, patch Rancher local cluster object to remove any dangling finalizers as a semi-hack to allow it to be deleted
- Do an `ensure-default-admin` with Rancher on install to avoid issues with resetting the password subsequently
- Honor `letsEncrypt` `environment` setting and use the ACME staging env URL when specified
- Updates for `verrazzano-install-loop` pipeline

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-1343, VZ-2348.

Might also address VZ-1975, VZ-1856, and VZ-2078.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
