### PR TITLE
VZ-2584.  Add retry/test settings to JDBC CP for Bob's Books and ToDo examples

### DIFF
--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -358,11 +358,6 @@ spec:
                   JNDIName: [
                     jdbc/books
                   ]
-                JDBCConnectionPoolParams:
-                  TestConnectionsOnReserve: true
-                  InactiveConnectionTimeoutSeconds: 30
-                  ConnectionCreationRetryFrequencySeconds: 5
-                  TestFrequencySeconds: 10
                 JDBCDriverParams:
                   DriverName: com.mysql.cj.jdbc.Driver
                   URL: '@@SECRET:mysql-credentials:url@@'
@@ -371,11 +366,14 @@ spec:
                     user:
                       Value: '@@SECRET:mysql-credentials:username@@'
                 JDBCConnectionPoolParams:
+                  ConnectionCreationRetryFrequencySeconds: 5
                   ConnectionReserveTimeoutSeconds: 10
                   InitialCapacity: 0
+                  InactiveConnectionTimeoutSeconds: 60
                   MaxCapacity: 5
                   MinCapacity: 0
                   TestConnectionsOnReserve: true
+                  TestFrequencySeconds: 10
                   TestTableName: SQL SELECT 1
 ---
 apiVersion: core.oam.dev/v1alpha2

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -358,6 +358,11 @@ spec:
                   JNDIName: [
                     jdbc/books
                   ]
+                JDBCConnectionPoolParams:
+                  TestConnectionsOnReserve: true
+                  InactiveConnectionTimeoutSeconds: 30
+                  ConnectionCreationRetryFrequencySeconds: 5
+                  TestFrequencySeconds: 10
                 JDBCDriverParams:
                   DriverName: com.mysql.cj.jdbc.Driver
                   URL: '@@SECRET:mysql-credentials:url@@'

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -69,6 +69,11 @@ spec:
                 JDBCDataSourceParams:
                   GlobalTransactionsProtocol: OnePhaseCommit
                   JNDIName: jdbc/ToDoDB
+                JDBCConnectionPoolParams:
+                  TestConnectionsOnReserve: true
+                  InactiveConnectionTimeoutSeconds: 30
+                  ConnectionCreationRetryFrequencySeconds: 5
+                  TestFrequencySeconds: 10
                 JDBCDriverParams:
                   # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server
                   URL: "jdbc:mysql://mysql.todo-list.svc.cluster.local:3306/tododb"

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -70,9 +70,13 @@ spec:
                   GlobalTransactionsProtocol: OnePhaseCommit
                   JNDIName: jdbc/ToDoDB
                 JDBCConnectionPoolParams:
-                  TestConnectionsOnReserve: true
-                  InactiveConnectionTimeoutSeconds: 30
                   ConnectionCreationRetryFrequencySeconds: 5
+                  ConnectionReserveTimeoutSeconds: 10
+                  InitialCapacity: 0
+                  InactiveConnectionTimeoutSeconds: 60
+                  MaxCapacity: 5
+                  MinCapacity: 0
+                  TestConnectionsOnReserve: true
                   TestFrequencySeconds: 10
                 JDBCDriverParams:
                   # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server


### PR DESCRIPTION
# Description

Add or update retry/timeout settings to JDBC CP for WLS examples (Bob's Books, and ToDo-List).
- Seems like the failures we've been seeing intermittently are due to a temporarily dropped connection during MySQL/adminServer startup, and the pool doesn't recover
- Bob's Books already had some settings, which tends to not have this failure whereas the tests based on the ToDo example do
- Align the settings across both examples

Fixes VZ-2584

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
