### PR TITLE
default k8s to v1.18.10

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.18.10", "v1.17.13" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
         string (name: 'failureCount',
                 defaultValue: '0',
                 description: 'Number of consecutive failures',

--- a/ci/looping-test/JenkinsfileCreateCluster
+++ b/ci/looping-test/JenkinsfileCreateCluster
@@ -35,7 +35,7 @@ pipeline {
             choices: availableRegions )
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.18.10", "v1.17.13" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
        booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
     }
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.18.10", "v1.17.13" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
             choices: [ "VM.Standard.E3.Flex-8-2", "VM.Standard2.4-2" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.17.13", "v1.18.10" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
         string defaultValue: 'dev', description: 'Verrazzano install profile name', name: "INSTALL_PROFILE", trim: true
 
         booleanParam (description: 'Whether to kick off acceptance test run at the end of this build', name: 'RUN_ACCEPTANCE_TESTS', defaultValue: true)

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             choices: [ "VM.Standard.E3.Flex-8-2", "VM.Standard2.4-2", "VM.Standard.E2.2" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.18.10", "v1.17.13" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
         choice (description: 'Certificate Issuer', name: 'CERT_ISSUER',
                 choices: certIssuers)
         choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.19.7", "v1.18.10", "v1.17.13" ])
+                choices: [ "v1.18.10", "v1.19.7", "v1.17.13" ])
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS',
                       defaultValue: false,
                       description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)')


### PR DESCRIPTION
# Description

We will revert the default back to v19.7 once there is a real solution.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
