### PR TITLE
Create the runtimeEncryptionSecret secret specified in domain spec

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -471,7 +471,7 @@ func genPassword(passSize int) string {
 	rand.Seed(time.Now().UnixNano())
 	var b strings.Builder
 	for i := 0; i < passSize; i++ {
-		b.WriteRune(passwordChars[rand.Intn(len(passwordChars))])
+		b.WriteRune(passwordChars[rand.Intn(len(passwordChars)-1)])
 	}
 	return b.String()
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -156,13 +156,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 	if found {
-		log.Info(fmt.Sprintf("Found runtimeEncryptionSecret: %s", secret))
 		err = r.createRuntimeEncryptionSecret(ctx, log, namespace.Name, secret, workload.ObjectMeta.Labels)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-	} else {
-		log.Info("runtimeEncryptionSecret not found")
 	}
 
 	// make a copy of the WebLogic spec since u.Object will get overwritten in CreateOrUpdate
@@ -340,7 +337,7 @@ func (r *Reconciler) addLogging(ctx context.Context, log logr.Logger, workload *
 func (r *Reconciler) createRuntimeEncryptionSecret(ctx context.Context, log logr.Logger, namespaceName string, secretName string, workloadLabels map[string]string) error {
 	appName, ok := workloadLabels[oam.LabelAppName]
 	if !ok {
-		return errors.New("OAM app name label missing from metadata, unable to generate destination rule name")
+		return errors.New("OAM app name label missing from metadata, unable to create owner reference to appconfig")
 	}
 
 	// Create the secret if it does not already exist
@@ -350,7 +347,7 @@ func (r *Reconciler) createRuntimeEncryptionSecret(ctx context.Context, log logr
 		secret = &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
-				Kind:       "secret",
+				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespaceName,

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -60,16 +60,8 @@ func deployBobsBooksExample() {
 	if _, err := pkg.CreateCredentialsSecret("bobs-books", "bobbys-front-end-weblogic-credentials", wlsUser, wlsPass, nil); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create WebLogic credentials secret: %v", err))
 	}
-	pkg.Log(pkg.Info, "Create Bobbys front end runtime encrypt secret")
-	if _, err := pkg.CreateCredentialsSecret("bobs-books", "bobbys-front-end-runtime-encrypt-secret", wlsUser, wlsPass, map[string]string{"weblogic.domainUID": "bobbys-front-end"}); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create WebLogic credentials secret: %v", err))
-	}
 	pkg.Log(pkg.Info, "Create Bobs Bookstore Weblogic credentials secret")
 	if _, err := pkg.CreateCredentialsSecret("bobs-books", "bobs-bookstore-weblogic-credentials", wlsUser, wlsPass, nil); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create WebLogic credentials secret: %v", err))
-	}
-	pkg.Log(pkg.Info, "Create Bobs Bookstore runtime encrypt secret")
-	if _, err := pkg.CreateCredentialsSecret("bobs-books", "bobs-bookstore-runtime-encrypt-secret", wlsUser, wlsPass, map[string]string{"weblogic.domainUID": "bobs-bookstore"}); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create WebLogic credentials secret: %v", err))
 	}
 	pkg.Log(pkg.Info, "Create database credentials secret")

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -65,10 +65,6 @@ func deployToDoListExample() {
 	if _, err := pkg.CreateCredentialsSecret("todo-list", "tododomain-jdbc-tododb", wlsUser, dbPass, map[string]string{"weblogic.domainUID": "tododomain"}); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create JDBC credentials secret: %v", err))
 	}
-	pkg.Log(pkg.Info, "Create encryption credentials secret")
-	if _, err := pkg.CreatePasswordSecret("todo-list", "tododomain-runtime-encrypt-secret", wlsPass, map[string]string{"weblogic.domainUID": "tododomain"}); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create encryption secret: %v", err))
-	}
 	pkg.Log(pkg.Info, "Create component resources")
 	if err := pkg.CreateOrUpdateResourceFromFile("examples/todo-list/todo-list-components.yaml"); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to create ToDo List component resources: %v", err))


### PR DESCRIPTION
# Description

This pull request includes new code to create the runtimeEncryptionSecret secret specified in the WebLogic domain spec, if the secret does not already exist.  The secret is created with a random password.  This change removes the need for this secret to be created before deploying the application.  If the application operator creates the secret then this secret will also be deleted when the application is deleted.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
