### PR TITLE
WVZ-2626: Change default wildcard DNS from xip.io to nip.io

### DIFF
--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -246,7 +246,7 @@ func getDNSConfig(vz *installv1alpha1.Verrazzano) DNS {
 	return DNS{
 		Type: DNSTypeWildcard,
 		Wildcard: &WildcardDNS{
-			Domain: "xip.io",
+			Domain: "nip.io",
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// TestXipIoInstallDefaults tests the creation of an xip.io install default configuration
+// TestNipIoInstallDefaults tests the creation of an xip.io install default configuration
 // GIVEN a verrazzano.install.verrazzano.io custom resource
 //  WHEN I call GetInstallConfig
-//  THEN the xip.io install configuration is created and verified
-func TestXipIoInstallDefaults(t *testing.T) {
+//  THEN the nip.io install configuration is created and verified
+func TestNipIoInstallDefaults(t *testing.T) {
 	vz := installv1alpha1.Verrazzano{}
 	config, err := GetInstallConfig(&vz)
 	assert.NoError(t, err)


### PR DESCRIPTION
# Description

Change the default wildcard DNS from xip.io to nip.io

Fixes VZ-2626

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
