### PR TITLE
Fix name of license file that we copy to the docker images

### DIFF
--- a/application-operator/Dockerfile
+++ b/application-operator/Dockerfile
@@ -1,20 +1,33 @@
 # Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
+
+# Need to use specific WORKDIR to match verrazzano-application-operator's source packages
+WORKDIR /root/go/src/github.com/verrazzano/application-operator
+COPY . .
+
+COPY out/linux_amd64/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
+
+RUN chmod 500 /usr/local/bin/verrazzano-application-operator
+
 # Create the verrazzano-application-operator image
 FROM ghcr.io/oracle/oraclelinux:7-slim
 
 RUN yum update -y \
     && yum clean all \
-    && rm -rf /var/cache/yum \
-    && groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
+    && rm -rf /var/cache/yum
+
+# Copy the operator binary
+WORKDIR /
+
+RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
     && mkdir /home/verrazzano \
     && chown -R 1000:verrazzano /home/verrazzano
 
-WORKDIR /
+COPY --from=build_base --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
 
-COPY --chown=verrazzano:verrazzano --chmod=500 out/linux_amd64/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
-COPY THIRD_PARTY_LICENSES.txt /licenses/
+COPY --from=build_base /root/go/src/github.com/verrazzano/application-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/application-operator/Dockerfile
+++ b/application-operator/Dockerfile
@@ -1,33 +1,20 @@
 # Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
-
-# Need to use specific WORKDIR to match verrazzano-application-operator's source packages
-WORKDIR /root/go/src/github.com/verrazzano/application-operator
-COPY . .
-
-COPY out/linux_amd64/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
-
-RUN chmod 500 /usr/local/bin/verrazzano-application-operator
-
 # Create the verrazzano-application-operator image
 FROM ghcr.io/oracle/oraclelinux:7-slim
 
 RUN yum update -y \
     && yum clean all \
-    && rm -rf /var/cache/yum
-
-# Copy the operator binary
-WORKDIR /
-
-RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
+    && rm -rf /var/cache/yum \
+    && groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
     && mkdir /home/verrazzano \
     && chown -R 1000:verrazzano /home/verrazzano
 
-COPY --from=build_base --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
+WORKDIR /
 
-COPY --from=build_base /root/go/src/github.com/verrazzano/application-operator/THIRD_PARTY_LICENSES.txt /licenses
+COPY --chown=verrazzano:verrazzano --chmod=500 out/linux_amd64/verrazzano-application-operator /usr/local/bin/verrazzano-application-operator
+COPY THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/image-patch-operator/Dockerfile
+++ b/image-patch-operator/Dockerfile
@@ -1,21 +1,32 @@
 # Copyright (C) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+FROM ghcr.io/oracle/oraclelinux:7-slim as builder
+
+# Need to use specific WORKDIR to match verrazzano-image-patch-operator's source packages
+WORKDIR /root/go/src/github.com/verrazzano/verrazzano/image-patch-operator
+COPY . .
+
+COPY out/linux_amd64/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
+
+RUN chmod 500 /usr/local/bin/verrazzano-image-patch-operator
+
 # Create the verrazzano-image-patch-operator image
 FROM ghcr.io/oracle/oraclelinux:7-slim
 
-
 RUN yum update -y \
     && yum clean all \
-    && rm -rf /var/cache/yum \
-    && groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
-    && mkdir /home/verrazzano \
-    && chown -R 1000:verrazzano /home/verrazzano
+    && rm -rf /var/cache/yum
 
 WORKDIR /
 
-COPY --chown=verrazzano:verrazzano --chmod=500 out/linux_amd64/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
-COPY THIRD_PARTY_LICENSES.txt /licenses/
+RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
+    && mkdir /home/verrazzano \
+    && chown -R 1000:verrazzano /home/verrazzano
+
+COPY --from=builder --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
+
+COPY --from=builder /root/go/src/github.com/verrazzano/verrazzano/image-patch-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/image-patch-operator/Dockerfile
+++ b/image-patch-operator/Dockerfile
@@ -1,32 +1,21 @@
 # Copyright (C) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM ghcr.io/oracle/oraclelinux:7-slim as builder
-
-# Need to use specific WORKDIR to match verrazzano-image-patch-operator's source packages
-WORKDIR /root/go/src/github.com/verrazzano/verrazzano/image-patch-operator
-COPY . .
-
-COPY out/linux_amd64/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
-
-RUN chmod 500 /usr/local/bin/verrazzano-image-patch-operator
-
 # Create the verrazzano-image-patch-operator image
 FROM ghcr.io/oracle/oraclelinux:7-slim
 
+
 RUN yum update -y \
     && yum clean all \
-    && rm -rf /var/cache/yum
-
-WORKDIR /
-
-RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
+    && rm -rf /var/cache/yum \
+    && groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
     && mkdir /home/verrazzano \
     && chown -R 1000:verrazzano /home/verrazzano
 
-COPY --from=builder --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
+WORKDIR /
 
-COPY --from=builder /root/go/src/github.com/verrazzano/verrazzano/image-patch-operator/THIRD_PARTY_LICENSES.txt /licenses
+COPY --chown=verrazzano:verrazzano --chmod=500 out/linux_amd64/verrazzano-image-patch-operator /usr/local/bin/verrazzano-image-patch-operator
+COPY THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/ver
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/helm_config ./platform-operator/helm_config
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/out/generated-verrazzano-bom.json ./platform-operator/verrazzano-bom.json
 
-COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/THIRD_PARTY_LICENSES.txt /licenses
+COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 


### PR DESCRIPTION
# Description

Fix name of third party license file on our docker images.  It was being copied as the name "licenses" instead of "THIRD_PARTY_LICENSES.txt"

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
