### PR TITLE
WIP: Allow NetworkPolicy ingress to istio port 15017 for webhook access

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/08-thirdparty-networkpolicy.yaml
@@ -538,6 +538,7 @@ spec:
 # Ingress: allow ingress to port 15012 from verrazzano-system prometheus and keycloak (for Istio proxy sidecar)
 #          allow port 443 for webhooks
 #          allow port 15014 from system-prometheus to scrape metrics
+#          allow port 15017 for Kubernetes API server webhook call
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -581,6 +582,9 @@ spec:
               app.kubernetes.io/name: ingress-nginx
     - ports:
         - port: 443
+          protocol: TCP
+    - ports:
+        - port: 15017
           protocol: TCP
     - ports:
         - port: 15014


### PR DESCRIPTION
WIP: Do not merge, needs more testing

Allow NetworkPolicy ingress to istio port 15017 for webhook access.  This is the port used by istiod which is where the webhook runs.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
