### PR TITLE
Test vz-2258

### DIFF
--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -63,7 +63,7 @@ spec:
         podSpec:
           containers:
             - name: robert-helidon-stock-application
-              image: container-registry.oracle.com/verrazzano/example-roberts-helidon-stock-application:0.1.12-1-20210315161529-c857d37
+              image: container-registry.oracle.com/verrazzano/example-roberts-helidon-stock-application:0.1.12-1-20210414151651-de0ff52 
               imagePullPolicy: IfNotPresent
               imagePullSecret: bobs-books-repo-credentials
               ports:
@@ -135,7 +135,7 @@ spec:
         podSpec:
           containers:
           - name: bobbys-helidon-stock-application
-            image: container-registry.oracle.com/verrazzano/example-bobbys-helidon-stock-application:0.1.12-1-20210205215204-b624b86
+            image: container-registry.oracle.com/verrazzano/example-bobbys-helidon-stock-application:0.1.12-1-20210414151651-de0ff52 
             imagePullPolicy: IfNotPresent
             imagePullSecret: bobs-books-repo-credentials
             ports:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-2258. This is an issue reported by Fortify scan and the fix takes care of closing IO resources. The fix has been merged to the examples repo. Here is the PR for VZ-2258: https://github.com/verrazzano/examples/pull/65
Note: None of the items in the checklist is applicable to this change.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
