### PR TITLE
Disable network logs from Kubernetes while configuring Keycloak realms

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -212,6 +212,9 @@ function configure_keycloak_realms() {
 
   local PW=$(kubectl get secret -n ${VERRAZZANO_NS} verrazzano -o jsonpath="{.data.password}" | base64 -d)
 
+  # Disable network logs on Kubernetes when running kubectl exec
+  local PRESERVE_DEBUG=${DEBUG}
+  unset DEBUG
   kubectl exec --stdin keycloak-0 -n keycloak -c keycloak -- bash -s <<EOF
     export PATH="/opt/jboss/keycloak/bin:\$PATH"
     unset JAVA_TOOL_OPTIONS
@@ -720,7 +723,7 @@ END
     rm \$HOME/.keycloak/kcadm.config || fail "Failed to remove login config file"
 
 EOF
-
+  export DEBUG=${PRESERVE_DEBUG}
 }
 
 # configure the prometheus deployment to limit istio proxy based communication to the keycloak service only.  Other


### PR DESCRIPTION

# Description

This change disables the network logs from Kubernetes when the Verrazzano installer configures Keycloak realms using kubectl exec, by unsetting the environment variable DEBUG. The variable is set back to original value after the kubectl exec call is over.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
