### PR TITLE
Fix a typo in tests/e2e/pkg/common.go

### DIFF
--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -84,7 +84,7 @@ func AssertURLAccessibleAndAuthorized(client *retryablehttp.Client, url string, 
 	ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		Log(Error, fmt.Sprintf("AssertURLAccessibleAndAuthorized: URL=%v, Unexpected statis code=%v", url, resp.StatusCode))
+		Log(Error, fmt.Sprintf("AssertURLAccessibleAndAuthorized: URL=%v, Unexpected status code=%v", url, resp.StatusCode))
 		return false
 	}
 	// HTTP Server headers should never be returned.


### PR DESCRIPTION
# Description

Change to fix a typo in tests/e2e/pkg/common.go.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
