### PR TITLE
 managed cluster uses admin keycloak for auth; remove keycloak from managed-cluster

### DIFF
--- a/examples/multicluster/README.md
+++ b/examples/multicluster/README.md
@@ -50,7 +50,6 @@ Complete the following sections prior to running the multicluster examples.
    ```
    $ export KUBECONFIG=$KUBECONFIG_MANAGED1
    $ echo "prometheus:" > managed1.yaml
-   $ echo "  authpasswd: $(KUBECONFIG=$KUBECONFIG_MANAGED1 kubectl get secret verrazzano -n verrazzano-system -o jsonpath='{.data.password}' | base64 --decode)" >> managed1.yaml
    $ echo "  host: $(KUBECONFIG=$KUBECONFIG_MANAGED1 kubectl get ing vmi-system-prometheus -n verrazzano-system -o jsonpath='{.spec.tls[0].hosts[0]}')" >> managed1.yaml
 
    # Perform the following commands if the result of this command is not null:

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -318,6 +318,8 @@ type KeycloakComponent struct {
 	// MySQL contains the MySQL component configuration needed for Keycloak
 	// +optional
 	MySQL MySQLComponent `json:"mysql,omitempty"`
+	// +optional
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // MySQLComponent specifies the MySQL configuration

--- a/platform-operator/config/samples/install-managed-cluster.yaml
+++ b/platform-operator/config/samples/install-managed-cluster.yaml
@@ -11,6 +11,7 @@
 # - Grafana
 # - Rancher
 # - Console
+# - Keycloak
 #
 # Prometheus is installed for recording metrics from the system services and deployed apps in the local
 # cluster, which will then be scraped from the admin cluster.

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -57,7 +57,6 @@ type AssertFn func(configMap *corev1.ConfigMap) error
 func TestCreateVMC(t *testing.T) {
 	namespace := constants.VerrazzanoMultiClusterNamespace
 	promData := "prometheus:\n" +
-		"  authpasswd: nRXlxXgMwN\n" +
 		"  host: prometheus.vmi.system.default.152.67.141.181.xip.io\n" +
 		"  cacrt: |\n" +
 		"    -----BEGIN CERTIFICATE-----\n" +
@@ -126,7 +125,6 @@ func TestCreateVMCOCIDNS(t *testing.T) {
 	namespace := "verrazzano-mc"
 	// OCI DNS cluster does not include a CA cert since the CA is public
 	promData := "prometheus:\n" +
-		"  authpasswd: nRXlxXgMwN\n" +
 		"  host: prometheus.vmi.system.default.152.67.141.181.xip.io\n"
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
@@ -189,7 +187,6 @@ func TestCreateVMCOCIDNS(t *testing.T) {
 func TestCreateVMCWithExistingScrapeConfiguration(t *testing.T) {
 	namespace := "verrazzano-mc"
 	promData := "prometheus:\n" +
-		"  authpasswd: nRXlxXgMwN\n" +
 		"  host: prometheus.vmi.system.default.152.67.141.181.xip.io\n" +
 		"  cacrt: |\n" +
 		"    -----BEGIN CERTIFICATE-----\n" +
@@ -268,7 +265,6 @@ scrape_configs:
 func TestReplaceExistingScrapeConfiguration(t *testing.T) {
 	namespace := "verrazzano-mc"
 	promData := "prometheus:\n" +
-		"  authpasswd: nRXlxXgMwN\n" +
 		"  host: prometheus.vmi.system.default.152.67.141.181.xip.io\n" +
 		"  cacrt: |\n" +
 		"    -----BEGIN CERTIFICATE-----\n" +
@@ -348,7 +344,6 @@ scrape_configs:
 func TestCreateVMCClusterAlreadyRegistered(t *testing.T) {
 	namespace := constants.VerrazzanoMultiClusterNamespace
 	promData := "prometheus:\n" +
-		"  authpasswd: nRXlxXgMwN\n" +
 		"  host: prometheus.vmi.system.default.152.67.141.181.xip.io\n" +
 		"  cacrt: |\n" +
 		"    -----BEGIN CERTIFICATE-----\n" +
@@ -1290,6 +1285,16 @@ func expectSyncPrometheusScraper(mock *mocks.MockClient, vmcName string, prometh
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				getClusterYamlKey(vmcName): []byte(prometheusSecretData),
+			}
+			return nil
+		})
+
+	// Expect a call to get the verrazzano secret - return it
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				PasswordKey: []byte("nRXlxXgMwN"),
 			}
 			return nil
 		})

--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -157,6 +157,7 @@ type DNS struct {
 type Keycloak struct {
 	KeycloakInstallArgs []InstallArg `json:"keycloakInstallArgs,omitempty"`
 	MySQL               MySQL        `json:"mysql,omitempty"`
+	Enabled             string       `json:"enabled,omitempty"`
 }
 
 // MySQL configuration
@@ -388,6 +389,7 @@ func getKeycloak(keycloak *installv1alpha1.KeycloakComponent, templates []instal
 		MySQL: MySQL{
 			MySQLInstallArgs: mySQLArgs,
 		},
+		Enabled: strconv.FormatBool(keycloak.Enabled),
 	}
 
 	// Use a volume source specified in the Keycloak config, otherwise use the default spec

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -32,6 +32,8 @@ func TestXipIoInstallDefaults(t *testing.T) {
 	assert.Equalf(t, "verrazzano-ca-certificate-secret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 	assert.Equalf(t, 0, len(config.Keycloak.KeycloakInstallArgs), "Expected keycloakInstallArgs length did not match")
 	assert.Equalf(t, 0, len(config.Keycloak.MySQL.MySQLInstallArgs), "Expected mySqlInstallArgs length did not match")
+	assert.Equalf(t, "", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
+	assert.Equalf(t, "", config.Rancher.Enabled, "Expected rancher enabled did not match")
 }
 
 // TestXipIoInstallNonDefaults tests the creation of an xip.io install non-default configuration
@@ -81,6 +83,9 @@ func TestXipIoInstallNonDefaults(t *testing.T) {
 						},
 					},
 				},
+				Rancher: &installv1alpha1.RancherComponent{
+					Enabled: true,
+				},
 				Keycloak: &installv1alpha1.KeycloakComponent{
 					KeycloakInstallArgs: []installv1alpha1.InstallArgs{
 						{
@@ -96,6 +101,7 @@ func TestXipIoInstallNonDefaults(t *testing.T) {
 							},
 						},
 					},
+					Enabled: true,
 				},
 			},
 		},
@@ -125,12 +131,15 @@ func TestXipIoInstallNonDefaults(t *testing.T) {
 	assert.Equalf(t, "customNamespace", config.Certificates.CA.ClusterResourceNamespace, "Expected namespace did not match")
 	assert.Equalf(t, "customSecret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 
+	assert.Equalf(t, "true", config.Rancher.Enabled, "Expected rancher enabled did not match")
+
 	assert.Equalf(t, 1, len(config.Keycloak.KeycloakInstallArgs), "Expected keycloakInstallArgs length did not match")
 	assert.Equalf(t, "keycloak-name", config.Keycloak.KeycloakInstallArgs[0].Name, "Expected keycloakInstallArgs name did not match")
 	assert.Equalf(t, "keycloak-value", config.Keycloak.KeycloakInstallArgs[0].Value, "Expected keycloakInstallArgs value did not match")
 	assert.Equalf(t, 1, len(config.Keycloak.MySQL.MySQLInstallArgs), "Expected mysqlInstallArgs length did not match")
 	assert.Equalf(t, "mysql-name", config.Keycloak.MySQL.MySQLInstallArgs[0].Name, "Expected mysqlInstallArgs name did not match")
 	assert.Equalf(t, "mysql-value", config.Keycloak.MySQL.MySQLInstallArgs[0].Value, "Expected mysqlInstallArgs value did not match")
+	assert.Equalf(t, "true", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
 }
 
 // TestExternalInstall tests the creation of an external install configuration

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -267,6 +267,8 @@ spec:
                   keycloak:
                     description: Keycloak contains the Keycloak component configuration
                     properties:
+                      enabled:
+                        type: boolean
                       keycloakInstallArgs:
                         description: Arguments for installing Keycloak
                         items:

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,7 +61,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.14.0-20210413150938-97333f5
+  imageVersion: 0.14.0-20210413210131-b2ec2e0
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,7 +61,7 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.14.0-20210406204855-2f17abf
+  imageVersion: 0.14.0-20210413150938-97333f5
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -73,7 +73,7 @@ monitoringOperator:
   alertManagerImage: "noimage"
   esWaitTargetVersion: 7.6.1
   esImage: ghcr.io/verrazzano/elasticsearch:7.6.1-20201130145440-5c76ab1
-  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.14.0-20210331214918-d703570
+  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.14.0-20210413210131-b2ec2e0
   esInitImage: ghcr.io/oracle/oraclelinux:7.8
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-20201130145840-7717e73
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e

--- a/platform-operator/scripts/create_managed_cluster_secret.sh
+++ b/platform-operator/scripts/create_managed_cluster_secret.sh
@@ -48,7 +48,6 @@ HOST=$(kubectl get ing vmi-system-prometheus -n verrazzano-system -o jsonpath='{
 
 #create the yaml file
 echo "prometheus:" > $OUTPUT_FILE
-echo "  authpasswd: $AUTH_PASSWORD" >> $OUTPUT_FILE
 echo "  host: $HOST" >> $OUTPUT_FILE
 if [ ! -z "${CA_CERT}" ] ; then
    echo "  cacrt: |" >> $OUTPUT_FILE

--- a/platform-operator/scripts/create_managed_cluster_secret.sh
+++ b/platform-operator/scripts/create_managed_cluster_secret.sh
@@ -43,7 +43,6 @@ TLS_SECRET=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r 
 if [ ! -z "${TLS_SECRET%%*( )}" ] ; then
   CA_CERT=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 -d)
 fi
-AUTH_PASSWORD=$(kubectl get secret verrazzano -n verrazzano-system -o jsonpath='{.data.password}' | base64 -d)
 HOST=$(kubectl get ing vmi-system-prometheus -n verrazzano-system -o jsonpath='{.spec.tls[0].hosts[0]}')
 
 #create the yaml file

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -154,6 +154,13 @@ data:
 DNS_TARGET_NAME=verrazzano-ingress.${ENV_NAME}.${DNS_SUFFIX}
 REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)
 
+CONFIG_CONTENT=$(cat $INSTALL_CONFIG_FILE)
+EFFECTIVE_CONTENT=$(cat $EFFECTIVE_CONFIG_VALUES)
+log "config content: $CONFIG_CONTENT"
+log "effective content: $EFFECTIVE_CONTENT"
+log "is keycloak enabled: $(is_keycloak_enabled)"
+log "is rancher enabled: $(is_rancher_enabled)"
+
 if [ $(is_keycloak_enabled) == "true" ]; then
   action "Installing MySQL" install_mysql
     if [ "$?" -ne 0 ]; then

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -166,7 +166,7 @@ if [ $(is_keycloak_enabled) == "true" ]; then
 
   action "Installing Keycloak" install_keycloak || exit 1
 else
-  log "Skip Keycloak installation on managed cluster"
+  log "Skip Keycloak installation, disabled"
 fi
 
 rm -rf $TMP_DIR

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -154,16 +154,18 @@ data:
 DNS_TARGET_NAME=verrazzano-ingress.${ENV_NAME}.${DNS_SUFFIX}
 REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)
 
-action "Installing MySQL" install_mysql
-  if [ "$?" -ne 0 ]; then
-    "$SCRIPT_DIR"/k8s-dump-objects.sh -o "pods" -n "${KEYCLOAK_NS}" -m "install_mysql"
-    "$SCRIPT_DIR"/k8s-dump-objects.sh -o "jobs" -n "${KEYCLOAK_NS}" -m "install_mysql"
-    "$SCRIPT_DIR"/k8s-dump-objects.sh -o "nodes" -n "default" -m "install_mysql"
-    log "For additional detailed information on the cluster at the time of this error, please check the diagnostics log file"
-    fail "Installation of MySQL failed"
-  fi
+if [ $(is_keycloak_enabled) == "true" ]; then
+  action "Installing MySQL" install_mysql
+    if [ "$?" -ne 0 ]; then
+      "$SCRIPT_DIR"/k8s-dump-objects.sh -o "pods" -n "${KEYCLOAK_NS}" -m "install_mysql"
+      "$SCRIPT_DIR"/k8s-dump-objects.sh -o "jobs" -n "${KEYCLOAK_NS}" -m "install_mysql"
+      "$SCRIPT_DIR"/k8s-dump-objects.sh -o "nodes" -n "default" -m "install_mysql"
+      log "For additional detailed information on the cluster at the time of this error, please check the diagnostics log file"
+      fail "Installation of MySQL failed"
+    fi
 
-action "Installing Keycloak" install_keycloak || exit 1
+  action "Installing Keycloak" install_keycloak || exit 1
+fi
 
 rm -rf $TMP_DIR
 
@@ -188,11 +190,12 @@ if [ $(is_rancher_enabled) == "true" ]; then
   consoleout "Password: kubectl get secret --namespace cattle-system rancher-admin-secret -o jsonpath={.data.password} | base64 --decode; echo"
   consoleout
 fi
-consoleout "Keycloak - https://keycloak.${ENV_NAME}.${DNS_SUFFIX}"
-consoleout "User: keycloakadmin"
-consoleout "Password: kubectl get secret --namespace keycloak ${KCADMIN_SECRET} -o jsonpath={.data.password} | base64 --decode; echo"
-if [ $(get_application_ingress_ip) == "null" ];
-then
+if [ $(is_keycloak_enabled) == "true" ]; then
+  consoleout "Keycloak - https://keycloak.${ENV_NAME}.${DNS_SUFFIX}"
+  consoleout "User: keycloakadmin"
+  consoleout "Password: kubectl get secret --namespace keycloak ${KCADMIN_SECRET} -o jsonpath={.data.password} | base64 --decode; echo"
+fi
+if [ $(get_application_ingress_ip) == "null" ]; then
   consoleout
   consoleout "WARNING: istio-ingressgateway service does not have a valid external IP assigned yet. Public access to deployed applications will not work."
   consoleout "Use the following command to check if an External IP has been assigned to the gateway."

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -165,6 +165,8 @@ if [ $(is_keycloak_enabled) == "true" ]; then
     fi
 
   action "Installing Keycloak" install_keycloak || exit 1
+else
+  log "Skip Keycloak installation on managed cluster"
 fi
 
 rm -rf $TMP_DIR

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -154,13 +154,6 @@ data:
 DNS_TARGET_NAME=verrazzano-ingress.${ENV_NAME}.${DNS_SUFFIX}
 REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)
 
-CONFIG_CONTENT=$(cat $INSTALL_CONFIG_FILE)
-EFFECTIVE_CONTENT=$(cat $EFFECTIVE_CONFIG_VALUES)
-log "config content: $CONFIG_CONTENT"
-log "effective content: $EFFECTIVE_CONTENT"
-log "is keycloak enabled: $(is_keycloak_enabled)"
-log "is rancher enabled: $(is_rancher_enabled)"
-
 if [ $(is_keycloak_enabled) == "true" ]; then
   action "Installing MySQL" install_mysql
     if [ "$?" -ne 0 ]; then

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -37,7 +37,10 @@ function get_config_value() {
     return 1
   fi
   if [ "$config_val" == "null" ]; then
-    # The configuration is not defined in CONFIG_JSON, check if it is defined in the json files under install-overrides
+    config_val=""
+  fi
+  # check if it is defined in the json files under install-overrides
+  if [ ! $(get_override_config_value "$jq_expr") == "" ]; then
     config_val=$(get_override_config_value "$jq_expr")
   fi
   echo $config_val

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -373,6 +373,12 @@ function is_rancher_enabled() {
   echo ${rancher_enabled}
 }
 
+# Return the value for the key keycloak.enabled
+function is_keycloak_enabled() {
+  local keycloak_enabled=$(get_config_value '.keycloak.enabled')
+  echo ${keycloak_enabled}
+}
+
 if [ -z "$INSTALL_CONFIG_FILE" ]; then
   INSTALL_CONFIG_FILE=$DEFAULT_CONFIG_FILE
 fi

--- a/platform-operator/scripts/install/install-overrides/config.dev.json
+++ b/platform-operator/scripts/install/install-overrides/config.dev.json
@@ -1,5 +1,8 @@
 {
   "rancher": {
     "enabled": true
+  },
+  "keycloak": {
+    "enabled": true
   }
 }

--- a/platform-operator/scripts/install/install-overrides/config.json
+++ b/platform-operator/scripts/install/install-overrides/config.json
@@ -1,5 +1,8 @@
 {
   "rancher": {
     "enabled": true
+  },
+  "keycloak": {
+    "enabled": true
   }
 }

--- a/platform-operator/scripts/install/install-overrides/config.managed-cluster.json
+++ b/platform-operator/scripts/install/install-overrides/config.managed-cluster.json
@@ -1,5 +1,8 @@
 {
   "rancher": {
     "enabled": false
+  },
+  "keycloak": {
+    "enabled": false
   }
 }

--- a/platform-operator/scripts/install/install-overrides/config.prod.json
+++ b/platform-operator/scripts/install/install-overrides/config.prod.json
@@ -1,5 +1,8 @@
 {
   "rancher": {
     "enabled": true
+  },
+  "keycloak": {
+    "enabled": true
   }
 }

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -41,7 +41,6 @@ fi
 AUTH_PASSWORD=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret verrazzano -o jsonpath='{.data.password}' | base64 --decode)
 HOST=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get ing vmi-system-prometheus -o jsonpath='{.spec.tls[0].hosts[0]}')
 echo "prometheus:" > ${PROMETHEUS_SECRET_FILE}
-echo "  authpasswd: $AUTH_PASSWORD" >> ${PROMETHEUS_SECRET_FILE}
 echo "  host: $HOST" >> ${PROMETHEUS_SECRET_FILE}
 if [ ! -z "${CA_CERT}" ] ; then
    echo "  cacrt: |" >> ${PROMETHEUS_SECRET_FILE}

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -38,7 +38,6 @@ TLS_SECRET=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get
 if [ ! -z "${TLS_SECRET%%*( )}" ] ; then
   CA_CERT=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 --decode)
 fi
-AUTH_PASSWORD=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret verrazzano -o jsonpath='{.data.password}' | base64 --decode)
 HOST=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get ing vmi-system-prometheus -o jsonpath='{.spec.tls[0].hosts[0]}')
 echo "prometheus:" > ${PROMETHEUS_SECRET_FILE}
 echo "  host: $HOST" >> ${PROMETHEUS_SECRET_FILE}

--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -21,12 +21,15 @@ var _ = ginkgo.Describe("keycloak url test", func() {
 
 	ginkgo.Context("Fetching the keycloak url using api and test ", func() {
 		ginkgo.It("Fetches keycloak url", func() {
-			ingress := api.GetIngress("keycloak", "keycloak")
-			keycloakURL := fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
-			gomega.Expect(keycloakURL).NotTo(gomega.BeEmpty())
+			isManagedClusterProfile := pkg.IsManagedClusterProfile()
+			if !isManagedClusterProfile {
+				ingress := api.GetIngress("keycloak", "keycloak")
+				keycloakURL := fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
+				gomega.Expect(keycloakURL).NotTo(gomega.BeEmpty())
 
-			httpClient := pkg.GetVerrazzanoHTTPClient()
-			pkg.ExpectHTTPGetOk(httpClient, keycloakURL)
+				httpClient := pkg.GetVerrazzanoHTTPClient()
+				pkg.ExpectHTTPGetOk(httpClient, keycloakURL)
+			}
 		})
 	})
 })

--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -11,18 +11,12 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-var api *pkg.APIEndpoint
-
 var _ = ginkgo.Describe("keycloak url test", func() {
-
-	var _ = ginkgo.BeforeEach(func() {
-		api = pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
-	})
-
 	ginkgo.Context("Fetching the keycloak url using api and test ", func() {
 		ginkgo.It("Fetches keycloak url", func() {
 			isManagedClusterProfile := pkg.IsManagedClusterProfile()
 			if !isManagedClusterProfile {
+				api := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
 				ingress := api.GetIngress("keycloak", "keycloak")
 				keycloakURL := fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
 				gomega.Expect(keycloakURL).NotTo(gomega.BeEmpty())

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -12,24 +12,18 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-var api *pkg.APIEndpoint
-
 const (
 	waitTimeout     = 5 * time.Minute
 	pollingInterval = 5 * time.Second
 )
 
-var kubeconfigPath = pkg.GetKubeConfigPathFromEnv()
 var _ = ginkgo.Describe("rancher url test", func() {
-
-	var _ = ginkgo.BeforeEach(func() {
-		api = pkg.GetAPIEndpoint(kubeconfigPath)
-	})
-
 	ginkgo.Context("Fetching the rancher url using api and test ", func() {
 		ginkgo.It("Fetches rancher url", func() {
 			isManagedClusterProfile := pkg.IsManagedClusterProfile()
 			if !isManagedClusterProfile {
+				kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
+				api := pkg.GetAPIEndpoint(kubeconfigPath)
 				rancherURL := func() string {
 					ingress := api.GetIngress("cattle-system", "rancher")
 					return fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -232,7 +232,9 @@ var _ = ginkgo.Describe("VMI", func() {
 	})
 
 	ginkgo.It("Verify the instance info endpoint URLs", func() {
-		assertInstanceInfoURLs()
+		if !isManagedClusterProfile {
+			assertInstanceInfoURLs()
+		}
 	})
 
 	size := "50Gi"

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -21,17 +21,22 @@ const (
 
 var _ = ginkgo.Describe("Verify Keycloak configuration", func() {
 	var _ = ginkgo.Describe("Verify password policies", func() {
+		isManagedClusterProfile := pkg.IsManagedClusterProfile()
 		ginkgo.It("Verify master realm password policy", func() {
-			// GIVEN the password policy setup for the master realm during installation
-			// WHEN valid and invalid password changes are attempted
-			// THEN verify valid passwords are accepted and invalid passwords are rejected.
-			gomega.Eventually(verifyKeycloakMasterRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			if !isManagedClusterProfile {
+				// GIVEN the password policy setup for the master realm during installation
+				// WHEN valid and invalid password changes are attempted
+				// THEN verify valid passwords are accepted and invalid passwords are rejected.
+				gomega.Eventually(verifyKeycloakMasterRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}
 		})
 		ginkgo.It("Verify Verrazzano-system realm password policy", func() {
-			// GIVEN the password policy setup for the Verrazzano-system realm during installation
-			// WHEN valid and invalid password changes are attempted
-			// THEN verify valid passwords are accepted and invalid passwords are rejected.
-			gomega.Eventually(verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			if !isManagedClusterProfile {
+				// GIVEN the password policy setup for the Verrazzano-system realm during installation
+				// WHEN valid and invalid password changes are attempted
+				// THEN verify valid passwords are accepted and invalid passwords are rejected.
+				gomega.Eventually(verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}
 		})
 	})
 })

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -71,7 +71,11 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 				}
 				gomega.Expect(nsListContains(namespaces.Items, "istio-system")).To(gomega.Equal(true))
 				gomega.Expect(nsListContains(namespaces.Items, "gitlab")).To(gomega.Equal(false))
-				gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.Equal(true))
+				if isManagedClusterProfile {
+					gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.Equal(false))
+				} else {
+					gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.Equal(true))
+				}
 				gomega.Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(gomega.Equal(true))
 				gomega.Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(gomega.Equal(true))
 				gomega.Expect(nsListContains(namespaces.Items, "cert-manager")).To(gomega.Equal(true))
@@ -111,12 +115,21 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 			ginkgoExt.Entry("includes ingress-controller-ingress-nginx-controller", "ingress-controller-ingress-nginx-controller", true),
 		)
 
-		ginkgoExt.DescribeTable("deployed keycloak components",
-			func(name string, expected bool) {
-				gomega.Expect(vzComponentPresent(name, "keycloak")).To(gomega.Equal(expected))
-			},
-			ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
-		)
+		if isManagedClusterProfile {
+			ginkgoExt.DescribeTable("keycloak components are not deployed",
+				func(name string, expected bool) {
+					gomega.Expect(vzComponentPresent(name, "keycloak")).To(gomega.BeFalse())
+				},
+				ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
+			)
+		} else {
+			ginkgoExt.DescribeTable("deployed keycloak components",
+				func(name string, expected bool) {
+					gomega.Expect(vzComponentPresent(name, "keycloak")).To(gomega.Equal(expected))
+				},
+				ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
+			)
+		}
 
 		if isManagedClusterProfile {
 			ginkgoExt.DescribeTable("rancher components are not deployed",
@@ -164,8 +177,10 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 						}
 					},
 					func() {
-						gomega.Eventually(pkg.PodsRunning("keycloak", expectedPodsKeycloak), waitTimeout, pollingInterval).
-							Should(gomega.BeTrue())
+						if !isManagedClusterProfile {
+							gomega.Eventually(pkg.PodsRunning("keycloak", expectedPodsKeycloak), waitTimeout, pollingInterval).
+								Should(gomega.BeTrue())
+						}
 					},
 					func() {
 						gomega.Eventually(pkg.PodsRunning("cert-manager", expectedPodsCertManager), waitTimeout, pollingInterval).


### PR DESCRIPTION
# Description

1. VMO redeploy to update the OIDC sidecars, upon cluster registration changes.
2. managed cluster prometheus secret no longer includes password.
3. prometheus scraper uses admin verrazzano password
4. remove keycloak in managed-cluster profile
5. uptake VMO in which managed cluster prometheus re-routes auth requests to admin keycloak, proxy-body-size and reduced log

Fixes VZ-2357

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
