### PR TITLE
Use latest master operator.yaml, not one for a specific commit-hash

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
                         cd ${GO_REPO_PATH}/verrazzano
                         if [ "NONE" = "${VERRAZZANO_OPERATOR_IMAGE}" ]; then
                             echo "Using operator.yaml from object storage"
-                            oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
+                            oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
                             cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
                         else
                             echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"


### PR DESCRIPTION
# Description

Update the install-loop Jenkinsfile to pull the latest master/operator.yaml, not one for a specific commit hash.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
