### PR TITLE
Network Policy to allow MC agent to connect to admin cluster

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                 description: 'Verrazzano Managed Cluster install profile name',
                 // 1st choice is the default value
                 choices: [ "managed-cluster", "dev", "prod" ])
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to false, flip will change default after it is supported)', name: 'CREATE_KIND_USE_CALICO', defaultValue: false)
+        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
     }
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
@@ -79,7 +79,7 @@ spec:
 ---
 # Network policy for Verrazzano application operator
 # Ingress: allow access from Kubernetes API server for webhook port 9443
-# Egress:  allow access to Kubernetes API server
+# Egress:  allow access to Kubernetes API server on its port, and to all destinations on 443
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -93,10 +93,17 @@ spec:
     - Ingress
     - Egress
   egress:
+    # Egress rule 1 - allow access to Kubernetes API server on its port
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+    # Egress rule 2 - allow access to all destinations on 443, so that a managed cluster
+    # can connect to the admin cluster
     - ports:
         - port: 443
-          protocol: TCP
-        - port: {{ .Values.kubernetes.service.endpoint.port }}
           protocol: TCP
   ingress:
     - ports:

--- a/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
@@ -94,11 +94,8 @@ spec:
     - Egress
   egress:
     - ports:
-        - port: {{ .Values.kubernetes.service.endpoint.port }}
+        - port: 443
           protocol: TCP
-      to:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   ingress:
     - ports:
         - port: 9443

--- a/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
@@ -93,16 +93,12 @@ spec:
     - Ingress
     - Egress
   egress:
-    # Egress rule 1 - allow access to Kubernetes API server on its port
+    # allow access to all destinations on Kubernetes API server port
+    # allow access to all destinations on 443
+    # So that a managed cluster can connect to admin cluster on both of those ports
     - ports:
         - port: {{ .Values.kubernetes.service.endpoint.port }}
           protocol: TCP
-      to:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
-    # Egress rule 2 - allow access to all destinations on 443, so that a managed cluster
-    # can connect to the admin cluster
-    - ports:
         - port: 443
           protocol: TCP
   ingress:

--- a/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
@@ -96,6 +96,8 @@ spec:
     - ports:
         - port: 443
           protocol: TCP
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
   ingress:
     - ports:
         - port: 9443


### PR DESCRIPTION
# Description

Network Policy to allow MC agent to connect to admin cluster. Enable Calico by default on MC tests.

Fixes VZ-2550

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
