### PR TITLE
Add logic to create 2 new internal users for metrics communication be…

### DIFF
--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -49,7 +49,7 @@ const (
 	DefaultElasticSearchURL = "http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local:9200"
 
 	// DefaultSecretName defines the default Elasticsearch secret name used if it is not specified in the logging scope
-	DefaultSecretName = "verrazzano"
+	DefaultSecretName = "verrazzano-es-internal"
 )
 
 // DefaultFluentdImage holds the default FLUENTD image that will be used if it is not specified in the logging scope

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -12,6 +12,9 @@ const VerrazzanoSystemNamespace = "verrazzano-system"
 // Verrazzano is the name of the verrazzano secret in the Verrazzano system namespace
 const Verrazzano = "verrazzano"
 
+// VerrazzanoPromInternal is the name of the verrazzano internal prometheus secret in the Verrazzano system namespace
+const VerrazzanoPromInternal = "verrazzano-prom-internal"
+
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano
 const VerrazzanoMultiClusterNamespace = "verrazzano-mc"
 

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -15,6 +15,9 @@ const Verrazzano = "verrazzano"
 // VerrazzanoPromInternal is the name of the verrazzano internal prometheus secret in the Verrazzano system namespace
 const VerrazzanoPromInternal = "verrazzano-prom-internal"
 
+// VerrazzanoESInternal is the name of the verrazzano internal elasticsearch secret in the Verrazzano system namespace
+const VerrazzanoESInternal = "verrazzano-es-internal"
+
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano
 const VerrazzanoMultiClusterNamespace = "verrazzano-mc"
 

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -36,7 +36,7 @@ static_configs:
   labels:
     managed_cluster: '##CLUSTER_NAME##'
 basic_auth:
-  username: verrazzano
+  username: verrazzano-prom-internal
   password: ##PASSWORD##
 `
 )
@@ -159,7 +159,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(info *prometheusInf
 		return newScrapeConfig, nil
 	}
 
-	vzSecret, err := r.getVzSecret()
+	vzPromSecret, err := r.getVzPromSecret()
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(info *prometheusInf
 	newScrapeConfigMappings := map[string]string{
 		"##JOB_NAME##":     vmc.Name,
 		"##HOST##":         info.Prometheus.Host,
-		"##PASSWORD##":     string(vzSecret.Data[PasswordKey]),
+		"##PASSWORD##":     string(vzPromSecret.Data[PasswordKey]),
 		"##CLUSTER_NAME##": vmc.Name}
 	configTemplate := scrapeConfigTemplate
 	for key, value := range newScrapeConfigMappings {

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -121,6 +121,19 @@ func (r *VerrazzanoManagedClusterReconciler) getVzSecret() (corev1.Secret, error
 	return secret, nil
 }
 
+// Get the Verrazzano Prometheus secret
+func (r *VerrazzanoManagedClusterReconciler) getVzPromSecret() (corev1.Secret, error) {
+	var secret corev1.Secret
+	nsn := types.NamespacedName{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.VerrazzanoPromInternal,
+	}
+	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
+		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
+	}
+	return secret, nil
+}
+
 // Get the system-tls secret
 func (r *VerrazzanoManagedClusterReconciler) getTLSSecret() (corev1.Secret, error) {
 	var secret corev1.Secret

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -55,7 +55,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 	if err != nil {
 		return err
 	}
-	vzSecret, err := r.getVzSecret()
+	vzSecret, err := r.getVzESSecret()
 	if err != nil {
 		return err
 	}
@@ -127,6 +127,19 @@ func (r *VerrazzanoManagedClusterReconciler) getVzPromSecret() (corev1.Secret, e
 	nsn := types.NamespacedName{
 		Namespace: constants.VerrazzanoSystemNamespace,
 		Name:      constants.VerrazzanoPromInternal,
+	}
+	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
+		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
+	}
+	return secret, nil
+}
+
+// Get the Verrazzano ElasticSearch/FluentD secret
+func (r *VerrazzanoManagedClusterReconciler) getVzESSecret() (corev1.Secret, error) {
+	var secret corev1.Secret
+	nsn := types.NamespacedName{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.VerrazzanoESInternal,
 	}
 	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
 		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1126,9 +1126,9 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 			return nil
 		})
 
-	// Expect a call to get the Verrazzano secret, return the secret with the fields set
+	// Expect a call to get the Verrazzano Elastic Search/FluentD secret, return the secret with the fields set
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoESInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				UsernameKey: []byte(userData),

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1289,9 +1289,9 @@ func expectSyncPrometheusScraper(mock *mocks.MockClient, vmcName string, prometh
 			return nil
 		})
 
-	// Expect a call to get the verrazzano secret - return it
+	// Expect a call to get the verrazzano prometheus internal secret - return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoPromInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				PasswordKey: []byte("nRXlxXgMwN"),


### PR DESCRIPTION
…tween admin and managed clusters

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

This initial commit creates 2 new users in keycloak, verrazzano-prom-internal and verrazzano-es-internal.  It creates the corresponding secrets in verrazzano-system. The following commits configure admin/managed Prometheus communication to use the new verrazzano-prom-internal secret and admin/managed Fluentd/ES communication to use verrazzano-es-internal secret.

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
