### PR TITLE
validation to disallow two projects having the same namespace

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -76,7 +76,7 @@ run:
 	# kubectl delete validatingwebhookconfigurations verrazzano-application-verrazzanoproject
 	# kubectl scale deployment verrazzano-application-operator --replicas=0 -n verrazzano-system
 
-	# To enable webhooks: $(GO) run main.go --kubeconfig=${KUBECONFIG} --cert-dir=build/webhook-certs
+	# To enable webhooks: $(GO) run main.go --kubeconfig=${KUBECONFIG} --enable-webhooks=true --metrics-addr=localhost:0 --cert-dir=build/webhook-certs
 	$(GO) run main.go --kubeconfig=${KUBECONFIG} --enable-webhooks=false --metrics-addr=localhost:0
 
 

--- a/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook.go
+++ b/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook.go
@@ -109,6 +109,9 @@ func (vp *VerrazzanoProject) validateNamespaceCanBeUsed() error {
 		nameSpace := ns.Metadata.Name
 		namespaceFound := false
 		for _, project := range projectsList.Items {
+			if project.Name == vp.Name {
+				continue
+			}
 			for _, ns := range project.Spec.Template.Namespaces {
 				if ns.Metadata.Name == nameSpace {
 					namespaceFound = true

--- a/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
+++ b/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
@@ -282,6 +282,9 @@ func TestNamespaceUniquenessForProjects(t *testing.T) {
 	// This test will fail because Verrazzano project test-project1 has conflicting namespace project2
 	err = currentVP.validateNamespaceCanBeUsed()
 	assert.NotNil(t, err)
+	// This test will fail same as above but this time coming in through parent validator
+	err = currentVP.validateVerrazzanoProject()
+	assert.NotNil(t, err)
 
 	currentVP = VerrazzanoProject{
 		ObjectMeta: metav1.ObjectMeta{

--- a/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
+++ b/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
@@ -64,6 +67,11 @@ func TestVerrazzanoProject(t *testing.T) {
 	// Test data
 	testVP := testProject
 
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
 	// Test create
 	err := testVP.ValidateCreate()
 	assert.NoError(t, err, "Error validating VerrazzanoMultiCluster resource")
@@ -82,6 +90,11 @@ func TestInvalidNamespace(t *testing.T) {
 	// Test data
 	testVP := testProject
 	testVP.Namespace = "invalid-namespace"
+
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
 
 	// Test create
 	err := testVP.ValidateCreate()
@@ -104,6 +117,11 @@ func TestInvalidNamespaces(t *testing.T) {
 	testVP := testProject
 	testVP.Spec.Template.Namespaces = []NamespaceTemplate{}
 
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
 	// Test create
 	err := testVP.ValidateCreate()
 	assert.Error(t, err, "Expected failure for invalid namespace list")
@@ -123,6 +141,11 @@ func TestNetworkPolicyNamespace(t *testing.T) {
 	// Test data
 	testVP := testNetworkPolicy
 
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
 	// Test create
 	err := testVP.ValidateCreate()
 	assert.NoError(t, err, "Error validating VerrazzanProject with NetworkPolicyTemplate")
@@ -141,6 +164,11 @@ func TestNetworkPolicyMissingNamespace(t *testing.T) {
 	testVP := testNetworkPolicy
 	testVP.Spec.Template.Namespaces[0].Metadata.Name = "ns2"
 
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
 	// Test create
 	err := testVP.ValidateCreate()
 	assert.EqualError(t, err, "namespace ns1 used in NetworkPolicy net1 does not exist in project", "Error validating VerrazzanProject with NetworkPolicyTemplate")
@@ -148,4 +176,136 @@ func TestNetworkPolicyMissingNamespace(t *testing.T) {
 	// Test update
 	err = testVP.ValidateUpdate(&VerrazzanoProject{})
 	assert.EqualError(t, err, "namespace ns1 used in NetworkPolicy net1 does not exist in project", "Error validating VerrazzanProject with NetworkPolicyTemplate")
+}
+
+// TestNamespaceUniquenessForProjects tests that the namespace of a VerrazzanoProject N does not conflict with a preexisting project
+// GIVEN a call validate VerrazzanoProject on create or update
+// WHEN the VerrazzanoProject has a a namespace that conflicts with any pre-existing projects
+// THEN the validation should fail
+func TestNamespaceUniquenessForProjects(t *testing.T) {
+
+	// When creating the fake client, prepopulate it with 2 Verrazzano projects
+	// existingVP1 has namespaces project1 and project2
+	// existingVP2 has namespaces project3 and project4
+	// Adding any new Verrazzano projects with these namespaces will fail validation
+	existingVP1 := &VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-project-1",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project1",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	existingVP2 := &VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-project-2",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project3",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	objs := []runtime.Object{existingVP1, existingVP2}
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme(), objs...), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
+	currentVP := VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-project",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project",
+						},
+					},
+				},
+			},
+		},
+	}
+	// This test will succeed because Verrazzano project test-project has unique namespace project
+	err := currentVP.validateNamespaceCanBeUsed()
+	assert.Nil(t, err)
+
+	currentVP = VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-project1",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// This test will fail because Verrazzano project test-project1 has conflicting namespace project2
+	err = currentVP.validateNamespaceCanBeUsed()
+	assert.NotNil(t, err)
+
+	currentVP = VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-project2",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project4",
+						},
+					},
+				},
+			},
+		},
+	}
+	// This test will fail because Verrazzano project test-project2 has conflicting namespace project4
+	err = currentVP.validateNamespaceCanBeUsed()
+	assert.NotNil(t, err)
 }

--- a/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
+++ b/application-operator/apis/clusters/v1alpha1/verrazzanoproject_webhook_test.go
@@ -305,7 +305,59 @@ func TestNamespaceUniquenessForProjects(t *testing.T) {
 			},
 		},
 	}
-	// This test will fail because Verrazzano project test-project2 has conflicting namespace project4
+	// UPDATE FAIL This test will fail because Verrazzano project test-project2 has conflicting namespace project4
 	err = currentVP.validateNamespaceCanBeUsed()
 	assert.NotNil(t, err)
+
+	currentVP = VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-project-1",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project4",
+						},
+					},
+				},
+			},
+		},
+	}
+	// This test will fail because Verrazzano project name, existing-project-1, is using a namespace in existing-project-2
+	err = currentVP.validateNamespaceCanBeUsed()
+	assert.NotNil(t, err)
+
+	currentVP = VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-project-1",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: VerrazzanoProjectSpec{
+			Template: ProjectTemplate{
+				Namespaces: []NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "project2",
+						},
+					},
+				},
+			},
+		},
+	}
+	// UPDATE PASS This test will pass because Verrazzano project name, existing-project-1, is not using a namespace associated with any existing projects
+	err = currentVP.validateNamespaceCanBeUsed()
+	assert.Nil(t, err)
 }

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml")
 		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be updated successfully")
 		gomega.Eventually(func() bool {
-			namespace, err := K8sClient.GetNamespace("test-namespace-1")
+			namespace, err := K8sClient.GetNamespace("test-namespace-11")
 			if err == nil {
 				return namespace.Labels[constants.LabelIstioInjection] == "disabled" &&
 					namespace.Labels[constants.LabelVerrazzanoManaged] == "false" &&
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("Testing VerrazzanoProject namespace generation", func()
 			return false
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 		gomega.Eventually(func() bool {
-			namespace, err := K8sClient.GetNamespace("test-namespace-2")
+			namespace, err := K8sClient.GetNamespace("test-namespace-12")
 			if err == nil {
 				return namespace.Labels[constants.LabelIstioInjection] == constants.LabelIstioInjectionDefault &&
 					namespace.Labels[constants.LabelVerrazzanoManaged] == constants.LabelVerrazzanoManagedDefault &&

--- a/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml
+++ b/application-operator/test/integ/testdata/multi-cluster/verrazzanoproject_namespace_override_labels.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     namespaces:
       - metadata:
-          name: test-namespace-1
+          name: test-namespace-11
           labels:
             label1: "test1"
             istio-injection: "disabled"
@@ -17,7 +17,7 @@ spec:
           annotations:
             annot1: "test1"
       - metadata:
-          name: test-namespace-2
+          name: test-namespace-12
           labels:
             label2: "test2"
           annotations:

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -346,6 +346,8 @@ func deployTestResources() {
 	gomega.Eventually(func() bool {
 		return pkg.DoesNamespaceExist(anotherTestNamespace)
 	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Expected to find namespace %s", anotherTestNamespace))
+	//  30 sec sleep for investigating weird race
+	time.Sleep(60 * time.Second)
 
 	// create a config map
 	pkg.Log(pkg.Info, "Creating MC config map")

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -346,8 +346,6 @@ func deployTestResources() {
 	gomega.Eventually(func() bool {
 		return pkg.DoesNamespaceExist(anotherTestNamespace)
 	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Expected to find namespace %s", anotherTestNamespace))
-	//  30 sec sleep for investigating weird race
-	time.Sleep(60 * time.Second)
 
 	// create a config map
 	pkg.Log(pkg.Info, "Creating MC config map")

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -130,7 +130,7 @@ func DoesNamespaceExistInCluster(name string, kubeconfigPath string) bool {
 		ginkgo.Fail(fmt.Sprintf("Failed to get namespace %s with error: %v", name, err))
 	}
 
-	return namespace != nil
+	return namespace != nil && len(namespace.Name) > 0
 }
 
 // ListNamespaces returns a namespace list for the given list options


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

VerrazzanoProject validation needs to disallow two projects having the same namespace
Added unit tests
fixed up integ tests
add fix for a race in AT support code

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ x] Added or updated unit tests for any new functions I added
- [ x] Added or updated integration tests if appropriate
- [ x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
