### PR TITLE
VZ-2909: Multi-cluster acceptance test improvements

### DIFF
--- a/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
+++ b/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
@@ -5,12 +5,13 @@ package mcnshelidon
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
-	"github.com/verrazzano/verrazzano/tests/e2e/multicluster/examples"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"os"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/multicluster/examples"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
 const (
@@ -28,104 +29,104 @@ var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
 // failed indicates whether any of the tests has failed
 var failed = false
 
-var _ = ginkgo.AfterEach(func() {
+var _ = AfterEach(func() {
 	// set failed to true if any of the tests has failed
-	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+	failed = failed || CurrentGinkgoTestDescription().Failed
 })
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	// deploy the VerrazzanoProject
 	err := examples.DeployHelloHelidonProject(adminKubeconfig, sourceDir)
 	if err != nil {
-		ginkgo.Fail(err.Error())
+		Fail(err.Error())
 	}
 	// wait for the namespace to be created on the cluster before deploying app
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		return examples.HelidonNamespaceExists(adminKubeconfig, sourceDir)
-	}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, pollingInterval).Should(BeTrue())
 
 	err = examples.DeployHelloHelidonApp(adminKubeconfig, sourceDir)
 	if err != nil {
-		ginkgo.Fail(err.Error())
+		Fail(err.Error())
 	}
 })
 
-var _ = ginkgo.Describe("Multi-cluster verify delete ns of hello-helidon-ns", func() {
-	ginkgo.Context("Admin Cluster", func() {
+var _ = Describe("Multi-cluster verify delete ns of hello-helidon-ns", func() {
+	Context("Admin Cluster", func() {
 		// GIVEN an admin cluster and at least one managed cluster
 		// WHEN the example application has been deployed to the admin cluster
 		// THEN expect that the multi-cluster resources have been created on the admin cluster
-		ginkgo.It("Has multi cluster resources", func() {
-			gomega.Eventually(func() bool {
+		It("Has multi cluster resources", func() {
+			Eventually(func() bool {
 				return examples.VerifyMCResources(adminKubeconfig, true, false, testNamespace)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 		// GIVEN an admin cluster
 		// WHEN the multi-cluster example application has been created on admin cluster but not placed there
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
-		ginkgo.It("Does not have application placed", func() {
-			gomega.Consistently(func() bool {
+		It("Does not have application placed", func() {
+			Consistently(func() bool {
 				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
-			}, consistentlyDuration, pollingInterval).Should(gomega.BeTrue())
+			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
 
-	ginkgo.Context("Managed Cluster", func() {
+	Context("Managed Cluster", func() {
 		// GIVEN an admin cluster and at least one managed cluster
 		// WHEN the example application has been deployed to the admin cluster
 		// THEN expect that the multi-cluster resources have been created on the managed cluster
-		ginkgo.It("Has multi cluster resources", func() {
-			gomega.Eventually(func() bool {
+		It("Has multi cluster resources", func() {
+			Eventually(func() bool {
 				return examples.VerifyMCResources(managedKubeconfig, false, true, testNamespace)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 		// GIVEN an admin cluster and at least one managed cluster
 		// WHEN the multi-cluster example application has been created on admin cluster and placed in managed cluster
 		// THEN expect that the app is deployed to the managed cluster
-		ginkgo.It("Has application placed", func() {
-			gomega.Eventually(func() bool {
+		It("Has application placed", func() {
+			Eventually(func() bool {
 				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 
-	ginkgo.Context("Delete resources", func() {
-		ginkgo.It("Delete project on admin cluster", func() {
+	Context("Delete resources", func() {
+		It("Delete project on admin cluster", func() {
 			err := deleteProject(adminKubeconfig)
 			if err != nil {
-				ginkgo.Fail(err.Error())
+				Fail(err.Error())
 			}
 		})
 
-		ginkgo.It("Delete test namespace on managed cluster", func() {
+		It("Delete test namespace on managed cluster", func() {
 			if err := pkg.DeleteNamespaceInCluster(testNamespace, managedKubeconfig); err != nil {
-				ginkgo.Fail(fmt.Sprintf("Could not delete %s namespace in managed cluster: %v\n", examples.TestNamespace, err))
+				Fail(fmt.Sprintf("Could not delete %s namespace in managed cluster: %v\n", examples.TestNamespace, err))
 			}
 		})
 
-		ginkgo.It("Verify deletion on managed cluster", func() {
-			gomega.Eventually(func() bool {
+		It("Verify deletion on managed cluster", func() {
+			Eventually(func() bool {
 				return examples.VerifyHelloHelidonDeletedInManagedCluster(managedKubeconfig, testNamespace, testProjectName)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Delete test namespace on admin cluster", func() {
+		It("Delete test namespace on admin cluster", func() {
 			if err := pkg.DeleteNamespaceInCluster(testNamespace, adminKubeconfig); err != nil {
-				ginkgo.Fail(fmt.Sprintf("Could not delete %s namespace in admin cluster: %v\n", examples.TestNamespace, err))
+				Fail(fmt.Sprintf("Could not delete %s namespace in admin cluster: %v\n", examples.TestNamespace, err))
 			}
 		})
 
-		ginkgo.It("Verify deletion on admin cluster", func() {
-			gomega.Eventually(func() bool {
+		It("Verify deletion on admin cluster", func() {
+			Eventually(func() bool {
 				return examples.VerifyHelloHelidonDeletedAdminCluster(adminKubeconfig, false, testNamespace, testProjectName)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 	})
 })
 
-var _ = ginkgo.AfterSuite(func() {
+var _ = AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
@@ -133,7 +134,7 @@ var _ = ginkgo.AfterSuite(func() {
 
 func deleteProject(kubeconfigPath string) error {
 	if err := pkg.DeleteResourceFromFileInCluster("examples/multicluster/hello-helidon-ns/verrazzano-project.yaml", kubeconfigPath); err != nil {
-		return fmt.Errorf("Failed to delete hello-helidon project resource: %v", err)
+		return fmt.Errorf("failed to delete hello-helidon project resource: %v", err)
 	}
 	return nil
 }

--- a/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
+++ b/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
@@ -37,19 +37,18 @@ var _ = AfterEach(func() {
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
 	// deploy the VerrazzanoProject
-	err := examples.DeployHelloHelidonProject(adminKubeconfig, sourceDir)
-	if err != nil {
-		Fail(err.Error())
-	}
+	Eventually(func() error {
+		return examples.DeployHelloHelidonProject(adminKubeconfig, sourceDir)
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
+
 	// wait for the namespace to be created on the cluster before deploying app
 	Eventually(func() bool {
 		return examples.HelidonNamespaceExists(adminKubeconfig, sourceDir)
 	}, waitTimeout, pollingInterval).Should(BeTrue())
 
-	err = examples.DeployHelloHelidonApp(adminKubeconfig, sourceDir)
-	if err != nil {
-		Fail(err.Error())
-	}
+	Eventually(func() error {
+		return examples.DeployHelloHelidonApp(adminKubeconfig, sourceDir)
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 })
 
 var _ = Describe("Multi-cluster verify delete ns of hello-helidon-ns", func() {
@@ -93,16 +92,15 @@ var _ = Describe("Multi-cluster verify delete ns of hello-helidon-ns", func() {
 
 	Context("Delete resources", func() {
 		It("Delete project on admin cluster", func() {
-			err := deleteProject(adminKubeconfig)
-			if err != nil {
-				Fail(err.Error())
-			}
+			Eventually(func() error {
+				return deleteProject(adminKubeconfig)
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
 		It("Delete test namespace on managed cluster", func() {
-			if err := pkg.DeleteNamespaceInCluster(testNamespace, managedKubeconfig); err != nil {
-				Fail(fmt.Sprintf("Could not delete %s namespace in managed cluster: %v\n", examples.TestNamespace, err))
-			}
+			Eventually(func() error {
+				return pkg.DeleteNamespaceInCluster(testNamespace, managedKubeconfig)
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
 		It("Verify deletion on managed cluster", func() {
@@ -112,9 +110,9 @@ var _ = Describe("Multi-cluster verify delete ns of hello-helidon-ns", func() {
 		})
 
 		It("Delete test namespace on admin cluster", func() {
-			if err := pkg.DeleteNamespaceInCluster(testNamespace, adminKubeconfig); err != nil {
-				Fail(fmt.Sprintf("Could not delete %s namespace in admin cluster: %v\n", examples.TestNamespace, err))
-			}
+			Eventually(func() error {
+				return pkg.DeleteNamespaceInCluster(testNamespace, adminKubeconfig)
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
 		It("Verify deletion on admin cluster", func() {

--- a/tests/e2e/multicluster/verify-api/verify_api_test.go
+++ b/tests/e2e/multicluster/verify-api/verify_api_test.go
@@ -8,11 +8,17 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	waitTimeout     = 3 * time.Minute
+	pollingInterval = 10 * time.Second
 )
 
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
@@ -25,28 +31,52 @@ var _ = Describe("Multi Cluster Verify API", func() {
 		})
 
 		It("Get and Validate Verrazzano resource for admin cluster", func() {
-			api, err := pkg.GetAPIEndpoint(adminKubeconfig)
-			Expect(err).ShouldNot(HaveOccurred(), "Erroring getting API endpoint")
-			response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos")
-			validateVerrazzanosResponse(response, err)
+			Eventually(func() bool {
+				api, err := pkg.GetAPIEndpoint(adminKubeconfig)
+				if err != nil {
+					pkg.Log(pkg.Error, fmt.Sprintf("Error fetching api: %v", err))
+					return false
+				}
+				response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos")
+				return isValidVerrazzanosResponse(response, err)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		It("Get and Validate Verrazzano resource for managed cluster", func() {
-			api, err := pkg.GetAPIEndpoint(adminKubeconfig)
-			Expect(err).ShouldNot(HaveOccurred(), "Erroring getting API endpoint")
-			response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos?cluster=" + managedClusterName)
-			validateVerrazzanosResponse(response, err)
+			Eventually(func() bool {
+				api, err := pkg.GetAPIEndpoint(adminKubeconfig)
+				if err != nil {
+					pkg.Log(pkg.Error, fmt.Sprintf("Error fetching api: %v", err))
+					return false
+				}
+				response, err := api.Get("apis/install.verrazzano.io/v1alpha1/verrazzanos?cluster=" + managedClusterName)
+				return isValidVerrazzanosResponse(response, err)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 })
 
-func validateVerrazzanosResponse(response *pkg.HTTPResponse, err error) {
-	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("Error fetching verrazzanos from api, error: %v", err))
-	Expect(response.StatusCode).To(Equal(http.StatusOK), fmt.Sprintf("Error fetching verrazzanos from api, response: %v", response))
+func isValidVerrazzanosResponse(response *pkg.HTTPResponse, err error) bool {
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error fetching verrazzanos from api, error: %v", err))
+		return false
+	}
+	if response.StatusCode != http.StatusOK {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error fetching verrazzanos from api, response: %v", response))
+		return false
+	}
 
 	verrazzanos := v1alpha1.VerrazzanoList{}
 	err = json.Unmarshal(response.Body, &verrazzanos)
-	Expect(err).To(BeNil(), fmt.Sprintf("Invalid response for verrazzanos from api, error: %v", err))
-	Expect(len(verrazzanos.Items)).To(Equal(1), fmt.Sprintf("Invalid number of verrazzanos from api, error: %v", err))
-	Expect(verrazzanos.Items[0].Spec.Version).To(Not(BeNil()), fmt.Sprintf("Invalid version of  verrazzano resource from api, error: %v", err))
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Unable to unmarshal api response, error: %v", err))
+		return false
+	}
+
+	if len(verrazzanos.Items) != 1 {
+		pkg.Log(pkg.Error, fmt.Sprintf("Expected to find 1 verrazzanos but found: %d", len(verrazzanos.Items)))
+		return false
+	}
+
+	return true
 }

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -42,10 +42,9 @@ var _ = Describe("Multi Cluster Verify Register", func() {
 
 		It("admin cluster create VerrazzanoProject", func() {
 			// create a project
-			err := pkg.CreateOrUpdateResourceFromFile(fmt.Sprintf("testdata/multicluster/verrazzanoproject-%s.yaml", managedClusterName))
-			if err != nil {
-				Fail(fmt.Sprintf("Failed to create VerrazzanoProject: %v", err))
-			}
+			Eventually(func() error {
+				return pkg.CreateOrUpdateResourceFromFile(fmt.Sprintf("testdata/multicluster/verrazzanoproject-%s.yaml", managedClusterName))
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 			Eventually(func() bool {
 				return findVerrazzanoProject(fmt.Sprintf("project-%s", managedClusterName))

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -21,10 +21,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-
-	"github.com/onsi/ginkgo"
 )
 
 const waitTimeout = 10 * time.Minute
@@ -35,88 +34,88 @@ const verrazzanoSystemNamespace = "verrazzano-system"
 
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 
-var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
-	ginkgo.Context("Admin Cluster", func() {
-		ginkgo.BeforeEach(func() {
+var _ = Describe("Multi Cluster Verify Register", func() {
+	Context("Admin Cluster", func() {
+		BeforeEach(func() {
 			os.Setenv("TEST_KUBECONFIG", os.Getenv("ADMIN_KUBECONFIG"))
 		})
 
-		ginkgo.It("admin cluster create VerrazzanoProject", func() {
+		It("admin cluster create VerrazzanoProject", func() {
 			// create a project
 			err := pkg.CreateOrUpdateResourceFromFile(fmt.Sprintf("testdata/multicluster/verrazzanoproject-%s.yaml", managedClusterName))
 			if err != nil {
-				ginkgo.Fail(fmt.Sprintf("Failed to create VerrazzanoProject: %v", err))
+				Fail(fmt.Sprintf("Failed to create VerrazzanoProject: %v", err))
 			}
 
-			gomega.Eventually(func() bool {
+			Eventually(func() bool {
 				return findVerrazzanoProject(fmt.Sprintf("project-%s", managedClusterName))
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find VerrazzanoProject")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find VerrazzanoProject")
 		})
 
-		ginkgo.It("admin cluster has the expected VerrazzanoManagedCluster", func() {
-			gomega.Eventually(func() bool {
+		It("admin cluster has the expected VerrazzanoManagedCluster", func() {
+			Eventually(func() bool {
 				vmc, err := pkg.GetVerrazzanoManagedClusterClientset().ClustersV1alpha1().VerrazzanoManagedClusters(multiclusterNamespace).Get(context.TODO(), managedClusterName, metav1.GetOptions{})
 				return err == nil &&
 					vmcStatusReady(vmc) &&
 					vmc.Status.LastAgentConnectTime != nil &&
 					vmc.Status.LastAgentConnectTime.After(time.Now().Add(-30*time.Minute))
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find VerrazzanoManagedCluster")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find VerrazzanoManagedCluster")
 		})
 
-		ginkgo.It("admin cluster has the expected ServiceAccounts and ClusterRoleBindings", func() {
+		It("admin cluster has the expected ServiceAccounts and ClusterRoleBindings", func() {
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesServiceAccountExist(multiclusterNamespace, fmt.Sprintf("verrazzano-cluster-%s", managedClusterName))
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find ServiceAccount")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find ServiceAccount")
 				},
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesClusterRoleBindingExist(fmt.Sprintf("verrazzano-cluster-%s", managedClusterName))
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find ClusterRoleBinding")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find ClusterRoleBinding")
 				},
 			)
 		})
 
-		ginkgo.It("admin cluster has the expected secrets", func() {
+		It("admin cluster has the expected secrets", func() {
 			pkg.Concurrently(
 				func() {
 					secretName := fmt.Sprintf("verrazzano-cluster-%s-manifest", managedClusterName)
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return findSecret(multiclusterNamespace, secretName)
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find secret "+secretName)
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find secret "+secretName)
 				},
 				func() {
 					secretName := fmt.Sprintf("verrazzano-cluster-%s-agent", managedClusterName)
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return findSecret(multiclusterNamespace, secretName)
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find secret "+secretName)
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find secret "+secretName)
 				},
 				func() {
 					secretName := fmt.Sprintf("verrazzano-cluster-%s-registration", managedClusterName)
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return findSecret(multiclusterNamespace, secretName)
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find secret "+secretName)
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find secret "+secretName)
 				},
 			)
 		})
 
-		ginkgo.It("admin cluster has the expected system logs from admin and managed cluster", func() {
+		It("admin cluster has the expected system logs from admin and managed cluster", func() {
 			verrazzanoIndex := "verrazzano-namespace-verrazzano-system"
 			systemdIndex := "verrazzano-systemd-journal"
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return pkg.FindLog(verrazzanoIndex,
 							[]pkg.Match{
 								{Key: "kubernetes.container_name", Value: "verrazzano-application-operator"},
 								{Key: "cluster_name.keyword", Value: constants.DefaultClusterName}},
 							[]pkg.Match{
 								{Key: "cluster_name", Value: "managed1"}})
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a systemd log record")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a systemd log record")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return pkg.FindLog(systemdIndex,
 							[]pkg.Match{
 								{Key: "tag", Value: "systemd"},
@@ -124,20 +123,20 @@ var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
 								{Key: "SYSTEMD_UNIT", Value: "kubelet.service"}},
 							[]pkg.Match{
 								{Key: "cluster_name", Value: "managed1"}})
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a systemd log record")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a systemd log record")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return pkg.FindLog(verrazzanoIndex,
 							[]pkg.Match{
 								{Key: "kubernetes.container_name", Value: "verrazzano-application-operator"},
 								{Key: "cluster_name.keyword", Value: "managed1"}},
 							[]pkg.Match{
 								{Key: "cluster_name.keyword", Value: constants.DefaultClusterName}})
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a systemd log record")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a systemd log record")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return pkg.FindLog(systemdIndex,
 							[]pkg.Match{
 								{Key: "tag", Value: "systemd"},
@@ -145,72 +144,72 @@ var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
 								{Key: "SYSTEMD_UNIT.keyword", Value: "kubelet.service"}},
 							[]pkg.Match{
 								{Key: "cluster_name", Value: constants.DefaultClusterName}})
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a systemd log record")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a systemd log record")
 				},
 			)
 		})
 
-		ginkgo.It("admin cluster has the expected metrics from managed cluster", func() {
-			gomega.Eventually(func() bool {
+		It("admin cluster has the expected metrics from managed cluster", func() {
+			Eventually(func() bool {
 				return pkg.MetricsExist("up", "managed_cluster", managedClusterName)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find a metrics from managed cluster")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a metrics from managed cluster")
 		})
 	})
 
-	ginkgo.Context("Managed Cluster", func() {
-		ginkgo.BeforeEach(func() {
+	Context("Managed Cluster", func() {
+		BeforeEach(func() {
 			os.Setenv("TEST_KUBECONFIG", os.Getenv("MANAGED_KUBECONFIG"))
 		})
 
-		ginkgo.It("managed cluster has the expected secrets", func() {
+		It("managed cluster has the expected secrets", func() {
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return findSecret(verrazzanoSystemNamespace, "verrazzano-cluster-agent")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find secret verrazzano-cluster-agent")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find secret verrazzano-cluster-agent")
 				},
 				func() {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return findSecret(verrazzanoSystemNamespace, "verrazzano-cluster-registration")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find secret verrazzano-cluster-registration")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find secret verrazzano-cluster-registration")
 				},
 			)
 		})
 
-		ginkgo.It("managed cluster has the expected VerrazzanoProject", func() {
-			gomega.Eventually(func() bool {
+		It("managed cluster has the expected VerrazzanoProject", func() {
+			Eventually(func() bool {
 				return findVerrazzanoProject(fmt.Sprintf("project-%s", managedClusterName))
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find VerrazzanoProject")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find VerrazzanoProject")
 		})
 
-		ginkgo.It("managed cluster has the expected namespace", func() {
-			gomega.Eventually(func() bool {
+		It("managed cluster has the expected namespace", func() {
+			Eventually(func() bool {
 				return findNamespace(fmt.Sprintf("ns-%s", managedClusterName))
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find namespace")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find namespace")
 		})
 
-		ginkgo.It("managed cluster has the expected RoleBindings", func() {
+		It("managed cluster has the expected RoleBindings", func() {
 			namespace := fmt.Sprintf("ns-%s", managedClusterName)
 			pkg.Concurrently(
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "verrazzano-project-admin", "User", "test-user")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding verrazzano-project-admin")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find role binding verrazzano-project-admin")
 				},
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "admin", "User", "test-user")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding admin")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find role binding admin")
 				},
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "verrazzano-project-monitor", "Group", "test-viewers")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding verrazzano-project-monitor")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find role binding verrazzano-project-monitor")
 				},
 				func() {
-					gomega.Eventually(func() (bool, error) {
+					Eventually(func() (bool, error) {
 						return pkg.DoesRoleBindingContainSubject(namespace, "view", "Group", "test-viewers")
-					}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "Expected to find role binding view")
+					}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find role binding view")
 				},
 			)
 		})
@@ -218,9 +217,9 @@ var _ = ginkgo.Describe("Multi Cluster Verify Register", func() {
 })
 
 func vmcStatusReady(vmc *vmcv1alpha1.VerrazzanoManagedCluster) bool {
-	fmt.Printf("VMC %s has %d status conditions\n", vmc.Name, len(vmc.Status.Conditions))
+	pkg.Log(pkg.Info, fmt.Sprintf("VMC %s has %d status conditions\n", vmc.Name, len(vmc.Status.Conditions)))
 	for _, cond := range vmc.Status.Conditions {
-		fmt.Printf("VMC %s has status condition %s with value %s with message %s\n", vmc.Name, cond.Type, cond.Status, cond.Message)
+		pkg.Log(pkg.Info, fmt.Sprintf("VMC %s has status condition %s with value %s with message %s\n", vmc.Name, cond.Type, cond.Status, cond.Message))
 		if cond.Type == vmcv1alpha1.ConditionReady && cond.Status == v1.ConditionTrue {
 			return true
 		}
@@ -230,14 +229,19 @@ func vmcStatusReady(vmc *vmcv1alpha1.VerrazzanoManagedCluster) bool {
 
 func findSecret(namespace, name string) bool {
 	s, err := pkg.GetSecret(namespace, name)
-	return s != nil && err == nil
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get secret %s in namespace %s with error: %v", name, namespace, err))
+		return false
+	}
+	return s != nil
 }
 
 func findNamespace(namespace string) bool {
 	ns, err := pkg.GetNamespace(namespace)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			ginkgo.Fail(fmt.Sprintf("Failed to get namespace %s with error: %v", namespace, err))
+			pkg.Log(pkg.Error, fmt.Sprintf("Failed to get namespace %s with error: %v", namespace, err))
+			return false
 		}
 		pkg.Log(pkg.Info, fmt.Sprintf("The namespace %q is not found", namespace))
 		return false
@@ -257,7 +261,7 @@ func findNamespace(namespace string) bool {
 func findVerrazzanoProject(projectName string) bool {
 	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("TEST_KUBECONFIG"))
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to build config from %s with error: %v", os.Getenv("TEST_KUBECONFIG"), err))
+		Fail(fmt.Sprintf("Failed to build config from %s with error: %v", os.Getenv("TEST_KUBECONFIG"), err))
 	}
 
 	scheme := runtime.NewScheme()
@@ -266,13 +270,14 @@ func findVerrazzanoProject(projectName string) bool {
 
 	clustersClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to get clusters client with error: %v", err))
+		Fail(fmt.Sprintf("Failed to get clusters client with error: %v", err))
 	}
 
 	projectList := clustersv1alpha1.VerrazzanoProjectList{}
 	err = clustersClient.List(context.TODO(), &projectList, &client.ListOptions{Namespace: constants.VerrazzanoMultiClusterNamespace})
 	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to list VerrazzanoProject with error: %v", err))
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to list VerrazzanoProject with error: %v", err))
+		return false
 	}
 	for _, item := range projectList.Items {
 		if item.Name == projectName && item.Namespace == multiclusterNamespace {

--- a/tests/e2e/multicluster/verify-resources/verify_resources_test.go
+++ b/tests/e2e/multicluster/verify-resources/verify_resources_test.go
@@ -9,22 +9,22 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
 const shortWaitTimeout = 3 * time.Minute
 const shortPollInterval = 5 * time.Second
 
-var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
-	ginkgo.Context("Admin Cluster", func() {
-		ginkgo.BeforeEach(func() {
+var _ = Describe("Multi Cluster Verify Resources", func() {
+	Context("Admin Cluster", func() {
+		BeforeEach(func() {
 			os.Setenv("TEST_KUBECONFIG", os.Getenv("ADMIN_KUBECONFIG"))
 		})
 
-		ginkgo.It("Create VerrazzanoProject with invalid content", func() {
-			gomega.Eventually(func() bool {
+		It("Create VerrazzanoProject with invalid content", func() {
+			Eventually(func() bool {
 				err := pkg.CreateOrUpdateResourceFromFile("testdata/multicluster/verrazzanoproject-placement-clusters-invalid.yaml")
 				if err == nil {
 					pkg.Log(pkg.Error, "Expected an error creating invalid VerrazzanoProject")
@@ -35,11 +35,11 @@ var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
 					return false
 				}
 				return true
-			}, shortWaitTimeout, shortPollInterval).Should(gomega.BeTrue(), "Expected VerrazzanoProject validation error")
+			}, shortWaitTimeout, shortPollInterval).Should(BeTrue(), "Expected VerrazzanoProject validation error")
 		})
 
-		ginkgo.It("Create MultiClusterSecret with invalid content", func() {
-			gomega.Eventually(func() bool {
+		It("Create MultiClusterSecret with invalid content", func() {
+			Eventually(func() bool {
 				err := pkg.CreateOrUpdateResourceFromFile("testdata/multicluster/multicluster_secret_placement_clusters_invalid.yaml")
 				if err == nil {
 					pkg.Log(pkg.Error, "Expected an error creating invalid resource")
@@ -50,11 +50,11 @@ var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
 					return false
 				}
 				return true
-			}, shortWaitTimeout, shortPollInterval).Should(gomega.BeTrue(), "Expected a resource validation error")
+			}, shortWaitTimeout, shortPollInterval).Should(BeTrue(), "Expected a resource validation error")
 		})
 
-		ginkgo.It("Create MultiClusterConfigmap with invalid content", func() {
-			gomega.Eventually(func() bool {
+		It("Create MultiClusterConfigmap with invalid content", func() {
+			Eventually(func() bool {
 				err := pkg.CreateOrUpdateResourceFromFile("testdata/multicluster/multicluster_configmap_placement_clusters_invalid.yaml")
 				if err == nil {
 					pkg.Log(pkg.Error, "Expected an error creating invalid resource")
@@ -65,11 +65,11 @@ var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
 					return false
 				}
 				return true
-			}, shortWaitTimeout, shortPollInterval).Should(gomega.BeTrue(), "Expected a resource validation error")
+			}, shortWaitTimeout, shortPollInterval).Should(BeTrue(), "Expected a resource validation error")
 		})
 
-		ginkgo.It("Create MultiClusterComponent with invalid content", func() {
-			gomega.Eventually(func() bool {
+		It("Create MultiClusterComponent with invalid content", func() {
+			Eventually(func() bool {
 				err := pkg.CreateOrUpdateResourceFromFile("testdata/multicluster/multicluster_component_placement_clusters_invalid.yaml")
 				if err == nil {
 					pkg.Log(pkg.Error, "Expected an error creating invalid resource")
@@ -80,11 +80,11 @@ var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
 					return false
 				}
 				return true
-			}, shortWaitTimeout, shortPollInterval).Should(gomega.BeTrue(), "Expected a resource validation error")
+			}, shortWaitTimeout, shortPollInterval).Should(BeTrue(), "Expected a resource validation error")
 		})
 
-		ginkgo.It("Create MultiClusterApplicationConfiguration with invalid content", func() {
-			gomega.Eventually(func() bool {
+		It("Create MultiClusterApplicationConfiguration with invalid content", func() {
+			Eventually(func() bool {
 				err := pkg.CreateOrUpdateResourceFromFile("testdata/multicluster/multicluster_appconf_placement_clusters_invalid.yaml")
 				if err == nil {
 					pkg.Log(pkg.Error, "Expected an error creating invalid resource")
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Multi Cluster Verify Resources", func() {
 					return false
 				}
 				return true
-			}, shortWaitTimeout, shortPollInterval).Should(gomega.BeTrue(), "Expected a resource validation error")
+			}, shortWaitTimeout, shortPollInterval).Should(BeTrue(), "Expected a resource validation error")
 		})
 
 	})


### PR DESCRIPTION
# Description

This PR improves the multi-cluster acceptance tests by:

1. Adding `Eventually` around calls that should be retried
2. Removing `Expect` calls inside `Eventually`
3. Use dot imports for gomega and ginkgo

Additional acceptance tests will be improved in subsequent PRs.

Implements VZ-2909

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
