### PR TITLE
Pickup new images for VMO and VO

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
@@ -372,8 +372,6 @@ spec:
               name: cert-volume
               readOnly: true
           env:
-            - name: ISTIO_PROXY_IMAGE
-              value: {{ .Values.monitoringOperator.istioProxyImage }}
             - name: GRAFANA_IMAGE
               value: {{ .Values.monitoringOperator.grafanaImage }}
             - name: PROMETHEUS_IMAGE
@@ -390,8 +388,6 @@ spec:
               value: {{ .Values.monitoringOperator.esInitImage }}
             - name: KIBANA_IMAGE
               value: {{ .Values.monitoringOperator.kibanaImage }}
-            - name: ELASTICSEARCH_WAIT_TARGET_VERSION
-              value: {{ .Values.monitoringOperator.esWaitTargetVersion }}
             - name: CONFIG_RELOADER_IMAGE
               value: {{ .Values.monitoringOperator.configReloaderImage }}
             - name: OIDC_PROXY_IMAGE

--- a/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
@@ -372,6 +372,8 @@ spec:
               name: cert-volume
               readOnly: true
           env:
+            - name: ISTIO_PROXY_IMAGE
+              value: {{ .Values.monitoringOperator.istioProxyImage }}
             - name: GRAFANA_IMAGE
               value: {{ .Values.monitoringOperator.grafanaImage }}
             - name: PROMETHEUS_IMAGE
@@ -388,6 +390,8 @@ spec:
               value: {{ .Values.monitoringOperator.esInitImage }}
             - name: KIBANA_IMAGE
               value: {{ .Values.monitoringOperator.kibanaImage }}
+            - name: ELASTICSEARCH_WAIT_TARGET_VERSION
+              value: {{ .Values.monitoringOperator.esWaitTargetVersion }}
             - name: CONFIG_RELOADER_IMAGE
               value: {{ .Values.monitoringOperator.configReloaderImage }}
             - name: OIDC_PROXY_IMAGE

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -49,7 +49,7 @@ kibana:
 verrazzanoOperator:
   name: verrazzano-operator
   imageName: ghcr.io/verrazzano/verrazzano-operator
-  imageVersion: 0.14.0-20210506185522-578eb9e
+  imageVersion: 0.15.0-20210512213227-2785c3a
   nodeExporterImage: ghcr.io/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
   apiServerRealm: verrazzano-system
   RequestMemory: 72Mi
@@ -57,18 +57,15 @@ verrazzanoOperator:
 monitoringOperator:
   name: verrazzano-monitoring-operator
   imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.15.0-20210512164725-0474499
+  imageVersion: 0.15.0-20210512224353-617a0c0
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
-  istioProxyImage: ghcr.io/verrazzano/proxyv2:1.7.3
   grafanaImage: ghcr.io/verrazzano/grafana:v6.4.4
   prometheusImage: ghcr.io/verrazzano/prometheus:v2.13.1
   prometheusInitImage: ghcr.io/oracle/oraclelinux:7-slim
   alertManagerImage: "noimage"
-  esWaitTargetVersion: 7.6.1
   esImage: ghcr.io/verrazzano/elasticsearch:7.6.1-20201130145440-5c76ab1
-  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.15.0-20210510204900-4a0dd4f
   esInitImage: ghcr.io/oracle/oraclelinux:7.8
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-20201130145840-7717e73
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,11 +61,14 @@ monitoringOperator:
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
+  istioProxyImage: ghcr.io/verrazzano/proxyv2:1.7.3
   grafanaImage: ghcr.io/verrazzano/grafana:v6.4.4
   prometheusImage: ghcr.io/verrazzano/prometheus:v2.13.1
   prometheusInitImage: ghcr.io/oracle/oraclelinux:7-slim
   alertManagerImage: "noimage"
+  esWaitTargetVersion: 7.6.1
   esImage: ghcr.io/verrazzano/elasticsearch:7.6.1-20201130145440-5c76ab1
+  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.15.0-20210510204900-4a0dd4f
   esInitImage: ghcr.io/oracle/oraclelinux:7.8
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-20201130145840-7717e73
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e


### PR DESCRIPTION
# Description

This pull request picks up new images for verrazzano-monitoring-operator and verrazzano-operator.

Fixes for VZ-2455 and VZ-2418

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
