### PR TITLE
Have it create the entire path for the directory if it needs to

### DIFF
--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -120,7 +120,7 @@ fi
 if [ -z $DIRECTORY ]; then
   CAPTURE_DIR=$(mktemp -d $(pwd)/capture_XXXXXXX)
 else
-  mkdir $DIRECTORY
+  mkdir -p $DIRECTORY
   CAPTURE_DIR=$DIRECTORY
 fi
 


### PR DESCRIPTION
# Description

Have the cluster dump create the entire output directory path not just the specific directory for the dump.

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
