### PR TITLE
Use ACME staging env for tests using OCI DNS by default

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -6,6 +6,7 @@ def SKIP_ACCEPTANCE_TESTS = false
 def availableRegions = [ "us-ashburn-1", "ap-chuncheon-1", "ap-hyderabad-1", "ap-melbourne-1", "ap-mumbai-1", "ap-osaka-1", "ap-seoul-1", "ap-sydney-1",
                           "ap-tokyo-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",
                           "sa-saopaulo-1", "uk-london-1", "us-phoenix-1" ]
+def acmeEnvironments = [ "staging", "production" ]
 Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,3).replace('-','')
 def dns_zone_ocid = 'dummy'
@@ -31,6 +32,8 @@ pipeline {
         choice (description: 'Number of Cluster', name: 'TOTAL_CLUSTERS', choices: ["2", "1", "3"])
         choice (description: 'Verrazzano Test Environment', name: 'TEST_ENV',
                 choices: ["kind", "magicdns_oke", "ocidns_oke"])
+        choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
+                choices: acmeEnvironments)
         choice (description: 'OCI region to launch OKE clusters', name: 'OKE_CLUSTER_REGION',
             // 1st choice is the default value
             choices: availableRegions )
@@ -123,6 +126,7 @@ pipeline {
         INSTALL_CONFIG_FILE_XIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-xipio.yaml"
         OCI_DNS_ZONE_SUFFIX=credentials('oci-dns-zone')
         OCI_DNS_ZONE_NAME="z${zoneId}." + "${OCI_DNS_ZONE_SUFFIX}"
+        ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
 
@@ -661,7 +665,7 @@ def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript
 
                 # Copy the template config over for the mgd cluster profile configuration
                 cp $installResourceTemplate $destinationPath
-                VZ_ENVIRONMENT_NAME="${envName}" INSTALL_PROFILE=$installProfile $configProcessorScript $destinationPath
+                VZ_ENVIRONMENT_NAME="${envName}" INSTALL_PROFILE=$installProfile $configProcessorScript $destinationPath $ACME_ENVIRONMENT
             """
         }
     }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -124,6 +124,7 @@ pipeline {
         INSTALL_CONFIG_FILE_NODEPORT = "${WORKSPACE}/tests/e2e/config/scripts/install-verrazzano-nodeport.yaml"
         //OCI_DNS_ZONE = credentials('oci-dns-zone')
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.oracledx.com"
+        ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
 
         VZ_ENVIRONMENT_NAME = "${params.TEST_ENV == 'ocidns_oke' ? 'b' + env.BUILD_NUMBER : 'default'}"
     }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -14,7 +14,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : env.JOB_NAME.contains('magic-dns')
                        ? ["magicdns_oke", "ocidns_oke", "kind"]
                        : ["kind", "magicdns_oke", "ocidns_oke"]
-
+def acmeEnvironments = [ "staging", "production" ]
 def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : "VM.Standard2.8"
 def availableRegions = [ "us-ashburn-1", "ap-chuncheon-1", "ap-hyderabad-1", "ap-melbourne-1", "ap-mumbai-1", "ap-osaka-1", "ap-seoul-1", "ap-sydney-1",
                           "ap-tokyo-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",
@@ -55,6 +55,8 @@ pipeline {
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
                         trim: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
+        choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
+                choices: acmeEnvironments)
     }
 
     environment {
@@ -253,7 +255,7 @@ pipeline {
                         echo "Installing yq"
                         GO111MODULE=on go get github.com/mikefarah/yq/v4
                         export PATH=${HOME}/go/bin:${PATH}
-                        ${WORKSPACE}/tests/e2e/config/scripts/process_oci_dns_install_yaml.sh $INSTALL_CONFIG_FILE_OCIDNS
+                        ${WORKSPACE}/tests/e2e/config/scripts/process_oci_dns_install_yaml.sh $INSTALL_CONFIG_FILE_OCIDNS $ACME_ENVIRONMENT
                     """
                 }
             }

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -305,9 +305,28 @@ function install_rancher()
     if [ "$useAdditionalCAs" == "true" ]; then
       log "Using ACME staging, create staging certs secret for Rancher"
       local acme_staging_certs=${TMP_DIR}/ca-additional.pem
-      curl https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem > ${acme_staging_certs}
-      curl https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem >> ${acme_staging_certs}
-      curl https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem >> ${acme_staging_certs}
+      echo -n "" > ${acme_staging_certs}
+      curl_args=(--output ${TMP_DIR}/int-r3.pem "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem")
+      call_curl 200 http_response http_status curl_args || true
+      if [ ${http_status:--1} -ne 200 ]; then
+        log "Error downloading LetsEncrypt Staging intermediate R3 cert"
+      else
+        cat ${TMP_DIR}/int-r3.pem >> ${acme_staging_certs}
+      fi
+      curl_args=(--output ${TMP_DIR}/int-e1.pem "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem")
+      call_curl 200 http_response http_status curl_args || true
+      if [ ${http_status:--1} -ne 200 ]; then
+        log "Error downloading LetsEncrypt Staging intermediate E1 cert"
+      else
+        cat ${TMP_DIR}/int-e1.pem >> ${acme_staging_certs}
+      fi
+      curl_args=(--output ${TMP_DIR}/root-x1.pem "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem")
+      call_curl 200 http_response http_status curl_args || true
+      if [ ${http_status:--1} -ne 200 ]; then
+        log "Error downloading LetsEncrypt Staging X1 Root cert"
+      else
+        cat ${TMP_DIR}/root-x1.pem >> ${acme_staging_certs}
+      fi
       kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=${acme_staging_certs}
     fi
 

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -112,6 +112,9 @@ function delete_rancher() {
   helm ls -n cattle-system | awk '/rancher/ {print $1}' | xargsr helm uninstall -n cattle-system \
     || err_return $? "Could not delete cattle-system from helm" || return $? # return on pipefail
 
+  log "Delete the additional CA secret for Rancher"
+  kubectl -n cattle-system delete secret tls-ca-additional 2>&1 > /dev/null || true
+
   log "Deleting CRDs from rancher"
 
   local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')

--- a/tests/e2e/config/scripts/process_oci_dns_install_yaml.sh
+++ b/tests/e2e/config/scripts/process_oci_dns_install_yaml.sh
@@ -4,12 +4,15 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 INSTALL_CONFIG_TO_EDIT=$1
+ACME_ENV=${2:-"staging"}
+
 echo "Editing install config file for OCI DNS ${INSTALL_CONFIG_TO_EDIT}"
 yq -i eval ".spec.environmentName = \"${VZ_ENVIRONMENT_NAME}\"" ${INSTALL_CONFIG_TO_EDIT}
 yq -i eval ".spec.profile = \"${INSTALL_PROFILE}\"" ${INSTALL_CONFIG_TO_EDIT}
 yq -i eval ".spec.components.dns.oci.dnsZoneCompartmentOCID = \"${OCI_DNS_COMPARTMENT_OCID}\"" ${INSTALL_CONFIG_TO_EDIT}
 yq -i eval ".spec.components.dns.oci.dnsZoneOCID = \"${OCI_DNS_ZONE_OCID}\"" ${INSTALL_CONFIG_TO_EDIT}
 yq -i eval ".spec.components.dns.oci.dnsZoneName = \"${OCI_DNS_ZONE_NAME}\"" ${INSTALL_CONFIG_TO_EDIT}
+yq -i eval ".spec.components.certManager.certificate.acme.environment = \"${ACME_ENV}\"" ${INSTALL_CONFIG_TO_EDIT}
 if [ $INSTALL_PROFILE == "dev" ]; then
   yq -i eval ".spec.components.keycloak.mysql.mysqlInstallArgs.[0].name = \"persistence.enabled\"" ${INSTALL_CONFIG_TO_EDIT}
   yq -i eval ".spec.components.keycloak.mysql.mysqlInstallArgs.[0].value = \"false\"" ${INSTALL_CONFIG_TO_EDIT}

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -39,7 +39,9 @@ var _ = ginkgo.BeforeSuite(func() {
 		ginkgo.Fail(fmt.Sprintf("Failed to create hello-helidon component resources: %v", err))
 	}
 	err := retry.Do(
-		func() error { return pkg.CreateOrUpdateResourceFromFile("examples/hello-helidon/hello-helidon-app.yaml") },
+		func() error {
+			return pkg.CreateOrUpdateResourceFromFile("examples/hello-helidon/hello-helidon-app.yaml")
+		},
 		retryAttempts, retryDelay)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create hello-helidon application resource: %v", err))

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -39,7 +39,9 @@ var _ = ginkgo.BeforeSuite(func() {
 		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-config component resources: %v", err))
 	}
 	err := retry.Do(
-		func() error { return pkg.CreateOrUpdateResourceFromFile("examples/helidon-config/helidon-config-app.yaml") },
+		func() error {
+			return pkg.CreateOrUpdateResourceFromFile("examples/helidon-config/helidon-config-app.yaml")
+		},
 		retryAttempts, retryDelay)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-config application resource: %v", err))

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -77,7 +77,9 @@ func deployToDoListExample() {
 	}
 	pkg.Log(pkg.Info, "Create application resources")
 	err := retry.Do(
-		func() error { return pkg.CreateOrUpdateResourceFromFile("examples/todo-list/todo-list-application.yaml") },
+		func() error {
+			return pkg.CreateOrUpdateResourceFromFile("examples/todo-list/todo-list-application.yaml")
+		},
 		retryAttempts, retryDelay)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create application resource: %v", err))

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package pkg
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const letsEncryptStagingIntR3 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
+const letsEncryptStagingIntE1 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
+
+type ACMEStagingCerts struct {
+	letsEncryptStagingIntR3CA []byte
+	letsEncryptStagingIntE1CA []byte
+}
+
+var stagingCerts = ACMEStagingCerts{
+	letsEncryptStagingIntE1CA: loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE1, "E1"),
+	letsEncryptStagingIntR3CA: loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntR3, "R3"),
+}
+
+func getACMEStagingCAs() [][]byte {
+	return [][]byte{stagingCerts.letsEncryptStagingIntE1CA, stagingCerts.letsEncryptStagingIntR3CA}
+}
+
+func newSimpleHTTPClient() *http.Client {
+	tr := &http.Transport{}
+	proxyURL := getProxyURL()
+	if proxyURL != "" {
+		tURL := url.URL{}
+		tURLProxy, _ := tURL.Parse(proxyURL)
+		tr.Proxy = http.ProxyURL(tURLProxy)
+	}
+	httpClient := &http.Client{Transport: tr}
+	return httpClient
+}
+
+func loadStagingCA(httpClient *http.Client, resURL string, caCertName string) []byte {
+	status, pemData := doGetWebPage(resURL, "", newRetryableHTTPClient(httpClient), "", "")
+	if status < 200 || status > 299 {
+		fmt.Printf("Unable to load ACME %s staging CA, status: %v\n", caCertName, status)
+		return nil
+	}
+	fmt.Printf("Loaded ACME %s staging CA, status == %v\n", caCertName, status)
+	return []byte(pemData)
+}

--- a/tests/e2e/pkg/vmi.go
+++ b/tests/e2e/pkg/vmi.go
@@ -36,7 +36,7 @@ func GetSystemVMICredentials() (*UsernamePassword, error) {
 // GetBindingVmiHTTPClient returns the VMI client for the prided binding
 func GetBindingVmiHTTPClient(bindingName string, kubeconfigPath string) *retryablehttp.Client {
 	bindingVmiCaCert := getBindingVMICACert(bindingName, kubeconfigPath)
-	vmiRawClient := getHTTPClientWIthCABundle(bindingVmiCaCert, kubeconfigPath)
+	vmiRawClient := getHTTPClientWithCABundle(bindingVmiCaCert, kubeconfigPath)
 	retryableClient := newRetryableHTTPClient(vmiRawClient)
 	retryableClient.CheckRetry = GetRetryPolicy()
 	return retryableClient


### PR DESCRIPTION
# Description

Convert OCI DNS pipeline to use ACME staging environment by default.
- update test client to load ACME staging CA certs
- Update OCI DNS and MC ATs to use staging env for certs by default
- fix typo in getHTTPClientWithCABundle function name
- some go fmt updates for e2e tests

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
