### PR TITLE
Capture cluster dump on test failure after verrazzano reinstall, in uninstall pipeline

### DIFF
--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -443,6 +443,9 @@ pipeline {
                         }
                     }
                 }
+                failure {
+                    dumpK8sCluster('verrazzano-test-failure-after-reinstall-cluster-dump')
+                }
             }
         }
     }


### PR DESCRIPTION
# Description

This change captures the cluster dump on test failure after verrazzano reinstall, in the uninstall pipeline.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
