### PR TITLE
Update Issuer and ClusterIssuer objects to v1

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -106,7 +106,7 @@ function setup_cluster_issuer() {
 
     # attempt first kubectl command with retry to ensure that cert-manager webhook is fully initialized
     kubectl_apply_with_retry "
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: verrazzano-cluster-issuer
@@ -132,7 +132,7 @@ spec:
 
     # attempt first kubectl command with retry to ensure that cert-manager webhook is fully initialized
     kubectl_apply_with_retry "
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: verrazzano-selfsigned-issuer
@@ -142,7 +142,7 @@ spec:
 "
 
     kubectl apply -f <(echo "
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: verrazzano-ca-certificate
@@ -157,7 +157,7 @@ spec:
 ")
     fi
     kubectl apply -f <(echo "
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: verrazzano-cluster-issuer


### PR DESCRIPTION
# Description

Update the `cert-manger` `ClusterIssuer` and `Issuer` objects to `v1` from `v1alpha1`.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
