### PR TITLE
VZ-2722.  Use webhook and cainjector images built from source

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -49,7 +49,7 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "1.2.0-20210602152031-aac6bdf62",
+              "tag": "1.2.0-20210602163405-aac6bdf62",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
@@ -60,13 +60,13 @@
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "1.2.0-20210602152031-aac6bdf62",
+              "tag": "1.2.0-20210602163405-aac6bdf62",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "1.2.0-20210602152031-aac6bdf62",
+              "tag": "1.2.0-20210602163405-aac6bdf62",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -49,7 +49,7 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "1.2.0-20210510184928-aac6bdf62",
+              "tag": "1.2.0-20210602152031-aac6bdf62",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
@@ -57,6 +57,18 @@
               "image": "cert-manager-acmesolver",
               "tag": "1.2.0-20210510185040-aac6bdf62",
               "helmFullImageKey": "extraArgs[0]=--acme-http01-solver-image"
+            },
+            {
+              "image": "cert-manager-cainjector",
+              "tag": "1.2.0-20210602152031-aac6bdf62",
+              "helmFullImageKey": "cainjector.image.repository",
+              "helmTagKey": "cainjector.image.tag"
+            },
+            {
+              "image": "cert-manager-webhook",
+              "tag": "1.2.0-20210602152031-aac6bdf62",
+              "helmFullImageKey": "webhook.image.repository",
+              "helmTagKey": "webhook.image.tag"
             }
           ]
         }

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -43,6 +43,5 @@ func loadStagingCA(httpClient *http.Client, resURL string, caCertName string) []
 		fmt.Printf("Unable to load ACME %s staging CA, status: %v\n", caCertName, status)
 		return nil
 	}
-	fmt.Printf("Loaded ACME %s staging CA, status == %v\n", caCertName, status)
 	return []byte(pemData)
 }

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -353,6 +353,15 @@ func IsManagedClusterProfile() bool {
 	return GetVerrazzanoInstallResourceInCluster(GetKubeConfigPathFromEnv()).Spec.Profile == v1alpha1.ManagedCluster
 }
 
+// IsACMEStagingEnabled returns true if the ACME staging environment is configured
+func IsACMEStagingEnabled() bool {
+	vz := GetVerrazzanoInstallResourceInCluster(GetKubeConfigPathFromEnv())
+	if vz.Spec.Components.CertManager == nil {
+		return false
+	}
+	return vz.Spec.Components.CertManager.Certificate.Acme.Environment == "staging"
+}
+
 // APIExtensionsClientSet returns a Kubernetes ClientSet for this cluster.
 func APIExtensionsClientSet() *apixv1beta1client.ApiextensionsV1beta1Client {
 	config := GetKubeConfig()

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -361,15 +361,19 @@ func newRetryableHTTPClient(client *http.Client) *retryablehttp.Client {
 
 // rootCertPool returns the root cert pool
 func rootCertPool(caData []byte) *x509.CertPool {
+	if len(caData) == 0 {
+		return nil
+	}
 	// if we have caData, use it
 	certPool := x509.NewCertPool()
-	for _, stagingCA := range getACMEStagingCAs() {
-		if len(stagingCA) > 0 {
-			certPool.AppendCertsFromPEM(stagingCA)
+	certPool.AppendCertsFromPEM(caData)
+
+	if IsACMEStagingEnabled() {
+		for _, stagingCA := range getACMEStagingCAs() {
+			if len(stagingCA) > 0 {
+				certPool.AppendCertsFromPEM(stagingCA)
+			}
 		}
-	}
-	if len(caData) != 0 {
-		certPool.AppendCertsFromPEM(caData)
 	}
 	return certPool
 }


### PR DESCRIPTION
# Description

Use cert-manager-controller, cert-manager-webhook, and cert-manager-cainjector images built from the Verrazzano forked repo to pick up support for OCI DNS added there.

Fixes VZ-2722

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
