### PR TITLE
Potential fix for MC change placement test failure

### DIFF
--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -330,7 +330,9 @@ func SetEffectiveStateIfChanged(placement clustersv1alpha1.Placement,
 	return statusPtr.State
 }
 
-// DeleteAssociatedResource will retrieve and delete the resource specified by the name
+// DeleteAssociatedResource will retrieve and delete the resource specified by the name. It is used to delete
+// the underlying resource corresponding to a MultiClusterxxx wrapper resource (e.g. the OAM app config corresponding
+// to a MultiClusterApplicationConfiguration)
 func DeleteAssociatedResource(ctx context.Context, c client.Client, mcResource runtime.Object, finalizerName string, resourceToDelete runtime.Object, name types.NamespacedName) error {
 	// Get and delete the associated with the name specified by resourceToDelete
 	err := c.Get(ctx, name, resourceToDelete)

--- a/application-operator/controllers/clusters/cluster_utils.go
+++ b/application-operator/controllers/clusters/cluster_utils.go
@@ -332,15 +332,7 @@ func SetEffectiveStateIfChanged(placement clustersv1alpha1.Placement,
 
 // DeleteAssociatedResource will retrieve and delete the resource specified by the name
 func DeleteAssociatedResource(ctx context.Context, c client.Client, mcResource runtime.Object, finalizerName string, resourceToDelete runtime.Object, name types.NamespacedName) error {
-	// assert the MC object is a controller util Object that can be processed by controller util convenience methods
-	mcObj, ok := mcResource.(controllerutil.Object)
-	if ok {
-		controllerutil.RemoveFinalizer(mcObj, finalizerName)
-		err := c.Update(ctx, mcResource)
-		if err != nil {
-			return err
-		}
-	}
+	// Get and delete the associated with the name specified by resourceToDelete
 	err := c.Get(ctx, name, resourceToDelete)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -351,6 +343,18 @@ func DeleteAssociatedResource(ctx context.Context, c client.Client, mcResource r
 	err = c.Delete(ctx, resourceToDelete)
 	if err != nil {
 		return err
+	}
+
+	// Deletion succeeded, now we can remove the finalizer
+
+	// assert the MC object is a controller util Object that can be processed by controllerutil.RemoveFinalizer
+	mcObj, ok := mcResource.(controllerutil.Object)
+	if ok {
+		controllerutil.RemoveFinalizer(mcObj, finalizerName)
+		err := c.Update(ctx, mcResource)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
+++ b/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
@@ -193,6 +193,14 @@ var _ = ginkgo.AfterSuite(func() {
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, adminKubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete %s namespace: %v\n", examples.TestNamespace, err))
 	}
+
+	// Wait until the namespace is fully deleted in both clusters, so that we don't interfere with other subsequent
+	// tests that may use the examples namespace
+	gomega.Eventually(func() bool {
+		return !pkg.DoesNamespaceExistInCluster(examples.TestNamespace, managed1Kubeconfig) &&
+			!pkg.DoesNamespaceExistInCluster(examples.TestNamespace, adminKubeconfig)
+	}, waitTimeout, pollingInterval)
+
 })
 
 func cleanUp() error {

--- a/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
+++ b/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
@@ -73,8 +73,7 @@ var _ = ginkgo.Describe("Multicluster app placed in managed cluster", func() {
 		// GIVEN an admin cluster and at least one managed cluster
 		// WHEN the example application has been deployed to the admin cluster
 		// THEN expect that the multi-cluster resources have been created on the managed cluster
-		// desagar Temporarily disabled pending fix (part of VZ-2559)
-		ginkgo.PIt("Has multi cluster resources", func() {
+		ginkgo.It("Has multi cluster resources", func() {
 			gomega.Eventually(func() bool {
 				return examples.VerifyMCResources(managed1Kubeconfig, false, true)
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
@@ -82,8 +81,7 @@ var _ = ginkgo.Describe("Multicluster app placed in managed cluster", func() {
 		// GIVEN an admin cluster and at least one managed cluster
 		// WHEN the multi-cluster example application has been created on admin cluster and placed in managed cluster
 		// THEN expect that the app is deployed to the managed cluster
-		// desagar Temporarily disabled pending fix (part of VZ-2559)
-		ginkgo.PIt("Has application placed", func() {
+		ginkgo.It("Has application placed", func() {
 			gomega.Eventually(func() bool {
 				return examples.VerifyHelloHelidonInCluster(managed1Kubeconfig, false, true)
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
@@ -154,8 +152,7 @@ var _ = ginkgo.Describe("Multicluster app placed in managed cluster", func() {
 		// GIVEN a managed cluster
 		// WHEN the multi-cluster example application has changed placement to this managed cluster
 		// THEN expect that the app is now deployed to the cluster
-		// desagar Temporarily disabled pending fix (part of VZ-2559)
-		ginkgo.PIt("Managed cluster again has application placed", func() {
+		ginkgo.It("Managed cluster again has application placed", func() {
 			gomega.Eventually(func() bool {
 				return examples.VerifyHelloHelidonInCluster(managed1Kubeconfig, false, true)
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())

--- a/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
+++ b/tests/e2e/multicluster/examples/change-placement/change_placement_example_test.go
@@ -25,6 +25,12 @@ var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managed1Kubeconfig = os.Getenv("MANAGED_KUBECONFIG")
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	// failed var indicates whether any of the tests has failed
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 // Deploy the example resources to the admin cluster
 var _ = ginkgo.BeforeSuite(func() {
 	// deploy the VerrazzanoProject
@@ -177,7 +183,9 @@ var _ = ginkgo.Describe("Multicluster app placed in managed cluster", func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	pkg.ExecuteClusterDumpWithEnvVarConfig()
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, managed1Kubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete hello-helidon namespace: %v\n", err))
 	}

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -110,7 +110,7 @@ func VerifyHelloHelidonDeletedAdminCluster(kubeconfigPath string, placedInCluste
 		return mcResDeleted
 	}
 
-	appDeleted := verifyAppDeleted(kubeconfigPath)
+	appDeleted := VerifyAppDeleted(kubeconfigPath)
 
 	return mcResDeleted && appDeleted
 }
@@ -131,7 +131,8 @@ func VerifyHelloHelidonDeletedInManagedCluster(kubeconfigPath string) bool {
 	*/
 }
 
-func verifyAppDeleted(kubeconfigPath string) bool {
+// VerifyAppDeleted - verifies that the workload and pods are deleted on the the specified cluster
+func VerifyAppDeleted(kubeconfigPath string) bool {
 	workloadExists := componentWorkloadExists(kubeconfigPath)
 	podsRunning := helloHelidonPodsRunning(kubeconfigPath)
 	return !workloadExists && !podsRunning

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("Multi-cluster verify hello-helidon", func() {
 
 	ginkgo.Context("Delete resources on admin cluster", func() {
 		ginkgo.It("Delete all the things", func() {
-			err := cleanUp()
+			err := cleanUp(adminKubeconfig)
 			if err != nil {
 				ginkgo.Fail(err.Error())
 			}
@@ -183,6 +183,13 @@ var _ = ginkgo.AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
+	// This is necessary because of VZ-2454 since resources are not automatically deleted on managed cluster
+	err := cleanUp(managedKubeconfig)
+	if err != nil {
+		fmt.Printf("Cleanup failed on managed cluster: %v", err.Error())
+	}
+	gomega.Eventually(examples.VerifyAppDeleted, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, managedKubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete hello-helidon namespace: %v\n", err))
 	}
@@ -191,7 +198,7 @@ var _ = ginkgo.AfterSuite(func() {
 		ginkgo.Fail(fmt.Sprintf("Could not delete %s namespace: %v\n", examples.TestNamespace, err))
 	}
 
-	// Wait until the namespace is fully deleted in both clusters, so that we don't interfere with other subsequent
+	// Wait until the namespace is deleted in both clusters, so that we don't interfere with other subsequent
 	// tests that may use the examples namespace
 	gomega.Eventually(func() bool {
 		return !pkg.DoesNamespaceExistInCluster(examples.TestNamespace, managedKubeconfig) &&
@@ -200,16 +207,16 @@ var _ = ginkgo.AfterSuite(func() {
 
 })
 
-func cleanUp() error {
-	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml", adminKubeconfig); err != nil {
+func cleanUp(kubeconfigPath string) error {
+	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml", kubeconfigPath); err != nil {
 		return fmt.Errorf("Failed to delete multi-cluster hello-helidon application resource: %v", err)
 	}
 
-	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/mc-hello-helidon-comp.yaml", adminKubeconfig); err != nil {
+	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/mc-hello-helidon-comp.yaml", kubeconfigPath); err != nil {
 		return fmt.Errorf("Failed to delete multi-cluster hello-helidon component resources: %v", err)
 	}
 
-	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/verrazzano-project.yaml", adminKubeconfig); err != nil {
+	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon/verrazzano-project.yaml", kubeconfigPath); err != nil {
 		return fmt.Errorf("Failed to delete hello-helidon project resource: %v", err)
 	}
 	return nil

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -25,6 +25,12 @@ var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	// failed var indicates whether any of the tests has failed
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = ginkgo.BeforeSuite(func() {
 	// deploy the VerrazzanoProject
@@ -174,7 +180,9 @@ var _ = ginkgo.Describe("Multi-cluster verify hello-helidon", func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	pkg.ExecuteClusterDumpWithEnvVarConfig()
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, managedKubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete hello-helidon namespace: %v\n", err))
 	}

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -188,7 +188,9 @@ var _ = ginkgo.AfterSuite(func() {
 	if err != nil {
 		fmt.Printf("Cleanup failed on managed cluster: %v", err.Error())
 	}
-	gomega.Eventually(examples.VerifyAppDeleted, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+	gomega.Eventually(func() bool {
+		return examples.VerifyAppDeleted(managedKubeconfig)
+	}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, managedKubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete hello-helidon namespace: %v\n", err))

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -190,6 +190,14 @@ var _ = ginkgo.AfterSuite(func() {
 	if err := pkg.DeleteNamespaceInCluster(examples.TestNamespace, adminKubeconfig); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Could not delete %s namespace: %v\n", examples.TestNamespace, err))
 	}
+
+	// Wait until the namespace is fully deleted in both clusters, so that we don't interfere with other subsequent
+	// tests that may use the examples namespace
+	gomega.Eventually(func() bool {
+		return !pkg.DoesNamespaceExistInCluster(examples.TestNamespace, managedKubeconfig) &&
+			!pkg.DoesNamespaceExistInCluster(examples.TestNamespace, adminKubeconfig)
+	}, waitTimeout, pollingInterval)
+
 })
 
 func cleanUp() error {

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -110,10 +110,15 @@ func DoesCRDExist(crdName string) bool {
 	return false
 }
 
-// DoesNamespaceExist returns whether a namespace with the given name exists for the cluster
+// DoesNamespaceExist returns whether a namespace with the given name exists for the cluster set in the environment
 func DoesNamespaceExist(name string) bool {
+	return DoesNamespaceExistInCluster(name, GetKubeConfigPathFromEnv())
+}
+
+// DoesNamespaceExistInCluster returns whether a namespace with the given name exists in the specified cluster
+func DoesNamespaceExistInCluster(name string, kubeconfigPath string) bool {
 	// Get the Kubernetes clientset
-	clientset := GetKubernetesClientset()
+	clientset := GetKubernetesClientsetForCluster(kubeconfigPath)
 
 	namespace, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -427,8 +427,7 @@ func DeleteNamespace(name string) error {
 func DeleteNamespaceInCluster(name string, kubeconfigPath string) error {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientsetForCluster(kubeconfigPath)
-	policy := metav1.DeletePropagationForeground // delete in the foreground and wait for the delete to complete
-	err := clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &policy})
+	err := clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
 		Log(Error, fmt.Sprintf("DeleteNamespace %s error: %v", name, err))
 	}

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -427,7 +427,8 @@ func DeleteNamespace(name string) error {
 func DeleteNamespaceInCluster(name string, kubeconfigPath string) error {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientsetForCluster(kubeconfigPath)
-	err := clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	policy := metav1.DeletePropagationForeground // delete in the foreground and wait for the delete to complete
+	err := clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &policy})
 	if err != nil {
 		Log(Error, fmt.Sprintf("DeleteNamespace %s error: %v", name, err))
 	}


### PR DESCRIPTION
# Description

Potential fix for MC change placement test failure - does the following things:
* Changes the Helidon and ChangePlacement example tests to explicitly delete apps in managed cluster and wait for namespace deletion to complete before proceeding
* Changes the finalizer removal logic for MC resources to remove the finalizer _after_ deleting the underlying resource
* Re-enables the disabled previously failing assertions in Change Placement test
* Only perform a cluster dump for the 2 examples e2e tests if they fail

Partially fixes VZ-2559

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
