### PR TITLE
Upgrade to cert-manager 1.2.0

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -102,7 +102,8 @@ function setup_cluster_issuer() {
       acmeURL="https://acme-staging-v02.api.letsencrypt.org/directory"
     fi
 
-    kubectl apply -f <(echo "
+    # attempt first kubectl command with retry to ensure that cert-manager webhook is fully initialized
+    kubectl_apply_with_retry "
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -121,13 +122,14 @@ spec:
               name: $OCI_DNS_CONFIG_SECRET
               key: "oci.yaml"
             ocizonename: $DNS_SUFFIX
-")
+"
   elif [ "$CERT_ISSUER_TYPE" == "ca" ]; then
     if [ $(get_config_value ".certificates.ca.secretName") == "$VERRAZZANO_DEFAULT_SECRET_NAME" ] &&
        [ $(get_config_value ".certificates.ca.clusterResourceNamespace") == "$VERRAZZANO_DEFAULT_SECRET_NAMESPACE" ]; then
     log "Certificate not specified. Creating default Verrazzano Issuer and Certificate in verrazzano-install namespace"
 
-    kubectl apply -f <(echo "
+    # attempt first kubectl command with retry to ensure that cert-manager webhook is fully initialized
+    kubectl_apply_with_retry "
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
@@ -135,7 +137,7 @@ metadata:
   namespace: $(get_config_value ".certificates.ca.clusterResourceNamespace")
 spec:
   selfSigned: {}
-")
+"
 
     kubectl apply -f <(echo "
 apiVersion: cert-manager.io/v1alpha2
@@ -516,6 +518,30 @@ function patch_rancher_agents() {
     else
         echo "Rancher host is the same from inside and outside the cluster.  No need to patch agents."
     fi
+}
+
+function kubectl_apply_with_retry() {
+  echo "Invoking: kubectl apply for $1"
+  local count=0
+  local ret=0
+  until kubectl apply -f <(echo "$1"); do
+    ret=$?
+    count=$((count+1))
+    if [[ "$count" -lt 60 ]]; then
+      echo "kubectl apply failed, waiting for 5 seconds and trying again"
+      sleep 5
+    else
+      break
+    fi
+  done
+
+  if [ $ret -ne 0 ]; then
+    echo "kubectl apply attempt timed out"
+  else
+    echo "kubectl apply succeeded"
+  fi
+
+  return $ret
 }
 
 REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)


### PR DESCRIPTION
# Description

Upgrade Verrazzano to use cert-manager version 1.2.0. 
The previously supported version was 0.13.1.
The cert-manager webhook has been enabled as it is now a required cert-manager component.

Fixes VZ-1873

# Checklist 

As the author of this PR, I have:

- [x ] Checked that I included or updated copyright and license notices in all files that I altered
- [x ] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
