### PR TITLE
Fix enable to connect to the server: x509: certificate signed by unknown authority

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -19,7 +19,7 @@ def certIssuers = [ "self-signed", "acme" ]
 def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : "VM.Standard2.8"
 def availableRegions = [  "ap-chuncheon-1", "ap-hyderabad-1", "ap-melbourne-1", "ap-osaka-1", "ap-seoul-1", "ap-sydney-1",
                           "ap-tokyo-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",
-                          "uk-london-1", "us-phoenix-1" ]
+                          "sa-saopaulo-1", "uk-london-1", "us-phoenix-1" ]
 Collections.shuffle(availableRegions)
 def keepOKEClusterOnFailure = "false"
 

--- a/tests/e2e/config/scripts/setup_ssh_tunnel.sh
+++ b/tests/e2e/config/scripts/setup_ssh_tunnel.sh
@@ -41,17 +41,6 @@ if [ -z "VCN_CIDR" ]; then
     exit 1
 fi
 
-# find availability domain for the bastion compute instance
-BASTION_AD=$(oci compute instance list \
-  --compartment-id "${TF_VAR_compartment_id}" \
-  --display-name "${TF_VAR_label_prefix}-bastion" \
-  | jq -r '.data[0]."availability-domain"')
-
-if [ -z "$BASTION_AD" ]; then
-    echo "Failed to get the AD for compute instance ${TF_VAR_label_prefix}-bastion"
-    exit 1
-fi
-
 # find bastion compute instance id
 BASTION_ID=$(oci compute instance list \
   --compartment-id "${TF_VAR_compartment_id}" \

--- a/tests/e2e/config/scripts/setup_ssh_tunnel.sh
+++ b/tests/e2e/config/scripts/setup_ssh_tunnel.sh
@@ -64,7 +64,7 @@ if [ -z "$BASTION_ID" ]; then
 fi
 
 # find public IP for the bastion compute instance
-BASTION_IP=$(oci compute instance listvnics \
+BASTION_IP=$(oci compute instance list-vnics \
   --compartment-id "${TF_VAR_compartment_id}" \
   --instance-id "${BASTION_ID}" \
   | jq -r '.data[0]."public-ip"')


### PR DESCRIPTION
# Description

- Fix problem of creating an OKE cluster for oke-ocidns test run.  The script that sets up an ssh tunnel to the OKE cluster was obtaining the incorrect public IP address.
- Re-enable the sao-paulo region for tests

Fixes VZ-2591

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
