### PR TITLE
VZ-2620: grafana endpoint test failing with http 407 in vmi_test

### DIFF
--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -289,14 +289,14 @@ func assertURLByIngressName(key string) {
 }
 
 func assertIngressURL(url string) {
-	assertUnAuthorized := assertURLAccessibleAndUnauthorized(url)
-	assertAuthorized := assertURLAccessibleAndAuthorized(url)
+	assertUnAuthorized := assertURLAccessibleAndUnauthorized
+	assertAuthorized := assertURLAccessibleAndAuthorized
 	pkg.Concurrently(
 		func() {
-			gomega.Eventually(assertUnAuthorized, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool { return assertUnAuthorized(url) }, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 		},
 		func() {
-			gomega.Eventually(assertAuthorized, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool { return assertAuthorized(url) }, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 		},
 	)
 }
@@ -356,18 +356,18 @@ func assertOidcIngressByName(key string) {
 }
 
 func assertOidcIngress(url string) {
-	assertUnAuthorized := assertOauthURLAccessibleAndUnauthorized(url)
-	assertBasicAuth := assertURLAccessibleAndAuthorized(url)
-	assertBearerAuth := assertBearerAuthorized(url)
+	assertUnAuthorized := assertOauthURLAccessibleAndUnauthorized
+	assertBasicAuth := assertURLAccessibleAndAuthorized
+	assertBearerAuth := assertBearerAuthorized
 	pkg.Concurrently(
 		func() {
-			gomega.Eventually(assertUnAuthorized, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool { return assertUnAuthorized(url) }, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 		},
 		func() {
-			gomega.Eventually(assertBasicAuth, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool { return assertBasicAuth(url) }, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 		},
 		func() {
-			gomega.Eventually(assertBearerAuth, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool { return assertBearerAuth(url) }, waitTimeout, pollingInterval).Should(gomega.BeTrue())
 		},
 	)
 }

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -171,26 +171,26 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 						// Rancher pods do not run on the managed cluster at install time (they do get started later when the managed
 						// cluster is registered)
 						if !isManagedClusterProfile {
-							gomega.Eventually(pkg.PodsRunning("cattle-system", expectedPodsCattleSystem), waitTimeout, pollingInterval).
+							gomega.Eventually(func() bool { return pkg.PodsRunning("cattle-system", expectedPodsCattleSystem) }, waitTimeout, pollingInterval).
 								Should(gomega.BeTrue())
 						}
 					},
 					func() {
 						if !isManagedClusterProfile {
-							gomega.Eventually(pkg.PodsRunning("keycloak", expectedPodsKeycloak), waitTimeout, pollingInterval).
+							gomega.Eventually(func() bool { return pkg.PodsRunning("keycloak", expectedPodsKeycloak) }, waitTimeout, pollingInterval).
 								Should(gomega.BeTrue())
 						}
 					},
 					func() {
-						gomega.Eventually(pkg.PodsRunning("cert-manager", expectedPodsCertManager), waitTimeout, pollingInterval).
+						gomega.Eventually(func() bool { return pkg.PodsRunning("cert-manager", expectedPodsCertManager) }, waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
 					},
 					func() {
-						gomega.Eventually(pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx), waitTimeout, pollingInterval).
+						gomega.Eventually(func() bool { return pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx) }, waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
 					},
 					func() {
-						gomega.Eventually(pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem), waitTimeout, pollingInterval).
+						gomega.Eventually(func() bool { return pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem) }, waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
 					},
 				)


### PR DESCRIPTION
# Description

Fixes intermittent tests failures caused by misuse of the gomega.Eventually utility.

Fixes VZ-2620: grafana endpoint test failing with http 407 in vmi_test

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
