### PR TITLE
Mgelleca/vz-2819-2 - Add build of WIT Docker Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ platform-operator/THIRD_PARTY_LICENSES.txt
 application-operator/THIRD_PARTY_LICENSES.txt
 image-patch-operator/THIRD_PARTY_LICENSES.txt
 image-patch-operator/weblogic-imagetool/THIRD_PARTY_LICENSES.txt
+image-patch-operator/weblogic-imagetool/installers
 tools/analysis/THIRD_PARTY_LICENSES.txt
 tests/e2e/**/*.test

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ platform-operator/THIRD_PARTY_LICENSES.txt
 application-operator/THIRD_PARTY_LICENSES.txt
 image-patch-operator/THIRD_PARTY_LICENSES.txt
 image-patch-operator/weblogic-imagetool/THIRD_PARTY_LICENSES.txt
-image-patch-operator/weblogic-imagetool/installers
+image-patch-operator/weblogic-imagetool/installers/*
+!image-patch-operator/weblogic-imagetool/installers/.gitkeep
 tools/analysis/THIRD_PARTY_LICENSES.txt
 tests/e2e/**/*.test

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ out/
 platform-operator/THIRD_PARTY_LICENSES.txt
 application-operator/THIRD_PARTY_LICENSES.txt
 image-patch-operator/THIRD_PARTY_LICENSES.txt
+image-patch-operator/weblogic-imagetool/THIRD_PARTY_LICENSES.txt
 tools/analysis/THIRD_PARTY_LICENSES.txt
 tests/e2e/**/*.test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,12 +232,12 @@ pipeline {
         }
 
         stage('Image Patch Operator') {
-            when {
-                allOf {
-                    not { buildingTag() }
-                    changeset "image-patch-operator/**"
-                }
-            }
+            // when {
+            //     allOf {
+            //         not { buildingTag() }
+            //         changeset "image-patch-operator/**"
+            //     }
+            // }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,6 +239,7 @@ pipeline {
             }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
+                buildWITImage("${DOCKER_IMAGE_TAG}")
             }
             post {
                 failure {
@@ -573,6 +574,18 @@ def buildImagePatchOperator(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano
         make docker-push-ipo VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME=${DOCKER_IMAGE_PATCH_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+    """
+}
+
+// Called in Stage Image Patch Operator
+def buildWITImage(dockerImageTag) {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool/installers
+        wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
+        oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
+        oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
+        cd ${GO_REPO_PATH}/verrazzano
+        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,11 +95,6 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_BUCKET="verrazzano-builds"
-        OCI_CLI_REGION = 'us-phoenix-1'
-
-        BUCKET_NAME = "build-shared-files"
-        JDK8_BUNDLE = "jdk-8u281-linux-x64.tar.gz"
-        WEBLOGIC_BUNDLE = "fmw_12.2.1.4.0_wls.jar"
     }
 
     stages {
@@ -581,7 +576,7 @@ def buildImagePatchOperator(dockerImageTag) {
 def buildWITImage(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano
-        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG} BUCKET_NAME=${BUCKET_NAME} JDK8_BUNDLE=${JDK8_BUNDLE} WEBLOGIC_BUNDLE=${WEBLOGIC_BUNDLE}
+        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_BUCKET="verrazzano-builds"
+        OCI_CLI_REGION = 'us-phoenix-1'
 
         BUCKET_NAME = "build-shared-files"
         JDK8_BUNDLE = "jdk-8u281-linux-x64.tar.gz"
@@ -231,12 +232,12 @@ pipeline {
         }
 
         stage('Image Patch Operator') {
-            // when {
-            //     allOf {
-            //         not { buildingTag() }
-            //         changeset "image-patch-operator/**"
-            //     }
-            // }
+            when {
+                allOf {
+                    not { buildingTag() }
+                    changeset "image-patch-operator/**"
+                }
+            }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -576,8 +576,8 @@ def buildImagePatchOperator(dockerImageTag) {
 // Called in Stage Image Patch Operator
 def buildWITImage(dockerImageTag) {
     sh """
-        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool
-        make ...
+        cd ${GO_REPO_PATH}/verrazzano/
+        make docker-push-wit VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME=${DOCKER_IMAGE_PATCH_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
     // TODO: fill in make command
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,12 +231,12 @@ pipeline {
         }
 
         stage('Image Patch Operator') {
-            when {
-                allOf {
-                    not { buildingTag() }
-                    changeset "image-patch-operator/**"
-                }
-            }
+            // when {
+            //     allOf {
+            //         not { buildingTag() }
+            //         changeset "image-patch-operator/**"
+            //     }
+            // }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -575,11 +575,13 @@ def buildImagePatchOperator(dockerImageTag) {
 
 // Called in Stage Image Patch Operator
 def buildWITImage(dockerImageTag) {
+    // FIXME: download installers for WLS and JDK
     sh """
-        cd ${GO_REPO_PATH}/verrazzano/
-        make docker-push-wit VERRAZZANO_WIT_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool/installers
+        wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
+        cd ${GO_REPO_PATH}/verrazzano
+        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
-    // VERRAZZANO_WIT_IMAGE_NAME define this somewhere
 }
 
 // Called in Stage Generate operator.yaml steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,13 +232,13 @@ pipeline {
         }
 
         stage('Image Patch Operator') {
-            // when {
-            //     allOf {
-            //         not { buildingTag() }
-            //         changeset "image-patch-operator/**"
-            //     }
-            // }
-            steps {
+            when {
+                allOf {
+                    not { buildingTag() }
+                    changeset "image-patch-operator/**"
+                }
+            }
+            ps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,12 +232,12 @@ pipeline {
         }
 
         stage('Image Patch Operator') {
-            // when {
-            //     allOf {
-            //         not { buildingTag() }
-            //         changeset "image-patch-operator/**"
-            //     }
-            // }
+            when {
+                allOf {
+                    not { buildingTag() }
+                    changeset "image-patch-operator/**"
+                }
+            }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,7 +239,6 @@ pipeline {
             }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
-                buildWITImage("${DOCKER_IMAGE_TAG}")
             }
             post {
                 failure {
@@ -574,19 +573,6 @@ def buildImagePatchOperator(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano
         make docker-push-ipo VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME=${DOCKER_IMAGE_PATCH_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
-    """
-}
-
-// Called in Stage Image Patch Operator
-def buildWITImage(dockerImageTag) {
-    // FIXME: download installers for WLS and JDK
-    sh """
-        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool/installers
-        wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
-        oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
-        oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
-        cd ${GO_REPO_PATH}/verrazzano
-        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,10 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_BUCKET="verrazzano-builds"
+
+        BUCKET_NAME = "build-shared-files"
+        JDK8_BUNDLE = "jdk-8u281-linux-x64.tar.gz"
+        WEBLOGIC_BUNDLE = "fmw_12.2.1.4.0_wls.jar"
     }
 
     stages {
@@ -579,6 +583,8 @@ def buildWITImage(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool/installers
         wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
+        oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
+        oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
         cd ${GO_REPO_PATH}/verrazzano
         make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,7 @@ pipeline {
                     changeset "image-patch-operator/**"
                 }
             }
-            ps {
+            steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
                 buildWITImage("${DOCKER_IMAGE_TAG}")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,7 +337,6 @@ pipeline {
                     clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_ANALYSIS_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
                     if (SCAN_IMAGE_PATCH_OPERATOR == true) {
                         clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_PATCH_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
-                        clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_WIT_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -577,9 +577,9 @@ def buildImagePatchOperator(dockerImageTag) {
 def buildWITImage(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/
-        make docker-push-wit VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME=${DOCKER_IMAGE_PATCH_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+        make docker-push-wit VERRAZZANO_WIT_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
-    // TODO: fill in make command
+    // VERRAZZANO_WIT_IMAGE_NAME define this somewhere
 }
 
 // Called in Stage Generate operator.yaml steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -580,12 +580,8 @@ def buildImagePatchOperator(dockerImageTag) {
 // Called in Stage Image Patch Operator
 def buildWITImage(dockerImageTag) {
     sh """
-        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool/installers
-        wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
-        oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
-        oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
         cd ${GO_REPO_PATH}/verrazzano
-        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+        make docker-push-wit VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME=${DOCKER_WIT_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG} BUCKET_NAME=${BUCKET_NAME} JDK8_BUNDLE=${JDK8_BUNDLE} WEBLOGIC_BUNDLE=${WEBLOGIC_BUNDLE}
     """
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,9 @@ pipeline {
         DOCKER_IMAGE_PATCH_CI_IMAGE_NAME = 'verrazzano-image-patch-operator-jenkins'
         DOCKER_IMAGE_PATCH_PUBLISH_IMAGE_NAME = 'verrazzano-image-patch-operator'
         DOCKER_IMAGE_PATCH_IMAGE_NAME = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_IMAGE_PATCH_PUBLISH_IMAGE_NAME : env.DOCKER_IMAGE_PATCH_CI_IMAGE_NAME}"
+        DOCKER_WIT_CI_IMAGE_NAME = 'verrazzano-weblogic-image-tool-jenkins'
+        DOCKER_WIT_PUBLISH_IMAGE_NAME = 'verrazzano-weblogic-image-tool'
+        DOCKER_WIT_IMAGE_NAME = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_WIT_PUBLISH_IMAGE_NAME : env.DOCKER_WIT_CI_IMAGE_NAME}"
         DOCKER_OAM_CI_IMAGE_NAME = 'verrazzano-application-operator-jenkins'
         DOCKER_OAM_PUBLISH_IMAGE_NAME = 'verrazzano-application-operator'
         DOCKER_OAM_IMAGE_NAME = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_OAM_PUBLISH_IMAGE_NAME : env.DOCKER_OAM_CI_IMAGE_NAME}"
@@ -232,6 +235,7 @@ pipeline {
             }
             steps {
                 buildImagePatchOperator("${DOCKER_IMAGE_TAG}")
+                buildWITImage("${DOCKER_IMAGE_TAG}")
             }
             post {
                 failure {
@@ -328,6 +332,7 @@ pipeline {
                     clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_ANALYSIS_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
                     if (SCAN_IMAGE_PATCH_OPERATOR == true) {
                         clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_PATCH_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+                        clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_WIT_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
                     }
                 }
             }
@@ -566,6 +571,15 @@ def buildImagePatchOperator(dockerImageTag) {
         cd ${GO_REPO_PATH}/verrazzano
         make docker-push-ipo VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME=${DOCKER_IMAGE_PATCH_IMAGE_NAME} DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} DOCKER_IMAGE_TAG=${dockerImageTag} CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
     """
+}
+
+// Called in Stage Image Patch Operator
+def buildWITImage(dockerImageTag) {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano/image-patch-operator/weblogic-imagetool
+        make ...
+    """
+    // TODO: fill in make command
 }
 
 // Called in Stage Generate operator.yaml steps

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ VERRAZZANO_PLATFORM_OPERATOR_IMAGE_NAME ?= verrazzano-platform-operator-dev
 VERRAZZANO_APPLICATION_OPERATOR_IMAGE_NAME ?= verrazzano-application-operator-dev
 VERRAZZANO_ANALYSIS_IMAGE_NAME ?= verrazzano-analysis-dev
 VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME ?= verrazzano-image-patch-operator-dev
+VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME ?= verrazzano-weblogic-image-tool-dev
 
 VERRAZZANO_PLATFORM_OPERATOR_IMAGE = ${DOCKER_REPO}/${DOCKER_NAMESPACE}/${VERRAZZANO_PLATFORM_OPERATOR_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 VERRAZZANO_APPLICATION_OPERATOR_IMAGE = ${DOCKER_REPO}/${DOCKER_NAMESPACE}/${VERRAZZANO_APPLICATION_OPERATOR_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
@@ -50,9 +51,9 @@ docker-push:
 docker-push-ipo:
 	(cd image-patch-operator; make docker-push DOCKER_IMAGE_NAME=${VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
-.PHONY: docker-push-wit-img
-docker-push-wit-img:
-	(cd image-patch-operator; make dockerpush )
+.PHONY: docker-push-wit
+docker-push-wit:
+	(cd image-patch-operator/weblogic-imagetool; make docker-push DOCKER_IMAGE_NAME=${VERRAZZANO_WEBLOGIC_IMAGE_TOOL_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
 .PHONY: create-test-deploy
 create-test-deploy: docker-push

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ docker-push:
 docker-push-ipo:
 	(cd image-patch-operator; make docker-push DOCKER_IMAGE_NAME=${VERRAZZANO_IMAGE_PATCH_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
+.PHONY: docker-push-wit-img
+docker-push-wit-img:
+	(cd image-patch-operator; make dockerpush )
+
 .PHONY: create-test-deploy
 create-test-deploy: docker-push
 	(cd platform-operator; make create-test-deploy VZ_DEV_IMAGE=${VERRAZZANO_PLATFORM_OPERATOR_IMAGE} VZ_APP_OP_IMAGE=${VERRAZZANO_APPLICATION_OPERATOR_IMAGE})

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -68,6 +68,8 @@ ENV WLSIMG_CACHEDIR="/home/verrazzano/cache"
 RUN ./imagetool/bin/imagetool.sh cache addInstaller --type wls --version 12.2.1.4.0 --path ./${WLS_BINARY} \
     && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY}
 
+# TODO: copy license into image
+
 USER 1000
 
 ENTRYPOINT ["imagetool/bin/imagetool.sh"]

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -35,6 +35,7 @@ FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the builder for WIT and dependencies
 RUN microdnf update -y \
+    && microdnf install -y libslirp \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \
     && microdnf clean all

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -69,7 +69,7 @@ RUN ./imagetool/bin/imagetool.sh cache addInstaller --type wls --version 12.2.1.
     && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY} \
     && ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version latest --path ./${WDT_BINARY}
 
-COPY ../../THIRD_PARTY_LICENSES.txt /licenses
+COPY ../../THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -35,7 +35,7 @@ FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the builder for WIT and dependencies
 RUN microdnf update -y \
-    && microdnf install -y libslirp \
+    && microdnf install -y libslirp criu conmon libslirp crun containernetworking-plugins slirp4netns \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \
     && microdnf clean all

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-ARG JDK_BINARY="${JDK_BINARY:-installers/jdk-8u291-linux-x64.tar.gz}"
+ARG JDK_BINARY="${JDK_BINARY:-installers/jdk-8u281-linux-x64.tar.gz}"
 
 # Build stage for required software installation
 FROM ghcr.io/oracle/oraclelinux:8-slim AS build_base
@@ -19,7 +19,7 @@ RUN wget https://github.com/oracle/weblogic-image-tool/releases/download/release
 # Setup for JDK installation
 ENV JAVA_HOME=/usr/java
 COPY ${JDK_BINARY} ./${JDK_BINARY}
-ENV JDK_DOWNLOAD_SHA256=c5052d2e1dd9621a44658ef06be145c5cdfcd7ea956c0c9d655ccd64e79c8613
+ENV JDK_DOWNLOAD_SHA256=85e8c7da7248c7450fb105567a78841d0973597850776c24a527feb02ef3e586
 
 # Install JDK
 RUN set -eux \
@@ -42,7 +42,7 @@ RUN microdnf update -y \
 WORKDIR /home/verrazzano
 
 ARG JDK_BINARY
-ARG WLS_BINARY="${WLS_BINARY:-installers/fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip}"
+ARG WLS_BINARY="${WLS_BINARY:-installers/fmw_12.2.1.4.0_wls.jar}"
 ARG WDT_BINARY="${WDT_BINARY:-installers/weblogic-deploy.zip}"
 
 RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
@@ -66,7 +66,7 @@ COPY --chown=verrazzano:verrazzano ./${JDK_BINARY} ./${WLS_BINARY} ./${WDT_BINAR
 # Add installers to WIT
 ENV WLSIMG_CACHEDIR="/home/verrazzano/cache"
 RUN ./imagetool/bin/imagetool.sh cache addInstaller --type wls --version 12.2.1.4.0 --path ./${WLS_BINARY} \
-    && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY} \
+    && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u281 --path ./${JDK_BINARY} \
     && ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version latest --path ./${WDT_BINARY}
 
 COPY THIRD_PARTY_LICENSES.txt /licenses/

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux \
 # Final image for deploying WebLogic Image Tool
 FROM ghcr.io/oracle/oraclelinux:8-slim
 
-# Install the builder for WIT and dependencies
+# Install the podman for WIT and dependencies
 RUN microdnf update -y \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -35,6 +35,17 @@ FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the podman for WIT and dependencies
 RUN microdnf update -y \
+    && microdnf install -y criu \
+    buildah \
+    cockpit-podman \
+    conmon \
+    libslirp \
+    containernetworking-plugins \
+    crun \
+    slirp4netns \
+    container-selinux \
+    runc \
+    udica \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \
     && microdnf clean all

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -35,17 +35,6 @@ FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the podman for WIT and dependencies
 RUN microdnf update -y \
-    && microdnf install -y criu \
-    buildah \
-    cockpit-podman \
-    conmon \
-    libslirp \
-    containernetworking-plugins \
-    crun \
-    slirp4netns \
-    container-selinux \
-    runc \
-    udica \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \
     && microdnf clean all

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -34,10 +34,10 @@ RUN set -eux \
 FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the builder for WIT and dependencies
-# RUN microdnf update -y \
-#     && microdnf install -y podman \
-#     && microdnf reinstall -y shadow-utils \
-#     && microdnf clean all
+RUN microdnf update -y \
+    && microdnf install -y podman \
+    && microdnf reinstall -y shadow-utils \
+    && microdnf clean all
 
 WORKDIR /home/verrazzano
 

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -66,9 +66,10 @@ COPY --chown=verrazzano:verrazzano ./${JDK_BINARY} ./${WLS_BINARY} ./${WDT_BINAR
 # Add installers to WIT
 ENV WLSIMG_CACHEDIR="/home/verrazzano/cache"
 RUN ./imagetool/bin/imagetool.sh cache addInstaller --type wls --version 12.2.1.4.0 --path ./${WLS_BINARY} \
-    && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY}
+    && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY} \
+    && ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version latest --path ./${WDT_BINARY}
 
-# TODO: copy license into image
+COPY ../../THIRD_PARTY_LICENSES.txt /licenses
 
 USER 1000
 

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -34,10 +34,10 @@ RUN set -eux \
 FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the builder for WIT and dependencies
-RUN microdnf update -y \
-    && microdnf install -y podman \
-    && microdnf reinstall -y shadow-utils \
-    && microdnf clean all
+# RUN microdnf update -y \
+#     && microdnf install -y podman \
+#     && microdnf reinstall -y shadow-utils \
+#     && microdnf clean all
 
 WORKDIR /home/verrazzano
 

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -35,7 +35,6 @@ FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Install the builder for WIT and dependencies
 RUN microdnf update -y \
-    && microdnf install -y libslirp criu conmon libslirp crun containernetworking-plugins slirp4netns \
     && microdnf install -y podman \
     && microdnf reinstall -y shadow-utils \
     && microdnf clean all

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -69,7 +69,7 @@ RUN ./imagetool/bin/imagetool.sh cache addInstaller --type wls --version 12.2.1.
     && ./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version 8u291 --path ./${JDK_BINARY} \
     && ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version latest --path ./${WDT_BINARY}
 
-COPY ../../THIRD_PARTY_LICENSES.txt /licenses/
+COPY THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -50,6 +50,7 @@ ENV_NAME=verrazzano-weblogic-image-tool
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
 # for retrieving installers from oci bucket
+OCI_CLI_REGION ?= 'us-phoenix-1'
 BUCKET_NAME ?= build-shared-files
 JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
 WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
@@ -57,6 +58,7 @@ WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
 .PHONY: get-installers
 get-installers:
 	cd ./installers; \
+	export OCI_CLI_REGION='us-phoenix-1'; \
 	(test -f "weblogic-deploy.zip" || wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip); \
 	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}); \
 	(test -f ${WEBLOGIC_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE})

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -50,9 +50,9 @@ ENV_NAME=verrazzano-weblogic-image-tool
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
 # for retrieving installers from oci bucket
-# BUCKET_NAME ?= build-shared-files
-# JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
-# WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
+BUCKET_NAME ?= build-shared-files
+JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
+WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
 
 .PHONY: get-installers
 get-installers:

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -50,7 +50,7 @@ ENV_NAME=verrazzano-weblogic-image-tool
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
 # for retrieving installers from oci bucket
-OCI_CLI_REGION ?= 'us-phoenix-1'
+OCI_CLI_REGION ?= us-phoenix-1
 BUCKET_NAME ?= build-shared-files
 JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
 WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
@@ -58,7 +58,7 @@ WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
 .PHONY: get-installers
 get-installers:
 	cd ./installers; \
-	export OCI_CLI_REGION='us-phoenix-1'; \
+	export OCI_CLI_REGION=${OCI_CLI_REGION}; \
 	(test -f "weblogic-deploy.zip" || wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip); \
 	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}); \
 	(test -f ${WEBLOGIC_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE})

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -1,0 +1,97 @@
+# Copyright (C) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+include ../make/quality.mk
+include ../make/generate.mk
+
+SCRIPT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../build
+
+NAME:=verrazzano-ipo-weblogic-image-tool
+REPO_NAME:=verrazzano-ipo-weblogic-image-tool
+
+CONTROLLER_GEN_VERSION ?= $(shell go list -m -f '{{.Version}}' sigs.k8s.io/controller-tools)
+CREATE_LATEST_TAG=0
+
+ifndef DOCKER_IMAGE_FULLNAME
+DOCKER_IMAGE_NAME ?= ${NAME}-dev
+DOCKER_IMAGE_FULLNAME=${DOCKER_IMAGE_NAME}
+ifeq ($(MAKECMDGOALS),$(filter $(MAKECMDGOALS),docker-push push-tag))
+	ifndef DOCKER_REPO
+		$(error DOCKER_REPO must be defined as the name of the Docker repository where image will be pushed)
+	endif
+	ifndef DOCKER_NAMESPACE
+		$(error DOCKER_NAMESPACE must be defined as the name of the Docker namespace where image will be pushed)
+	endif
+endif
+ifdef DOCKER_NAMESPACE
+DOCKER_IMAGE_FULLNAME := ${DOCKER_NAMESPACE}/${DOCKER_IMAGE_FULLNAME}
+endif
+ifdef DOCKER_REPO
+DOCKER_IMAGE_FULLNAME := ${DOCKER_REPO}/${DOCKER_IMAGE_FULLNAME}
+endif
+endif
+
+DOCKER_IMAGE_TAG ?= local-$(shell git rev-parse --short HEAD)
+
+OPERATOR_VERSION = ${DOCKER_IMAGE_TAG}
+ifdef RELEASE_VERSION
+	OPERATOR_VERSION = ${RELEASE_VERSION}
+endif
+ifndef RELEASE_BRANCH
+	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+endif
+
+# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
+CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+DIST_DIR:=dist
+K8S_NAMESPACE:=default
+WATCH_NAMESPACE:=
+EXTRA_PARAMS=
+INTEG_RUN_ID=
+ENV_NAME=verrazzano-image-patch-operator
+GO ?= CGO_ENABLED=0 GO111MODULE=on GOPRIVATE=github.com/verrazzano go
+GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}
+KIND_CONFIG ?= kind-config.yaml
+CRD_PATH=../image-patch-operator/config/crd/bases
+
+CLUSTER_DUMP_LOCATION ?= image-patch-operator-integ-cluster-dump
+
+.PHONY: go-build
+go-build:
+	$(GO) build \
+		-ldflags "${GO_LDFLAGS}" \
+		-o out/$(shell uname)_$(shell uname -m)/verrazzano-image-patch-operator \
+		main.go
+
+.PHONY: go-build-linux
+go-build-linux:
+	GOOS=linux GOARCH=amd64 $(GO) build \
+		-ldflags "${GO_LDFLAGS}" \
+		-o out/linux_amd64/verrazzano-image-patch-operator \
+		main.go
+
+.PHONY: go-install
+go-install:
+	$(GO) install
+
+.PHONY: docker-clean
+docker-clean:
+	rm -rf ${DIST_DIR}
+
+.PHONY: docker-build
+docker-build: go-build-linux
+	# the TPL file needs to be copied into this dir so it is in the docker build context
+	cp ../THIRD_PARTY_LICENSES.txt .
+	docker build --pull \
+		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
+
+.PHONY: docker-push
+docker-push: docker-build
+	docker tag ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}
+	docker push ${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}
+
+ifeq ($(CREATE_LATEST_TAG), "1")
+	docker tag ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_FULLNAME}:latest;
+	docker push ${DOCKER_IMAGE_FULLNAME}:latest;
+endif

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -49,12 +49,19 @@ ENV_NAME=verrazzano-weblogic-image-tool
 
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
+.PHONY: get-installers
+get-installers:
+	cd ./installers
+	wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
+	oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
+	oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
+
 .PHONY: docker-clean
 docker-clean:
 	rm -rf ${DIST_DIR}
 
 .PHONY: docker-build
-docker-build:
+docker-build: get-installers
 	# the TPL file needs to be copied into this dir so it is in the docker build context
 	cp ../../THIRD_PARTY_LICENSES.txt .
 	docker build --pull \

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -50,9 +50,9 @@ ENV_NAME=verrazzano-weblogic-image-tool
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
 # for retrieving installers from oci bucket
-BUCKET_NAME ?= build-shared-files
-JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
-WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
+# BUCKET_NAME ?= build-shared-files
+# JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
+# WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
 
 .PHONY: get-installers
 get-installers:

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -49,12 +49,17 @@ ENV_NAME=verrazzano-weblogic-image-tool
 
 CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
+# for retrieving installers from oci bucket
+BUCKET_NAME ?= build-shared-files
+JDK8_BUNDLE ?= jdk-8u281-linux-x64.tar.gz
+WEBLOGIC_BUNDLE ?= fmw_12.2.1.4.0_wls.jar
+
 .PHONY: get-installers
 get-installers:
-	cd ./installers
-	wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip
-	oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}
-	oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE}
+	cd ./installers; \
+	(test -f "weblogic-deploy.zip" || wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip); \
+	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}); \
+	(test -f ${WEBLOGIC_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE})
 
 .PHONY: docker-clean
 docker-clean:

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -82,7 +82,7 @@ docker-clean:
 .PHONY: docker-build
 docker-build: go-build-linux
 	# the TPL file needs to be copied into this dir so it is in the docker build context
-	cp ../THIRD_PARTY_LICENSES.txt .
+	cp ../../THIRD_PARTY_LICENSES.txt .
 	docker build --pull \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -1,15 +1,14 @@
 # Copyright (C) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-include ../make/quality.mk
-include ../make/generate.mk
+include ../../make/quality.mk
+include ../../make/generate.mk
 
 SCRIPT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../build
 
-NAME:=verrazzano-ipo-weblogic-image-tool
-REPO_NAME:=verrazzano-ipo-weblogic-image-tool
+NAME:=verrazzano-weblogic-image-tool
+REPO_NAME:=verrazzano-weblogic-image-tool
 
-CONTROLLER_GEN_VERSION ?= $(shell go list -m -f '{{.Version}}' sigs.k8s.io/controller-tools)
 CREATE_LATEST_TAG=0
 
 ifndef DOCKER_IMAGE_FULLNAME
@@ -41,46 +40,21 @@ ifndef RELEASE_BRANCH
 	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 endif
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
-
 DIST_DIR:=dist
 K8S_NAMESPACE:=default
 WATCH_NAMESPACE:=
 EXTRA_PARAMS=
 INTEG_RUN_ID=
-ENV_NAME=verrazzano-image-patch-operator
-GO ?= CGO_ENABLED=0 GO111MODULE=on GOPRIVATE=github.com/verrazzano go
-GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}
-KIND_CONFIG ?= kind-config.yaml
-CRD_PATH=../image-patch-operator/config/crd/bases
+ENV_NAME=verrazzano-weblogic-image-tool
 
-CLUSTER_DUMP_LOCATION ?= image-patch-operator-integ-cluster-dump
-
-.PHONY: go-build
-go-build:
-	$(GO) build \
-		-ldflags "${GO_LDFLAGS}" \
-		-o out/$(shell uname)_$(shell uname -m)/verrazzano-image-patch-operator \
-		main.go
-
-.PHONY: go-build-linux
-go-build-linux:
-	GOOS=linux GOARCH=amd64 $(GO) build \
-		-ldflags "${GO_LDFLAGS}" \
-		-o out/linux_amd64/verrazzano-image-patch-operator \
-		main.go
-
-.PHONY: go-install
-go-install:
-	$(GO) install
+CLUSTER_DUMP_LOCATION ?= weblogic-image-tool-integ-cluster-dump
 
 .PHONY: docker-clean
 docker-clean:
 	rm -rf ${DIST_DIR}
 
 .PHONY: docker-build
-docker-build: go-build-linux
+docker-build:
 	# the TPL file needs to be copied into this dir so it is in the docker build context
 	cp ../../THIRD_PARTY_LICENSES.txt .
 	docker build --pull \

--- a/image-patch-operator/weblogic-imagetool/README.md
+++ b/image-patch-operator/weblogic-imagetool/README.md
@@ -1,7 +1,6 @@
 # WIT in Docker Image
 
 This Dockerfile is used to run WebLogic Image Tool inside a Docker container. <br>
-Each of the `.download` files in the `installers` directory are placeholders for the installer files that need to be downloaded. <br>
 Docker Desktop is needed to run the below example.
 
 ## Create a Image using WIT inside a Docker container
@@ -10,11 +9,11 @@ This example shows how to use this Dockerfile to create a container that support
 First, build the image from the Dockerfile.
 ```bash
 # This command assumes that your current working directory is the directory that contains this README.
-docker build -t wit:1 .
+make docker-build
 ```
-Start the container with the following command. This should start an interactive shell prompt inside the Docker container.
+Start the container with the following command. Replace `image-id` with the id corresponding to the newly created `verrazzano-weblogic-image-tool-dev` image, which can be seen by using the `docker images` command. This should start an interactive shell prompt inside the Docker container.
 ```bash
-docker run -it --privileged --entrypoint /bin/bash wit:1
+docker run -it --privileged --entrypoint /bin/bash image-id
 ```
 
 While inside the container's shell prompt, use the imagetool to create a sample image.
@@ -22,13 +21,13 @@ While inside the container's shell prompt, use the imagetool to create a sample 
 # Creates an alias for the `imagetool.sh` shell script for convenience
 alias imagetool=/home/verrazzano/imagetool/bin/imagetool.sh
 
-imagetool create --tag testimage:1 --builder podman --jdkVersion 8u291 --version 12.2.1.4.0 --dryRun
+imagetool create --tag testimage:1 --builder podman --jdkVersion 8u281 --version 12.2.1.4.0 --dryRun
 ```
 Because of the `--dryRun` flag that was passed in, the Dockerfile for the new image is dumped to standard output, but no image is actually created.
 
 Omit the `--dryRun` option to actually create an image.
 ```bash
-imagetool create --tag testimage:1 --builder podman --jdkVersion 8u291 --version 12.2.1.4.0
+imagetool create --tag testimage:1 --builder podman --jdkVersion 8u281 --version 12.2.1.4.0
 ```
 After creating an image this way, we can verify that it exists by running `podman images`, whose output should include an image called "testimage" with a tag of 1.
 
@@ -36,11 +35,11 @@ After creating an image this way, we can verify that it exists by running `podma
 As an alternative to entering the container's shell prompt, the same `imagetool create` commands can be used as inputs to `docker run`. The following commands should result in a similar output to the above instructions.
 ```bash
 # This command assumes that your current working directory is the directory that contains this README.
-docker build -t wit:1 .
+make docker-build
 
-docker run --privileged wit:1 create --tag testimage:1 --builder podman --jdkVersion 8u291 --version 12.2.1.4.0 --dryRun
+docker run --privileged image-id create --tag testimage:1 --builder podman --jdkVersion 8u281 --version 12.2.1.4.0 --dryRun
 
 # Without --dryRun, this actually creates the image, but the container shuts down afterward anyway.
-docker run --privileged wit:1 create --tag testimage:1 --builder podman --jdkVersion 8u291 --version 12.2.1.4.0
+docker run --privileged image-id create --tag testimage:1 --builder podman --jdkVersion 8u281 --version 12.2.1.4.0
 ```
 

--- a/image-patch-operator/weblogic-imagetool/README.md
+++ b/image-patch-operator/weblogic-imagetool/README.md
@@ -4,7 +4,7 @@ This Dockerfile is used to run WebLogic Image Tool inside a Docker container. <b
 Docker Desktop is needed to run the below example.
 
 ## Create a Image using WIT inside a Docker container
-This example shows how to use this Dockerfile to create a container that supports the WebLogic Image Tool.
+This example shows how to use this Dockerfile to create a local container that supports the WebLogic Image Tool.
 
 First, build the image from the Dockerfile.
 ```bash

--- a/image-patch-operator/weblogic-imagetool/README.md
+++ b/image-patch-operator/weblogic-imagetool/README.md
@@ -11,7 +11,7 @@ First, build the image from the Dockerfile.
 # This command assumes that your current working directory is the directory that contains this README.
 make docker-build
 ```
-Start the container with the following command. Replace `image-id` with the ID corresponding to the newly created `verrazzano-weblogic-image-tool-dev` image, which can be seen by using the `docker images` command. This will start an interactive shell prompt inside the Docker container.
+Start the container with the following command. Replace `image-id` with the ID corresponding to the newly created `verrazzano-weblogic-image-tool-dev` image, which you can view by using the `docker images` command. This will start an interactive shell prompt inside the Docker container.
 ```bash
 docker run -it --privileged --entrypoint /bin/bash image-id
 ```

--- a/image-patch-operator/weblogic-imagetool/README.md
+++ b/image-patch-operator/weblogic-imagetool/README.md
@@ -11,7 +11,7 @@ First, build the image from the Dockerfile.
 # This command assumes that your current working directory is the directory that contains this README.
 make docker-build
 ```
-Start the container with the following command. Replace `image-id` with the id corresponding to the newly created `verrazzano-weblogic-image-tool-dev` image, which can be seen by using the `docker images` command. This should start an interactive shell prompt inside the Docker container.
+Start the container with the following command. Replace `image-id` with the ID corresponding to the newly created `verrazzano-weblogic-image-tool-dev` image, which can be seen by using the `docker images` command. This will start an interactive shell prompt inside the Docker container.
 ```bash
 docker run -it --privileged --entrypoint /bin/bash image-id
 ```

--- a/image-patch-operator/weblogic-imagetool/installers/.gitkeep
+++ b/image-patch-operator/weblogic-imagetool/installers/.gitkeep
@@ -1,0 +1,2 @@
+# Copyright (C) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.

--- a/image-patch-operator/weblogic-imagetool/installers/fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip.download
+++ b/image-patch-operator/weblogic-imagetool/installers/fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip.download
@@ -3,6 +3,6 @@
 #
 # Download WebLogic Server, version 12.2.1.4
 #
-# - https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.htm://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html
+# - https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html
 #
 fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip

--- a/image-patch-operator/weblogic-imagetool/installers/fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip.download
+++ b/image-patch-operator/weblogic-imagetool/installers/fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip.download
@@ -1,8 +1,0 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-#
-# Download WebLogic Server, version 12.2.1.4
-#
-# - https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html
-#
-fmw_12.2.1.4.0_wls_lite_Disk1_1of1.zip

--- a/image-patch-operator/weblogic-imagetool/installers/jdk-8u291-linux-x64.tar.gz.download
+++ b/image-patch-operator/weblogic-imagetool/installers/jdk-8u291-linux-x64.tar.gz.download
@@ -1,8 +1,0 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-#
-# Download Java Development Kit, version 8
-#
-# - https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
-#
-c5052d2e1dd9621a44658ef06be145c5cdfcd7ea956c0c9d655ccd64e79c8613 jdk-8u291-linux-x64.tar.gz

--- a/image-patch-operator/weblogic-imagetool/installers/weblogic-deploy.zip.download
+++ b/image-patch-operator/weblogic-imagetool/installers/weblogic-deploy.zip.download
@@ -1,8 +1,0 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-#
-# Download WebLogic Deploy Tooling, version 1.9.15
-#
-# - https://github.com/oracle/weblogic-deploy-tooling/releases
-#
-weblogic-deploy.zip

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -80,8 +80,8 @@ var (
 		".cov",
 		".iml",
     ".jar",
-    ".tar.gz",
     ".zip",
+    ".gz",
 	}
 
 	// copyrightRegex is the regular expression for recognizing correctly formatted copyright statements

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -79,9 +79,9 @@ var (
 		".map",
 		".cov",
 		".iml",
-    ".jar",
-    ".zip",
-    ".gz",
+		".jar",
+		".zip",
+		".gz",
 	}
 
 	// copyrightRegex is the regular expression for recognizing correctly formatted copyright statements

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -79,6 +79,9 @@ var (
 		".map",
 		".cov",
 		".iml",
+    ".jar",
+    ".tar.gz",
+    ".zip",
 	}
 
 	// copyrightRegex is the regular expression for recognizing correctly formatted copyright statements


### PR DESCRIPTION
# Description

These changes add the Docker image running WIT to the Jenkins pipeline. Does not run the clairScan on the image as a temporary measure.

Fixes VZ-2819

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
