### PR TITLE
Fix setting and checking of return code in DNS zone ops script

### DIFF
--- a/tests/e2e/config/scripts/oci_dns_ops.sh
+++ b/tests/e2e/config/scripts/oci_dns_ops.sh
@@ -47,17 +47,18 @@ if [ $OPERATION == "create" ]; then
   sudo yum -y install patch >/dev/null 2>&1
   zone_ocid=$(oci dns zone create -c ${COMPARTMENT_OCID} --name ${ZONE_NAME} --zone-type PRIMARY | jq -r ".data | .[\"id\"]")
   status_code=$?
-  if [ $? -ne 0 ]; then
+  if [ ${status_code} -ne 0 ]; then
     echo "Failed creating zone, attempting to fetch zone to see if it already exists"
     oci dns zone get --zone-name-or-id ${ZONE_NAME}
   fi
 elif [ $OPERATION == "delete" ]; then
   oci dns zone delete --zone-name-or-id ${ZONE_NAME} --force
-  if [ $? -ne 0 ]; then
+  status_code=$?
+  if [ ${status_code} -ne 0 ]; then
     echo "DNS zone deletion failed on first try. Retrying once."
     oci dns zone delete --zone-name-or-id ${ZONE_NAME} --force
+    status_code=$?
   fi
-  status_code=$?
 else
   echo "Unknown operation: ${OPERATION}"
   usage


### PR DESCRIPTION
# Description

I discovered a bug in the DNS zone ops script used by the CI pipeline, introduced by my previous change to attempt to capture more information in the event that zone creation fails. The script lines I added to fetch the zone if we fail creating it will never be called because the conditional was checking `$?` which will always be `0` because we assigned `$?` to `status_code`. Fixed it by checking `status_code` instead of `$?`.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
