### PR TITLE
VZ-2548: Uninstall test failing intermittently with internal error in todo list test

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -90,7 +90,7 @@ Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
 Copyright 2020, Oracle Corporation and/or its affiliates.
 Copyright (c) 2015-2021 Bitnami
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
 Copyright (c) 2020, Oracle and/or its affiliates.
 fmt.Println("// Copyright (c) 2021, Oracle and/or its affiliates.")
@@ -2440,4 +2440,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 474fe1337dca3b5e2ca90690b11cfcc6
+License file based on go.mod with md5 sum: 3915f9df13bdc583854360b7932bf2c7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ go 1.15
 
 require (
 	github.com/Jeffail/gabs/v2 v2.2.0
-	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/crossplane/crossplane-runtime v0.10.0
 	github.com/crossplane/oam-kubernetes-runtime v0.3.2
 	github.com/gertd/go-pluralize v0.1.7

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -19,11 +18,6 @@ const (
 	shortPollingInterval = 10 * time.Second
 	longWaitTimeout      = 20 * time.Minute
 	longPollingInterval  = 20 * time.Second
-)
-
-var (
-	retryDelay    = retry.Delay(shortPollingInterval)
-	retryAttempts = retry.Attempts(3)
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -88,12 +82,8 @@ func deployBobsBooksExample() {
 		ginkgo.Fail(fmt.Sprintf("Failed to create Bobs Books component resources: %v", err))
 	}
 	pkg.Log(pkg.Info, "Create application resources")
-	err := retry.Do(
-		func() error { return pkg.CreateOrUpdateResourceFromFile("examples/bobs-books/bobs-books-app.yaml") },
-		retryAttempts, retryDelay)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create Bobs Books application resource: %v", err))
-	}
+	gomega.Eventually(func() error { return pkg.CreateOrUpdateResourceFromFile("examples/bobs-books/bobs-books-app.yaml") },
+		shortWaitTimeout, shortPollingInterval, "Failed to create Bobs Books application resource").Should(gomega.BeNil())
 }
 
 func undeployBobsBooksExample() {

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -20,11 +19,6 @@ const (
 	longPollingInterval  = 20 * time.Second
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute
-)
-
-var (
-	retryDelay    = retry.Delay(shortPollingInterval)
-	retryAttempts = retry.Attempts(3)
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -38,15 +32,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	if err := pkg.CreateOrUpdateResourceFromFile("examples/hello-helidon/hello-helidon-comp.yaml"); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create hello-helidon component resources: %v", err))
 	}
-	err := retry.Do(
-		func() error {
-			return pkg.CreateOrUpdateResourceFromFile("examples/hello-helidon/hello-helidon-app.yaml")
-		},
-		retryAttempts, retryDelay)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create hello-helidon application resource: %v", err))
-	}
-
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("examples/hello-helidon/hello-helidon-app.yaml")
+	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeNil(), "Failed to create hello-helidon application resource")
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -20,11 +19,6 @@ const (
 	longPollingInterval  = 20 * time.Second
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute
-)
-
-var (
-	retryDelay    = retry.Delay(shortPollingInterval)
-	retryAttempts = retry.Attempts(3)
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -38,15 +32,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	if err := pkg.CreateOrUpdateResourceFromFile("examples/helidon-config/helidon-config-comp.yaml"); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-config component resources: %v", err))
 	}
-	err := retry.Do(
-		func() error {
-			return pkg.CreateOrUpdateResourceFromFile("examples/helidon-config/helidon-config-app.yaml")
-		},
-		retryAttempts, retryDelay)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create helidon-config application resource: %v", err))
-	}
-
+	gomega.Eventually(func() error {
+			return pkg.CreateOrUpdateResourceFromFile("examples/helidon-config/helidon-config-app.yaml")},
+			shortWaitTimeout, shortPollingInterval, "Failed to create helidon-config application resource").Should(gomega.BeNil())
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -7,11 +7,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-
-	"github.com/avast/retry-go"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -25,8 +23,6 @@ var shortPollingInterval = 10 * time.Second
 var shortWaitTimeout = 5 * time.Minute
 var longWaitTimeout = 10 * time.Minute
 var longPollingInterval = 20 * time.Second
-var retryDelay = retry.Delay(shortPollingInterval)
-var retryAttempts = retry.Attempts(3)
 
 var _ = ginkgo.BeforeSuite(func() {
 	deploySpringBootApplication()
@@ -60,12 +56,9 @@ func deploySpringBootApplication() {
 		ginkgo.Fail(fmt.Sprintf("Failed to create Spring Boot component resources: %v", err))
 	}
 	pkg.Log(pkg.Info, "Create application resource")
-	err := retry.Do(
-		func() error { return pkg.CreateOrUpdateResourceFromFile("examples/springboot-app/springboot-app.yaml") },
-		retryAttempts, retryDelay)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create Spring Boot application resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("examples/springboot-app/springboot-app.yaml")
+	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeNil(), "Failed to create Spring Boot application resource")
 }
 
 func undeploySpringBootApplication() {

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -20,11 +19,6 @@ const (
 	shortPollingInterval = 10 * time.Second
 	longWaitTimeout      = 15 * time.Minute
 	longPollingInterval  = 20 * time.Second
-)
-
-var (
-	retryDelay    = retry.Delay(shortPollingInterval)
-	retryAttempts = retry.Attempts(3)
 )
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -80,14 +74,9 @@ func deployToDoListExample() {
 		ginkgo.Fail(fmt.Sprintf("Failed to create ToDo List component resources: %v", err))
 	}
 	pkg.Log(pkg.Info, "Create application resources")
-	err := retry.Do(
-		func() error {
-			return pkg.CreateOrUpdateResourceFromFile("examples/todo-list/todo-list-application.yaml")
-		},
-		retryAttempts, retryDelay)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create application resource: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("examples/todo-list/todo-list-application.yaml")},
+		shortWaitTimeout, shortPollingInterval, "Failed to create application resource").Should(gomega.BeNil())
 }
 
 func undeployToDoListExample() {


### PR DESCRIPTION
# Description

Removes the use of the avast/go-retry modules in tests.

Related to fix for VZ-2548: Uninstall test failing intermittently with internal error in todo list test

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
