### PR TITLE
VZ-2482: Add Rancher network policies

### DIFF
--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -621,6 +621,7 @@ func getVerrazzanoInstallArgs(vzSpec *installv1alpha1.VerrazzanoSpec) ([]Install
 			Value: strconv.FormatBool(vzSpec.Components.Console.Enabled),
 		})
 	}
+
 	return args, nil
 }
 

--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -621,7 +621,6 @@ func getVerrazzanoInstallArgs(vzSpec *installv1alpha1.VerrazzanoSpec) ([]Install
 			Value: strconv.FormatBool(vzSpec.Components.Console.Enabled),
 		})
 	}
-
 	return args, nil
 }
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -95,36 +95,6 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-# Network policy for Rancher cluster agent
-# Ingress: deny all
-# Egress: Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher on the admin cluster
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: cattle-cluster-agent
-  namespace: cattle-system
-spec:
-  podSelector:
-    matchLabels:
-      app: cattle-cluster-agent
-  policyTypes:
-    - Ingress
-    - Egress
-  egress:
-    - ports:
-      - port: 443
-        protocol: TCP
-    - ports:
-        - port: {{ .Values.kubernetes.service.endpoint.port }}
-          protocol: TCP
-      to:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
-    - ports:
-      - port: 53
-        protocol: UDP
-      - port: 53
-        protocol: TCP
       to:
         - namespaceSelector:
             matchLabels:
@@ -173,11 +143,59 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+---
+# Network policy for Rancher cluster agent
+# Ingress: deny all
+# Egress:  Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher on the admin cluster
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cattle-cluster-agent
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: cattle-cluster-agent
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+      - port: 443
+        protocol: TCP
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: keycloak
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloak
 {{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher UI/API
 # Ingress: allow nginx ingress
-# Egress: deny all
+# Egress:  deny all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -197,14 +215,14 @@ spec:
             verrazzano.io/namespace: ingress-nginx
       - podSelector:
           matchLabels:
-            app.kubernetes.io/instance: ingress-nginx
+            app.kubernetes.io/instance: ingress-controller
       ports:
         - protocol: TCP
           port: 80
 ---
 # Network policy for Rancher operator
 # Ingress: deny all
-# Egress: Kubernetes API server
+# Egress:  Kubernetes API server
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -97,7 +97,7 @@ spec:
           protocol: TCP
 # Network policy for Rancher cluster agent
 # Ingress: deny all
-# Egress: Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher
+# Egress: Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher on the admin cluster
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -95,6 +95,36 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
+# Network policy for Rancher cluster agent
+# Ingress: deny all
+# Egress: Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cattle-cluster-agent
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: cattle-cluster-agent
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+      - port: 443
+        protocol: TCP
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
       to:
         - namespaceSelector:
             matchLabels:
@@ -143,3 +173,55 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+{{- if .Values.rancher.enabled }}
+---
+# Network policy for Rancher UI/API
+# Ingress: allow nginx ingress
+# Egress: deny all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: ingress-nginx
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 80
+---
+# Network policy for Rancher operator
+# Ingress: deny all
+# Egress: Kubernetes API server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher-operator
+  namespace: rancher-operator-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+{{- end }}

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -408,7 +408,3 @@ if [ $(is_rancher_enabled) == "true" ]; then
   action "Setting Rancher Server URL" set_rancher_server_url || true
   action "Patching Rancher Agents" patch_rancher_agents || true
 fi
-
-# Label the kube-system namespace so that we can apply network policies
-log "Adding label needed by network policies to kube-system namespace"
-kubectl label namespace kube-system "verrazzano.io/namespace=kube-system" || true

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -212,18 +212,25 @@ function install_external_dns()
   fi
 }
 
-function install_rancher()
+function create_rancher_namespace()
 {
-    local RANCHER_CHART_DIR=${CHARTS_DIR}/rancher
-
-    log "Create Rancher namespace (if required)"
     if ! kubectl get namespace cattle-system > /dev/null 2>&1; then
         kubectl create namespace cattle-system
     fi
+}
 
+function install_rancher()
+{
+    local RANCHER_CHART_DIR=${CHARTS_DIR}/rancher
     local INGRESS_TLS_SOURCE=""
     local EXTRA_RANCHER_ARGUMENTS=""
     local RANCHER_PATCH_DATA=""
+
+    # Create the rancher-operator-system namespace so we can create network policies
+    if ! kubectl get namespace rancher-operator-system > /dev/null 2>&1; then
+        kubectl create namespace rancher-operator-system
+    fi
+
     if [ "$CERT_ISSUER_TYPE" == "acme" ]; then
       INGRESS_TLS_SOURCE="letsEncrypt"
       EXTRA_RANCHER_ARGUMENTS="--set letsEncrypt.ingress.class=rancher --set letsEncrypt.email=$(get_config_value ".certificates.acme.emailAddress") --set letsEncrypt.environment=$(get_acme_environment)"
@@ -392,9 +399,16 @@ RANCHER_HOSTNAME=rancher.${NAME}.${DNS_SUFFIX}
 
 action "Installing cert manager" install_cert_manager || exit 1
 action "Installing external DNS" install_external_dns || exit 1
+
+# Always create the Rancher namespace so we can create network policies
+action "Creating Rancher namespace" create_rancher_namespace || exit 1
+
 if [ $(is_rancher_enabled) == "true" ]; then
   action "Installing Rancher" install_rancher || exit 1
   action "Setting Rancher Server URL" set_rancher_server_url || true
   action "Patching Rancher Agents" patch_rancher_agents || true
 fi
 
+# Label the kube-system namespace so that we can apply network policies
+log "Adding label needed by network policies to kube-system namespace"
+kubectl label namespace kube-system "verrazzano.io/namespace=kube-system" || true

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -124,6 +124,7 @@ function install_verrazzano()
       --set config.enableMonitoringStorage=true \
       --set kubernetes.service.endpoint.ip=${ENDPOINT_ARRAY[0]} \
       --set kubernetes.service.endpoint.port=${ENDPOINT_ARRAY[1]} \
+      --set rancher.enabled=$(is_rancher_enabled) \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?
 


### PR DESCRIPTION
# Description

This PR adds network policies for Rancher. Since we are not use many of Rancher's features, these policies are fairly restrictive. As we take advantage of more of Rancher's features in the future, we will likely need to relax these policies.

I tested by installing admin and managed clusters and validating that I could still register managed clusters and they show up properly in the Rancher UI. I also verified that I could inspect managed cluster events, services, etc. in the UI.

NOTE: We create the `cattle-system` namespace and network policy even if the `rancher.enabled` flag is false. That way when the user applies the managed cluster registration YAML at some point in the future, the network policy will already exist. 

Implements VZ-2482

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
