### PR TITLE
VZ-2898: Remove most gomega.Fail calls from shared acceptance test code

### DIFF
--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -101,7 +101,7 @@ func undeployToDoListExample() {
 	gomega.Eventually(func() bool {
 		s, err := pkg.GetSecret("istio-system", "todo-list-todo-appconf-cert-secret")
 		return s == nil && err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeFalse())
+	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 }
 
 var _ = ginkgo.Describe("Verify ToDo List example application.", func() {

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -476,8 +476,8 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 		gomega.Eventually(func() bool {
 			var httpsFound bool = false
 
-			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
-			if configMap == nil {
+			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if err != nil {
 				return false
 			}
 			dataMap := configMap.Data
@@ -514,8 +514,8 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 		gomega.Eventually(func() bool {
 			var httpsFound bool = false
 
-			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
-			if configMap == nil {
+			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if err != nil {
 				return false
 			}
 			dataMap := configMap.Data
@@ -552,8 +552,8 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 		gomega.Eventually(func() bool {
 			var httpsNotFound bool = true
 
-			configMap := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
-			if configMap == nil {
+			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
+			if err != nil {
 				return false
 			}
 			dataMap := configMap.Data

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -5,11 +5,12 @@ package syscomponents
 
 import (
 	"fmt"
-	"github.com/onsi/gomega"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 
 	"github.com/onsi/ginkgo"
 )
@@ -163,7 +164,10 @@ func verifyEnvoyStats(metricName string) bool {
 	}
 	clientset := pkg.GetKubernetesClientsetForCluster(kubeConfig)
 	for _, ns := range envoyStatsNamespaces {
-		pods := pkg.ListPodsInCluster(ns, clientset)
+		pods, err := pkg.ListPodsInCluster(ns, clientset)
+		if err != nil {
+			return false
+		}
 		for _, pod := range pods.Items {
 			var retValue bool
 			switch ns {

--- a/tests/e2e/multicluster/verify-api/verify_api_test.go
+++ b/tests/e2e/multicluster/verify-api/verify_api_test.go
@@ -26,14 +26,16 @@ var _ = ginkgo.Describe("Multi Cluster Verify API", func() {
 
 		ginkgo.It("Get and Validate Verrazzano resource for admin cluster", func() {
 			// create a project
-			api := pkg.GetAPIEndpoint(adminKubeconfig)
+			api, err := pkg.GetAPIEndpoint(adminKubeconfig)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Erroring getting API endpoint")
 			response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos")
 			validateVerrazzanosResponse(response, err)
 		})
 
 		ginkgo.It("Get and Validate Verrazzano resource for managed cluster", func() {
 			// create a project
-			api := pkg.GetAPIEndpoint(adminKubeconfig)
+			api, err := pkg.GetAPIEndpoint(adminKubeconfig)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Erroring getting API endpoint")
 			response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos?cluster=" + managedClusterName)
 			validateVerrazzanosResponse(response, err)
 		})

--- a/tests/e2e/multicluster/verify-install/defaultresource_test.go
+++ b/tests/e2e/multicluster/verify-install/defaultresource_test.go
@@ -68,7 +68,10 @@ func nsListContains(list []v1.Namespace, target string) bool {
 func listPodsInKubeSystem() {
 	// Get the Kubernetes clientset and list pods in cluster
 	clientset := pkg.GetKubernetesClientset()
-	pods := pkg.ListPodsInCluster("kube-system", clientset)
+	pods, err := pkg.ListPodsInCluster("kube-system", clientset)
+	if err != nil {
+		fmt.Printf("Error listing pods: %v", err)
+	}
 	for _, podInfo := range (*pods).Items {
 		fmt.Printf("pods-name=%v\n", podInfo.Name)
 		fmt.Printf("pods-status=%v\n", podInfo.Status.Phase)

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -340,10 +340,10 @@ func deployTestResources() {
 
 	// Wait for the namespaces to be created
 	pkg.Log(pkg.Info, "Wait for the project namespaces to be created")
-	gomega.Eventually(func() bool {
+	gomega.Eventually(func() (bool, error) {
 		return pkg.DoesNamespaceExist(testNamespace)
 	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Expected to find namespace %s", testNamespace))
-	gomega.Eventually(func() bool {
+	gomega.Eventually(func() (bool, error) {
 		return pkg.DoesNamespaceExist(anotherTestNamespace)
 	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Expected to find namespace %s", anotherTestNamespace))
 

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -66,12 +66,12 @@ var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
 		ginkgo.It("admin cluster has the expected ServiceAccounts and ClusterRoleBindings", func() {
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesServiceAccountExist(multiclusterNamespace, fmt.Sprintf("verrazzano-cluster-%s", managedClusterName))
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find ServiceAccount")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesClusterRoleBindingExist(fmt.Sprintf("verrazzano-cluster-%s", managedClusterName))
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find ClusterRoleBinding")
 				},
@@ -193,22 +193,22 @@ var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
 			namespace := fmt.Sprintf("ns-%s", managedClusterName)
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "verrazzano-project-admin", "User", "test-user")
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding verrazzano-project-admin")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "admin", "User", "test-user")
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding admin")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "verrazzano-project-monitor", "Group", "test-viewers")
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding verrazzano-project-monitor")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					gomega.Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "view", "Group", "test-viewers")
 					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding view")
 				},

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -6,6 +6,7 @@ package pkg
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -86,51 +87,54 @@ func GetKubeConfigPathFromEnv() string {
 		kubeconfig = filepath.Join(home, ".kube", "config")
 	} else {
 		// give up
-		ginkgo.Fail("Could not find kube")
+		ginkgo.Fail("Could not find kube config")
 	}
 	return kubeconfig
 }
 
 // DoesCRDExist returns whether a CRD with the given name exists for the cluster
-func DoesCRDExist(crdName string) bool {
+func DoesCRDExist(crdName string) (bool, error) {
 	// use the current context in the kubeconfig
 	config := GetKubeConfig()
 
 	apixClient, err := apixv1beta1client.NewForConfig(config)
 	if err != nil {
-		ginkgo.Fail("Could not get apix client")
+		Log(Error, "Could not get apix client")
+		return false, err
 	}
 
 	crds, err := apixClient.CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get CRDS with error: %v", err))
+		Log(Error, fmt.Sprintf("Failed to get CRDS with error: %v", err))
+		return false, err
 	}
 
 	for i := range crds.Items {
 		if strings.Compare(crds.Items[i].ObjectMeta.Name, crdName) == 0 {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // DoesNamespaceExist returns whether a namespace with the given name exists for the cluster set in the environment
-func DoesNamespaceExist(name string) bool {
+func DoesNamespaceExist(name string) (bool, error) {
 	return DoesNamespaceExistInCluster(name, GetKubeConfigPathFromEnv())
 }
 
 // DoesNamespaceExistInCluster returns whether a namespace with the given name exists in the specified cluster
-func DoesNamespaceExistInCluster(name string, kubeconfigPath string) bool {
+func DoesNamespaceExistInCluster(name string, kubeconfigPath string) (bool, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientsetForCluster(kubeconfigPath)
 
 	namespace, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		ginkgo.Fail(fmt.Sprintf("Failed to get namespace %s with error: %v", name, err))
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Log(Error, fmt.Sprintf("Failed to get namespace %s with error: %v", name, err))
+		return false, err
 	}
 
-	return namespace != nil && len(namespace.Name) > 0
+	return namespace != nil && len(namespace.Name) > 0, nil
 }
 
 // ListNamespaces returns a namespace list for the given list options
@@ -148,41 +152,30 @@ func ListPods(namespace string, opts metav1.ListOptions) (*corev1.PodList, error
 	return GetKubernetesClientset().CoreV1().Pods(namespace).List(context.TODO(), opts)
 }
 
-// DoesJobExist returns whether a job with the given name and namespace exists for the cluster
-func DoesJobExist(namespace string, name string) bool {
-	// Get the Kubernetes clientset
-	clientset := GetKubernetesClientset()
-
-	job, err := clientset.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get job %s in namespace %s with error: %v", name, namespace, err))
-	}
-
-	return job != nil
-}
-
 // ListDeployments returns the list of deployments in a given namespace for the cluster
-func ListDeployments(namespace string) *appsv1.DeploymentList {
+func ListDeployments(namespace string) (*appsv1.DeploymentList, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	deployments, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to list deployments in namespace %s with error: %v", namespace, err))
+		Log(Error, fmt.Sprintf("Failed to list deployments in namespace %s with error: %v", namespace, err))
+		return nil, err
 	}
-	return deployments
+	return deployments, nil
 }
 
 // ListNodes returns the list of nodes for the cluster
-func ListNodes() *corev1.NodeList {
+func ListNodes() (*corev1.NodeList, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to list nodes with error: %v", err))
+		Log(Error, fmt.Sprintf("Failed to list nodes with error: %v", err))
+		return nil, err
 	}
-	return nodes
+	return nodes, nil
 }
 
 // GetPodsFromSelector returns a collection of pods for the given namespace and selector
@@ -205,18 +198,22 @@ func GetPodsFromSelector(selector *metav1.LabelSelector, namespace string) ([]co
 }
 
 // ListPodsInCluster returns the list of pods in a given namespace for the cluster
-func ListPodsInCluster(namespace string, clientset *kubernetes.Clientset) *corev1.PodList {
+func ListPodsInCluster(namespace string, clientset *kubernetes.Clientset) (*corev1.PodList, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to list pods in namespace %s with error: %v", namespace, err))
+		Log(Error, fmt.Sprintf("Failed to list pods in namespace %s with error: %v", namespace, err))
+		return nil, err
 	}
-	return pods
+	return pods, nil
 }
 
 // DoesPodExist returns whether a pod with the given name and namespace exists for the cluster
 func DoesPodExist(namespace string, name string) bool {
 	clientset := GetKubernetesClientset()
-	pods := ListPodsInCluster(namespace, clientset)
+	pods, err := ListPodsInCluster(namespace, clientset)
+	if err != nil {
+		return false
+	}
 	for i := range pods.Items {
 		if strings.HasPrefix(pods.Items[i].Name, name) {
 			return true
@@ -227,7 +224,10 @@ func DoesPodExist(namespace string, name string) bool {
 
 // DoesServiceExist returns whether a service with the given name and namespace exists for the cluster
 func DoesServiceExist(namespace string, name string) bool {
-	services := ListServices(namespace)
+	services, err := ListServices(namespace)
+	if err != nil {
+		return false
+	}
 	for i := range services.Items {
 		if strings.HasPrefix(services.Items[i].Name, name) {
 			return true
@@ -352,28 +352,17 @@ func APIExtensionsClientSet() *apixv1beta1client.ApiextensionsV1beta1Client {
 	return clientset
 }
 
-// CertManagerClient returns a CertmanagerV1alpha2Client for this cluster
-//func CertManagerClient() *certclientv1alpha2.CertmanagerV1alpha2Client {
-//	config := GetKubeConfig()
-//
-//	client, err := certclientv1alpha2.NewForConfig(config)
-//	if err != nil {
-//		ginkgo.Fail(fmt.Sprintf("Failed to create cert-manager client: %v", err))
-//	}
-//
-//	return client
-//}
-
 // ListServices returns the list of services in a given namespace for the cluster
-func ListServices(namespace string) *corev1.ServiceList {
+func ListServices(namespace string) (*corev1.ServiceList, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	services, err := clientset.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to list services in namespace %s with error: %v", namespace, err))
+		Log(Error, fmt.Sprintf("Failed to list services in namespace %s with error: %v", namespace, err))
+		return nil, err
 	}
-	return services
+	return services, nil
 }
 
 // GetNamespace returns a namespace
@@ -448,95 +437,104 @@ func DeleteNamespaceInCluster(name string, kubeconfigPath string) error {
 }
 
 // DoesClusterRoleExist returns whether a cluster role with the given name exists in the cluster
-func DoesClusterRoleExist(name string) bool {
+func DoesClusterRoleExist(name string) (bool, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	clusterrole, err := clientset.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role %s with error: %v", name, err))
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Log(Error, fmt.Sprintf("Failed to get cluster role %s with error: %v", name, err))
+		return false, err
 	}
 
-	return clusterrole != nil
+	return clusterrole != nil, nil
 }
 
 // GetClusterRole returns the cluster role with the given name
-func GetClusterRole(name string) *rbacv1.ClusterRole {
+func GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	clusterrole, err := clientset.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role %s with error: %v", name, err))
+		Log(Error, fmt.Sprintf("Failed to get cluster role %s with error: %v", name, err))
+		return nil, err
 	}
 
-	return clusterrole
+	return clusterrole, nil
 }
 
-//DoesServiceAccountExist returns whether a service account with the given name and namespace exists in the cluster
-func DoesServiceAccountExist(namespace, name string) bool {
-	sa := GetServiceAccount(namespace, name)
-	return sa != nil
+// DoesServiceAccountExist returns whether a service account with the given name and namespace exists in the cluster
+func DoesServiceAccountExist(namespace, name string) (bool, error) {
+	sa, err := GetServiceAccount(namespace, name)
+	if err != nil {
+		return false, err
+	}
+	return sa != nil, nil
 }
 
 // DoesClusterRoleBindingExist returns whether a cluster role with the given name exists in the cluster
-func DoesClusterRoleBindingExist(name string) bool {
+func DoesClusterRoleBindingExist(name string) (bool, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	clusterrolebinding, err := clientset.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role binding %s with error: %v", name, err))
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Log(Error, fmt.Sprintf("Failed to get cluster role binding %s with error: %v", name, err))
+		return false, err
 	}
 
-	return clusterrolebinding != nil
+	return clusterrolebinding != nil, nil
 }
 
 // GetClusterRoleBinding returns the cluster role with the given name
-func GetClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
+func GetClusterRoleBinding(name string) (*rbacv1.ClusterRoleBinding, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	crb, err := clientset.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role binding %s with error: %v", name, err))
+		Log(Error, fmt.Sprintf("Failed to get cluster role binding %s with error: %v", name, err))
+		return nil, err
 	}
 
-	return crb
+	return crb, err
 }
 
 // ListClusterRoleBindings returns the list of cluster role bindings for the cluster
-func ListClusterRoleBindings() *rbacv1.ClusterRoleBindingList {
+func ListClusterRoleBindings() (*rbacv1.ClusterRoleBindingList, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 
 	bindings, err := clientset.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get cluster role bindings with error: %v", err))
+		Log(Error, fmt.Sprintf("Failed to get cluster role bindings with error: %v", err))
+		return nil, err
 	}
 
-	return bindings
+	return bindings, err
 }
 
 // DoesRoleBindingContainSubject returns true if the RoleBinding exists and it contains the
 // specified subject
-func DoesRoleBindingContainSubject(namespace, name, subjectKind, subjectName string) bool {
+func DoesRoleBindingContainSubject(namespace, name, subjectKind, subjectName string) (bool, error) {
 	clientset := GetKubernetesClientset()
 
 	rb, err := clientset.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			ginkgo.Fail(fmt.Sprintf("Failed to get RoleBinding %s in namespace %s: %v", name, namespace, err))
+		if !k8serrors.IsNotFound(err) {
+			Log(Error, fmt.Sprintf("Failed to get RoleBinding %s in namespace %s: %v", name, namespace, err))
+			return false, err
 		}
-		return false
+		return false, nil
 	}
 
 	for _, s := range rb.Subjects {
 		if s.Kind == subjectKind && s.Name == subjectName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func CreateRoleBinding(userOCID string, namespace string, rolebindingname string, clusterrolename string) error {
@@ -625,15 +623,16 @@ func GetIstioClientset() *istioClient.Clientset {
 }
 
 // GetConfigMap returns the config map for the passed in ConfigMap Name and Namespace
-func GetConfigMap(configMapName string, namespace string) *corev1.ConfigMap {
+func GetConfigMap(configMapName string, namespace string) (*corev1.ConfigMap, error) {
 	// Get the Kubernetes clientset
 	clientset := GetKubernetesClientset()
 	cmi := clientset.CoreV1().ConfigMaps(namespace)
 	configMap, err := cmi.Get(context.TODO(), configMapName, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		ginkgo.Fail(fmt.Sprintf("Failed to get Config Map %v from namespace %v:  Error = %v ", configMapName, namespace, err))
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get Config Map %v from namespace %v:  Error = %v ", configMapName, namespace, err))
+		return nil, err
 	}
-	return configMap
+	return configMap, nil
 }
 
 /*
@@ -665,15 +664,15 @@ func (h *headerAdder) RoundTrip(req *http.Request) (*http.Response, error) {
 	return h.rt.RoundTrip(req)
 }
 
-func CanI(userOCID string, namespace string, verb string, resource string) (bool, string) {
+func CanI(userOCID string, namespace string, verb string, resource string) (bool, string, error) {
 	return CanIForAPIGroup(userOCID, namespace, verb, resource, "")
 }
 
-func CanIForAPIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string) {
+func CanIForAPIGroup(userOCID string, namespace string, verb string, resource string, group string) (bool, string, error) {
 	return CanIForAPIGroupForServiceAccountOrUser(userOCID, namespace, verb, resource, group, false, "")
 }
 
-func CanIForAPIGroupForServiceAccountOrUser(saOrUserOCID string, namespace string, verb string, resource string, group string, isServiceAccount bool, saNamespace string) (bool, string) {
+func CanIForAPIGroupForServiceAccountOrUser(saOrUserOCID string, namespace string, verb string, resource string, group string, isServiceAccount bool, saNamespace string) (bool, string, error) {
 	canI := &v1beta1.SelfSubjectAccessReview{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SelfSubjectAccessReview",
@@ -696,7 +695,10 @@ func CanIForAPIGroupForServiceAccountOrUser(saOrUserOCID string, namespace strin
 
 	wt := config.WrapTransport // Config might already have a transport wrapper
 	if isServiceAccount {
-		token := GetTokenForServiceAccount(saOrUserOCID, saNamespace)
+		token, err := GetTokenForServiceAccount(saOrUserOCID, saNamespace)
+		if err != nil {
+			return false, "", err
+		}
 		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			&clientcmd.ClientConfigLoadingRules{ExplicitPath: GetKubeConfigPathFromEnv()},
 			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}})
@@ -743,40 +745,51 @@ func CanIForAPIGroupForServiceAccountOrUser(saOrUserOCID string, namespace strin
 
 	auth, err := clientset.AuthorizationV1beta1().SelfSubjectAccessReviews().Create(context.TODO(), canI, metav1.CreateOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to check perms: %v", err))
+		Log(Error, fmt.Sprintf("Failed to check perms: %v", err))
+		return false, "", err
 	}
 
-	return auth.Status.Allowed, auth.Status.Reason
+	return auth.Status.Allowed, auth.Status.Reason, nil
 }
 
 //GetTokenForServiceAccount returns the token associated with service account
-func GetTokenForServiceAccount(sa string, namespace string) []byte {
-	serviceAccount := GetServiceAccount(namespace, sa)
+func GetTokenForServiceAccount(sa string, namespace string) ([]byte, error) {
+	serviceAccount, err := GetServiceAccount(namespace, sa)
+	if err != nil {
+		return nil, err
+	}
 	if len(serviceAccount.Secrets) == 0 {
-		ginkgo.Fail(fmt.Sprintf("No secrets present in service account %s in namespace %s", sa, namespace))
+		msg := fmt.Sprintf("no secrets present in service account %s in namespace %s", sa, namespace)
+		Log(Error, msg)
+		return nil, errors.New(msg)
 	}
 
 	secretName := serviceAccount.Secrets[0].Name
 	clientset := GetKubernetesClientset()
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get secret %s for service account %s in namespace %s with error: %v", secretName, sa, namespace, err))
+		msg := fmt.Sprintf("failed to get secret %s for service account %s in namespace %s with error: %v", secretName, sa, namespace, err)
+		Log(Error, msg)
+		return nil, errors.New(msg)
 	}
 
 	token, ok := secret.Data["token"]
 
 	if !ok {
-		ginkgo.Fail(fmt.Sprintf("No token present in secret %s for service account %s in namespace %s with error: %v", secretName, sa, namespace, err))
+		msg := fmt.Sprintf("no token present in secret %s for service account %s in namespace %s with error: %v", secretName, sa, namespace, err)
+		Log(Error, msg)
+		return nil, errors.New(msg)
 	}
 
-	return token
+	return token, nil
 }
 
-func GetServiceAccount(namespace, name string) *corev1.ServiceAccount {
+func GetServiceAccount(namespace, name string) (*corev1.ServiceAccount, error) {
 	clientset := GetKubernetesClientset()
 	sa, err := clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		ginkgo.Fail(fmt.Sprintf("Failed to get service account %s in namespace %s with error: %v", name, namespace, err))
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get service account %s in namespace %s with error: %v", name, namespace, err))
+		return nil, err
 	}
-	return sa
+	return sa, nil
 }

--- a/tests/e2e/pkg/logging.go
+++ b/tests/e2e/pkg/logging.go
@@ -64,14 +64,15 @@ func Log(level LogLevel, message string) {
 
 // CreateLogFile creates a file with the given name (or truncates the file if it already exists)
 // and writes the given content string to the file.
-func CreateLogFile(filename string, content string) {
+func CreateLogFile(filename string, content string) error {
 	// create out output file
 	f, err := os.Create(filename + ".log")
 	if err != nil {
-		ginkgo.Fail("Could not create output file")
+		return err
 	}
 	defer f.Close()
 
 	f.WriteString(content)
 	f.Sync()
+	return nil
 }

--- a/tests/e2e/pkg/secrets.go
+++ b/tests/e2e/pkg/secrets.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +39,9 @@ func GetSecretInCluster(namespace string, name string, kubeconfigPath string) (*
 
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		Log(Error, fmt.Sprintf("Failed to get secret %s in namespace %s with error: %v", name, namespace, err))
+		if !errors.IsNotFound(err) {
+			Log(Error, fmt.Sprintf("Failed to get secret %s in namespace %s with error: %v", name, namespace, err))
+		}
 		return nil, err
 	}
 	return secret, nil

--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -49,7 +49,11 @@ func (e *Elastic) PodsRunning() bool {
 // Connect checks if the elasticsearch cluster can be connected
 func (e *Elastic) Connect() bool {
 	kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-	esURL, err := pkg.GetAPIEndpoint(kubeconfigPath).GetElasticURL()
+	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+	if err != nil {
+		return false
+	}
+	esURL, err := api.GetElasticURL()
 	if err != nil {
 		return false
 	}
@@ -102,7 +106,11 @@ func (e *Elastic) ListIndices() []string {
 
 // getIndices gets index metadata (aliases, mappings, and settings) of all elasticsearch indices in the given cluster
 func (e *Elastic) getIndices(kubeconfigPath string) map[string]interface{} {
-	esURL, err := pkg.GetAPIEndpoint(kubeconfigPath).GetElasticURL()
+	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+	if err != nil {
+		return nil
+	}
+	esURL, err := api.GetElasticURL()
 	if err != nil {
 		return nil
 	}
@@ -142,7 +150,10 @@ func (e *Elastic) CheckTLSSecret() bool {
 
 // CheckIngress checks the Elasticsearch Ingress
 func (e *Elastic) CheckIngress() bool {
-	ingressList, _ := pkg.ListIngresses("verrazzano-system")
+	ingressList, err := pkg.ListIngresses("verrazzano-system")
+	if err != nil {
+		return false
+	}
 	for _, ingress := range ingressList.Items {
 		if ingress.Name == fmt.Sprintf("vmi-%v-es-ingest", e.binding) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Found Ingress %v for binding %v", ingress.Name, e.binding))

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,8 +49,8 @@ func GetWebPageWithCABundle(url string, hostHeader string) (int, string) {
 func GetCertificates(url string) ([]*x509.Certificate, error) {
 	resp, err := GetVerrazzanoHTTPClient().Get(url)
 	if err != nil {
-		Log(Error, err.Error())
-		ginkgo.Fail("Could not get web page " + url)
+		Log(Error, fmt.Sprintf("Could not get web page at URL: %s, error: %v", url, err))
+		return nil, err
 	}
 	defer resp.Body.Close()
 	return resp.TLS.PeerCertificates, nil
@@ -238,7 +237,7 @@ func doReq(url, method string, contentType string, hostHeader string, username s
 	html, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		Log(Error, err.Error())
-		ginkgo.Fail("Could not read content of response body")
+		return teapot, ""
 	}
 	return resp.StatusCode, string(html)
 }

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -144,7 +144,10 @@ func getConsoleURLsFromLog(installLog string) ([]string, error) {
 
 // Get the expected console URLs in the install log for the given cluster
 func getExpectedConsoleURLs(kubeConfig string) ([]string, error) {
-	api := pkg.GetAPIEndpoint(kubeConfig)
+	api, err := pkg.GetAPIEndpoint(kubeConfig)
+	if api == nil {
+		return nil, err
+	}
 	ingress, err := api.GetIngress(keycloakNamespace, keycloakIngress)
 	if err != nil {
 		return nil, err

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -62,10 +62,10 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
@@ -81,55 +81,55 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
 		})
 
 		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in verrazzano-system namespace: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
 		})
 
@@ -145,37 +145,37 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user create OAM Components. Timeout Expired")
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components. Timeout Expired")
 		})
 
@@ -187,10 +187,10 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
@@ -206,55 +206,55 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
 		})
 
 		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in verrazzano-system namespace: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration. Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list ApplicationConfiguration. Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components. Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
 		})
 
 		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list OAM Components. Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
 		})
 
@@ -270,37 +270,37 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
 		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration.  Timeout Expired")
 		})
 
 		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components.  Timeout Expired")
 		})
 
 		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() bool {
-				allowed, reason := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
+			gomega.Eventually(func() (bool, error) {
+				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
-				return allowed
+				return allowed, err
 			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components.  Timeout Expired")
 		})
 
@@ -309,21 +309,25 @@ var _ = ginkgo.Describe("Test RBAC Permission", func() {
 
 var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 	ginkgo.Context("for serviceaccount verrazzano-api", func() {
-		var apiProxy corev1.Pod
-		sa := pkg.GetServiceAccount(verrazzanoSystemNS, verrazzanoAPI)
-		if sa == nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to get service account %s in namespace %s", verrazzanoAPI, verrazzanoSystemNS))
-		}
+		var serviceAccount *corev1.ServiceAccount
+
+		ginkgo.BeforeEach(func() {
+			var err error
+			serviceAccount, err = pkg.GetServiceAccount(verrazzanoSystemNS, verrazzanoAPI)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), fmt.Sprintf("Failed to get service account %s in namespace %s", verrazzanoAPI, verrazzanoSystemNS))
+		})
+
 		ginkgo.It("Validate the secret of the Service Account of Verrazzano API", func() {
 			// Get secret for the SA
-			saSecret := sa.Secrets[0]
+			saSecret := serviceAccount.Secrets[0]
 			clientset := pkg.GetKubernetesClientset()
-			pods := pkg.ListPodsInCluster(verrazzanoSystemNS, clientset)
+			pods, err := pkg.ListPodsInCluster(verrazzanoSystemNS, clientset)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			secretMatched := false
 			for i := range pods.Items {
 				// Get the secret of the API proxy pod
 				if strings.HasPrefix(pods.Items[i].Name, verrazzanoAPI) {
-					apiProxy = pods.Items[i]
+					apiProxy := pods.Items[i]
 					for j := range apiProxy.Spec.Volumes {
 						if apiProxy.Spec.Volumes[j].Secret != nil && apiProxy.Spec.Volumes[j].Secret.SecretName == saSecret.Name {
 							secretMatched = true
@@ -338,8 +342,9 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 		})
 
 		ginkgo.It("Validate the role binding of the Service Account of Verrazzano API", func() {
-			bindings := pkg.ListClusterRoleBindings()
-			saName := sa.Name
+			bindings, err := pkg.ListClusterRoleBindings()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error listing cluster role bindings")
+			saName := serviceAccount.Name
 			bcount := 0
 			var rbinding v1.ClusterRoleBinding
 			for rb := range bindings.Items {
@@ -364,7 +369,8 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 					rbinding.Subjects[0].Namespace, verrazzanoSystemNS))
 
 			// There should be a single rule with resources - users and groups, and verbs impersonate
-			crole := pkg.GetClusterRole(rbinding.RoleRef.Name)
+			crole, err := pkg.GetClusterRole(rbinding.RoleRef.Name)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role")
 			gomega.Expect(len(crole.Rules) == 1).To(gomega.BeTrue(),
 				fmt.Sprintf("FAIL: The cluster role %s contains more than one rules.", crole))
 
@@ -389,7 +395,8 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 
 		ginkgo.It("Fail impersonating any other service account", func() {
 			pkg.Log(pkg.Info, "Can verrazzano-api service account impersonate any other service account?  No")
-			allowed, reason := pkg.CanIForAPIGroupForServiceAccountOrUser("verrazzano-api", "", "impersonate", "serviceaccounts", "core", true, verrazzanoSystemNS)
+			allowed, reason, err := pkg.CanIForAPIGroupForServiceAccountOrUser("verrazzano-api", "", "impersonate", "serviceaccounts", "core", true, verrazzanoSystemNS)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on impersonating service accounts: Allowed = %t, reason = %s", allowed, reason))
 		})
 

--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -21,10 +21,12 @@ var _ = ginkgo.Describe("keycloak url test", func() {
 	ginkgo.Context("Fetching the keycloak url using api and test ", func() {
 		ginkgo.It("Fetches keycloak url", func() {
 			if !pkg.IsManagedClusterProfile() {
-				api := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
-
 				var keycloakURL string
 				gomega.Eventually(func() error {
+					api, err := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+					if err != nil {
+						return err
+					}
 					ingress, err := api.GetIngress("keycloak", "keycloak")
 					if err != nil {
 						return err

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -23,10 +23,13 @@ var _ = ginkgo.Describe("rancher url test", func() {
 		ginkgo.It("Fetches rancher url", func() {
 			if !pkg.IsManagedClusterProfile() {
 				kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-				api := pkg.GetAPIEndpoint(kubeconfigPath)
-
 				var rancherURL string
+
 				gomega.Eventually(func() error {
+					api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+					if err != nil {
+						return err
+					}
 					ingress, err := api.GetIngress("cattle-system", "rancher")
 					if err != nil {
 						return err

--- a/tests/e2e/verify-infra/restapi/vmi_urls_test.go
+++ b/tests/e2e/verify-infra/restapi/vmi_urls_test.go
@@ -31,7 +31,10 @@ var _ = ginkgo.Describe("VMI urls test", func() {
 		ginkgo.It("Fetches VMI", func() {
 			if !isManagedClusterProfile {
 				gomega.Eventually(func() bool {
-					api := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+					api, err := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+					if err != nil {
+						return false
+					}
 					response, err := api.Get("apis/verrazzano.io/v1/namespaces/verrazzano-system/verrazzanomonitoringinstances/system")
 					if !pkg.IsHTTPStatusOk(response, err, fmt.Sprintf("Error fetching system VMI from api, error: %v, response: %v", err, response)) {
 						return false
@@ -55,9 +58,10 @@ var _ = ginkgo.Describe("VMI urls test", func() {
 
 		ginkgo.It("Accesses VMI endpoints", func() {
 			if !isManagedClusterProfile {
-				api := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+				api, err := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), fmt.Sprintf("Error retrieving system VMI credentials: %v", err))
 				vmiCredentials, err := pkg.GetSystemVMICredentials()
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("Error retrieving system VMI credentials: %v", err))
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), fmt.Sprintf("Error retrieving system VMI credentials: %v", err))
 
 				// Test VMI endpoints
 				sysVmiHTTPClient := pkg.GetSystemVmiHTTPClient()

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -274,7 +274,10 @@ func assertURLAccessibleAndAuthorized(url string) bool {
 
 func assertBearerAuthorized(url string) bool {
 	vmiHTTPClient := pkg.GetSystemVmiHTTPClient()
-	api := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+	api, err := pkg.GetAPIEndpoint(pkg.GetKubeConfigPathFromEnv())
+	if err != nil {
+		return false
+	}
 	req, _ := retryablehttp.NewRequest("GET", url, nil)
 	if api.AccessToken != "" {
 		bearer := fmt.Sprintf("Bearer %v", api.AccessToken)

--- a/tests/e2e/verify-install/istio/istio_test.go
+++ b/tests/e2e/verify-install/istio/istio_test.go
@@ -39,7 +39,8 @@ var _ = ginkgo.Describe("Istio", func() {
 				}
 				return deploymentNames
 			}
-			deployments := pkg.ListDeployments(namespace)
+			deployments, err := pkg.ListDeployments(namespace)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error listing deployments")
 			gomega.Expect(deployments).Should(
 				gomega.SatisfyAll(
 					gomega.Not(gomega.BeNil()),

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -49,7 +49,8 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgo.It("has the expected number of nodes",
 			func() {
-				nodes := pkg.ListNodes()
+				nodes, err := pkg.ListNodes()
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error listing nodes")
 				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">=", 1))
 
 				// dump out node data to file

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -71,7 +71,9 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgoExt.DescribeTable("CRD for",
 		func(name string) {
-			gomega.Expect(pkg.DoesCRDExist(name)).To(gomega.BeTrue())
+			exists, err := pkg.DoesCRDExist(name)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(exists).To(gomega.BeTrue())
 		},
 		ginkgoExt.Entry("verrazzanos should exist in cluster", "verrazzanos.install.verrazzano.io"),
 		ginkgoExt.Entry("verrazzanomanagedclusters should exist in cluster", "verrazzanomanagedclusters.clusters.verrazzano.io"),
@@ -89,15 +91,22 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgoExt.DescribeTable("ClusterRoleBinding",
 		func(name string) {
-			gomega.Expect(pkg.DoesClusterRoleBindingExist(name)).To(gomega.BeTrue())
+			exists, err := pkg.DoesClusterRoleBindingExist(name)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role binding")
+			gomega.Expect(exists).To(gomega.BeTrue())
 		},
 		ginkgoExt.Entry("verrazzano-admin should exist", "verrazzano-admin"),
 		ginkgoExt.Entry("verrazzano-monitor should exist", "verrazzano-monitor"),
 	)
 
 	ginkgo.Describe("ClusterRole verrazzano-admin", func() {
-		cr := pkg.GetClusterRole("verrazzano-admin")
-		rules := cr.Rules
+		var rules []rbacv1.PolicyRule
+
+		ginkgo.BeforeEach(func() {
+			cr, err := pkg.GetClusterRole("verrazzano-admin")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role")
+			rules = cr.Rules
+		})
 
 		ginkgo.It("has correct number of rules", func() {
 			gomega.Expect(len(rules)).To(gomega.Equal(11),
@@ -105,26 +114,31 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
-			func(ruleSlice []rbacv1.PolicyRule, rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(ruleSlice, rule)).To(gomega.BeTrue())
+			func(rule rbacv1.PolicyRule) {
+				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
 			},
-			ginkgoExt.Entry("vzInstallReadRule should exist", rules, vzInstallReadRule),
-			ginkgoExt.Entry("vzInstallWriteRule should exist", rules, vzInstallWriteRule),
-			ginkgoExt.Entry("vzSystemReadRule should exist", rules, vzSystemReadRule),
-			ginkgoExt.Entry("vzSystemWriteRule should exist", rules, vzSystemWriteRule),
-			ginkgoExt.Entry("vzAppReadRule should exist", rules, vzAppReadRule),
-			ginkgoExt.Entry("vzAppWriteRule should exist", rules, vzAppWriteRule),
-			ginkgoExt.Entry("vzWebLogicReadRule should exist", rules, vzWebLogicReadRule),
-			ginkgoExt.Entry("vzWebLogicWriteRule should exist", rules, vzWebLogicWriteRule),
-			ginkgoExt.Entry("vzCoherenceReadRule should exist", rules, vzCoherenceReadRule),
-			ginkgoExt.Entry("vzCoherenceReadRule should exist", rules, vzCoherenceReadRule),
-			ginkgoExt.Entry("vzIstioReadRule should exist", rules, vzIstioReadRule),
+			ginkgoExt.Entry("vzInstallReadRule should exist", vzInstallReadRule),
+			ginkgoExt.Entry("vzInstallWriteRule should exist", vzInstallWriteRule),
+			ginkgoExt.Entry("vzSystemReadRule should exist", vzSystemReadRule),
+			ginkgoExt.Entry("vzSystemWriteRule should exist", vzSystemWriteRule),
+			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
+			ginkgoExt.Entry("vzAppWriteRule should exist", vzAppWriteRule),
+			ginkgoExt.Entry("vzWebLogicReadRule should exist", vzWebLogicReadRule),
+			ginkgoExt.Entry("vzWebLogicWriteRule should exist", vzWebLogicWriteRule),
+			ginkgoExt.Entry("vzCoherenceReadRule should exist", vzCoherenceReadRule),
+			ginkgoExt.Entry("vzCoherenceReadRule should exist", vzCoherenceReadRule),
+			ginkgoExt.Entry("vzIstioReadRule should exist", vzIstioReadRule),
 		)
 	})
 
 	ginkgo.Describe("ClusterRole verrazzano-monitor", func() {
-		cr := pkg.GetClusterRole("verrazzano-monitor")
-		rules := cr.Rules
+		var rules []rbacv1.PolicyRule
+
+		ginkgo.BeforeEach(func() {
+			cr, err := pkg.GetClusterRole("verrazzano-monitor")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role")
+			rules = cr.Rules
+		})
 
 		ginkgo.It("has correct number of rules", func() {
 			gomega.Expect(len(rules)).To(gomega.Equal(5),
@@ -132,20 +146,25 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
-			func(ruleSlice []rbacv1.PolicyRule, rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(ruleSlice, rule)).To(gomega.BeTrue())
+			func(rule rbacv1.PolicyRule) {
+				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
 			},
-			ginkgoExt.Entry("vzSystemReadRule should exist", rules, vzSystemReadRule),
-			ginkgoExt.Entry("vzAppReadRule should exist", rules, vzAppReadRule),
-			ginkgoExt.Entry("vzWebLogicReadRule should exist", rules, vzWebLogicReadRule),
-			ginkgoExt.Entry("vzCoherenceReadRule should exist", rules, vzCoherenceReadRule),
-			ginkgoExt.Entry("vzIstioReadRule should exist", rules, vzIstioReadRule),
+			ginkgoExt.Entry("vzSystemReadRule should exist", vzSystemReadRule),
+			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
+			ginkgoExt.Entry("vzWebLogicReadRule should exist", vzWebLogicReadRule),
+			ginkgoExt.Entry("vzCoherenceReadRule should exist", vzCoherenceReadRule),
+			ginkgoExt.Entry("vzIstioReadRule should exist", vzIstioReadRule),
 		)
 	})
 
 	ginkgo.Describe("ClusterRole verrazzano-project-admin", func() {
-		cr := pkg.GetClusterRole("verrazzano-project-admin")
-		rules := cr.Rules
+		var rules []rbacv1.PolicyRule
+
+		ginkgo.BeforeEach(func() {
+			cr, err := pkg.GetClusterRole("verrazzano-project-admin")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role")
+			rules = cr.Rules
+		})
 
 		ginkgo.It("has correct number of rules", func() {
 			gomega.Expect(len(rules)).To(gomega.Equal(6),
@@ -153,21 +172,26 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
-			func(ruleSlice []rbacv1.PolicyRule, rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(ruleSlice, rule)).To(gomega.BeTrue())
+			func(rule rbacv1.PolicyRule) {
+				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
 			},
-			ginkgoExt.Entry("vzAppReadRule should exist", rules, vzAppReadRule),
-			ginkgoExt.Entry("vzAppWriteRule should exist", rules, vzAppWriteRule),
-			ginkgoExt.Entry("vzWebLogicReadRule should exist", rules, vzWebLogicReadRule),
-			ginkgoExt.Entry("vzWebLogicWriteRule should exist", rules, vzWebLogicWriteRule),
-			ginkgoExt.Entry("vzCoherenceReadRule should exist", rules, vzCoherenceReadRule),
-			ginkgoExt.Entry("vzCoherenceWriteRule should exist", rules, vzCoherenceWriteRule),
+			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
+			ginkgoExt.Entry("vzAppWriteRule should exist", vzAppWriteRule),
+			ginkgoExt.Entry("vzWebLogicReadRule should exist", vzWebLogicReadRule),
+			ginkgoExt.Entry("vzWebLogicWriteRule should exist", vzWebLogicWriteRule),
+			ginkgoExt.Entry("vzCoherenceReadRule should exist", vzCoherenceReadRule),
+			ginkgoExt.Entry("vzCoherenceWriteRule should exist", vzCoherenceWriteRule),
 		)
 	})
 
 	ginkgo.Describe("ClusterRole verrazzano-project-monitor", func() {
-		cr := pkg.GetClusterRole("verrazzano-project-monitor")
-		rules := cr.Rules
+		var rules []rbacv1.PolicyRule
+
+		ginkgo.BeforeEach(func() {
+			cr, err := pkg.GetClusterRole("verrazzano-project-monitor")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role")
+			rules = cr.Rules
+		})
 
 		ginkgo.It("has correct number of rules", func() {
 			gomega.Expect(len(rules)).To(gomega.Equal(3),
@@ -175,18 +199,19 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
-			func(ruleSlice []rbacv1.PolicyRule, rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(ruleSlice, rule)).To(gomega.BeTrue())
+			func(rule rbacv1.PolicyRule) {
+				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
 			},
-			ginkgoExt.Entry("vzAppReadRule should exist", rules, vzAppReadRule),
-			ginkgoExt.Entry("vzWebLogicReadRule should exist", rules, vzWebLogicReadRule),
-			ginkgoExt.Entry("vzCoherenceReadRule should exist", rules, vzCoherenceReadRule),
+			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
+			ginkgoExt.Entry("vzWebLogicReadRule should exist", vzWebLogicReadRule),
+			ginkgoExt.Entry("vzCoherenceReadRule should exist", vzCoherenceReadRule),
 		)
 	})
 
 	ginkgo.Describe("ClusterRoleBinding verrazzano-admin", func() {
 		ginkgo.It("has correct subjects and refs", func() {
-			crb := pkg.GetClusterRoleBinding("verrazzano-admin")
+			crb, err := pkg.GetClusterRoleBinding("verrazzano-admin")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role binding")
 			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
 			gomega.Expect(crb.RoleRef.Name == "verrazzano-admin").To(gomega.BeTrue(),
@@ -208,7 +233,8 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgo.Describe("ClusterRoleBinding verrazzano-admin-k8s", func() {
 		ginkgo.It("has correct subjects and refs", func() {
-			crb := pkg.GetClusterRoleBinding("verrazzano-admin-k8s")
+			crb, err := pkg.GetClusterRoleBinding("verrazzano-admin-k8s")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role binding")
 			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
 			gomega.Expect(crb.RoleRef.Name == "admin").To(gomega.BeTrue(),
@@ -230,7 +256,8 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgo.Describe("ClusterRoleBinding verrazzano-monitor", func() {
 		ginkgo.It("has correct subjects and refs", func() {
-			crb := pkg.GetClusterRoleBinding("verrazzano-monitor")
+			crb, err := pkg.GetClusterRoleBinding("verrazzano-monitor")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role binding")
 			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
 			gomega.Expect(crb.RoleRef.Name == "verrazzano-monitor").To(gomega.BeTrue(),
@@ -252,7 +279,8 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgo.Describe("ClusterRoleBinding verrazzano-monitor-k8s", func() {
 		ginkgo.It("has correct subjects and refs", func() {
-			crb := pkg.GetClusterRoleBinding("verrazzano-monitor-k8s")
+			crb, err := pkg.GetClusterRoleBinding("verrazzano-monitor-k8s")
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error getting cluster role binding")
 			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
 			gomega.Expect(crb.RoleRef.Name == "view").To(gomega.BeTrue(),


### PR DESCRIPTION
# Description

This PR removes most of the `gomega.Fail` calls from the shared acceptance test code. I analyzed the shared test code to find assertions, expectations, and `Fail` calls that might prevent tests from retrying operations. Previous rounds of test fixes have removed all of the `gomega.Expect` calls, so I only needed to remove `gomega.Fail`.

Note that I did leave in some `gomega.Fail` calls, particularly for operations that will never succeed no matter how many times they are retried. For example, loading a kubeconfig, fetching a clientset, and passing a bad log level to the `Log` function.

I have additional tasks for more improvements to the tests, refactoring to eliminate duplication and confusing code, wrap operations in Eventually where needed, etc. That work will be done in future PRs.

Implements VZ-2898

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
