### PR TITLE
Updated Jenkinsfile to work around method code too large issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -394,7 +394,6 @@ pipeline {
             }
 
             stages {
-
                 stage('Prepare AT environment') {
                     environment {
                         VERRAZZANO_OPERATOR_IMAGE="NONE"
@@ -410,15 +409,7 @@ pipeline {
                     post {
                         always {
                             archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml", allowEmptyArchive: true
-                            sh """
-                                ## dump out install logs
-                                mkdir -p ${VERRAZZANO_INSTALL_LOGS_DIR}
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
-                                echo "Verrazzano Installation logs dumped to verrazzano-install.log"
-                                echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
-                                echo "------------------------------------------"
-                            """
+                            prepareAtEnvironment()
                         }
                     }
                 }
@@ -721,6 +712,19 @@ pipeline {
             deleteDir()
         }
     }
+}
+
+// Called in Stage Prepare AT Environment post
+def prepareAtEnvironment() {
+    sh """
+        ## dump out install logs
+        mkdir -p ${VERRAZZANO_INSTALL_LOGS_DIR}
+        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
+        echo "Verrazzano Installation logs dumped to verrazzano-install.log"
+        echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
+        echo "------------------------------------------"
+    """
 }
 
 // Called in Stage Integration Tests steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,7 +342,7 @@ pipeline {
         stage('Integration Tests') {
             when { not { buildingTag() } }
             steps {
-                integrationTests()
+                integrationTests("${DOCKER_IMAGE_TAG}")
             }
             post {
                 failure {
@@ -733,7 +733,7 @@ def prepareAtEnvironment() {
 }
 
 // Called in Stage Integration Tests steps
-def integrationTests() {
+def integrationTests(dockerImageTag) {
     sh """
         if [ "${params.SIMULATE_FAILURE}" == "true" ]; then
             echo "Simulate failure from a stage"
@@ -744,11 +744,11 @@ def integrationTests() {
         make cleanup-cluster
         make create-cluster KIND_CONFIG="kind-config-ci.yaml"
         ../ci/scripts/setup_kind_for_jenkins.sh
-        make integ-test CLUSTER_DUMP_LOCATION=${WORKSPACE}/platform-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
+        make integ-test CLUSTER_DUMP_LOCATION=${WORKSPACE}/platform-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} DOCKER_IMAGE_TAG=${dockerImageTag}
         ../build/copy-junit-output.sh ${WORKSPACE}
         cd ${GO_REPO_PATH}/verrazzano/application-operator
         make cleanup-cluster
-        make integ-test KIND_CONFIG="kind-config-ci.yaml" CLUSTER_DUMP_LOCATION=${WORKSPACE}/application-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
+        make integ-test KIND_CONFIG="kind-config-ci.yaml" CLUSTER_DUMP_LOCATION=${WORKSPACE}/application-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} DOCKER_IMAGE_TAG=${dockerImageTag}
         ../build/copy-junit-output.sh ${WORKSPACE}
         make cleanup-cluster
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,24 +342,7 @@ pipeline {
         stage('Integration Tests') {
             when { not { buildingTag() } }
             steps {
-                sh """
-                    if [ "${params.SIMULATE_FAILURE}" == "true" ]; then
-                        echo "Simulate failure from a stage"
-                        exit 1
-                    fi
-                    cd ${GO_REPO_PATH}/verrazzano/platform-operator
-
-                    make cleanup-cluster
-                    make create-cluster KIND_CONFIG="kind-config-ci.yaml"
-                    ../ci/scripts/setup_kind_for_jenkins.sh
-                    make integ-test CLUSTER_DUMP_LOCATION=${WORKSPACE}/platform-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
-                    ../build/copy-junit-output.sh ${WORKSPACE}
-                    cd ${GO_REPO_PATH}/verrazzano/application-operator
-                    make cleanup-cluster
-                    make integ-test KIND_CONFIG="kind-config-ci.yaml" CLUSTER_DUMP_LOCATION=${WORKSPACE}/application-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
-                    ../build/copy-junit-output.sh ${WORKSPACE}
-                    make cleanup-cluster
-                """
+                integrationTests()
             }
             post {
                 failure {
@@ -738,6 +721,28 @@ pipeline {
             deleteDir()
         }
     }
+}
+
+// Called in Stage Integration Tests steps
+def integrationTests() {
+    sh """
+        if [ "${params.SIMULATE_FAILURE}" == "true" ]; then
+            echo "Simulate failure from a stage"
+            exit 1
+        fi
+        cd ${GO_REPO_PATH}/verrazzano/platform-operator
+
+        make cleanup-cluster
+        make create-cluster KIND_CONFIG="kind-config-ci.yaml"
+        ../ci/scripts/setup_kind_for_jenkins.sh
+        make integ-test CLUSTER_DUMP_LOCATION=${WORKSPACE}/platform-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_PLATFORM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
+        ../build/copy-junit-output.sh ${WORKSPACE}
+        cd ${GO_REPO_PATH}/verrazzano/application-operator
+        make cleanup-cluster
+        make integ-test KIND_CONFIG="kind-config-ci.yaml" CLUSTER_DUMP_LOCATION=${WORKSPACE}/application-operator-integ-cluster-dump DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_NAME=${DOCKER_OAM_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
+        ../build/copy-junit-output.sh ${WORKSPACE}
+        make cleanup-cluster
+    """
 }
 
 // Called in Stage Analysis Tool steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -566,22 +566,7 @@ pipeline {
                                 CHROMEDRIVER_VERSION="90.0.4430.24"
                             }
                             steps {
-                                sh """
-                                    # Temporarily clone the console repo until it is moved to the verrazzano repo
-                                    cd ${GO_REPO_PATH}
-                                    git clone https://${GITHUB_PKGS_CREDS_USR}:${GITHUB_PKGS_CREDS_PSW}@github.com/verrazzano/console.git
-                                    cd console
-                                    git checkout ${params.CONSOLE_REPO_BRANCH}
-
-                                    # Configure headless browser
-                                    google-chrome --version || (curl -o google-chrome.rpm "https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${GOOGLE_CHROME_VERSION}.x86_64.rpm"; sudo yum install -y ./google-chrome.rpm)
-                                    curl -o chromedriver.zip "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-                                    unzip chromedriver.zip
-                                    sudo cp chromedriver /usr/local/bin/
-
-                                    # Run the tests
-                                    make run-ui-tests
-                                """
+                                acceptanceTestsConsole()
                             }
                         }
                     }
@@ -712,6 +697,26 @@ pipeline {
             deleteDir()
         }
     }
+}
+
+// Called in parallel Stage console of Stage Run Acceptance Tests
+def acceptanceTestsConsole() {
+    sh """
+        # Temporarily clone the console repo until it is moved to the verrazzano repo
+        cd ${GO_REPO_PATH}
+        git clone https://${GITHUB_PKGS_CREDS_USR}:${GITHUB_PKGS_CREDS_PSW}@github.com/verrazzano/console.git
+        cd console
+        git checkout ${params.CONSOLE_REPO_BRANCH}
+
+        # Configure headless browser
+        google-chrome --version || (curl -o google-chrome.rpm "https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${GOOGLE_CHROME_VERSION}.x86_64.rpm"; sudo yum install -y ./google-chrome.rpm)
+        curl -o chromedriver.zip "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+        unzip chromedriver.zip
+        sudo cp chromedriver /usr/local/bin/
+
+        # Run the tests
+        make run-ui-tests
+    """
 }
 
 // Called in Stage Prepare AT Environment post

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,23 +225,6 @@ pipeline {
             }
         }
 
-        stage('DummyBuild') {
-            when { not { buildingTag() } }
-            steps {
-                buildImages("${DOCKER_IMAGE_TAG}")
-            }
-            post {
-                failure {
-                    script {
-                        SKIP_TRIGGERED_TESTS = true
-                    }
-                }
-                success {
-                    archiveArtifacts artifacts: "generated-verrazzano-bom.json", allowEmptyArchive: true
-                }
-            }
-        }
-
         stage('Save Generated Files') {
             when {
                 allOf {


### PR DESCRIPTION
# Description

The Jenkins file for the default build pipeline has reached a limit where no more stages can be added.  Adding a new stage results in the pipeline immediate failing with this error:

org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
General error during class generation: Method code too large!

This is due to a limit between Java and Groovy, requiring that method bytecode be no larger than 64kb. There is an outstanding bug for this issue. We did some experimentation and found that by moving portions of the code executed for a stage into a function will work around this issue. This task is to change some of our stages to call functions to perform the steps to create additional head room for adding new stages.

Fixes VZ-2858

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
