### PR TITLE
Remove hardcoding checks of wildcard domains xio.io, nip.io, and sslip.io

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -719,6 +719,7 @@ func buildAppFullyQualifiedHostName(cli client.Reader, trait *vzapi.IngressTrait
 // For example: cars.example.com
 func buildNamespacedDomainName(cli client.Reader, trait *vzapi.IngressTrait) (string, error) {
 	const externalDNSKey = "external-dns.alpha.kubernetes.io/target"
+	const wildcardDomainKey = "verrazzano.io/dns.wildcard.domain"
 
 	// Extract the domain name from the verrazzano ingress
 	ingress := k8net.Ingress{}
@@ -733,13 +734,12 @@ func buildNamespacedDomainName(cli client.Reader, trait *vzapi.IngressTrait) (st
 
 	domain := externalDNSAnno[len(constants.VzConsoleIngress)+1:]
 
+	// Get the DNS wildcard domain from the annotation if it exist.  This annotation is only available
+	// when the install is using DNS type wildcard (xip.io, nip.io, etc.)
 	suffix := ""
-	if strings.HasSuffix(domain, "xip.io") {
-		suffix = "xip.io"
-	} else if strings.HasSuffix(domain, "nip.io") {
-		suffix = "nip.io"
-	} else if strings.HasSuffix(domain, "sslip.io") {
-		suffix = "sslip.io"
+	wildcardDomainAnno, ok := ingress.Annotations[wildcardDomainKey]
+	if ok {
+		suffix = wildcardDomainAnno
 	}
 
 	// Build the domain name using Istio info

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -24,6 +23,7 @@ import (
 	certapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	asserts "github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	istionet "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -1332,9 +1332,13 @@ func TestBuildAppHostNameLoadBalancerXIP(t *testing.T) {
 				APIVersion: "extensions/v1beta1",
 				Kind:       "ingress"}
 			ingress.ObjectMeta = metav1.ObjectMeta{
-				Namespace:   name.Namespace,
-				Name:        name.Name,
-				Annotations: map[string]string{"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io"}}
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Annotations: map[string]string{
+					"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io",
+					"verrazzano.io/dns.wildcard.domain":       "xip.io",
+				},
+			}
 			return nil
 		})
 
@@ -1387,9 +1391,13 @@ func TestFailureBuildAppHostNameLoadBalancerXIP(t *testing.T) {
 				APIVersion: "extensions/v1beta1",
 				Kind:       "ingress"}
 			ingress.ObjectMeta = metav1.ObjectMeta{
-				Namespace:   name.Namespace,
-				Name:        name.Name,
-				Annotations: map[string]string{"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io"}}
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Annotations: map[string]string{
+					"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io",
+					"verrazzano.io/dns.wildcard.domain":       "xip.io",
+				},
+			}
 			return nil
 		})
 
@@ -1439,9 +1447,13 @@ func TestBuildAppHostNameNodePortXIP(t *testing.T) {
 				APIVersion: "extensions/v1beta1",
 				Kind:       "ingress"}
 			ingress.ObjectMeta = metav1.ObjectMeta{
-				Namespace:   name.Namespace,
-				Name:        name.Name,
-				Annotations: map[string]string{"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io"}}
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Annotations: map[string]string{
+					"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io",
+					"verrazzano.io/dns.wildcard.domain":       "xip.io",
+				},
+			}
 			return nil
 		})
 
@@ -1503,9 +1515,13 @@ func TestFailureBuildAppHostNameNodePortXIP(t *testing.T) {
 				APIVersion: "extensions/v1beta1",
 				Kind:       "ingress"}
 			ingress.ObjectMeta = metav1.ObjectMeta{
-				Namespace:   name.Namespace,
-				Name:        name.Name,
-				Annotations: map[string]string{"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io"}}
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Annotations: map[string]string{
+					"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.1.2.3.4.xip.io",
+					"verrazzano.io/dns.wildcard.domain":       "xip.io",
+				},
+			}
 			return nil
 		})
 
@@ -2454,7 +2470,9 @@ func newVerrazzanoIngress(ipAddress string) *k8net.Ingress {
 			Name:      constants.VzConsoleIngress,
 			Namespace: constants.VerrazzanoSystemNamespace,
 			Annotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/target": fmt.Sprintf("verrazzano-ingress.default.%s.xip.io", ipAddress)},
+				"external-dns.alpha.kubernetes.io/target": fmt.Sprintf("verrazzano-ingress.default.%s.xip.io", ipAddress),
+				"verrazzano.io/dns.wildcard.domain":       "xip.io",
+			},
 		},
 	}
 	return &rangerIngress

--- a/platform-operator/helm_config/charts/verrazzano/templates/04-verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/04-verrazzano-ingress.yaml
@@ -6,6 +6,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    {{- if .Values.dns.wildcard.domain}}
+    verrazzano.io/dns.wildcard.domain: {{ .Values.dns.wildcard.domain }}
+    {{- end }}
     external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -139,3 +139,7 @@ kubernetes:
 
 externaldns:
   enabled: false
+
+dns:
+  wildcard:
+    domain:

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -121,6 +121,10 @@ function install_verrazzano()
     EXTERNAL_DNS_ENABLED=true
   fi
 
+  if [ "$DNS_TYPE" == "wildcard" ]; then
+    EXTRA_V8O_ARGUMENTS="${EXTRA_V8O_ARGUMENTS} --set dns.wildcard.domain=$(get_config_value ".dns.wildcard.domain")"
+  fi
+
   helm \
       upgrade --install verrazzano \
       ${VZ_CHARTS_DIR}/verrazzano \


### PR DESCRIPTION
# Description

This pull request removes the harding of wildcard domain checks and instead reads an annotation to get the wildcard domain.  This allows the code to be generic and work with any wildcard DNS provider.

This is a follow on pull request from a post merge comment from @gilbode.

Tested with OCI DNS, xio,io and nip.io.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
