### PR TITLE
swap dns zone to v8o.io

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -127,7 +127,7 @@ pipeline {
         INSTALL_CONFIG_FILE_XIPIO = "${WORKSPACE}/tests/e2e/config/scripts/install-verrazzano-xipio.yaml"
         INSTALL_CONFIG_FILE_NODEPORT = "${WORKSPACE}/tests/e2e/config/scripts/install-verrazzano-nodeport.yaml"
 
-        OCI_DNS_ZONE_NAME="z${zoneId}.v8o.oracledx.com"
+        OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
         CERT_ISSUER="${params.CERT_ISSUER}"
         ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
 

--- a/tests/e2e/config/scripts/oci_dns_ops.sh
+++ b/tests/e2e/config/scripts/oci_dns_ops.sh
@@ -10,7 +10,7 @@ function usage {
     echo "usage: $0 [-o operation] [-c compartment_ocid] [-s subdomain_name] "
     echo "  -o operation               'create' or 'delete'. Optional.  Defaults to 'create'."
     echo "  -c compartment_ocid        Compartment OCID. Optional.  Defaults to TIBURON-DEV compartment OCID."
-    echo "  -s submdomain_name         subdomain prefix for v8o.oracledx.com. Required."
+    echo "  -s submdomain_name         subdomain prefix for v8o.io. Required."
     echo "  -h                         Help"
     echo
     exit 1
@@ -37,7 +37,7 @@ if [ -z "${SUBDOMAIN_NAME}" ] ; then
 fi
 
 set -o pipefail
-ZONE_NAME="${SUBDOMAIN_NAME}.v8o.oracledx.com"
+ZONE_NAME="${SUBDOMAIN_NAME}.v8o.io"
 
 zone_ocid=""
 if [ $OPERATION == "create" ]; then


### PR DESCRIPTION
Signed-off-by: Mark Nelson <mark.x.nelson@oracle.com>

# Description

This PR changes the acceptance tests that use OCI DNS to use a new DNS zone (v8o.io).

Contributes to VZ-2612

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
