### PR TITLE
VMO uses self-signed cert for liveness

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
@@ -29,19 +29,6 @@ data:
   private_key: {{ .Values.oci.privateKey | b64enc }}
   {{ end }}
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
-metadata:
-  name: vmo-tls
-  namespace: {{ .Release.Namespace }}
-spec:
-  secretName: vmo-tls
-  dnsNames:
-    - {{ .Values.monitoringOperator.name }}
-  issuerRef:
-    name: verrazzano-cluster-issuer
-    kind: ClusterIssuer
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/03-verrazzano-monitoring-operator.yaml
@@ -368,9 +368,8 @@ spec:
             requests:
               memory: {{ .Values.monitoringOperator.RequestMemory }}
           volumeMounts:
-            - mountPath: /cert
-              name: cert-volume
-              readOnly: true
+            - name: cert-volume
+              mountPath: /etc/certs
           env:
             - name: ISTIO_PROXY_IMAGE
               value: {{ .Values.monitoringOperator.istioProxyImage }}
@@ -415,8 +414,7 @@ spec:
       serviceAccountName: {{ .Values.monitoringOperator.name }}
       volumes:
         - name: cert-volume
-          secret:
-            secretName: vmo-tls
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -3,7 +3,7 @@
 name: verrazzano
 
 global:
-  imagePullSecrets: []
+  imagePullSecrets: [verrazzano-container-registry]
 
 image:
   pullPolicy: IfNotPresent
@@ -56,8 +56,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
-  imageVersion: 0.15.0-20210512224353-617a0c0
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
+  imageVersion: 0.15.0-20210520204325-427277b
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -3,7 +3,7 @@
 name: verrazzano
 
 global:
-  imagePullSecrets: [verrazzano-container-registry]
+  imagePullSecrets: []
 
 image:
   pullPolicy: IfNotPresent
@@ -56,8 +56,8 @@ verrazzanoOperator:
 
 monitoringOperator:
   name: verrazzano-monitoring-operator
-  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator-jenkins
-  imageVersion: 0.15.0-20210520204325-427277b
+  imageName: ghcr.io/verrazzano/verrazzano-monitoring-operator
+  imageVersion: 0.15.0-20210521020822-9b87485
   metricsPort: 8090
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
@@ -68,7 +68,7 @@ monitoringOperator:
   alertManagerImage: "noimage"
   esWaitTargetVersion: 7.6.1
   esImage: ghcr.io/verrazzano/elasticsearch:7.6.1-20201130145440-5c76ab1
-  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.15.0-20210510204900-4a0dd4f
+  esWaitImage: ghcr.io/verrazzano/verrazzano-monitoring-instance-eswait:0.15.0-20210521020822-9b87485
   esInitImage: ghcr.io/oracle/oraclelinux:7.8
   kibanaImage: ghcr.io/verrazzano/kibana:7.6.1-20201130145840-7717e73
   configReloaderImage: ghcr.io/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e


### PR DESCRIPTION
# Description

Instead of cert issued by cert-manager, VMO uses self-signed cert for liveness probe.

Fixes VZ-2667

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
