### PR TITLE
VZ-2484: Add support for Calico on OKE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     parameters {
         booleanParam (description: 'Whether to kick off acceptance test run at the end of this build', name: 'RUN_ACCEPTANCE_TESTS', defaultValue: true)
         booleanParam (description: 'Whether to include the slow tests in the acceptance tests', name: 'RUN_SLOW_TESTS', defaultValue: false)
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
         booleanParam (description: 'Whether to trigger full testing after a successful run. Off by default. This is always done for successful master and release* builds, this setting only is used to enable the trigger for other branches', name: 'TRIGGER_FULL_TESTS', defaultValue: false)
         choice (name: 'WILDCARD_DNS_DOMAIN',
@@ -383,7 +383,7 @@ pipeline {
                     steps {
                         sh """
                             cd ${GO_REPO_PATH}/verrazzano
-                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_KIND_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
+                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_CLUSTER_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
                         """
                     }
                     post {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 description: 'This is the wildcard DNS domain',
                 // 1st choice is the default value
                 choices: [ "nip.io", "xip.io", "sslip.io"])
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
     }
 
@@ -173,7 +173,7 @@ pipeline {
                     steps {
                         sh """
                             cd ${GO_REPO_PATH}/verrazzano
-                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_KIND_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
+                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_CLUSTER_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
                         """
                     }
                     post {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                 description: 'This is the wildcard DNS domain',
                 // 1st choice is the default value
                 choices: [ "nip.io", "xip.io", "sslip.io"])
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
     }
 
@@ -570,16 +570,16 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
                 # specify the cache name based on the count value, this is assuming 1 or 2 clusters
                 case "${count}" in
                     1)
-                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${params.CREATE_KIND_USE_CALICO} "vpo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${params.CREATE_CLUSTER_USE_CALICO} "vpo_integ"
                         ;;
                     2)
-                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${params.CREATE_KIND_USE_CALICO} "apo_integ"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" true ${params.CREATE_CLUSTER_USE_CALICO} "apo_integ"
                         ;;
                     *)
-                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${params.CREATE_KIND_USE_CALICO} "NONE"
+                        ./create_kind_cluster.sh "${CLUSTER_NAME_PREFIX}-$count" "${GO_REPO_PATH}/verrazzano/platform-operator" "${KUBECONFIG_DIR}/$count/kube_config" "${params.KIND_CLUSTER_VERSION}" "$cleanupKindContainers" "$connectJenkinsRunnerToNetwork" false ${params.CREATE_CLUSTER_USE_CALICO} "NONE"
                         ;;
                 esac
-                if [ ${params.CREATE_KIND_USE_CALICO} == true ]; then
+                if [ ${params.CREATE_CLUSTER_USE_CALICO} == true ]; then
                     echo "Install Calico"
                     cd ${GO_REPO_PATH}/verrazzano
                     ./ci/scripts/install_calico.sh "${CLUSTER_NAME_PREFIX}-$count" "${CALICO_VERSION}"
@@ -743,7 +743,7 @@ def createOKEClusters() {
             mkdir -p ${KUBECONFIG_DIR}
             echo "Create OKE cluster"
             cd ${TEST_SCRIPTS_DIR}
-            TF_VAR_label_prefix=multicluster-${env.BUILD_NUMBER} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}"
+            TF_VAR_label_prefix=multicluster-${env.BUILD_NUMBER} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}" ${CREATE_CLUSTER_USE_CALICO}
         """
     }
 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -206,12 +206,14 @@ pipeline {
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
 
-                            if [ ${CREATE_CLUSTER_USE_CALICO} == true ]; then
-                                ${WORKSPACE}/ci/scripts/download_calico.sh ${CALICO_VERSION}
+                            echo "Checking if Calico needs to be downloaded"
+                            if [ ${params.CREATE_CLUSTER_USE_CALICO} == true ]; then
+                                echo "Downloading Calico"
+                                ${WORKSPACE}/ci/scripts/download_calico.sh ${env.CALICO_VERSION}
                             fi
 
                             # call create_oke_cluster with cluster access private
-                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${CREATE_CLUSTER_USE_CALICO} ${CALICO_VERSION}
+                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO} ${env.CALICO_VERSION}
                         """
                     }
                 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -206,7 +206,7 @@ pipeline {
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
 
-                            if [ ${params.CREATE_CLUSTER_USE_CALICO} == true ]; then
+                            if [ "${params.CREATE_CLUSTER_USE_CALICO}" == "true" ]; then
                                 echo "Download Calico"
                             fi
 

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -203,8 +203,8 @@ pipeline {
                             export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
-                            # call create_oke_cluster with cluster access private (-p)
-                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh ${CREATE_CLUSTER_USE_CALICO}" -p
+                            # call create_oke_cluster with cluster access private
+                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${CREATE_CLUSTER_USE_CALICO}
                         """
                     }
                 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -139,6 +139,8 @@ pipeline {
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
+
+        CALICO_VERSION="3.18.1"
     }
 
     stages {
@@ -203,8 +205,13 @@ pipeline {
                             export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
+
+                            if [ ${CREATE_CLUSTER_USE_CALICO} == true ]; then
+                                ${WORKSPACE}/ci/scripts/download_calico.sh ${CALICO_VERSION}
+                            fi
+
                             # call create_oke_cluster with cluster access private
-                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${CREATE_CLUSTER_USE_CALICO}
+                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${CREATE_CLUSTER_USE_CALICO} ${CALICO_VERSION}
                         """
                     }
                 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
                         trim: true)
-        booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: false)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
                 choices: acmeEnvironments)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -205,11 +205,6 @@ pipeline {
                             export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
-
-                            if [ "${params.CREATE_CLUSTER_USE_CALICO}" == "true" ]; then
-                                echo "Download Calico"
-                            fi
-
                             # call create_oke_cluster with cluster access private
                             ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO} ${env.CALICO_VERSION}
                         """

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -206,12 +206,6 @@ pipeline {
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
 
-                            echo "Checking if Calico needs to be downloaded"
-                            if [ ${params.CREATE_CLUSTER_USE_CALICO} == true ]; then
-                                echo "Downloading Calico"
-                                ${WORKSPACE}/ci/scripts/download_calico.sh ${env.CALICO_VERSION}
-                            fi
-
                             # call create_oke_cluster with cluster access private
                             ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO} ${env.CALICO_VERSION}
                         """

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -60,6 +60,9 @@ pipeline {
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
                         trim: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: false)
+        choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
+                choices: acmeEnvironments)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
     }
 
@@ -201,7 +204,7 @@ pipeline {
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
                             # call create_oke_cluster with cluster access private (-p)
-                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh -p
+                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh ${CREATE_CLUSTER_USE_CALICO}" -p
                         """
                     }
                 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -206,6 +206,10 @@ pipeline {
                             export TF_VAR_label_prefix=${env.BUILD_NUMBER}-${env.TIMESTAMP}
                             export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
 
+                            if [ ${params.CREATE_CLUSTER_USE_CALICO} == true ]; then
+                                echo "Download Calico"
+                            fi
+
                             # call create_oke_cluster with cluster access private
                             ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO} ${env.CALICO_VERSION}
                         """

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                 description: 'This is the wildcard DNS domain',
                 // 1st choice is the default value
                 choices: [ "nip.io", "xip.io", "sslip.io"])
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
     }
 
@@ -151,7 +151,7 @@ pipeline {
                     steps {
                         sh """
                             cd ${GO_REPO_PATH}/verrazzano
-                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_KIND_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
+                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_CLUSTER_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
                         """
                     }
                     post {

--- a/ci/scripts/download_calico.sh
+++ b/ci/scripts/download_calico.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+CALICO_DIR=$(cd $(dirname "$0"); pwd -P)
+CALICO_VERSION=${1:-"3.18.1"}
+
+download_calico() {
+  mkdir -p ${CALICO_DIR}/calico/${CALICO_VERSION}
+  curl -LJo ${CALICO_DIR}/calico/"${CALICO_VERSION}".tgz https://github.com/projectcalico/calico/releases/download/v"${CALICO_VERSION}"/release-v"${CALICO_VERSION}".tgz
+  cd ${CALICO_DIR}/calico
+  tar xzvf "${CALICO_VERSION}".tgz --strip-components=1 -C ${CALICO_DIR}/calico/${CALICO_VERSION}
+  rm ${CALICO_VERSION}.tgz
+  export CALICO_HOME=${CALICO_DIR}/calico
+}
+
+# Install Calico using the release bundle under CALICO_HOME. When the environment variable CALICO_HOME is set, the script
+# expects the directory CALICO_VERSION inside it. When the environment variable is not set, the script downloads the
+# bundle for version CALICO_VERSION from the Calico release location.
+#
+if [ -z "$CALICO_HOME" ]; then
+  echo "CALICO_HOME is not set, downloading Calico release bundle."
+  download_calico
+fi
+
+# Download the release bundle, if $CALICO_HOME/${CALICO_VERSION} doesn't exist
+if [ ! -d "${CALICO_HOME}/${CALICO_VERSION}" ]; then
+  echo "CALICO_HOME doesn't exist, downloading the Calico release bundle."
+  download_calico
+fi

--- a/ci/scripts/install_calico.sh
+++ b/ci/scripts/install_calico.sh
@@ -4,33 +4,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
-CALICO_DIR=$(cd $(dirname "$0"); pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 CLUSTER_NAME=${1:-"kind"}
 CALICO_VERSION=${2:-"3.18.1"}
 
-download_calico() {
-  mkdir -p ${CALICO_DIR}/calico/${CALICO_VERSION}
-  curl -LJo ${CALICO_DIR}/calico/"${CALICO_VERSION}".tgz https://github.com/projectcalico/calico/releases/download/v"${CALICO_VERSION}"/release-v"${CALICO_VERSION}".tgz
-  cd ${CALICO_DIR}/calico
-  tar xzvf "${CALICO_VERSION}".tgz --strip-components=1 -C ${CALICO_DIR}/calico/${CALICO_VERSION}
-  rm ${CALICO_VERSION}.tgz
-  export CALICO_HOME=${CALICO_DIR}/calico
-}
-
-# Install Calico using the release bundle under CALICO_HOME. When the environment variable CALICO_HOME is set, the script
-# expects the directory CALICO_VERSION inside it. When the environment variable is not set, the script downloads the
-# bundle for version CALICO_VERSION from the Calico release location.
-#
-if [ -z "$CALICO_HOME" ]; then
-  echo "CALICO_HOME is not set, downloading Calico release bundle."
-  download_calico
-fi
-
-# Download the release bundle, if $CALICO_HOME/${CALICO_VERSION} doesn't exist
-if [ ! -d "${CALICO_HOME}/${CALICO_VERSION}" ]; then
-  echo "CALICO_HOME doesn't exist, downloading the Calico release bundle."
-  download_calico
-fi
+$SCRIPT_DIR/download_calico.sh ${CALICO_VERSION}
 
 echo "Load the docker image from Calico archives at ${CALICO_HOME}/${CALICO_VERSION}/images."
 cd ${CALICO_HOME}/${CALICO_VERSION}/images

--- a/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/07-networkpolicy.yaml
@@ -105,9 +105,6 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
-      from:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
 ---
 # Network policy for Verrazzano monitoring operator
 # Ingress: deny all

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -43,9 +43,6 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
-      from:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
     - ports:
         - port: {{ .Values.kubernetes.service.endpoint.port }}
@@ -454,9 +451,6 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
-      from:
-        - ipBlock:
-            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
   egress:
     - {}
 {{- end }}

--- a/platform-operator/internal/netpolicy/netpolicy.go
+++ b/platform-operator/internal/netpolicy/netpolicy.go
@@ -172,13 +172,6 @@ func newNetworkPolicy(apiServerIP string, apiServerPort int32) *netv1.NetworkPol
 							Port:     &webhookPort,
 						},
 					},
-					From: []netv1.NetworkPolicyPeer{
-						{
-							IPBlock: &netv1.IPBlock{
-								CIDR: apiServerCidr,
-							},
-						},
-					},
 				},
 			},
 		},

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -96,6 +96,7 @@ if [ ${status_code:-1} -eq 0 ]; then
 
     # Calico needs to be installed before any pods are created, so do it here before the nodes are ready
     if [ $INSTALL_CALICO == true ] ; then
+        ${GO_REPO_PATH}/verrazzano/ci/scipts/download_calico.sh ${CALICO_VERSION}
         ${SCRIPT_DIR}/install_calico_oke.sh ${CALICO_VERSION}
     fi
 

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -6,14 +6,8 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-INSTALL_CALICO=${1:-false}
-
-usage() {
-  echo "Usage: $0 [-p] [install_calico]" 1>&2
-  echo "-p create cluster with private endpoints" 1>&2
-  echo "install_calico true/false, defaults to false" 1>&2
-  exit 1
-}
+PRIVATE_CLUSTER=${1:-false}
+INSTALL_CALICO=${2:-false}
 
 set_private_access() {
   echo "Cluster access set to private."
@@ -46,12 +40,9 @@ check_for_resources() {
   fi
 }
 
-while getopts ":p" arg; do
-  case $arg in
-    p) set_private_access;;
-    \?) usage;;
-  esac
-done
+if [ $PRIVATE_CLUSTER == true ] ; then
+    set_private_access
+fi
 
 if [ -z "$TF_VAR_compartment_id" ] ; then
     echo "TF_VAR_compartment_id env var must be set!"

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -6,9 +6,12 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
+INSTALL_CALICO=${1:-false}
+
 usage() {
-  echo "Usage: $0 [-p]" 1>&2
+  echo "Usage: $0 [-p] [install_calico]" 1>&2
   echo "-p create cluster with private endpoints" 1>&2
+  echo "install_calico true/false, defaults to false" 1>&2
   exit 1
 }
 
@@ -105,6 +108,10 @@ if [ ${status_code:-1} -eq 0 ]; then
     timeout 15m bash -c 'until kubectl get nodes | grep NAME; do sleep 10; done'
     echo "Waiting for nodes to transition to 'READY' at $(date)..."
     kubectl wait --for=condition=ready nodes --timeout=5m --all
+
+    if [ $INSTALL_CALICO == true ] ; then
+        ${SCRIPT_DIR}/install_calico_oke.sh
+    fi
 else
     echo "OKE Cluster creation request failed!"
     exit 1

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 PRIVATE_CLUSTER=${1:-false}
 INSTALL_CALICO=${2:-false}
+CALICO_VERSION=${3:-"3.18.1"}
 
 set_private_access() {
   echo "Cluster access set to private."
@@ -95,7 +96,7 @@ if [ ${status_code:-1} -eq 0 ]; then
 
     # Calico needs to be installed before any pods are created, so do it here before the nodes are ready
     if [ $INSTALL_CALICO == true ] ; then
-        ${SCRIPT_DIR}/install_calico_oke.sh
+        ${SCRIPT_DIR}/install_calico_oke.sh ${CALICO_VERSION}
     fi
 
     # Right after oke cluster is provisioned, it takes a while before any node is added to the cluster

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -96,7 +96,7 @@ if [ ${status_code:-1} -eq 0 ]; then
 
     # Calico needs to be installed before any pods are created, so do it here before the nodes are ready
     if [ $INSTALL_CALICO == true ] ; then
-        ${GO_REPO_PATH}/verrazzano/ci/scipts/download_calico.sh ${CALICO_VERSION}
+        ${WORKSPACE}/ci/scripts/download_calico.sh ${CALICO_VERSION}
         ${SCRIPT_DIR}/install_calico_oke.sh ${CALICO_VERSION}
     fi
 

--- a/tests/e2e/config/scripts/create_oke_multi_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_multi_cluster.sh
@@ -7,6 +7,7 @@
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 CLUSTER_COUNT=${1:-1}
 KUBECONFIG_DIR=$2
+INSTALL_CALICO=${3:-false}
 REQUIRED_VNC_COUNT=0
 REQUIRED_LB_COUNT=0
 CLUSTER_NAME_PREFIX="oke"
@@ -99,6 +100,10 @@ if [ ${status_code:-1} -eq 0 ]; then
       timeout 15m bash -c 'until kubectl get nodes | grep NAME; do sleep 10; done'
       echo "Waiting for nodes to transition to 'READY'..."
       kubectl wait --for=condition=ready nodes --timeout=5m --all
+
+      if [ $INSTALL_CALICO == true ] ; then
+        ${SCRIPT_DIR}/install_calico_oke.sh
+      fi
     done
 else
     echo "OKE Cluster creation request failed!"

--- a/tests/e2e/config/scripts/install_calico_oke.sh
+++ b/tests/e2e/config/scripts/install_calico_oke.sh
@@ -4,13 +4,17 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
-echo "Install Calico..."
+CALICO_VERSION=${1:-"3.18.1"}
 
-curl -sS https://docs.projectcalico.org/v3.18/manifests/calico-policy-only.yaml -o /tmp/calico.yaml
+echo "Install Calico ${CALICO_VERSION}..."
+
+# CALICO_HOME must be set to the location of the downloaded Calico bundle
+CALICO_YAML=${CALICO_HOME}/${CALICO_VERSION}/k8s-manifests/calico-policy-only.yaml
 
 # uncomment the pod CIDR setting and replace the default pod CIDR with the OKE pod CIDR default
-sed -i -e "s?# - name: CALICO_IPV4POOL_CIDR?- name: CALICO_IPV4POOL_CIDR?" /tmp/calico.yaml
-sed -i -e "s?#   value: \"192.168.0.0/16\"?  value: \"10.244.0.0/16\"?" /tmp/calico.yaml
-grep -B 1 -A 2 POOL_CIDR /tmp/calico.yaml
+sed -i -e "s?# - name: CALICO_IPV4POOL_CIDR?- name: CALICO_IPV4POOL_CIDR?" ${CALICO_YAML}
+sed -i -e "s?#   value: \"192.168.0.0/16\"?  value: \"10.244.0.0/16\"?" ${CALICO_YAML}
+grep -B 1 -A 2 POOL_CIDR ${CALICO_YAML}
 
-kubectl apply -f /tmp/calico.yaml
+echo "Applying Calico YAML: ${CALICO_YAML}"
+kubectl apply -f ${CALICO_YAML}

--- a/tests/e2e/config/scripts/install_calico_oke.sh
+++ b/tests/e2e/config/scripts/install_calico_oke.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+echo "Install Calico..."
+
+curl -sS https://docs.projectcalico.org/v3.18/manifests/calico-policy-only.yaml -o /tmp/calico.yaml
+
+# uncomment the pod CIDR setting and replace the default pod CIDR with the OKE pod CIDR default
+sed -i -e "s?# - name: CALICO_IPV4POOL_CIDR?- name: CALICO_IPV4POOL_CIDR?" /tmp/calico.yaml
+sed -i -e "s?#   value: \"192.168.0.0/16\"?  value: \"10.244.0.0/16\"?" /tmp/calico.yaml
+grep -B 1 -A 2 POOL_CIDR /tmp/calico.yaml
+
+kubectl apply -f /tmp/calico.yaml


### PR DESCRIPTION
# Description

This PR adds support for installing Calico on OKE when running OKE tests.

Notes:

- The OKE documentation for Calico recommends installing Calico in the cluster before the node pool is created. I'm doing it this way in the script that creates the OKE cluster and it seems to solve the issues with coredns pods restarting and getting into a bad state.
- For some reason I can't explain, the network policy for webhook ingress was causing problems with our operator webhooks. Removing the source IP from the rule and just specifying the 9443 ingress port solved the problem. I don't think we saw this problem with Kind, so not sure what's going on, but this seems like a reasonable solution (at least for now).
- The `create_oke_cluster.sh` script was using an optional arg to setup the cluster with private access. None of our other scripts use optional args, we use positional args, so I changed it to be consistent and replaced the "-p" with a boolean positional arg.

Implements VZ-2484

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
