### PR TITLE
Add simplified diffing utility, with unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/mock v1.4.4
+	github.com/google/go-cmp v0.5.0
 	github.com/gordonklaus/ineffassign v0.0.0-20210104184537-8eed68eb605f
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/jetstack/cert-manager v0.13.1

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,10 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package diff
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+//
+// Diff diffs two Golang objects recursively, but treats any elements whose values are empty
+// in the 'fromObject' as "no diff".  This is useful when comparing a desired Kubernetes object against a
+// live Kubernetes object:
+// 1) The 'fromObject' is constructed via code, and doesn't specify a value for every nested field in the struct.
+//    Most Kubernetes object structs have an enormous number of fields, and it's not feasible to try to set them all
+//    when constructing the object.  Also, note that some fields in the structs (like UUID, resourceVersion, or
+//    creationTime), are completely determined by Kubernetes at runtime.
+// 2) The 'toObject' has been retrieved via the Kubernetes API, and has had many of the fields that were unspecified
+//    in the fromObject populated with Kubernetes-generated values.
+// In this situation, to determine whether our fromObject is truly different than the toObject, we ignore processing
+// of elements whose values are empty in the fromObject.
+//
+func Diff(fromObject interface{}, toObject interface{}) string {
+	return cmp.Diff(fromObject, toObject, IgnoreUnset())
+}
+
+// Extended from https://github.com/kubernetes/apimachinery/blob/master/pkg/util/diff/diff.go
+// IgnoreUnset return a cmp.Option to ignore changes for values that are unset in the toObject
+func IgnoreUnset() cmp.Option {
+	return cmp.Options{
+		// ignore unset fields in v2
+		cmp.FilterPath(func(path cmp.Path) bool {
+			_, v2 := path.Last().Values()
+
+			switch v2.Kind() {
+			case reflect.Slice, reflect.Map:
+				if v2.IsNil() || v2.Len() == 0 {
+					return true
+				}
+			case reflect.String:
+				if v2.Len() == 0 {
+					return true
+				}
+			case reflect.Interface, reflect.Ptr:
+				if v2.IsNil() {
+					return true
+				}
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+				if v2.IsZero() {
+					return true
+				}
+			case reflect.Struct:
+				{
+					// Handle empty Time value
+					if v2.Type() == reflect.TypeOf(time.Time{}) {
+						if fmt.Sprintf("%s", v2) == "0001-01-01 00:00:00 +0000 UTC" {
+							return true
+						}
+					}
+				}
+			}
+			return false
+		}, cmp.Ignore()),
+		// ignore map entries that aren't set in v2
+		cmp.FilterPath(func(path cmp.Path) bool {
+			switch i := path.Last().(type) {
+			case cmp.MapIndex:
+				if _, v2 := i.Values(); !v2.IsValid() {
+					return true
+				}
+			}
+			return false
+		}, cmp.Ignore()),
+	}
+}

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -1,0 +1,440 @@
+// Copyright (C) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package diff
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"testing"
+)
+
+// Test structs
+type X struct {
+	String1     string
+	String2     string
+	String3     *string
+	Int1        int
+	Int2        *int
+	Int32       int32
+	Int64       *int64
+	StringSlice []string
+	YSlice1     []Y
+	YSlice2     []*Y
+	StringMap   map[string]string
+	YMap        map[string]Y
+	Time        time.Time
+}
+
+type Y struct {
+	String      string
+	Int         int
+	StringSlice []string
+	ZSlice      []Z
+	ZMap        map[string]Z
+}
+
+type Z struct {
+	String string
+	Int    int
+	Time   time.Time
+}
+
+func TestStrings(t *testing.T) {
+	fromObj := X{String1: "sanitizeString"}
+	toObj := X{String1: "sanitizeString"}
+	verifyDiff(t, fromObj, toObj, false, "String unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "String not specified")
+	toObj = X{String1: ""}
+	verifyDiff(t, fromObj, toObj, false, "String empty")
+	toObj = X{String1: "fooa"}
+	verifyDiff(t, fromObj, toObj, true, "String changed")
+
+	fromObj = X{String1: "sanitizeString", String2: "foo2", String3: NewString("foo3")}
+	toObj = X{String1: "sanitizeString"}
+	verifyDiff(t, fromObj, toObj, false, "String pointer not specified")
+	toObj = X{String1: "sanitizeString", String3: nil}
+	verifyDiff(t, fromObj, toObj, false, "String pointer nil")
+	toObj = X{String1: "sanitizeString", String3: NewString("foo3a")}
+	verifyDiff(t, fromObj, toObj, true, "String pointer changed")
+}
+
+func TestInts(t *testing.T) {
+	fromObj := X{Int1: 3}
+	toObj := X{Int1: 3}
+	verifyDiff(t, fromObj, toObj, false, "Int unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Int not specified")
+	toObj = X{Int1: 0}
+	verifyDiff(t, fromObj, toObj, false, "Int empty")
+	toObj = X{Int1: 4}
+	verifyDiff(t, fromObj, toObj, true, "Int changed")
+
+	fromObj = X{Int1: 3, Int2: NewInt(4)}
+	toObj = X{Int1: 3}
+	verifyDiff(t, fromObj, toObj, false, "Int pointer not specified")
+	toObj = X{Int1: 3, Int2: nil}
+	verifyDiff(t, fromObj, toObj, false, "Int pointer nil")
+	toObj = X{Int1: 3, Int2: NewInt(5)}
+	verifyDiff(t, fromObj, toObj, true, "Int pointer changed")
+
+	fromObj = X{Int32: 4}
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Int32 not specified")
+	toObj = X{Int32: 5}
+	verifyDiff(t, fromObj, toObj, true, "Int32 changed")
+
+	fromObj = X{Int64: NewInt64(6)}
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Int64 pointer not specified")
+	toObj = X{Int64: NewInt64(7)}
+	verifyDiff(t, fromObj, toObj, true, "Int64 pointer changed")
+}
+
+func TestSlices(t *testing.T) {
+	fromObj := X{StringSlice: []string{"foo1", "foo2", "foo3"}}
+	toObj := X{StringSlice: []string{"foo1", "foo2", "foo3"}}
+	verifyDiff(t, fromObj, toObj, false, "String slice unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "String slice not specified")
+	toObj = X{StringSlice: []string{}}
+	verifyDiff(t, fromObj, toObj, false, "String slice empty")
+	toObj = X{StringSlice: []string{"foo1", "foo2", "foo4"}}
+	verifyDiff(t, fromObj, toObj, true, "String slice changed")
+	toObj = X{StringSlice: []string{"foo1", "foo2"}}
+	verifyDiff(t, fromObj, toObj, true, "String slice changed")
+
+	fromObj = X{YSlice1: []Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 3}}}
+	toObj = X{YSlice1: []Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 3}}}
+	verifyDiff(t, fromObj, toObj, false, "Y slice unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Y slice not specified")
+	toObj = X{YSlice1: []Y{}}
+	verifyDiff(t, fromObj, toObj, false, "Y slice empty")
+	toObj = X{YSlice1: []Y{{String: "foo1", Int: 2}, {String: "foo3", Int: 4}, {String: "foo2", Int: 3}}}
+	verifyDiff(t, fromObj, toObj, true, "Y slice members changed")
+	toObj = X{YSlice1: []Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 4}}}
+	verifyDiff(t, fromObj, toObj, true, "Y slice nested contents changed")
+
+	fromObj = X{YSlice2: []*Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 3}}}
+	toObj = X{YSlice2: []*Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 3}}}
+	verifyDiff(t, fromObj, toObj, false, "Y pointer slice unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Y pointer slice not specified")
+	toObj = X{YSlice2: []*Y{}}
+	verifyDiff(t, fromObj, toObj, false, "Y pointer slice empty")
+	toObj = X{YSlice2: []*Y{{String: "foo1", Int: 2}, {String: "foo3", Int: 4}, {String: "foo2", Int: 3}}}
+	verifyDiff(t, fromObj, toObj, true, "Y pointer slice members changed")
+	toObj = X{YSlice2: []*Y{{String: "foo1", Int: 2}, {String: "foo2", Int: 4}}}
+	verifyDiff(t, fromObj, toObj, true, "Y pointer  slice nested contents changed")
+}
+
+func TestMaps(t *testing.T) {
+	fromObj := X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2", "foo3": "bar3"}}
+	toObj := X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2", "foo3": "bar3"}}
+	verifyDiff(t, fromObj, toObj, false, "String map unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "String map not specified")
+	toObj = X{StringMap: map[string]string{}}
+	verifyDiff(t, fromObj, toObj, false, "String map empty")
+	toObj = X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2", "foo3": "bar3", "foo4": "bar4"}}
+	verifyDiff(t, fromObj, toObj, true, "String map element added")
+	toObj = X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2", "foo3": "bar4"}}
+	verifyDiff(t, fromObj, toObj, true, "String map element changed")
+	toObj = X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2", "foo4": "bar4"}}
+	verifyDiff(t, fromObj, toObj, true, "String map element added, one removed")
+	toObj = X{StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2"}}
+	verifyDiff(t, fromObj, toObj, false, "String map value removed only")
+
+	fromObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}, "foo2": {String: "foo2", Int: 3}}}
+	toObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}, "foo2": {String: "foo2", Int: 3}}}
+	verifyDiff(t, fromObj, toObj, false, "Y map unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Y map not specified")
+	toObj = X{YMap: map[string]Y{}}
+	verifyDiff(t, fromObj, toObj, false, "Y map empty")
+	toObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}, "foo2": {String: "foo2", Int: 3}, "foo3": {String: "foo3", Int: 4}}}
+	verifyDiff(t, fromObj, toObj, true, "Y map element added")
+	toObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}, "foo2": {String: "foo2", Int: 4}}}
+	verifyDiff(t, fromObj, toObj, true, "Y map element changed")
+	toObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}, "foo3": {String: "foo3", Int: 4}}}
+	verifyDiff(t, fromObj, toObj, true, "Y map element added, one removed")
+	toObj = X{YMap: map[string]Y{"foo1": {String: "foo1", Int: 2}}}
+	verifyDiff(t, fromObj, toObj, false, "Y map value removed only")
+}
+
+func TestTimes(t *testing.T) {
+	now := time.Now()
+	fromObj := X{Time: now}
+	toObj := X{Time: now}
+	verifyDiff(t, fromObj, toObj, false, "Time unchanged")
+	toObj = X{}
+	verifyDiff(t, fromObj, toObj, false, "Time not specified")
+	toObj = X{Time: time.Time{}}
+	verifyDiff(t, fromObj, toObj, false, "Time empty")
+	toObj = X{Time: now.Add(time.Hour)}
+	verifyDiff(t, fromObj, toObj, true, "Time changed")
+}
+
+// One unit test that contains a complex diff and actually verifies the full output
+func TestOutput(t *testing.T) {
+	fromObj := X{
+		String1:     "foo1",
+		String3:     NewString("foo3"),
+		Int1:        0,
+		Int2:        NewInt(4),
+		Int32:       5,
+		StringSlice: []string{"foo1", "foo2", "foo3"},
+		YSlice1: []Y{
+			{
+				String: "foo1",
+				Int:    2,
+				ZSlice: []Z{{String: "foo1", Int: 3}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 3}},
+			},
+			{
+				String: "foo2",
+				Int:    3,
+				ZSlice: []Z{{String: "foo2", Int: 4}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 3}},
+			},
+		},
+		StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2"},
+		YMap: map[string]Y{
+			"foo1": {
+				String: "foo1",
+				Int:    2,
+				ZSlice: []Z{{String: "foo1", Int: 3}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 3}},
+			},
+			"foo2": {
+				String: "foo2",
+				Int:    3,
+				ZSlice: []Z{{String: "foo3", Int: 5}},
+				ZMap:   map[string]Z{"foo3": {String: "foo3", Int: 4}},
+			},
+		},
+	}
+	toObj := X{
+		String1:     "",
+		String3:     nil,
+		Int1:        0,
+		Int2:        NewInt(5),
+		StringSlice: []string{"foo1", "foo2"},
+		YSlice1: []Y{
+			{
+				String: "foo1",
+				Int:    2,
+				ZSlice: []Z{{String: "foo1", Int: 3}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 3}},
+			},
+			{
+				String: "foo2",
+				Int:    3,
+				ZSlice: []Z{{String: "foo2", Int: 4}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 4}},
+			},
+			{
+				String: "foo3",
+				Int:    4,
+				ZSlice: []Z{{String: "foo2", Int: 4}},
+				ZMap:   map[string]Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 4}},
+			},
+		},
+		StringMap: map[string]string{"foo1": "bar1", "foo2": "bar2"},
+		YMap: map[string]Y{
+			"foo1": {
+				String: "foo1",
+				Int:    2,
+				ZSlice: []Z{{String: "foo1", Int: 3}},
+				ZMap:   map[string]Z{"foo1": {String: "foo4", Int: 3}, "foo2": {String: "foo2", Int: 3}},
+			},
+			"foo3": {
+				String: "foo3",
+				Int:    4,
+				ZSlice: []Z{{String: "foo3", Int: 5}},
+				ZMap:   map[string]Z{"foo3": {String: "foo3", Int: 4}},
+			},
+		},
+	}
+
+	expectedResult := `  diff.X{
+  	... // 4 ignored fields
+- 	Int2: &4,
++ 	Int2: &5,
+  	... // 2 ignored fields
+  	StringSlice: []string{
+  		"foo1",
+  		"foo2",
+- 		"foo3",
+  	},
+  	YSlice1: []diff.Y{
+  		{String: "foo1", Int: 2, ZSlice: {{String: "foo1", Int: 3}}, ZMap: {"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 3}}},
+  		{
+  			... // 1 ignored and 2 identical fields
+  			ZSlice: {{String: "foo2", Int: 4}},
+  			ZMap: map[string]diff.Z{
+  				"foo1": {String: "foo1", Int: 3},
+  				"foo2": {
+  					String: "foo2",
+- 					Int:    3,
++ 					Int:    4,
+  					... // 1 ignored field
+  				},
+  			},
+  		},
++ 		{
++ 			String: "foo3",
++ 			Int:    4,
++ 			ZSlice: []diff.Z{{String: "foo2", Int: 4}},
++ 			ZMap:   map[string]diff.Z{"foo1": {String: "foo1", Int: 3}, "foo2": {String: "foo2", Int: 4}},
++ 		},
+  	},
+  	... // 1 ignored field
+  	StringMap: {"foo1": "bar1", "foo2": "bar2"},
+  	YMap: map[string]diff.Y{
+  		"foo1": {
+  			... // 1 ignored and 2 identical fields
+  			ZSlice: {{String: "foo1", Int: 3}},
+  			ZMap: map[string]diff.Z{
+  				"foo1": {
+- 					String: "foo1",
++ 					String: "foo4",
+  					Int:    3,
+  					... // 1 ignored field
+  				},
+  				"foo2": {String: "foo2", Int: 3},
+  			},
+  		},
+  		... // 1 ignored entry
++ 		"foo3": {
++ 			String: "foo3",
++ 			Int:    4,
++ 			ZSlice: []diff.Z{{String: "foo3", Int: 5}},
++ 			ZMap:   map[string]diff.Z{"foo3": {String: "foo3", Int: 4}},
++ 		},
+  	},
+  	... // 1 ignored field
+  }`
+
+	assert.Equal(t, sanitizeString(expectedResult), sanitizeString(Diff(fromObj, toObj)), "Many nested changes")
+}
+
+// Some examples with real k8s Deployment objects
+func TestK8sDeployment(t *testing.T) {
+	// Empty deployments
+	fromDeployment := appsv1.Deployment{}
+	toDeployment := appsv1.Deployment{}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty objects")
+
+	// Simple values set in the source deployment and not in the target
+	fromDeployment.Name = "sanitizeString"
+	fromDeployment.Spec.Replicas = NewInt32(5)
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty values in source")
+
+	// Simple values set in the target deployment
+	toDeployment.Name = "sanitizeString"
+	toDeployment.Spec.Replicas = NewInt32(5)
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Same values in source object as from")
+	toDeployment.Spec.Replicas = NewInt32(6)
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different value in source object from target")
+	toDeployment.Spec.Replicas = NewInt32(5)
+	toDeployment.Spec.MinReadySeconds = 500
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different value in source object from target")
+	toDeployment.Spec.MinReadySeconds = 0
+
+	// List (containers) specified in from deployment, empty in to
+	fromContainer := corev1.Container{}
+	fromContainer.Name = "bar"
+	fromDeployment.Spec.Template.Spec.Containers = []corev1.Container{fromContainer}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty list in source object")
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty list in source object")
+
+	// Non-empty list (containers) in to
+	toContainer := corev1.Container{}
+	toContainer.Name = "bar"
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Same values in source object as from")
+	toContainer.Name = "bar1"
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different value in source object from target")
+	toContainer.Name = "bar"
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer, toContainer}
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different sized list in source object from target")
+
+	// Same thing as the above, but go one level deeper into EnvVars for a Container
+	// List (EnvVars) specified in source deployment, empty in target deployment
+	fromContainer = corev1.Container{}
+	fromContainer.Env = []corev1.EnvVar{{Name: "sanitizeString", Value: "bar"}}
+	fromDeployment.Spec.Template.Spec.Containers = []corev1.Container{fromContainer}
+	toContainer = corev1.Container{}
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty list in source object")
+	toContainer = corev1.Container{}
+	toContainer.Env = []corev1.EnvVar{}
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Empty list in source object")
+
+	// Non-empty list (EnvVars) in to
+	toContainer = corev1.Container{}
+	toContainer.Env = []corev1.EnvVar{{Name: "sanitizeString", Value: "bar"}}
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.Equal(t, "", Diff(fromDeployment, toDeployment), "Same values in source object as target")
+	toContainer.Env = []corev1.EnvVar{{Name: "sanitizeString", Value: "bar1"}}
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different value in source object from target")
+	toContainer.Env = []corev1.EnvVar{{Name: "sanitizeString", Value: "bar"}, {Name: "foo1", Value: "bar1"}}
+	toDeployment.Spec.Template.Spec.Containers = []corev1.Container{toContainer}
+	assert.NotEqual(t, "", Diff(fromDeployment, toDeployment), "Different sized list in source object from target")
+}
+
+func verifyDiff(t *testing.T, fromObj interface{}, toObj interface{}, expectDiffs bool, description string) {
+	diffResult := Diff(fromObj, toObj)
+	if expectDiffs {
+		assert.NotEmpty(t, diffResult, description)
+	} else {
+		assert.Empty(t, diffResult, description)
+	}
+}
+
+// Removes unicode tabs from the given string - this is needed to workaround issue https://github.com/google/go-cmp/issues/235
+// in gocmp, which causes inconsistent Diff() output
+func sanitizeString(s string) string {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	lines := []string{}
+	for scanner.Scan() {
+		line, _ := strconv.Unquote(strings.Replace(fmt.Sprintf("%#v", scanner.Text()), "\\u00a0", " ", -1))
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func NewInt(value int) *int {
+	var val = value
+	return &val
+}
+
+func NewInt32(value int32) *int32 {
+	var val = value
+	return &val
+}
+
+func NewInt64(value int64) *int64 {
+	var val = value
+	return &val
+}
+
+func NewString(value string) *string {
+	var val = value
+	return &val
+}


### PR DESCRIPTION
# Description

This PR introduces a greatly simplified k8s object diffing function over what we have currently in use, which is duplicated across several projects:
https://github.com/verrazzano/verrazzano-operator/blob/master/pkg/util/diff/diff.go
https://github.com/verrazzano/verrazzano-cluster-operator/blob/master/pkg/util/diff/diff.go
https://github.com/verrazzano/verrazzano-monitoring-operator/blob/master/pkg/util/diff/diff.go

The simplified code here uses github.com/google/go-cmp/cmp with a custom filter to achieve the same functionality as before: compare 2 Golang structs, but ignore any fields that are not specified in the “source” object.

The plan after this is to update the 3 repos referenced above to make use of this utility.

Fixes VZ-2649

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [x] Addressed the requirement and meets the acceptance criteria
- [x] Does not introduce unrelated or spurious changes
- [x] Does not introduce any unapproved dependency
- [x] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
