### PR TITLE
Add network policies for the Coherence operator

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -54,8 +54,8 @@ const LabelVerrazzanoManagedDefault = "true"
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
 
-// LabelVerrazzanoIONamespace - constant for a Kubernetes label that is used by network policies
-const LabelVerrazzanoIONamespace = "verrazzano.io/namespace"
+// LabelVerrazzanoNamespace - constant for a Kubernetes label that is used by network policies
+const LabelVerrazzanoNamespace = "verrazzano.io/namespace"
 
 // LabelIstioInjectionDefault - default value for LabelIstioInjection
 const LabelIstioInjectionDefault = "enabled"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -54,6 +54,9 @@ const LabelVerrazzanoManagedDefault = "true"
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
 
+// LabelVerrazzanoIONamespace - constant for a Kubernetes label that is used by network policies
+const LabelVerrazzanoIONamespace = "verrazzano.io/namespace"
+
 // LabelIstioInjectionDefault - default value for LabelIstioInjection
 const LabelIstioInjectionDefault = "enabled"
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -596,12 +596,12 @@ func (r *Reconciler) createNetworkPolicies(ctx context.Context, log logr.Logger,
 	}
 
 	// Add required label to application namespace if not already included.
-	label, ok := appNamespace.Labels[constants.LabelVerrazzanoIONamespace]
+	label, ok := appNamespace.Labels[constants.LabelVerrazzanoNamespace]
 	if !ok || label != constants.VerrazzanoSystemNamespace {
 		if appNamespace.Labels == nil {
 			appNamespace.Labels = make(map[string]string)
 		}
-		appNamespace.Labels[constants.LabelVerrazzanoIONamespace] = appNamespace.Name
+		appNamespace.Labels[constants.LabelVerrazzanoNamespace] = appNamespace.Name
 		err := r.Update(ctx, appNamespace)
 		if err != nil {
 			return err
@@ -611,7 +611,7 @@ func (r *Reconciler) createNetworkPolicies(ctx context.Context, log logr.Logger,
 	// Create a network policy in the verrazzano-system namespace, if it does not already exist.
 	// This network policy is an egress for the Coherence operator to Coherence pods in application namespaces.
 	networkPolicy := &netv1.NetworkPolicy{}
-	appNamespaceName := fmt.Sprintf("%s-%s", appNamespace.Name, appName)
+	appNamespaceName := fmt.Sprintf("coh-%s-%s", appNamespace.Name, appName)
 	err := r.Get(ctx, client.ObjectKey{Namespace: constants.VerrazzanoSystemNamespace, Name: appNamespaceName}, networkPolicy)
 	if err != nil && k8serrors.IsNotFound(err) {
 		networkPolicy = &netv1.NetworkPolicy{
@@ -637,7 +637,7 @@ func (r *Reconciler) createNetworkPolicies(ctx context.Context, log logr.Logger,
 							{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										constants.LabelVerrazzanoIONamespace: appNamespace.Name,
+										constants.LabelVerrazzanoNamespace: appNamespace.Name,
 									},
 								},
 								PodSelector: &metav1.LabelSelector{

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -83,17 +83,14 @@ const (
 	specField                 = "spec"
 	jvmField                  = "jvm"
 	argsField                 = "args"
-	healthPortField           = "healthPort"
 	workloadType              = "coherence"
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
 	networkPolicyAPIVersion   = "networking.k8s.io/v1"
 	networkPolicyKind         = "NetworkPolicy"
-	coherenceDeploymentLabel  = "coherenceDeployment"
 	coherenceControlPaneLabel = "control-plane"
 	coherenceComponentLabel   = "coherenceComponent"
 	coherenceExtendPort       = 9000
-	defaultHealthPort         = 6676
 )
 
 var specLabelsFields = []string{specField, "labels"}
@@ -598,20 +595,18 @@ func (r *Reconciler) createNetworkPolicies(ctx context.Context, log logr.Logger,
 		return errors.New("OAM app name label missing from metadata, unable to generate network policies")
 	}
 
-	/*
-		// Add required label to application namespace if not already included.
-		label, ok := appNamespace.Labels[constants.LabelVerrazzanoIONamespace]
-		if !ok || label != constants.VerrazzanoSystemNamespace {
-			if appNamespace.Labels == nil {
-				appNamespace.Labels = make(map[string]string)
-			}
-			appNamespace.Labels[constants.LabelVerrazzanoIONamespace] = appNamespace.Name
-			err := r.Update(ctx, appNamespace)
-			if err != nil {
-				return err
-			}
+	// Add required label to application namespace if not already included.
+	label, ok := appNamespace.Labels[constants.LabelVerrazzanoIONamespace]
+	if !ok || label != constants.VerrazzanoSystemNamespace {
+		if appNamespace.Labels == nil {
+			appNamespace.Labels = make(map[string]string)
 		}
-	*/
+		appNamespace.Labels[constants.LabelVerrazzanoIONamespace] = appNamespace.Name
+		err := r.Update(ctx, appNamespace)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Create a network policy in the verrazzano-system namespace, if it does not already exist.
 	// This network policy is an egress for the Coherence operator to Coherence pods in application namespaces.
@@ -667,89 +662,6 @@ func (r *Reconciler) createNetworkPolicies(ctx context.Context, log logr.Logger,
 	}
 	log.Info(fmt.Sprintf("Network policy %s:%s already exist", constants.VerrazzanoSystemNamespace, appNamespaceName))
 
-	/*
-		// Get the health port if specified.  If found, use the port specified otherwise use the deafult of 6676.
-		// The health port is used during shutdown of coherence pods so we create an ingress for that port.
-		healthPort, found, err := unstructured.NestedFieldNoCopy(coherence.Object, specField, healthPortField)
-		if err != nil {
-			return err
-		}
-		var port intstr.IntOrString
-		if found {
-			port = intstr.FromInt(int(healthPort.(int64)))
-		} else {
-			port = intstr.FromInt(defaultHealthPort)
-		}
-
-		protocol := corev1.ProtocolTCP
-
-		// Create a network policy in the application namespace, if it does not already exist.
-		// This network policy is an ingress for a Coherence deployment from the Coherence operator health check port.
-		networkPolicy = &netv1.NetworkPolicy{}
-		err = r.Get(ctx, client.ObjectKey{Namespace: appNamespace.Name, Name: coherence.GetName()}, networkPolicy)
-		if err != nil && k8serrors.IsNotFound(err) {
-			networkPolicy = &netv1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: networkPolicyAPIVersion,
-					Kind:       networkPolicyKind},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: appNamespace.Name,
-					Name:      coherence.GetName(),
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: coherence.GetAPIVersion(),
-							Kind:       coherence.GetKind(),
-							Name:       coherence.GetName(),
-							UID:        coherence.GetUID(),
-						},
-					},
-				},
-				Spec: netv1.NetworkPolicySpec{
-					PodSelector: metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							coherenceDeploymentLabel: coherence.GetName(),
-						},
-					},
-					PolicyTypes: []netv1.PolicyType{
-						netv1.PolicyTypeIngress,
-					},
-					Ingress: []netv1.NetworkPolicyIngressRule{
-						{
-							Ports: []netv1.NetworkPolicyPort{
-								{
-									Protocol: &protocol,
-									Port:     &port,
-								},
-							},
-							From: []netv1.NetworkPolicyPeer{
-								{
-									NamespaceSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											constants.LabelVerrazzanoIONamespace: constants.VerrazzanoSystemNamespace,
-										},
-									},
-									PodSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											coherenceControlPaneLabel: "coherence",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-
-			log.Info(fmt.Sprintf("Creating network policy %s:%s", appNamespace.Name, coherence.GetName()))
-			err = r.Create(ctx, networkPolicy)
-			if err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-		log.Info(fmt.Sprintf("Network policy %s:%s already exist", appNamespace.Name, coherence.GetName()))
-	*/
 	return nil
 }
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -25,6 +25,7 @@ import (
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,6 +153,72 @@ func TestReconcileCreateCoherence(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			namespace.Name = "test-namespace"
+			return nil
+		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			assert.Equal(1, len(namespace.Labels))
+			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			assert.Equal("NetworkPolicy", networkPolicy.Kind)
+			assert.Equal("networking.k8s.io/v1", networkPolicy.APIVersion)
+			assert.Equal(1, len(networkPolicy.Spec.PodSelector.MatchLabels))
+			assert.Equal(map[string]string{"control-plane": "coherence"}, networkPolicy.Spec.PodSelector.MatchLabels)
+			assert.Equal(0, len(networkPolicy.Spec.Ingress))
+			assert.Equal(1, len(networkPolicy.Spec.Egress))
+			assert.Nil(networkPolicy.Spec.Egress[0].Ports)
+			assert.Equal(1, len(networkPolicy.Spec.Egress[0].To))
+			assert.Equal(map[string]string{"coherenceComponent": "coherencePod"}, networkPolicy.Spec.Egress[0].To[0].PodSelector.MatchLabels)
+			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, networkPolicy.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels)
+			assert.Nil(networkPolicy.Spec.Egress[0].To[0].IPBlock)
+			assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
+			assert.Equal(netv1.PolicyTypeEgress, networkPolicy.Spec.PolicyTypes[0])
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			assert.Equal("NetworkPolicy", networkPolicy.Kind)
+			assert.Equal("networking.k8s.io/v1", networkPolicy.APIVersion)
+			assert.Equal("unit-test-cluster", networkPolicy.Name)
+			assert.Equal(1, len(networkPolicy.OwnerReferences))
+			assert.Equal("coherence.oracle.com/v1", networkPolicy.OwnerReferences[0].APIVersion)
+			assert.Equal("Coherence", networkPolicy.OwnerReferences[0].Kind)
+			assert.Equal("unit-test-cluster", networkPolicy.OwnerReferences[0].Name)
+			assert.Equal(1, len(networkPolicy.Spec.PodSelector.MatchLabels))
+			assert.Equal(map[string]string{"coherenceDeployment": "unit-test-cluster"}, networkPolicy.Spec.PodSelector.MatchLabels)
+			assert.Equal(1, len(networkPolicy.Spec.Ingress))
+			assert.Equal(1, len(networkPolicy.Spec.Ingress[0].Ports))
+			assert.Equal(corev1.ProtocolTCP, *networkPolicy.Spec.Ingress[0].Ports[0].Protocol)
+			assert.Equal(int32(6676), networkPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
+			assert.Equal(1, len(networkPolicy.Spec.Ingress[0].From))
+			assert.Equal(map[string]string{"control-plane": "coherence"}, networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels)
+			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: constants.VerrazzanoSystemNamespace}, networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels)
+			assert.Nil(networkPolicy.Spec.Ingress[0].From[0].IPBlock)
+			assert.Equal(0, len(networkPolicy.Spec.Egress))
+			assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
+			assert.Equal(netv1.PolicyTypeIngress, networkPolicy.Spec.PolicyTypes[0])
 			return nil
 		})
 
@@ -297,6 +364,36 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
 
@@ -454,6 +551,36 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
 	// expect a call to status update
 	cli.EXPECT().Status().Return(mockStatus).AnyTimes()
 	mockStatus.EXPECT().
@@ -599,6 +726,37 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
 	reconciler := newReconciler(cli)
@@ -689,6 +847,36 @@ func TestReconcileUpdateCR(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
 
@@ -837,6 +1025,36 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+			return nil
+		})
+	// expect call to fetch existing NetworkPolicy resource
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to create the NetworkPolicy resource
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -156,14 +156,14 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			namespace.Name = "test-namespace"
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			assert.Equal(1, len(namespace.Labels))
-			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					assert.Equal(1, len(namespace.Labels))
+					assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
+					return nil
+				}) */
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -189,39 +189,39 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Equal(netv1.PolicyTypeEgress, networkPolicy.Spec.PolicyTypes[0])
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			assert.Equal("NetworkPolicy", networkPolicy.Kind)
-			assert.Equal("networking.k8s.io/v1", networkPolicy.APIVersion)
-			assert.Equal("unit-test-cluster", networkPolicy.Name)
-			assert.Equal(1, len(networkPolicy.OwnerReferences))
-			assert.Equal("coherence.oracle.com/v1", networkPolicy.OwnerReferences[0].APIVersion)
-			assert.Equal("Coherence", networkPolicy.OwnerReferences[0].Kind)
-			assert.Equal("unit-test-cluster", networkPolicy.OwnerReferences[0].Name)
-			assert.Equal(1, len(networkPolicy.Spec.PodSelector.MatchLabels))
-			assert.Equal(map[string]string{"coherenceDeployment": "unit-test-cluster"}, networkPolicy.Spec.PodSelector.MatchLabels)
-			assert.Equal(1, len(networkPolicy.Spec.Ingress))
-			assert.Equal(1, len(networkPolicy.Spec.Ingress[0].Ports))
-			assert.Equal(corev1.ProtocolTCP, *networkPolicy.Spec.Ingress[0].Ports[0].Protocol)
-			assert.Equal(int32(6676), networkPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
-			assert.Equal(1, len(networkPolicy.Spec.Ingress[0].From))
-			assert.Equal(map[string]string{"control-plane": "coherence"}, networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels)
-			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: constants.VerrazzanoSystemNamespace}, networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels)
-			assert.Nil(networkPolicy.Spec.Ingress[0].From[0].IPBlock)
-			assert.Equal(0, len(networkPolicy.Spec.Egress))
-			assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
-			assert.Equal(netv1.PolicyTypeIngress, networkPolicy.Spec.PolicyTypes[0])
-			return nil
-		})
-
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					assert.Equal("NetworkPolicy", networkPolicy.Kind)
+					assert.Equal("networking.k8s.io/v1", networkPolicy.APIVersion)
+					assert.Equal("unit-test-cluster", networkPolicy.Name)
+					assert.Equal(1, len(networkPolicy.OwnerReferences))
+					assert.Equal("coherence.oracle.com/v1", networkPolicy.OwnerReferences[0].APIVersion)
+					assert.Equal("Coherence", networkPolicy.OwnerReferences[0].Kind)
+					assert.Equal("unit-test-cluster", networkPolicy.OwnerReferences[0].Name)
+					assert.Equal(1, len(networkPolicy.Spec.PodSelector.MatchLabels))
+					assert.Equal(map[string]string{"coherenceDeployment": "unit-test-cluster"}, networkPolicy.Spec.PodSelector.MatchLabels)
+					assert.Equal(1, len(networkPolicy.Spec.Ingress))
+					assert.Equal(1, len(networkPolicy.Spec.Ingress[0].Ports))
+					assert.Equal(corev1.ProtocolTCP, *networkPolicy.Spec.Ingress[0].Ports[0].Protocol)
+					assert.Equal(int32(6676), networkPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
+					assert.Equal(1, len(networkPolicy.Spec.Ingress[0].From))
+					assert.Equal(map[string]string{"control-plane": "coherence"}, networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels)
+					assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: constants.VerrazzanoSystemNamespace}, networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels)
+					assert.Nil(networkPolicy.Spec.Ingress[0].From[0].IPBlock)
+					assert.Equal(0, len(networkPolicy.Spec.Egress))
+					assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
+					assert.Equal(netv1.PolicyTypeIngress, networkPolicy.Spec.PolicyTypes[0])
+					return nil
+				})
+		*/
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
 	reconciler := newReconciler(cli)
@@ -366,12 +366,12 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					return nil
+				})*/
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -384,18 +384,18 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			return nil
-		})
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					return nil
+				}) */
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
@@ -551,12 +551,12 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					return nil
+				})*/
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -569,18 +569,18 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			return nil
-		})
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					return nil
+				}) */
 	// expect a call to status update
 	cli.EXPECT().Status().Return(mockStatus).AnyTimes()
 	mockStatus.EXPECT().
@@ -726,12 +726,12 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					return nil
+				})*/
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -744,19 +744,19 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			return nil
-		})
-
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					return nil
+				})
+		*/
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
 	reconciler := newReconciler(cli)
@@ -849,12 +849,12 @@ func TestReconcileUpdateCR(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					return nil
+				})*/
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -867,18 +867,18 @@ func TestReconcileUpdateCR(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			return nil
-		})
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					return nil
+				})*/
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
@@ -1027,12 +1027,12 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to update a label for the namespace
-	cli.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-			return nil
-		})
+		/*	// expect a call to update a label for the namespace
+			cli.EXPECT().
+				Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+					return nil
+				})*/
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -1045,18 +1045,18 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-	// expect call to fetch existing NetworkPolicy resource
-	cli.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-		})
-	// expect a call to create the NetworkPolicy resource
-	cli.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-			return nil
-		})
+		/*	// expect call to fetch existing NetworkPolicy resource
+			cli.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
+					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+				})
+			// expect a call to create the NetworkPolicy resource
+			cli.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
+					return nil
+				})*/
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -161,7 +161,7 @@ func TestReconcileCreateCoherence(t *testing.T) {
 		Update(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
 			assert.Equal(1, len(namespace.Labels))
-			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
+			assert.Equal(map[string]string{constants.LabelVerrazzanoNamespace: "test-namespace"}, namespace.Labels)
 			return nil
 		})
 	// expect call to fetch existing NetworkPolicy resource
@@ -183,7 +183,7 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Nil(networkPolicy.Spec.Egress[0].Ports)
 			assert.Equal(1, len(networkPolicy.Spec.Egress[0].To))
 			assert.Equal(map[string]string{"coherenceComponent": "coherencePod"}, networkPolicy.Spec.Egress[0].To[0].PodSelector.MatchLabels)
-			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, networkPolicy.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels)
+			assert.Equal(map[string]string{constants.LabelVerrazzanoNamespace: "test-namespace"}, networkPolicy.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels)
 			assert.Nil(networkPolicy.Spec.Egress[0].To[0].IPBlock)
 			assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
 			assert.Equal(netv1.PolicyTypeEgress, networkPolicy.Spec.PolicyTypes[0])

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -156,14 +156,14 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			namespace.Name = "test-namespace"
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					assert.Equal(1, len(namespace.Labels))
-					assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
-					return nil
-				}) */
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			assert.Equal(1, len(namespace.Labels))
+			assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: "test-namespace"}, namespace.Labels)
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -189,39 +189,6 @@ func TestReconcileCreateCoherence(t *testing.T) {
 			assert.Equal(netv1.PolicyTypeEgress, networkPolicy.Spec.PolicyTypes[0])
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					assert.Equal("NetworkPolicy", networkPolicy.Kind)
-					assert.Equal("networking.k8s.io/v1", networkPolicy.APIVersion)
-					assert.Equal("unit-test-cluster", networkPolicy.Name)
-					assert.Equal(1, len(networkPolicy.OwnerReferences))
-					assert.Equal("coherence.oracle.com/v1", networkPolicy.OwnerReferences[0].APIVersion)
-					assert.Equal("Coherence", networkPolicy.OwnerReferences[0].Kind)
-					assert.Equal("unit-test-cluster", networkPolicy.OwnerReferences[0].Name)
-					assert.Equal(1, len(networkPolicy.Spec.PodSelector.MatchLabels))
-					assert.Equal(map[string]string{"coherenceDeployment": "unit-test-cluster"}, networkPolicy.Spec.PodSelector.MatchLabels)
-					assert.Equal(1, len(networkPolicy.Spec.Ingress))
-					assert.Equal(1, len(networkPolicy.Spec.Ingress[0].Ports))
-					assert.Equal(corev1.ProtocolTCP, *networkPolicy.Spec.Ingress[0].Ports[0].Protocol)
-					assert.Equal(int32(6676), networkPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
-					assert.Equal(1, len(networkPolicy.Spec.Ingress[0].From))
-					assert.Equal(map[string]string{"control-plane": "coherence"}, networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels)
-					assert.Equal(map[string]string{constants.LabelVerrazzanoIONamespace: constants.VerrazzanoSystemNamespace}, networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels)
-					assert.Nil(networkPolicy.Spec.Ingress[0].From[0].IPBlock)
-					assert.Equal(0, len(networkPolicy.Spec.Egress))
-					assert.Equal(1, len(networkPolicy.Spec.PolicyTypes))
-					assert.Equal(netv1.PolicyTypeIngress, networkPolicy.Spec.PolicyTypes[0])
-					return nil
-				})
-		*/
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
 	reconciler := newReconciler(cli)
@@ -366,12 +333,12 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					return nil
-				})*/
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -384,18 +351,6 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					return nil
-				}) */
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
@@ -551,12 +506,12 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					return nil
-				})*/
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -569,18 +524,6 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					return nil
-				}) */
 	// expect a call to status update
 	cli.EXPECT().Status().Return(mockStatus).AnyTimes()
 	mockStatus.EXPECT().
@@ -726,12 +669,12 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					return nil
-				})*/
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -744,19 +687,6 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					return nil
-				})
-		*/
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
 	reconciler := newReconciler(cli)
@@ -849,12 +779,12 @@ func TestReconcileUpdateCR(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					return nil
-				})*/
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -867,18 +797,6 @@ func TestReconcileUpdateCR(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					return nil
-				})*/
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")
@@ -1027,12 +945,12 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-		/*	// expect a call to update a label for the namespace
-			cli.EXPECT().
-				Update(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
-					return nil
-				})*/
+	// expect a call to update a label for the namespace
+	cli.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, namespace *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
 	// expect call to fetch existing NetworkPolicy resource
 	cli.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
@@ -1045,18 +963,6 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
 			return nil
 		})
-		/*	// expect call to fetch existing NetworkPolicy resource
-			cli.EXPECT().
-				Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
-				DoAndReturn(func(ctx context.Context, name types.NamespacedName, networkPolicy *netv1.NetworkPolicy) error {
-					return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
-				})
-			// expect a call to create the NetworkPolicy resource
-			cli.EXPECT().
-				Create(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, networkPolicy *netv1.NetworkPolicy, opts ...client.CreateOption) error {
-					return nil
-				})*/
 
 	// create a request and reconcile it
 	request := newRequest(namespace, "unit-test-verrazzano-coherence-workload")

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -60,6 +60,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - '*'
+  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterroles

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml
@@ -10,7 +10,7 @@ global:
 # during the platform operator docker image build.
 image:
 imagePullPolicy: IfNotPresent
-logLevel: debug
+logLevel: info
 
 requestMemory: 72Mi
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -41,15 +41,15 @@ spec:
     - Egress
   ingress:
     - ports:
-        - port: 9443
-          protocol: TCP
-        from:
-          - ipBlock:
-              cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+      - port: 9443
+        protocol: TCP
+      from:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
-      - ports:
-        - port: {{ .Values.kubernetes.service.endpoint.port }}
-          protocol: TCP
-        to:
-          - ipBlock:
-              cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+    - ports:
+      - port: {{ .Values.kubernetes.service.endpoint.port }}
+        protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 # Network policy for WebLogic operator
-# Ingress:  deny all
+# Ingress: deny all
 # Egress: allow WebLogic Operator to connect to Kubernetes API server
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -23,3 +23,36 @@ spec:
       to:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+---
+# Network policy for Coherence Operator
+# Ingress:  allow Kubernetes API server to connect to the Coherence Operator validating webhook
+# Egress: allow Coherence Operator to connect to Kubernetes API server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coherence-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: coherence
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+      from:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+  egress:
+      - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+        to:
+          - ipBlock:
+              cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+      - ports:
+        - port: 6676
+          protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -41,15 +41,15 @@ spec:
     - Egress
   ingress:
     - ports:
-      - port: 9443
-        protocol: TCP
+        - port: 9443
+          protocol: TCP
       from:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
     - ports:
-      - port: {{ .Values.kubernetes.service.endpoint.port }}
-        protocol: TCP
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
       to:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -25,7 +25,7 @@ spec:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
 ---
 # Network policy for Coherence Operator
-# Ingress:  allow Kubernetes API server to connect to the Coherence Operator validating webhook
+# Ingress:  allow Kubernetes API server to connect to the Coherence Operator validating webhook with port 9443
 # Egress: allow Coherence Operator to connect to Kubernetes API server
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -43,6 +43,9 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
+        from:
+          - ipBlock:
+              cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
       - ports:
         - port: {{ .Values.kubernetes.service.endpoint.port }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -43,9 +43,6 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
-      from:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
       - ports:
         - port: {{ .Values.kubernetes.service.endpoint.port }}
@@ -53,6 +50,3 @@ spec:
         to:
           - ipBlock:
               cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
-      - ports:
-        - port: 6676
-          protocol: TCP

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -225,6 +225,9 @@ if ! kubectl get namespace ${VERRAZZANO_NS} ; then
   action "Creating ${VERRAZZANO_NS} namespace" kubectl create namespace ${VERRAZZANO_NS} || exit 1
 fi
 
+log "Adding label needed by network policies to ${VERRAZZANO_NS} namespace"
+kubectl label namespace ${VERRAZZANO_NS} "verrazzano.io/namespace=${VERRAZZANO_NS}"
+
 if ! kubectl get namespace ${VERRAZZANO_MC} ; then
   action "Creating ${VERRAZZANO_MC} namespace" kubectl create namespace ${VERRAZZANO_MC} || exit 1
 fi


### PR DESCRIPTION
# Description

This pull request adds the network policies needed for the Coherence operator.
The network policies required are:
1. ingress from Kubernetes API server
2. egress to Kubernetes API server
3. egress to Coherence pods in application namespace

Fixes VZ-2479

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
