### PR TITLE
Temporarily remove the console UI tests

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -359,15 +359,15 @@ pipeline {
                                 runGinkgo('ingress/console')
                             }
                         }
-                        stage ('console') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
-                                GOOGLE_CHROME_VERSION="90.0.4430.93-1"
-                                CHROMEDRIVER_VERSION="90.0.4430.24"
-                            }
-                            steps {
-                                acceptanceTestsConsole()
-                            }
+                    }
+                    stage ('console') {
+                        environment {
+                            DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
+                            GOOGLE_CHROME_VERSION="90.0.4430.93-1"
+                            CHROMEDRIVER_VERSION="90.0.4430.24"
+                        }
+                        steps {
+                            acceptanceTestsConsole()
                         }
                     }
                     post {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -360,18 +360,6 @@ pipeline {
                             }
                         }
                     }
-                    stages {
-                        stage ('console') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
-                                GOOGLE_CHROME_VERSION="90.0.4430.93-1"
-                                CHROMEDRIVER_VERSION="90.0.4430.24"
-                            }
-                            steps {
-                                acceptanceTestsConsole()
-                            }
-                        }
-                    }
                     post {
                         always {
                             archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-dumps/**', allowEmptyArchive: true

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -360,14 +360,16 @@ pipeline {
                             }
                         }
                     }
-                    stage ('console') {
-                        environment {
-                            DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
-                            GOOGLE_CHROME_VERSION="90.0.4430.93-1"
-                            CHROMEDRIVER_VERSION="90.0.4430.24"
-                        }
-                        steps {
-                            acceptanceTestsConsole()
+                    stages {
+                        stage ('console') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
+                                GOOGLE_CHROME_VERSION="90.0.4430.93-1"
+                                CHROMEDRIVER_VERSION="90.0.4430.24"
+                            }
+                            steps {
+                                acceptanceTestsConsole()
+                            }
                         }
                     }
                     post {


### PR DESCRIPTION
# Description

Temporarily remove the console UI tests so that the yum install of Chrome is not being called.  This is to alleviate the builds that are hanging due to a race condition between the stages.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
