### PR TITLE
Use branch name to download operator.yaml from OS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,6 +210,16 @@ pipeline {
             }
         }
 
+        stage('Build') {
+            when { not { buildingTag() } }
+            steps {
+                sh """
+                    cd ${GO_REPO_PATH}/verrazzano
+                    make docker-push VERRAZZANO_PLATFORM_OPERATOR_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} VERRAZZANO_APPLICATION_OPERATOR_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} VERRAZZANO_ANALYSIS_IMAGE_NAME=${DOCKER_ANALYSIS_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+                   """
+            }
+        }
+
         stage('Update operator.yaml') {
             when {
                 allOf {
@@ -226,16 +236,6 @@ pipeline {
                     cd ${GO_REPO_PATH}/verrazzano
                     oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/operator.yaml --file $WORKSPACE/generated-operator.yaml
                     oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${SHORT_COMMIT_HASH}/operator.yaml --file $WORKSPACE/generated-operator.yaml
-                   """
-            }
-        }
-
-        stage('Build') {
-            when { not { buildingTag() } }
-            steps {
-                sh """
-                    cd ${GO_REPO_PATH}/verrazzano
-                    make docker-push VERRAZZANO_PLATFORM_OPERATOR_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} VERRAZZANO_APPLICATION_OPERATOR_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} VERRAZZANO_ANALYSIS_IMAGE_NAME=${DOCKER_ANALYSIS_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
                    """
             }
         }

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -185,7 +185,7 @@ pipeline {
                         cd ${GO_REPO_PATH}/verrazzano
                         if [ "NONE" = "${VERRAZZANO_OPERATOR_IMAGE}" ]; then
                             echo "Using operator.yaml from object storage"
-                            oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
+                            oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
                             cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
                         else
                             echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"


### PR DESCRIPTION
# Description

The install loop test pipeline, unless overridden through a parameter, tries to download the latest `operator.yaml` file from ObjectStore based on the most recent commit hash for the branch it's running off of (typically `master`).

However,  depending on when the file download and Verrazzano install occurs on the loop test pipeline, it may result in trying to pull an operator.yaml from ObjectStore before the image has been built and pushed.  This will cause the image pull errors in the cluster for the operator.

The solution is:
- Move the`Update operator.yaml` stage in the master build that pushes the operator.yaml to ObjectStore to run after the `Build` stage to ensure the `branch-name/operator.yaml` file always contains an image that has been successfully pushed
- In the loop-install Jenkinsfile, pull the `operator.yaml` from ObjectStore using `branch-name/operator.yaml`.  

It's still possible it may not exist in the boundary case where a non-master branch has not had a build yet, but that case already exists.  But as long as there has been one successful build/push the branch-named operator.yaml should contain a valid image.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
