### PR TITLE
Update weblogic operator to 3.2.2

### DIFF
--- a/application-operator/installer/scripts/2-install-wls-operator.sh
+++ b/application-operator/installer/scripts/2-install-wls-operator.sh
@@ -17,7 +17,7 @@ function install_wls_operator {
   fi
 
   log "Checkout WebLogic Kubernetes operator"
-  git --git-dir=$TMP_DIR/weblogic-kubernetes-operator/.git --work-tree=$TMP_DIR/weblogic-kubernetes-operator checkout v3.1.0
+  git --git-dir=$TMP_DIR/weblogic-kubernetes-operator/.git --work-tree=$TMP_DIR/weblogic-kubernetes-operator checkout v3.2.2
   if [ $? -ne 0 ]; then
     error "Failed to checkout WebLogic Kubernetes operator."
     return 1
@@ -31,7 +31,7 @@ function install_wls_operator {
   fi
 
   log "Install WebLogic Kubernetes operator"
-  helm install weblogic-operator $TMP_DIR/weblogic-kubernetes-operator/kubernetes/charts/weblogic-operator --namespace verrazzano-system --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.1.0 --set serviceAccount=weblogic-operator-sa --set domainNamespaceSelectionStrategy=LabelSelector --set domainNamespaceLabelSelector=verrazzano-managed --set enableClusterRoleBinding=true --wait
+  helm install weblogic-operator $TMP_DIR/weblogic-kubernetes-operator/kubernetes/charts/weblogic-operator --namespace verrazzano-system --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2 --set serviceAccount=weblogic-operator-sa --set domainNamespaceSelectionStrategy=LabelSelector --set domainNamespaceLabelSelector=verrazzano-managed --set enableClusterRoleBinding=true --wait
   if [ $? -ne 0 ]; then
     error "Failed to install WebLogic Kubernetes operator."
     return 1

--- a/platform-operator/helm_config/overrides/weblogic-values.yaml
+++ b/platform-operator/helm_config/overrides/weblogic-values.yaml
@@ -1,4 +1,4 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-image: ghcr.io/oracle/weblogic-kubernetes-operator:3.1.0
+image: ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2

--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -94,7 +94,7 @@ The `wls-operator` folder was created by running the following commands:
 
 ```
 export WEBLOGIC_OPERATOR_CHART_REPO=https://oracle.github.io/weblogic-kubernetes-operator/charts
-export WEBLOGIC_OPERATOR_CHART_VERSION=3.1.0
+export WEBLOGIC_OPERATOR_CHART_VERSION=3.2.2
 rm -rf weblogic-operator
 helm repo add weblogic-operator ${WEBLOGIC_OPERATOR_CHART_REPO}
 helm repo update

--- a/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
@@ -1,6 +1,10 @@
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: v1
-appVersion: 3.1.0
-description: Helm chart for configuring the WebLogic operator.
 name: weblogic-operator
+description: Helm chart for configuring the WebLogic operator.
+
 type: application
-version: 3.1.0
+version: 3.2.2
+appVersion: 3.2.2

--- a/platform-operator/thirdparty/charts/weblogic-operator/LICENSE.txt
+++ b/platform-operator/thirdparty/charts/weblogic-operator/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_domain-namespaces.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_domain-namespaces.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.domainNamespaces" }}
@@ -17,7 +17,7 @@
 {{-   $args := include "utils.cloneDictionary" . | fromYaml -}}
 {{- /*
       Split terms on commas not contained in parentheses. Unfortunately, the regular expression
-      support included with Helm tempalates does not include lookarounds.
+      support included with Helm templates does not include lookarounds.
 */ -}}
 {{-   $working := dict "rejected" (list) "terms" (list $args.domainNamespaceLabelSelector) }}
 {{-   if contains "," $args.domainNamespaceLabelSelector }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-domain-admin.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-domain-admin.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorClusterRoleDomainAdmin" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorClusterRoleGeneral" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorClusterRoleNamespace" }}
@@ -33,5 +33,8 @@ rules:
   verbs: ["get", "create"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 {{- end }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-nonresource.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-nonresource.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorClusterRoleNonResource" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-operator-admin.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrole-operator-admin.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorClusterRoleOperatorAdmin" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-auth-delegator.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-auth-delegator.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.clusterRoleBindingAuthDelegator" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-discovery.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-discovery.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.clusterRoleBindingDiscovery" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-general.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-general.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.clusterRoleBindingGeneral" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-nonresource.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-clusterrolebinding-nonresource.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.clusterRoleBindingNonResource" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-cm.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-cm.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorConfigMap" }}
@@ -11,6 +11,13 @@ data:
     {{- else }}
   externalOperatorCert: {{ .externalOperatorCert | quote }}
     {{- end }}
+  {{- end }}
+  {{- $configmap := (lookup "v1" "ConfigMap" .Release.Namespace "weblogic-operator-cm") }}
+  {{- if (and $configmap $configmap.data) }}
+  {{- $internalOperatorCert := index $configmap.data "internalOperatorCert" }}
+  {{- if $internalOperatorCert }}
+  internalOperatorCert: {{ $internalOperatorCert }}
+  {{- end }}
   {{- end }}
   serviceaccount: {{ .serviceAccount | quote }}
   domainNamespaceSelectionStrategy: {{ (default "List" .domainNamespaceSelectionStrategy) | quote }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, 2021, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorDeployment" }}
@@ -11,6 +11,8 @@ metadata:
   labels:
     weblogic.operatorName: {{ .Release.Namespace | quote }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       weblogic.operatorName: {{ .Release.Namespace | quote }}
@@ -41,10 +43,22 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
+        - name: "OPERATOR_POD_NAME"
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.name"
+        - name: "OPERATOR_POD_UID"
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.uid"
         - name: "OPERATOR_VERBOSE"
           value: "false"
         - name: "JAVA_LOGGING_LEVEL"
           value: {{ .javaLoggingLevel | quote }}
+        - name: "JAVA_LOGGING_MAXSIZE"
+          value: {{ .javaLoggingFileSizeLimit | default 20000000 | quote }}
+        - name: "JAVA_LOGGING_COUNT"
+          value: {{ .javaLoggingFileCount | default 10 | quote }}
         - name: ISTIO_ENABLED
           value: {{ .istioEnabled | quote }}
         {{- if .remoteDebugNodePortEnabled }}
@@ -109,8 +123,10 @@ spec:
         - name: "log-dir"
           mountPath: "/logs"
         env:
-        - name: "ELASTICSEARCH_URL"
-          value: {{ .elasticSearchURL | quote }}
+        - name: "ELASTICSEARCH_HOST"
+          value: {{ .elasticSearchHost | quote }}
+        - name: "ELASTICSEARCH_PORT"
+          value: {{ .elasticSearchPort | quote }}
       {{- end }}
       {{- if .imagePullSecrets }}
       imagePullSecrets:

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-external-svc.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-external-svc.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorExternalService" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-internal-svc.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-internal-svc.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorInternalService" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-role.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorRole" }}
@@ -12,6 +12,9 @@ metadata:
     weblogic.operatorName: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
-  resources: ["secrets", "configmaps", "events"]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 {{- end }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-rolebinding-namespace.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-rolebinding-namespace.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorRoleBindingNamespace" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-rolebinding.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-rolebinding.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorRoleBinding" }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-secret.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-secret.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorSecrets" }}
@@ -10,7 +10,7 @@ data:
   externalOperatorKey: {{ .externalOperatorKey | quote }}
   {{- end }}
   {{- $secret := (lookup "v1" "Secret" .Release.Namespace "weblogic-operator-secrets") }}
-  {{- if $secret }}
+  {{- if (and $secret $secret.data) }}
   {{- $internalOperatorKey := index $secret.data "internalOperatorKey" }}
   {{- if $internalOperatorKey }}
   internalOperatorKey: {{ $internalOperatorKey }}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operator" -}}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_utils.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_utils.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{/*

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_validate-inputs.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_validate-inputs.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, 2021, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.validateInputs" -}}
@@ -43,7 +43,8 @@
 {{- if include "utils.verifyBoolean" (list $scope "elkIntegrationEnabled") -}}
 {{-   if $scope.elkIntegrationEnabled -}}
 {{-     $ignore := include "utils.verifyString" (list $scope "logStashImage") -}}
-{{-     $ignore := include "utils.verifyString" (list $scope "elasticSearchURL") -}}
+{{-     $ignore := include "utils.verifyString" (list $scope "elasticSearchHost") -}}
+{{-     $ignore := include "utils.verifyInteger" (list $scope "elasticSearchPort") -}}
 {{-   end -}}
 {{- end -}}
 {{- $ignore := include "utils.verifyOptionalBoolean" (list $scope "dedicated") -}}

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/main.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/main.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- $scope := include "utils.cloneDictionary" .Values | fromYaml -}}

--- a/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020, 2021, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # serviceAccount specifies the name of the ServiceAccount in the operator's namespace that the
@@ -62,14 +62,14 @@ domainNamespaces:
 # will be granted using a ClusterRoleBinding rather than using RoleBindings in each managed namespace.
 enableClusterRoleBinding: false
 
-# image specifies the Docker image containing the operator.
-image: "oracle/weblogic-kubernetes-operator:3.1.0"
+# image specifies the container image containing the operator.
+image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2"
 
-# imagePullPolicy specifies the image pull policy for the operator's Docker image.
+# imagePullPolicy specifies the image pull policy for the operator's container image.
 imagePullPolicy: IfNotPresent
 
 # imagePullSecrets contains an optional list of Kubernetes Secrets, in the operator's namespace,
-# that are needed to access the registry containing the operator's Docker image.
+# that are needed to access the registry containing the operator's container image.
 # The customer is responsible for creating the Secret.
 # If no Secrets are required, then omit this property.
 #
@@ -105,17 +105,30 @@ istioEnabled: false
 # elkIntegrationEnabled specifies whether or not ELK integration is enabled.
 elkIntegrationEnabled: false
 
-# logStashImage specifies the Docker image containing logstash.
+# logStashImage specifies the container image containing logstash.
 # This parameter is ignored if 'elkIntegrationEnabled' is false.
 logStashImage: "logstash:6.6.0"
 
-# elasticSearchURL specifies the URL of where elasticsearch is running.
+# elasticSearchHost specifies the hostname of where elasticsearch is running.
 # This parameter is ignored if 'elkIntegrationEnabled' is false.
-elasticSearchURL: "http://elasticsearch.default.svc.cluster.local:9200"
+elasticSearchHost: "elasticsearch.default.svc.cluster.local"
 
-# javaLoggingLevel specifies the Java logging level for the operator.
+# elasticSearchPort specifies the port number of where elasticsearch is running.
+# This parameter is ignored if 'elkIntegrationEnabled' is false.
+elasticSearchPort: 9200
+
+# javaLoggingLevel specifies the Java logging level for the operator. This affects the operator pod's
+# log output and the contents of log files in the container's /logs/ directory.
 # Valid values are: "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", and "FINEST".
 javaLoggingLevel: "INFO"
+
+# javaLoggingFileSizeLimit specifies the maximum size in bytes for an individual Java logging file in the operator container's
+# /logs/ directory.
+javaLoggingFileSizeLimit: 20000000
+
+# javaLoggingFileCount specifies the number of Java logging files to preserve in the operator container's /logs/
+# directory as the files are rotated.
+javaLoggingFileCount: 10
 
 # nodeSelector specifies a matching rule that the Kubernetes scheduler will use when selecting the node
 # where the operator will run. If the nodeSelector value is specified, then this content will be added to


### PR DESCRIPTION
# Description

This pull request updates the weblogic-operator version to 3.2.2 from 3.1.1.

Fixes VZ-2515

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
