### PR TITLE
Remove set -o pipefail from functions, where it is not required

### DIFF
--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -339,7 +339,6 @@ function get_nginx_nodeport() {
 
 # Merge the default config json under install/install-overrides with the corresponding override for the profile
 function compute_effective_override() {
-  set -o pipefail
   local profile=$(get_install_profile)
   local default_config="${INSTALL_OVERRIDES_DIR}/config.json"
   local profile_config_override="${INSTALL_OVERRIDES_DIR}/config.${profile}.json"
@@ -355,7 +354,6 @@ function compute_effective_override() {
 
 # Read the value for a given key from effective.config.json
 function get_override_config_value() {
-  set -o pipefail
   local jq_expr="$1"
   local config_val=$(jq -r "$jq_expr" $EFFECTIVE_CONFIG_VALUES)
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
# Description

This change removes "set -o pipefail" from platform-operator/scripts/install/config.sh, where it is not necessary.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
