### PR TITLE
Fix Rancher managed cluster registration with OCI DNS+ACME

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -132,7 +132,6 @@ pipeline {
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-nipio.yaml"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
-        ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
 
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
         SHORT_TIME_STAMP = sh(returnStdout: true, script: "date +%m%d%H%M%S").trim()

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -12,6 +12,7 @@ def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+boolean skip_ats = false
 
 installerFileName = "install-verrazzano.yaml"
 
@@ -408,8 +409,18 @@ pipeline {
                     steps {
                         registerManagedClusters()
                     }
+                    post {
+                        failure {
+                            script {
+                                skip_ats = true
+                            }
+                        }
+                    }
                 }
                 stage ('Verify Register') {
+                    when {
+                        expression { skip_ats == false }
+                    }
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
@@ -427,6 +438,9 @@ pipeline {
                     }
                 }
                 stage ('Verify Managed Cluster Permissions') {
+                    when {
+                        expression { skip_ats == false }
+                    }
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
@@ -445,6 +459,9 @@ pipeline {
                     }
                 }
                 stage ('Example apps') {
+                    when {
+                        expression { skip_ats == false }
+                    }
                     parallel {
                         stage ('Examples Helidon') {
                             steps {

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -34,6 +34,7 @@ const (
 	rancherIngressName = "rancher"
 	rancherAdminSecret = "rancher-admin-secret"
 	rancherTLSCaSecret = "tls-ca"
+	tlsCaSecretKey     = "cacerts.pem"
 
 	clusterPath         = "/v3/cluster"
 	clustersByNamePath  = "/v3/clusters?name="
@@ -367,7 +368,7 @@ func getRancherTLSRootCA(rdr client.Reader) ([]byte, error) {
 	if err := rdr.Get(context.TODO(), nsName, secret); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
-	return secret.Data["cacerts.pem"], nil
+	return secret.Data[tlsCaSecretKey], nil
 }
 
 // sendRequest builds an HTTP request, sends it, and returns the response

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -33,7 +33,7 @@ const (
 	rancherNamespace   = "cattle-system"
 	rancherIngressName = "rancher"
 	rancherAdminSecret = "rancher-admin-secret"
-	rancherTLSSecret   = "tls-ca"
+	rancherTLSCaSecret = "tls-ca"
 
 	clusterPath         = "/v3/cluster"
 	clustersByNamePath  = "/v3/clusters?name="
@@ -362,7 +362,7 @@ func getRancherTLSRootCA(rdr client.Reader) ([]byte, error) {
 	secret := &corev1.Secret{}
 	nsName := types.NamespacedName{
 		Namespace: rancherNamespace,
-		Name:      rancherTLSSecret}
+		Name:      rancherTLSCaSecret}
 
 	if err := rdr.Get(context.TODO(), nsName, secret); err != nil {
 		return nil, client.IgnoreNotFound(err)

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -367,7 +367,13 @@ func getRancherTLSRootCA(rdr client.Reader) ([]byte, error) {
 	if err := rdr.Get(context.TODO(), nsName, secret); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
-	return secret.Data["ca.crt"], nil
+
+	caCrt, ok := secret.Data["ca.crt"]
+	if !ok {
+		// ca.crt is not present, so we should be using certs signed by a public provider
+		return nil, nil
+	}
+	return caCrt, nil
 }
 
 // sendRequest builds an HTTP request, sends it, and returns the response

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -148,7 +148,7 @@ func (r *VerrazzanoManagedClusterReconciler) getVzESSecret() (corev1.Secret, err
 }
 
 // Get the system-tls secret
-func (r *VerrazzanoManagedClusterReconciler) getTLSSecret() (corev1.Secret, error) {
+func (r *VerrazzanoManagedClusterReconciler) getSystemTLSSecret() (corev1.Secret, error) {
 	var secret corev1.Secret
 	nsn := types.NamespacedName{
 		Namespace: constants.VerrazzanoSystemNamespace,

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -64,6 +64,11 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 		return err
 	}
 
+	caBundle := tlsSecret.Data[CaCrtKey]
+	additionalCAs, _ := getRancherAdditionalCAs(r)
+	for _, ca := range additionalCAs {
+		caBundle = append(caBundle, ca...)
+	}
 	// Write the keycloak URL to secret
 	keycloakURL, err := r.getKeycloakURL()
 	if err != nil {
@@ -74,7 +79,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 	secret.Data = map[string][]byte{
 		ManagedClusterNameKey: []byte(manageClusterName),
 		ESURLKey:              []byte(url),
-		CaBundleKey:           tlsSecret.Data[CaCrtKey],
+		CaBundleKey:           caBundle,
 		UsernameKey:           vzSecret.Data[UsernameKey],
 		PasswordKey:           vzSecret.Data[PasswordKey],
 		KeycloakURLKey:        []byte(keycloakURL),

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -59,16 +59,11 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 	if err != nil {
 		return err
 	}
-	tlsSecret, err := r.getTLSSecret()
+	caBundle, err := getRancherTLSRootCA(r)
 	if err != nil {
 		return err
 	}
 
-	caBundle := tlsSecret.Data[CaCrtKey]
-	additionalCAs, _ := getRancherAdditionalCAs(r)
-	for _, ca := range additionalCAs {
-		caBundle = append(caBundle, ca...)
-	}
 	// Write the keycloak URL to secret
 	keycloakURL, err := r.getKeycloakURL()
 	if err != nil {

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1247,7 +1247,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSCaSecret}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				"cacerts.pem": []byte(caData),
+				tlsCaSecretKey: []byte(caData),
 			}
 			return nil
 		})

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1298,6 +1298,16 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockRequestSender 
 	kubeconfigData := "fakekubeconfig"
 	urlData := "https://testhost:443"
 
+	// Expect a call to get the secret with the Rancher additional CA certs
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherAdditionalCAsSecret}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				"ca-additional.pem": {},
+			}
+			return nil
+		})
+
 	// Expect a call to get the Agent secret
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetAgentSecretName(name)}, gomock.Not(gomock.Nil())).
@@ -1453,6 +1463,16 @@ func expectRegisterClusterWithRancherK8sCalls(t *testing.T, k8sMock *mocks.MockC
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				"ca.crt": {},
+			}
+			return nil
+		})
+
+	// Expect a call to get the secret with the Rancher additional CA certs
+	k8sMock.EXPECT().
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherAdditionalCAsSecret}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				"ca-additional.pem": {},
 			}
 			return nil
 		})

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1244,10 +1244,10 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 
 	// Expect a call to get the system-tls secret, return the secret with the fields set
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.SystemTLS}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSSecret}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				CaCrtKey: []byte(caData),
+				"cacerts.pem": []byte(caData),
 			}
 			return nil
 		})
@@ -1297,16 +1297,6 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockRequestSender 
 	passwordData := "pw"
 	kubeconfigData := "fakekubeconfig"
 	urlData := "https://testhost:443"
-
-	// Expect a call to get the secret with the Rancher additional CA certs
-	mock.EXPECT().
-		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherAdditionalCAsSecret}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				"ca-additional.pem": {},
-			}
-			return nil
-		})
 
 	// Expect a call to get the Agent secret
 	mock.EXPECT().
@@ -1463,16 +1453,6 @@ func expectRegisterClusterWithRancherK8sCalls(t *testing.T, k8sMock *mocks.MockC
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				"ca.crt": {},
-			}
-			return nil
-		})
-
-	// Expect a call to get the secret with the Rancher additional CA certs
-	k8sMock.EXPECT().
-		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherAdditionalCAsSecret}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				"ca-additional.pem": {},
 			}
 			return nil
 		})

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -717,7 +717,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 
 	// Expect a call to get the secret with the Rancher root CA cert but the call fails
 	mock.EXPECT().
-		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSSecret}), gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSCaSecret}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
 			return errors.NewResourceExpired("something bad happened")
 		})
@@ -1244,7 +1244,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string) {
 
 	// Expect a call to get the system-tls secret, return the secret with the fields set
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSSecret}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSCaSecret}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				"cacerts.pem": []byte(caData),
@@ -1449,7 +1449,7 @@ func expectRegisterClusterWithRancherK8sCalls(t *testing.T, k8sMock *mocks.MockC
 
 	// Expect a call to get the secret with the Rancher root CA cert
 	k8sMock.EXPECT().
-		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSSecret}), gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSCaSecret}), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				"ca.crt": {},

--- a/platform-operator/scripts/create_managed_cluster_secret.sh
+++ b/platform-operator/scripts/create_managed_cluster_secret.sh
@@ -42,6 +42,11 @@ OUTPUT_FILE=$OUTPUT_DIR/$CLUSTER_NAME.yaml
 TLS_SECRET=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"')
 if [ ! -z "${TLS_SECRET%%*( )}" ] && [ "null" != "${TLS_SECRET}" ] ; then
   CA_CERT=$(kubectl -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 -d)
+else
+  ACME_SECRET=$(kubectl -n cattle-system get secret tls-ca-additional -o json | jq -r '.data."ca-additional.pem"')
+  if [ ! -z "${ACME_SECRET%%*( )}" ] && [ "null" != "${ACME_SECRET}" ] ; then
+    CA_CERT=$(kubectl -n cattle-system get secret tls-ca-additional -o json | jq -r '.data."ca-additional.pem"' | base64 -d)
+  fi
 fi
 HOST=$(kubectl get ing vmi-system-prometheus -n verrazzano-system -o jsonpath='{.spec.tls[0].hosts[0]}')
 

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -404,7 +404,8 @@ function install_rancher()
         [ $(get_config_value ".certificates.ca.clusterResourceNamespace") == "$VERRAZZANO_DEFAULT_SECRET_NAMESPACE" ]; then
         EXTRA_RANCHER_ARGUMENTS="--set privateCA=true"
         kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode >${TMP_DIR}/cacerts.pem
-      fi
+        kubectl -n cattle-system create secret generic tls-ca --from-file=${TMP_DIR}/cacerts.pem
+     fi
       RANCHER_PATCH_DATA="{\"metadata\":{\"annotations\":{\"kubernetes.io/tls-acme\":\"true\",\"nginx.ingress.kubernetes.io/auth-realm\":\"${NAME}.${DNS_SUFFIX} auth\",\"cert-manager.io/cluster-issuer\":\"verrazzano-cluster-issuer\"}}}"
     else
       fail "certificates issuerType $CERT_ISSUER_TYPE is not supported."

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -181,7 +181,7 @@ function get_verrazzano_ingress_ip {
     # Test for IP from status, if that is not present then assume an on premises installation and use the externalIPs hint
     ingress_ip=$(kubectl get svc ingress-controller-ingress-nginx-controller -n ingress-nginx -o json | jq -r '.status.loadBalancer.ingress[0].ip')
     # In case of OLCNE, it would return null
-    if [ ${ingress_ip} == "null" ]; then
+    if [ "${ingress_ip}" == "null" ]; then
       ingress_ip=$(kubectl get svc ingress-controller-ingress-nginx-controller -n ingress-nginx -o json  | jq -r '.spec.externalIPs[0]')
     fi
   fi

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -37,6 +37,12 @@ PROMETHEUS_SECRET_FILE=${MANAGED_CLUSTER_NAME}.yaml
 TLS_SECRET=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"')
 if [ ! -z "${TLS_SECRET%%*( )}" ] && [ "null" != "${TLS_SECRET}" ] ; then
   CA_CERT=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret system-tls -o json | jq -r '.data."ca.crt"' | base64 --decode)
+else
+  # For Let's Encrypt staging, we need to use the ACME staging CAs
+  ACME_SECRET=$(kubectl -n cattle-system get secret tls-ca-additional -o json | jq -r '.data."ca-additional.pem"')
+  if [ ! -z "${ACME_SECRET%%*( )}" ] && [ "null" != "${ACME_SECRET}" ] ; then
+    CA_CERT=$(kubectl -n cattle-system get secret tls-ca-additional -o json | jq -r '.data."ca-additional.pem"' | base64 -d)
+  fi
 fi
 HOST=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get ing vmi-system-prometheus -o jsonpath='{.spec.tls[0].hosts[0]}')
 echo "prometheus:" > ${PROMETHEUS_SECRET_FILE}


### PR DESCRIPTION
# Description

Fix multicluster registration when using OKE with OCI DNS and LetsEncrypt staging or production envs
- also, update AT pipeline to skip tests when install or mgd cluster registration fails
- Use the flag "privateCA=true" and create a "tls-ca" secret with the ACME staging CAs to allow the remote cattle-agent to talk to Rancher when it's installed with an ACME staging cert
- Update platform operator to use the "tls-ca" secret to load any additional CAs instead of "tls-rancher-ingress", for Rancher interaction and generation of the managed cluster secrets.  This should work across both the self-signed and ACME staging scenarios.
- Update `platform-operator/scripts/create_managed_cluster_secret.sh` and `tests/e2e/config/scripts/register_managed_cluster.sh` to add the ACME staging CA bundle from `tls-ca-additional` if it isn't found in `system-tls` first
- fix a conditional in `config.sh` in the install scripts

Fixes VZ-2788.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
