### PR TITLE
Load calico images in a loop

### DIFF
--- a/ci/scripts/install_calico.sh
+++ b/ci/scripts/install_calico.sh
@@ -34,13 +34,10 @@ fi
 
 echo "Load the docker image from Calico archives at ${CALICO_HOME}/${CALICO_VERSION}/images."
 cd ${CALICO_HOME}/${CALICO_VERSION}/images
-kind load image-archive calico-cni.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-dikastes.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-flannel-migration-controller.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-kube-controllers.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-node.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-pod2daemon-flexvol.tar --name ${CLUSTER_NAME}
-kind load image-archive calico-typha.tar --name ${CLUSTER_NAME}
+for image_archive in *.tar; do
+    echo "Loading image archive $image_archive ..."
+    kind load image-archive "$image_archive" --name "${CLUSTER_NAME}"
+done
 
 echo "Apply ${CALICO_HOME}/${CALICO_VERSION}/k8s-manifests/calico.yaml."
 cd ${CALICO_HOME}/${CALICO_VERSION}/k8s-manifests


### PR DESCRIPTION
# Description

This change loads all the .tar files from ${CALICO_HOME}/${CALICO_VERSION}/images in a loop, rather than loading individual tar files.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
