### PR TITLE
Keep OKE cluster on failure in OCI DNS tests

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -21,6 +21,7 @@ def availableRegions = [ "ap-chuncheon-1", "ap-hyderabad-1", "ap-melbourne-1", "
                           "ap-tokyo-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",
                           "sa-saopaulo-1", "uk-london-1", "us-phoenix-1" ]
 Collections.shuffle(availableRegions)
+def keepOKEClusterOnFailure = "false"
 
 pipeline {
     options {
@@ -202,6 +203,14 @@ pipeline {
                             # call create_oke_cluster with cluster access private (-p)
                             ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh -p
                         """
+                    }
+                }
+            }
+            post {
+                failure {
+                    script {
+                        echo "Cluster create failed"
+                        keepOKEClusterOnFailure = "true"
                     }
                 }
             }
@@ -543,7 +552,7 @@ pipeline {
                 fi
                 if [ "${TEST_ENV}" == "kind" ]; then
                   ${WORKSPACE}/tests/e2e/config/scripts/delete-kind-cluster.sh
-                else
+                elif [ "${keepOKEClusterOnFailure}" == "false" ]; then
                   TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP} TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME} ${WORKSPACE}/tests/e2e/config/scripts/delete_oke_cluster.sh
                 fi
                 if [ -f ${POST_DUMP_FAILED_FILE} ]; then

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -72,7 +72,9 @@ check_for_resources LB load-balancer lb-100mbps-count 2
 echo 'Install OKE...'
 echo 'Create cluster...'
 cd ${SCRIPT_DIR}/terraform/cluster
+echo "Create cluster started at $(date)"
 ./create-cluster.sh
+echo "Create cluster completed at $(date)"
 status_code=$?
 if [ ${status_code:-1} -eq 0 ]; then
 
@@ -86,17 +88,22 @@ if [ ${status_code:-1} -eq 0 ]; then
       fi
     fi
 
-    echo "OKE Cluster creation request submitted."
+
+    echo "Updating generated KUBECONFIG $(date)"
     cat generated/kubeconfig > ${KUBECONFIG}
+    echo "Generated KUBECONFIG contents:"
+    cat ${KUBECONFIG}
     # Adding a Service Account Authentication Token to kubeconfig
     # https://docs.cloud.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengaddingserviceaccttoken.htm
     ${SCRIPT_DIR}/update_oke_kubeconfig.sh
+    echo "KUBECONFIG contents after update:"
+    cat ${KUBECONFIG}
 
     # Right after oke cluster is provisioned, it takes a while before any node is added to the cluster
     # The next command will wait for node to come up before continue
-    echo "Waiting for nodes to be added to cluster..."
+    echo "Waiting for nodes to be added to cluster at $(date)..."
     timeout 15m bash -c 'until kubectl get nodes | grep NAME; do sleep 10; done'
-    echo "Waiting for nodes to transition to 'READY'..."
+    echo "Waiting for nodes to transition to 'READY' at $(date)..."
     kubectl wait --for=condition=ready nodes --timeout=5m --all
 else
     echo "OKE Cluster creation request failed!"


### PR DESCRIPTION
# Description

Keep the OKE cluster on failure for post-mortem analysis for VZ-2591.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
