### PR TITLE
Tvlatas/metallb pulls

### DIFF
--- a/tests/e2e/config/scripts/install-metallb.sh
+++ b/tests/e2e/config/scripts/install-metallb.sh
@@ -8,8 +8,8 @@ set -e
 
 ADDRESS_RANGE=${1:-"172.18.0.230-172.18.0.254"}
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.6/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.6/manifests/metallb.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 kubectl apply -f - <<-EOF
 apiVersion: v1

--- a/tests/e2e/config/scripts/install-metallb.sh
+++ b/tests/e2e/config/scripts/install-metallb.sh
@@ -8,8 +8,9 @@ set -e
 
 ADDRESS_RANGE=${1:-"172.18.0.230-172.18.0.254"}
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.6/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.6/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
+curl --silent https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml | sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' > metallb.yaml
+kubectl apply -f metallb.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 kubectl apply -f - <<-EOF
 apiVersion: v1


### PR DESCRIPTION
# Description

This munges the metallb.yaml file for 0.9.5 to change the image pull policy so we find the images pre-pulled on the agent rather than always pulling them and hitting the docker rate limits.

Note when we pickup 0.9.7 we can get rid of the munging

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
