### PR TITLE
VZ-2532: Fix DoesNamespaceExist test function

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -116,7 +116,7 @@ func DoesNamespaceExist(name string) bool {
 	clientset := GetKubernetesClientset()
 
 	namespace, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ginkgo.Fail(fmt.Sprintf("Failed to get namespace %s with error: %v", name, err))
 	}
 


### PR DESCRIPTION
# Description

The `DoesNamespaceExist` test utility function fails hard if the namespace doesn't exist. Any "Eventually" calls that use this function will not retry. The fix is to add a check so the test does not fail if the namespace is not found.

Fixes VZ-2532

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
