### PR TITLE
Disable OCI DNS keeping clusters around on failure

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -212,7 +212,6 @@ pipeline {
                 failure {
                     script {
                         echo "Cluster create failed"
-                        keepOKEClusterOnFailure = "true"
                     }
                 }
             }


### PR DESCRIPTION
# Description

Disable keepig OKE cluster on failure

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
