### PR TITLE
Honor APP_OPERATOR_IMAGE override during upgrade if present

### DIFF
--- a/platform-operator/controllers/verrazzano/component/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/app_operator.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package component
+
+import (
+	"os"
+
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"go.uber.org/zap"
+)
+
+// appendApplicationOperatorOverrides Honor the APP_OPERATOR_IMAGE env var if set; this allows an explicit override
+// of the verrazzano-application-operator image when set.
+func appendApplicationOperatorOverrides(_ *zap.SugaredLogger, _ string, _ string, _ string, kvs []keyValue) ([]keyValue, error) {
+	envImageOverride := os.Getenv(constants.VerrazzanoAppOperatorImageEnvVar)
+	if len(envImageOverride) == 0 {
+		return nil, nil
+	}
+	kvs = append(kvs, keyValue{
+		key:   "image",
+		value: envImageOverride,
+	})
+	return kvs, nil
+}

--- a/platform-operator/controllers/verrazzano/component/app_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/app_operator_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package component
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+)
+
+// TestAppendAppOperatorOverrides tests the Keycloak override for the theme images
+// GIVEN an env override for the app operator image
+//  WHEN I call appendApplicationOperatorOverrides
+//  THEN the "image" key is set with the image override.
+func TestAppendAppOperatorOverrides(t *testing.T) {
+	assert := assert.New(t)
+
+	customImage := "myreg.io/myrepo/v8o/verrazzano-application-operator-dev:local-20210707002801-b7449154"
+
+	kvs, err := appendApplicationOperatorOverrides(nil, "", "", "", nil)
+	assert.NoError(err, "appendApplicationOperatorOverrides returned an error ")
+	assert.Len(kvs, 0, "appendApplicationOperatorOverrides returned an unexpected number of key:value pairs")
+
+	os.Setenv(constants.VerrazzanoAppOperatorImageEnvVar, customImage)
+	defer os.Unsetenv(constants.RegistryOverrideEnvVar)
+
+	SetUnitTestBomFilePath(sampleTestBomFilePath)
+	kvs, err = appendApplicationOperatorOverrides(nil, "", "", "", nil)
+	assert.NoError(err, "appendApplicationOperatorOverrides returned an error ")
+	assert.Len(kvs, 1, "appendApplicationOperatorOverrides returned wrong number of key:value pairs")
+	assert.Equalf("image", kvs[0].key, "Did not get expected image key")
+	assert.Equalf(customImage, kvs[0].value, "Did not get expected image value")
+}

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -119,6 +119,7 @@ func GetComponents() []Component {
 			chartNamespace:          constants.VerrazzanoSystemNamespace,
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "verrazzano-application-operator-values.yaml"),
+			appendOverridesFunc:     appendApplicationOperatorOverrides,
 		},
 		helmComponent{
 			releaseName:             "mysql",


### PR DESCRIPTION

# Description

The APP_OPERATOR_IMAGE is used to override the application operator image when using a dev build, but isn't being honored for the upgrade scenario.  This change addresses that; if set, the app operator helm upgrade is appended with an image override for that value.

This mimics what we do at install time in the scripts.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
