### PR TITLE
Add support for ensuring the test jenkinsfiles are refreshed in downs…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,28 @@ pipeline {
             }
         }
 
+        stage('Refresh Downstream Jenkinsfiles') {
+            when {
+                allOf {
+                    not { buildingTag() }
+                    anyOf {
+                        branch 'master';
+                        branch 'release-*';
+                        expression {params.TRIGGER_FULL_TESTS == true};
+                    }
+                }
+            }
+            steps {
+                script {
+                    build job: "verrazzano-push-triggered-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
+                        parameters: [
+                            string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
+                            booleanParam(name: 'REFRESH_JENKINS', value: true)
+                        ], wait: false
+                }
+            }
+        }
+
         stage('Analysis Tool') {
             when {
                 allOf {

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -34,6 +34,7 @@ pipeline {
                         defaultValue: 'NONE',
                         description: 'This is for manually testing only where someone needs to use a specific operator image, otherwise the default value of NONE is used',
                         trim: true)
+        booleanParam (description: 'Whether to only run the first stage to refresh the Jenkinsfile for the job (defaults to false)', name: 'REFRESH_JENKINS', defaultValue: false)
     }
 
     environment {
@@ -86,7 +87,11 @@ pipeline {
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
-                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    if (params.REFRESH_JENKINS) {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + "REFRESH_JENKINS"
+                    } else {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
+                    }
                 }
             }
         }
@@ -99,7 +104,8 @@ pipeline {
                             build job: "/verrazzano-multi-cluster-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE)
+                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                    booleanParam(name: 'REFRESH_JENKINS', value: params.REFRESH_JENKINS)
                                 ], wait: true
                         }
                     }
@@ -110,7 +116,8 @@ pipeline {
                             build job: "/verrazzano-uninstall-test/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE)
+                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                    booleanParam(name: 'REFRESH_JENKINS', value: params.REFRESH_JENKINS)
                                 ], wait: true
                         }
                     }
@@ -121,11 +128,14 @@ pipeline {
                             build job: "/verrazzano-new-oci-dns-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE)
+                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                    booleanParam(name: 'REFRESH_JENKINS', value: params.REFRESH_JENKINS)
                                 ], wait: true
                         }
                     }
                 }
+                // Only pass the REFRESH_JENKINS to one variant of these jobs if it is set to true (we only need one
+                // to run to refresh the Jenkinsfile)
                 stage('Kind Acceptance Tests on 1.17') {
                     steps {
                         script {
@@ -133,12 +143,15 @@ pipeline {
                                 parameters: [
                                     string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.17'),
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE)
+                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                    booleanParam(name: 'REFRESH_JENKINS', value: params.REFRESH_JENKINS)
                                 ], wait: true
                         }
                     }
                 }
+                // skip this if REFRESH_JENKINS == true
                 stage('Kind Acceptance Tests on 1.19') {
+                    when { expression {params.REFRESH_JENKINS == false} }
                     steps {
                         script {
                             build job: "/verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
@@ -150,7 +163,9 @@ pipeline {
                         }
                     }
                 }
+                // skip this if REFRESH_JENKINS == true
                 stage('Kind Acceptance Tests on 1.20') {
+                    when { expression {params.REFRESH_JENKINS == false} }
                     steps {
                         script {
                             build job: "/verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
                         trim: true)
         booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
+        booleanParam (description: 'Whether to only run the first stage to refresh the Jenkinsfile for the job (defaults to false)', name: 'REFRESH_JENKINS', defaultValue: false)
     }
 
     environment {
@@ -148,12 +149,17 @@ pipeline {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
                     // update the description with some meaningful info
-                    currentBuild.description = KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    if (params.REFRESH_JENKINS) {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + "REFRESH_JENKINS"
+                    } else {
+                        currentBuild.description = KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
+                    }
                 }
             }
         }
 
         stage('Acceptance Tests') {
+            when { expression {params.REFRESH_JENKINS == false} }
             stages {
                 stage('Prepare AT environment') {
                     environment {
@@ -262,7 +268,7 @@ pipeline {
     post {
         always {
             script {
-                if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                if ( fileExists(env.TESTS_EXECUTED_FILE) && params.REFRESH_JENKINS == false) {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
                     dumpNginxIngressControllerLogs()
@@ -276,12 +282,14 @@ pipeline {
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
 
             sh """
-                cd ${GO_REPO_PATH}/verrazzano/platform-operator
-                make delete-cluster
-                cd ${WORKSPACE}/verrazzano
-                if [ -f ${POST_DUMP_FAILED_FILE} ]; then
-                  echo "Failures seen during dumping of artifacts, treat post as failed"
-                  exit 1
+                if [ "$REFRESH_JENKINS" == "false" ]; then
+                  cd ${GO_REPO_PATH}/verrazzano/platform-operator
+                  make delete-cluster
+                  cd ${WORKSPACE}/verrazzano
+                  if [ -f ${POST_DUMP_FAILED_FILE} ]; then
+                    echo "Failures seen during dumping of artifacts, treat post as failed"
+                    exit 1
+                  fi
                 fi
             """
         }
@@ -290,7 +298,7 @@ pipeline {
             subject: "Verrazzano: ${env.JOB_NAME} - Failed",
             body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
             script {
-                if (env.BRANCH_NAME == "master") {
+                if (env.BRANCH_NAME == "master" && params.REFRESH_JENKINS == false) {
                     pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
                     slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
                 choices: [ "managed-cluster", "dev", "prod" ])
         booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to false, flip will change default after it is supported)', name: 'CREATE_KIND_USE_CALICO', defaultValue: false)
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
+        booleanParam (description: 'Whether to only run the first stage to refresh the Jenkinsfile for the job (defaults to false)', name: 'REFRESH_JENKINS', defaultValue: false)
     }
 
     environment {
@@ -209,7 +210,11 @@ pipeline {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
                     // update the description with some meaningful info
-                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    if (params.REFRESH_JENKINS) {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + "REFRESH_JENKINS"
+                    } else {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
+                    }
                 }
             }
         }
@@ -218,6 +223,7 @@ pipeline {
             when {
                 allOf {
                     not { buildingTag() }
+                    expression {params.REFRESH_JENKINS == false}
                     anyOf {
                         branch 'master';
                         expression {SKIP_ACCEPTANCE_TESTS == false};
@@ -484,7 +490,7 @@ pipeline {
         }
         always {
             script {
-                if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                if ( fileExists(env.TESTS_EXECUTED_FILE) && params.REFRESH_JENKINS == false) {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
                     dumpNginxIngressControllerLogs()
@@ -497,33 +503,35 @@ pipeline {
             archiveArtifacts artifacts: '**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump*/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             script {
-                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                if (env.TEST_ENV == "kind") {
-                    for(int count=1; count<=clusterCount; count++) {
+                if (params.REFRESH_JENKINS == false) {
+                    int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                    if (env.TEST_ENV == "kind") {
+                        for(int count=1; count<=clusterCount; count++) {
+                            sh """
+                                if [ "${env.TEST_ENV}" == "kind" ]
+                                then
+                                    kind delete cluster --name ${CLUSTER_NAME_PREFIX}-$count
+                                fi
+                            """
+                        }
+                    } else {
                         sh """
-                            if [ "${env.TEST_ENV}" == "kind" ]
-                            then
-                                kind delete cluster --name ${CLUSTER_NAME_PREFIX}-$count
+                            mkdir -p ${KUBECONFIG_DIR}
+                            if [ "${TEST_ENV}" == "ocidns_oke" ]; then
+                              cd ${GO_REPO_PATH}/verrazzano
+                              ./tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} || echo "Failed to delete DNS zone z${zoneId}"
                             fi
+                            cd ${TEST_SCRIPTS_DIR}
+                            TF_VAR_label_prefix=multicluster-${env.BUILD_NUMBER} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./delete_oke_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}"
                         """
                     }
-                } else {
                     sh """
-                        mkdir -p ${KUBECONFIG_DIR}
-                        if [ "${TEST_ENV}" == "ocidns_oke" ]; then
-                          cd ${GO_REPO_PATH}/verrazzano
-                          ./tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} || echo "Failed to delete DNS zone z${zoneId}"
+                        if [ -f ${POST_DUMP_FAILED_FILE} ]; then
+                            echo "Failures seen during dumping of artifacts, treat post as failed"
+                            exit 1
                         fi
-                        cd ${TEST_SCRIPTS_DIR}
-                        TF_VAR_label_prefix=multicluster-${env.BUILD_NUMBER} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./delete_oke_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}"
                     """
                 }
-                sh """
-                    if [ -f ${POST_DUMP_FAILED_FILE} ]; then
-                        echo "Failures seen during dumping of artifacts, treat post as failed"
-                        exit 1
-                    fi
-                """
             }
         }
         cleanup {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
                         trim: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
+        booleanParam (description: 'Whether to only run the first stage to refresh the Jenkinsfile for the job (defaults to false)', name: 'REFRESH_JENKINS', defaultValue: false)
     }
 
     environment {
@@ -169,20 +170,34 @@ pipeline {
                 script {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
-                    currentBuild.description = SHORT_COMMIT_HASH + " : " + params.OKE_CLUSTER_REGION + " : " + params.OKE_CLUSTER_VERSION
+                    if (params.REFRESH_JENKINS) {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + "REFRESH_JENKINS"
+                    } else {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + params.OKE_CLUSTER_REGION + " : " + params.OKE_CLUSTER_VERSION
+                    }
                 }
             }
         }
 
         stage("install-oke") {
-            when { expression { return params.TEST_ENV != 'kind' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV != 'kind' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 sh "TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME} ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 
         stage('install-kind') {
-            when { expression { return params.TEST_ENV == 'kind' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'kind' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 sh """
                     cd ${WORKSPACE}/verrazzano-acceptance-test-suite
@@ -192,6 +207,7 @@ pipeline {
         }
 
         stage("create-image-pull-secrets") {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 sh """
                     # Create image pull secret for Verrazzano docker images
@@ -204,6 +220,7 @@ pipeline {
         }
 
         stage("install-platform-operator") {
+            when { expression {params.REFRESH_JENKINS == false} }
             environment {
                 OCI_CLI_AUTH="instance_principal"
                 OCI_OS_NAMESPACE = credentials('oci-os-namespace')
@@ -232,7 +249,12 @@ pipeline {
         }
 
         stage("create-dns-zone") {
-            when { expression { return params.TEST_ENV == 'ocidns_oke' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'ocidns_oke' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 script {
                     dns_zone_ocid = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${TF_VAR_compartment_id} -s z${zoneId}", returnStdout: true)
@@ -241,7 +263,12 @@ pipeline {
         }
 
         stage("setup-oci-dns-config") {
-            when { expression { return params.TEST_ENV == 'ocidns_oke' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'ocidns_oke' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             environment {
                 OCI_DNS_COMPARTMENT_OCID = credentials('oci-dns-compartment')
                 OCI_PRIVATE_KEY_FILE = credentials('oci-api-key')
@@ -260,7 +287,12 @@ pipeline {
         }
 
         stage("create-oci-config-secret") {
-            when { expression { return params.TEST_ENV == 'ocidns_oke' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'ocidns_oke' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 script {
                     sh """
@@ -271,7 +303,12 @@ pipeline {
         }
 
         stage("setup-xip-io-config") {
-            when { expression { return params.TEST_ENV == 'magicdns_oke' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'magicdns_oke' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 script {
                     sh """
@@ -285,7 +322,12 @@ pipeline {
         }
 
         stage("setup-nodeport-config") {
-            when { expression { return params.TEST_ENV == 'kind' } }
+            when {
+                allOf {
+                    expression { return params.TEST_ENV == 'kind' }
+                    expression {params.REFRESH_JENKINS == false}
+                }
+            }
             steps {
                 script {
                     sh """
@@ -299,6 +341,7 @@ pipeline {
         }
 
         stage("install-verrazzano") {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 sh """
                     echo "Waiting for Operator to be ready"
@@ -346,6 +389,7 @@ pipeline {
         }
 
         stage('acceptance-tests-1') {
+            when { expression {params.REFRESH_JENKINS == false} }
             parallel {
                 // Quick fix for Bob's Books test failure that reports "Webpage is NOT Robert's Books Greetings from Verrazzano!"
                 //     Do not run this in parallel with Bob's Books because both specify a mapping for "/" path.
@@ -371,6 +415,7 @@ pipeline {
         }
 
         stage('acceptance-tests-2') {
+            when { expression {params.REFRESH_JENKINS == false} }
             parallel {
                 stage('verify-install') {
                     steps {
@@ -479,15 +524,16 @@ pipeline {
     post {
         always {
             script {
-                if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
-                    dumpK8sCluster('oke-acceptance-tests-cluster-dump')
+                if (params.REFRESH_JENKINS == false) {
+                    if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
+                        dumpK8sCluster('oke-acceptance-tests-cluster-dump')
+                    }
+                    dumpVerrazzanoSystemPods()
+                    dumpCattleSystemPods()
+                    dumpNginxIngressControllerLogs()
+                    dumpVerrazzanoPlatformOperatorLogs()
                 }
             }
-
-            dumpVerrazzanoSystemPods()
-            dumpCattleSystemPods()
-            dumpNginxIngressControllerLogs()
-            dumpVerrazzanoPlatformOperatorLogs()
 
             sh """
                 echo "sorting the images file prior to archiving"
@@ -499,30 +545,34 @@ pipeline {
             archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
-                if [ "${TEST_ENV}" == "ocidns_oke" ]; then
-                  ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} || echo "Failed to delete DNS zone z${zoneId}"
-                fi
-                if [ "${TEST_ENV}" == "kind" ]; then
-                  ${WORKSPACE}/tests/e2e/config/scripts/delete-kind-cluster.sh
-                else
-                  TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME} ${WORKSPACE}/tests/e2e/config/scripts/delete_oke_cluster.sh
-                fi
-                if [ -f ${POST_DUMP_FAILED_FILE} ]; then
-                  echo "Failures seen during dumping of artifacts, treat post as failed"
-                  exit 1
+                if [ "$REFRESH_JENKINS" == "false" ]; then
+                  if [ "${TEST_ENV}" == "ocidns_oke" ]; then
+                    ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} || echo "Failed to delete DNS zone z${zoneId}"
+                  fi
+                  if [ "${TEST_ENV}" == "kind" ]; then
+                    ${WORKSPACE}/tests/e2e/config/scripts/delete-kind-cluster.sh
+                  else
+                    TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME} ${WORKSPACE}/tests/e2e/config/scripts/delete_oke_cluster.sh
+                  fi
+                  if [ -f ${POST_DUMP_FAILED_FILE} ]; then
+                    echo "Failures seen during dumping of artifacts, treat post as failed"
+                    exit 1
+                  fi
                 fi
             """
        }
        failure {
             script {
-                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME == "verrazzano/develop") {
-                    emailext recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']],
-                       subject: "Verrazzano: ${env.JOB_NAME} - Failed",
-                       body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
-                    pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
-                    slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                if (params.REFRESH_JENKINS == false) {
+                    if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME == "verrazzano/develop") {
+                        emailext recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']],
+                           subject: "Verrazzano: ${env.JOB_NAME} - Failed",
+                           body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
+                        pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
+                        slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                   }
                 }
-           }
+            }
        }
     }
 }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS',
                       defaultValue: false,
                       description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)')
+        booleanParam (description: 'Whether to only run the first stage to refresh the Jenkinsfile for the job (defaults to false)', name: 'REFRESH_JENKINS', defaultValue: false)
     }
 
     environment {
@@ -185,18 +186,24 @@ pipeline {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
                     // update the description with some meaningful info
-                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    if (params.REFRESH_JENKINS) {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + "REFRESH_JENKINS"
+                    } else {
+                        currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
+                    }
                 }
             }
         }
 
         stage("Create Cluster") {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 sh "TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}-${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 
         stage('Install Verrazzano') {
+            when { expression {params.REFRESH_JENKINS == false} }
             environment {
                 OCI_OS_NAMESPACE = credentials('oci-os-namespace')
                 OCI_OS_BUCKET="verrazzano-builds"
@@ -284,6 +291,7 @@ pipeline {
         }
 
         stage('Run Test') {
+            when { expression {params.REFRESH_JENKINS == false} }
             environment {
                 TEST_ENV = "OKE"
             }
@@ -300,6 +308,7 @@ pipeline {
         }
 
         stage('Uninstall Verrazzano') {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
@@ -323,6 +332,7 @@ pipeline {
         }
 
         stage("Verify Uninstall") {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
@@ -334,6 +344,7 @@ pipeline {
         }
 
         stage("Reinstall Verrazzano") {
+            when { expression {params.REFRESH_JENKINS == false} }
             steps {
                 listNamepacesAndPods('before reinstalling Verrazzano')
                 sh """
@@ -374,6 +385,7 @@ pipeline {
         }
 
         stage('Rerun Test') {
+            when { expression {params.REFRESH_JENKINS == false} }
             environment {
                 TEST_ENV = "OKE"
             }
@@ -387,7 +399,7 @@ pipeline {
     post {
         always {
             script {
-                if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && params.REFRESH_JENKINS == false) {
                     dumpK8sCluster('verrazzano-uninstall-test-dump')
                 }
             }
@@ -396,21 +408,27 @@ pipeline {
         }
         failure {
             script {
-                dumpK8sCluster('verrazzano-uninstall-test-dump')
-                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
-                mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
-                subject: "Verrazzano: ${env.JOB_NAME} - Failed",
-                body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
-                script {
-                    if (env.JOB_NAME == "verrazzano-uninstall-test/master") {
-                        pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
-                        slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                if (params.REFRESH_JENKINS == false) {
+                    dumpK8sCluster('verrazzano-uninstall-test-dump')
+                    archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
+                    mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
+                    subject: "Verrazzano: ${env.JOB_NAME} - Failed",
+                    body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
+                    script {
+                        if (env.JOB_NAME == "verrazzano-uninstall-test/master") {
+                            pagerduty(resolve: false, serviceKey: "$SERVICE_KEY", incDescription: "Verrazzano: ${env.JOB_NAME} - Failed", incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
+                            slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+                        }
                     }
                 }
             }
         }
         cleanup {
-            sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}-${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
+            script {
+                if (params.REFRESH_JENKINS == false) {
+                    sh "VERRAZZANO_KUBECONFIG=${env.KUBECONFIG} TF_VAR_label_prefix=uninstall-${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}-${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/delete_oke_cluster.sh"
+                }
+            }
             deleteDir()
         }
     }


### PR DESCRIPTION
…tream tests for master/release*/branches where full tests are triggered

# Description

This adds in a REFRESH_JENKINS capability for the master, release*, and any feature branch that is running the full triggered set of tests.

When REFRESH_JENKINS is true, the test job will just execute the init stage then nothing else (except for some post stuff, most of that is not executed too)

For master, release*, and branches that are set to trigger all tests. the stage after the init will start a triggered tests build but giving it the REFRESH_JENKINS==true, and it will not wait for that. That will fan out and call all triggered tests telling them to also REFRESH_JENKINS. So when the actual jobs gets around to triggering the tests for real, they will have a current Jenkinsfile there.

This allows master/release* to automatically run successfully if someone changes a test Jenkinsfile to add/change parameters. This also allows devs to run their branch triggering all tests when they need to do so without starting and killing jobs manually.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
