### PR TITLE
Add missing slash to bobbys-front-end urls

### DIFF
--- a/examples/bobs-books/README.md
+++ b/examples/bobs-books/README.md
@@ -93,7 +93,7 @@ The Bob's Books example is an application based on WebLogic, Helidon, and Cohere
 
       * Robert's Books UI at `https://bobs-books.bobs-books.11.22.33.44.nip.io/`.
 
-      * Bobby's Books UI at `https://bobs-books.bobs-books.11.22.33.44.nip.io/bobbys-front-end`.
+      * Bobby's Books UI at `https://bobs-books.bobs-books.11.22.33.44.nip.io/bobbys-front-end/`.
 
       * Bob's order manager  UI at `https://bobs-books.bobs-books.11.22.33.44.nip.io/bobs-bookstore-order-manager/orders`.
 
@@ -105,7 +105,7 @@ The Bob's Books example is an application based on WebLogic, Helidon, and Cohere
 
       * Robert's Books UI at `https://bobs-books.example.com/`.
 
-      * Bobby's Books UI at `https://bobs-books.example.com/bobbys-front-end`.
+      * Bobby's Books UI at `https://bobs-books.example.com/bobbys-front-end/`.
 
       * Bob's order manager  UI at `https://bobs-books.example.com/bobs-bookstore-order-manager/orders`.
 
@@ -114,7 +114,7 @@ The Bob's Books example is an application based on WebLogic, Helidon, and Cohere
 
       * Robert's Books UI at `https://<your-roberts-books-host.your.domain>/`.
 
-      * Bobby's Books UI at `https://<your-bobbys-books-host.your.domain>/bobbys-front-end`.
+      * Bobby's Books UI at `https://<your-bobbys-books-host.your.domain>/bobbys-front-end/`.
 
       * Bob's order manager UI at `https://<your-bobs-orders-host.your.domain>/`.
 


### PR DESCRIPTION
# Description

Add missing "/" to the end of the bobbys-front-end URLs.  The omission of the slash is resulting in a redirect to a URL that contains the trailing "/", however, the redirect is going to "http" instead of "https".  The redirect to http is a separate issue that may need to be resolved.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
