### PR TITLE
Run verrazzano-api pod as non root user

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-logging.yaml
@@ -417,8 +417,6 @@ spec:
           image: {{ .Values.logging.fluentdImage }}
           imagePullPolicy: IfNotPresent
           name: {{ .Values.logging.name }}
-          securityContext:
-            runAsUser: 0
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -279,8 +279,9 @@ data:
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     ln -s /etc/ssl/certs/ca-bundle.trust.crt /etc/nginx/ca-bundle
-    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -t --prefix /etc/nginx
-    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf --prefix /etc/nginx
+
+    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -t -p /etc/nginx
+    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx
 
     sh -c "`dirname $0`/reload.sh &"
     tail -f /etc/nginx/logs/error.log
@@ -364,16 +365,16 @@ spec:
                 items:
                   - key: startup.sh
                     path: startup.sh
-                    mode: 0744
+                    mode: 0755
                   - key: nginx.conf
                     path: nginx.conf
                     mode: 0744 
                   - key: conf.lua
                     path: conf.lua
-                    mode: 0744 
+                    mode: 0755
                   - key: reload.sh
                     path: reload.sh
-                    mode: 0744
+                    mode: 0755
       containers:
       - image: {{ .Values.api.imageName }}:{{ .Values.api.imageVersion }}
         imagePullPolicy: {{ .Values.api.pullPolicy }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -138,9 +138,9 @@ data:
     #user  nobody;
     worker_processes  1;
 
-    #error_log  logs/error.log;
-    #error_log  logs/error.log  notice;
-    #error_log  logs/error.log  info;
+    #error_log  /etc/nginx/logs/error.log;
+    #error_log  /etc/nginx/logs/error.log  notice;
+    #error_log  /etc/nginx/logs/error.log  info;
 
     #pid        logs/nginx.pid;
 
@@ -158,7 +158,7 @@ data:
         #                  '$status $body_bytes_sent "$http_referer" '
         #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
-        error_log  logs/error.log  info;
+        error_log  /etc/nginx/logs/error.log  info;
 
         sendfile        on;
         #tcp_nopush     on;
@@ -274,8 +274,8 @@ data:
     nameserver=$(grep -i nameserver /etc/resolv.conf | awk '{split($0,line," "); print line[2]}')
     sed -i -e "s|_NAMESERVER_|${nameserver}|g" /etc/nginx/nginx.conf
 
-    mkdir -p /usr/local/nginx/logs
-    touch /usr/local/nginx/logs/error.log
+    mkdir -p /etc/nginx/logs
+    touch /etc/nginx/logs/error.log
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     ln -s /etc/ssl/certs/ca-bundle.trust.crt /etc/nginx/ca-bundle
@@ -283,7 +283,7 @@ data:
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf
 
     sh -c "`dirname $0`/reload.sh &"
-    tail -f /usr/local/nginx/logs/error.log
+    tail -f /etc/nginx/logs/error.log
   reload.sh: |
     #!/bin/bash
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -138,11 +138,11 @@ data:
     #user  nobody;
     worker_processes  1;
 
-    #error_log  /etc/nginx/logs/error.log;
-    #error_log  /etc/nginx/logs/error.log  notice;
-    #error_log  /etc/nginx/logs/error.log  info;
+    #error_log  logs/error.log;
+    #error_log  logs/error.log  notice;
+    #error_log  logs/error.log  info;
 
-    pid        /etc/nginx/logs/nginx.pid;
+    pid        logs/nginx.pid;
 
 
     events {
@@ -158,7 +158,7 @@ data:
         #                  '$status $body_bytes_sent "$http_referer" '
         #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
-        error_log  /etc/nginx/logs/error.log  info;
+        error_log  logs/error.log  info;
 
         sendfile        on;
         #tcp_nopush     on;

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -142,7 +142,7 @@ data:
     #error_log  /etc/nginx/logs/error.log  notice;
     #error_log  /etc/nginx/logs/error.log  info;
 
-    #pid        logs/nginx.pid;
+    pid        /etc/nginx/logs/nginx.pid;
 
 
     events {

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -343,8 +343,7 @@ spec:
         app: {{ .Values.api.name }}
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
+        runAsUser: 101
       volumes:
        - name: api-config
          projected:

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -342,8 +342,6 @@ spec:
       labels:
         app: {{ .Values.api.name }}
     spec:
-      securityContext:
-        runAsUser: 101
       volumes:
        - name: api-config
          projected:

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -279,8 +279,8 @@ data:
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     ln -s /etc/ssl/certs/ca-bundle.trust.crt /etc/nginx/ca-bundle
-    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -t
-    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf
+    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -t --prefix /etc/nginx
+    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf --prefix /etc/nginx
 
     sh -c "`dirname $0`/reload.sh &"
     tail -f /etc/nginx/logs/error.log


### PR DESCRIPTION
# Description

Run verrazzano-api pod as non-root user. This required changing the default prefix path to a location that the nginx user has permissions to, and changing the permissions on some of the startup shell scripts, since those are owned by root. 

**Note**: I tried to fix fluentd to not run as root, but from what I can gather, it needs root permission to read /var/log. Found some info [here](https://github.com/fluent/fluentd-kubernetes-daemonset/issues/420) and [here](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset/)

Partially Fixes VZ-2504

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
