### PR TITLE
add security headers related annotations to verrazzano ingress

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/04-verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/04-verrazzano-ingress.yaml
@@ -9,6 +9,25 @@ metadata:
     external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_hide_header X-Powered-By;
+      add_header Last-Modified "$date_gmt";
+      add_header Pragma "no-cache";
+      add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+      add_header Expect-CT "max-age=86400, enforce";
+      add_header Referrer-Policy "strict-origin";
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header X-Frame-Options "DENY" always;
+      add_header X-Permitted-Cross-Domain-Policies "none";
+      add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+      add_header X-XSS-Protection "1; mode=block";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' static.oracle.com; form-action 'none'; connect-src 'self' https:; media-src 'none'; object-src 'none'; font-src 'self' static.oracle.com; img-src 'self' data:; style-src 'self' static.oracle.com; frame-ancestors 'none';" always;
+    nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "86400"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
+    nginx.ingress.kubernetes.io/session-cookie-name: route
+    nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
   name: verrazzano-ingress
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

add security headers related annotations to verrazzano ingress. Adds all headers suggested by the [Oracle JET Developers Guide](https://docs.oracle.com/en/middleware/developer-tools/jet/10/develop/securing-oracle-jet-applications.html#GUID-D5B80E16-C323-4940-9605-C8B84B114FFA) and as well as the ones found in testing using [zap](https://www.zaproxy.org/)

Fixes VZ-2526

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
