### PR TITLE
systemd journal fix

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/02-verrazzano-logging.yaml
@@ -96,20 +96,6 @@ data:
   systemd-input.conf: |
     <source>
       @type systemd
-      @id in_systemd
-      read_from_head true
-      tag systemd
-      <storage>
-        @type local
-        persistent true
-        path /tmp/journald_pos.json
-      </storage>
-      <entry>
-        fields_strip_underscores true
-      </entry>
-    </source>
-    <source>
-      @type systemd
       @id in_systemd_run
       read_from_head true
       tag systemd

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -185,6 +185,7 @@ var _ = ginkgo.Describe("VMI", func() {
 				return pkg.FindLog("verrazzano-systemd-journal",
 					[]pkg.Match{
 						{Key: "tag", Value: "systemd"},
+						{Key: "TRANSPORT", Value: "journal"},
 						{Key: "cluster_name", Value: constants.MCLocalCluster}},
 					[]pkg.Match{})
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a systemd log record")


### PR DESCRIPTION
# Description
Remove the systemd source which is without path and defaults to /var/log/journal
* /var/log/journal may be missing on some instances without persistent systemd journal causing repeated warnings of "Systemd::JournalError: No such file or directory"
* /var/log/journal may contains old systemd journal

Fixes VZ-2646

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
