### PR TITLE
JIRA:VZ-2425 Add message indicating ability to remove OCI DNS secret post-installation

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -267,10 +267,7 @@ fi
 if [ $(is_oci_dns) == "true" ]; then
   secret_name=$(get_config_value ".dns.oci.ociConfigSecret")
   consoleout
-  consoleout "Post-Installation Notes:"
-  consoleout "-----------------------"
-  consoleout
-  consoleout "- The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
+  consoleout "NOTE: The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
   consoleout "You may delete it now.  DO NOT delete the secret of the same name in the cert-manager namespace."
   consoleout
 fi

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -264,3 +264,15 @@ if [ $(get_application_ingress_ip) == "null" ]; then
   consoleout "Use the following command to check if an External IP has been assigned to the gateway."
   consoleout "kubectl get svc istio-ingressgateway -n istio-system"
 fi
+if [ $(is_oci_dns) == "true" ]; then
+  secret_name=$(get_config_value ".dns.oci.ociConfigSecret")
+  consoleout
+  consoleout "Post-Installation Notes:"
+  consoleout "-----------------------"
+  consoleout
+  consoleout "- The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
+  consoleout "You may delete it now.  DO NOT delete the secret of the same name in the cert-manager namespace."
+  consoleout
+fi
+
+sync

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -397,6 +397,16 @@ function is_keycloak_enabled() {
   echo ${keycloak_enabled}
 }
 
+# Return a flag indicating whether this is an installation leveraging OCI DNS
+function is_oci_dns() {
+  local dns_type=$(get_config_value '.dns.type')
+  if [ "$dns_type" == "oci" ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 if [ -z "$INSTALL_CONFIG_FILE" ]; then
   INSTALL_CONFIG_FILE=$DEFAULT_CONFIG_FILE
 fi


### PR DESCRIPTION
# Description

A message has been added to the messages printed at the end of an installation indicating to the user that the OCI DNS secret can be removed post-installation (if the user indicate the use of OCI DNS)

Fixes VZ-2425

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
