### PR TITLE
Update timeout for Springboot tests, add test-specific cluster dumps on failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 platform-operator/THIRD_PARTY_LICENSES.txt
 application-operator/THIRD_PARTY_LICENSES.txt
 tools/analysis/THIRD_PARTY_LICENSES.txt
+tests/e2e/**/*.test

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -134,6 +134,7 @@ pipeline {
 
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
     }
 
     stages {
@@ -364,7 +365,7 @@ pipeline {
                 stage('generic-springboot') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/generic-springboot-test.log"
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-springboot-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-springboot"
                     }
                     steps {
                         script {
@@ -395,7 +396,7 @@ pipeline {
                 }
                 stage('hello-helidon') {
                     environment {
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-hello-helidon-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-hello-helidon"
                     }
                     steps {
                         script {
@@ -427,7 +428,7 @@ pipeline {
                 stage('lift-and-shift') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/lift-and-shift-test.log"
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-lift-and-shift-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-lift-and-shift"
                     }
                     steps {
                         script {
@@ -437,7 +438,7 @@ pipeline {
                 }
                 stage('istio authorization policy') {
                     environment {
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-istio-auth-policy-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-istio-auth-policy"
                     }
                     steps {
                         runGinkgo('istio/authz')
@@ -445,7 +446,7 @@ pipeline {
                 }
                 stage('security role based access') {
                     environment {
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-rbac-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-rbac"
                     }
                     steps {
                         runGinkgo('security/rbac')
@@ -454,7 +455,7 @@ pipeline {
                 stage('bobs-books') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-book-test.log"
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-bobs-books-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-bobs-books-dump"
                     }
                     steps {
                         script {
@@ -476,7 +477,7 @@ pipeline {
                 stage('socks') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/socks-test.log"
-                        DUMP_DIRECTORY="${WORKSPACE}/examples-socks-cluster-dump"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-socks"
                     }
                     steps {
                         script {
@@ -519,7 +520,7 @@ pipeline {
                     sort -u -o ${IMG_LIST_FILE} ${IMG_LIST_FILE}
                 fi
             """
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/test-cluster-dumps/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
             sh """
                 if [ "${TEST_ENV}" == "ocidns_oke" ]; then

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -432,7 +432,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            runGinkgo('examples/todo')
+                            runGinkgoFailFast('examples/todo')
                         }
                     }
                 }
@@ -459,7 +459,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            runGinkgo('examples/bobsbooks')
+                            runGinkgoFailFast('examples/bobsbooks')
                         }
                         sh """
                             ${WORKSPACE}/tests/e2e/config/scripts/get_verrazzano_image.sh bob >> ${IMG_LIST_FILE}

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -131,6 +131,9 @@ pipeline {
         ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
 
         VZ_ENVIRONMENT_NAME = "${params.TEST_ENV == 'ocidns_oke' ? 'b' + env.BUILD_NUMBER : 'default'}"
+
+        DUMP_KUBECONFIG="${KUBECONFIG}"
+        DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
     }
 
     stages {
@@ -361,6 +364,7 @@ pipeline {
                 stage('generic-springboot') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/generic-springboot-test.log"
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-springboot-cluster-dump"
                     }
                     steps {
                         script {
@@ -390,6 +394,9 @@ pipeline {
                     }
                 }
                 stage('hello-helidon') {
+                    environment {
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-hello-helidon-cluster-dump"
+                    }
                     steps {
                         script {
                             runGinkgoFailFast('examples/helidon')
@@ -420,6 +427,7 @@ pipeline {
                 stage('lift-and-shift') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/lift-and-shift-test.log"
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-lift-and-shift-cluster-dump"
                     }
                     steps {
                         script {
@@ -428,11 +436,17 @@ pipeline {
                     }
                 }
                 stage('istio authorization policy') {
+                    environment {
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-istio-auth-policy-cluster-dump"
+                    }
                     steps {
                         runGinkgo('istio/authz')
                     }
                 }
                 stage('security role based access') {
+                    environment {
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-rbac-cluster-dump"
+                    }
                     steps {
                         runGinkgo('security/rbac')
                     }
@@ -440,6 +454,7 @@ pipeline {
                 stage('bobs-books') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-book-test.log"
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-bobs-books-dump"
                     }
                     steps {
                         script {
@@ -461,6 +476,7 @@ pipeline {
                 stage('socks') {
                     environment {
                         DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/socks-test.log"
+                        DUMP_DIRECTORY="${WORKSPACE}/examples-socks-cluster-dump"
                     }
                     steps {
                         script {

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -29,7 +29,7 @@ function install_nginx_ingress_controller()
     local EXTRA_NGINX_ARGUMENTS=$(get_nginx_helm_args_from_config)
 
     if [ "$DNS_TYPE" == "oci" ]; then
-      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=\"60\""
+      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=60"
       local dns_zone=$(get_config_value ".dns.oci.dnsZoneName")
       EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/hostname=verrazzano-ingress.${NAME}.${dns_zone}"
     fi

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -29,7 +29,7 @@ function install_nginx_ingress_controller()
     local EXTRA_NGINX_ARGUMENTS=$(get_nginx_helm_args_from_config)
 
     if [ "$DNS_TYPE" == "oci" ]; then
-      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=\"60\""
+      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set-string controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=60"
       local dns_zone=$(get_config_value ".dns.oci.dnsZoneName")
       EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/hostname=verrazzano-ingress.${NAME}.${dns_zone}"
     fi

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -29,7 +29,7 @@ function install_nginx_ingress_controller()
     local EXTRA_NGINX_ARGUMENTS=$(get_nginx_helm_args_from_config)
 
     if [ "$DNS_TYPE" == "oci" ]; then
-      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=60"
+      EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/ttl=\"60\""
       local dns_zone=$(get_config_value ".dns.oci.dnsZoneName")
       EXTRA_NGINX_ARGUMENTS="$EXTRA_NGINX_ARGUMENTS --set controller.service.annotations.external-dns\.alpha\.kubernetes\.io/hostname=verrazzano-ingress.${NAME}.${dns_zone}"
     fi

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -45,7 +45,15 @@ var _ = ginkgo.BeforeSuite(func() {
 
 })
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 var _ = ginkgo.AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	undeployBobsBooksExample()
 })
 

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -28,21 +28,6 @@ var (
 
 var _ = ginkgo.BeforeSuite(func() {
 	deployBobsBooksExample()
-
-	gomega.Eventually(func() bool {
-		expectedPods := []string{
-			"bobbys-front-end-adminserver",
-			"bobs-bookstore-adminserver",
-			"bobbys-coherence-0",
-			"roberts-coherence-0",
-			"roberts-coherence-1",
-			"bobbys-helidon-stock-application",
-			"robert-helidon",
-			"mysql",
-		}
-		return pkg.PodsRunning("bobs-books", expectedPods)
-	}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Bobs Books Application Failed to Deploy")
-
 })
 
 var failed = false
@@ -136,7 +121,25 @@ func undeployBobsBooksExample() {
 }
 
 var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
+
+	ginkgo.It("Wait for deployment.", func() {
+		gomega.Eventually(func() bool {
+			expectedPods := []string{
+				"bobbys-front-end-adminserver",
+				"bobs-bookstore-adminserver",
+				"bobbys-coherence-0",
+				"roberts-coherence-0",
+				"roberts-coherence-1",
+				"bobbys-helidon-stock-application",
+				"robert-helidon",
+				"mysql",
+			}
+			return pkg.PodsRunning("bobs-books", expectedPods)
+		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Bobs Books Application Failed to Deploy")
+	})
+
 	var host = ""
+
 	// Get the host from the Istio gateway resource.
 	// GIVEN the Istio gateway for the bobs-books namespace
 	// WHEN GetHostnameFromGateway is called

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -51,6 +51,17 @@ var _ = BeforeSuite(func() {
 	}
 })
 
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
+})
+
+var _ = AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
+})
+
 // the list of expected pods
 var expectedPods = []string{
 	"carts-coh-0",

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -51,17 +51,6 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentGinkgoTestDescription().Failed
-})
-
-var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
-})
-
 // the list of expected pods
 var expectedPods = []string{
 	"carts-coh-0",
@@ -206,8 +195,16 @@ var _ = Describe("Sock Shop Application", func() {
 
 })
 
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
+})
+
 // undeploys the application, components, and namespace
 var _ = AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	err := undeploySockShopApplication()
 	if err != nil {
 		Fail(fmt.Sprintf("Could not undeploy sock shop application: %v\n", err.Error()))

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -32,7 +32,15 @@ var _ = ginkgo.BeforeSuite(func() {
 	deploySpringBootApplication()
 })
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 var _ = ginkgo.AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	undeploySpringBootApplication()
 })
 

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("Verify Spring Boot Application", func() {
 			status, content := pkg.GetWebPageWithCABundle(url, host)
 			return gomega.Expect(status).To(gomega.Equal(200)) &&
 				gomega.Expect(content).To(gomega.ContainSubstring("Greetings from Verrazzano Enterprise Container Platform"))
-		}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 	})
 
 	ginkgo.It("Verify Verrazzano facts endpoint is working.", func() {
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Verify Spring Boot Application", func() {
 			status, content := pkg.GetWebPageWithCABundle(url, host)
 			gomega.Expect(len(content) > 0, fmt.Sprintf("An empty string returned from /facts endpoint %v", content))
 			return gomega.Expect(status).To(gomega.Equal(200))
-		}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 	})
 
 	ginkgo.Context("Logging.", func() {

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -31,7 +31,15 @@ var _ = ginkgo.BeforeSuite(func() {
 	deployToDoListExample()
 })
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 var _ = ginkgo.AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	undeployToDoListExample()
 })
 

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -43,7 +43,15 @@ var _ = ginkgo.BeforeSuite(func() {
 	deployNoIstioApplication()
 })
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 var _ = ginkgo.AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	undeployFooApplication()
 	undeployBarApplication()
 	undeployNoIstioApplication()

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -33,7 +33,15 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 })
 
+var failed = false
+var _ = ginkgo.AfterEach(func() {
+	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+})
+
 var _ = ginkgo.AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	pkg.Log(pkg.Info, "Delete namespace")
 	if err := pkg.DeleteNamespace(rbacTestNamespace); err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))


### PR DESCRIPTION
# Description

Update timeout for Springboot tests, add test-specific cluster dumps on failure.
- fix ingress-nginx service TTL annotation for external-dns
- add cluster-dump on failure to tests
- update .gitignore to ignore ginkgo generated ".test" files

Fixes VZ-2572

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
