### PR TITLE
Fix operator.yaml generation in local builds

### DIFF
--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -162,7 +162,7 @@ integ-test: create-cluster generate-operator-yaml
 generate-operator-yaml:
 	OPERATOR_DIR=$$(dirname ${OPERATOR_YAML}) ; \
 	mkdir -p $${OPERATOR_DIR} ; \
-	env DOCKER_IMAGE=${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG} IMAGE_PULL_SECRETS=${IMAGE_PULL_SECRETS} ../tools/scripts/generate_operator_yaml.sh > ${OPERATOR_YAML}
+	env DOCKER_IMAGE=${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG} IMAGE_PULL_SECRETS=${IMAGE_PULL_SECRETS} APP_OPERATOR_IMAGE=${VERRAZZANO_APPLICATION_OPERATOR_IMAGE} ../tools/scripts/generate_operator_yaml.sh > ${OPERATOR_YAML}
 
 .PHONY: cleanup-cluster
 cleanup-cluster:

--- a/tools/scripts/generate_operator_yaml.sh
+++ b/tools/scripts/generate_operator_yaml.sh
@@ -39,7 +39,7 @@ if [ -n "${IMAGE_PULL_SECRETS}" ] ; then
 fi
 
 APP_OPERATOR_IMAGE_ARG=
-if [ -n "${APP_OPERATOR_IMAGE}" ] ; then
+if [ -n "${APP_OPERATOR_IMAGE}" ] && [[ "${APP_OPERATOR_IMAGE}" == *:* ]] ; then
     APP_OPERATOR_IMAGE_ARG="--set global.appOperatorImage=${APP_OPERATOR_IMAGE}"
 fi
 

--- a/tools/scripts/generate_operator_yaml.sh
+++ b/tools/scripts/generate_operator_yaml.sh
@@ -38,10 +38,16 @@ if [ -n "${IMAGE_PULL_SECRETS}" ] ; then
     IMAGE_PULL_SECRET_ARG="--set global.imagePullSecrets={${IMAGE_PULL_SECRETS}}"
 fi
 
+APP_OPERATOR_IMAGE_ARG=
+if [ -n "${APP_OPERATOR_IMAGE}" ] ; then
+    APP_OPERATOR_IMAGE_ARG="--set global.appOperatorImage=${APP_OPERATOR_IMAGE}"
+fi
+
 helm template \
     --include-crds \
     ${IMAGE_PULL_SECRET_ARG} \
     --set image=${DOCKER_IMAGE} \
+    ${APP_OPERATOR_IMAGE_ARG} \
     $SCRIPT_DIR/../../platform-operator/helm_config/charts/verrazzano-platform-operator
 
 exit $?


### PR DESCRIPTION
# Description

This PR fixes a problem introduced by the new bill of materials-based installation. The developer `make create-test-deploy` scenario resulted in an operator.yaml that when applied, failed to install the Verrazzano Application Operator.

The fix is to add a `--set` argument to the `helm template` command that sets the helm value to override the application operator image. I searched through the makefiles and jenkinsfiles to make sure this only gets applied when building locally, and as best I can tell, that is the case.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
