### PR TITLE
Network Policies Test oam-kubernetes-runtime egress rules failed

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -193,8 +193,6 @@ spec:
       ports:
         - port: 9100
           protocol: TCP
-        - port: 15090
-          protocol: TCP
 {{- if .Values.keycloak.enabled }}
 ---
 # Network policy for Keycloak

--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -179,7 +179,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      verrazzano.io/namespace: monitoring
+      app: node-exporter
   policyTypes:
     - Ingress
   ingress:

--- a/tests/e2e/security/network-policies/network_policy_test.go
+++ b/tests/e2e/security/network-policies/network_policy_test.go
@@ -75,37 +75,21 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 	})
 
 	// GIVEN a Verrazzano deployment
-	// WHEN access is attempted between pods within the ingress/egress rules of the Verrazzano network policies
+	// WHEN access is attempted between pods within the rules of the Verrazzano network policies
 	// THEN the attempted access should succeed
 	ginkgo.It("Test NetworkPolicy Rules", func() {
 		pkg.Concurrently(
 			func() {
-				pkg.Log(pkg.Info, "Test cattle-cluster-agent egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "cattle-cluster-agent"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cattle-cluster-agent egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "cattle-cluster-agent"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", 443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cattle-cluster-agent egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "cattle-cluster-agent"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}, "kube-system", 53, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cattle-cluster-agent egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "cattle-cluster-agent"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cattle-cluster-agent egress failed: reason = %s", err))
-			},
-			func() {
 				pkg.Log(pkg.Info, "Test rancher ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher egress failed: reason = %s", err))
+				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher egress failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test rancher egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher egress failed: reason = %s", err))
+				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test rancher-webhook ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher-webhook"}}, "cattle-system", 9443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher-webhook egress failed: reason = %s", err))
+				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher-webhook ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test cert-manager ingress rules")
@@ -113,31 +97,11 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cert-manager ingress failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test cert-manager egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "cert-manager"}}, "cert-manager", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cert-manager egress rules failed: reason = %s", err))
-			},
-			func() {
 				pkg.Log(pkg.Info, "Test ingress-nginx-controller ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", 443, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", 80, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test ingress-nginx-controller egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}, "kube-system", 53, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-api"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-console"}}, "verrazzano-system", 8000, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller egress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test ingress-nginx-default-backend ingress rules")
@@ -155,35 +119,9 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test keycloak ingress rules failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test keycloak egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}, "kube-system", 53, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test keycloak egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", metav1.LabelSelector{MatchLabels: map[string]string{"app": "mysql"}}, "keycloak", 3306, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test keycloak egress rules failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test monitoring egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"verrazzano.io/namespace": "monitoring"}}, "monitoring", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", 9100, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test monitoring egress rules failed: reason = %s", err))
-			},
-			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-platform-operator ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator"}}, "verrazzano-install", 9443, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator ingress rules failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test verrazzano-platform-operator egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator"}}, "verrazzano-install", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator"}}, "verrazzano-install", metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}, "kube-system", 53, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator"}}, "verrazzano-install", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", 443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator egress rules failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test oam-kubernetes-runtime egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "oam-kubernetes-runtime"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test oam-kubernetes-runtime egress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-api ingress rules")
@@ -196,26 +134,9 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator ingress rules failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test verrazzano-application-operator egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", 443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator egress rules failed: reason = %s", err))
-			},
-			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-console ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-console"}}, "verrazzano-system", 8000, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-console ingress rules failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test verrazzano-monitoring-operator egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "verrazzano-monitoring-operator"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-monitoring-operator egress rules failed: reason = %s", err))
-			},
-			func() {
-				pkg.Log(pkg.Info, "Test verrazzano-operator egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-operator"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-operator egress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-es-master ingress rules")
@@ -234,41 +155,32 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana ingress rules failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test vmi-system-grafana egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", 9090, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}, "kube-system", 53, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana egress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana egress rules failed: reason = %s", err))
-			},
-			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-kibana ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-kibana"}}, "verrazzano-system", 8775, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-kibana ingress rules failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test vmi-system-prometheus rules")
+				pkg.Log(pkg.Info, "Test vmi-system-prometheus ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", 8775, true)
 				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-prometheus ingress rules failed: reason = %s", err))
 			},
 			func() {
-				pkg.Log(pkg.Info, "Test vweblogic-operator egress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "weblogic-operator"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 6443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test weblogic-operator egress rules failed: reason = %s", err))
+				pkg.Log(pkg.Info, "Test node-exporter ingress rules")
+				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 9100, true)
+				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
 			},
 		)
 	})
 
 	// GIVEN a Verrazzano deployment
-	// WHEN access is attempted between pods that violate the ingress/egress rules of the Verrazzano network policies
+	// WHEN access is attempted between pods that violate the rules of the Verrazzano network policies
 	// THEN the attempted access should fail
 	ginkgo.It("Negative Test NetworkPolicy Rules", func() {
 		pkg.Concurrently(
 			func() {
-				pkg.Log(pkg.Info, "Negative test  rancher ingress rules")
+				pkg.Log(pkg.Info, "Negative test rancher ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test  rancher egress failed: reason = %s", err))
+				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test  rancher ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test cert-manager ingress rules")

--- a/tests/e2e/security/network-policies/network_policy_test.go
+++ b/tests/e2e/security/network-policies/network_policy_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 	})
 
 	// GIVEN a Verrazzano deployment
-	// WHEN access is attempted between pods within the rules of the Verrazzano network policies
+	// WHEN access is attempted between pods within the ingress rules of the Verrazzano network policies
 	// THEN the attempted access should succeed
 	ginkgo.It("Test NetworkPolicy Rules", func() {
 		pkg.Concurrently(


### PR DESCRIPTION
# Description

There are 3 problems:

1) The node exporter network policy has the wrong target label. 

It has this
```
podSelector:
  matchLabels:
    verrazzano.io/namespace: monitoring
```
Should be this
```
podSelector:
  matchLabels:
    app: node-exporter
```
2) This error was found in an egress test, which we should not be testing anymore since we allow all egress. Those egress tests need to be removed.

3) We are missing a node exporter ingress test, that needs to be added.

Fixes VZ-2841

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
