### PR TITLE
OKE With Private Endpoints

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     agent {
         docker {
             image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            args "${RUNNER_DOCKER_ARGS} --cap-add=NET_ADMIN"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             label "${agentLabel}"
         }
@@ -180,7 +180,22 @@ pipeline {
         stage("install-oke") {
             when { expression { return params.TEST_ENV != 'kind' } }
             steps {
-                sh "TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME} ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh"
+                script {
+                    withCredentials([sshUserPrivateKey(credentialsId: '5fcc03de-31ce-4566-b11f-9de38e5d98fd', keyFileVariable: 'OPC_USER_KEY_FILE', passphraseVariable: 'OPC_USER_PASSPHRASE', usernameVariable: 'OPC_USERNAME')]) {
+                        sh """
+                            # get the ssh public key
+                            ssh-keygen -y -e -f ${OPC_USER_KEY_FILE} > /tmp/opc_ssh2.pub
+                            # convert SSH2 public key into an OpenSSH format
+                            ssh-keygen -i -f /tmp/opc_ssh2.pub > /tmp/opc_ssh.pub
+                            # set the ssh public key value for terraform
+                            export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
+                            export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
+                            export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
+                            # call create_oke_cluster with cluster access private (-p)
+                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh -p
+                        """
+                    }
+                }
             }
         }
 

--- a/tests/e2e/config/scripts/setup_ssh_tunnel.sh
+++ b/tests/e2e/config/scripts/setup_ssh_tunnel.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+if [ -z "TF_VAR_api_private_key_path" ] ; then
+    echo "TF_VAR_api_private_key_path env var must be set!"
+    exit 1
+fi
+if [ -z "TF_VAR_compartment_id" ] ; then
+    echo "TF_VAR_compartment_id env var must be set!"
+    exit 1
+fi
+if [ -z "TF_VAR_label_prefix" ] ; then
+    echo "TF_VAR_label_prefix env var must be set!"
+    exit 1
+fi
+if [ -z "${KUBECONFIG}" ] ; then
+    echo "KUBECONFIG env var must be set!"
+    exit 1
+fi
+
+# install sshuttle
+sudo yum -y install oracle-epel-release-el7
+sudo yum -y install sshuttle
+if [ $? -ne 0 ]; then
+  echo "Failed to install sshuttle."
+  exit 1
+fi
+
+# find the CIDR for the VPN
+VCN_CIDR=$(oci network vcn list \
+  --compartment-id "${TF_VAR_compartment_id}" \
+  --display-name "${TF_VAR_label_prefix}-oke-vcn" \
+  | jq -r '.data[0]."cidr-block"')
+
+if [ -z "VCN_CIDR" ]; then
+    echo "Failed to get the CIDR for VCN ${TF_VAR_label_prefix}-oke-vcn"
+    exit 1
+fi
+
+# find availability domain for the bastion compute instance
+BASTION_AD=$(oci compute instance list \
+  --compartment-id "${TF_VAR_compartment_id}" \
+  --display-name "${TF_VAR_label_prefix}-bastion" \
+  | jq -r '.data[0]."availability-domain"')
+
+if [ -z "$BASTION_AD" ]; then
+    echo "Failed to get the AD for compute instance ${TF_VAR_label_prefix}-bastion"
+    exit 1
+fi
+
+# find public IP for the bastion compute instance
+BASTION_IP=$(oci network public-ip list \
+  --compartment-id "${TF_VAR_compartment_id}" \
+  --scope AVAILABILITY_DOMAIN \
+  --availability-domain "${BASTION_AD}" \
+  --all \
+  | jq -r '.data[] | select(."freeform-tags".role=="bastion") | ."ip-address"')
+
+if [ -z "$BASTION_IP" ]; then
+    echo "Failed to get the public IP for compute instance ${TF_VAR_label_prefix}-bastion"
+    exit 1
+fi
+
+# run sshuttle
+sshuttle -r opc@$BASTION_IP $VCN_CIDR --ssh-cmd 'ssh -o StrictHostKeyChecking=no -i '${OPC_USER_KEY_FILE}'' &
+SHUTTLE_PID=$!
+if [ $? -ne 0 ]; then
+  echo "Failed to ssh tunnel to the bastion host ${TF_VAR_label_prefix}-bastion at ${BASTION_IP}"
+  exit 1
+fi

--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -45,12 +45,12 @@ fi
 # find private_workers_seclist id
 SEC_LIST_ID=$(oci network security-list list \
   --compartment-id "${TF_VAR_compartment_id}" \
-  --display-name "${TF_VAR_label_prefix}-private-workers" \
+  --display-name "${TF_VAR_label_prefix}-workers" \
   --vcn-id "${VCN_ID}" \
   | jq -r '.data[0].id')
 
 if [ -z "$SEC_LIST_ID" ]; then
-    echo "Failed to get the id for security-list ${TF_VAR_label_prefix}-private-workers"
+    echo "Failed to get the id for security-list ${TF_VAR_label_prefix}-workers"
     exit 0
 fi
 

--- a/tests/e2e/config/scripts/terraform/cluster/main.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/main.tf
@@ -3,7 +3,7 @@
 
 module "oke" {
   source = "oracle-terraform-modules/oke/oci"
-  version = "3.1.0"
+  version = "3.2.0-RC1"
 
   tenancy_id = var.tenancy_id
   user_id = var.user_id
@@ -16,6 +16,7 @@ module "oke" {
   kubernetes_version = var.kubernetes_version
   allow_worker_ssh_access = var.allow_worker_ssh_access
   worker_mode = var.worker_mode
+  cluster_access = var.cluster_access
   ssh_private_key_path = var.ssh_private_key_path
   ssh_public_key_path = var.ssh_public_key_path
   node_pools =var.node_pools
@@ -25,8 +26,8 @@ module "oke" {
   username = var.username
 
   vcn_name = "${var.cluster_name}-vcn"
-  vcn_dns_label = "${var.cluster_name}"
-  label_prefix = "${var.label_prefix}"
+  vcn_dns_label = var.cluster_name
+  label_prefix = var.label_prefix
 
   operator_shape = { shape="VM.Standard.E3.Flex", ocpus=1, memory=4, boot_volume_size=50 }
   operator_notification_endpoint = ""
@@ -38,7 +39,6 @@ module "oke" {
   bastion_timezone = "UTC"
   bastion_notification_enabled = false
   bastion_notification_endpoint = ""
-  bastion_image_id = ""
 
   email_address = ""
 

--- a/tests/e2e/config/scripts/terraform/cluster/variables.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/variables.tf
@@ -27,6 +27,9 @@ variable "allow_worker_ssh_access" {
 variable "worker_mode" {
   default = "private"
 }
+variable "cluster_access" {
+  default = "public"
+}
 variable "ssh_public_key_path" {
   default = ""
 }


### PR DESCRIPTION
# Description

Install and run Verrazzano in an OKE cluster that is in a VCN that is not internet accessible (no Internet gateway) and has private workers and private endpoints.

- add cluster_access variable to terraform files
- update oci-dns Jenkinsfile 
    - create OKE cluster with private endpoints
    -  add`--cap-add=NET_ADMIN` to `RUNNER_DOCKER_ARGS` (required for sshuttle)
- set oci-oke terraform option `TF_VAR_cluster_access=private` to create cluster with private endpoint
- set oci-oke terraform option `TF_VAR_bastion_enabled=true` to create bastion host
- create script to setup ssh tunnel through bastion host
    - install sshuttle for ssh tunnel through bastion host
    - get the VCN CIDR and bastion host public IP
    - run sshuttle in background


Fixes VZ-VZ-2453

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
