### PR TITLE
VZ-2584.  Change the MySQL driver to the non-deprecated one

### DIFF
--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -73,7 +73,7 @@ spec:
                   # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server
                   URL: "jdbc:mysql://mysql.todo-list.svc.cluster.local:3306/tododb"
                   PasswordEncrypted: '@@SECRET:tododomain-jdbc-tododb:password@@'
-                  DriverName: com.mysql.jdbc.Driver
+                  DriverName: com.mysql.cj.jdbc.Driver
                   Properties:
                     user:
                       Value: '@@SECRET:tododomain-jdbc-tododb:username@@'

--- a/tests/testdata/ingress/console/components.yaml
+++ b/tests/testdata/ingress/console/components.yaml
@@ -73,7 +73,7 @@ spec:
                   # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server
                   URL: "jdbc:mysql://mysql.todo-list.svc.cluster.local:3306/tododb"
                   PasswordEncrypted: '@@SECRET:tododomain-jdbc-tododb:password@@'
-                  DriverName: com.mysql.jdbc.Driver
+                  DriverName: com.mysql.cj.jdbc.Driver
                   Properties:
                     user:
                       Value: '@@SECRET:tododomain-jdbc-tododb:username@@'


### PR DESCRIPTION
# Description

Not sure it's related to the transient issues we see with the to-do list app, but this will get rid of the JDBC driver deprecation warnings in the tests/examples:

> Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary. 


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
