### PR TITLE
Add retries around lookup of Rancher admin user

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -210,6 +210,61 @@ function install_external_dns()
       || return $?
 }
 
+function ensure_rancher_admin_user() {
+  log "Ensure default Rancher admin user is present"
+  local STDERROR_FILE="${TMP_DIR}/rancher_ensureadminuser.err"
+  kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- ensure-default-admin 2>$STDERROR_FILE
+  local max_retries=5
+  local retries=0
+  while true ; do
+    RANCHER_ADMIN_USERNAME=$(kubectl get users -l authz.management.cattle.io/bootstrapping=admin-user -o jsonpath={'.items[].username'} || true)
+    if [ -z "${RANCHER_ADMIN_USERNAME}" ] ; then
+      sleep 10
+    else
+      log "Rancher admin user: ${RANCHER_ADMIN_USERNAME}"
+      break
+    fi
+    ((retries+=1))
+    if [ "$retries" -ge "$max_retries" ] ; then
+      echo "Could not detect default Rancher admin user"
+      local std_error_file=$(cat $STDERROR_FILE)
+      log "${std_error_file}"
+      rm "$STDERROR_FILE"
+      return 1
+    fi
+    log "Retry Rancher admin user lookup..."
+  done
+  return 0
+}
+
+function reset_rancher_admin_password() {
+  log "Reset Rancher admin password and create secrets"
+  local STDERROR_FILE="${TMP_DIR}/rancher_resetpwd.err"
+  local max_retries=5
+  local retries=0
+  while true ; do
+    RANCHER_DATA=$(kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password 2>$STDERROR_FILE)
+    ADMIN_PW=$(echo -n $RANCHER_DATA | awk 'END{ print $NF }')
+
+    if [ -z "$ADMIN_PW" ] ; then
+      sleep 10
+    else
+      break
+    fi
+    ((retries+=1))
+    if [ "$retries" -ge "$max_retries" ] ; then
+      error "ERROR: Failed to reset Rancher password"
+      local std_error_file=$(cat $STDERROR_FILE)
+      log "${std_error_file}"
+      rm "$STDERROR_FILE"
+      return 1
+    fi
+    log "Retry Rancher admin password reset..."
+  done
+
+  kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
+}
+
 function install_rancher()
 {
     local RANCHER_CHART_DIR=${CHARTS_DIR}/rancher
@@ -252,53 +307,8 @@ function install_rancher()
     log "Rollout Rancher"
     kubectl -n cattle-system rollout status -w deploy/rancher || return $?
 
-    log "Ensure default Rancher admin user is present"
-    STDERROR_FILE="${TMP_DIR}/rancher_ensureadminuser.err"
-    kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- ensure-default-admin 2>$STDERROR_FILE
-    local max_retries=5
-    local retries=0
-    while true ; do
-      RANCHER_ADMIN_USERNAME=$(kubectl get users -l authz.management.cattle.io/bootstrapping=admin-user -o jsonpath={'.items[].username'} || true)
-      if [ -z "${RANCHER_ADMIN_USERNAME}" ] ; then
-        sleep 10
-      else
-        echo "Rancher admin user: ${RANCHER_ADMIN_USERNAME}"
-        break
-      fi
-      ((retries+=1))
-      if [ "$retries" -ge "$max_retries" ] ; then
-        echo "Could not detect default Rancher admin user"
-        local std_error_file=$(cat $STDERROR_FILE)
-        log "${std_error_file}"
-        rm "$STDERROR_FILE"
-        return 1
-      fi
-    done
-
-    log "Reset Rancher admin password and create secrets"
-    STDERROR_FILE="${TMP_DIR}/rancher_resetpwd.err"
-    max_retries=5
-    retries=0
-    while true ; do
-      RANCHER_DATA=$(kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password 2>$STDERROR_FILE)
-      ADMIN_PW=$(echo -n $RANCHER_DATA | awk 'END{ print $NF }')
-
-      if [ -z "$ADMIN_PW" ] ; then
-        sleep 10
-      else
-        break
-      fi
-      ((retries+=1))
-      if [ "$retries" -ge "$max_retries" ] ; then
-        error "ERROR: Failed to reset Rancher password"
-        local std_error_file=$(cat $STDERROR_FILE)
-        log "${std_error_file}"
-        rm "$STDERROR_FILE"
-        return 1
-      fi
-    done
-
-    kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
+    ensure_rancher_admin_user || return $?
+    reset_rancher_admin_password || return $?
 }
 
 function set_rancher_server_url


### PR DESCRIPTION
# Description

Recently some code was added to the install scripts to ensure that the default admin user is present during Rancher bootstrapping before trying to reset the password.  This PR tries to make that more resilient by adding retries around it to avoid any timing issues during the lookup.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
