### PR TITLE
Allow empty values for helm overrides in config.json

### DIFF
--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -276,7 +276,7 @@ function config_array_to_helm_args {
       param_name=$(echo "$arg" | jq -r '.name')
       param_value=$(echo "$arg" | jq -r '.value')
       param_set_string=$(echo "$arg" | jq -r '.setString')
-      if [ ! -z "$param_name" ] && [ ! -z "$param_value" ]; then
+      if [ ! -z "$param_name" ]; then
         if [ "$param_set_string" == "true" ]; then
           helm_args="$helm_args --set-string $param_name=$param_value"
         else

--- a/tests/testdata/install-configurations/install-managed-cluster-default-volume-override.yaml
+++ b/tests/testdata/install-configurations/install-managed-cluster-default-volume-override.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Configure emphemeral storage for a managed cluster profile.  This should only affect the Prometheus component.
+#
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: mgdcluster-storage-override-example
+spec:
+  profile: managed-cluster
+  defaultVolumeSource:
+    persistentVolumeClaim:
+      claimName: promstorage  # Use the "promstorage" PVC template for the storage configuration
+  volumeClaimSpecTemplates:
+  - metadata:
+      name: promstorage
+    spec:
+      resources:
+        requests:
+          storage: 8Gi
+

--- a/tests/testdata/install-configurations/install-managed-cluster-default-volume-override.yaml
+++ b/tests/testdata/install-configurations/install-managed-cluster-default-volume-override.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
-# Configure emphemeral storage for a managed cluster profile.  This should only affect the Prometheus component.
+# Configure a storage override for a managed cluster profile.  This should only affect the Prometheus component.
 #
 apiVersion: install.verrazzano.io/v1alpha1
 kind: Verrazzano

--- a/tests/testdata/install-configurations/install-managed-cluster-emptydir-default.yaml
+++ b/tests/testdata/install-configurations/install-managed-cluster-emptydir-default.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Configure emphemeral storage for a managed cluster profile.  This should only affect the Prometheus component.
+#
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: mgdcluster-empty-storage-example
+spec:
+  profile: managed-cluster
+  defaultVolumeSource:
+    emptyDir: {}  # Use emphemeral storage for all Components unless overridden
+


### PR DESCRIPTION
# Description

Allow empty values for helm overrides, to allow `emptyDir` volumeSource overrides with non-dev profiles to work.

At present, the VZ install prunes out helm overrides specified by the user in the CR if the values are empty (e.g., `name=`).  However, to allow the `defaultVolumeSource` to override the default VMI settings for any given profile, we need to set storage values equivalent to the empty string to tell the VMI to not allocate a PVC for a particular component, e.g.,

        "verrazzanoInstallArgs": [
          {
            "name": "elasticSearch.nodes.data.requests.storage",
            "value": "",
            "setString": true
          },
          {
            "name": "grafana.requests.storage",
            "value": "",
            "setString": true
          },
          {
            "name": "prometheus.requests.storage",
            "value": "",
            "setString": true
          }
        ]



Fixes VZ-2938

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
