### PR TITLE
disable custom DNS resolver for wildcard domain in acceptance tests

### DIFF
--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -220,7 +220,8 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) *http.Clien
 		tr.Proxy = http.ProxyURL(tURLProxy)
 	}
 
-	setupCustomDNSResolver(tr, kubeconfigPath)
+	// disable the custom DNS resolver
+	// setupCustomDNSResolver(tr, kubeconfigPath)
 
 	return &http.Client{Transport: tr}
 }

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -220,6 +220,12 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) *http.Clien
 		tr.Proxy = http.ProxyURL(tURLProxy)
 	}
 
+	setupCustomDNSResolver(tr, kubeconfigPath)
+
+	return &http.Client{Transport: tr}
+}
+
+func setupCustomDNSResolver(tr *http.Transport, kubeconfigPath string) {
 	ipResolve := getNginxNodeIP(kubeconfigPath)
 	if ipResolve != "" {
 		dialer := &net.Dialer{
@@ -249,8 +255,6 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) *http.Clien
 			return dialer.DialContext(ctx, network, addr)
 		}
 	}
-
-	return &http.Client{Transport: tr}
 }
 
 func getEnvName(kubeconfigPath string) string {


### PR DESCRIPTION
# Description

disable custom DNS resolver for wildcard domain in acceptance tests.

Fixes VZ-2589

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
