### PR TITLE
Add message field to ClusterLevelStatus

### DIFF
--- a/application-operator/apis/clusters/v1alpha1/multicluster_common_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multicluster_common_types.go
@@ -38,6 +38,8 @@ type ClusterLevelStatus struct {
 	Name string `json:"name"`
 	// State of the resource in this cluster
 	State StateType `json:"state"`
+	// Message with details about the status in this cluster
+	Message string `json:"message,omitempty"`
 	// LastUpdateTime of the resource state in this cluster
 	LastUpdateTime string `json:"lastUpdateTime"`
 }

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -124,7 +124,7 @@ func CreateClusterLevelStatus(condition clustersv1alpha1.Condition, clusterName 
 		state = clustersv1alpha1.Pending
 	}
 	return clustersv1alpha1.ClusterLevelStatus{
-		Name: clusterName, State: state, LastUpdateTime: condition.LastTransitionTime}
+		Name: clusterName, State: state, Message: condition.Message, LastUpdateTime: condition.LastTransitionTime}
 }
 
 // ComputeEffectiveState computes the overall state of the multi cluster resource from the statuses

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterapplicationconfigurations.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterapplicationconfigurations.yaml
@@ -349,6 +349,9 @@ spec:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
                       type: string
+                    message:
+                      description: Message with details about the status in this cluster
+                      type: string
                     name:
                       description: Name of the cluster
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
@@ -135,6 +135,9 @@ spec:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
                       type: string
+                    message:
+                      description: Message with details about the status in this cluster
+                      type: string
                     name:
                       description: Name of the cluster
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
@@ -98,6 +98,9 @@ spec:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
                       type: string
+                    message:
+                      description: Message with details about the status in this cluster
+                      type: string
                     name:
                       description: Name of the cluster
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterloggingscopes.yaml
@@ -125,6 +125,9 @@ spec:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
                       type: string
+                    message:
+                      description: Message with details about the status in this cluster
+                      type: string
                     name:
                       description: Name of the cluster
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
@@ -97,6 +97,9 @@ spec:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
                       type: string
+                    message:
+                      description: Message with details about the status in this cluster
+                      type: string
                     name:
                       description: Name of the cluster
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_verrazzanoprojects.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_verrazzanoprojects.yaml
@@ -93,7 +93,7 @@ spec:
                     properties:
                       projectAdminSubjects:
                         description: ProjectAdminSubjects specifies the list of subjects
-                          that should be bound to the verrazzano-project-admins role
+                          that should be bound to the verrazzano-project-admin role
                         items:
                           description: Subject contains a reference to the object
                             or user identities a role binding applies to.  This can
@@ -128,7 +128,7 @@ spec:
                         type: array
                       projectMonitorSubjects:
                         description: ProjectMonitorBinding specifies the subject that
-                          should be bound to the verrazzano-project-monitors role
+                          should be bound to the verrazzano-project-monitor role
                         items:
                           description: Subject contains a reference to the object
                             or user identities a role binding applies to.  This can
@@ -180,6 +180,9 @@ spec:
                   properties:
                     lastUpdateTime:
                       description: LastUpdateTime of the resource state in this cluster
+                      type: string
+                    message:
+                      description: Message with details about the status in this cluster
                       type: string
                     name:
                       description: Name of the cluster


### PR DESCRIPTION
# Description

Add a message field to the ClusterLevelStatus reported back from managed clusters to the admin cluster.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
