### PR TITLE
Tvlatas/add debug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -735,7 +735,7 @@ def getSuspectList(userMappings) {
             def commit = commits[j]
             def author = commit.author.toString()
             def id = commit.commitId
-            echo "Commit id: ${id}  author: ${author}"
+            echo "Commit id: ${id}   author: ${author}"
             if (userMappings.containsKey(author)) {
                 def slackUser = userMappings.get(author)
                 if (!suspectList.contains(slackUser)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -734,6 +734,8 @@ def getSuspectList(userMappings) {
         for (int j = 0; j < commits.length; j++) {
             def commit = commits[j]
             def author = commit.author.toString()
+            def id = commit.commitId
+            echo "Commit id: ${id}  author: ${author}"
             if (userMappings.containsKey(author)) {
                 def slackUser = userMappings.get(author)
                 if (!suspectList.contains(slackUser)) {
@@ -754,4 +756,3 @@ def getSuspectList(userMappings) {
     echo "returning suspect list: ${retValue}"
     return retValue
 }
-


### PR DESCRIPTION
# Description

Approach 2 didn't work for suspect list because we don't get the changeset info from the last clean build when running on master (worked on branches).

A hybrid approach might work to use the changeset info we get back to get the commit ids (ie: from approach 1), and then use git to get the users (like approach 2). That will only work if the commit ids we get back from Jenkins are real ones (not masked like they do with the user noreply). Also there is a question on if git will give us the real user as well there for master (I think it should).

This adds debug only to see if Jenkins will give us real commit ids for master. If that doesn't work on master the hybrid approach will not work. This should be a low risk change to get that info first from master (will be watching and revert though if something goes awry).

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
