### PR TITLE
Fix echo of the kind config being used, always report it

### DIFF
--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -54,9 +54,9 @@ create_kind_cluster() {
   cd ${SCRIPT_DIR}/
   KIND_CONFIG_FILE=kind-config${CALICO_SUFFIX}.yaml
   if [ ${KIND_AT_CACHE} == true ]; then
-    echo "Using kind-config-ci.yaml for pre-created cache"
     KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}.yaml
   fi
+  echo "Using ${KIND_CONFIG_FILE}"
   sed -i "s/KIND_IMAGE/${KIND_IMAGE}/g" ${KIND_CONFIG_FILE}
   HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster -v 1 --name ${CLUSTER_NAME} --wait 5m --config=${KIND_CONFIG_FILE}
   kubectl config set-context kind-${CLUSTER_NAME}


### PR DESCRIPTION
# Description

Small tweak to fix the echo of which config yaml being used for kind and always echo it.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
