### PR TITLE
Add cluster dump when verify uninstall stage fails

### DIFF
--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -360,6 +360,16 @@ pipeline {
                     """
                 }
             }
+            success {
+                script {
+                    if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                        dumpK8sCluster('verify-uninstall-cluster-dump')
+                    }
+                }
+            }
+            failure {
+                dumpK8sCluster('verify-uninstall-cluster-dump')
+            }
         }
 
         stage("Reinstall Verrazzano") {

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -360,15 +360,17 @@ pipeline {
                     """
                 }
             }
-            success {
-                script {
-                    if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
-                        dumpK8sCluster('verify-uninstall-cluster-dump')
+            post {
+                success {
+                    script {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('verify-uninstall-cluster-dump')
+                        }
                     }
                 }
-            }
-            failure {
-                dumpK8sCluster('verify-uninstall-cluster-dump')
+                failure {
+                    dumpK8sCluster('verify-uninstall-cluster-dump')
+                }
             }
         }
 


### PR DESCRIPTION
# Description

Add a dump of the verrazzano cluster when the verify uninstall stage fails.  Currently if that stage fails, the dump does not occur until after the reinstall stage runs, so it is not dumping the actual failed environment.

Fixes VZ-2724

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
