### PR TITLE
VZ-2482: Add Rancher network policies

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -437,7 +437,7 @@ spec:
 ---
 # Network policy for Rancher webhook
 # Ingress: allow access from Kubernetes API server for webhook port 9443
-# Egress:  allow port 443
+# Egress:  allow all egress
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -458,7 +458,5 @@ spec:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
-    - ports:
-      - port: 443
-        protocol: TCP
+    - {}
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -335,3 +335,103 @@ spec:
         - protocol: TCP
           port: 3306
 {{- end }}
+---
+# Network policy for Rancher cluster agent
+# Ingress: deny all
+# Egress:  Kubernetes API server, DNS for Rancher host lookups, and port 443 to talk to Rancher on the admin cluster
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cattle-cluster-agent
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: cattle-cluster-agent
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+      - port: 443
+        protocol: TCP
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: keycloak
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloak
+{{- if .Values.rancher.enabled }}
+---
+# Network policy for Rancher UI/API
+# Ingress: allow nginx ingress
+# Egress:  deny all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: ingress-nginx
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: ingress-controller
+      ports:
+        - protocol: TCP
+          port: 80
+---
+# Network policy for Rancher operator
+# Ingress: deny all
+# Egress:  Kubernetes API server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher-operator
+  namespace: rancher-operator-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+{{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -437,7 +437,7 @@ spec:
 ---
 # Network policy for Rancher webhook
 # Ingress: allow access from Kubernetes API server for webhook port 9443
-# Egress:  deny all
+# Egress:  allow port 443
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -457,4 +457,8 @@ spec:
       from:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+  egress:
+    - ports:
+      - port: 443
+        protocol: TCP
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -434,4 +434,27 @@ spec:
       to:
         - ipBlock:
             cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+---
+# Network policy for Rancher webhook
+# Ingress: allow access from Kubernetes API server for webhook port 9443
+# Egress:  deny all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher-webhook
+  namespace: cattle-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher-webhook
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+      from:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
 {{- end }}

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -265,7 +265,7 @@ function reset_rancher_admin_password() {
   kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
 }
 
-function create_rancher_namespace()
+function create_cattle_system_namespace()
 {
     if ! kubectl get namespace cattle-system > /dev/null 2>&1; then
         kubectl create namespace cattle-system
@@ -452,8 +452,8 @@ if [ "$DNS_TYPE" == "oci" ]; then
   action "Installing external DNS" install_external_dns || exit 1
 fi
 
-# Always create the Rancher namespace so we can create network policies
-action "Creating Rancher namespace" create_rancher_namespace || exit 1
+# Always create the cattle-system namespace so we can create network policies
+action "Creating cattle-system namespace" create_cattle_system_namespace || exit 1
 
 if [ $(is_rancher_enabled) == "true" ]; then
   action "Installing Rancher" install_rancher || exit 1

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -265,13 +265,20 @@ function reset_rancher_admin_password() {
   kubectl -n cattle-system create secret generic rancher-admin-secret --from-literal=password="$ADMIN_PW"
 }
 
+function create_rancher_namespace()
+{
+    if ! kubectl get namespace cattle-system > /dev/null 2>&1; then
+        kubectl create namespace cattle-system
+    fi
+}
+
 function install_rancher()
 {
     local RANCHER_CHART_DIR=${CHARTS_DIR}/rancher
 
-    log "Create Rancher namespace (if required)"
-    if ! kubectl get namespace cattle-system > /dev/null 2>&1; then
-        kubectl create namespace cattle-system
+    # Create the rancher-operator-system namespace so we can create network policies
+    if ! kubectl get namespace rancher-operator-system > /dev/null 2>&1; then
+        kubectl create namespace rancher-operator-system
     fi
 
     local INGRESS_TLS_SOURCE=""
@@ -444,9 +451,12 @@ action "Installing cert manager" install_cert_manager || exit 1
 if [ "$DNS_TYPE" == "oci" ]; then
   action "Installing external DNS" install_external_dns || exit 1
 fi
+
+# Always create the Rancher namespace so we can create network policies
+action "Creating Rancher namespace" create_rancher_namespace || exit 1
+
 if [ $(is_rancher_enabled) == "true" ]; then
   action "Installing Rancher" install_rancher || exit 1
   action "Setting Rancher Server URL" set_rancher_server_url || true
   action "Patching Rancher Agents" patch_rancher_agents || true
 fi
-

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -137,6 +137,7 @@ function install_verrazzano()
       --set kubernetes.service.endpoint.port=${ENDPOINT_ARRAY[1]} \
       --set externaldns.enabled=${EXTERNAL_DNS_ENABLED} \
       --set keycloak.enabled=$(is_keycloak_enabled) \
+      --set rancher.enabled=$(is_rancher_enabled) \
       ${PROFILE_VALUES_OVERRIDE} \
       ${EXTRA_V8O_ARGUMENTS} || return $?
 

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -61,7 +61,10 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 				if isManagedClusterProfile {
 					gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeFalse())
 					gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeFalse())
-					gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeFalse())
+					// Even though we do not install Rancher on managed clusters, we do create the namespace
+					// so we can create network policies. Rancher will run pods in this namespace once
+					// the managed cluster manifest YAML is applied to the managed cluster.
+					gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
 					gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeFalse())
 				} else {
 					gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeTrue())
@@ -165,8 +168,8 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 			func() {
 				pkg.Concurrently(
 					func() {
-						// The test above asserts the namespace cattle-system doesn't exist for managed-cluster profile,
-						// so the following check is not enabled for that profile.
+						// Rancher pods do not run on the managed cluster at install time (they do get started later when the managed
+						// cluster is registered)
 						if !isManagedClusterProfile {
 							gomega.Eventually(pkg.PodsRunning("cattle-system", expectedPodsCattleSystem), waitTimeout, pollingInterval).
 								Should(gomega.BeTrue())


### PR DESCRIPTION
# Description

This PR adds Rancher network policies. A previous PR with these changes (minus the test fix) was already reviewed and approved, but it was reverted with the revert of the Rancher upgrade.

Note that the previous PR did not include a test fix now included here. The `cattle-system` namespace gets created even if the installation profile is "managed", so that we can create the network policies. When the user applies the managed cluster registration manifest YAML, there will be pods that get started in `cattle-system` on the managed cluster.

Implements VZ-2482

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
