### PR TITLE
Capture install logs before uninstall in the multi-cluster pipeline

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -361,6 +361,11 @@ pipeline {
                             parallel verrazzanoInstallStages
                         }
                     }
+                    post {
+                        always {
+                            dumpInstallLogs()
+                        }
+                    }
                 }
                 stage ('Verify Install') {
                     // NOTE: The stages are executed in parallel, however the tests themselves are executed against
@@ -546,7 +551,6 @@ pipeline {
         }
         always {
             script {
-                dumpInstallLogs()
                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
@@ -988,7 +992,7 @@ def dumpUninstallLogs() {
     script {
         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
-            LOG_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/cluster-$count"
+            LOG_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/uninstall/build/logs/cluster-$count"
             sh """
                 ## dump verrazzano uninstall logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config


### PR DESCRIPTION
# Description

The multi-cluster pipeline attempts to capture the install log, after uninstall, resulting in an empty file. This PR fixes that.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
