### PR TITLE
update nginx image version for ingress controller (to make it same as image being used by verrazzano api server)

### DIFF
--- a/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
+++ b/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
@@ -4,7 +4,7 @@
 controller:
   image:
     repository: ghcr.io/verrazzano/nginx-ingress-controller
-    tag: 0.32-20201016205412-8580ea0ef
+    tag: 0.32-20210122132046-a84f6166a
   config:
     client-body-buffer-size: 64k
   metrics:
@@ -22,6 +22,6 @@ controller:
 defaultBackend:
   image:
     repository: ghcr.io/verrazzano/nginx-ingress-default-backend
-    tag: 0.32-20201016205412-8580ea0ef
+    tag: 0.32-20210122132046-a84f6166a
   enabled:
     true


### PR DESCRIPTION
# Description

Currently verrazzano seems to be using two version of nginx-ingress-controller image
nginx-ingress-controller:0.32-20201016205412-8580ea0ef  for the ingress-nginx controller and nginx-ingress-controller:0.32-20210122132046-a84f6166a for verrazzano api server. The later image is an upgrade to the former and contains additional lua modules required for verrazzano api servers and updates to dependencies to remove security vulnerabilities. and therefore the image being used by verrazzano api server can also be used by the ingress nginx controller. This change to enable that.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
