### PR TITLE
Delete default logging scope on app configuration delete

### DIFF
--- a/application-operator/controllers/webhooks/appconfig_defaulter.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter.go
@@ -59,10 +59,11 @@ func (a *AppConfigWebhook) Handle(ctx context.Context, req admission.Request) ad
 	appConfig := &oamv1.ApplicationConfiguration{}
 	//This json can be used to curl -X POST the webhook endpoint
 	log.V(1).Info("admission.Request", "request", req)
+	log.Info("Handling appconfig default",
+		"request.Operation", req.Operation, "appconfig.Name", req.Name)
 
 	// if the operation is Delete then decode the old object and call the defaulter to cleanup any app conf defaults
 	if req.Operation == v1beta12.Delete {
-		log.Info("cleaning up appconfig default", "appconfig.Name", req.Name)
 		err := a.decoder.DecodeRaw(req.OldObject, appConfig)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
@@ -82,8 +83,6 @@ func (a *AppConfigWebhook) Handle(ctx context.Context, req admission.Request) ad
 		return admission.Allowed("cleaned up appconfig default")
 	}
 
-	log.Info("Handling appconfig default",
-		"request.Operation", req.Operation, "appconfig.Name", req.Name)
 	err := a.decoder.Decode(req, appConfig)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)

--- a/application-operator/controllers/webhooks/logging_scope_defaulter.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter.go
@@ -36,10 +36,10 @@ func (d *LoggingScopeDefaulter) Default(appConfig *oamv1.ApplicationConfiguratio
 	if err == nil && ns != nil {
 		defaultLoggingScopeName := getDefaultLoggingScopeName(appConfig)
 		log.Info("defaultLoggingScope",
-			"loggingScope", defaultLoggingScopeName, "dryRun", dryRun, "namespaceStatus", ns.Status.Phase)
+			"loggingScope", defaultLoggingScopeName, "dryRun", dryRun, "namespaceStatus", ns.Status.Phase, "appConfigDeleteTimeStamp", appConfig.DeletionTimestamp)
 
-		// don't attempt to create a default logging scope if the namespace is terminating
-		if ns.Status.Phase != v1.NamespaceTerminating {
+		// don't attempt to create a default logging scope if the namespace or application config is terminating
+		if ns.Status.Phase != v1.NamespaceTerminating && appConfig.DeletionTimestamp.IsZero() {
 			defaultLoggingComponentScope := oamv1.ComponentScope{
 				ScopeReference: runtimev1alpha1.TypedReference{
 					APIVersion: loggingScopeAPIVersion,
@@ -165,7 +165,7 @@ func fetchLoggingScope(ctx context.Context, c client.Reader, name types.Namespac
 
 // fetchNamespace attempts to get a namespace for the given name
 func fetchNamespace(ctx context.Context, c client.Reader, name types.NamespacedName) (*v1.Namespace, error) {
-	log.Info("Fetch scope", "scope", name)
+	log.Info("Fetch namespace", "namespace", name)
 	var ns v1.Namespace
 	err := c.Get(ctx, name, &ns)
 	if err != nil {

--- a/application-operator/controllers/webhooks/testdata/hello-conf-deleting.yaml
+++ b/application-operator/controllers/webhooks/testdata/hello-conf-deleting.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: hello-app
+  namespace: default
+  annotations:
+    version: v1.0.0
+    description: "Hello application"
+  creationTimestamp: "2021-04-21T20:30:49Z"
+  deletionTimestamp: "2021-04-21T20:35:49Z"
+spec:
+  components:
+    - componentName: hello-component


### PR DESCRIPTION
# Description

Currently, the default logging scope is deleted but then recreated with empty workload reference on app configuration delete. This change provides the fix such that its not recreated.

Fixes VZ-2407

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
