### PR TITLE
Remove premature Fail in acceptance tests

### DIFF
--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -478,6 +478,9 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 			var httpsFound bool = false
 
 			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if configMap == nil {
+				return false
+			}
 			dataMap := configMap.Data
 			v := dataMap[prometheusConfigMapName]
 			rdr := strings.NewReader(v)
@@ -513,6 +516,9 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 			var httpsFound bool = false
 
 			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if configMap == nil {
+				return false
+			}
 			dataMap := configMap.Data
 			v := dataMap[prometheusConfigMapName]
 			rdr := strings.NewReader(v)
@@ -548,6 +554,9 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 			var httpsNotFound bool = true
 
 			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if configMap == nil {
+				return false
+			}
 			dataMap := configMap.Data
 			v := dataMap[prometheusConfigMapName]
 			rdr := strings.NewReader(v)

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -354,21 +354,6 @@ func ListServices(namespace string) *corev1.ServiceList {
 	return services
 }
 
-// GetService returns a service in a given namespace for the cluster
-func GetService(namespace string, name string) *corev1.Service {
-	services := ListServices(namespace)
-	if services == nil {
-		ginkgo.Fail(fmt.Sprintf("No services in namespace %s", namespace))
-	}
-	for _, service := range services.Items {
-		if name == service.Name {
-			return &service
-		}
-	}
-	ginkgo.Fail(fmt.Sprintf("No service %s in namespace %s", name, namespace))
-	return nil
-}
-
 // GetNamespace returns a namespace
 func GetNamespace(name string) (*corev1.Namespace, error) {
 	// Get the Kubernetes clientset
@@ -446,7 +431,7 @@ func DoesClusterRoleExist(name string) bool {
 	clientset := GetKubernetesClientset()
 
 	clusterrole, err := clientset.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role %s with error: %v", name, err))
 	}
 
@@ -478,7 +463,7 @@ func DoesClusterRoleBindingExist(name string) bool {
 	clientset := GetKubernetesClientset()
 
 	clusterrolebinding, err := clientset.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role binding %s with error: %v", name, err))
 	}
 
@@ -597,7 +582,7 @@ func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
 	clientset := GetKubernetesClientset()
 	cmi := clientset.CoreV1().ConfigMaps(namespace)
 	configMap, err := cmi.Get(context.TODO(), configMapName, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ginkgo.Fail(fmt.Sprintf("Failed to get Config Map %v from namespace %v:  Error = %v ", configMapName, namespace, err))
 	}
 	return configMap
@@ -686,7 +671,7 @@ func CanIForAPIGroup(userOCID string, namespace string, verb string, resource st
 func GetServiceAccount(namespace, name string) *corev1.ServiceAccount {
 	clientset := GetKubernetesClientset()
 	sa, err := clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ginkgo.Fail(fmt.Sprintf("Failed to get service account %s in namespace %s with error: %v", name, namespace, err))
 	}
 	return sa

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -253,6 +253,9 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 	ginkgo.Context("for serviceaccount verrazzano-api", func() {
 		var apiProxy corev1.Pod
 		sa := pkg.GetServiceAccount(verrazzanoSystemNS, verrazzanoAPI)
+		if sa == nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to get service account %s in namespace %s", verrazzanoAPI, verrazzanoSystemNS))
+		}
 		ginkgo.It("Validate the secret of the Service Account of Verrazzano API", func() {
 			// Get secret for the SA
 			saSecret := sa.Secrets[0]


### PR DESCRIPTION
# Description

Remove some premature Fail in acceptance tests.
For example, instead of Fail, we want to return false in case of IsNotFound when getting a resource.  So, Eventually block in tests would have a chance to come back later to retry.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
