### PR TITLE
Remove gomega.Expect calls from inside Eventually

### DIFF
--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -5,6 +5,7 @@ package springboot
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -114,18 +115,16 @@ var _ = ginkgo.Describe("Verify Spring Boot Application", func() {
 		gomega.Eventually(func() bool {
 			url := fmt.Sprintf("https://%s/", host)
 			status, content := pkg.GetWebPageWithCABundle(url, host)
-			return gomega.Expect(status).To(gomega.Equal(200)) &&
-				gomega.Expect(content).To(gomega.ContainSubstring("Greetings from Verrazzano Enterprise Container Platform"))
-		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			return status == 200 && strings.Contains(content, "Greetings from Verrazzano Enterprise Container Platform")
+		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to get welcome page content")
 	})
 
 	ginkgo.It("Verify Verrazzano facts endpoint is working.", func() {
 		gomega.Eventually(func() bool {
 			url := fmt.Sprintf("https://%s/facts", host)
 			status, content := pkg.GetWebPageWithCABundle(url, host)
-			gomega.Expect(len(content) > 0, fmt.Sprintf("An empty string returned from /facts endpoint %v", content))
-			return gomega.Expect(status).To(gomega.Equal(200))
-		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			return status == 200 && len(content) > 0
+		}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to get a non-empty string returned from /facts endpoint")
 	})
 
 	ginkgo.Context("Logging.", func() {

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -433,7 +433,7 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 				// could be a transient network error so log it and let the Eventually retry
 				pkg.Log(pkg.Error, fmt.Sprintf("Failed to do http request: %v", err))
 			}
-			return gomega.Expect(resp.StatusCode).To(gomega.Equal(500))
+			return resp.StatusCode == 500
 		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify NoIstio Frontend canNOT call Bar Backend")
 	})
 


### PR DESCRIPTION
# Description

There are two tests that called `gomega.Expect` inside of an `Eventually` block. Calling `Expect` inside `Eventually` fails immediately if the conditions aren't met, which means the block is never retried. This could be why we saw intermittent failures in these tests.

I ran a few different tests and confirmed that failed expectations cause the tests to fail without retrying, and I also validated that the `Eventually` blocks work as expected after removing the `Expect` calls.

Fixes VZ-2579

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
