### PR TITLE
VZ-2542: Add network policies for Istio

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -165,6 +165,9 @@ setup-cluster: create-cluster
 	echo 'Load Docker image for the Verrazzano application operator...'
 	time kind load docker-image --name ${CLUSTER_NAME} ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 
+	# The application operator creates network policies in the istio-system namespace, so make sure it exists
+	kubectl create ns istio-system
+
 	echo 'Install OAM runtime and Verrazzano application operator...'
 	time installer/install.sh || (echo 'Application operator install failed, capturing kind cluster dump'; ../tools/scripts/k8s-dump-cluster.sh -d ${CLUSTER_DUMP_LOCATION} -r ${CLUSTER_DUMP_LOCATION}/analysis.report; exit 1)
 

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -78,3 +78,6 @@ const LabelUpgradeVersion = "upgrade-version"
 
 // VzConsoleIngress - the name of the ingress for verrazzano console and api
 const VzConsoleIngress = "verrazzano-ingress"
+
+// IstioSystemNamespace - the Istio system namespace
+const IstioSystemNamespace = "istio-system"

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	istioNamespace           = "istio-system"
 	gatewayAPIVersion        = "networking.istio.io/v1alpha3"
 	gatewayKind              = "Gateway"
 	virtualServiceAPIVersion = "networking.istio.io/v1alpha3"
@@ -302,7 +301,7 @@ func (r *Reconciler) createGatewayCertificate(ctx context.Context, trait *vzapi.
 			APIVersion: certificateAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: istioNamespace,
+			Namespace: constants.IstioSystemNamespace,
 			Name:      certName,
 		}}
 
@@ -756,10 +755,9 @@ func buildNamespacedDomainName(cli client.Reader, trait *vzapi.IngressTrait) (st
 // Get the IP from Istio resources
 func buildDomainNameForWildcard(cli client.Reader, trait *vzapi.IngressTrait, suffix string) (string, error) {
 	const istioIngressGateway = "istio-ingressgateway"
-	const istioNamespace = "istio-system"
 
 	istio := corev1.Service{}
-	err := cli.Get(context.TODO(), types.NamespacedName{Name: istioIngressGateway, Namespace: istioNamespace}, &istio)
+	err := cli.Get(context.TODO(), types.NamespacedName{Name: istioIngressGateway, Namespace: constants.IstioSystemNamespace}, &istio)
 	if err != nil {
 		return "", err
 	}

--- a/application-operator/controllers/webhooks/appconfig_defaulter.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter.go
@@ -11,6 +11,7 @@ import (
 
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	certapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 	v1beta12 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,10 +26,7 @@ import (
 var log = ctrl.Log.WithName("webhooks.appconfig-defaulter")
 
 // AppConfigDefaulterPath specifies the path of AppConfigDefaulter
-const (
-	AppConfigDefaulterPath = "/appconfig-defaulter"
-	istioSystemNamespace   = "istio-system"
-)
+const AppConfigDefaulterPath = "/appconfig-defaulter"
 
 // +kubebuilder:webhook:verbs=create;update,path=/appconfig-defaulter,mutating=true,failurePolicy=fail,groups=core.oam.dev,resources=ApplicationConfigurations,versions=v1alpha2,name=appconfig-defaulter.kb.io
 
@@ -127,7 +125,7 @@ func (a *AppConfigWebhook) cleanupAppConfig(appConfig *oamv1.ApplicationConfigur
 // cleanupCert cleans up the generated certificate for the given app config
 func (a *AppConfigWebhook) cleanupCert(appConfig *oamv1.ApplicationConfiguration) (err error) {
 	gatewayCertName := fmt.Sprintf("%s-%s-cert", appConfig.Namespace, appConfig.Name)
-	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: istioSystemNamespace}
+	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: constants.IstioSystemNamespace}
 	var cert *certapiv1alpha2.Certificate
 	cert, err = fetchCert(context.TODO(), a.Client, namespacedName)
 	if err != nil {
@@ -142,7 +140,7 @@ func (a *AppConfigWebhook) cleanupCert(appConfig *oamv1.ApplicationConfiguration
 // cleanupSecret cleans up the generated secret for the given app config
 func (a *AppConfigWebhook) cleanupSecret(appConfig *oamv1.ApplicationConfiguration) (err error) {
 	gatewaySecretName := fmt.Sprintf("%s-%s-cert-secret", appConfig.Namespace, appConfig.Name)
-	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: istioSystemNamespace}
+	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: constants.IstioSystemNamespace}
 	var secret *corev1.Secret
 	secret, err = fetchSecret(context.TODO(), a.Client, namespacedName)
 	if err != nil {

--- a/application-operator/controllers/webhooks/appconfig_defaulter_test.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
-	"k8s.io/api/admission/v1beta1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -215,7 +214,7 @@ func testAppConfigWebhookHandleDelete(t *testing.T, certFound, secretFound, dryR
 	}
 	webhook.InjectDecoder(decoder)
 	req := admission.Request{
-		AdmissionRequest: admissionv1beta1.AdmissionRequest{Operation: v1beta1.Delete},
+		AdmissionRequest: admissionv1beta1.AdmissionRequest{Operation: admissionv1beta1.Delete},
 	}
 	req.OldObject = runtime.RawExtension{Raw: readYaml2Json(t, "hello-conf.yaml")}
 	if dryRun {

--- a/application-operator/controllers/webhooks/istio_defaulter_test.go
+++ b/application-operator/controllers/webhooks/istio_defaulter_test.go
@@ -14,7 +14,6 @@ import (
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -72,7 +71,7 @@ func TestHandleIstioDisabled(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := defaulter.Handle(context.TODO(), req)
 	assert.True(t, res.Allowed)
-	assert.Equal(t, v1.StatusReason("No action required, pod labeled with sidecar.istio.io/inject: false"), res.Result.Reason)
+	assert.Equal(t, metav1.StatusReason("No action required, pod labeled with sidecar.istio.io/inject: false"), res.Result.Reason)
 }
 
 // TestHandleNoOnwerReference tests handling an admission.Request
@@ -105,7 +104,7 @@ func TestHandleNoOnwerReference(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := defaulter.Handle(context.TODO(), req)
 	assert.True(t, res.Allowed)
-	assert.Equal(t, v1.StatusReason("No action required, pod is not a child of an ApplicationConfiguration resource"), res.Result.Reason)
+	assert.Equal(t, metav1.StatusReason("No action required, pod is not a child of an ApplicationConfiguration resource"), res.Result.Reason)
 }
 
 // TestHandleNoAppConfigOnwerReference tests handling an admission.Request
@@ -172,7 +171,7 @@ func TestHandleNoAppConfigOnwerReference(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := defaulter.Handle(context.TODO(), req)
 	assert.True(t, res.Allowed)
-	assert.Equal(t, v1.StatusReason("No action required, pod is not a child of an ApplicationConfiguration resource"), res.Result.Reason)
+	assert.Equal(t, metav1.StatusReason("No action required, pod is not a child of an ApplicationConfiguration resource"), res.Result.Reason)
 }
 
 // TestHandleAppConfigOnwerReference1 tests handling an admission.Request

--- a/application-operator/controllers/webhooks/logging_scope_defaulter.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter.go
@@ -6,10 +6,10 @@ package webhooks
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -87,7 +87,7 @@ func createDefaultLoggingScope(name types.NamespacedName) *vzapi.LoggingScope {
 }
 
 // includeDefaultLoggingScope updates the scopes of the given component to include the default logging scope, if appropriate
-func includeDefaultLoggingScope(component *v1alpha2.ApplicationConfigurationComponent, defaultLoggingComponentScope oamv1.ComponentScope) (includeDefault bool) {
+func includeDefaultLoggingScope(component *oamv1.ApplicationConfigurationComponent, defaultLoggingComponentScope oamv1.ComponentScope) (includeDefault bool) {
 	includeDefault = true
 	var scopes []oamv1.ComponentScope
 	for _, scope := range component.Scopes {
@@ -108,7 +108,7 @@ func includeDefaultLoggingScope(component *v1alpha2.ApplicationConfigurationComp
 }
 
 // getDefaultLoggingScopeName gets the default logging scope name for a given app config
-func getDefaultLoggingScopeName(appConfig *v1alpha2.ApplicationConfiguration) string {
+func getDefaultLoggingScopeName(appConfig *oamv1.ApplicationConfiguration) string {
 	return fmt.Sprintf("default-%s-logging-scope", appConfig.Name)
 }
 

--- a/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
+++ b/application-operator/controllers/webhooks/logging_scope_defaulter_test.go
@@ -5,16 +5,15 @@ package webhooks
 
 import (
 	"context"
-	v1 "k8s.io/api/core/v1"
 	"net/http"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,8 +25,6 @@ import (
 // NotFoundError indicates an error caused by a StatusNotFound status
 type NotFoundError struct {
 }
-
-var emptyEsDetails = clusters.ElasticsearchDetails{}
 
 func (s NotFoundError) Error() string {
 	return "StatusNotFound"
@@ -300,7 +297,7 @@ func testLoggingScopeDefaulterDefault(t *testing.T, cli client.Client, configPat
 	for _, component := range appConfig.Spec.Components {
 		foundLoggingScope := false
 		for _, scope := range component.Scopes {
-			if scope.ScopeReference.APIVersion == apiVersion && scope.ScopeReference.Kind == v1alpha1.LoggingScopeKind && scope.ScopeReference.Name == scopeNames[component.ComponentName] {
+			if scope.ScopeReference.APIVersion == apiVersion && scope.ScopeReference.Kind == vzapi.LoggingScopeKind && scope.ScopeReference.Name == scopeNames[component.ComponentName] {
 				foundLoggingScope = true
 			}
 		}

--- a/application-operator/controllers/webhooks/net_policy_defaulter.go
+++ b/application-operator/controllers/webhooks/net_policy_defaulter.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+
+	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var logger = ctrl.Log.WithName("webhooks.network.policy")
+
+type NetPolicyDefaulter struct {
+	Client client.Client
+}
+
+// Default handles creating the Istio network policy for the application. The network policy is needed
+// to allow ingress to the istiod pod from the Istio proxy sidecar that runs in the application pods.
+// This function also adds the Verrazzano namespace label to the app config namespace (if needed) so
+// the network policy can match the namespace with a selector.
+func (n *NetPolicyDefaulter) Default(appConfig *oamv1.ApplicationConfiguration, dryRun bool) error {
+	if appConfig.DeletionTimestamp != nil {
+		logger.Info("App config is being deleted, nothing to do", "namespace", appConfig.Namespace, "app config name", appConfig.Name)
+		return nil
+	}
+
+	if !dryRun {
+		// label the namespace
+		n.ensureNamespaceLabel(appConfig.Namespace)
+
+		// create/update the network policy
+		logger.Info("Ensuring Istio network policy exists", "namespace", appConfig.Namespace, "app config name", appConfig.Name)
+		netpol := newNetworkPolicy(appConfig)
+
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), n.Client, &netpol, func() error {
+			netpol.Spec = newNetworkPolicySpec(appConfig.Namespace)
+			return nil
+		})
+
+		if err != nil {
+			logger.Error(err, "Unable to create or update network policy", "namespace", appConfig.Namespace, "app config name", appConfig.Name)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Cleanup deletes the Istio network policy associated with the app config.
+func (n *NetPolicyDefaulter) Cleanup(appConfig *oamv1.ApplicationConfiguration, dryRun bool) error {
+	if !dryRun {
+		// delete the network policy
+		logger.Info("Deleting Istio network policy", "namespace", appConfig.Namespace, "app config name", appConfig.Name)
+		netpol := newNetworkPolicy(appConfig)
+		err := n.Client.Delete(context.TODO(), &netpol, &client.DeleteOptions{})
+		if err != nil {
+			// log the error but don't return it so we continue processing
+			logger.Error(err, "Unable to delete network policy")
+		}
+	}
+
+	return nil
+}
+
+// ensureNamespaceLabel fetches the namespace and checks to see if it has the Verrazzano
+// namespace label. If not, we add the label.
+func (n *NetPolicyDefaulter) ensureNamespaceLabel(namespace string) error {
+	var ns corev1.Namespace
+	namespacedName := types.NamespacedName{Name: namespace}
+	err := n.Client.Get(context.TODO(), namespacedName, &ns)
+	if err != nil {
+		logger.Error(err, "Unable to fetch namespace", "namespace", namespace)
+		return err
+	}
+
+	val, exists := ns.ObjectMeta.Labels[constants.LabelVerrazzanoNamespace]
+	if !exists || val != namespace {
+		logger.Info("Updating namespace with Verrazzano namespace label", "namespace", namespace)
+		ns.ObjectMeta.Labels[constants.LabelVerrazzanoNamespace] = namespace
+
+		err = n.Client.Update(context.TODO(), &ns, &client.UpdateOptions{})
+		if err != nil {
+			logger.Error(err, "Unable to add label to namespace", "namespace", namespace)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// newNetworkPolicy returns a NetworkPolicy struct populated with the namespace and name.
+func newNetworkPolicy(appConfig *oamv1.ApplicationConfiguration) netv1.NetworkPolicy {
+	return netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.IstioSystemNamespace,
+			Name:      appConfig.Namespace + "-" + appConfig.Name,
+		},
+	}
+}
+
+// newNetworkPolicySpec returns a NetworkPolicySpec struct populated with the istiod
+// ingress rule that allows ingress to istiod from the application namespace.
+func newNetworkPolicySpec(namespace string) netv1.NetworkPolicySpec {
+	tcpProtocol := corev1.ProtocolTCP
+	istiodPort := intstr.FromInt(15012)
+
+	return netv1.NetworkPolicySpec{
+		PolicyTypes: []netv1.PolicyType{
+			netv1.PolicyTypeIngress,
+		},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				// ingress from app namespace to istiod
+				Ports: []netv1.NetworkPolicyPort{
+					{
+						Protocol: &tcpProtocol,
+						Port:     &istiodPort,
+					},
+				},
+				From: []netv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{constants.LabelVerrazzanoNamespace: namespace},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/application-operator/controllers/webhooks/net_policy_defaulter_test.go
+++ b/application-operator/controllers/webhooks/net_policy_defaulter_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace = "unit-test-ns"
+	appConfigName = "unit-test-app-config"
+)
+
+// erroringFakeClient is a client wrapper that allows us to simulate a conflict error on update
+type erroringFakeClient struct {
+	client.Client
+	conflictReturned bool
+}
+
+// Update returns a conflict error one time, and then passes through to the wrapped client on subsequent calls.
+// This allows us to test retries when updating the namespace with a label.
+func (e *erroringFakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	if !e.conflictReturned {
+		e.conflictReturned = true
+		return errors.NewConflict(schema.GroupResource{}, "", nil)
+	}
+	return e.Client.Update(ctx, obj, opts...)
+}
+
+// GIVEN an app config is being created
+// WHEN the network policy defaulter Default function is called
+// THEN the network policy defaulter labels the app namespace and creates a network policy in the Istio system namespace
+func TestDefaultNetworkPolicy(t *testing.T) {
+	appConfig := &oamv1.ApplicationConfiguration{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: appConfigName}}
+	fakeClient := newFakeClient()
+	defaulter := &NetPolicyDefaulter{Client: fakeClient}
+
+	// create the test namespace so the defaulter can add a label to it
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	fakeClient.Create(context.TODO(), ns, &client.CreateOptions{})
+
+	// this is the function under test, we expect this to label the namespace and create the network policy
+	err := defaulter.Default(appConfig, false)
+	assert.NoError(t, err, "Unexpected error creating network policy")
+
+	// assert that the app namespace was labeled
+	assertNamespaceLabeled(t, fakeClient)
+
+	// assert that the network policy was created and the spec has the expected data
+	assertNetworkPolicy(t, fakeClient)
+}
+
+// GIVEN an app config is being created
+// WHEN the network policy defaulter Default function is called
+// AND there is a conflict updating the app namespace
+// THEN the network policy defaulter retries adding the label to the namespace, succeeds, and creates a network policy
+func TestRetryLabelNamespace(t *testing.T) {
+	appConfig := &oamv1.ApplicationConfiguration{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: appConfigName}}
+	fakeClient := newFakeClient()
+	errFakeClient := &erroringFakeClient{Client: fakeClient, conflictReturned: false}
+	defaulter := &NetPolicyDefaulter{Client: errFakeClient}
+
+	// create the test namespace so the defaulter can add a label to it
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	fakeClient.Create(context.TODO(), ns, &client.CreateOptions{})
+
+	// this is the function under test, we expect this to label the namespace and create the network policy
+	err := defaulter.Default(appConfig, false)
+	assert.NoError(t, err, "Unexpected error creating network policy")
+
+	// assert that the erroring fake client returned a conflict error
+	assert.True(t, errFakeClient.conflictReturned)
+
+	// assert that the app namespace was labeled
+	assertNamespaceLabeled(t, fakeClient)
+
+	// assert that the network policy was created and the spec has the expected data
+	assertNetworkPolicy(t, fakeClient)
+}
+
+// GIVEN an app config is being deleted
+// WHEN the network policy defaulter Cleanup function is called
+// THEN the network policy defaulter deletes the network policy from the Istio system namespace
+func TestDeleteNetworkPolicy(t *testing.T) {
+	// create the app config with a non-nil deletion timestamp
+	appConfig := &oamv1.ApplicationConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         testNamespace,
+			Name:              appConfigName,
+			DeletionTimestamp: &metav1.Time{},
+		},
+	}
+	fakeClient := newFakeClient()
+	defaulter := &NetPolicyDefaulter{Client: fakeClient}
+
+	// create a network policy so the defaulter can delete it
+	netPol := newNetworkPolicy(appConfig)
+	err := fakeClient.Create(context.TODO(), &netPol, &client.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error creating network policy")
+
+	// this is the function under test, we expect this to delete the network policy
+	err = defaulter.Cleanup(appConfig, false)
+	assert.NoError(t, err, "Unexpected error deleting network policy")
+
+	// assert that the network policy no longer exists
+	assertNoNetworkPolicy(t, fakeClient)
+}
+
+// GIVEN an app config is being deleted
+// WHEN the network policy defaulter Default function is called
+// THEN the network policy defaulter does nothing
+func TestAppConfigInDelete(t *testing.T) {
+	// create the app config with a non-nil deletion timestamp
+	appConfig := &oamv1.ApplicationConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         testNamespace,
+			Name:              appConfigName,
+			DeletionTimestamp: &metav1.Time{},
+		},
+	}
+	fakeClient := newFakeClient()
+	defaulter := &NetPolicyDefaulter{Client: fakeClient}
+
+	// this is the function under test, since the app config is being deleted, we expect
+	// no resources to be created or updated
+	err := defaulter.Default(appConfig, false)
+	assert.NoError(t, err)
+
+	// assert that the network policy did not get created
+	assertNoNetworkPolicy(t, fakeClient)
+}
+
+// newFakeClient returns a new fake client
+func newFakeClient() client.Client {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	netv1.AddToScheme(scheme)
+	return ctrlfake.NewFakeClientWithScheme(scheme)
+}
+
+// fetchNetworkPolicy fetches the network policy using the provided client
+func fetchNetworkPolicy(t *testing.T, client client.Client) (*netv1.NetworkPolicy, error) {
+	netPolicyName := testNamespace + "-" + appConfigName
+	var netPolicy netv1.NetworkPolicy
+	namespacedName := types.NamespacedName{Namespace: constants.IstioSystemNamespace, Name: netPolicyName}
+
+	err := client.Get(context.TODO(), namespacedName, &netPolicy)
+
+	return &netPolicy, err
+}
+
+// assertNetworkPolicy asserts that the network policy exists and that the spec contains the expected data.
+func assertNetworkPolicy(t *testing.T, client client.Client) {
+	netPolicy, err := fetchNetworkPolicy(t, client)
+
+	assert.NoError(t, err, "Unexpected error fetching network policy")
+	assert.Equal(t, newNetworkPolicySpec(testNamespace), netPolicy.Spec)
+}
+
+// assertNoNetworkPolicy asserts that the network policy does not exist
+func assertNoNetworkPolicy(t *testing.T, client client.Client) {
+	_, err := fetchNetworkPolicy(t, client)
+
+	assert.True(t, errors.IsNotFound(err), "Expected to get NotFound error")
+}
+
+// assertNamespaceLabeled asserts that the namespace has been labeled with the Verrazzano namespace label.
+func assertNamespaceLabeled(t *testing.T, client client.Client) {
+	var ns corev1.Namespace
+	namespacedName := types.NamespacedName{Name: testNamespace}
+
+	err := client.Get(context.TODO(), namespacedName, &ns)
+
+	assert.NoError(t, err, "Unexpected error fetching namespace")
+	assert.Equal(t, testNamespace, ns.Labels[constants.LabelVerrazzanoNamespace])
+}

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -190,12 +190,6 @@ func main() {
 			os.Exit(1)
 		}
 
-		restConfig, err = clientcmd.BuildConfigFromFlags("", "")
-		if err != nil {
-			setupLog.Error(err, "unable to build kube config")
-			os.Exit(1)
-		}
-
 		istioClientSet, err := istioversionedclient.NewForConfig(restConfig)
 		if err != nil {
 			setupLog.Error(err, "Failed to create istio client")

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -225,6 +225,9 @@ func main() {
 				&webhooks.LoggingScopeDefaulter{
 					Client: mgr.GetClient(),
 				},
+				&webhooks.NetPolicyDefaulter{
+					Client: mgr.GetClient(),
+				},
 			},
 		}
 		mgr.GetWebhookServer().Register(webhooks.AppConfigDefaulterPath, &webhook.Admission{Handler: appconfigWebhook})

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -226,7 +226,8 @@ func main() {
 					Client: mgr.GetClient(),
 				},
 				&webhooks.NetPolicyDefaulter{
-					Client: mgr.GetClient(),
+					Client:          mgr.GetClient(),
+					NamespaceClient: kubeClient.CoreV1().Namespaces(),
 				},
 			},
 		}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -580,3 +580,81 @@ spec:
       ports:
         - port: 8080
           protocol: TCP
+---
+# Network policy for istio-system pod communication
+# Ingress: allow all pod-to-pod communication within the namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: istio-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+# Network policy for Istio ingress gateway
+# Ingress: allow ingress to port 8443 from anywhere
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+---
+# Network policy for Istio egress gateway
+# Ingress: allow ingress to port 8443 from anywhere
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-egressgateway
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: istio-egressgateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+---
+# Network policy for Istio coredns
+# Ingress: allow ingress to port 53 from kube-system DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istiocoredns
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: istiocoredns
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -658,3 +658,28 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+---
+# Network policy for Istiod
+# Ingress: allow ingress to port 15012 from verrazzano-system prometheus
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: istiod
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 15012
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app: system-prometheus

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -660,7 +660,8 @@ spec:
               k8s-app: kube-dns
 ---
 # Network policy for Istiod
-# Ingress: allow ingress to port 15012 from verrazzano-system prometheus
+# Ingress: allow ingress to port 15012 from verrazzano-system prometheus (for Istio proxy sidecar)
+#          allow port 443 for webhooks
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -683,3 +684,6 @@ spec:
           podSelector:
             matchLabels:
               app: system-prometheus
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -664,7 +664,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: istiod
+  name: istiod-verrazzano-system
   namespace: istio-system
 spec:
   podSelector:


### PR DESCRIPTION
# Description

This PR adds ingress network policies for things running in the `istio-system` namespace. There are static policies that get created at Verrazzano install time (in `08-thirdparty-networkpolicy.yaml`) as well as dynamic policies created by the Verrazzano Application Operator by the app config mutating webhook. The dynamic policies allow the Istio proxy sidecars in pods in the application namespaces to talk to iostiod.

**Notes**:

- I ran into intermittent problems labeling the application namespace because other things were updating the namespace at the same time. This resulted in sporadic "the resource has already been updated, please retry..." errors that resulted in test failures. I added retries around labeling the namespace to handle that case.
- The application operator integration tests failed because the `istio-system` namespace did not exist. I updated the Makefile target that sets up the integration test cluster to create the namespace.
- This PR also includes cleanup of duplicate imports in several files, as well as removing an unused variable, and refactoring to use shared constants to remove code duplication (not related to this work).


Implements VZ-2542

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
