### PR TITLE
Bump install loop test timeout to prevent aborts

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             throttleEnabled: true,
             throttleOption: 'category'
         )
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
     }
 
     agent {


### PR DESCRIPTION
# Description

Increase the install-loop test timeout to 120 min, to prevent aborting a run due to extended test retries.  The aborts seem to be preventing cleanup also, and preventing capturing relevant diagnostic data.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
