### PR TITLE
Verify_Permissions potential fix

### DIFF
--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -268,7 +269,7 @@ func UpdateStatus(resource MultiClusterResource, mcStatus *clustersv1alpha1.Mult
 	clusterLevelStatus := CreateClusterLevelStatus(newCondition, clusterName)
 
 	if StatusNeedsUpdate(*mcStatus, newCondition, clusterLevelStatus) {
-		mcStatus.Conditions = append(mcStatus.Conditions, newCondition)
+		addOrUpdateCondition(mcStatus, newCondition)
 		SetClusterLevelStatus(mcStatus, clusterLevelStatus)
 		mcStatus.State = ComputeEffectiveState(*mcStatus, placement)
 		err := updateFunc()
@@ -288,6 +289,31 @@ func UpdateStatus(resource MultiClusterResource, mcStatus *clustersv1alpha1.Mult
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+// addOrUpdateCondition adds or updates the newCondition in the status' list of existing conditions
+func addOrUpdateCondition(status *clustersv1alpha1.MultiClusterResourceStatus, condition clustersv1alpha1.Condition) {
+	var matchingCondition *clustersv1alpha1.Condition
+	for i, existingCondition := range status.Conditions {
+		if condition.Type == existingCondition.Type &&
+			condition.Status == existingCondition.Status &&
+			condition.Message == existingCondition.Message {
+			// the exact same condition already exists, don't update
+			return
+		}
+		if condition.Type == existingCondition.Type {
+			// use the index here since "existingCondition" is a copy and won't point to the object in the slice
+			matchingCondition = &status.Conditions[i]
+			break
+		}
+	}
+	if matchingCondition == nil {
+		status.Conditions = append(status.Conditions, condition)
+	} else {
+		matchingCondition.Message = condition.Message
+		matchingCondition.Status = condition.Status
+		matchingCondition.LastTransitionTime = condition.LastTransitionTime
+	}
 }
 
 // SetEffectiveStateIfChanged - if the effective state of the resource has changed, set it on the
@@ -340,4 +366,11 @@ func AddFinalizer(ctx context.Context, r client.Client, obj controllerutil.Objec
 	}
 
 	return controllerruntime.Result{}, nil
+}
+
+// GetRandomRequeueDelay returns a random delay to be used for RequeueAfter
+func GetRandomRequeueDelay() time.Duration {
+	// get a jittered delay to use for requeueing reconcile
+	var seconds = rand.IntnRange(2, 8)
+	return time.Duration(seconds) * time.Second
 }

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
@@ -77,7 +77,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		_, err = clusters.AddFinalizer(ctx, r.Client, &mcAppConfig, finalizerName)
 	}
 
-	return r.updateStatus(ctx, &mcAppConfig, opResult, err)
+	ctrlResult, updateErr := r.updateStatus(ctx, &mcAppConfig, opResult, err)
+
+	// if an error occurred in createOrUpdate, return that error with a requeue
+	// even if update status succeeded
+	if err != nil {
+		res := ctrl.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}
+		return res, err
+	}
+
+	return ctrlResult, updateErr
 }
 
 // SetupWithManager registers our controller with the manager

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -218,8 +218,9 @@ func TestReconcileCreateAppConfigFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcileUpdateAppConfigFailed tests the path of reconciling a
@@ -267,8 +268,9 @@ func TestReconcileUpdateAppConfigFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcileResourceNotFound tests the path of reconciling a

--- a/application-operator/controllers/clusters/multiclustercomponent/controller.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller.go
@@ -74,7 +74,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		_, err = clusters.AddFinalizer(ctx, r.Client, &mcComp, finalizerName)
 	}
 
-	return r.updateStatus(ctx, &mcComp, opResult, err)
+	ctrlResult, updateErr := r.updateStatus(ctx, &mcComp, opResult, err)
+
+	// if an error occurred in createOrUpdate, return that error with a requeue
+	// even if update status succeeded
+	if err != nil {
+		res := ctrl.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}
+		return res, err
+	}
+
+	return ctrlResult, updateErr
 }
 
 // SetupWithManager registers our controller with the manager

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -217,8 +217,9 @@ func TestReconcileCreateComponentFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcileCreateComponentFailed tests the path of reconciling a MultiClusterComponent
@@ -269,8 +270,9 @@ func TestReconcileUpdateComponentFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterComponent which

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -75,8 +75,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		_, err = clusters.AddFinalizer(ctx, r.Client, &mcConfigMap, finalizerName)
 	}
 
-	return r.updateStatus(ctx, &mcConfigMap, opResult, err)
+	ctrlResult, updateErr := r.updateStatus(ctx, &mcConfigMap, opResult, err)
 
+	// if an error occurred in createOrUpdate, return that error with a requeue
+	// even if update status succeeded
+	if err != nil {
+		res := ctrl.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}
+		return res, err
+	}
+
+	return ctrlResult, updateErr
 }
 
 // SetupWithManager registers our controller with the manager

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -213,8 +213,9 @@ func TestReconcileCreateConfigMapFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcileCreateConfigMapFailed tests the path of reconciling a MultiClusterConfigMap
@@ -260,8 +261,8 @@ func TestReconcileUpdateConfigMapFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterConfigMap which

--- a/application-operator/controllers/clusters/multiclusterloggingscope/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterloggingscope/controller_test.go
@@ -218,8 +218,9 @@ func TestReconcileCreateLoggingScopeFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcileCreateLoggingScopeFailed tests the path of reconciling a MultiClusterLoggingScope
@@ -270,8 +271,9 @@ func TestReconcileUpdateLoggingScopeFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterLoggingScope which

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -73,7 +73,17 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		_, err = clusters.AddFinalizer(ctx, r.Client, &mcSecret, finalizerName)
 	}
 
-	return r.updateStatus(ctx, &mcSecret, opResult, err)
+	ctrlResult, updateErr := r.updateStatus(ctx, &mcSecret, opResult, err)
+
+	// if an error occurred in createOrUpdate, return that error with a requeue
+	// even if update status succeeded
+	if err != nil {
+		res := ctrl.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}
+		return res, err
+	}
+
+	return ctrlResult, updateErr
+
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, mcSecret *clustersv1alpha1.MultiClusterSecret, opResult controllerutil.OperationResult, err error) (ctrl.Result, error) {

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -208,8 +208,9 @@ func TestReconcileCreateSecretFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 func TestReconcileUpdateSecretFailed(t *testing.T) {
@@ -250,8 +251,9 @@ func TestReconcileUpdateSecretFailed(t *testing.T) {
 	result, err := reconciler.Reconcile(request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	// expect an error and requeue upon failure
+	assert.NotNil(err)
+	assert.Equal(true, result.Requeue)
 }
 
 // TestReconcilePlacementInDifferentCluster tests the path of reconciling a MultiClusterSecret which


### PR DESCRIPTION
# Description

Return errors from MC controllers when the create/update fails but the status update succeeds. Previously they were swallowing these errors and failing to requeue.

expected to fix VZ-2549 

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
