### PR TITLE
VZ-2737.  Make ca.crt TLS secret field mount optional in the verrazzano-api deployment

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                                     }
                                     steps {
                                         script {
-                                            configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_OCIDNS, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", $ACME_ENVIRONMENT)
+                                            configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_OCIDNS, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", params.ACME_ENVIRONMENT)
                                         }
                                     }
                                 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -128,11 +128,12 @@ pipeline {
         OCI_CLI_KEY_FILE = credentials('oci-api-key')
         OCI_CLI_REGION = "${params.OKE_CLUSTER_REGION}"
         OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING = 'True'
+
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-nipio.yaml"
-        OCI_DNS_ZONE_SUFFIX=credentials('oci-dns-zone')
-        OCI_DNS_ZONE_NAME="z${zoneId}." + "${OCI_DNS_ZONE_SUFFIX}"
+        OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
         ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
+
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
         SHORT_TIME_STAMP = sh(returnStdout: true, script: "date +%m%d%H%M%S").trim()
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                                     }
                                     steps {
                                         script {
-                                            configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_OCIDNS, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", params.ACME_ENVIRONMENT)
+                                            configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_OCIDNS, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", "acme", params.ACME_ENVIRONMENT)
                                         }
                                     }
                                 }
@@ -754,8 +754,12 @@ def runGinkgoRandomize(testSuitePath) {
 }
 
 // Configure the Admin and Managed cluster installer custom resources
-def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript, String extraArgs) {
+def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript, String... extraArgs) {
     script {
+        // Concatenate the variable args into a single string
+        String allArgs = ""
+        extraArgs.each { allArgs += it + " " }
+
         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
             def destinationPath = "${env.KUBECONFIG_DIR}/${count}/${installerFileName}"
@@ -776,7 +780,7 @@ def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript
 
                 # Copy the template config over for the mgd cluster profile configuration
                 cp $installResourceTemplate $destinationPath
-                VZ_ENVIRONMENT_NAME="${envName}" INSTALL_PROFILE=$installProfile $configProcessorScript $destinationPath $extraArgs
+                VZ_ENVIRONMENT_NAME="${envName}" INSTALL_PROFILE=$installProfile $configProcessorScript $destinationPath $allArgs
             """
         }
     }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -63,8 +63,6 @@ pipeline {
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
                         trim: true)
         booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
-        choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
-                choices: acmeEnvironments)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
     }
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/06-verrazzano-api.yaml
@@ -74,7 +74,7 @@ data:
       local host = os.getenv("KUBERNETES_SERVICE_HOST")
       local port = os.getenv("KUBERNETES_SERVICE_PORT")
       local serverUrl = "https://" .. host .. ":" .. port
-      return serverUrl  
+      return serverUrl
     end
 
     local function split(s, delimiter)
@@ -140,7 +140,7 @@ data:
       ngx.status = 200
       ngx.exit(ngx.HTTP_OK)
     end
- 
+
     logJsonMessage(ngx.INFO, "Extracting authorization header from request.")
     local h, err = ngx.req.get_headers()["authorization"]
     if err then
@@ -253,11 +253,11 @@ data:
           write_file("/etc/nginx/upstream.pem", string.sub(sub, startIndex, endIndex))
         end
       end
-      
+
       args.cluster = nil
       ngx.req.set_uri_args(args)
       ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
-    else 
+    else
       logJsonMessage(ngx.INFO, "Read service account token and set auth header.")
       local serviceAccountToken = getServiceAccountToken();
       ngx.req.set_header("Authorization", "Bearer " .. serviceAccountToken)
@@ -475,8 +475,8 @@ data:
             fi
         fi
 
-        sleep 5 
-    done 
+        sleep 5
+    done
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -511,6 +511,7 @@ spec:
                   - key: ca.crt
                     path: default-ca-bundle
                 name: system-tls
+                optional: true
             - secret:
                 name: verrazzano-cluster-registration
                 optional: true

--- a/platform-operator/scripts/create_managed_cluster_secret.sh
+++ b/platform-operator/scripts/create_managed_cluster_secret.sh
@@ -40,7 +40,7 @@ fi
 
 OUTPUT_FILE=$OUTPUT_DIR/$CLUSTER_NAME.yaml
 TLS_SECRET=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"')
-if [ ! -z "${TLS_SECRET%%*( )}" ] ; then
+if [ ! -z "${TLS_SECRET%%*( )}" ] && [ "null" != "${TLS_SECRET}" ] ; then
   CA_CERT=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 -d)
 fi
 HOST=$(kubectl get ing vmi-system-prometheus -n verrazzano-system -o jsonpath='{.spec.tls[0].hosts[0]}')

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -35,7 +35,7 @@ fi
 # create managed cluster prometheus secret yaml on managed
 PROMETHEUS_SECRET_FILE=${MANAGED_CLUSTER_NAME}.yaml
 TLS_SECRET=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"')
-if [ ! -z "${TLS_SECRET%%*( )}" ] ; then
+if [ ! -z "${TLS_SECRET%%*( )}" ] && [ "null" != "${TLS_SECRET}" ] ; then
   CA_CERT=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 --decode)
 fi
 HOST=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get ing vmi-system-prometheus -o jsonpath='{.spec.tls[0].hosts[0]}')

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -62,9 +62,10 @@ spec:
 EOF
 
 # wait for VMC to be ready - that means the manifest has been created
-kubectl --kubeconfig ${ADMIN_KUBECONFIG} wait --for=condition=Ready --timeout=15s vmc ${MANAGED_CLUSTER_NAME} -n verrazzano-mc
+echo "Creating VMC for ${MANAGED_CLUSTER_NAME}"
+kubectl --kubeconfig ${ADMIN_KUBECONFIG} wait --for=condition=Ready --timeout=60s vmc ${MANAGED_CLUSTER_NAME} -n verrazzano-mc
 if [ $? -ne 0 ]; then
-  echo "VMC ${MANAGED_CLUSTER_NAME} not ready after 15 seconds. Registration failed."
+  echo "VMC ${MANAGED_CLUSTER_NAME} not ready after 60 seconds. Registration failed."
   exit 1
 fi
 

--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -231,8 +231,8 @@ function full_k8s_cluster_dump() {
     kubectl --insecure-skip-tls-verify get netpol -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.json || true
     kubectl --insecure-skip-tls-verify describe netpol -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.txt || true
     kubectl --insecure-skip-tls-verify describe ClusterIssuer -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/cluster-issuers.txt || true
-    kubectl --insecure-skip-tls-verify describe MutatingWebhookConfigurations -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/mutating-webhook-configs.txt || true
-    kubectl --insecure-skip-tls-verify describe ValidatingWebhookConfigurations -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/validating-webhook-configs.txt || true
+    kubectl --insecure-skip-tls-verify get MutatingWebhookConfigurations -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/mutating-webhook-configs.txt || true
+    kubectl --insecure-skip-tls-verify get ValidatingWebhookConfigurations -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/validating-webhook-configs.txt || true
     # squelch the "too many clients" warnings from newer kubectl versions
     dump_extra_details_per_namespace
     dump_configmaps

--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -231,8 +231,8 @@ function full_k8s_cluster_dump() {
     kubectl --insecure-skip-tls-verify get netpol -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.json || true
     kubectl --insecure-skip-tls-verify describe netpol -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.txt || true
     kubectl --insecure-skip-tls-verify describe ClusterIssuer -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/cluster-issuers.txt || true
-    kubectl --insecure-skip-tls-verify describe MutatingWebhookConfigurations -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/mutating-webhook-configs.txt || true
-    kubectl --insecure-skip-tls-verify describe ValidatingWebhookConfigurations -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/validating-webhook-configs.txt || true
+    kubectl --insecure-skip-tls-verify describe MutatingWebhookConfigurations -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/mutating-webhook-configs.txt || true
+    kubectl --insecure-skip-tls-verify describe ValidatingWebhookConfigurations -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/validating-webhook-configs.txt || true
     # squelch the "too many clients" warnings from newer kubectl versions
     dump_extra_details_per_namespace
     dump_configmaps

--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -231,6 +231,8 @@ function full_k8s_cluster_dump() {
     kubectl --insecure-skip-tls-verify get netpol -A -o json 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.json || true
     kubectl --insecure-skip-tls-verify describe netpol -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/network-policies.txt || true
     kubectl --insecure-skip-tls-verify describe ClusterIssuer -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/cluster-issuers.txt || true
+    kubectl --insecure-skip-tls-verify describe MutatingWebhookConfigurations -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/mutating-webhook-configs.txt || true
+    kubectl --insecure-skip-tls-verify describe ValidatingWebhookConfigurations -A 2>/dev/null > $CAPTURE_DIR/cluster-dump/validating-webhook-configs.txt || true
     # squelch the "too many clients" warnings from newer kubectl versions
     dump_extra_details_per_namespace
     dump_configmaps


### PR DESCRIPTION
# Description

Fixes behavior change in CM 1.2 by marking the `ca.crt` secret mount optional, as CM no longer creates an empty `ca.crt` field in the cert secret in the case where no CA is provided when the `ClusterIssuer` is created.

Also
* Fix the `platform-operator/scripts/create_managed_cluster_secret.sh` and `tests/e2e/config/scripts/register_managed_cluster.sh` scripts to handle the case where `ca.crt` is not present in the secret
* Fix Multicluster pipeline OCI DNS/ACME configurations
* Remove a duplicate ACME_ENVIRONMENT parameter from the OCI DNS Jenkinsfile
* Add Mutating/Validating webhooks to cluster dump script

Note that there is still an issue with managed cluster registration in the OCI-DNS/ACME configuration, which we will resolve through a subsequent PR.

Fixes VZ-2737

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
