### PR TITLE
Grant specific privileges instead of 'ALL' for keycloak user in MySQL

### DIFF
--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -7,8 +7,6 @@ busybox:
   image: ghcr.io/oracle/oraclelinux
   tag: 7-slim
 
-mysqlDatabase: keycloak
-
 imagePullPolicy: IfNotPresent
 
 ssl:

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -45,7 +45,8 @@ function install_mysql {
 
   echo "CREATE DATABASE IF NOT EXISTS keycloak DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" > ${TMP_DIR}/create-db.sql
   echo "USE keycloak;" >> ${TMP_DIR}/create-db.sql
-  echo "GRANT ALL ON keycloak.* TO '${MYSQL_USERNAME}'@'%';" >> ${TMP_DIR}/create-db.sql
+  # Allow the keycloak user to create/drop tables, indices, foreign key references, and read/write to all tables in keycloak schema
+  echo "GRANT CREATE, ALTER, DROP, INDEX, REFERENCES, SELECT, INSERT, UPDATE, DELETE ON keycloak.* TO '${MYSQL_USERNAME}'@'%';" >> ${TMP_DIR}/create-db.sql
   echo "FLUSH PRIVILEGES;" >> ${TMP_DIR}/create-db.sql
   EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set-file initializationFiles.create-db=${TMP_DIR}/create-db.sql"
 

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -41,7 +41,6 @@ function install_mysql {
 
   # Handle any additional MySQL install args that cannot be in mysql-values.yaml
   local EXTRA_MYSQL_ARGUMENTS=$(get_mysql_helm_args_from_config)
-  EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set mysqlUser=${MYSQL_USERNAME}"
 
   echo "CREATE DATABASE IF NOT EXISTS keycloak DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" > ${TMP_DIR}/create-db.sql
   echo "USE keycloak;" >> ${TMP_DIR}/create-db.sql

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -48,8 +48,9 @@ function install_mysql {
   # Allow the keycloak user to create/drop tables, indices, foreign key references, and read/write to all tables in keycloak schema
   echo "GRANT CREATE, ALTER, DROP, INDEX, REFERENCES, SELECT, INSERT, UPDATE, DELETE ON keycloak.* TO '${MYSQL_USERNAME}'@'%';" >> ${TMP_DIR}/create-db.sql
   echo "FLUSH PRIVILEGES;" >> ${TMP_DIR}/create-db.sql
-  EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set-file initializationFiles.create-db=${TMP_DIR}/create-db.sql"
+  EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set-file initializationFiles.create-db\.sql=${TMP_DIR}/create-db.sql"
 
+  log "EXTRA MYSQL ARGS: ${EXTRA_MYSQL_ARGUMENTS}"
   log "Install MySQL helm chart"
   helm upgrade mysql ${MYSQL_CHART_DIR} \
       --install \

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -41,6 +41,7 @@ function install_mysql {
 
   # Handle any additional MySQL install args that cannot be in mysql-values.yaml
   local EXTRA_MYSQL_ARGUMENTS=$(get_mysql_helm_args_from_config)
+  EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set mysqlUser=${MYSQL_USERNAME}"
 
   echo "CREATE DATABASE IF NOT EXISTS keycloak DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" > ${TMP_DIR}/create-db.sql
   echo "USE keycloak;" >> ${TMP_DIR}/create-db.sql

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -50,7 +50,6 @@ function install_mysql {
   echo "FLUSH PRIVILEGES;" >> ${TMP_DIR}/create-db.sql
   EXTRA_MYSQL_ARGUMENTS="$EXTRA_MYSQL_ARGUMENTS --set-file initializationFiles.create-db\.sql=${TMP_DIR}/create-db.sql"
 
-  log "EXTRA MYSQL ARGS: ${EXTRA_MYSQL_ARGUMENTS}"
   log "Install MySQL helm chart"
   helm upgrade mysql ${MYSQL_CHART_DIR} \
       --install \


### PR DESCRIPTION
# Description

Grant specific privileges instead of 'ALL', to the keycloak user on the keycloak database schema in MySQL. This required the following additional changes:
* Disabling the keycloak database as the default mysqlDatabase in the MySQL Helm chart overrides - otherwise, MySQL automatically created the database and the user specified in mysqlUser, and granted all privileges on the database to the user.
* Changing the intializationFiles key to have a ".sql" extension - otherwise MySQL does not execute the SQL at all - the only reason keycloak database was being created was because of the mysqlDatabase Helm chart setting which I removed as explained above.

Fixes VZ-2182

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
