### PR TITLE
VZ-2347: More changes to support authorization in the VMI stack

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -127,10 +127,8 @@ data:
     logJsonMessage(ngx.INFO, "Set headers")
     ngx.req.set_header("Authorization", "Bearer " .. serviceAccountToken)
     if ( jwt_obj.payload and jwt_obj.payload.groups) then
-      for i,group in pairs(jwt_obj.payload.groups) do
-        logJsonMessage(ngx.INFO, ("Adding group " .. group))
-        ngx.req.set_header("Impersonate-Group", group)
-      end
+      logJsonMessage(ngx.INFO, ("Adding groups " .. cjson.encode(jwt_obj.payload.groups)))
+      ngx.req.set_header("Impersonate-Group", jwt_obj.payload.groups)
     end
     if ( jwt_obj.payload and jwt_obj.payload.sub) then
       logJsonMessage(ngx.INFO, ("Adding sub " .. jwt_obj.payload.sub))

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,7 +61,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.14.0-20210331214918-d703570
+  imageVersion: 0.14.0-20210401205456-967e791
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,7 +61,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.14.0-20210401205456-967e791
+  imageVersion: 0.14.0-20210406204855-2f17abf
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/platform-operator/scripts/install/config/keycloak.json
+++ b/platform-operator/scripts/install/config/keycloak.json
@@ -361,7 +361,7 @@
     "clientRoles" : { },
     "subGroups" : [ ]
   } ],
-  "defaultRoles" : [ "offline_access", "uma_authorization" ],
+  "defaultRoles" : [ "offline_access", "uma_authorization", "console_users" ],
   "requiredCredentials" : [ "password" ],
   "otpPolicyType" : "totp",
   "otpPolicyAlgorithm" : "HmacSHA1",
@@ -394,7 +394,7 @@
     } ],
     "disableableCredentialTypes" : [ "password" ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "admin", "offline_access", "uma_authorization", "Admin" ],
+    "realmRoles" : [ "admin", "offline_access", "uma_authorization", "Admin", "console_users" ],
     "clientRoles" : {
       "verrazzano-oauth-client" : [ "Admin" ],
       "account" : [ "manage-account", "view-profile" ],
@@ -905,7 +905,22 @@
             "claim.name": "groups",
             "userinfo.token.claim": "true"
           }
-	      }
+        },
+        {
+          "id": "5a713e4a-b114-4780-9eb8-2e3aa43e20b2",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
       ],
     "defaultClientScopes": [
       "web-origins",

--- a/platform-operator/scripts/install/config/keycloak.json
+++ b/platform-operator/scripts/install/config/keycloak.json
@@ -431,24 +431,6 @@
     },
     "notBefore" : 0,
     "groups" : [ ]
-  }, {
-    "id" : "0f3293ca-009e-401f-9dbe-ac0c31d2906f",
-    "createdTimestamp" : 1564417628739,
-    "username" : "service-account-verrazzano-oauth-client",
-    "enabled" : true,
-    "totp" : false,
-    "emailVerified" : false,
-    "email" : "service-account-verrazzano-oauth-client@placeholder.org",
-    "serviceAccountClientId" : "verrazzano-oauth-client",
-    "credentials" : [ ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "offline_access", "uma_authorization" ],
-    "clientRoles" : {
-      "account" : [ "view-profile", "manage-account" ]
-    },
-    "notBefore" : 0,
-    "groups" : [ ]
   } ],
   "scopeMappings" : [ {
     "clientScope" : "offline_access",
@@ -712,7 +694,7 @@
     "implicitFlowEnabled" : false,
     "directAccessGrantsEnabled" : true,
     "serviceAccountsEnabled" : true,
-    "publicClient" : false,
+    "publicClient" : true,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {
@@ -777,6 +759,21 @@
         "jsonType.label" : "String"
       }
     }, {
+      "id": "67ef034c-ab84-42d3-9428-b2d6ca4d8979",
+      "name": "realm roles",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-usermodel-realm-role-mapper",
+      "consentRequired": false,
+      "config": {
+        "multivalued": "true",
+        "user.attribute": "foo",
+        "id.token.claim": "true",
+        "access.token.claim": "true",
+        "claim.name": "realm_access.roles",
+        "jsonType.label": "String"
+      }
+    },
+    {
       "id" : "e1d1e81b-308b-4f85-a55c-e75e1eff88e3",
       "name" : "Client Host",
       "protocol" : "openid-connect",


### PR DESCRIPTION
# Description

This PR includes the following:

- Pulls in the latest version of the verrazzano-monitoring-operator with support for VMI authorization and Grafana identity propagation
- Updates the Keycloak configuration to make the verrazzano-oauth-client public, adds console_user as a default realm role for users, and adds a mapper to the webui and verrazzano-oauth-client clients so that realm roles are included in the id_token
- Fixes a Lua script bug with user impersonation in the API proxy.

Implements VZ-2347

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
