### PR TITLE
Fix regression in hello-helidon multicluster test

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -353,9 +353,9 @@ func IsManagedClusterProfile() bool {
 	return GetVerrazzanoInstallResourceInCluster(GetKubeConfigPathFromEnv()).Spec.Profile == v1alpha1.ManagedCluster
 }
 
-// IsACMEStagingEnabled returns true if the ACME staging environment is configured
-func IsACMEStagingEnabled() bool {
-	vz := GetVerrazzanoInstallResourceInCluster(GetKubeConfigPathFromEnv())
+// IsACMEStagingEnabledInCluster returns true if the ACME staging environment is configured
+func IsACMEStagingEnabledInCluster(kubeconfigPath string) bool {
+	vz := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if vz.Spec.Components.CertManager == nil {
 		return false
 	}

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -233,7 +233,7 @@ func doReq(url, method string, contentType string, hostHeader string, username s
 
 // getHTTPClientWithCABundle returns an HTTP client configured with the provided CA cert
 func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) *http.Client {
-	tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCertPool(caData)}}
+	tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCertPoolInCluster(caData, kubeconfigPath)}}
 
 	proxyURL := getProxyURL()
 	if proxyURL != "" {
@@ -310,8 +310,8 @@ func newRetryableHTTPClient(client *http.Client) *retryablehttp.Client {
 	return retryableClient
 }
 
-// rootCertPool returns the root cert pool
-func rootCertPool(caData []byte) *x509.CertPool {
+// rootCertPoolInCluster returns the root cert pool
+func rootCertPoolInCluster(caData []byte, kubeconfigPath string) *x509.CertPool {
 	var certPool *x509.CertPool = nil
 
 	if len(caData) != 0 {
@@ -320,7 +320,7 @@ func rootCertPool(caData []byte) *x509.CertPool {
 		certPool.AppendCertsFromPEM(caData)
 	}
 
-	if IsACMEStagingEnabled() {
+	if IsACMEStagingEnabledInCluster(kubeconfigPath) {
 		// Add the ACME staging CAs if necessary
 		if certPool == nil {
 			certPool = x509.NewCertPool()


### PR DESCRIPTION
# Description

A recent change regressed the hello-helidon multicluster test.  An underlying function was obtaining the default kubeconfig for a system instead of the specific kubeconfig for the cluster being tested.

Fixes VZ-2741

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
