### PR TITLE
Fix jq error complaining about non-existing effective.config.json in install/uninstall logs

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -484,6 +484,7 @@ pipeline {
         }
         always {
             script {
+                dumpInstallLogs()
                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
@@ -849,6 +850,23 @@ def dumpVerrazzanoApiLogs() {
                 mkdir -p ${LOG_DIR}
                 export DIAGNOSTIC_LOG="${LOG_DIR}/verrazzano-api.log"
                 ${GO_REPO_PATH}/verrazzano/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-api-*" -m "verrazzano api" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+            """
+        }
+    }
+}
+
+def dumpInstallLogs() {
+    script {
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            LOG_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/cluster-$count"
+            sh """
+                ## dump verrazzano install logs
+                export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+                mkdir -p ${LOG_DIR}
+                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install.log --tail -1
+                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                echo "------------------------------------------"
             """
         }
     }

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -14,6 +14,9 @@ EFFECTIVE_CONFIG_VALUES="${INSTALL_OVERRIDES_DIR}/effective.config.json"
 # The max length of the environment name passed in by the user.
 ENV_NAME_LENGTH_LIMIT=10
 
+# Flag to differentiate install from uninstall
+INSTALL_PATH=true
+
 # Read a JSON installation config file and output the JSON to stdout
 function read_config() {
   local config_file=$1
@@ -40,7 +43,7 @@ function get_config_value() {
     config_val=""
   fi
   # check if it is defined in the json files under install-overrides
-  if [ ! $(get_override_config_value "$jq_expr") == "" ]; then
+  if [ $INSTALL_PATH = true ] && [ ! $(get_override_config_value "$jq_expr") == "" ]; then
     config_val=$(get_override_config_value "$jq_expr")
   fi
   echo $config_val
@@ -384,6 +387,7 @@ function is_keycloak_enabled() {
 
 if [ -z "$INSTALL_CONFIG_FILE" ]; then
   INSTALL_CONFIG_FILE=$DEFAULT_CONFIG_FILE
+  INSTALL_PATH=false
 fi
 log "Reading installation config file $INSTALL_CONFIG_FILE"
 if [ ! -f "$INSTALL_CONFIG_FILE" ]; then
@@ -393,4 +397,6 @@ CONFIG_JSON="$(read_config $INSTALL_CONFIG_FILE)"
 
 validate_config_json "$CONFIG_JSON" || fail "Installation config is invalid"
 
-compute_effective_override  || fail "Failure to merge the install overrides"
+if [ $INSTALL_PATH = true ]; then
+  compute_effective_override  || fail "Failure to merge the install overrides"
+fi

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -45,7 +45,7 @@ function get_config_value() {
 
   # check if it is defined in the json files under install-overrides
   local config_override_value=$(get_override_config_value "$jq_expr")
-  if [ ! $config_override_value == "" ]; then
+  if [ ! "$config_override_value" == "" ]; then
     config_val=$config_override_value
   fi
   echo $config_val

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -14,9 +14,6 @@ EFFECTIVE_CONFIG_VALUES="${INSTALL_OVERRIDES_DIR}/effective.config.json"
 # The max length of the environment name passed in by the user.
 ENV_NAME_LENGTH_LIMIT=10
 
-# Flag to differentiate install from uninstall
-INSTALL_PATH=true
-
 # Read a JSON installation config file and output the JSON to stdout
 function read_config() {
   local config_file=$1
@@ -396,7 +393,6 @@ function is_keycloak_enabled() {
 
 if [ -z "$INSTALL_CONFIG_FILE" ]; then
   INSTALL_CONFIG_FILE=$DEFAULT_CONFIG_FILE
-  INSTALL_PATH=false
 fi
 log "Reading installation config file $INSTALL_CONFIG_FILE"
 if [ ! -f "$INSTALL_CONFIG_FILE" ]; then
@@ -406,6 +402,4 @@ CONFIG_JSON="$(read_config $INSTALL_CONFIG_FILE)"
 
 validate_config_json "$CONFIG_JSON" || fail "Installation config is invalid"
 
-if [ $INSTALL_PATH = true ]; then
-  compute_effective_override  || fail "Failure to merge the install overrides"
-fi
+compute_effective_override  || fail "Failure to merge the install overrides"

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -45,7 +45,7 @@ function get_config_value() {
 
   # check if it is defined in the json files under install-overrides
   local config_override_value=$(get_override_config_value "$jq_expr")
-  if [ ! "$config_override_value" == "" ]; then
+  if [ "$config_override_value" != "" ]; then
     config_val=$config_override_value
   fi
   echo $config_val
@@ -370,7 +370,7 @@ function get_override_config_value() {
   local config_val=""
   # The install-overrides is meant for install operation, return empty string for uninstall.
   # Also when get_config_value is called before creating the effective config, return an empty string.
-  if [ $INSTALL_PATH = false ] || [ ! -f "$EFFECTIVE_CONFIG_VALUES" ]; then
+  if [ ! -f "$EFFECTIVE_CONFIG_VALUES" ]; then
     echo $config_val
     return 0
   fi

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -14,6 +14,7 @@ EFFECTIVE_CONFIG_VALUES="${INSTALL_OVERRIDES_DIR}/effective.config.json"
 # The max length of the environment name passed in by the user.
 ENV_NAME_LENGTH_LIMIT=10
 
+# Flag to differentiate install from uninstall
 INSTALL_PATH=true
 
 # Read a JSON installation config file and output the JSON to stdout
@@ -167,6 +168,8 @@ function validate_config_json {
 
 # Make sure the environmentName, dns entries and certificates are valid in CONFIG_JSON
 function validate_config_json_entries {
+  set -o pipefail
+  local jsonToValidate=$1
   validate_environment_name "$jsonToValidate"
   validate_dns_section "$jsonToValidate"
   validate_certificates_section "$jsonToValidate"
@@ -365,6 +368,8 @@ function compute_effective_override() {
 # Read the value for a given key from effective.config.json
 function get_override_config_value() {
   local config_val=""
+  # The install-overrides is meant for install operation, return empty string for uninstall.
+  # Also when get_config_value is called before creating the effective config, return an empty string.
   if [ $INSTALL_PATH = false ] || [ ! -f "$EFFECTIVE_CONFIG_VALUES" ]; then
     echo $config_val
     return 0

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -164,12 +164,6 @@ function validate_config_json {
   set -o pipefail
   local jsonToValidate=$1
   echo "$jsonToValidate" | jq . > /dev/null || fail "Failed to read installation config file contents. Make sure it is valid JSON"
-}
-
-# Make sure the environmentName, dns entries and certificates are valid in CONFIG_JSON
-function validate_config_json_entries {
-  set -o pipefail
-  local jsonToValidate=$1
   validate_environment_name "$jsonToValidate"
   validate_dns_section "$jsonToValidate"
   validate_certificates_section "$jsonToValidate"
@@ -368,8 +362,8 @@ function compute_effective_override() {
 # Read the value for a given key from effective.config.json
 function get_override_config_value() {
   local config_val=""
-  # The install-overrides is meant for install operation, return empty string for uninstall.
-  # Also when get_config_value is called before creating the effective config, return an empty string.
+  # Return an empty string when effective.config.json is not there - during uninstall and when validate_config_json
+  # calls get_config_value.
   if [ ! -f "$EFFECTIVE_CONFIG_VALUES" ]; then
     echo $config_val
     return 0
@@ -415,5 +409,3 @@ validate_config_json "$CONFIG_JSON" || fail "Installation config is invalid"
 if [ $INSTALL_PATH = true ]; then
   compute_effective_override  || fail "Failure to merge the install overrides"
 fi
-
-validate_config_json_entries "$CONFIG_JSON" || fail "Failure to validate the entries in config file"


### PR DESCRIPTION
# Description

This PR fixes the jq error, complaining about non-existing effective.config.json when config.sh reads the value from CONFIG_JSON from function validate_config_json() before the step which generates "effective.config.json" and during undeploy.

As part of this change, the Jenkinsfile used by multi-cluster test is updated to archive the install and uninstall logs.

Fixes VZ-2564

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
