### PR TITLE
Capture cluster dump and helm releases on install, uninstall and re-install

### DIFF
--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "v1.18.10", "v1.17.13" ])
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS',
-                      defaultValue: false,
+                      defaultValue: true,
                       description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)')
     }
 
@@ -301,6 +301,13 @@ pipeline {
                 }
             }
             post {
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verrazzano-testrun-after-install-cluster-dump')
+                        }
+                    }
+                }
                 failure {
                     dumpK8sCluster('verrazzano-test-failure-cluster-dump')
 
@@ -329,7 +336,6 @@ pipeline {
                     """
                     listNamepacesAndPods('after Verrazzano uninstall')
                     listHelmReleases('after Verrazzano uninstall')
-
                 }
                 success {
                     script {
@@ -412,6 +418,15 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     runGinkgo('examples/todo')
+                }
+            }
+            post {
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verrazzano-testrun-after-reinstall-cluster-dump')
+                        }
+                    }
                 }
             }
         }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -259,9 +259,9 @@ pipeline {
                     archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml", allowEmptyArchive: true
                     sh """
                         ## dump out install logs
-                        mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                        mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs
+                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"
@@ -274,10 +274,18 @@ pipeline {
                     dumpOamKubernetesRuntimeLogs('install')
                     dumpVerrazzanoApiLogs('install')
                     listNamepacesAndPods('after Verrazzano install')
+                    listHelmReleases('after Verrazzano install')
+                }
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verrazzano-install-cluster-dump')
+                        }
+                    }
                 }
                 failure {
                     script {
-                        dumpK8sCluster('verrazzano-uninstall-install-failure-test-dump')
+                        dumpK8sCluster('verrazzano-install-failure-cluster-dump')
                     }
                 }
             }
@@ -294,7 +302,8 @@ pipeline {
             }
             post {
                 failure {
-                    dumpK8sCluster('verrazzano-uninstall-after-test-dump')
+                    dumpK8sCluster('verrazzano-test-failure-cluster-dump')
+
                 }
             }
         }
@@ -311,13 +320,26 @@ pipeline {
                 always {
                     sh """
                         ## dump out uninstall logs
-                        mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/uninstall/build/logs
-                        kubectl logs --selector=job-name=verrazzano-uninstall-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/uninstall/build/logs/verrazzano-uninstall.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-uninstall-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/uninstall/build/logs/verrazzano-uninstall-job-pod.out
+                        mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/uninstall/build/logs
+                        kubectl logs --selector=job-name=verrazzano-uninstall-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/uninstall/build/logs/verrazzano-uninstall.log --tail -1
+                        kubectl describe pod --selector=job-name=verrazzano-uninstall-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/uninstall/build/logs/verrazzano-uninstall-job-pod.out
                         echo "Listing all pods in all namespaces after uninstall"
                         kubectl get pods --all-namespaces
                         echo "-----------------------------------------------------"
                     """
+                    listNamepacesAndPods('after Verrazzano uninstall')
+                    listHelmReleases('after Verrazzano uninstall')
+
+                }
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verrazzano-uninstall-cluster-dump')
+                        }
+                    }
+                }
+                failure {
+                    dumpK8sCluster('verrazzano-uninstall-failure-cluster-dump')
                 }
             }
         }
@@ -335,7 +357,6 @@ pipeline {
 
         stage("Reinstall Verrazzano") {
             steps {
-                listNamepacesAndPods('before reinstalling Verrazzano')
                 sh """
                     # sleep for a period to ensure async deletion of verrazzano components from uninstall above has completed
                     sleep 90
@@ -354,9 +375,9 @@ pipeline {
                 always {
                     sh """
                         ## dump out install logs
-                        mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/reinstall/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
+                        mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs
+                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
+                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-reinstall.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-reinstall-job-pod.out"
                         echo "------------------------------------------"
@@ -369,6 +390,17 @@ pipeline {
                     dumpOamKubernetesRuntimeLogs('reinstall')
                     dumpVerrazzanoApiLogs('reinstall')
                     listNamepacesAndPods('after reinstalling Verrazzano')
+                    listHelmReleases('after reinstalling Verrazzano')
+                }
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verrazzano-reinstall-cluster-dump')
+                        }
+                    }
+                }
+                failure {
+                    dumpK8sCluster('verrazzano-uninstall-failure-cluster-dump')
                 }
             }
         }
@@ -386,18 +418,12 @@ pipeline {
     }
     post {
         always {
-            script {
-                if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
-                    dumpK8sCluster('verrazzano-uninstall-test-dump')
-                }
-            }
-            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*cluster-dump/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
         failure {
             script {
-                dumpK8sCluster('verrazzano-uninstall-test-dump')
-                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*test-dump/**', allowEmptyArchive: true
+                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*cluster-dump/**', allowEmptyArchive: true
                 mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
                 subject: "Verrazzano: ${env.JOB_NAME} - Failed",
                 body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"
@@ -434,13 +460,13 @@ def dumpK8sCluster(dumpDirectory) {
 def dumpVerrazzanoSystemPods(logDirectory) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-pods.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-pods.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -m "verrazzano system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-certs.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-certs.log"
         ./scripts/install/k8s-dump-objects.sh -o cert -n verrazzano-system -m "verrazzano system certs" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-kibana.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-kibana.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-kibana-*" -m "verrazzano system kibana log" -l -c kibana || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-es-master.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/verrazzano-system-es-master.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-es-master-*" -m "verrazzano system kibana log" -l -c es-master || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
@@ -448,9 +474,9 @@ def dumpVerrazzanoSystemPods(logDirectory) {
 def dumpCattleSystemPods(logDirectory) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/cattle-system-pods.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/cattle-system-pods.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -m "cattle system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/rancher.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/rancher.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -r "rancher-*" -m "Rancher logs" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
@@ -458,7 +484,7 @@ def dumpCattleSystemPods(logDirectory) {
 def dumpNginxIngressControllerLogs(logDirectory) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/nginx-ingress-controller.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/nginx-ingress-controller.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n ingress-nginx -r "nginx-ingress-controller-*" -m "Nginx Ingress Controller" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
@@ -502,7 +528,7 @@ def dumpOamKubernetesRuntimeLogs(logDirectory) {
 def dumpVerrazzanoApiLogs(logDirectory) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/${logDirectory}/build/logs/verrazzano-api.log"
+        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano-platform-operator/scripts/${logDirectory}/build/logs/verrazzano-api.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-api-*" -m "verrazzano api" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
@@ -511,7 +537,15 @@ def listNamepacesAndPods(customMessage) {
     sh """
         echo "Listing all the namespaces and pods the namespaces ${customMessage}."
         kubectl get namespaces
-        kubectl get all --all-namespaces
+        kubectl get pods -A
+        echo "-----------------------------------------------------"
+    """
+}
+
+def listHelmReleases(customMessage) {
+    sh """
+        echo "Listing the releases across all namespaces ${customMessage}."
+        helm list -A
         echo "-----------------------------------------------------"
     """
 }


### PR DESCRIPTION
# Description

This change captures the cluster dumps and output of helm list -A after install, uninstall and re-install, from the uninstall CI pipeline. The default value for DUMP_K8S_CLUSTER_ON_SUCCESS is set to true, will be reverted once the uninstall job becomes stable. The intention is to get more information when one of these stages fail in the pipeline.


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
