### PR TITLE
During uninstall, only delete application resources from namespaces which are managed by Verrazzano

### DIFF
--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -322,7 +322,7 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources false
                         ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources
                     """
                 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -752,7 +752,7 @@ def verifyUninstall(count) {
         script {
             sh """
                 export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/cluster${count}/post-uninstall-resources
+                ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/cluster${count}/post-uninstall-resources false
                 ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources/cluster${count}
             """
         }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -357,7 +357,7 @@ pipeline {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources
+                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources false
                         ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources
                     """
                 }

--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -94,12 +94,12 @@ function delete_multicluster_resources {
 
 # Delete all of the OAM ApplicationConfiguration resources in all namespaces.
 function delete_oam_applications_configurations {
-  delete_k8s_resource_from_all_namespaces applicationconfigurations.core.oam.dev no
+  delete_managed_k8s_resources applicationconfigurations.core.oam.dev no
 }
 
 # Delete all of the OAM Component resources in all namespaces.
 function delete_oam_components {
-  delete_k8s_resource_from_all_namespaces components.core.oam.dev no
+  delete_managed_k8s_resources components.core.oam.dev no
 }
 
 action "Deleting Rancher Local Cluster" delete_rancher_local_cluster || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -60,10 +60,10 @@ function delete_verrazzano() {
 
   # Delete CRDS from all namespaces
   delete_k8s_resource_from_all_namespaces applicationconfigurations.core.oam.dev
-  delete_k8s_resource_from_all_namespaces coherence.coherence.oracle.com
+#  delete_k8s_resource_from_all_namespaces coherence.coherence.oracle.com
   delete_k8s_resource_from_all_namespaces components.core.oam.dev
   delete_k8s_resource_from_all_namespaces containerizedworkloads.core.oam.dev
-  delete_k8s_resource_from_all_namespaces domains.weblogic.oracle
+#  delete_k8s_resource_from_all_namespaces domains.weblogic.oracle
   delete_k8s_resource_from_all_namespaces healthscopes.core.oam.dev
   delete_k8s_resource_from_all_namespaces manualscalertraits.core.oam.dev
   delete_k8s_resource_from_all_namespaces traitdefinitions.core.oam.dev

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -58,17 +58,17 @@ function delete_verrazzano() {
   delete_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not delete Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano.io\/namespace:monitoring|verrazzano-system|verrazzano-mc/ {print $1}' \
     || return $? # return on pipefail
 
-  # Delete CRDS from all namespaces
-  delete_k8s_resource_from_all_namespaces applicationconfigurations.core.oam.dev
-#  delete_k8s_resource_from_all_namespaces coherence.coherence.oracle.com
-  delete_k8s_resource_from_all_namespaces components.core.oam.dev
-  delete_k8s_resource_from_all_namespaces containerizedworkloads.core.oam.dev
-#  delete_k8s_resource_from_all_namespaces domains.weblogic.oracle
-  delete_k8s_resource_from_all_namespaces healthscopes.core.oam.dev
-  delete_k8s_resource_from_all_namespaces manualscalertraits.core.oam.dev
-  delete_k8s_resource_from_all_namespaces traitdefinitions.core.oam.dev
-  delete_k8s_resource_from_all_namespaces workloaddefinitions.core.oam.dev
-  delete_k8s_resource_from_all_namespaces scopedefinitions.core.oam.dev
+  # Delete CRDS from all Verrazzano managed namespaces
+  delete_managed_k8s_resources applicationconfigurations.core.oam.dev
+  delete_managed_k8s_resources coherence.coherence.oracle.com
+  delete_managed_k8s_resources components.core.oam.dev
+  delete_managed_k8s_resources containerizedworkloads.core.oam.dev
+  delete_managed_k8s_resources domains.weblogic.oracle
+  delete_managed_k8s_resources healthscopes.core.oam.dev
+  delete_managed_k8s_resources manualscalertraits.core.oam.dev
+  delete_managed_k8s_resources traitdefinitions.core.oam.dev
+  delete_managed_k8s_resources workloaddefinitions.core.oam.dev
+  delete_managed_k8s_resources scopedefinitions.core.oam.dev
 }
 
 function delete_oam_operator {

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -58,7 +58,7 @@ function delete_verrazzano() {
   delete_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not delete Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano.io\/namespace:monitoring|verrazzano-system|verrazzano-mc/ {print $1}' \
     || return $? # return on pipefail
 
-  # Delete CRDS from all Verrazzano managed namespaces
+  # Delete CR'S from all Verrazzano managed namespaces
   delete_managed_k8s_resources applicationconfigurations.core.oam.dev
   delete_managed_k8s_resources coherence.coherence.oracle.com
   delete_managed_k8s_resources components.core.oam.dev

--- a/platform-operator/scripts/uninstall/uninstall-utils.sh
+++ b/platform-operator/scripts/uninstall/uninstall-utils.sh
@@ -82,6 +82,28 @@ function delete_k8s_resources() {
     || err_return $? "$3" || return $? # return on pipefail
 }
 
+# Deletes kubernetes resources of the specified type from all namespaces that have the verrazzano-managed label set to true
+# $1 resource-type - type of the resources being deleted
+# $2 crd-delete-flag - value of "yes" or "no" to also delete crd, default is "yes" for compatibility
+function delete_managed_k8s_resources {
+  local res=$1
+  local delcrd=$2
+  if kubectl get crd "${res}"> /dev/null 2>&1 ; then
+    IFS=$'\n' read -r -d '' -a namespaces < <( kubectl get namespaces -l verrazzano-managed="true" --no-headers -o custom-columns=":metadata.name" && printf '\0' )
+    for ns in "${namespaces[@]}" ; do
+      if ! kubectl delete "${res}" --namespace ${ns} --all > /dev/null 2>&1 ; then
+        log "Failed to delete ${res} from namespace ${ns}"
+      fi
+    done
+  fi
+  # Delete the CRDs, without any CRs based on that, from all the namespaces
+  if [ -z "${delcrd}" ] || [ "${delcrd}" == "yes" ]; then
+    if kubectl get crd "${res}"> /dev/null 2>&1 ; then
+      kubectl delete crd "${res}" --ignore-not-found > /dev/null 2>&1
+    fi
+  fi
+}
+
 # utility function to patch kubernetes resources
 # $1 resource-type - type of the resources being patched
 # $2 custom-cols   - custom columns used when getting the resources

--- a/platform-operator/scripts/uninstall/uninstall-utils.sh
+++ b/platform-operator/scripts/uninstall/uninstall-utils.sh
@@ -82,9 +82,9 @@ function delete_k8s_resources() {
     || err_return $? "$3" || return $? # return on pipefail
 }
 
-# Deletes kubernetes resources of the specified type from all namespaces that have the verrazzano-managed label set to true
+# Deletes kubernetes resources of the specified type from all namespaces that have the verrazzano-managed label set to true.
+# No CRD's are deleted.
 # $1 resource-type - type of the resources being deleted
-# $2 crd-delete-flag - value of "yes" or "no" to also delete crd, default is "yes" for compatibility
 function delete_managed_k8s_resources {
   local res=$1
   local delcrd=$2

--- a/platform-operator/scripts/uninstall/uninstall-utils.sh
+++ b/platform-operator/scripts/uninstall/uninstall-utils.sh
@@ -96,12 +96,6 @@ function delete_managed_k8s_resources {
       fi
     done
   fi
-  # Delete the CRDs, without any CRs based on that, from all the namespaces
-  if [ -z "${delcrd}" ] || [ "${delcrd}" == "yes" ]; then
-    if kubectl get crd "${res}"> /dev/null 2>&1 ; then
-      kubectl delete crd "${res}" --ignore-not-found > /dev/null 2>&1
-    fi
-  fi
 }
 
 # utility function to patch kubernetes resources

--- a/tests/e2e/config/scripts/looping-test/dump_cluster.sh
+++ b/tests/e2e/config/scripts/looping-test/dump_cluster.sh
@@ -4,10 +4,15 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+INCLUDE_CRDS=true
 
 if [ -z "$1" ] ; then
   echo "Please provide directory to place resource dump"
   exit 1
+fi
+
+if [ -n "$2" ] ; then
+  INCLUDE_CRDS=$2
 fi
 
 mkdir -p "$1"
@@ -16,13 +21,13 @@ touch default.txt kube-node-lease.txt kube-public.txt kube-system.txt
 cd "$SCRIPT_DIR"
 
 echo "retrieving default resources"
-"${SCRIPT_DIR}"/get_resources.sh default > "$1"/default.txt
+"${SCRIPT_DIR}"/get_resources.sh default "${INCLUDE_CRDS}" > "$1"/default.txt
 
 echo "retrieving kube-node-lease resources"
-"${SCRIPT_DIR}"/get_resources.sh kube-node-lease > "$1"/kube-node-lease.txt
+"${SCRIPT_DIR}"/get_resources.sh kube-node-lease "${INCLUDE_CRDS}" > "$1"/kube-node-lease.txt
 
 echo "retrieving kube-public resources"
-"${SCRIPT_DIR}"/get_resources.sh kube-public > "$1"/kube-public.txt
+"${SCRIPT_DIR}"/get_resources.sh kube-public "${INCLUDE_CRDS}" > "$1"/kube-public.txt
 
 echo "retrieving kube-system resources"
-"${SCRIPT_DIR}"/get_resources.sh kube-system > "$1"/kube-system.txt
+"${SCRIPT_DIR}"/get_resources.sh kube-system "${INCLUDE_CRDS}" > "$1"/kube-system.txt

--- a/tests/e2e/config/scripts/looping-test/get_resources.sh
+++ b/tests/e2e/config/scripts/looping-test/get_resources.sh
@@ -6,14 +6,25 @@
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 TYPES=`cat $SCRIPT_DIR/types.txt`
+INCLUDE_CRDS=true
 
-if [ -z $1 ] ; then
+if [ -z "$1" ] ; then
   echo "Please provide a namespace."
   exit 1
 fi
 
+if [ -n "$2" ] ; then
+  INCLUDE_CRDS=$2
+fi
+
 namespace=$1
 for type in ${TYPES} ; do
+  if [ "$type" == "CustomResourceDefinition"  ] || [ "$type" == "APIService" ]; then
+    if [ "${INCLUDE_CRDS}" != true ]; then
+      continue
+    fi
+  fi
+
   echo "kubectl get ${type} --show-kind -o custom-columns=NAME:.metadata.name,KIND:.kind --ignore-not-found --no-headers -n ${namespace}"
   kubectl get "${type}" --show-kind -o custom-columns=NAME:.metadata.name,KIND:.kind --ignore-not-found --no-headers -n ${namespace}
   echo


### PR DESCRIPTION
# Description

Made changes to Verrazzano uninstall so that application resources are only deleted if they are in a namespace which is managed by Verrazzano. Namespaces indicate that they are Verrazzano managed via a namespace label: "verrazzano-managed=true". Additionally, no application CRD's are deleted regardless of namespace.

Fixes VZ-2872

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ x] Added or updated unit tests for any new functions I added
- [x ] Added or updated integration tests if appropriate
- [x ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
