### PR TITLE
Test fix, remove Fail() call

### DIFF
--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -202,7 +202,8 @@ func doReq(url, method string, contentType string, hostHeader string, username s
 	req, err := retryablehttp.NewRequest(method, url, body)
 	if err != nil {
 		Log(Error, err.Error())
-		ginkgo.Fail("Could not create request")
+		// See comment below about not calling Fail() here - there are cases where this should be retried
+		return teapot, ""
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)


### PR DESCRIPTION
# Description

While investigating a different build issue, I found a few failures due to calling `Fail()` from a function that makes HTTP requests. It looks like this code path fails occasionally and results in a panic, and the `Fail()` also prevents retries. The fix is to return an error and let the test code retry.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
