### PR TITLE
Add some logging to help diagnose Kind create cluster failure

### DIFF
--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -65,6 +65,9 @@ create_kind_cluster() {
       KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}.yaml
     fi
   fi
+  # List the permissions of /dev/null.  We have seen a failure where `docker ps` gets a operation not permitted error.
+  # Listing the permissions will help to analyze what is wrong, if we see the failure again.
+  ls -l /dev/null
   echo "Using ${KIND_CONFIG_FILE}"
   sed -i "s/KIND_IMAGE/${KIND_IMAGE}/g" ${KIND_CONFIG_FILE}
   HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster -v 1 --name ${CLUSTER_NAME} --config=${KIND_CONFIG_FILE}

--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -67,7 +67,7 @@ create_kind_cluster() {
   fi
   # List the permissions of /dev/null.  We have seen a failure where `docker ps` gets an operation not permitted error.
   # Listing the permissions will help to analyze what is wrong, if we see the failure again.
-  echo "Listing permissons for /dev/null"
+  echo "Listing permissions for /dev/null"
   ls -l /dev/null
   echo "Using ${KIND_CONFIG_FILE}"
   sed -i "s/KIND_IMAGE/${KIND_IMAGE}/g" ${KIND_CONFIG_FILE}

--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -65,8 +65,9 @@ create_kind_cluster() {
       KIND_CONFIG_FILE=kind-config-ci${CALICO_SUFFIX}.yaml
     fi
   fi
-  # List the permissions of /dev/null.  We have seen a failure where `docker ps` gets a operation not permitted error.
+  # List the permissions of /dev/null.  We have seen a failure where `docker ps` gets an operation not permitted error.
   # Listing the permissions will help to analyze what is wrong, if we see the failure again.
+  echo "Listing permissons for /dev/null"
   ls -l /dev/null
   echo "Using ${KIND_CONFIG_FILE}"
   sed -i "s/KIND_IMAGE/${KIND_IMAGE}/g" ${KIND_CONFIG_FILE}


### PR DESCRIPTION
# Description

This pull request adds some logging during the "Prepare AT Environment" stage to help diagnose a failure seen creating a Kind cluster

Fixes VZ-2725

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
