### PR TITLE
Tvlatas/calico version and mccaching

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,6 +305,7 @@ pipeline {
                     make cleanup-cluster
                     make integ-test KIND_CONFIG="kind-config-ci.yaml" CLUSTER_DUMP_LOCATION=${WORKSPACE}/application-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
                     ../build/copy-junit-output.sh ${WORKSPACE}
+                    make cleanup-cluster
                 """
             }
             post {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -554,10 +554,10 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 # specify the cache name based on the count value, this is assuming 1 or 2 clusters
                 case "${count}" in
                     1)
-                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "vpo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${CREATE_KIND_USE_CALICO} "vpo_integ"
                         ;;
                     2)
-                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "apo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${CREATE_KIND_USE_CALICO} "apo_integ"
                         ;;
                     *)
                         ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "NONE"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -554,7 +554,7 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO}
                 if [ ${CREATE_KIND_USE_CALICO} == true ]; then
                     echo "Install Calico"
-                    kubectl apply -f https://docs.projectcalico.org/manifests/canal.yaml
+                    kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml
                 fi
                 echo "Install metallb"
                 cd ${GO_REPO_PATH}/verrazzano

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -550,8 +550,20 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 echo "Create Kind cluster \$1"
                 cd ${TEST_SCRIPTS_DIR}
-                # Not using the caching, and not setting up Calico
-                ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO}
+                # As a stop gap, for now we are using the api/vpo caches here to see if it helps with rate limiting issues, we will need to add specific caches so for now
+                # specify the cache name based on the count value, this is assuming 1 or 2 clusters
+                case "${count}" in
+                    1)
+                        export CACHE_NAME="vpo_integ"
+                        ;;
+                    2)
+                        export CACHE_NAME="apo_integ"
+                        ;;
+                    *)
+                        export CACHE_NAME="NONE"
+                        ;;
+                esac
+                ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} ${CACHE_NAME}
                 if [ ${CREATE_KIND_USE_CALICO} == true ]; then
                     echo "Install Calico"
                     kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -565,7 +565,7 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 esac
                 if [ ${CREATE_KIND_USE_CALICO} == true ]; then
                     echo "Install Calico"
-                    kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml
+                    kubectl apply -f https://docs.projectcalico.org/v3.18/manifests/calico.yaml
                 fi
                 echo "Install metallb"
                 cd ${GO_REPO_PATH}/verrazzano

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -554,16 +554,15 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 # specify the cache name based on the count value, this is assuming 1 or 2 clusters
                 case "${count}" in
                     1)
-                        export CACHE_NAME="vpo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "vpo_integ"
                         ;;
                     2)
-                        export CACHE_NAME="apo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "apo_integ"
                         ;;
                     *)
-                        export CACHE_NAME="NONE"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} "NONE"
                         ;;
                 esac
-                ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${CREATE_KIND_USE_CALICO} ${CACHE_NAME}
                 if [ ${CREATE_KIND_USE_CALICO} == true ]; then
                     echo "Install Calico"
                     kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -25,7 +25,7 @@ cd ${TEST_SCRIPTS_DIR}
 
 if [ $INSTALL_CALICO == true ]; then
     echo "Install Calico"
-    kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml
+    kubectl apply -f https://docs.projectcalico.org/v3.18/manifests/calico.yaml
 fi
 
 echo "Install metallb"

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -25,7 +25,7 @@ cd ${TEST_SCRIPTS_DIR}
 
 if [ $INSTALL_CALICO == true ]; then
     echo "Install Calico"
-    kubectl apply -f https://docs.projectcalico.org/manifests/canal.yaml
+    kubectl apply -f https://docs.projectcalico.org/archive/v3.18/manifests/canal.yaml
 fi
 
 echo "Install metallb"

--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -13,6 +13,7 @@ CLEANUP_KIND_CONTAINERS=${5:-true}
 CONNECT_JENKINS_RUNNER_TO_NETWORK=${6:-true}
 KIND_AT_CACHE=${7:-false}
 SETUP_CALICO=${8:-false}
+KIND_AT_CACHE_NAME=${9:-"NONE"}
 KIND_IMAGE=""
 CALICO_SUFFIX=""
 
@@ -54,7 +55,15 @@ create_kind_cluster() {
   cd ${SCRIPT_DIR}/
   KIND_CONFIG_FILE=kind-config${CALICO_SUFFIX}.yaml
   if [ ${KIND_AT_CACHE} == true ]; then
-    KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}.yaml
+    if [ ${KIND_AT_CACHE_NAME} != "NONE" ]; then
+      # If a cache name was specified, replace the at_test cache name with the one specified (this is used only
+      # for multi-cluster tests at the moment)
+      sed "s;v8o_cache/at_tests;v8o_cache/${KIND_AT_CACHE_NAME};g" kind-config-ci${CALICO_SUFFIX}.yaml > kind-config-ci${CALICO_SUFFIX}_${KIND_AT_CACHE_NAME}.yaml
+      KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}_${KIND_AT_CACHE_NAME}.yaml
+    else
+      # If no cache name specified use at_tests cache
+      KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}.yaml
+    fi
   fi
   echo "Using ${KIND_CONFIG_FILE}"
   sed -i "s/KIND_IMAGE/${KIND_IMAGE}/g" ${KIND_CONFIG_FILE}


### PR DESCRIPTION
# Description

This includes:

-  Added multi-cluster caching support (it is using the caches we have now, we can follow up with specific caches for multi-cluster). The intention is that this can help with rate limiting on Calico related image pulls. The images were already on the VM in docker, the suspicion is that we needed to use the cache as well. This is working and it looks like install time is down, but we won't really know related to rate limiting if it will really help or if something else with Calico could be forcing the images to always be pulled that I'm not seeing under the covers.
-  Changed the Calico yaml we are using to be as specific as they allow for version, and which yaml we use: https://docs.projectcalico.org/v3.18/manifests/calico.yaml
-  Fixed problem where apo-integ tests were not deleting the cluster in Jenkins, we had hoped it was related to the long cluster time with Calico but it isn't so this is more just a cleanup


# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
