### PR TITLE
Application operator creates a default metrics trait for configmap

### DIFF
--- a/application-operator/controllers/webhooks/metrics_trait_defaulter.go
+++ b/application-operator/controllers/webhooks/metrics_trait_defaulter.go
@@ -4,15 +4,24 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	metricsTraitType = "metricstraits.oam.verrazzano.io"
 )
 
 //MetricsTraitDefaulter supplies default MetricsTrait
 type MetricsTraitDefaulter struct {
+	Client client.Client
 }
 
 var (
@@ -44,10 +53,20 @@ func (m *MetricsTraitDefaulter) addDefaultTrait(component *oamv1.ApplicationConf
 
 //Default method adds default MetricsTrait to ApplicationConfiguration
 func (m *MetricsTraitDefaulter) Default(appConfig *oamv1.ApplicationConfiguration, dryRun bool) error {
+	appliesToWorkloads, err := m.getAppliesToWorkloads()
+	if err != nil {
+		return err
+	}
 	for i := range appConfig.Spec.Components {
 		found := m.findMetricsTrait(&appConfig.Spec.Components[i])
 		if !found {
-			m.addDefaultTrait(&appConfig.Spec.Components[i])
+			applies, err := m.appliesToWorkload(appConfig, &appConfig.Spec.Components[i], appliesToWorkloads)
+			if err != nil {
+				return err
+			}
+			if applies {
+				m.addDefaultTrait(&appConfig.Spec.Components[i])
+			}
 		}
 	}
 	return nil
@@ -56,4 +75,41 @@ func (m *MetricsTraitDefaulter) Default(appConfig *oamv1.ApplicationConfiguratio
 // Cleanup is not used by the metrics trait defaulter
 func (m *MetricsTraitDefaulter) Cleanup(appConfig *oamv1.ApplicationConfiguration, dryRun bool) error {
 	return nil
+}
+
+// getAppliesToWorkloads gets the set of AppliesToWorkloads from the metrics trait definition
+func (m *MetricsTraitDefaulter) getAppliesToWorkloads() (map[string]struct{}, error) {
+	// get the metrics trait definition
+	appliesToWorkloads := make(map[string]struct{})
+	td := &oamv1.TraitDefinition{}
+	err := m.Client.Get(context.TODO(), types.NamespacedName{Name: metricsTraitType}, td)
+	if err != nil {
+		return nil, err
+	}
+	// build the set of AppliesToWorkloads
+	for _, wl := range td.Spec.AppliesToWorkloads {
+		appliesToWorkloads[wl] = struct{}{}
+	}
+	return appliesToWorkloads, nil
+}
+
+// appliesToWorkload determines if the workload specified in the given component is in the list of workload kinds
+// that the metrics trait applies to.
+func (m *MetricsTraitDefaulter) appliesToWorkload(appConfig *oamv1.ApplicationConfiguration, component *oamv1.ApplicationConfigurationComponent, appliesToWorkloads map[string]struct{}) (bool, error) {
+	// get the workload from the given component
+	comp := &oamv1.Component{}
+	err := m.Client.Get(context.TODO(), types.NamespacedName{Namespace: appConfig.Namespace, Name: component.ComponentName}, comp)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	var workload map[string]interface{}
+	err = json.Unmarshal(comp.Spec.Workload.Raw, &workload)
+	if err != nil {
+		return false, err
+	}
+	_, applies := appliesToWorkloads[fmt.Sprintf("%s.%s", workload["apiVersion"], workload["kind"])]
+	return applies, nil
 }

--- a/application-operator/controllers/webhooks/metrics_trait_defaulter_test.go
+++ b/application-operator/controllers/webhooks/metrics_trait_defaulter_test.go
@@ -4,7 +4,14 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
+	"github.com/golang/mock/gomock"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime2 "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
@@ -21,12 +28,13 @@ import (
 //  WHEN Default is called with an appconfig
 //  THEN Default should add a default MetricsTrait to the appconfig
 func TestMetricsTraitDefaulter_Default(t *testing.T) {
-	testDefaulter(t, "hello-comp.yaml", "hello-conf.yaml",
-		0, 1)
-	testDefaulter(t, "hello-comp.yaml", "hello-conf_withTrait.yaml",
-		1, 2)
-	testDefaulter(t, "hello-comp.yaml", "hello-conf_withMetricsTrait.yaml",
-		2, 2)
+	containerizedWorkload := oamv1.ContainerizedWorkload{TypeMeta: metav1.TypeMeta{Kind: "ContainerizedWorkload", APIVersion: "core.oam.dev/v1alpha2"}}
+	testDefaulter(t, "hello-conf.yaml", &containerizedWorkload, 0, 1, true)
+	testDefaulter(t, "hello-conf_withTrait.yaml", &containerizedWorkload, 1, 2, true)
+	testDefaulter(t, "hello-conf_withMetricsTrait.yaml", &containerizedWorkload, 2, 2, true)
+
+	configMapWorkload := v1.ConfigMap{TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}}
+	testDefaulter(t, "hello-conf.yaml", &configMapWorkload, 0, 0, false)
 }
 
 // TestMetricsTraitDefaulter_Cleanup tests cleaning up the default MetricsTrait on an appconfig
@@ -38,7 +46,7 @@ func TestMetricsTraitDefaulter_Cleanup(t *testing.T) {
 	testMetricsTraitDefaulterCleanup(t, "hello-conf.yaml", true)
 }
 
-func testDefaulter(t *testing.T, componentPath, configPath string, initTraitsSize, expectedTraitsSize int) {
+func testDefaulter(t *testing.T, configPath string, workloadObject runtime2.Object, initTraitsSize, expectedTraitsSize int, expectedMetricsTrait bool) {
 	req := admission.Request{}
 	req.Object = runtime.RawExtension{Raw: readYaml2Json(t, configPath)}
 	decoder := decoder()
@@ -49,7 +57,30 @@ func testDefaulter(t *testing.T, componentPath, configPath string, initTraitsSiz
 	}
 	assert.Equal(t, 1, len(appConfig.Spec.Components))
 	assert.Equal(t, initTraitsSize, len(appConfig.Spec.Components[0].Traits))
-	defaulter := &MetricsTraitDefaulter{}
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: metricsTraitType}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, td *oamv1.TraitDefinition) error {
+			td.Spec.AppliesToWorkloads = []string{
+				"core.oam.dev/v1alpha2.ContainerizedWorkload",
+				"oam.verrazzano.io/v1alpha1.VerrazzanoCoherenceWorkload",
+				"oam.verrazzano.io/v1alpha1.VerrazzanoHelidonWorkload",
+				"oam.verrazzano.io/v1alpha1.VerrazzanoWebLogicWorkload",
+			}
+			return nil
+		})
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "hello-component"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, comp *oamv1.Component) error {
+			b, err := json.Marshal(workloadObject)
+			if err != nil {
+				t.Fatalf("Error in json.Marshal %v", err)
+			}
+			comp.Spec.Workload = runtime.RawExtension{Raw: b, Object: workloadObject}
+			return nil
+		})
+	defaulter := &MetricsTraitDefaulter{cli}
 	err = defaulter.Default(appConfig, false)
 	if err != nil {
 		t.Fatalf("Error in defaulter.Default %v", err)
@@ -63,7 +94,7 @@ func testDefaulter(t *testing.T, componentPath, configPath string, initTraitsSiz
 			foundMetricsTrait = true
 		}
 	}
-	assert.True(t, foundMetricsTrait)
+	assert.Equal(t, expectedMetricsTrait, foundMetricsTrait)
 }
 
 func testMetricsTraitDefaulterCleanup(t *testing.T, configPath string, dryRun bool) {
@@ -76,7 +107,9 @@ func testMetricsTraitDefaulterCleanup(t *testing.T, configPath string, dryRun bo
 		t.Fatalf("Error in decoder.Decode %v", err)
 	}
 	assert.Equal(t, 1, len(appConfig.Spec.Components))
-	defaulter := &MetricsTraitDefaulter{}
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+	defaulter := &MetricsTraitDefaulter{Client: cli}
 	err = defaulter.Cleanup(appConfig, dryRun)
 	if err != nil {
 		t.Fatalf("Error in defaulter.Default %v", err)

--- a/application-operator/deploy/traitdefinition_ingresstrait.yaml
+++ b/application-operator/deploy/traitdefinition_ingresstrait.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - core.oam.dev/v1alpha2.ContainerizedWorkload
-    - weblogic.oracle/v8.Domain
+    - oam.verrazzano.io/v1alpha1.VerrazzanoWebLogicWorkload
   definitionRef:
     name: ingresstraits.oam.verrazzano.io
   workloadRefPath: spec.workloadRef

--- a/application-operator/deploy/traitdefinition_metricstrait.yaml
+++ b/application-operator/deploy/traitdefinition_metricstrait.yaml
@@ -8,8 +8,9 @@ metadata:
 spec:
   appliesToWorkloads:
     - core.oam.dev/v1alpha2.ContainerizedWorkload
-    - weblogic.oracle/v8.Domain
-    - coherence.oracle.com/v1.Coherence
+    - oam.verrazzano.io/v1alpha1.VerrazzanoCoherenceWorkload
+    - oam.verrazzano.io/v1alpha1.VerrazzanoHelidonWorkload
+    - oam.verrazzano.io/v1alpha1.VerrazzanoWebLogicWorkload
   definitionRef:
     name: metricstraits.oam.verrazzano.io
   workloadRefPath: spec.workloadRef

--- a/application-operator/deploy/verrazzano.yaml_template
+++ b/application-operator/deploy/verrazzano.yaml_template
@@ -116,6 +116,7 @@ rules:
       - components
       - containerizedworkloads
       - workloaddefinitions
+      - traitdefinitions
     verbs:
       - '*'
   - apiGroups:

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -212,7 +212,9 @@ func main() {
 			KubeClient:  kubeClient,
 			IstioClient: istioClientSet,
 			Defaulters: []webhooks.AppConfigDefaulter{
-				&webhooks.MetricsTraitDefaulter{},
+				&webhooks.MetricsTraitDefaulter{
+					Client: mgr.GetClient(),
+				},
 				&webhooks.NetPolicyDefaulter{
 					Client:          mgr.GetClient(),
 					NamespaceClient: kubeClient.CoreV1().Namespaces(),

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_traitdefinition_ingresstrait.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_traitdefinition_ingresstrait.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - core.oam.dev/v1alpha2.ContainerizedWorkload
-    - weblogic.oracle/v8.Domain
+    - oam.verrazzano.io/v1alpha1.VerrazzanoWebLogicWorkload
   definitionRef:
     name: ingresstraits.oam.verrazzano.io
   workloadRefPath: spec.workloadRef

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_traitdefinition_metricstrait.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_traitdefinition_metricstrait.yaml
@@ -8,8 +8,9 @@ metadata:
 spec:
   appliesToWorkloads:
     - core.oam.dev/v1alpha2.ContainerizedWorkload
-    - weblogic.oracle/v8.Domain
-    - coherence.oracle.com/v1.Coherence
+    - oam.verrazzano.io/v1alpha1.VerrazzanoCoherenceWorkload
+    - oam.verrazzano.io/v1alpha1.VerrazzanoHelidonWorkload
+    - oam.verrazzano.io/v1alpha1.VerrazzanoWebLogicWorkload
   definitionRef:
     name: metricstraits.oam.verrazzano.io
   workloadRefPath: spec.workloadRef


### PR DESCRIPTION
# Description

The Application operator creates a default metrics trait for configmap, which causes metricstrait  reconcile to fail. 

The metrics trait defaulter should only add default metrics traits to components with workload types listed in the appliesToWorkloads field of the trait definition.  

- Add all of the wrapper workload types to the metrics trait definition.
- In metrics trait defaulter, check that workload kind is in appliesToWorkloads set before adding a default metrics trait.
- Add tests case for workload kind not in appliesToWorkloads.

Fixes VZ-2397

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
