### PR TITLE
remove spurious check for condition msg in integ tests

### DIFF
--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -6,7 +6,6 @@ package integ_test
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -71,7 +70,7 @@ var _ = ginkgo.Describe("Testing Multi-Cluster CRDs", func() {
 			// Verify we have the expected status update
 			mcRetrievedSecret, err := K8sClient.GetMultiClusterSecret(multiclusterTestNamespace, "mymcsecret2")
 			return err == nil && mcRetrievedSecret.Status.State == clustersv1alpha1.Pending &&
-				isStatusAsExpected(mcRetrievedSecret.Status, clustersv1alpha1.DeployComplete, "created", clustersv1alpha1.Succeeded, "managed1")
+				isStatusAsExpected(mcRetrievedSecret.Status, clustersv1alpha1.DeployComplete, clustersv1alpha1.Succeeded, "managed1")
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 	ginkgo.It("Apply MultiClusterComponent creates OAM component ", func() {
@@ -101,7 +100,7 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 		gomega.Eventually(func() bool {
 			// Verify we have the expected status update
 			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "mymcconfigmap")
-			return err == nil && isStatusAsExpected(mcConfigMap.Status, clustersv1alpha1.DeployComplete, "created", clustersv1alpha1.Succeeded, managedClusterName)
+			return err == nil && isStatusAsExpected(mcConfigMap.Status, clustersv1alpha1.DeployComplete, clustersv1alpha1.Succeeded, managedClusterName)
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 	ginkgo.It("Apply Invalid MultiClusterConfigMap results in Failed Status", func() {
@@ -117,7 +116,7 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 			// Verify the controller is not updating the status more than once with the failure,
 			// and is adding exactly one cluster level status entry
 			mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "invalid-mccm")
-			return err == nil && isStatusAsExpected(mcConfigMap.Status, clustersv1alpha1.DeployFailed, "", clustersv1alpha1.Failed, managedClusterName)
+			return err == nil && isStatusAsExpected(mcConfigMap.Status, clustersv1alpha1.DeployFailed, clustersv1alpha1.Failed, managedClusterName)
 		}, duration, pollInterval).Should(gomega.BeTrue())
 	})
 })
@@ -186,7 +185,7 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 		gomega.Eventually(func() bool {
 			vp, err := K8sClient.GetVerrazzanoProject(constants.VerrazzanoMultiClusterNamespace, "test-default-labels")
-			return err == nil && isStatusAsExpected(vp.Status, clustersv1alpha1.DeployComplete, "created", clustersv1alpha1.Succeeded, "managed1")
+			return err == nil && isStatusAsExpected(vp.Status, clustersv1alpha1.DeployComplete, clustersv1alpha1.Succeeded, "managed1")
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 	ginkgo.It("Apply VerrazzanoProject to override default verrazzano labels", func() {
@@ -232,7 +231,7 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 		gomega.Eventually(func() bool {
 			vp, err := K8sClient.GetVerrazzanoProject(constants.VerrazzanoMultiClusterNamespace, "test-default-labels")
-			return err == nil && isStatusAsExpected(vp.Status, clustersv1alpha1.DeployComplete, "created", clustersv1alpha1.Succeeded, "managed1")
+			return err == nil && isStatusAsExpected(vp.Status, clustersv1alpha1.DeployComplete, clustersv1alpha1.Succeeded, "managed1")
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 })
@@ -360,13 +359,13 @@ func createRegistrationSecret() {
 }
 
 func isStatusAsExpected(status clustersv1alpha1.MultiClusterResourceStatus,
-	expectedConditionType clustersv1alpha1.ConditionType, conditionMsgContains string,
+	expectedConditionType clustersv1alpha1.ConditionType,
 	expectedClusterState clustersv1alpha1.StateType,
 	expectedClusterName string) bool {
 	matchingConditionCount := 0
 	matchingClusterStatusCount := 0
 	for _, condition := range status.Conditions {
-		if condition.Type == expectedConditionType && strings.Contains(condition.Message, conditionMsgContains) {
+		if condition.Type == expectedConditionType {
 			matchingConditionCount++
 		}
 	}


### PR DESCRIPTION
# Description

Fixes the integ test failure in master - integ tests have a check for a string value in the condition message field which may no longer be there.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
