### PR TITLE
VZ-2579: Keycloak installation failure

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -123,6 +123,7 @@ data:
       --namespace ${KEYCLOAK_NS} \
       -f $VZ_OVERRIDES_DIR/keycloak-values.yaml \
       ${KEYCLOAK_ARGUMENTS} \
+      --timeout 10m \
       --wait
 
   kubectl exec keycloak-0 \


### PR DESCRIPTION
# Description

There was a single failure of the OCI DNS acceptance test run that showed a failure installing Keycloak during the Verrazzano install. Looking at the installation logs and cluster dump info it appears that the helm install of Keycloak timed out waiting for pods, services, etc. to become ready. The MySQL pod shows ready but the Keycloak pod was still initializing when helm timed out.

This PR bumps the helm timeout from 5 minutes to 10 minutes (we use 10m in other helm install commands). Will leave the ticket open and watch the builds to see if the problem occurs again.

Fixes VZ-2579

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
