### PR TITLE
Tvlatas/suspects take3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -768,7 +768,7 @@ def getSuspectList(commitList, userMappings) {
         ).trim()
         if (gitAuthor != null) {
             def author = trimIfGithubNoreplyUser(gitAuthor)
-            echo "DEBUG: author: ${gitAuthor}, ${author}, id: ${id}"
+            echo "DEBUG: author: ${gitAuthor}, ${author},  id: ${id}"
             if (userMappings.containsKey(author)) {
                 def slackUser = userMappings.get(author)
                 if (!suspectList.contains(slackUser)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -728,11 +728,14 @@ def dumpVerrazzanoApiLogs() {
 
 @NonCPS
 def getCommitList() {
+    echo "Checking for change sets"
     def commitList = []
     def changeSets = currentBuild.changeSets
     for (int i = 0; i < changeSets.size(); i++) {
+        echo "get commits from change set"
         def commits = changeSets[i].items
         for (int j = 0; j < commits.length; j++) {
+            def commit = commits[j]
             def id = commit.commitId
             echo "Add commit id: ${id}"
             commitList.add(id)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -755,14 +755,13 @@ def trimIfGithubNoreplyUser(userIn) {
 
 def getSuspectList(commitList, userMappings) {
     def retValue = ""
-    def commits = null
-    if (commitList.size() == 0) {
+    if (commitList == null || commitList.size() == 0) {
         echo "No commits to form suspect list"
         return retValue
     }
     def suspectList = []
-    for (int i = 0; i < commits.size(); i++) {
-        def id = commits[i]
+    for (int i = 0; i < commitList.size(); i++) {
+        def id = commitList[i]
         def gitAuthor = sh(
             script: "git log --format='%ae' '$id^!'",
             returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -745,12 +745,20 @@ def getCommitList() {
 }
 
 def trimIfGithubNoreplyUser(userIn) {
-    if (userIn == null || !userIn.matches(".*\\+.*@users.noreply.github.com.*")) {
+    if (userIn == null) {
         echo "Not a github noreply user, not trimming: ${userIn}"
         return userIn
     }
-    def userOut = userIn.substring(userIn.indexOf("+") + 1, userIn.indexOf("@"))
-    return userOut
+    if (userIn.matches(".*\\+.*@users.noreply.github.com.*")) {
+        def userOut = userIn.substring(userIn.indexOf("+") + 1, userIn.indexOf("@"))
+        return userOut;
+    }
+    if (userIn.matches(".*<.*@users.noreply.github.com.*")) {
+        def userOut = userIn.substring(userIn.indexOf("<") + 1, userIn.indexOf("@"))
+        return userOut;
+    }
+    echo "Not a github noreply user, not trimming: ${userIn}"
+    return userIn
 }
 
 def getSuspectList(commitList, userMappings) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,9 +147,11 @@ pipeline {
                     DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
+                    def currentCommitHash = env.GIT_COMMIT
+                    def previousCleanBuildCommitId = getPreviousCleanBuildCommit(currentCommitHash)
                     withCredentials([file(credentialsId: 'jenkins-to-slack-users', variable: 'JENKINS_TO_SLACK_JSON')]) {
                         def userMappings = readJSON file: JENKINS_TO_SLACK_JSON
-                        SUSPECT_LIST = getSuspectList( userMappings )
+                        SUSPECT_LIST = getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings)
                         echo "Suspect list: ${SUSPECT_LIST}"
                     }
                 }
@@ -725,29 +727,73 @@ def dumpVerrazzanoApiLogs() {
 }
 
 @NonCPS
-def getSuspectList(userMappings) {
-    def suspectList = []
+def getPreviousCleanBuildCommit(currentCommitHash) {
+    // If we can't determine the previous clean commit hash for some reason, return the current hash
+    // effectively it will give us a rev-list later that is empty (ie: if this is a new branch with no previous clean build)
+    def previousCleanBuildCommitId = currentCommitHash
+
+     // if this is the first run of a branch it will be null (no previous successful build yet)
+    def previousSuccessfulBuild = currentBuild.getPreviousSuccessfulBuild()
+    if (previousSuccessfulBuild == null) {
+        echo "There was not a previous successful build, not forming a suspect list. We should not see this in master, only in new branches"
+        return previousCleanBuildCommitId
+    }
+
+    // We don't have access to the raw build, but we can get the changeset from the previous build and get the commit from that
+    // Assuming the first one is the last change in the change set
+    def previousChangeSets = previousSuccessfulBuild.changeSets
+    if (previousChangeSets.size() == 0) {
+        echo "No change sets found from the previous successful build"
+        return previousCleanBuildCommitId
+    }
+    def lastChangeSet = previousChangeSets.get(0)
+    if (lastChangeSet == null) {
+        echo "last change set was null"
+        return previousCleanBuildCommitId
+    }
+    def prevCommits = lastChangeSet.items
+    if (prevCommits.length == 0) {
+        echo "empty commits in last change set found"
+        return previousCleanBuildCommitId
+    }
+    previousCleanBuildCommitId = prevCommits[0].id
+    echo "previous clean commit id = ${previousCleanBuildCommitId}"
+    return previousCleanBuildCommitId
+}
+
+def getSuspectList(previousCleanBuildCommitId, currentCommitHash, userMappings) {
     def retValue = ""
-    def changeSets = currentBuild.changeSets
-    for (int i = 0; i < changeSets.size(); i++) {
-        def commits = changeSets[i].items
-        for (int j = 0; j < commits.length; j++) {
-            def commit = commits[j]
-            def author = commit.author.toString()
-            if (userMappings.containsKey(author)) {
-                def slackUser = userMappings.get(author)
-                if (!suspectList.contains(slackUser)) {
-                    echo "Added ${slackUser} as suspect"
-                    retValue += " ${slackUser}"
-                    suspectList.add(slackUser)
-                }
-            } else {
-                // If we don't have a name mapping use the commit.author, at least we can easily tell if the mapping gets dated
-                if (!suspectList.contains(author)) {
-                    echo "Added ${author} as suspect"
-                    retValue += " ${author}"
-                    suspectList.add(author)
-                }
+    def commits = null
+    if (previousCleanBuildCommitId.equals(currentCommitHash)) {
+        echo "Previous and current are the same"
+        return retValue
+    }
+    def commits = sh(
+        script: "git rev-list $currentCommitHash \"^$previousCleanBuildCommitId\"",
+        returnStdout: true
+    ).split('\n')
+    echo "Commits are: $commits"
+    def suspectList = []
+    for (int i = 0; i < commits.length; i++) {
+        def id = commits[i]
+        def author = sh(
+            script: "git log --format='%ae' '$id^!'",
+            returnStdout: true
+        ).trim()
+        echo "DEBUG: author: ${author}, id: ${id}"
+        if (userMappings.containsKey(author)) {
+            def slackUser = userMappings.get(author)
+            if (!suspectList.contains(slackUser)) {
+                echo "Added ${slackUser} as suspect"
+                retValue += " ${slackUser}"
+                suspectList.add(slackUser)
+            }
+        } else {
+            // If we don't have a name mapping use the commit.author, at least we can easily tell if the mapping gets dated
+            if (!suspectList.contains(author)) {
+                echo "Added ${author} as suspect"
+                retValue += " ${author}"
+                suspectList.add(author)
             }
         }
     }


### PR DESCRIPTION
# Description

This updates the suspect list handling to use a hybrid approach:

- Get the commit ids from the Jenkins supplied changeset for the job (those caveats apply)
- Use git to get the commit author. For github UI committed changes (like master, or a branch where you commit from the UI), this returns the github form of the noreply user. We then trim that if it matches that format down to the actual github username.
- The github usernames are then mapped to slack. note that other format names also work here as well (email names, etc... for branches where you committed using git), so those are also still included in the mapping and continue to work as well. Though we only currently care about suspect notification in master at the moment.

Both forms of the user have been tested in the branch

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
