### PR TITLE
VZ-2486: Add network policies for Keycloak

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -255,3 +255,83 @@ spec:
       ports:
         - port: 9100
           protocol: TCP
+{{- if .Values.keycloak.enabled }}
+---
+# Network policy for Keycloak
+# Ingress: allow nginx ingress and ingress from pods in the verrazzano-system namespace
+# Egress:  DNS and the port to talk to MySQL
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: ingress-nginx
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: ingress-controller
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+      - port: 3306
+        protocol: TCP
+      to:
+        - podSelector:
+            matchLabels:
+              app: mysql
+---
+# Network policy for Keycloak MySQL
+# Ingress: allow port 3306 from Keycloak pods
+# Egress:  deny all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak-mysql
+  namespace: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app: mysql
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: keycloak
+      ports:
+        - protocol: TCP
+          port: 3306
+{{- end }}

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -132,6 +132,7 @@ function install_verrazzano()
       --set kubernetes.service.endpoint.ip=${ENDPOINT_ARRAY[0]} \
       --set kubernetes.service.endpoint.port=${ENDPOINT_ARRAY[1]} \
       --set externaldns.enabled=${EXTERNAL_DNS_ENABLED} \
+      --set keycloak.enabled=$(is_keycloak_enabled) \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?
 
@@ -240,6 +241,11 @@ fi
 
 log "Adding label needed by network policies to ${MONITORING_NS} namespace"
 kubectl label namespace ${MONITORING_NS} "verrazzano.io/namespace=${MONITORING_NS}" --overwrite
+
+# If Keycloak is being installed, create the Keycloak namespace if it doesn't exist so we can apply network policies
+if [ $(is_keycloak_enabled) == "true" ] && ! kubectl get namespace keycloak ; then
+  action "Creating keycloak namespace" kubectl create namespace keycloak || exit 1
+fi
 
 if [ "${REGISTRY_SECRET_EXISTS}" == "TRUE" ]; then
   if ! kubectl get secret ${GLOBAL_IMAGE_PULL_SECRET} -n ${VERRAZZANO_NS} > /dev/null 2>&1 ; then


### PR DESCRIPTION
# Description

Adds network policies to limit ingress and egress in the Keycloak namespace.

Implements VZ-2486

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
