### PR TITLE
nginx reload should use correct prefix path

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -289,12 +289,12 @@ data:
     #!/bin/bash
 
     function reload() {
-      nginx -t
+      nginx -t -p /etc/nginx
       if [ $? -eq 0 ]
       then
         echo "Detected Nginx Configuration Change"
-        echo "Executing: nginx -s reload"
-        nginx -s reload
+        echo "Executing: nginx -s reload -p /etc/nginx"
+        nginx -s reload -p /etc/nginx
       fi
     }
 


### PR DESCRIPTION
# Description

nginx reload should use correct prefix path


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
