### PR TITLE
Remove CSRs from the resource list that gets dumped and compared

### DIFF
--- a/tests/e2e/config/scripts/looping-test/types.txt
+++ b/tests/e2e/config/scripts/looping-test/types.txt
@@ -6,5 +6,3 @@ APIService
 ClusterRoleBinding
 ClusterRole
 RoleBinding
-CertificateSigningRequest
-


### PR DESCRIPTION
# Description

Remove CSRs from the resources being checked before/after, this is causing intermittent failures and we need to review whether that really makes sense to compare those for testing

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
