### PR TITLE
Suspect notifications Part Deux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     parameters {
         booleanParam (description: 'Whether to kick off acceptance test run at the end of this build', name: 'RUN_ACCEPTANCE_TESTS', defaultValue: true)
         booleanParam (description: 'Whether to include the slow tests in the acceptance tests', name: 'RUN_SLOW_TESTS', defaultValue: false)
-        booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
+        booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
         booleanParam (description: 'Whether to trigger full testing after a successful run. Off by default. This is always done for successful master and release* builds, this setting only is used to enable the trigger for other branches', name: 'TRIGGER_FULL_TESTS', defaultValue: false)
         choice (name: 'WILDCARD_DNS_DOMAIN',
@@ -374,6 +374,7 @@ pipeline {
                 stage('Prepare AT environment') {
                     environment {
                         VERRAZZANO_OPERATOR_IMAGE="NONE"
+                        KIND_KUBERNETES_CLUSTER_VERSION="1.18"
                         OCI_CLI_AUTH="instance_principal"
                         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
                         OCI_OS_BUCKET="verrazzano-builds"
@@ -382,7 +383,7 @@ pipeline {
                     steps {
                         sh """
                             cd ${GO_REPO_PATH}/verrazzano
-                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_KIND_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
+                            ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_CLUSTER_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN} ${CALICO_VERSION}
                         """
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -732,13 +732,10 @@ def getPreviousCleanBuildCommit(currentCommitHash) {
     // effectively it will give us a rev-list later that is empty (ie: if this is a new branch with no previous clean build)
     def previousCleanBuildCommitId = currentCommitHash
 
-    // Determine if there was a previous successful build or not (ie: this is more for user branches rather than master),
-    // if this is the first run of a branch it will be null (no previous successful build yet)
+     // if this is the first run of a branch it will be null (no previous successful build yet)
     def previousSuccessfulBuild = currentBuild.getPreviousSuccessfulBuild()
     if (previousSuccessfulBuild == null) {
         echo "There was not a previous successful build, not forming a suspect list. We should not see this in master, only in new branches"
-        // We don't really care about notifications/suspects on user branches (if we form long running branches with multiple folks
-        // we may care in the future and can add logic to handle those cases)
         return previousCleanBuildCommitId
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -734,8 +734,8 @@ def debugNewGetSuspectList(currentCommitHash) {
 
     // Determine if there was a previous successful build or not (ie: this is more for user branches rather than master),
     // if this is the first run of a branch it will be null (no previous successful build yet)
-    def lastSuccessfulBuild = currentBuild.previousSuccessfulBuild()
-    if (lastSuccessfulBuild == null) {
+    def previousSuccessfulBuild = currentBuild.getPreviousSuccessfulBuild()
+    if (previousSuccessfulBuild == null) {
         echo "There was not a previous successful build, not forming a suspect list. We should not see this in master, only in new branches"
         // We don't really care about notifications/suspects on user branches (if we form long running branches with multiple folks
         // we may care in the future and can add logic to handle those cases)
@@ -747,7 +747,7 @@ def debugNewGetSuspectList(currentCommitHash) {
     // it may be confused if someone is manually triggering runs and specifying various commit hashs back in time. Ie: this
     // assumes the builds in the project are generally following the flow of commits in the scm repo. That should be enough to meet
     // our needs here without adding special edge case handling (if we find we do need to do that we can add it)
-    def scmAction = build?.actions.find { action -> action instanceof jenkins.scm.api.SCMRevisionAction }
+    def scmAction = previousSuccessfulBuild?.actions.find { action -> action instanceof jenkins.scm.api.SCMRevisionAction }
     def lastSuccessfulCommitHash = scmAction?.revision?.hash
     def commits = sh(
         script: "git rev-list $currentCommitHash \"^$lastSuccessfulCommitHash\"",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -765,6 +765,9 @@ def getPreviousCleanBuildCommit(currentCommitHash) {
 }
 
 def getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings) {
+    map.each { entry ->
+        echo "Key: $entry.key Value: $entry.value"
+    }
     def commits = sh(
         script: "git rev-list $currentCommitHash \"^$previousCleanBuildCommitId\"",
         returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -745,6 +745,19 @@ def debugNewGetSuspectList(currentCommitHash) {
     // We don't have access to the raw build, but we can get the changeset from the previous build and get the commit from that
     // Assuming the first one is the last change in the change set
     def previousChangeSets = previousSuccessfulBuild.changeSets
+    if (previousChangeSets == null) {
+        echo "Got null change sets from the previous successful build"
+        return
+    }
+    if (previousChangeSets.length == 0) {
+        echo "Got empty change set array from the previous successful build"
+        return
+    }
+    if (previousChangeSets[0] == null) {
+        echo "Got null first element from change sets from the previous successful build, length was ${previousChangeSets.length}"
+        return
+    }
+
     def previousBuildLastCommitId = previousChangeSets[0].items[0].id
     echo "previous clean commit id = ${previousBuildLastCommitId}"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -744,7 +744,7 @@ def debugNewGetSuspectList(currentCommitHash) {
 
     // We don't have access to the raw build, but we can get the changeset from the previous build and get the commit from that
     // Assuming the first one is the last change in the change set
-    def previousChangeSets = previousBuild.changeSets
+    def previousChangeSets = previousSuccessfulBuild.changeSets
     def previousBuildLastCommitId = previousChangeSets[0].items[0].id
     echo "previous clean commit id = ${previousBuildLastCommitId}"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -765,9 +765,6 @@ def getPreviousCleanBuildCommit(currentCommitHash) {
 }
 
 def getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings) {
-    userMappings.each { entry ->
-        echo "Key: $entry.key Value: $entry.value"
-    }
     def commits = sh(
         script: "git rev-list $currentCommitHash \"^$previousCleanBuildCommitId\"",
         returnStdout: true
@@ -780,7 +777,7 @@ def getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings) 
         def author = sh(
             script: "git log --format='%ae' '$id^!'",
             returnStdout: true
-        )
+        ).trim()
         echo "DEBUG: author: ${author}, id: ${id}"
         if (userMappings.containsKey(author)) {
             def slackUser = userMappings.get(author)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -765,7 +765,7 @@ def getPreviousCleanBuildCommit(currentCommitHash) {
 }
 
 def getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings) {
-    map.each { entry ->
+    userMappings.each { entry ->
         echo "Key: $entry.key Value: $entry.value"
     }
     def commits = sh(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -734,7 +734,7 @@ def debugNewGetSuspectList(currentCommitHash) {
 
     // Determine if there was a previous successful build or not (ie: this is more for user branches rather than master),
     // if this is the first run of a branch it will be null (no previous successful build yet)
-    def lastSuccessfulBuild = currentBuild.rawBuild.getPreviousSuccessfulBuild()
+    def lastSuccessfulBuild = currentBuild.previousSuccessfulBuild()
     if (lastSuccessfulBuild == null) {
         echo "There was not a previous successful build, not forming a suspect list. We should not see this in master, only in new branches"
         // We don't really care about notifications/suspects on user branches (if we form long running branches with multiple folks

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -759,7 +759,7 @@ def getPreviousCleanBuildCommit(currentCommitHash) {
         echo "empty commits in last change set found"
         return previousBuildLastCommitId
     }
-    def previousBuildLastCommitId = prevCommits[0].id
+    previousBuildLastCommitId = prevCommits[0].id
     echo "previous clean commit id = ${previousBuildLastCommitId}"
     return previousBuildLastCommitId
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -745,20 +745,21 @@ def debugNewGetSuspectList(currentCommitHash) {
     // We don't have access to the raw build, but we can get the changeset from the previous build and get the commit from that
     // Assuming the first one is the last change in the change set
     def previousChangeSets = previousSuccessfulBuild.changeSets
-    if (previousChangeSets == null) {
-        echo "Got null change sets from the previous successful build"
+    if (previousChangeSets.size() == 0) {
+        echo "No change sets found from the previous successful build"
         return
     }
-    if (previousChangeSets.length == 0) {
-        echo "Got empty change set array from the previous successful build"
+    def lastChangeSet = previousChangeSets.get(0)
+    if (lastChangeSet == null) {
+        echo "last change set was null"
         return
     }
-    if (previousChangeSets[0] == null) {
-        echo "Got null first element from change sets from the previous successful build, length was ${previousChangeSets.length}"
+    def prevCommits = lastChangeSet.items
+    if (prevCommits.length == 0) {
+        echo "empty commits in last change set found"
         return
     }
-
-    def previousBuildLastCommitId = previousChangeSets[0].items[0].id
+    def previousBuildLastCommitId = prevCommits[0].id
     echo "previous clean commit id = ${previousBuildLastCommitId}"
 
     // If we have a previous successful build, form the rev-list based on the last commit that passed and the current commit.
@@ -774,7 +775,7 @@ def debugNewGetSuspectList(currentCommitHash) {
 }
 
 @NonCPS
-def getSuspectList(currentCommitHash, userMappings) {
+def getSuspectList(userMappings) {
     def suspectList = []
     def retValue = ""
     def changeSets = currentBuild.changeSets


### PR DESCRIPTION
# Description

The commit authors that we get back from the changeSets when in master behave differently than for other branches. We are seeing "noreply" as the user there.

This does a few things:

1. Directly call git to get the commit author information, this doesn't rely on what the plugin gives us in changeSets
2. Look further back to the changes since the last clean build. This way the suspect list includes everyone who has a commit while master is broken if multiple runs have failed in a row.
3. Add more debugging. Unfortunately as we have seen with the previous attempt master doesn't behave the same way as branches, so it is possible that this will not work on master as well and if that is the case we at least will have more debug to look at.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
