### PR TITLE
Fix test client to accommodate ACME staging and self-signed scenarios

### DIFF
--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -361,14 +361,19 @@ func newRetryableHTTPClient(client *http.Client) *retryablehttp.Client {
 
 // rootCertPool returns the root cert pool
 func rootCertPool(caData []byte) *x509.CertPool {
-	if len(caData) == 0 {
-		return nil
+	var certPool *x509.CertPool = nil
+
+	if len(caData) != 0 {
+		// if we have caData, use it
+		certPool = x509.NewCertPool()
+		certPool.AppendCertsFromPEM(caData)
 	}
-	// if we have caData, use it
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caData)
 
 	if IsACMEStagingEnabled() {
+		// Add the ACME staging CAs if necessary
+		if certPool == nil {
+			certPool = x509.NewCertPool()
+		}
 		for _, stagingCA := range getACMEStagingCAs() {
 			if len(stagingCA) > 0 {
 				certPool.AppendCertsFromPEM(stagingCA)


### PR DESCRIPTION
# Description

Fix CA handling in the e2e test client to account for both the self-signed and ACME staging scenarios.

Additional test fix for VZ-2722

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
