### PR TITLE
Test enhancement, remove gingko.Fail inside Eventually

### DIFF
--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -430,7 +430,8 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 
 			resp, err := client.Do(req)
 			if err != nil {
-				ginkgo.Fail(fmt.Sprintf("Http Request failed for %s. Dump Request Object %+v", err, req))
+				// could be a transient network error so log it and let the Eventually retry
+				pkg.Log(pkg.Error, fmt.Sprintf("Failed to do http request: %v", err))
 			}
 			return gomega.Expect(resp.StatusCode).To(gomega.Equal(500))
 		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify NoIstio Frontend canNOT call Bar Backend")


### PR DESCRIPTION
# Description

Minor test enhancement to not fail immediately inside an `Eventually` block. If we encounter any transient network issues we want to retry, so just log the error and continue.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
