### PR TITLE
VZ-2385 (Partial).  More resiliency around Rancher install and cleanup

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -31,16 +31,17 @@ function delete_rancher_local_cluster {
   if [ "${RANCHER_ACCESS_TOKEN}" ]; then
     log "Updating ${rancher_cluster_url}"
     local temp_output="/tmp/delete_cluster.out"
-    status=$(curl -o ${temp_output} -s -w "%{http_code}\n" $(get_rancher_resolve ${rancher_hostname}) -X DELETE -H "Accept: application/json" -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" --insecure "${rancher_cluster_url}")
-    if [ "$status" != 200 ] ; then
+    status=$(curl -o ${temp_output} --max-time 60 -s -w "%{http_code}\n" $(get_rancher_resolve ${rancher_hostname}) -X DELETE -H "Accept: application/json" -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" --insecure "${rancher_cluster_url}")
+    log "Status: ${status}"
+    if [ "$status" != "200" ]; then
       local cluster_delete_output=$(cat $temp_output)
       log "${cluster_delete_output}"
       rm "$temp_output"
       return 0
     fi
 
-    # Wait 60s for local cluster to delete
-    local max_retries=6
+    # Wait 180s for local cluster to delete
+    local max_retries=18
     local retries=0
     while true ; do
       still_exists="$(curl -s $(get_rancher_resolve ${rancher_hostname}) -X GET -H "Accept: application/json" -H "Authorization: Bearer ${RANCHER_ACCESS_TOKEN}" --insecure "${rancher_cluster_url}")"

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -75,17 +75,33 @@ function delete_cert_manager() {
   kubectl delete namespace cert-manager --ignore-not-found=true || err_return $? "Could not delete namespace cert-manager" || return $?
 }
 
+function cleanup_rancher_local_cluster() {
+  if kubectl get cluster local > /dev/null 2>&1 ; then
+    # Occasionally we have problems deleting 'local' Rancher cluster object nicely, and it gets stuck and puts any
+    # re-installed cluster in a bad state.  So here we force the delete of the object, wait for it, and then
+    # patch out any remaining finalizers and check one more time for delete success.
+    log "Found 'local' cluster object still present, removing..."
+    kubectl delete --wait=false clusters.management.cattle.io local || true
+    kubectl wait --for=delete -n kube-system clusters.management.cattle.io/local --timeout=2m || true
+    # Patch any dangling finalizers
+    kubectl patch clusters.management.cattle.io local -p '{"metadata":{"finalizers":null}}' --type=merge || true
+    kubectl wait --for=delete -n kube-system clusters.management.cattle.io/local --timeout=2m || true
+    if kubectl get cluster local > /dev/null 2>&1 ; then
+      log "Unable to delete Rancher 'local' cluster object"
+    else
+      log "Rancher 'local' cluster deleted successfully"
+    fi
+  fi
+}
+
 function delete_rancher() {
   local rancher_exists=$(kubectl get namespace cattle-system --ignore-not-found)
   if [ -z "$rancher_exists" ] ; then
     return 0
   fi
 
-  # Occasionally the 'local' Rancher cluster object is stuck with a dangling finalizer, remove it so
-  # we don't orphan the cluster info between installs
-  log "Remove any dangling finalizers from the 'local' Rancher cluster object"
-  kubectl patch cluster local -n kube-system -p '{"metadata":{"finalizers":null}}' --type=merge || true
-  kubectl wait --for=delete -n kube-system cluster/local --timeout=2m || true
+  # Clean up the local rancher cluster object if necessary
+  cleanup_rancher_local_cluster
 
   # Deleting rancher components
   log "Deleting rancher"

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -18,15 +18,15 @@ import (
 )
 
 const (
-	TestNamespace = "hello-helidon"
+	TestNamespace   = "hello-helidon"
 	pollingInterval = 5 * time.Second
 	waitTimeout     = 5 * time.Minute
 
 	multiclusterNamespace = "verrazzano-mc"
-	projectName   = "hello-helidon"
-	appConfigName = "hello-helidon-appconf"
-	componentName = "hello-helidon-component"
-	workloadName  = "hello-helidon-workload"
+	projectName           = "hello-helidon"
+	appConfigName         = "hello-helidon-appconf"
+	componentName         = "hello-helidon-component"
+	workloadName          = "hello-helidon-workload"
 )
 
 var expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}


### PR DESCRIPTION
# Description

More resiliency around Rancher install/uninstall
- Create rancher secret using apply, so re-runs of install are idempotent
- Add more checks around cleanup of 'local' cluster object prior to patching out the finalizers; may have been contributing to cluster instability on reinstalls
- Fix go fmt error in MC test code

Partially addresses VZ-2385.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
