### PR TITLE
Add bare formatted no-reply user match

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -767,6 +767,10 @@ def trimIfGithubNoreplyUser(userIn) {
         def userOut = userIn.substring(userIn.indexOf("<") + 1, userIn.indexOf("@"))
         return userOut;
     }
+    if (userIn.matches(".*@users.noreply.github.com")) {
+        def userOut = userIn.substring(0, userIn.indexOf("@"))
+        return userOut;
+    }
     echo "Not a github noreply user, not trimming: ${userIn}"
     return userIn
 }


### PR DESCRIPTION
# Description

Add bare formatted noreply user match for slack notifications, seeing that with some users.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
