### PR TITLE
Ddrechse/vz2505

### DIFF
--- a/application-operator/controllers/loggingscope/fluentd.go
+++ b/application-operator/controllers/loggingscope/fluentd.go
@@ -49,7 +49,7 @@ const (
 	DefaultElasticSearchURL = "http://vmi-system-es-ingest.verrazzano-system.svc.cluster.local:9200"
 
 	// DefaultSecretName defines the default Elasticsearch secret name used if it is not specified in the logging scope
-	DefaultSecretName = "verrazzano"
+	DefaultSecretName = "verrazzano-es-internal"
 )
 
 // DefaultFluentdImage holds the default FLUENTD image that will be used if it is not specified in the logging scope

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -18,6 +18,9 @@ const Verrazzano = "verrazzano"
 // VerrazzanoPromInternal is the name of the verrazzano internal prometheus secret in the Verrazzano system namespace
 const VerrazzanoPromInternal = "verrazzano-prom-internal"
 
+// VerrazzanoESInternal is the name of the verrazzano internal elasticsearch secret in the Verrazzano system namespace
+const VerrazzanoESInternal = "verrazzano-es-internal"
+
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano
 const VerrazzanoMultiClusterNamespace = "verrazzano-mc"
 

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -15,10 +15,10 @@ const VerrazzanoInstallNamespace = "verrazzano-install"
 // Verrazzano is the name of the verrazzano secret in the Verrazzano system namespace
 const Verrazzano = "verrazzano"
 
-// VerrazzanoPromInternal is the name of the verrazzano internal Prometheus secret in the Verrazzano system namespace
+// VerrazzanoPromInternal is the name of the Verrazzano internal Prometheus secret in the Verrazzano system namespace
 const VerrazzanoPromInternal = "verrazzano-prom-internal"
 
-// VerrazzanoESInternal is the name of the verrazzano internal Elasticsearch secret in the Verrazzano system namespace
+// VerrazzanoESInternal is the name of the Verrazzano internal Elasticsearch secret in the Verrazzano system namespace
 const VerrazzanoESInternal = "verrazzano-es-internal"
 
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -15,10 +15,10 @@ const VerrazzanoInstallNamespace = "verrazzano-install"
 // Verrazzano is the name of the verrazzano secret in the Verrazzano system namespace
 const Verrazzano = "verrazzano"
 
-// VerrazzanoPromInternal is the name of the verrazzano internal prometheus secret in the Verrazzano system namespace
+// VerrazzanoPromInternal is the name of the verrazzano internal Prometheus secret in the Verrazzano system namespace
 const VerrazzanoPromInternal = "verrazzano-prom-internal"
 
-// VerrazzanoESInternal is the name of the verrazzano internal elasticsearch secret in the Verrazzano system namespace
+// VerrazzanoESInternal is the name of the verrazzano internal Elasticsearch secret in the Verrazzano system namespace
 const VerrazzanoESInternal = "verrazzano-es-internal"
 
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -15,6 +15,9 @@ const VerrazzanoInstallNamespace = "verrazzano-install"
 // Verrazzano is the name of the verrazzano secret in the Verrazzano system namespace
 const Verrazzano = "verrazzano"
 
+// VerrazzanoPromInternal is the name of the verrazzano internal prometheus secret in the Verrazzano system namespace
+const VerrazzanoPromInternal = "verrazzano-prom-internal"
+
 // VerrazzanoMultiClusterNamespace is the multi-cluster namespace for verrazzano
 const VerrazzanoMultiClusterNamespace = "verrazzano-mc"
 

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -36,7 +36,7 @@ static_configs:
   labels:
     managed_cluster: '##CLUSTER_NAME##'
 basic_auth:
-  username: verrazzano
+  username: verrazzano-prom-internal
   password: ##PASSWORD##
 `
 )
@@ -159,7 +159,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(info *prometheusInf
 		return newScrapeConfig, nil
 	}
 
-	vzSecret, err := r.getVzSecret()
+	vzPromSecret, err := r.getVzPromSecret()
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(info *prometheusInf
 	newScrapeConfigMappings := map[string]string{
 		"##JOB_NAME##":     vmc.Name,
 		"##HOST##":         info.Prometheus.Host,
-		"##PASSWORD##":     string(vzSecret.Data[PasswordKey]),
+		"##PASSWORD##":     string(vzPromSecret.Data[PasswordKey]),
 		"##CLUSTER_NAME##": vmc.Name}
 	configTemplate := scrapeConfigTemplate
 	for key, value := range newScrapeConfigMappings {

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -121,6 +121,19 @@ func (r *VerrazzanoManagedClusterReconciler) getVzSecret() (corev1.Secret, error
 	return secret, nil
 }
 
+// Get the Verrazzano Prometheus secret
+func (r *VerrazzanoManagedClusterReconciler) getVzPromSecret() (corev1.Secret, error) {
+	var secret corev1.Secret
+	nsn := types.NamespacedName{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.VerrazzanoPromInternal,
+	}
+	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
+		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
+	}
+	return secret, nil
+}
+
 // Get the system-tls secret
 func (r *VerrazzanoManagedClusterReconciler) getTLSSecret() (corev1.Secret, error) {
 	var secret corev1.Secret

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -55,7 +55,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 	if err != nil {
 		return err
 	}
-	vzSecret, err := r.getVzSecret()
+	vzSecret, err := r.getVzESSecret()
 	if err != nil {
 		return err
 	}
@@ -127,6 +127,19 @@ func (r *VerrazzanoManagedClusterReconciler) getVzPromSecret() (corev1.Secret, e
 	nsn := types.NamespacedName{
 		Namespace: constants.VerrazzanoSystemNamespace,
 		Name:      constants.VerrazzanoPromInternal,
+	}
+	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
+		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)
+	}
+	return secret, nil
+}
+
+// Get the Verrazzano ElasticSearch/FluentD secret
+func (r *VerrazzanoManagedClusterReconciler) getVzESSecret() (corev1.Secret, error) {
+	var secret corev1.Secret
+	nsn := types.NamespacedName{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.VerrazzanoESInternal,
 	}
 	if err := r.Get(context.TODO(), nsn, &secret); err != nil {
 		return corev1.Secret{}, fmt.Errorf("Failed to fetch the secret %s/%s, %v", nsn.Namespace, nsn.Name, err)

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -134,7 +134,7 @@ func (r *VerrazzanoManagedClusterReconciler) getVzPromSecret() (corev1.Secret, e
 	return secret, nil
 }
 
-// Get the Verrazzano ElasticSearch/FluentD secret
+// Get the Verrazzano Elasticsearch/FluentD secret
 func (r *VerrazzanoManagedClusterReconciler) getVzESSecret() (corev1.Secret, error) {
 	var secret corev1.Secret
 	nsn := types.NamespacedName{

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1289,7 +1289,7 @@ func expectSyncPrometheusScraper(mock *mocks.MockClient, vmcName string, prometh
 			return nil
 		})
 
-	// Expect a call to get the verrazzano prometheus internal secret - return it
+	// Expect a call to get the Verrazzano Prometheus internal secret - return it
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoPromInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1126,9 +1126,9 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 			return nil
 		})
 
-	// Expect a call to get the Verrazzano secret, return the secret with the fields set
+	// Expect a call to get the Verrazzano Elastic Search/FluentD secret, return the secret with the fields set
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoESInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				UsernameKey: []byte(userData),

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1289,9 +1289,9 @@ func expectSyncPrometheusScraper(mock *mocks.MockClient, vmcName string, prometh
 			return nil
 		})
 
-	// Expect a call to get the verrazzano secret - return it
+	// Expect a call to get the verrazzano prometheus internal secret - return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.Verrazzano}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoPromInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				PasswordKey: []byte("nRXlxXgMwN"),

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1126,7 +1126,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 			return nil
 		})
 
-	// Expect a call to get the Verrazzano Elastic Search/FluentD secret, return the secret with the fields set
+	// Expect a call to get the Verrazzano Elasticsearch/FluentD secret, return the secret with the fields set
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoESInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -95,9 +95,9 @@ data:
 ")
 
 VPROMUSR=$(echo -n $VERRAZZANO_INTERNAL_PROM_USER | base64)
-VPROM=$(echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64))
+VPROM=$( (echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1) ) | base64)
 VESUSR=$(echo -n $VERRAZZANO_INTERNAL_ES_USER | base64)
-VES=$(echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64))
+VES=$( (echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1) ) | base64)
 
   # Create a random secret for the verrazzano-prom-internal user
   kubectl apply -f <(echo "

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -13,6 +13,8 @@ KEYCLOAK_NS=keycloak
 KCADMIN_REALM=master
 KCADMIN_USERNAME=keycloakadmin
 KCADMIN_SECRET=keycloak-http
+VERRAZZANO_INTERNAL_PROM_USER=verrazzano-prom-internal
+VERRAZZANO_INTERNAL_ES_USER=verrazzano-es-internal
 MYSQL_USERNAME=keycloak
 VERRAZZANO_NS=verrazzano-system
 VZ_SYS_REALM=verrazzano-system
@@ -92,6 +94,35 @@ data:
   password: $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
 ")
 
+
+VPROM=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
+VES=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
+
+  # Create a random secret for the verrazzano-prom-internal user
+  kubectl apply -f <(echo "
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${VERRAZZANO_INTERNAL_PROM_USER}
+  namespace: ${VERRAZZANO_NS}
+type: Opaque
+data:
+  password: ${VPROM}
+")
+
+
+  # Create a random secret for the verrazzano-es-internal user
+  kubectl apply -f <(echo "
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${VERRAZZANO_INTERNAL_ES_USER}
+  namespace: ${VERRAZZANO_NS}
+type: Opaque
+data:
+  password: ${VES}
+")
+
   # Check if using the optional imagePullSecret
   local KEYCLOAK_ARGUMENTS=""
   if [ "${REGISTRY_SECRET_EXISTS}" == "TRUE" ]; then
@@ -131,6 +162,17 @@ data:
     -c keycloak \
     -- bash -c \
     "/opt/jboss/keycloak/bin/kcadm.sh update realms/master -s loginTheme=oracle --no-config --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --password \$(cat /etc/${KCADMIN_SECRET}/password)"
+
+  kubectl exec keycloak-0 \
+    -n ${KEYCLOAK_NS} \
+    -c keycloak \
+    -- bash -c \
+    "/opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --client admin-cli --password \$(cat /etc/${KCADMIN_SECRET}/password) && \
+     /opt/jboss/keycloak/bin/kcadm.sh create users -r verrazzano-system -s username=${VERRAZZANO_INTERNAL_PROM_USER} -s enabled=true && \
+     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_PROM_USER} --new-password $(echo "${VPROM}" | base64 --decode) && \
+     /opt/jboss/keycloak/bin/kcadm.sh create users -r verrazzano-system -s username=${VERRAZZANO_INTERNAL_ES_USER} -s enabled=true && \
+     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_ES_USER} --new-password $(echo "${VES}" | base64 --decode) "
+
 
   # Update the password policies.
   log "Setting password policies"

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -172,9 +172,9 @@ data:
     -- bash -c \
     "/opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user ${KCADMIN_USERNAME} --client admin-cli --password \$(cat /etc/${KCADMIN_SECRET}/password) && \
      /opt/jboss/keycloak/bin/kcadm.sh create users -r verrazzano-system -s username=${VERRAZZANO_INTERNAL_PROM_USER} -s enabled=true && \
-     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_PROM_USER} --new-password $(echo "${VPROM}" | base64 --decode) && \
+     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_PROM_USER} --new-password $(echo -n "${VPROM}" | base64 --decode) && \
      /opt/jboss/keycloak/bin/kcadm.sh create users -r verrazzano-system -s username=${VERRAZZANO_INTERNAL_ES_USER} -s enabled=true && \
-     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_ES_USER} --new-password $(echo "${VES}" | base64 --decode) "
+     /opt/jboss/keycloak/bin/kcadm.sh set-password -r verrazzano-system --username ${VERRAZZANO_INTERNAL_ES_USER} --new-password $(echo -n "${VES}" | base64 --decode) "
 
 
   # Update the password policies.

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -94,8 +94,9 @@ data:
   password: $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
 ")
 
-
+VPROMUSR=$(echo $VERRAZZANO_INTERNAL_PROM_USER | base64)
 VPROM=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
+VESUSR=$(echo $VERRAZZANO_INTERNAL_ES_USER | base64)
 VES=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
 
   # Create a random secret for the verrazzano-prom-internal user
@@ -107,6 +108,7 @@ metadata:
   namespace: ${VERRAZZANO_NS}
 type: Opaque
 data:
+  username: ${VPROMUSR}
   password: ${VPROM}
 ")
 
@@ -120,6 +122,7 @@ metadata:
   namespace: ${VERRAZZANO_NS}
 type: Opaque
 data:
+  username: ${VESUSR}
   password: ${VES}
 ")
 

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -95,9 +95,9 @@ data:
 ")
 
 VPROMUSR=$(echo -n $VERRAZZANO_INTERNAL_PROM_USER | base64)
-VPROM=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
+VPROM=$(echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64))
 VESUSR=$(echo -n $VERRAZZANO_INTERNAL_ES_USER | base64)
-VES=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
+VES=$(echo -n $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64))
 
   # Create a random secret for the verrazzano-prom-internal user
   kubectl apply -f <(echo "

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -94,9 +94,9 @@ data:
   password: $(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
 ")
 
-VPROMUSR=$(echo $VERRAZZANO_INTERNAL_PROM_USER | base64)
+VPROMUSR=$(echo -n $VERRAZZANO_INTERNAL_PROM_USER | base64)
 VPROM=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
-VESUSR=$(echo $VERRAZZANO_INTERNAL_ES_USER | base64)
+VESUSR=$(echo -n $VERRAZZANO_INTERNAL_ES_USER | base64)
 VES=$(cat /dev/urandom | LC_ALL=C tr -dc "a-zA-Z0-9" | fold -w 10 | head -n 1 | base64)
 
   # Create a random secret for the verrazzano-prom-internal user


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

This change creates 2 new internal verrazzano user accounts that will be used for multicluster metrics communication.  
One, verrazzano-prom-internal, is used for communication between managed and admin Prometheus. The other, verrazzano-es-internal, is used for managed fluentd to comm with admin elastic search

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
