### PR TITLE
Put WebLogic operator into the Istio Mesh

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -60,6 +60,12 @@ const LabelVerrazzanoNamespace = "verrazzano.io/namespace"
 // LabelIstioInjectionDefault - default value for LabelIstioInjection
 const LabelIstioInjectionDefault = "enabled"
 
+// LabelWorkloadType - the type of workload, such as WebLogic
+const LabelWorkloadType = "verrazzano.io/workload-type"
+
+// WorkloadTypeWeblogic indicates the workload is WebLogic
+const WorkloadTypeWeblogic = "weblogic"
+
 // StatusUpdateChannelBufferSize - the number of status update messages that will be buffered
 // by the agent channel before controllers trying to send more status updates will start blocking
 const StatusUpdateChannelBufferSize = 50

--- a/application-operator/controllers/webhooks/istio_defaulter.go
+++ b/application-operator/controllers/webhooks/istio_defaulter.go
@@ -142,7 +142,7 @@ func (a *IstioWebhook) createUpdateAuthorizationPolicy(namespace string, service
 	podPrincipal := fmt.Sprintf("cluster.local/ns/%s/sa/%s", namespace, serviceAccountName)
 	gwPrincipal := "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
 	promPrincipal := "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator"
-	weblogicOperPrincipal := "cluster.local/ns/verrazzano-system/sa/weblogic-operator"
+	weblogicOperPrincipal := "cluster.local/ns/verrazzano-system/sa/weblogic-operator-sa"
 
 	principals := []string{
 		podPrincipal,

--- a/application-operator/controllers/webhooks/istio_defaulter.go
+++ b/application-operator/controllers/webhooks/istio_defaulter.go
@@ -10,12 +10,10 @@ import (
 	"net/http"
 	"strings"
 
-	vzstring "github.com/verrazzano/verrazzano/pkg/string"
-
-	"github.com/verrazzano/verrazzano/application-operator/constants"
-
 	"github.com/gertd/go-pluralize"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	"istio.io/api/type/v1beta1"
 	clisecurity "istio.io/client-go/pkg/apis/security/v1beta1"

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -207,6 +207,9 @@ func copyLabels(log logr.Logger, workloadLabels map[string]string, weblogic *uns
 		labels[oam.LabelAppName] = appName
 	}
 
+	// Set the label indicating this is WebLogic workload
+	labels[constants.LabelWorkloadType] = constants.WorkloadTypeWeblogic
+
 	err := unstructured.SetNestedStringMap(weblogic.Object, labels, specServerPodLabelsFields...)
 	if err != nil {
 		log.Error(err, "Unable to set labels in spec serverPod")

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -83,7 +83,8 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 
 	appConfigName := "unit-test-app-config"
 	componentName := "unit-test-component"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
@@ -171,7 +172,8 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	appConfigName := "unit-test-app-config"
 	componentName := "unit-test-component"
 	fluentdImage := "unit-test-image:latest"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
 	// set the Fluentd image which is obtained via env then reset at end of test
 	initialDefaultFluentdImage := logging.DefaultFluentdImage
@@ -267,7 +269,8 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 	componentName := "unit-test-component"
 	fluentdImage := "unit-test-image:latest"
 	newUpgradeVersion := "new-upgrade"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName, constants.LabelUpgradeVersion: newUpgradeVersion}
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelUpgradeVersion: newUpgradeVersion, constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
 	// set the Fluentd image which is obtained via env then reset at end of test
 	initialDefaultFluentdImage := logging.DefaultFluentdImage
@@ -334,11 +337,12 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
 			assert.Equal(weblogicKind, u.GetKind())
 
-			// make sure the OAM component and app name labels were copied
+			// make sure the OAM component and app name labels were copied and the WebLogic type lobel applied
 			specLabels, _, _ := unstructured.NestedStringMap(u.Object, specServerPodLabelsFields...)
-			assert.Equal(2, len(specLabels))
+			assert.Equal(3, len(specLabels))
 			assert.Equal("unit-test-component", specLabels["app.oam.dev/component"])
 			assert.Equal("unit-test-app-config", specLabels["app.oam.dev/name"])
+			assert.Equal(constants.WorkloadTypeWeblogic, specLabels[constants.LabelWorkloadType])
 
 			// make sure the FLUENTD sidecar was added
 			containers, _, _ := unstructured.NestedSlice(u.Object, specServerPodContainersFields...)
@@ -384,7 +388,8 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 	fluentdImage := "unit-test-image:latest"
 	existingFluentdImage := "unit-test-image:existing"
 	previousUpgradeVersion := "new-upgrade"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName, constants.LabelUpgradeVersion: previousUpgradeVersion}
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelUpgradeVersion: previousUpgradeVersion, constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
 	// existing domain containers
 	containers := []corev1.Container{{Name: logging.FluentdContainerName, Image: existingFluentdImage}}
@@ -474,7 +479,8 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 
 	appConfigName := "unit-test-app-config"
 	componentName := "unit-test-component"
-	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName}
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().

--- a/pkg/string/slice.go
+++ b/pkg/string/slice.go
@@ -44,3 +44,12 @@ func UnorderedEqual(mapBool map[string]bool, arrayStr []string) bool {
 	}
 	return true
 }
+
+// SliceToSet converts a slice of strings to a set of strings
+func SliceToSet(list []string) map[string]bool {
+	outSet := make(map[string]bool)
+	for _, f := range list {
+		outSet[f] = true
+	}
+	return outSet
+}

--- a/pkg/string/slice_test.go
+++ b/pkg/string/slice_test.go
@@ -117,3 +117,37 @@ func TestUnorderedEqual(t *testing.T) {
 	success = UnorderedEqual(mapBool, arrayStr)
 	assert.Equal(false, success)
 }
+
+// TestSliceToSet tests the SliceContainsString function
+func TestSliceToSet(t *testing.T) {
+	assert := asserts.New(t)
+	slice := []string{"s1", "s2", "s3"}
+
+	// GIVEN a slice with several strings
+	// WHEN the slice is converted to a set
+	// THEN verify the set is correct
+	set := SliceToSet(slice)
+	assert.Len(set, 3)
+	assert.Contains(slice, "s1", "Set should contain string")
+	assert.Contains(slice, "s2", "Set should contain string")
+	assert.Contains(slice, "s3", "Set should contain string")
+	assert.NotContains(slice, "s4", "Set should not contain string")
+}
+
+// TestEmptyOrNilSliceToSet tests the SliceContainsString function
+func TestEmptyOrNilSliceToSet(t *testing.T) {
+	assert := asserts.New(t)
+	slice := []string{}
+
+	// GIVEN an empty slice
+	// WHEN the slice is converted to a set
+	// THEN verify the set is empty
+	set := SliceToSet(slice)
+	assert.Len(set, 0, "Empty slice should result in empty set")
+
+	// GIVEN an nil slice
+	// WHEN the slice is converted to a set
+	// THEN verify the set is empty
+	set = SliceToSet(nil)
+	assert.Len(set, 0, "Nil slice should result in empty set")
+}

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 # Network policy for WebLogic operator
-# Ingress: allow from Istio ingress gateway
+# Ingress: allow from istio-system
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -16,9 +16,10 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - ports:
-      - port: 8443
-        protocol: TCP
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: istio-system
 ---
 # Network policy for Coherence Operator
 # Ingress: allow connect from Kubernetes API server to validating webhook port 9443

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 # Network policy for WebLogic operator
-# Ingress: deny all
+# Ingress: allow from Istio ingress gateway
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -15,6 +15,10 @@ spec:
       app: weblogic-operator
   policyTypes:
     - Ingress
+  ingress:
+    - ports:
+      - port: 8443
+        protocol: TCP
 ---
 # Network policy for Coherence Operator
 # Ingress: allow connect from Kubernetes API server to validating webhook port 9443

--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -466,7 +466,7 @@ spec:
               verrazzano.io/namespace: {{ .Release.Namespace }}
           podSelector:
             matchExpressions:
-              - {key: app, operator: In, values: [system-prometheus, fluentd, verrazzano-api, verrazzano-console, system-es-master, system-es-ingest, system-es-data, system-grafana, system-kibana]}
+              - {key: app, operator: In, values: [system-prometheus, fluentd, verrazzano-api, verrazzano-console, system-es-master, system-es-ingest, system-es-data, system-grafana, system-kibana, weblogic-operator]}
         - namespaceSelector:
             matchLabels:
               verrazzano.io/namespace: keycloak

--- a/platform-operator/helm_config/overrides/istio-values.yaml
+++ b/platform-operator/helm_config/overrides/istio-values.yaml
@@ -41,7 +41,7 @@ sidecarInjectorWebhook:
   rewriteAppHTTPProbe: true
   neverInjectSelector:
     - matchExpressions:
-        - {key: app, operator: In, values: [verrazzano-application-operator, verrazzano-operator, weblogic-operator]}
+        - {key: app, operator: In, values: [verrazzano-application-operator, verrazzano-operator]}
     - matchExpressions:
         - {key: control-plane, operator: In, values: [coherence]}
     - matchExpressions:

--- a/platform-operator/helm_config/overrides/weblogic-values.yaml
+++ b/platform-operator/helm_config/overrides/weblogic-values.yaml
@@ -2,3 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 image: ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2
+
+pod:
+  annotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: "443"

--- a/platform-operator/helm_config/overrides/weblogic-values.yaml
+++ b/platform-operator/helm_config/overrides/weblogic-values.yaml
@@ -3,6 +3,5 @@
 
 image: ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2
 
-pod:
-  annotations:
+podAnnotations:
     traffic.sidecar.istio.io/excludeOutboundPorts: "443"

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -23,7 +23,7 @@ spec:
         weblogic.operatorName: {{ .Release.Namespace | quote }}
         app: "weblogic-operator"
      annotations:
-       {{- range $key, $value := .Values.pod.annotations }}
+       {{- range $key, $value := .podAnnotations }}
          {{ $key }}: {{ $value | quote }}
        {{- end }}
     spec:

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -22,6 +22,10 @@ spec:
      labels:
         weblogic.operatorName: {{ .Release.Namespace | quote }}
         app: "weblogic-operator"
+     annotations:
+       {{- range $key, $value := .Values.pod.annotations }}
+         {{ $key }}: {{ $value | quote }}
+       {{- end }}
     spec:
       serviceAccountName: {{ .serviceAccount | quote }}
       {{- with .nodeSelector }}


### PR DESCRIPTION
This PR has changes to put the WebLogic Operator in the Istio mesh and configure it to have access to WebLogic applications in the mesh.  This is needed so that the operator can make admin REST calls to the WebLogic applications in the mesh.  When this is working correctly, the domain status is correctly updated, for example:

    servers:
    - desiredState: RUNNING
      health:
        activationTime: "2021-05-18T18:23:49.440000Z"
        overallHealth: ok

When it was NOT working (the bug), the overallHealth is [not available]

The following changes were made:
1. Remove weblogic-operator from the istio sidecar config neverInjectSelector. 
2. Add the excludeOutbound port annotation to the weblogic operator so that it can access the API server
3. Add the WebLogic operator service account to the list of principals in istio AuthorizationPolicy for the application.
4. Fix the NetworkPolicies so that the weblogic operator can talk to the istio control plane

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
