### PR TITLE
VZ-2498: Enable a password policy.

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -131,7 +131,7 @@ data:
     "/opt/jboss/keycloak/bin/kcadm.sh update realms/master -s loginTheme=oracle --no-config --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --password \$(cat /etc/${KCADMIN_SECRET}/password)"
 
   # Update the password policy.
-  local PASSWORD_POLICY="length(8)"
+  local PASSWORD_POLICY="length(8) and notUsername and notEmail"
   kubectl exec keycloak-0 \
     -n ${KEYCLOAK_NS} \
     -c keycloak \

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -130,6 +130,14 @@ data:
     -- bash -c \
     "/opt/jboss/keycloak/bin/kcadm.sh update realms/master -s loginTheme=oracle --no-config --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --password \$(cat /etc/${KCADMIN_SECRET}/password)"
 
+  # Update the password policy.
+  local PASSWORD_POLICY="length(8)"
+  kubectl exec keycloak-0 \
+    -n ${KEYCLOAK_NS} \
+    -c keycloak \
+    -- bash -c \
+    "/opt/jboss/keycloak/bin/kcadm.sh update realms/master -s \'passwordPolicy=\"${PASSWORD_POLICY}\"\' --no-config --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --password \$(cat /etc/${KCADMIN_SECRET}/password)"
+
   # Label the keycloak namespace so that we can apply network policies
   log "Adding label needed by network policies to keycloak namespace"
   kubectl label namespace keycloak "verrazzano.io/namespace=keycloak"

--- a/tests/e2e/pkg/keycloak.go
+++ b/tests/e2e/pkg/keycloak.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"io/ioutil"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type KeycloakRESTClient struct {
+	kubeConfigPath      string
+	keycloakIngressHost string
+	adminAccessToken    string
+	httpClient          *retryablehttp.Client
+}
+
+const (
+	keycloakNamespace               = "keycloak"
+	keycloadIngressName             = "keycloak"
+	keycloakAdminUserPasswordSecret = "keycloak-http"
+	keycloakAdminUserRealm          = "master"
+	keycloakAdminUserName           = "keycloakadmin"
+)
+
+// NewKeycloakRESTClient creates a new Keycloak REST client.
+func NewKeycloakRESTClient() (*KeycloakRESTClient, error) {
+	kubeconfigPath := GetKubeConfigPathFromEnv()
+	ingress, _ := GetKubernetesClientsetForCluster(kubeconfigPath).ExtensionsV1beta1().Ingresses(keycloakNamespace).Get(context.TODO(), keycloadIngressName, k8smeta.GetOptions{})
+	ingressHost := ingress.Spec.Rules[0].Host
+	httpClient := GetKeycloakHTTPClient(kubeconfigPath)
+
+	secret, err := GetSecret(keycloakNamespace, keycloakAdminUserPasswordSecret)
+	if err != nil {
+		return nil, err
+	}
+	keycloakAdminPassword := strings.TrimSpace(string(secret.Data["password"]))
+
+	keycloakLoginURL := fmt.Sprintf("https://%s/auth/realms/%s/protocol/openid-connect/token", ingressHost, keycloakAdminUserRealm)
+	body := fmt.Sprintf("username=%s&password=%s&grant_type=password&client_id=%s", keycloakAdminUserName, keycloakAdminPassword, clientID)
+	status, response := PostWithHostHeader(keycloakLoginURL, "application/x-www-form-urlencoded", ingressHost, strings.NewReader(body))
+	if status != 200 {
+		return nil, fmt.Errorf("failed to login as admin user")
+	}
+	token := JTq(response, "access_token").(string)
+	if token == "" {
+		return nil, fmt.Errorf("failed to obtain valid access token")
+	}
+
+	client := KeycloakRESTClient{
+		kubeConfigPath:      kubeconfigPath,
+		keycloakIngressHost: ingress.Spec.Rules[0].Host,
+		adminAccessToken:    token,
+		httpClient:          httpClient}
+	return &client, nil
+}
+
+// GetRealm gets realm data from Keycloak.
+func (c *KeycloakRESTClient) GetRealm(realm string) (map[string]interface{}, error) {
+	requestURL := fmt.Sprintf("https://%s/auth/admin/realms/%s", c.keycloakIngressHost, realm)
+	request, err := retryablehttp.NewRequest("GET", requestURL, nil)
+	request.Host = c.keycloakIngressHost
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %v", c.adminAccessToken))
+	request.Header.Add("Accept", "application/json")
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("invalid response")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid response status: %d", response.StatusCode)
+	}
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	jsonMap := make(map[string]interface{})
+	err = json.Unmarshal(responseBody, &jsonMap)
+	if err != nil {
+		return nil, err
+	}
+	return jsonMap, nil
+}
+
+// CreateUser creates a user in Keycloak
+// curl -v http://localhost:8080/auth/admin/realms/apiv2/users -H "Content-Type: application/json" -H "Authorization: bearer $TOKEN"   --data '{"username":"someuser", "firstName":"xyz", "lastName":"xyz", "email":"demo2@gmail.com", "enabled":"true"}'
+func (c *KeycloakRESTClient) CreateUser(userRealm string, userName string, firstName string, lastName string, password string) (string, error) {
+	requestData := map[string]interface{}{
+		"username":  userName,
+		"firstName": firstName,
+		"lastName":  lastName,
+		"credentials": [...]map[string]interface{}{{
+			"type":      "password",
+			"value":     password,
+			"temporary": false},
+		},
+	}
+	requestBody, err := json.Marshal(requestData)
+	if err != nil {
+		fmt.Printf("marshal request failed: %v\n", err)
+		return "", err
+	}
+
+	requestURL := fmt.Sprintf("https://%s/auth/admin/realms/%s/users", c.keycloakIngressHost, userRealm)
+	request, err := retryablehttp.NewRequest("POST", requestURL, requestBody)
+	if err != nil {
+		return "", err
+	}
+	request.Host = c.keycloakIngressHost
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %v", c.adminAccessToken))
+	request.Header.Add("Content-Type", "application/json")
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	if response == nil {
+		return "", fmt.Errorf("invalid response")
+	}
+	defer response.Body.Close()
+	location := response.Header.Get("Location")
+	if response.StatusCode != 201 {
+		return location, fmt.Errorf("invalid response status code: %d", response.StatusCode)
+	}
+	if location == "" {
+		return location, fmt.Errorf("invalid response location")
+	}
+	return location, nil
+}
+
+// DeleteUser deletes a user from Keycloak
+// DELETE /auth/admin/realms/<realm>/users/<userID>
+func (c *KeycloakRESTClient) DeleteUser(userRealm string, userID string) error {
+	requestURL := fmt.Sprintf("https://%s/auth/admin/realms/%s/users/%s", c.keycloakIngressHost, userRealm, userID)
+	request, err := retryablehttp.NewRequest("DELETE", requestURL, nil)
+	if err != nil {
+		return err
+	}
+	request.Host = c.keycloakIngressHost
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %v", c.adminAccessToken))
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	if response == nil {
+		return fmt.Errorf("invalid response")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		return fmt.Errorf("invalid response status: %d", response.StatusCode)
+	}
+	return nil
+}
+
+// SetPassword sets a user's password in Keycloak
+// PUT /auth/admin/realms/{realm}/users/{id}/reset-password
+// { "type": "password", "temporary": false, "value": "..." }
+func (c *KeycloakRESTClient) SetPassword(userRealm string, userID string, password string) error {
+	requestData := map[string]interface{}{
+		"type":      "password",
+		"value":     password,
+		"temporary": false}
+	requestBody, err := json.Marshal(requestData)
+	if err != nil {
+		return err
+	}
+	requestURL := fmt.Sprintf("https://%s/auth/admin/realms/%s/users/%s/reset-password", c.keycloakIngressHost, userRealm, userID)
+	request, err := retryablehttp.NewRequest("PUT", requestURL, requestBody)
+	if err != nil {
+		fmt.Printf("create reset-password request failed=%v\n", err)
+		return err
+	}
+	request.Host = c.keycloakIngressHost
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %v", c.adminAccessToken))
+	request.Header.Add("Content-Type", "application/json")
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	if response == nil {
+		return fmt.Errorf("invalid response")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 204 {
+		return fmt.Errorf("invalid response status: %d", response.StatusCode)
+	}
+	return nil
+}

--- a/tests/e2e/verify-install/keycloak/keycloak_suite_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_suite_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package keycloak_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+)
+
+func TestKeycloak(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("keycloak-%d-test-result.xml", config.GinkgoConfig.ParallelNode))
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Keycloak Suite", []ginkgo.Reporter{junitReporter})
+}

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package keycloak_test
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	waitTimeout     = 10 * time.Minute
+	pollingInterval = 30 * time.Second
+)
+
+var _ = ginkgo.Describe("Verify Keycloak configuration", func() {
+	var _ = ginkgo.Describe("Verify password policies", func() {
+		ginkgo.It("Verify master realm password policy", func() {
+			// GIVEN the password policy setup for the master realm during installation
+			// WHEN valid and invalid password changes are attempted
+			// THEN verify valid passwords are accepted and invalid passwords are rejected.
+			gomega.Eventually(verifyKeycloakMasterRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+		})
+		ginkgo.It("Verify Verrazzano-system realm password policy", func() {
+			// GIVEN the password policy setup for the Verrazzano-system realm during installation
+			// WHEN valid and invalid password changes are attempted
+			// THEN verify valid passwords are accepted and invalid passwords are rejected.
+			gomega.Eventually(verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+		})
+	})
+})
+
+func verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect() bool {
+	return verifyKeycloakRealmPasswordPolicyIsCorrect("Verrazzano-system")
+}
+
+func verifyKeycloakMasterRealmPasswordPolicyIsCorrect() bool {
+	return verifyKeycloakRealmPasswordPolicyIsCorrect("master")
+}
+
+func verifyKeycloakRealmPasswordPolicyIsCorrect(realm string) bool {
+	kc, err := pkg.NewKeycloakRESTClient()
+	if err != nil {
+		fmt.Printf("Failed to create Keycloak REST client: %v\n", err)
+		return false
+	}
+
+	var realmData map[string]interface{}
+	realmData, err = kc.GetRealm(realm)
+	if err != nil {
+		fmt.Printf("Failed to get realm %s\n", realm)
+		return false
+	}
+	if realmData["passwordPolicy"] == nil {
+		fmt.Printf("Failed to find password policy for realm: %s\n", realm)
+		return false
+	}
+	policy := realmData["passwordPolicy"].(string)
+	if len(policy) == 0 || !strings.Contains(policy, "length") {
+		fmt.Printf("Failed to find password policy for realm: %s\n", realm)
+		return false
+	}
+
+	salt := time.Now().Format("20060102150405.000000000")
+	userName := fmt.Sprintf("test-user-%s", salt)
+	firstName := fmt.Sprintf("test-first-%s", salt)
+	lastName := fmt.Sprintf("test-last-%s", salt)
+	validPassword := fmt.Sprintf("test-password-12-!@-AB-%s", salt)
+	userURL, err := kc.CreateUser(realm, userName, firstName, lastName, validPassword)
+	if err != nil {
+		fmt.Printf("Failed to create user %s/%s: %v\n", realm, userName, err)
+		return false
+	}
+	userID := path.Base(userURL)
+	defer func() {
+		err = kc.DeleteUser(realm, userID)
+		if err == nil {
+			fmt.Printf("Failed to delete user %s/%s: %v\n", realm, userID, err)
+		}
+	}()
+	err = kc.SetPassword(realm, userID, "invalid")
+	if err == nil {
+		fmt.Printf("Should not have been able to set password for %s/%s\n", realm, userID)
+		return false
+	}
+	newValidPassword := fmt.Sprintf("test-new-password-12-!@-AB-%s", salt)
+	err = kc.SetPassword(realm, userID, newValidPassword)
+	if err != nil {
+		fmt.Printf("Failed to set password for %s/%s: %v\n", realm, userID, err)
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
# Description

Adds Keycloak password policy for master and Verrazzano-system realm during install.

Fixes VZ-2498

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
