### PR TITLE
Installation examples, and fix Keycloak install when Prometheus disabled.

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -768,7 +768,9 @@ if [ $(is_keycloak_enabled) == "true" ]; then
 
   action "Installing Keycloak" install_keycloak || exit 1
 
-  action "patching the prometheus deployment to enable communication with keycloak" patch_prometheus || exit 1
+  if [ $(is_prometheus_console_enabled) == "true" ]; then
+    action "patching the prometheus deployment to enable communication with keycloak" patch_prometheus || exit 1
+  fi
 
 else
   log "Skip Keycloak installation, disabled"

--- a/tests/testdata/install-configurations/install-dev-custom-monitoring-keycloak.yaml
+++ b/tests/testdata/install-configurations/install-dev-custom-monitoring-keycloak.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Customized dev profile install that disables Prometheus and Grafana, and enables persistent storage
+# for Keycloak.
+#
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: custom-dev-example
+spec:
+  profile: dev
+  components:
+    prometheus:
+      enabled: false
+    grafana:
+      enabled: false
+    keycloak:
+      mysql:
+        volumeSource:
+          persistentVolumeClaim:
+            claimName: mysql
+  volumeClaimSpecTemplates:
+  - metadata:
+      name: mysql      
+    spec:
+      resources:
+        requests:
+          storage: 8Gi
+

--- a/tests/testdata/install-configurations/install-dev-custom-monitoring-keycloak.yaml
+++ b/tests/testdata/install-configurations/install-dev-custom-monitoring-keycloak.yaml
@@ -7,7 +7,7 @@
 apiVersion: install.verrazzano.io/v1alpha1
 kind: Verrazzano
 metadata:
-  name: custom-dev-example
+  name: dev-custom-keycloak-disable-prometheus
 spec:
   profile: dev
   components:


### PR DESCRIPTION
# Description

Added a `dev` profile example that
* Disables prometheus and Grafana
* Uses custom storage for Keycloak

This example surfaced a bug in the install scripts with this configuration, the fix is included in the MR also.


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
