### PR TITLE
Fix the jenkins job which triggers KIND AT and uninstall test

### DIFF
--- a/ci/JenkinsfileBuildTrigger
+++ b/ci/JenkinsfileBuildTrigger
@@ -44,7 +44,6 @@ pipeline {
                     build job: 'verrazzano-uninstall-test/master',
                         parameters: [
                             string(name: 'VERRAZZANO_BRANCH', value: params.VERRAZZANO_BRANCH),
-                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                             booleanParam(name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', value: params.DUMP_K8S_CLUSTER_ON_SUCCESS)
                         ], wait: false
                 }


### PR DESCRIPTION
# Description

This PR removes supplying VERRAZZANO_OPERATOR_IMAGE to the uninstall job.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
