### PR TITLE
Do not log stack trace when a VerrazzanoProject resource is deleted

### DIFF
--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,8 +54,18 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger.Info("Fetching VerrazzanoProject")
 	err := r.Get(ctx, req.NamespacedName, &vp)
 	if err != nil {
+		// If the resource is not found, that means all of the finalizers have been removed,
+		// and the verrazzano resource has been deleted, so there is nothing left to do.
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+
 		logger.Error(err, "Failed to fetch VerrazzanoProject")
 		return result, client.IgnoreNotFound(err)
+	}
+
+	if !vp.ObjectMeta.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
 	}
 
 	// Use OperationResultCreated by default since we don't really know what happened to individual NS

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,13 +53,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger.Info("Fetching VerrazzanoProject")
 	err := r.Get(ctx, req.NamespacedName, &vp)
 	if err != nil {
-		// If the resource is not found, that means all of the finalizers have been removed,
-		// and the verrazzano resource has been deleted, so there is nothing left to do.
-		if errors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
-
-		logger.Error(err, "Failed to fetch VerrazzanoProject")
 		return result, client.IgnoreNotFound(err)
 	}
 

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_exists.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_exists.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: VerrazzanoProject
+metadata:
+  name: test-namespace-exists
+  namespace: verrazzano-mc
+spec:
+  template:
+    namespaces:
+      - metadata:
+          name: test-namespace-exists
+          labels:
+            label1: "test1"
+          annotations:
+            annot1: "test1"
+  placement:
+    clusters:
+      - name: managed1


### PR DESCRIPTION
# Description

Do not log stack trace when a VerrazzanoProject resource is not found.

Add a test for deleting a VerrazzanoProject resource

Add a test for creating a VerrazzanoProject for an existing namespace, make sure the Verrazzano labels get applied.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
