### PR TITLE
VZ-2909: More acceptance test improvements

### DIFF
--- a/tests/e2e/ingress/console/console_ingress_test.go
+++ b/tests/e2e/ingress/console/console_ingress_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -22,11 +22,11 @@ const (
 	namespace            = "console-ingress"
 )
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	deployApplication()
 })
 
-var _ = ginkgo.AfterSuite(func() {
+var _ = AfterSuite(func() {
 	undeployApplication()
 })
 
@@ -40,118 +40,118 @@ func deployApplication() {
 	regPass := pkg.GetRequiredEnvVarOrFail("OCR_CREDS_PSW")
 
 	// Wait for namespace to finish deletion possibly from a prior run.
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(namespace)
 		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 
 	pkg.Log(pkg.Info, "Create namespace")
-	gomega.Eventually(func() (*v1.Namespace, error) {
+	Eventually(func() (*v1.Namespace, error) {
 		nsLabels := map[string]string{
 			"verrazzano-managed": "true",
 			"istio-injection":    "enabled"}
 		return pkg.CreateNamespace(namespace, nsLabels)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create Docker repository secret")
-	gomega.Eventually(func() (*v1.Secret, error) {
+	Eventually(func() (*v1.Secret, error) {
 		return pkg.CreateDockerSecret(namespace, "tododomain-repo-credentials", regServ, regUser, regPass)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create WebLogic credentials secret")
-	gomega.Eventually(func() (*v1.Secret, error) {
+	Eventually(func() (*v1.Secret, error) {
 		return pkg.CreateCredentialsSecret(namespace, "tododomain-weblogic-credentials", wlsUser, wlsPass, nil)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create database credentials secret")
-	gomega.Eventually(func() (*v1.Secret, error) {
+	Eventually(func() (*v1.Secret, error) {
 		return pkg.CreateCredentialsSecret(namespace, "tododomain-jdbc-tododb", wlsUser, dbPass, map[string]string{"weblogic.domainUID": "cidomain"})
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create encryption credentials secret")
-	gomega.Eventually(func() (*v1.Secret, error) {
+	Eventually(func() (*v1.Secret, error) {
 		return pkg.CreatePasswordSecret(namespace, "tododomain-runtime-encrypt-secret", wlsPass, map[string]string{"weblogic.domainUID": "cidomain"})
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create component resources")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/ingress/console/components.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create application resources")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/ingress/console/application.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 }
 
 func undeployApplication() {
 	pkg.Log(pkg.Info, "Delete application")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/ingress/console/application.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete components")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/ingress/console/components.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(namespace)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(namespace)
 		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 }
 
-var _ = ginkgo.Describe("Verify application.", func() {
+var _ = Describe("Verify application.", func() {
 
-	ginkgo.Context("Deployment.", func() {
+	Context("Deployment.", func() {
 		// GIVEN the app is deployed
 		// WHEN the running pods are checked
 		// THEN the adminserver and mysql pods should be found running
-		ginkgo.It("Verify 'cidomain-adminserver' and 'mysql' pods are running", func() {
-			gomega.Eventually(func() bool {
+		It("Verify 'cidomain-adminserver' and 'mysql' pods are running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(namespace, []string{"mysql", "cidomain-adminserver"})
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 	})
 
-	ginkgo.Context("Ingress.", func() {
+	Context("Ingress.", func() {
 		var host = ""
 		// Get the host from the Istio gateway resource.
 		// GIVEN the Istio gateway for the test namespace
 		// WHEN GetHostnameFromGateway is called
 		// THEN return the host name found in the gateway.
-		ginkgo.It("Get host from gateway.", func() {
-			gomega.Eventually(func() string {
+		It("Get host from gateway.", func() {
+			Eventually(func() string {
 				host = pkg.GetHostnameFromGateway(namespace, "")
 				return host
-			}, shortWaitTimeout, shortPollingInterval).Should(gomega.Not(gomega.BeEmpty()))
+			}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
 		})
 
 		// Verify the console endpoint is working.
 		// GIVEN the app is deployed
 		// WHEN the console endpoint is accessed
 		// THEN the expected results should be returned
-		ginkgo.It("Verify '/console' endpoint is working.", func() {
-			gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+		It("Verify '/console' endpoint is working.", func() {
+			Eventually(func() (*pkg.HTTPResponse, error) {
 				url := fmt.Sprintf("https://%s/console/login/LoginForm.jsp", host)
 				return pkg.GetWebPage(url, host)
-			}, shortWaitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(200), pkg.BodyContains("Oracle WebLogic Server Administration Console")))
+			}, shortWaitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(200), pkg.BodyContains("Oracle WebLogic Server Administration Console")))
 		})
 
 		// Verify the application REST endpoint is working.
 		// GIVEN the app is deployed
 		// WHEN the REST endpoint is accessed
 		// THEN the expected results should be returned
-		ginkgo.It("Verify '/todo/rest/items' REST endpoint is working.", func() {
-			gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+		It("Verify '/todo/rest/items' REST endpoint is working.", func() {
+			Eventually(func() (*pkg.HTTPResponse, error) {
 				url := fmt.Sprintf("https://%s/todo/rest/items", host)
 				return pkg.GetWebPage(url, host)
-			}, shortWaitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(200), pkg.BodyContains("["), pkg.BodyContains("]")))
+			}, shortWaitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(200), pkg.BodyContains("["), pkg.BodyContains("]")))
 		})
 	})
 })

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -59,29 +60,29 @@ func deployFooApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in foo namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	if _, err := pkg.CreateNamespace(fooNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
-	}
+	gomega.Eventually(func() (*v1.Namespace, error) {
+		return pkg.CreateNamespace(fooNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"})
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy application resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy Sleep component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy BackEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy FrontEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 }
 
@@ -89,29 +90,29 @@ func deployBarApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in bar namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	if _, err := pkg.CreateNamespace(barNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"}); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
-	}
+	gomega.Eventually(func() (*v1.Namespace, error) {
+		return pkg.CreateNamespace(barNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"})
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy application resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy Sleep component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy BackEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy FrontEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 }
 
@@ -119,123 +120,135 @@ func deployNoIstioApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in NoIstio namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	if _, err := pkg.CreateNamespace(noIstioNamespace, map[string]string{"verrazzano-managed": "true"}); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create namespace: %v", err))
-	}
+	gomega.Eventually(func() (*v1.Namespace, error) {
+		return pkg.CreateNamespace(noIstioNamespace, map[string]string{"verrazzano-managed": "true"})
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy application resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy Sleep component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy BackEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	if err := pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml"); err != nil {
-		ginkgo.Fail(fmt.Sprintf("Failed to create AuthPolicy FrontEnd component resources: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 }
 
 func undeployFooApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in foo namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the application: %v", err))
-	}
-	pkg.Log(pkg.Info, "Delete components")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
-	if noPods := pkg.PodsNotRunning(fooNamespace, expectedPodsFoo); noPods != true {
-		pkg.Log(pkg.Error, fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
-	}
+	pkg.Log(pkg.Info, "Delete components")
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
+	notRunning := pkg.PodsNotRunning(fooNamespace, expectedPodsFoo)
+	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	if err := pkg.DeleteNamespace(fooNamespace); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteNamespace(fooNamespace)
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
 	gomega.Eventually(func() bool {
-		ns, err := pkg.GetNamespace(fooNamespace)
-		return ns == nil && err != nil && errors.IsNotFound(err)
-	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+		_, err := pkg.GetNamespace(fooNamespace)
+		return err != nil && errors.IsNotFound(err)
+	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 }
 
 func undeployBarApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in bar namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the application: %v", err))
-	}
-	pkg.Log(pkg.Info, "Delete components")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
-	if noPods := pkg.PodsNotRunning(barNamespace, expectedPodsBar); noPods != true {
-		pkg.Log(pkg.Error, fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
-	}
+	pkg.Log(pkg.Info, "Delete components")
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
+	notRunning := pkg.PodsNotRunning(barNamespace, expectedPodsBar)
+	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	if err := pkg.DeleteNamespace(barNamespace); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteNamespace(barNamespace)
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
 	gomega.Eventually(func() bool {
-		ns, err := pkg.GetNamespace(barNamespace)
-		return ns == nil && err != nil && errors.IsNotFound(err)
-	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+		_, err := pkg.GetNamespace(barNamespace)
+		return err != nil && errors.IsNotFound(err)
+	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 }
 
 func undeployNoIstioApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in noistio namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the application: %v", err))
-	}
-	pkg.Log(pkg.Info, "Delete components")
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
-	if err := pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml"); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the component: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
-	if noPods := pkg.PodsNotRunning(noIstioNamespace, expectedPodsBar); noPods != true {
-		pkg.Log(pkg.Error, fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
-	}
+	pkg.Log(pkg.Info, "Delete components")
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() error {
+		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml")
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
+	notRunning := pkg.PodsNotRunning(noIstioNamespace, expectedPodsBar)
+	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	if err := pkg.DeleteNamespace(noIstioNamespace); err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to delete the namespace: %v", err))
-	}
+	gomega.Eventually(func() error {
+		return pkg.DeleteNamespace(noIstioNamespace)
+	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
 	gomega.Eventually(func() bool {
-		ns, err := pkg.GetNamespace(noIstioNamespace)
-		return ns == nil && err != nil && errors.IsNotFound(err)
-	}, 3*time.Minute, 15*time.Second).Should(gomega.BeFalse())
+		_, err := pkg.GetNamespace(noIstioNamespace)
+		return err != nil && errors.IsNotFound(err)
+	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 }
 
 var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,18 +36,18 @@ var waitTimeout = 10 * time.Minute
 var pollingInterval = 30 * time.Second
 var shortPollingInterval = 10 * time.Second
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	deployFooApplication()
 	deployBarApplication()
 	deployNoIstioApplication()
 })
 
 var failed = false
-var _ = ginkgo.AfterEach(func() {
-	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
 })
 
-var _ = ginkgo.AfterSuite(func() {
+var _ = AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
@@ -60,29 +60,29 @@ func deployFooApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in foo namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	gomega.Eventually(func() (*v1.Namespace, error) {
+	Eventually(func() (*v1.Namespace, error) {
 		return pkg.CreateNamespace(fooNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"})
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, waitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 }
 
@@ -90,29 +90,29 @@ func deployBarApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in bar namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	gomega.Eventually(func() (*v1.Namespace, error) {
+	Eventually(func() (*v1.Namespace, error) {
 		return pkg.CreateNamespace(barNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"})
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, waitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 }
 
@@ -120,224 +120,224 @@ func deployNoIstioApplication() {
 	pkg.Log(pkg.Info, "Deploy Auth Policy Application in NoIstio namespace")
 
 	pkg.Log(pkg.Info, "Create namespace")
-	gomega.Eventually(func() (*v1.Namespace, error) {
+	Eventually(func() (*v1.Namespace, error) {
 		return pkg.CreateNamespace(noIstioNamespace, map[string]string{"verrazzano-managed": "true"})
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
+	}, waitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	pkg.Log(pkg.Info, "Create AuthPolicy App resources")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Sleep Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Backend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create Frontend Component")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 }
 
 func undeployFooApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in foo namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete components")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
 	notRunning := pkg.PodsNotRunning(fooNamespace, expectedPodsFoo)
-	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
+	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(fooNamespace)
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(fooNamespace)
 		return err != nil && errors.IsNotFound(err)
-	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, shortPollingInterval).Should(BeTrue())
 }
 
 func undeployBarApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in bar namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete components")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
 	notRunning := pkg.PodsNotRunning(barNamespace, expectedPodsBar)
-	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
+	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(barNamespace)
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(barNamespace)
 		return err != nil && errors.IsNotFound(err)
-	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, shortPollingInterval).Should(BeTrue())
 }
 
 func undeployNoIstioApplication() {
 	pkg.Log(pkg.Info, "Undeploy Auth Policy Application in noistio namespace")
 	pkg.Log(pkg.Info, "Delete application")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/istio-securitytest-app.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete components")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/sleep-comp.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-backend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml")
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
 	notRunning := pkg.PodsNotRunning(noIstioNamespace, expectedPodsBar)
-	gomega.Expect(notRunning).Should(gomega.BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
+	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(noIstioNamespace)
-	}, waitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(noIstioNamespace)
 		return err != nil && errors.IsNotFound(err)
-	}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, shortPollingInterval).Should(BeTrue())
 }
 
-var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
+var _ = Describe("Verify AuthPolicy Applications", func() {
 	// Verify springboot-workload pod is running
 	// GIVEN springboot app is deployed
 	// WHEN the component and appconfig are created
 	// THEN the expected pod must be running in the test namespace
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(fooNamespace, expectedPodsFoo)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
 		})
 	})
 
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(barNamespace, expectedPodsBar)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
 		})
 	})
 
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(noIstioNamespace, expectedPodsBar)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
 		})
 	})
 
 	var fooHost = ""
-	ginkgo.It("Get foo host from gateway.", func() {
-		gomega.Eventually(func() string {
+	It("Get foo host from gateway.", func() {
+		Eventually(func() string {
 			fooHost = pkg.GetHostnameFromGateway(fooNamespace, "")
 			return fooHost
-		}, waitTimeout, shortPollingInterval).Should(gomega.Not(gomega.BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", fooNamespace))
+		}, waitTimeout, shortPollingInterval).Should(Not(BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", fooNamespace))
 	})
 
 	var barHost = ""
-	ginkgo.It("Get bar host from gateway.", func() {
-		gomega.Eventually(func() string {
+	It("Get bar host from gateway.", func() {
+		Eventually(func() string {
 			barHost = pkg.GetHostnameFromGateway(barNamespace, "")
 			return barHost
-		}, waitTimeout, shortPollingInterval).Should(gomega.Not(gomega.BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", barNamespace))
+		}, waitTimeout, shortPollingInterval).Should(Not(BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", barNamespace))
 	})
 
 	var noIstioHost = ""
-	ginkgo.It("Get noistio host from gateway.", func() {
-		gomega.Eventually(func() string {
+	It("Get noistio host from gateway.", func() {
+		Eventually(func() string {
 			noIstioHost = pkg.GetHostnameFromGateway(noIstioNamespace, "")
 			return noIstioHost
-		}, waitTimeout, shortPollingInterval).Should(gomega.Not(gomega.BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", noIstioNamespace))
+		}, waitTimeout, shortPollingInterval).Should(Not(BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", noIstioNamespace))
 	})
 
 	// Verify application in namespace foo is working
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	ginkgo.It("Verify welcome page of Foo Spring Boot FrontEnd is working.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify welcome page of Foo Spring Boot FrontEnd is working.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/", fooHost)
 			return pkg.GetWebPage(url, fooHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
 	})
 
 	// Verify application in namespace bar is working
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	ginkgo.It("Verify welcome page of Bar Spring Boot FrontEnd is working.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify welcome page of Bar Spring Boot FrontEnd is working.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/", barHost)
 			return pkg.GetWebPage(url, barHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
 	})
 
 	// Verify application in namespace bar is working
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	ginkgo.It("Verify welcome page of NoIstio Spring Boot FrontEnd is working.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify welcome page of NoIstio Spring Boot FrontEnd is working.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", noIstioHost))
 			url := fmt.Sprintf("https://%s/", noIstioHost)
 			return pkg.GetWebPage(url, noIstioHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyContains("Greetings from Verrazzano Enterprise Container Platform")))
 	})
 
 	// Verify Frontend can call Backend in foo
@@ -345,12 +345,12 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	ginkgo.It("Verify Foo Frontend can call Foo Backend.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify Foo Frontend can call Foo Backend.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.foo:8080/", fooHost)
 			return pkg.GetWebPage(url, fooHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
 	})
 
 	// Verify Frontend can call Backend in bar
@@ -358,12 +358,12 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	ginkgo.It("Verify Bar Frontend can call Bar Backend.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify Bar Frontend can call Bar Backend.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.bar:8080/", barHost)
 			return pkg.GetWebPage(url, barHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
 	})
 
 	// Verify Foo Frontend can't call bar Backend
@@ -371,12 +371,12 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	ginkgo.It("Verify Foo Frontend canNOT call Bar Backend.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify Foo Frontend canNOT call Bar Backend.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.bar:8080/", fooHost)
 			return pkg.GetWebPage(url, fooHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("403")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("403")))
 	})
 
 	// Verify Bar Frontend can't call Foo Backend
@@ -384,12 +384,12 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	ginkgo.It("Verify Bar Frontend canNOT call Foo Backend.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify Bar Frontend canNOT call Foo Backend.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.foo:8080/", barHost)
 			return pkg.GetWebPage(url, barHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("403")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("403")))
 	})
 
 	// Verify Bar Frontend can call NoIstio Backend
@@ -397,12 +397,12 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	ginkgo.It("Verify Bar Frontend can call NoIstio Backend.", func() {
-		gomega.Eventually(func() (*pkg.HTTPResponse, error) {
+	It("Verify Bar Frontend can call NoIstio Backend.", func() {
+		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.noistio:8080/", barHost)
 			return pkg.GetWebPage(url, barHost)
-		}, waitTimeout, shortPollingInterval).Should(gomega.And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
+		}, waitTimeout, shortPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyEquals("200")))
 	})
 
 	// Verify noistio Frontend can't call bar Backend
@@ -412,8 +412,8 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 	// the http code is returned in the response body and captured in content
 	// *** This call should fail for a 500 because Non-Istio can't call Istio when MTLS is STRICT
 	// If this should fail because the call succeeded, verify that peerauthentication exists in istio-system and is set to STRICT
-	ginkgo.It("Verify NoIstio Frontend canNOT call Bar Backend.", func() {
-		gomega.Eventually(func() bool {
+	It("Verify NoIstio Frontend canNOT call Bar Backend.", func() {
+		Eventually(func() bool {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", noIstioHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.bar:8080/", noIstioHost)
 
@@ -441,37 +441,37 @@ var _ = ginkgo.Describe("Verify AuthPolicy Applications", func() {
 				return false
 			}
 			return resp.StatusCode == 500
-		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify NoIstio Frontend canNOT call Bar Backend")
+		}, waitTimeout, shortPollingInterval).Should(BeTrue(), "Failed to Verify NoIstio Frontend canNOT call Bar Backend")
 	})
 
 })
 
-var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
+var _ = Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// Verify springboot-workload pod is running
 	// GIVEN springboot app is deployed
 	// WHEN the component and appconfig are created
 	// THEN the expected pod must be running in the test namespace
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(fooNamespace, expectedPodsFoo)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
 		})
 	})
 
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(barNamespace, expectedPodsBar)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
 		})
 	})
 
-	ginkgo.Context("Deployment.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(func() bool {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(noIstioNamespace, expectedPodsBar)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
+			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
 		})
 	})
 
@@ -479,8 +479,8 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// GIVEN that springboot deployed to Istio namespace foo
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the https protocol
-	ginkgo.It("Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping.", func() {
-		gomega.Eventually(func() bool {
+	It("Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping.", func() {
+		Eventually(func() bool {
 			var httpsFound bool = false
 
 			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
@@ -510,15 +510,15 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				}
 			}
 			return httpsFound == true
-		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping")
+		}, waitTimeout, shortPollingInterval).Should(BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping")
 	})
 
 	// Verify That Generated Prometheus Scrape Targets for authpolicy-appconf_default_bar_springboot-frontend is using https for scraping
 	// GIVEN that springboot deployed to Istio namespace bar
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the https protocol
-	ginkgo.It("Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping.", func() {
-		gomega.Eventually(func() bool {
+	It("Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping.", func() {
+		Eventually(func() bool {
 			var httpsFound bool = false
 
 			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
@@ -548,15 +548,15 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				}
 			}
 			return httpsFound == true
-		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping")
+		}, waitTimeout, shortPollingInterval).Should(BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping")
 	})
 
 	// Verify That Generated Prometheus Scrape Targets for authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping
 	// GIVEN that springboot deployed to namespace noistio
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the http protocol
-	ginkgo.It("Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping.", func() {
-		gomega.Eventually(func() bool {
+	It("Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping.", func() {
+		Eventually(func() bool {
 			var httpsNotFound bool = true
 
 			configMap, err := pkg.GetConfigMap(vmiPromConfigName, verrazzanoNamespace)
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				}
 			}
 			return httpsNotFound == true
-		}, waitTimeout, shortPollingInterval).Should(gomega.BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping")
+		}, waitTimeout, shortPollingInterval).Should(BeTrue(), "Failed to Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping")
 	})
 
 })

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-
-	"github.com/onsi/ginkgo"
 )
 
 const (
@@ -77,13 +76,13 @@ var excludePodsIstio = []string{
 	"istiod",
 }
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	present := false
 	adminKubeConfig, present = os.LookupEnv("ADMIN_KUBECONFIG")
 	isManagedClusterProfile = pkg.IsManagedClusterProfile()
 	if isManagedClusterProfile {
 		if !present {
-			ginkgo.Fail(fmt.Sprintln("Environment variable ADMIN_KUBECONFIG is required to run the test"))
+			Fail(fmt.Sprintln("Environment variable ADMIN_KUBECONFIG is required to run the test"))
 		}
 	} else {
 		// Include the namespace keycloak for the validation for admin cluster and single cluster installation
@@ -92,66 +91,66 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 })
 
-var _ = ginkgo.Describe("Prometheus Metrics", func() {
+var _ = Describe("Prometheus Metrics", func() {
 	// Query Prometheus for the sample metrics from the default scraping jobs
-	var _ = ginkgo.Describe("for the system components", func() {
-		ginkgo.It("Verify sample NGINX metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+	var _ = Describe("for the system components", func() {
+		It("Verify sample NGINX metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				kv := map[string]string{
 					controllerNamespace: ingressNginxNamespace,
 					appK8SIOInstance:    ingressController,
 				}
 				return metricsContainLabels(ingressControllerSuccess, kv)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify sample Container Advisor metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+		It("Verify sample Container Advisor metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				return metricsContainLabels(containerStartTimeSeconds, map[string]string{})
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify sample Node Exporter metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+		It("Verify sample Node Exporter metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				kv := map[string]string{
 					job: nodeExporter,
 				}
 				return metricsContainLabels(cpuSecondsTotal, kv)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify sample mesh metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+		It("Verify sample mesh metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				kv := map[string]string{
 					namespace: verrazzanoSystemNamespace,
 				}
 				return metricsContainLabels(totolTCPConnectionsOpened, kv)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify sample istiod metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+		It("Verify sample istiod metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				kv := map[string]string{
 					app: istiod,
 					job: pilot,
 				}
 				return metricsContainLabels(sidecarInjectionRequests, kv)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify sample metrics can be queried from Prometheus", func() {
-			gomega.Eventually(func() bool {
+		It("Verify sample metrics can be queried from Prometheus", func() {
+			Eventually(func() bool {
 				kv := map[string]string{
 					job: prometheus,
 				}
 				return metricsContainLabels(prometheusTargetIntervalLength, kv)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
-		ginkgo.It("Verify envoy stats", func() {
-			gomega.Eventually(func() bool {
+		It("Verify envoy stats", func() {
+			Eventually(func() bool {
 				return verifyEnvoyStats(envoyStatsRecentLookups)
-			}, longWaitTimeout, longPollingInterval).Should(gomega.BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 	})
 })

--- a/tests/e2e/registry/registry_test.go
+++ b/tests/e2e/registry/registry_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,9 +45,9 @@ var listOfNamespaces = []string{
 	"verrazzano-system",
 }
 
-var _ = ginkgo.Describe("Private Registry Verification",
+var _ = Describe("Private Registry Verification",
 	func() {
-		ginkgo.It("All the pods in the cluster have the expected registry URLs",
+		It("All the pods in the cluster have the expected registry URLs",
 			func() {
 				var pod corev1.Pod
 				imagePrefix := "ghcr.io"
@@ -59,21 +59,21 @@ var _ = ginkgo.Describe("Private Registry Verification",
 				}
 				for i, ns := range listOfNamespaces {
 					var pods *corev1.PodList
-					gomega.Eventually(func() (*corev1.PodList, error) {
+					Eventually(func() (*corev1.PodList, error) {
 						var err error
 						pods, err = pkg.ListPods(ns, metav1.ListOptions{})
 						return pods, err
-					}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil(), fmt.Sprintf("Error listing pods in the namespace %s", ns))
+					}, waitTimeout, pollingInterval).ShouldNot(BeNil(), fmt.Sprintf("Error listing pods in the namespace %s", ns))
 
 					for j := range pods.Items {
 						pod = pods.Items[j]
 						pkg.Log(pkg.Info, fmt.Sprintf("%d. Validating the registry url prefix for pod: %s in namespace: %s", i, pod.Name, ns))
 						for k := range pod.Spec.Containers {
-							gomega.Expect(strings.HasPrefix(pod.Spec.Containers[k].Image, imagePrefix)).To(gomega.BeTrue(),
+							Expect(strings.HasPrefix(pod.Spec.Containers[k].Image, imagePrefix)).To(BeTrue(),
 								fmt.Sprintf("FAIL: The image for the pod %s in containers, doesn't starts with expected registry URL prefix %s", pod.Name, registry))
 						}
 						for k := range pod.Spec.InitContainers {
-							gomega.Expect(strings.HasPrefix(pod.Spec.InitContainers[k].Image, imagePrefix)).To(gomega.BeTrue(),
+							Expect(strings.HasPrefix(pod.Spec.InitContainers[k].Image, imagePrefix)).To(BeTrue(),
 								fmt.Sprintf("FAIL: The image for the pod %s in initContainers, doesn't starts with expected registry URL prefix %s", pod.Name, registry))
 						}
 					}

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
@@ -43,41 +43,41 @@ var installLog = os.Getenv("VERRAZZANO_INSTALL_LOG")
 var kubeConfigFromEnv = os.Getenv("KUBECONFIG")
 var totalClusters, present = os.LookupEnv("CLUSTER_COUNT")
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	if len(installLogDir) < 1 {
-		ginkgo.Fail("Specify the directory containing the install logs using environment variable VERRAZZANO_INSTALL_LOGS_DIR")
+		Fail("Specify the directory containing the install logs using environment variable VERRAZZANO_INSTALL_LOGS_DIR")
 	}
 	if len(installLog) < 1 {
-		ginkgo.Fail("Specify the install log file using environment variable VERRAZZANO_INSTALL_LOG")
+		Fail("Specify the install log file using environment variable VERRAZZANO_INSTALL_LOG")
 	}
 })
 
-var _ = ginkgo.Describe("Verify Verrazzano install scripts", func() {
+var _ = Describe("Verify Verrazzano install scripts", func() {
 
-	ginkgo.Context("Verify Console URLs in the install log", func() {
+	Context("Verify Console URLs in the install log", func() {
 		clusterCount, _ := strconv.Atoi(totalClusters)
 		if present && clusterCount > 0 {
-			ginkgo.It("Verify the expected console URLs are there in the install logs for the managed cluster(s)", func() {
+			It("Verify the expected console URLs are there in the install logs for the managed cluster(s)", func() {
 				// Validation for admin cluster
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return validateConsoleUrlsCluster(kubeConfigFromEnv, "cluster-1")
-				}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+				}, waitTimeout, pollingInterval).Should(BeTrue())
 
 				// Validation for managed clusters
 				for i := 2; i <= clusterCount; i++ {
 					installLogForCluster := filepath.FromSlash(installLogDir + "/cluster-" + strconv.Itoa(i) + "/" + installLog)
 					consoleUrls, err := getConsoleURLsFromLog(installLogForCluster)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "There is an error getting console URLs from the log file")
+					Expect(err).ShouldNot(HaveOccurred(), "There is an error getting console URLs from the log file")
 
 					// By default, install logs of the managed clusters do not contain the console URLs
-					gomega.Expect(consoleUrls).To(gomega.BeEmpty())
+					Expect(consoleUrls).To(BeEmpty())
 				}
 			})
 		} else {
-			ginkgo.It("Verify the expected console URLs are there in the install log", func() {
-				gomega.Eventually(func() bool {
+			It("Verify the expected console URLs are there in the install log", func() {
+				Eventually(func() bool {
 					return validateConsoleUrlsCluster(kubeConfigFromEnv, "")
-				}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		}
 	})

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -67,11 +67,10 @@ var _ = ginkgo.Describe("Verify Verrazzano install scripts", func() {
 				for i := 2; i <= clusterCount; i++ {
 					installLogForCluster := filepath.FromSlash(installLogDir + "/cluster-" + strconv.Itoa(i) + "/" + installLog)
 					consoleUrls, err := getConsoleURLsFromLog(installLogForCluster)
-					if err != nil {
-						gomega.Expect(false).To(gomega.BeTrue(), "There is an error getting console URLs from the log file ", err)
-					}
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "There is an error getting console URLs from the log file")
+
 					// By default, install logs of the managed clusters do not contain the console URLs
-					gomega.Expect(len(consoleUrls) == 0).To(gomega.BeTrue())
+					gomega.Expect(consoleUrls).To(gomega.BeEmpty())
 				}
 			})
 		} else {
@@ -105,14 +104,13 @@ func getConsoleURLsFromLog(installLog string) ([]string, error) {
 	var consoleUrls []string
 	if _, err := os.Stat(installLog); err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println("The value set for installLog doesn't exist.")
-			return consoleUrls, err
+			pkg.Log(pkg.Error, "The value set for installLog doesn't exist.")
 		}
+		return consoleUrls, err
 	}
 	inFile, err := os.Open(installLog)
 
 	if err != nil {
-		fmt.Println("Error reading install log file ", err.Error())
 		return consoleUrls, err
 	}
 	defer inFile.Close()


### PR DESCRIPTION
# Description

This PR improves more of the acceptance tests by:

1. Adding `Eventually` around calls that should be retried
2. Removing `Expect` and `Fail` calls inside `Eventually`
3. Use dot imports for gomega and ginkgo

Note that I put all of the dot import changes into a single commit to make it easier to review the other changes.

Additional acceptance tests will be improved in one last PR.

Implements VZ-2909

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
