### PR TITLE
add default monitoringExporter to wls domain spec.

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -49,28 +49,105 @@ const monitoringExporterData = `
       "metricsNameSnakeCase": true,
       "queries": [
         {
-          "applicationRuntimes": {
-            "componentRuntimes": {
+           "key": "name",
+           "keyName": "location",
+           "prefix": "wls_server_",
+           "applicationRuntimes": {
               "key": "name",
-              "prefix": "webapp_config_",
-              "servlets": {
-                "key": "servletName",
-                "prefix": "weblogic_servlet_",
-                "values": "invocationTotalCount"
-              },
-              "type": "WebAppComponentRuntime",
+              "keyName": "app",
+              "componentRuntimes": {
+                 "prefix": "wls_webapp_config_",
+                 "type": "WebAppComponentRuntime",
+                 "key": "name",
+                 "values": [
+                    "deploymentState",
+                    "contextRoot",
+                    "sourceInfo",
+                    "sessionsOpenedTotalCount",
+                    "openSessionsCurrentCount",
+                    "openSessionsHighCount"
+                 ],
+                 "servlets": {
+                    "prefix": "wls_servlet_",
+                    "key": "servletName"
+                 }
+              }
+           }
+        },
+        {
+           "JVMRuntime": {
+              "prefix": "wls_jvm_",
+              "key": "name"
+           }
+        },
+        {
+           "executeQueueRuntimes": {
+              "prefix": "wls_socketmuxer_",
+              "key": "name",
               "values": [
-                "deploymentState",
-                "contextRoot",
-                "sourceInfo",
-                "openSessionsHighCount"
+                 "pendingRequestCurrentCount"
               ]
-            },
-            "key": "name",
-            "keyName": "app"
-          },
-          "key": "name",
-          "keyName": "server"
+           }
+        },
+        {
+           "workManagerRuntimes": {
+              "prefix": "wls_workmanager_",
+              "key": "name",
+              "values": [
+                 "stuckThreadCount",
+                 "pendingRequests",
+                 "completedRequests"
+              ]
+           }
+        },
+        {
+           "threadPoolRuntime": {
+              "prefix": "wls_threadpool_",
+              "key": "name",
+              "values": [
+                 "executeThreadTotalCount",
+                 "queueLength",
+                 "stuckThreadCount",
+                 "hoggingThreadCount"
+              ]
+           }
+        },
+        {
+           "JMSRuntime": {
+              "key": "name",
+              "keyName": "jmsruntime",
+              "prefix": "wls_jmsruntime_",
+              "JMSServers": {
+                 "prefix": "wls_jms_",
+                 "key": "name",
+                 "keyName": "jmsserver",
+                 "destinations": {
+                    "prefix": "wls_jms_dest_",
+                    "key": "name",
+                    "keyName": "destination"
+                 }
+              }
+           }
+        },
+        {
+           "persistentStoreRuntimes": {
+              "prefix": "wls_persistentstore_",
+              "key": "name"
+           }
+        },
+        {
+           "JDBCServiceRuntime": {
+              "JDBCDataSourceRuntimeMBeans": {
+                 "prefix": "wls_datasource_",
+                 "key": "name"
+              }
+           }
+        },
+        {
+           "JTARuntime": {
+              "prefix": "wls_jta_",
+              "key": "name"
+           }
         }
       ]
     },

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -42,7 +42,7 @@ const (
 	destinationRuleKind       = "DestinationRule"
 )
 
-const monitoringExporterData = `
+const defaultMonitoringExporterData = `
   {
     "configuration": {
       "domainQualifier": true,
@@ -249,7 +249,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Add the monitoringExporter to the spec if not already present
-	if err = addMonitoringExporter(u); err != nil {
+	if err = addDefaultMonitoringExporter(u); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -596,14 +596,14 @@ func genPassword(passSize int) string {
 	return b.String()
 }
 
-// addMonitoringExporter adds monitoringExporter to the WebLogic spec if there is not one present
-func addMonitoringExporter(weblogic *unstructured.Unstructured) error {
+// addDefaultMonitoringExporter adds monitoringExporter to the WebLogic spec if there is not one present
+func addDefaultMonitoringExporter(weblogic *unstructured.Unstructured) error {
 	if _, found, _ := unstructured.NestedFieldNoCopy(weblogic.Object, specMonitoringExporterFields...); !found {
-		monitoringExporter, err := createMonitoringExporter()
+		defaultMonitoringExporter, err := getDefaultMonitoringExporter()
 		if err != nil {
 			return err
 		}
-		err = unstructured.SetNestedField(weblogic.Object, monitoringExporter, specMonitoringExporterFields...)
+		err = unstructured.SetNestedField(weblogic.Object, defaultMonitoringExporter, specMonitoringExporterFields...)
 		if err != nil {
 			return err
 		}
@@ -611,8 +611,8 @@ func addMonitoringExporter(weblogic *unstructured.Unstructured) error {
 	return nil
 }
 
-func createMonitoringExporter() (interface{}, error) {
-	bytes := []byte(monitoringExporterData)
+func getDefaultMonitoringExporter() (interface{}, error) {
+	bytes := []byte(defaultMonitoringExporterData)
 	var monitoringExporter map[string]interface{}
 	json.Unmarshal(bytes, &monitoringExporter)
 	result, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&monitoringExporter)

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -39,6 +39,41 @@ import (
 const namespace = "unit-test-namespace"
 const weblogicAPIVersion = "weblogic.oracle/v8"
 const weblogicKind = "Domain"
+const weblogicDomain = `
+{
+   "metadata": {
+      "name": "unit-test-cluster"
+   },
+   "spec": {
+      "domainUID": "unit-test-domain"
+   }
+}
+`
+const weblogicDomainWithMonitoringExporter = `
+{
+   "metadata": {
+      "name": "unit-test-cluster"
+   },
+   "spec": {
+      "domainUID": "unit-test-domain",
+      "monitoringExporter": {
+         "imagePullPolicy": "IfNotPresent",
+         "configuration": {
+            "metricsNameSnakeCase": true,
+            "domainQualifier": true,
+            "queries": [
+               {
+                  "JVMRuntime": {
+                     "prefix": "wls_jvm_",
+                     "key": "name"
+                  }
+               }
+            ]
+         }
+      }
+   }
+}
+`
 
 // TestReconcilerSetupWithManager test the creation of the VerrazzanoWebLogicWorkload reconciler.
 // GIVEN a controller implementation
@@ -96,8 +131,7 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomain, " ", ""), "\n", ""))}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.SchemeGroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
@@ -146,7 +180,97 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 			assert.Equal(specIstioEnabled, false)
 
 			// make sure monitoringExporter exists
-			validateMonitoringExporter(u, t)
+			validateDefaultMonitoringExporter(u, t)
+
+			return nil
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileCreateWebLogicDomainWithMonitoringExporter tests the basic happy path of reconciling a VerrazzanoWebLogicWorkload
+// with monitoringExporter. We expect to write out a WebLogic domain CR with this monitoringExporter intact.
+// GIVEN a VerrazzanoWebLogicWorkload resource is created
+// WHEN the controller Reconcile function is called
+// THEN expect a WebLogic domain CR to be written
+func TestReconcileCreateWebLogicDomainWithMonitoringExporter(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
+
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomainWithMonitoringExporter, " ", ""), "\n", ""))}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.SchemeGroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(logging.WlsFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
+			return nil
+		})
+	// expect a call to get the namespace for the domain
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: "", Name: namespace}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to attempt to get the WebLogic CR - return not found
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, u *unstructured.Unstructured) error {
+			return errors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+	// expect a call to create the WebLogic domain CR
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+
+			// make sure the OAM component and app name labels were copied
+			specLabels, _, _ := unstructured.NestedStringMap(u.Object, specServerPodLabelsFields...)
+			assert.Equal(labels, specLabels)
+
+			// make sure configuration.istio.enabled is false
+			specIstioEnabled, _, _ := unstructured.NestedBool(u.Object, specConfigurationIstioEnabledFields...)
+			assert.Equal(specIstioEnabled, false)
+
+			// make sure monitoringExporter exists
+			validateTestMonitoringExporter(u, t)
 
 			return nil
 		})
@@ -194,8 +318,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomain, " ", ""), "\n", ""))}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.SchemeGroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
@@ -249,7 +372,8 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 			assert.Equal(fluentdImage, containers[0].(map[string]interface{})["image"])
 
 			// make sure monitoringExporter exists
-			validateMonitoringExporter(u, t)
+			validateDefaultMonitoringExporter(u, t)
+
 			return nil
 		})
 
@@ -299,8 +423,7 @@ func TestReconcileAlreadyExistsUpgrade(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomain, " ", ""), "\n", ""))}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.SchemeGroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
@@ -422,8 +545,7 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomain, " ", ""), "\n", ""))}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.SchemeGroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
@@ -503,8 +625,7 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
-			weblogicJSON := `{"metadata":{"name":"unit-test-cluster"},"spec":{"domainUID":"unit-test-domain"}}`
-			workload.Spec.Template = runtime.RawExtension{Raw: []byte(weblogicJSON)}
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomain, " ", ""), "\n", ""))}
 			workload.ObjectMeta.Labels = labels
 			workload.APIVersion = vzapi.SchemeGroupVersion.String()
 			workload.Kind = "VerrazzanoWebLogicWorkload"
@@ -932,8 +1053,8 @@ func newRequest(namespace string, name string) ctrl.Request {
 	}
 }
 
-// validateMonitoringExporter validates the monitoringExporter in the Weblogic domain spec
-func validateMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
+// validateDefaultMonitoringExporter validates the default monitoringExporter in the Weblogic domain spec
+func validateDefaultMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
 	_, found, err := unstructured.NestedFieldNoCopy(u.Object, specMonitoringExporterFields...)
 	asserts.Nil(t, err, "Expect no error finding monitoringExporter in WebLogic domain CR")
 	asserts.True(t, found, "Found monitoringExporter in WebLogic domain CR")
@@ -948,4 +1069,22 @@ func validateMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
 	query, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&queries[0])
 	runtimeType, _, _ := unstructured.NestedString(query, "applicationRuntimes", "componentRuntimes", "type")
 	asserts.Equal(t, "WebAppComponentRuntime", runtimeType, "query runtime type should be WebAppComponentRuntime")
+}
+
+// validateTestMonitoringExporter validates the test monitoringExporter in the Weblogic domain spec
+func validateTestMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
+	_, found, err := unstructured.NestedFieldNoCopy(u.Object, specMonitoringExporterFields...)
+	asserts.Nil(t, err, "Expect no error finding monitoringExporter in WebLogic domain CR")
+	asserts.True(t, found, "Found monitoringExporter in WebLogic domain CR")
+	imagePullPolicy, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "imagePullPolicy")...)
+	asserts.Equal(t, "IfNotPresent", imagePullPolicy, "monitoringExporter.imagePullPolicy should be IfNotPresent in WebLogic domain CR")
+	domainQualifier, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "domainQualifier")...)
+	asserts.True(t, domainQualifier, "monitoringExporter.configuration.domainQualifier should be TRUE")
+	metricsNameSnakeCase, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "metricsNameSnakeCase")...)
+	asserts.True(t, metricsNameSnakeCase, "monitoringExporter.configuration.metricsNameSnakeCase should be TRUE")
+	queries, _, _ := unstructured.NestedSlice(u.Object, append(specMonitoringExporterFields, "configuration", "queries")...)
+	asserts.Equal(t, 1, len(queries), "there should be 1 query")
+	query, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&queries[0])
+	jvmRuntimePrefix, _, _ := unstructured.NestedString(query, "JVMRuntime", "prefix")
+	asserts.Equal(t, "wls_jvm_", jvmRuntimePrefix, "query JVMRuntime prefix should be wls_jvm_")
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -944,7 +944,7 @@ func validateMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
 	metricsNameSnakeCase, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "metricsNameSnakeCase")...)
 	asserts.True(t, metricsNameSnakeCase, "monitoringExporter.configuration.metricsNameSnakeCase should be TRUE")
 	queries, _, _ := unstructured.NestedSlice(u.Object, append(specMonitoringExporterFields, "configuration", "queries")...)
-	asserts.Equal(t, len(queries), 1, "there should be one query")
+	asserts.Equal(t, 9, len(queries), "there should be one query")
 	query, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&queries[0])
 	runtimeType, _, _ := unstructured.NestedString(query, "applicationRuntimes", "componentRuntimes", "type")
 	asserts.Equal(t, "WebAppComponentRuntime", runtimeType, "query runtime type should be WebAppComponentRuntime")

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -944,7 +944,7 @@ func validateMonitoringExporter(u *unstructured.Unstructured, t *testing.T) {
 	metricsNameSnakeCase, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "metricsNameSnakeCase")...)
 	asserts.True(t, metricsNameSnakeCase, "monitoringExporter.configuration.metricsNameSnakeCase should be TRUE")
 	queries, _, _ := unstructured.NestedSlice(u.Object, append(specMonitoringExporterFields, "configuration", "queries")...)
-	asserts.Equal(t, 9, len(queries), "there should be one query")
+	asserts.Equal(t, 9, len(queries), "there should be 9 queries")
 	query, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&queries[0])
 	runtimeType, _, _ := unstructured.NestedString(query, "applicationRuntimes", "componentRuntimes", "type")
 	asserts.Equal(t, "WebAppComponentRuntime", runtimeType, "query runtime type should be WebAppComponentRuntime")

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -202,19 +202,22 @@ spec:
               domainQualifier: true
               queries:
                 - key: name
-                  keyName: server
+                  keyName: location
+                  prefix: wls_server_
                   applicationRuntimes:
                     key: name
                     keyName: app
                     componentRuntimes:
+                      prefix: wls_webapp_config_
                       type: WebAppComponentRuntime
-                      prefix: webapp_config_
                       key: name
-                      values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
+                      values: [ deploymentState, contextRoot, sourceInfo, sessionsOpenedTotalCount, openSessionsCurrentCount, openSessionsHighCount ]
                       servlets:
-                        prefix: weblogic_servlet_
+                        prefix: wls_servlet_
                         key: servletName
-                        values: invocationTotalCount
+                - JVMRuntime:
+                  prefix: wls_jvm_
+                  key: name
           serverPod:
             env:
               - name: JAVA_OPTIONS
@@ -448,19 +451,22 @@ spec:
               domainQualifier: true
               queries:
                 - key: name
-                  keyName: server
+                  keyName: location
+                  prefix: wls_server_
                   applicationRuntimes:
                     key: name
                     keyName: app
                     componentRuntimes:
+                      prefix: wls_webapp_config_
                       type: WebAppComponentRuntime
-                      prefix: webapp_config_
                       key: name
-                      values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
+                      values: [ deploymentState, contextRoot, sourceInfo, sessionsOpenedTotalCount, openSessionsCurrentCount, openSessionsHighCount ]
                       servlets:
-                        prefix: weblogic_servlet_
+                        prefix: wls_servlet_
                         key: servletName
-                        values: invocationTotalCount
+                - JVMRuntime:
+                  prefix: wls_jvm_
+                  key: name
           serverPod:
             env:
               - name: JAVA_OPTIONS

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -216,8 +216,8 @@ spec:
                         prefix: wls_servlet_
                         key: servletName
                 - JVMRuntime:
-                  prefix: wls_jvm_
-                  key: name
+                    prefix: wls_jvm_
+                    key: name
           serverPod:
             env:
               - name: JAVA_OPTIONS
@@ -465,8 +465,8 @@ spec:
                         prefix: wls_servlet_
                         key: servletName
                 - JVMRuntime:
-                  prefix: wls_jvm_
-                  key: name
+                    prefix: wls_jvm_
+                    key: name
           serverPod:
             env:
               - name: JAVA_OPTIONS

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -195,6 +195,26 @@ spec:
             introspectorJobActiveDeadlineSeconds: 600
             model:
               runtimeEncryptionSecret: bobbys-front-end-runtime-encrypt-secret
+          monitoringExporter:
+            imagePullPolicy: IfNotPresent
+            configuration:
+              metricsNameSnakeCase: true
+              domainQualifier: true
+              queries:
+                - key: name
+                  keyName: server
+                  applicationRuntimes:
+                    key: name
+                    keyName: app
+                    componentRuntimes:
+                      type: WebAppComponentRuntime
+                      prefix: webapp_config_
+                      key: name
+                      values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
+                      servlets:
+                        prefix: weblogic_servlet_
+                        key: servletName
+                        values: invocationTotalCount
           serverPod:
             env:
               - name: JAVA_OPTIONS
@@ -421,6 +441,26 @@ spec:
               runtimeEncryptionSecret: bobs-bookstore-runtime-encrypt-secret
             secrets:
               - mysql-credentials
+          monitoringExporter:
+            imagePullPolicy: IfNotPresent
+            configuration:
+              metricsNameSnakeCase: true
+              domainQualifier: true
+              queries:
+                - key: name
+                  keyName: server
+                  applicationRuntimes:
+                    key: name
+                    keyName: app
+                    componentRuntimes:
+                      type: WebAppComponentRuntime
+                      prefix: webapp_config_
+                      key: name
+                      values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
+                      servlets:
+                        prefix: weblogic_servlet_
+                        key: servletName
+                        values: invocationTotalCount
           serverPod:
             env:
               - name: JAVA_OPTIONS

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -211,6 +211,16 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 				},
 				func() {
 					gomega.Eventually(func() bool {
+						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobbys-front-end")
+					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+				},
+				func() {
+					gomega.Eventually(func() bool {
+						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobs-bookstore")
+					}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+				},
+				func() {
+					gomega.Eventually(func() bool {
 						return pkg.MetricsExist("vendor:coherence_cluster_size", "coherenceCluster", "bobbys-coherence")
 					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 				},

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -201,12 +201,12 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 				},
 				func() {
 					gomega.Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobbys-front-end")
+						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobbys-front-end")
 					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 				},
 				func() {
 					gomega.Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobs-bookstore")
+						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobs-bookstore")
 					}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 				},
 				func() {

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -201,12 +201,12 @@ var _ = ginkgo.Describe("Verify Bobs Books example application.", func() {
 				},
 				func() {
 					gomega.Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobbys-front-end")
+						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobbys-front-end")
 					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
 				},
 				func() {
 					gomega.Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobs-bookstore")
+						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobs-bookstore")
 					}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 				},
 				func() {

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -210,9 +210,18 @@ var _ = ginkgo.Describe("Verify ToDo List example application.", func() {
 		// WHEN the application configuration uses a default metrics trait
 		// THEN confirm that metrics are being collected
 		ginkgo.It("Retrieve Prometheus scraped metrics", func() {
-			gomega.Eventually(func() bool {
-				return pkg.MetricsExist("wls_scrape_mbeans_count_total", "app_oam_dev_name", "todo-appconf")
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find metrics for todo-list")
+			pkg.Concurrently(
+				func() {
+					gomega.Eventually(func() bool {
+						return pkg.MetricsExist("wls_jvm_process_cpu_load", "app_oam_dev_name", "todo-appconf")
+					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find metrics for todo-list")
+				},
+				func() {
+					gomega.Eventually(func() bool {
+						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "app_oam_dev_name", "todo-appconf")
+					}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue(), "Expected to find metrics for todo-list")
+				},
+			)
 		})
 	})
 

--- a/tests/testdata/ingress/console/application.yaml
+++ b/tests/testdata/ingress/console/application.yaml
@@ -20,12 +20,13 @@ spec:
                       pathType: Prefix
                   destination:
                     host: cidomain-adminserver.console-ingress.svc.cluster.local
+                    port: 7001
                 - paths:
                     - path: "/console"
                       pathType: Prefix
                   destination:
-                      host: cidomain-adminserver.console-ingress.svc.cluster.local
-                      port: 7001
+                    host: cidomain-adminserver.console-ingress.svc.cluster.local
+                    port: 7001
     - componentName: todo-jdbc-configmap
     - componentName: todo-mysql-configmap
     - componentName: todo-mysql-service

--- a/tests/testdata/ingress/console/components.yaml
+++ b/tests/testdata/ingress/console/components.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           domainUID: cidomain
           domainHome: /u01/domains/tododomain
-          image: container-registry.oracle.com/verrazzano/example-todo:0.1.12-1-20210525221857-a44442d
+          image: container-registry.oracle.com/verrazzano/example-todo:0.1.12-1-20210607165639-4755b1f
           imagePullSecrets:
             - name: tododomain-repo-credentials
           domainHomeSourceType: "FromModel"


### PR DESCRIPTION
# Description

- Add the default monitoringExporter to the weblogic domain spec if it is not specified.
- Add sample monitoringExporter to the domain specs in bobs-books example.

Fixes VZ-2706

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
