### PR TITLE
Explicitly pre-create the Verrazzano system namespace

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -135,7 +135,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// since it is needed for the subsequent step to syncLocalRegistration secret.
 	err = r.createVerrazzanoSystemNamespace(ctx, log)
 	if err != nil {
-		log.Errorf("Failed to create or update namespace %v: %v", constants.VerrazzanoSystemNamespace, err)
+		log.Errorf("Failed to create namespace %v: %v", constants.VerrazzanoSystemNamespace, err)
 		return reconcile.Result{}, err
 	}
 

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -1111,7 +1111,6 @@ func TestConfigMapGetError(t *testing.T) {
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
-
 	// Expect a call to get the ConfigMap - return a failure error
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -152,6 +152,9 @@ func TestSuccessfulInstall(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the verrazzano system namespace (return exists)
+	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
+
 	// Expect a call to get the Job - return that it exists
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
@@ -286,6 +289,9 @@ func TestCreateVerrazzano(t *testing.T) {
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			return nil
 		})
+
+	// Expect a call to get the verrazzano system namespace (mock does not exist) and to create it
+	expectVerrazzanoSystemNamespaceDoesNotExist(mock, asserts)
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
@@ -442,6 +448,9 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 			asserts.NotNil(configMap.Data[vzapi.OciPrivateKeyFileName], "OCI Config entry not found")
 			return nil
 		})
+
+	// Expect a call to get the verrazzano system namespace (return exists)
+	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
@@ -1256,6 +1265,117 @@ func TestConfigMapCreateError(t *testing.T) {
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
 }
 
+// TestVZSystemNamespaceGetError tests the Reconcile method for the following use case
+// GIVEN a request to reconcile an verrazzano resource
+// WHEN a there is an error getting the verrazzano system namespace
+// THEN return error
+func TestVZSystemNamespaceGetError(t *testing.T) {
+	namespace := "verrazzano"
+	name := "test"
+	labels := map[string]string{"label1": "test"}
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	var verrazzanoToUse vzapi.Verrazzano
+	asserts.NotNil(mockStatus)
+
+	verrazzanoToUse.TypeMeta = metav1.TypeMeta{
+		APIVersion: "install.verrazzano.io/v1alpha1",
+		Kind:       "Verrazzano"}
+	verrazzanoToUse.ObjectMeta = metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		Labels:    labels}
+
+	// Expect a call to get the verrazzano resource.
+	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, namespace, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Expect a call to get the ConfigMap
+	expectConfigMapExists(mock, namespace, name, labels)
+
+	errMsg := "get vz system namespace error"
+	// Expect a call to get the verrazzano system namespace - return a failure error
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
+		Return(errors.NewBadRequest(errMsg))
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.EqualError(err, errMsg)
+	asserts.Equal(false, result.Requeue)
+	asserts.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestVZSystemNamespaceCreateError tests the Reconcile method for the following use case
+// GIVEN a request to reconcile an verrazzano resource
+// WHEN a there is an error creating the verrazzano system namespace
+// THEN return error
+func TestVZSystemNamespaceCreateError(t *testing.T) {
+	namespace := "verrazzano"
+	name := "test"
+	labels := map[string]string{"label1": "test"}
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	var verrazzanoToUse vzapi.Verrazzano
+	asserts.NotNil(mockStatus)
+
+	verrazzanoToUse.TypeMeta = metav1.TypeMeta{
+		APIVersion: "install.verrazzano.io/v1alpha1",
+		Kind:       "Verrazzano"}
+	verrazzanoToUse.ObjectMeta = metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		Labels:    labels}
+
+	// Expect a call to get the verrazzano resource.
+	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, namespace, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Expect a call to get the ConfigMap
+	expectConfigMapExists(mock, namespace, name, labels)
+
+	errMsg := "create vz system namespace error"
+	// Expect a call to get the verrazzano system namespace - return an IsNotFound
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.ParseGroupResource("namespaces"), constants.VerrazzanoSystemNamespace))
+
+	// Expect a call to create the verrazzano system namespace - return a failure error
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Namespace{})).
+		Return(errors.NewBadRequest(errMsg))
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.EqualError(err, errMsg)
+	asserts.Equal(false, result.Requeue)
+	asserts.Equal(time.Duration(0), result.RequeueAfter)
+}
+
 // TestJobGetError tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an verrazzano resource
 // WHEN a there is an error getting the Job
@@ -1314,6 +1434,9 @@ func TestJobGetError(t *testing.T) {
 			configMap.ObjectMeta = cm.ObjectMeta
 			return nil
 		})
+
+	// Expect a call to get the verrazzano system namespace (return exists)
+	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return a failure error
 	mock.EXPECT().
@@ -1465,6 +1588,9 @@ func TestJobCreateError(t *testing.T) {
 			configMap.ObjectMeta = cm.ObjectMeta
 			return nil
 		})
+
+	// Expect a call to get the verrazzano system namespace (return exists)
+	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return not found
 	mock.EXPECT().
@@ -1928,6 +2054,86 @@ func expectSyncLocalRegistration(t *testing.T, mock *mocks.MockClient, name stri
 			secret.Data = map[string][]byte{
 				clusters.ManagedClusterNameKey: []byte("cluster1"),
 			}
+			return nil
+		})
+}
+
+// expectGetVerrazzanoSystemNamespaceExists expects a call to get the verrazzano system namespace and returns
+// that it exists
+func expectGetVerrazzanoSystemNamespaceExists(mock *mocks.MockClient, asserts *assert.Assertions) {
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
+			ns.Name = constants.VerrazzanoSystemNamespace
+			return nil
+		})
+}
+
+// expectVerrazzanoSystemNamespaceDoesNotExist expects a call to get the verrazzano system namespace and returns
+// that it does not exist, then expects a call to create it
+func expectVerrazzanoSystemNamespaceDoesNotExist(mock *mocks.MockClient, asserts *assert.Assertions) {
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.ParseGroupResource("namespaces"), constants.VerrazzanoSystemNamespace))
+
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Namespace{})).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.CreateOption) error {
+			asserts.Equalf(constants.VerrazzanoSystemNamespace, ns.Name, "Verrazzano system namespace did not match")
+			return nil
+		})
+}
+
+// expectConfigMapExists expects a call to get the config map for the Verrazzano with the given namespace and name,
+// and returns that it exists
+func expectConfigMapExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
+	// Expect a call to get the ConfigMap - return that it exists
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
+			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
+			configMap.ObjectMeta = cm.ObjectMeta
+			return nil
+		})
+}
+
+// expectClusterRoleBindingExists expects a call to get the cluster role binding for the Verrazzano with the given
+// namespace and name, and returns that it exists
+func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Verrazzano, namespace string, name string) {
+	// Expect a call to get the ClusterRoleBinding - return that it exists
+	clusterRoleBindingName := buildClusterRoleBindingName(namespace, name)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: clusterRoleBindingName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
+			crb := installjob.NewClusterRoleBinding(&verrazzanoToUse, nsName.Name, buildServiceAccountName(nsName.Name))
+			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
+			clusterRoleBinding.RoleRef = crb.RoleRef
+			clusterRoleBinding.Subjects = crb.Subjects
+			return nil
+		})
+}
+
+// expectGetServiceAccountExists expects a call to get the service account for the Verrazzano with the given
+// namespace and name, and returns that it exists
+func expectGetServiceAccountExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
+	// Expect a call to get the ServiceAccount - return that it exists
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
+			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, []string{}, labels)
+			serviceAccount.ObjectMeta = newSA.ObjectMeta
+			return nil
+		})
+}
+
+// expectGetVerrazzanoExists expects a call to get a Verrazzano with the given namespace and name, and returns
+// one that has the same content as the verrazzanoToUse argument
+func expectGetVerrazzanoExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Verrazzano, namespace string, name string, labels map[string]string) {
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, verrazzano *vzapi.Verrazzano) error {
+			verrazzano.TypeMeta = verrazzanoToUse.TypeMeta
+			verrazzano.ObjectMeta = verrazzanoToUse.ObjectMeta
 			return nil
 		})
 }


### PR DESCRIPTION
# Description

Explicitly pre-create the Verrazzano system namespace before kicking off install, so that sync_local_registration_secret does not have failures due to missing namespace.
Refactored the verrazzano controller_test to reduce duplication of the similar mocks in several tests.

Fixes VZ-2404

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
