### PR TITLE
Add rancher egress to api server and ingress/egress to cattle-system

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -405,6 +405,10 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
+            verrazzano.io/namespace: cattle-system
+    - from:
+      - namespaceSelector:
+          matchLabels:
             verrazzano.io/namespace: ingress-nginx
       - podSelector:
           matchLabels:
@@ -412,6 +416,18 @@ spec:
       ports:
         - protocol: TCP
           port: 80
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: cattle-system
+    - ports:
+        - port: {{ .Values.kubernetes.service.endpoint.port }}
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.kubernetes.service.endpoint.ip }}/32
+
 ---
 # Network policy for Rancher operator
 # Ingress: deny all


### PR DESCRIPTION
Allow Rancher to talk to Kubernetes API server.   This fixes errors seen in the AT logs.  Also, allow Rancher to communicate with other pods in the Rancher namespace.  We can see from the logs that it is attempting to do that.

From. the logs, this is the new policy

Name:         rancher
Namespace:    cattle-system
Created on:   2021-05-07 19:09:03 +0000 UTC
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     app=rancher
  Allowing ingress traffic:
    To Port: <any> (traffic allowed to all ports)
    From:
      NamespaceSelector: verrazzano.io/namespace=cattle-system
    ----------
    To Port: 80/TCP
    From:
      NamespaceSelector: verrazzano.io/namespace=ingress-nginx
    From:
      PodSelector: app.kubernetes.io/instance=ingress-controller
  Allowing egress traffic:
    To Port: <any> (traffic allowed to all ports)
    To:
      NamespaceSelector: verrazzano.io/namespace=cattle-system
    ----------
    To Port: 6443/TCP
    To:
      IPBlock:
        CIDR: 172.18.0.3/32
        Except: 
  Policy Types: Ingress, Egress


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
