### PR TITLE
Build fixes for operator.yaml generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docker-push:
 
 .PHONY: create-test-deploy
 create-test-deploy: docker-push
-	(cd platform-operator; make create-test-deploy VZ_DEV_IMAGE=${VERRAZZANO_PLATFORM_OPERATOR_IMAGE})
+	(cd platform-operator; make create-test-deploy VZ_DEV_IMAGE=${VERRAZZANO_PLATFORM_OPERATOR_IMAGE} VZ_APP_OP_IMAGE=${VERRAZZANO_APPLICATION_OPERATOR_IMAGE})
 
 .PHONY: test-platform-operator-install
 test-platform-operator-install:

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -198,7 +198,7 @@ create-test-deploy:
 	if [ -n "${VZ_DEV_IMAGE}" ]; then \
 		IMAGE=$$(echo $${VZ_DEV_IMAGE} | cut -f 1 -d :) ; \
 		IMAGE_TAG=$$(echo $${VZ_DEV_IMAGE} | cut -f 2 -d :) ; \
-		DOCKER_IMAGE_FULLNAME=$${IMAGE} DOCKER_IMAGE_TAG=$${IMAGE_TAG} $(MAKE) generate-operator-yaml ; \
+		DOCKER_IMAGE_FULLNAME=$${IMAGE} DOCKER_IMAGE_TAG=$${IMAGE_TAG} VERRAZZANO_APPLICATION_OPERATOR_IMAGE=$${VZ_APP_OP_IMAGE} $(MAKE) generate-operator-yaml ; \
 	else \
 		echo "VZ_DEV_IMAGE not defined, please set it to a valid image name/tag"; \
 	fi

--- a/tools/scripts/generate_operator_yaml.sh
+++ b/tools/scripts/generate_operator_yaml.sh
@@ -38,6 +38,7 @@ if [ -n "${IMAGE_PULL_SECRETS}" ] ; then
     IMAGE_PULL_SECRET_ARG="--set global.imagePullSecrets={${IMAGE_PULL_SECRETS}}"
 fi
 
+APP_OPERATOR_IMAGE=${APP_OPERATOR_IMAGE:-}
 APP_OPERATOR_IMAGE_ARG=
 if [ -n "${APP_OPERATOR_IMAGE}" ] && [[ "${APP_OPERATOR_IMAGE}" == *:* ]] ; then
     APP_OPERATOR_IMAGE_ARG="--set global.appOperatorImage=${APP_OPERATOR_IMAGE}"


### PR DESCRIPTION
# Description

This PR fixes two build-related issues with the generated `operator.yaml` file:

1. A build issue discovered by @mgianatagh. When doing a MC AT run using "build with parameters", if you specify a platform operator image to use, the build would fail with an "unbound variable" shell script error. The `generate_operator_yaml.sh` script uses `set -u` and in this case the `APP_OPERATOR_IMAGE` optional env var was not set. The fix is to default the value to empty before testing the variable.
2. The developer case when running `make create-test-deploy` was broken. I had tested that previously and it worked, but I must have had an environment variable set. The fix is to pass the correct environment variable so the application operator image is correctly overridden in the generated operator.yaml. This does not affect the Jenkins pipelines, only the developer local testing scenario.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
