### PR TITLE
VZ-2909: Improve remaining acceptance tests

### DIFF
--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -313,6 +313,11 @@ func BodyContains(expected string) types.GomegaMatcher {
 	return gomega.WithTransform(func(response *HTTPResponse) string { return string(response.Body) }, gomega.ContainSubstring(expected))
 }
 
+// BodyDoesNotContain asserts that an HTTPResponse body does not contain a given substring.
+func BodyDoesNotContain(unexpected string) types.GomegaMatcher {
+	return gomega.WithTransform(func(response *HTTPResponse) string { return string(response.Body) }, gomega.Not(gomega.ContainSubstring(unexpected)))
+}
+
 // BodyEquals asserts that an HTTPResponse body equals a given string.
 func BodyEquals(expected string) types.GomegaMatcher {
 	return gomega.WithTransform(func(response *HTTPResponse) string { return string(response.Body) }, gomega.Equal(expected))

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/gomega"
-
-	"github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,31 +34,31 @@ var (
 	pollingInterval = 30 * time.Second
 )
 
-var _ = ginkgo.BeforeSuite(func() {
-	gomega.Eventually(func() (*corev1.Namespace, error) {
+var _ = BeforeSuite(func() {
+	Eventually(func() (*corev1.Namespace, error) {
 		nsLabels := map[string]string{}
 		return pkg.CreateNamespace(testNamespace, nsLabels)
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFile("testdata/security/network-policies/netpol-test.yaml")
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 })
 
 var failed = false
-var _ = ginkgo.AfterEach(func() {
-	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
 })
 
-var _ = ginkgo.AfterSuite(func() {
+var _ = AfterSuite(func() {
 	// undeploy the application here
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/security/network-policies/netpol-test.yaml")
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(testNamespace)
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	if failed {
 		err := pkg.ExecuteClusterDumpWithEnvVarConfig()
@@ -69,161 +68,161 @@ var _ = ginkgo.AfterSuite(func() {
 	}
 })
 
-var _ = ginkgo.Describe("Test Network Policies", func() {
+var _ = Describe("Test Network Policies", func() {
 	// Verify test pod is running
 	// GIVEN netpol-test is deployed
 	// WHEN the pod is created
 	// THEN the expected pod must be running in the test namespace
-	ginkgo.Describe("Verify test pod is running.", func() {
-		ginkgo.It("and waiting for expected pod must be running", func() {
-			gomega.Eventually(func() bool {
+	Describe("Verify test pod is running.", func() {
+		It("and waiting for expected pod must be running", func() {
+			Eventually(func() bool {
 				return pkg.PodsRunning(testNamespace, expectedPods)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 
 	// GIVEN a Verrazzano deployment
 	// WHEN access is attempted between pods within the ingress rules of the Verrazzano network policies
 	// THEN the attempted access should succeed
-	ginkgo.It("Test NetworkPolicy Rules", func() {
+	It("Test NetworkPolicy Rules", func() {
 		pkg.Concurrently(
 			func() {
 				pkg.Log(pkg.Info, "Test rancher ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test rancher ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test rancher-webhook ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher-webhook"}}, "cattle-system", 9443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test rancher-webhook ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test rancher-webhook ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test cert-manager ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "cert-manager"}}, "cert-manager", 9402, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test cert-manager ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test cert-manager ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test ingress-nginx-controller ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", 443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", 80, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", ingressControllerMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-controller ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test ingress-nginx-default-backend ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "default-backend"}}, "ingress-nginx", 8080, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-default-backend ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-default-backend ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "default-backend"}}, "ingress-nginx", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-default-backend ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test ingress-nginx-default-backend ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test istiod-verrazzano-system ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istiod"}}, "istio-system", 15012, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test istiod-verrazzano-system ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test istiod-verrazzano-system ingress failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istiod"}}, "istio-system", istiodMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test istiod-verrazzano-system ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test istiod-verrazzano-system ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test keycloak ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test keycloak ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test keycloak ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test keycloak ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test keycloak ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test mysql ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "mysql"}}, "keycloak", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test mysql ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test mysql ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-platform-operator ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator"}}, "verrazzano-install", 9443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-api ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-api"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-api ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-api ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-api"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-api ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-api ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-application-operator ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator"}}, "verrazzano-system", 9443, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test verrazzano-console ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-console"}}, "verrazzano-system", 8000, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-console ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-console ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-console"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test verrazzano-console ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-console ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test node-exporter ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"verrazzano.io/namespace": "monitoring"}}, "monitoring", nodeExporterMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"verrazzano.io/namespace": "monitoring"}}, "monitoring", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test istio-ingressgateway ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istio-ingressgateway"}}, "istio-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test istio-ingressgateway ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test istio-ingressgateway ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test istio-egressgateway ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istio-egressgateway"}}, "istio-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test istio-egressgateway ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test istio-egressgateway ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-es-master ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-kibana"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 9200, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "fluentd"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"verrazzano.binding": "system"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 9200, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-es-master ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-grafana ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-grafana ingress rules failed: reason = %s", err))
 
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-kibana ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-kibana"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-kibana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-kibana ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-kibana"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-kibana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-kibana ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test vmi-system-prometheus ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "ingress-controller"}}, "ingress-nginx", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", 8775, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test vmi-system-prometheus ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test vmi-system-prometheus ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test node-exporter ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-exporter"}}, "monitoring", 9100, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test node-exporter ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Test weblogic-operator ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", metav1.LabelSelector{MatchLabels: map[string]string{"app": "weblogic-operator"}}, "verrazzano-system", envoyStatsMetricsPort, true)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Test weblogic-operator ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test weblogic-operator ingress rules failed: reason = %s", err))
 			},
 		)
 	})
@@ -231,83 +230,83 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 	// GIVEN a Verrazzano deployment
 	// WHEN access is attempted between pods that violate the rules of the Verrazzano network policies
 	// THEN the attempted access should fail
-	ginkgo.It("Negative Test NetworkPolicy Rules", func() {
+	It("Negative Test NetworkPolicy Rules", func() {
 		pkg.Concurrently(
 			func() {
 				pkg.Log(pkg.Info, "Negative test rancher ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "rancher"}}, "cattle-system", 80, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test  rancher ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test  rancher ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test cert-manager ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "cert-manager"}}, "cert-manager", 9402, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test cert-manager ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test cert-manager ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test ingress-nginx-controller ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "controller"}}, "ingress-nginx", 80, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test ingress-nginx-controller ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test ingress-nginx-controller ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test ingress-nginx-default-backend ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/component": "default-backend"}}, "ingress-nginx", 8080, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test ingress-nginx-default-backend ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test ingress-nginx-default-backend ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative testistio-egressgateway ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istio-egressgateway"}}, "istio-system", 6443, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative testistio-egressgateway ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative testistio-egressgateway ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative testistio-ingressgateway ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istio-ingressgateway"}}, "istio-system", 6443, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative testistio-ingressgateway ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative testistio-ingressgateway ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test istiod-verrazzano-system ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "istiod"}}, "istio-system", 15012, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test istiod-verrazzano-system ingress failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test istiod-verrazzano-system ingress failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test keycloak ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test keycloak ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test keycloak ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "keycloak"}}, "keycloak", 8080, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test keycloak ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test keycloak ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test verrazzano-api ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-api"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test verrazzano-api ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test verrazzano-api ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test verrazzano-console ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-console"}}, "verrazzano-system", 8000, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test verrazzano-console ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test verrazzano-console ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test vmi-system-es-master ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 9200, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
 				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-es-master"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-es-master ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test vmi-system-grafana ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-grafana"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-grafana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-grafana ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test vmi-system-kibana ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-kibana"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-kibana ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-kibana ingress rules failed: reason = %s", err))
 			},
 			func() {
 				pkg.Log(pkg.Info, "Negative test vmi-system-prometheus ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "system-prometheus"}}, "verrazzano-system", 8775, false)
-				gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-prometheus ingress rules failed: reason = %s", err))
+				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Negative test vmi-system-prometheus ingress rules failed: reason = %s", err))
 			},
 		)
 	})
@@ -317,20 +316,20 @@ var _ = ginkgo.Describe("Test Network Policies", func() {
 func testAccess(fromSelector metav1.LabelSelector, fromNamespace string, toSelector metav1.LabelSelector, toNamespace string, port int, expectAccess bool) error {
 	// get the FROM pod
 	var pods []corev1.Pod
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		var err error
 		pods, err = pkg.GetPodsFromSelector(&fromSelector, fromNamespace)
 		return err
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	if len(pods) > 0 {
 		fromPod := pods[0]
 		// get the TO pod
-		gomega.Eventually(func() error {
+		Eventually(func() error {
 			var err error
 			pods, err = pkg.GetPodsFromSelector(&toSelector, toNamespace)
 			return err
-		}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+		}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 		if len(pods) > 0 {
 			toPod := pods[0]

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -9,8 +9,8 @@ import (
 
 	"strings"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
@@ -31,310 +31,310 @@ const (
 	impersonateVerb    = "impersonate"
 )
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	pkg.Log(pkg.Info, "Create namespace")
-	gomega.Eventually(func() (*corev1.Namespace, error) {
+	Eventually(func() (*corev1.Namespace, error) {
 		return pkg.CreateNamespace(rbacTestNamespace, map[string]string{"verrazzano-managed": "true", "istio-injection": "enabled"})
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 })
 
 var failed = false
-var _ = ginkgo.AfterEach(func() {
-	failed = failed || ginkgo.CurrentGinkgoTestDescription().Failed
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
 })
 
-var _ = ginkgo.AfterSuite(func() {
+var _ = AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
 
 	pkg.Log(pkg.Info, "Delete namespace")
-	gomega.Eventually(func() error {
+	Eventually(func() error {
 		return pkg.DeleteNamespace(rbacTestNamespace)
-	}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		_, err := pkg.GetNamespace(rbacTestNamespace)
 		return err != nil && errors.IsNotFound(err)
-	}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, pollingInterval).Should(BeTrue())
 })
 
-var _ = ginkgo.Describe("Test RBAC Permission", func() {
-	ginkgo.Context("for user with role verrazzano-project-admin", func() {
+var _ = Describe("Test RBAC Permission", func() {
+	Context("for user with role verrazzano-project-admin", func() {
 
-		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+		It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL Authorization on user list pods: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Create RoleBinding Admin for verrazzano-project-admin", func() {
+		It("Create RoleBinding Admin for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-admin")
-			gomega.Eventually(func() error {
+			Eventually(func() error {
 				return pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "admin-binding", "admin")
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
-		ginkgo.It("Verify RoleBinding Admin for verrazzano-project-admin", func() {
+		It("Verify RoleBinding Admin for verrazzano-project-admin", func() {
 			verifyRoleBindingExists("admin-binding")
 		})
 
-		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+		It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectAdmin, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+		It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectAdmin, verrazzanoSystemNS, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in verrazzano-system namespace: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+		It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+		It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+		It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
 		})
 
-		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+		It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
 		})
 
-		ginkgo.It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
+		It("Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin")
-			gomega.Eventually(func() error {
+			Eventually(func() error {
 				return pkg.CreateRoleBinding(v80ProjectAdmin, rbacTestNamespace, "verrazzano-project-admin-binding", "verrazzano-project-admin")
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
-		ginkgo.It("Verify RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
+		It("Verify RoleBinding verrazzano-project-admin-binding for verrazzano-project-admin", func() {
 			verifyRoleBindingExists("verrazzano-project-admin-binding")
 		})
 
-		ginkgo.It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
+		It("Succeed create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user create ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+		It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Succeed create OAM Components in namespace rbactest", func() {
+		It("Succeed create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user create OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user create OAM Components. Timeout Expired")
 		})
 
-		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+		It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectAdmin, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components. Timeout Expired")
 		})
 
 	})
 })
 
-var _ = ginkgo.Describe("Test RBAC Permission", func() {
-	ginkgo.Context("for user with role verrazzano-project-monitor", func() {
+var _ = Describe("Test RBAC Permission", func() {
+	Context("for user with role verrazzano-project-monitor", func() {
 
-		ginkgo.It("Fail getting Pods in namespace rbactest", func() {
+		It("Fail getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
+		It("Create RoleBinding Admin for verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding Admin for verrazzano-project-monitor")
-			gomega.Eventually(func() error {
+			Eventually(func() error {
 				return pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "monitor-binding", "admin")
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
-		ginkgo.It("Verify RoleBinding monitor-binding for verrazzano-project-monitor", func() {
+		It("Verify RoleBinding monitor-binding for verrazzano-project-monitor", func() {
 			verifyRoleBindingExists("monitor-binding")
 		})
 
-		ginkgo.It("Succeed getting Pods in namespace rbactest", func() {
+		It("Succeed getting Pods in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectMonitor, rbacTestNamespace, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list pods in rbactest namespace: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Fail getting Pods in namespace verrazzano-system", func() {
+		It("Fail getting Pods in namespace verrazzano-system", func() {
 			pkg.Log(pkg.Info, "Can User List Pods in NameSpace verrazzano-system?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanI(v80ProjectMonitor, verrazzanoSystemNS, "list", "pods")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list pods in verrazzano-system namespace: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list pods. Timeout Expired")
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+		It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration. Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Fail list ApplicationConfiguration in namespace rbactest", func() {
+		It("Fail list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list ApplicationConfiguration. Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Fail create OAM Component in namespace rbactest", func() {
+		It("Fail create OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components. Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create OAM Components. Timeout Expired")
 		})
 
-		ginkgo.It("Fail list OAM Component in namespace rbactest", func() {
+		It("Fail list OAM Component in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user list OAM Components. Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user list OAM Components. Timeout Expired")
 		})
 
-		ginkgo.It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
+		It("Create RoleBinding verrazzano-project-monitor-binding for cluster role verrazzano-project-monitor", func() {
 			pkg.Log(pkg.Info, "Create RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor")
-			gomega.Eventually(func() error {
+			Eventually(func() error {
 				return pkg.CreateRoleBinding(v80ProjectMonitor, rbacTestNamespace, "verrazzano-project-monitor-binding", "verrazzano-project-monitor")
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.HaveOccurred())
+			}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		})
 
-		ginkgo.It("Verify RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor", func() {
+		It("Verify RoleBinding verrazzano-project-monitor-binding for verrazzano-project-monitor", func() {
 			verifyRoleBindingExists("verrazzano-project-monitor-binding")
 		})
 
-		ginkgo.It("Fail create ApplicationConfiguration in namespace rbactest", func() {
+		It("Fail create ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create ApplicationConfiguration in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create ApplicationConfiguration. Timeout Expired")
 		})
 
-		ginkgo.It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
+		It("Succeed list ApplicationConfiguration in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list ApplicationConfiguration in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "applicationconfigurations", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list ApplicationConfiguration: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration.  Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list ApplicationConfiguration.  Timeout Expired")
 		})
 
-		ginkgo.It("Fail create OAM Components in namespace rbactest", func() {
+		It("Fail create OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User create OAM Components in NameSpace rbactest?  No")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "create", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should FAIL on user create OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeFalse(), "FAIL: Passed Authorization on user create OAM Components.  Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "FAIL: Passed Authorization on user create OAM Components.  Timeout Expired")
 		})
 
-		ginkgo.It("Succeed list OAM Components in namespace rbactest", func() {
+		It("Succeed list OAM Components in namespace rbactest", func() {
 			pkg.Log(pkg.Info, "Can User list OAM Components in NameSpace rbactest?  Yes")
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				allowed, reason, err := pkg.CanIForAPIGroup(v80ProjectMonitor, rbacTestNamespace, "list", "components", "core.oam.dev")
 				pkg.Log(pkg.Info, fmt.Sprintf("Status: Should SUCCEED on user list OAM Components: Allowed = %t, reason = %s", allowed, reason))
 				return allowed, err
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components.  Timeout Expired")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "FAIL: Did Not Pass Authorization on user list OAM Components.  Timeout Expired")
 		})
 
 	})
 })
 
-var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
-	ginkgo.Context("for serviceaccount verrazzano-api", func() {
+var _ = Describe("Test Verrazzano API Service Account", func() {
+	Context("for serviceaccount verrazzano-api", func() {
 		var serviceAccount *corev1.ServiceAccount
 
-		ginkgo.BeforeEach(func() {
-			gomega.Eventually(func() (*corev1.ServiceAccount, error) {
+		BeforeEach(func() {
+			Eventually(func() (*corev1.ServiceAccount, error) {
 				var err error
 				serviceAccount, err = pkg.GetServiceAccount(verrazzanoSystemNS, verrazzanoAPI)
 				return serviceAccount, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil(), fmt.Sprintf("Failed to get service account %s in namespace %s", verrazzanoAPI, verrazzanoSystemNS))
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil(), fmt.Sprintf("Failed to get service account %s in namespace %s", verrazzanoAPI, verrazzanoSystemNS))
 		})
 
-		ginkgo.It("Validate the secret of the Service Account of Verrazzano API", func() {
+		It("Validate the secret of the Service Account of Verrazzano API", func() {
 			// Get secret for the SA
 			var pods *corev1.PodList
 			saSecret := serviceAccount.Secrets[0]
-			gomega.Eventually(func() (*corev1.PodList, error) {
+			Eventually(func() (*corev1.PodList, error) {
 				var err error
 				clientset := pkg.GetKubernetesClientset()
 				pods, err = pkg.ListPodsInCluster(verrazzanoSystemNS, clientset)
 				return pods, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			secretMatched := false
 			for i := range pods.Items {
@@ -350,17 +350,17 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 					break
 				}
 			}
-			gomega.Expect(secretMatched).To(gomega.BeTrue(), fmt.Sprintf("FAIL: The secret name of ServiceAccount "+
+			Expect(secretMatched).To(BeTrue(), fmt.Sprintf("FAIL: The secret name of ServiceAccount "+
 				"%s differs from the secret obtained from the Verrazzano API pod.", verrazzanoAPI))
 		})
 
-		ginkgo.It("Validate the role binding of the Service Account of Verrazzano API", func() {
+		It("Validate the role binding of the Service Account of Verrazzano API", func() {
 			var bindings *v1.ClusterRoleBindingList
-			gomega.Eventually(func() (*v1.ClusterRoleBindingList, error) {
+			Eventually(func() (*v1.ClusterRoleBindingList, error) {
 				var err error
 				bindings, err = pkg.ListClusterRoleBindings()
 				return bindings, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			saName := serviceAccount.Name
 			bcount := 0
@@ -375,28 +375,28 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 				}
 			}
 			// There should be a single cluster role binding, which references service account of Verrazzano API
-			gomega.Expect(bcount > 1).To(gomega.BeFalse())
-			gomega.Expect(len(rbinding.Subjects) > 1).To(gomega.BeFalse(),
+			Expect(bcount > 1).To(BeFalse())
+			Expect(len(rbinding.Subjects) > 1).To(BeFalse(),
 				fmt.Sprintf("FAIL: There are more than one Subjects for the cluster role binding %s", rbinding.Subjects))
 
 			// There should be a single subject of kind service account in verrazzano-system namespace
-			gomega.Expect(rbinding.Subjects[0].Kind == "ServiceAccount").To(gomega.BeTrue(),
+			Expect(rbinding.Subjects[0].Kind == "ServiceAccount").To(BeTrue(),
 				fmt.Sprintf("FAIL: The KIND for service account %s is different than ServiceAccount.", rbinding.Subjects[0].Kind))
-			gomega.Expect(rbinding.Subjects[0].Namespace == verrazzanoSystemNS).To(gomega.BeTrue(),
+			Expect(rbinding.Subjects[0].Namespace == verrazzanoSystemNS).To(BeTrue(),
 				fmt.Sprintf("FAIL: The namespace for service account %s is different than %s.",
 					rbinding.Subjects[0].Namespace, verrazzanoSystemNS))
 
 			// There should be a single rule with resources - users and groups, and verbs impersonate
 			var crole *v1.ClusterRole
-			gomega.Eventually(func() (*v1.ClusterRole, error) {
+			Eventually(func() (*v1.ClusterRole, error) {
 				return pkg.GetClusterRole(rbinding.RoleRef.Name)
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(len(crole.Rules) == 1).To(gomega.BeTrue(),
+			Expect(len(crole.Rules) == 1).To(BeTrue(),
 				fmt.Sprintf("FAIL: The cluster role %v contains more than one rules.", crole))
 
 			crule := crole.Rules[0]
-			gomega.Expect(len(crule.Resources) == 2).To(gomega.BeTrue(),
+			Expect(len(crule.Resources) == 2).To(BeTrue(),
 				fmt.Sprintf("FAIL: There are more resources than the expected users and groups %s", crule.Resources))
 			res := make(map[string]bool)
 			res["users"] = true
@@ -404,28 +404,28 @@ var _ = ginkgo.Describe("Test Verrazzano API Service Account", func() {
 			for r := range crule.Resources {
 				delete(res, crule.Resources[r])
 			}
-			gomega.Expect(len(res) == 0).To(gomega.BeTrue(),
+			Expect(len(res) == 0).To(BeTrue(),
 				fmt.Sprintf("FAIL: The rule contains resource(s) other than expected users and groups - %s", crule.Resources))
 
 			verbs := crule.Verbs
-			gomega.Expect(len(verbs) == 1).To(gomega.BeTrue(),
+			Expect(len(verbs) == 1).To(BeTrue(),
 				fmt.Sprintf("FAIL: The cluster role %s contains more than one verbs.", crole))
-			gomega.Expect(verbs[0] == impersonateVerb).To(gomega.BeTrue(),
+			Expect(verbs[0] == impersonateVerb).To(BeTrue(),
 				fmt.Sprintf("FAIL: The cluster role %s contains verb other than impersonate.", crole))
 		})
 
-		ginkgo.It("Fail impersonating any other service account", func() {
+		It("Fail impersonating any other service account", func() {
 			pkg.Log(pkg.Info, "Can verrazzano-api service account impersonate any other service account?  No")
 			allowed, reason, err := pkg.CanIForAPIGroupForServiceAccountOrUser("verrazzano-api", "", "impersonate", "serviceaccounts", "core", true, verrazzanoSystemNS)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(allowed).To(gomega.BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on impersonating service accounts: Allowed = %t, reason = %s", allowed, reason))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(allowed).To(BeFalse(), fmt.Sprintf("FAIL: Passed Authorization on impersonating service accounts: Allowed = %t, reason = %s", allowed, reason))
 		})
 
 	})
 })
 
 func verifyRoleBindingExists(name string) {
-	gomega.Eventually(func() bool {
+	Eventually(func() bool {
 		return pkg.DoesRoleBindingExist(name, rbacTestNamespace)
-	}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+	}, waitTimeout, pollingInterval).Should(BeTrue())
 }

--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -389,7 +389,9 @@ var _ = Describe("Test Verrazzano API Service Account", func() {
 			// There should be a single rule with resources - users and groups, and verbs impersonate
 			var crole *v1.ClusterRole
 			Eventually(func() (*v1.ClusterRole, error) {
-				return pkg.GetClusterRole(rbinding.RoleRef.Name)
+				var err error
+				crole, err = pkg.GetClusterRole(rbinding.RoleRef.Name)
+				return crole, err
 			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			Expect(len(crole.Rules) == 1).To(BeTrue(),

--- a/tests/e2e/verify-infra/oam/oam_test.go
+++ b/tests/e2e/verify-infra/oam/oam_test.go
@@ -6,8 +6,8 @@ package oam
 import (
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
@@ -22,16 +22,16 @@ const (
 	verrazzanoSystemNS = "verrazzano-system"
 )
 
-var _ = ginkgo.Describe("Verify OAM Infra.", func() {
-	ginkgo.Describe("Verify verrazzano-application-operator pod is running.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(applicationOperatorPodRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+var _ = Describe("Verify OAM Infra.", func() {
+	Describe("Verify verrazzano-application-operator pod is running.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(applicationOperatorPodRunning, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 
-	ginkgo.Describe("Verify oam-kubernetes-runtime pod is running.", func() {
-		ginkgo.It("and waiting for expected pods must be running", func() {
-			gomega.Eventually(kubernetesRuntimePodRunning, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+	Describe("Verify oam-kubernetes-runtime pod is running.", func() {
+		It("and waiting for expected pods must be running", func() {
+			Eventually(kubernetesRuntimePodRunning, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 })

--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -35,26 +35,17 @@ var _ = Describe("keycloak url test", func() {
 					keycloakURL = fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
 					pkg.Log(pkg.Info, fmt.Sprintf("Found ingress URL: %s", keycloakURL))
 					return nil
-				}, waitTimeout, pollingInterval).Should(BeNil())
+				}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 				Expect(keycloakURL).NotTo(BeEmpty())
 				var httpResponse *pkg.HTTPResponse
 
-				Eventually(func() bool {
+				Eventually(func() (*pkg.HTTPResponse, error) {
 					var err error
 					httpResponse, err = pkg.GetWebPage(keycloakURL, "")
-					if err != nil {
-						pkg.Log(pkg.Error, fmt.Sprintf("Error making get request to url: %s, error: %v", keycloakURL, err))
-						return false
-					}
-					if httpResponse.StatusCode != http.StatusOK {
-						pkg.Log(pkg.Error, fmt.Sprintf("Error making get request to url: %s, response: %v", keycloakURL, httpResponse))
-						return false
-					}
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return httpResponse, err
+				}, waitTimeout, pollingInterval).Should(pkg.HasStatus(http.StatusOK))
 
-				Expect(httpResponse).NotTo(BeNil())
 				Expect(pkg.CheckNoServerHeader(httpResponse)).To(BeTrue(), "Found unexpected server header in response")
 			}
 		})

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -42,25 +42,15 @@ var _ = Describe("rancher url test", func() {
 				Expect(rancherURL).NotTo(BeEmpty())
 				var httpResponse *pkg.HTTPResponse
 
-				Eventually(func() bool {
+				Eventually(func() (*pkg.HTTPResponse, error) {
 					httpClient, err := pkg.GetRancherHTTPClient(kubeconfigPath)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf("Error getting HTTP client: %v", err))
-						return false
+						return nil, err
 					}
-					httpResponse, err = pkg.GetWebPageWithClient(httpClient, rancherURL, "")
-					if err != nil {
-						pkg.Log(pkg.Error, fmt.Sprintf("Error making get request to url: %s, error: %v", rancherURL, err))
-						return false
-					}
-					if httpResponse.StatusCode != http.StatusOK {
-						pkg.Log(pkg.Error, fmt.Sprintf("Error making get request to url: %s, response: %v", rancherURL, httpResponse))
-						return false
-					}
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return pkg.GetWebPageWithClient(httpClient, rancherURL, "")
+				}, waitTimeout, pollingInterval).Should(pkg.HasStatus(http.StatusOK))
 
-				Expect(httpResponse).NotTo(BeNil())
 				Expect(pkg.CheckNoServerHeader(httpResponse)).To(BeTrue(), "Found unexpected server header in response")
 			}
 		})

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -48,7 +48,8 @@ var _ = Describe("rancher url test", func() {
 						pkg.Log(pkg.Error, fmt.Sprintf("Error getting HTTP client: %v", err))
 						return nil, err
 					}
-					return pkg.GetWebPageWithClient(httpClient, rancherURL, "")
+					httpResponse, err = pkg.GetWebPageWithClient(httpClient, rancherURL, "")
+					return httpResponse, err
 				}, waitTimeout, pollingInterval).Should(pkg.HasStatus(http.StatusOK))
 
 				Expect(pkg.CheckNoServerHeader(httpResponse)).To(BeTrue(), "Found unexpected server header in response")

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -78,30 +78,31 @@ var (
 var _ = BeforeSuite(func() {
 	var err error
 
-	vzCRD, err = verrazzanoInstallerCRD()
-	if err != nil {
-		Fail(fmt.Sprintf("Error retrieving Verrazzano Installer CRD: %v", err))
-	}
+	Eventually(func() (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+		vzCRD, err = verrazzanoInstallerCRD()
+		return vzCRD, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-	ingressURLs, err = vmiIngressURLs()
-	if err != nil {
-		Fail(fmt.Sprintf("Error retrieving system VMI ingress URLs: %v", err))
-	}
+	Eventually(func() (map[string]string, error) {
+		ingressURLs, err = vmiIngressURLs()
+		return ingressURLs, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeEmpty())
 
-	volumeClaims, err = pkg.GetPersistentVolumes(verrazzanoNamespace)
-	if err != nil {
-		Fail(fmt.Sprintf("Error retrieving persistent volumes for verrazzano-system: %v", err))
-	}
+	Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
+		volumeClaims, err = pkg.GetPersistentVolumes(verrazzanoNamespace)
+		return volumeClaims, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-	vmiCRD, err = verrazzanoMonitoringInstanceCRD()
-	if err != nil {
-		Fail(fmt.Sprintf("Error retrieving system VMI CRD: %v", err))
-	}
+	Eventually(func() (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+		vmiCRD, err = verrazzanoMonitoringInstanceCRD()
+		return vmiCRD, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-	creds, err = pkg.GetSystemVMICredentials()
-	if err != nil {
-		Fail(fmt.Sprintf("Error retrieving system VMI credentials: %v", err))
-	}
+	Eventually(func() (*pkg.UsernamePassword, error) {
+		creds, err = pkg.GetSystemVMICredentials()
+		return creds, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+
 	elastic = vmi.GetElastic("system")
 })
 

--- a/tests/e2e/verify-install/istio/istio_test.go
+++ b/tests/e2e/verify-install/istio/istio_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo"
 	ginkgoExt "github.com/onsi/ginkgo/extensions/table"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	appsv1 "k8s.io/api/apps/v1"
 )
@@ -19,14 +19,14 @@ const (
 	pollingInterval = 10 * time.Second
 )
 
-var _ = ginkgo.Describe("Istio", func() {
+var _ = Describe("Istio", func() {
 	const istioNamespace = "istio-system"
 
 	ginkgoExt.DescribeTable("namespace",
 		func(name string) {
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				return pkg.DoesNamespaceExist(name)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		},
 		ginkgoExt.Entry(fmt.Sprintf("%s namespace should exist", istioNamespace), istioNamespace),
 	)
@@ -49,14 +49,14 @@ var _ = ginkgo.Describe("Istio", func() {
 			}
 
 			var deployments *appsv1.DeploymentList
-			gomega.Eventually(func() (*appsv1.DeploymentList, error) {
+			Eventually(func() (*appsv1.DeploymentList, error) {
 				var err error
 				deployments, err = pkg.ListDeployments(namespace)
 				return deployments, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(deployments).Should(gomega.WithTransform(deploymentNames, gomega.ContainElements(expectedDeployments)))
-			gomega.Expect(len(deployments.Items)).To(gomega.Equal(len(expectedDeployments)))
+			Expect(deployments).Should(WithTransform(deploymentNames, ContainElements(expectedDeployments)))
+			Expect(len(deployments.Items)).To(Equal(len(expectedDeployments)))
 		},
 		ginkgoExt.Entry(fmt.Sprintf("%s namespace should contain expected list of deployments", istioNamespace), istioNamespace),
 	)

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -25,6 +25,14 @@ const (
 
 var volumeClaims map[string]*corev1.PersistentVolumeClaim
 
+var _ = BeforeSuite(func() {
+	Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
+		var err error
+		volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
+		return volumeClaims, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+})
+
 var _ = Describe("Verify Keycloak configuration", func() {
 	var _ = Context("Verify password policies", func() {
 		isManagedClusterProfile := pkg.IsManagedClusterProfile()
@@ -51,14 +59,6 @@ var _ = Describe("Verify MySQL Persistent Volumes based on install profile", fun
 	var _ = Context("Verify Persistent volumes allocated per install profile", func() {
 
 		const size = "8Gi" // based on values set in platform-operator/thirdparty/charts/mysql
-
-		It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {
-			Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
-				var err error
-				volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
-				return volumeClaims, err
-			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
-		})
 
 		if pkg.IsDevProfile() {
 			It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -50,14 +50,15 @@ var _ = Describe("Verify Keycloak configuration", func() {
 var _ = Describe("Verify MySQL Persistent Volumes based on install profile", func() {
 	var _ = Context("Verify Persistent volumes allocated per install profile", func() {
 
-		var err error
-		size := "8Gi" // based on values set in platform-operator/thirdparty/charts/mysql
+		const size = "8Gi" // based on values set in platform-operator/thirdparty/charts/mysql
 
-		var volumeClaims map[string]*corev1.PersistentVolumeClaim
-		Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
-			volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
-			return volumeClaims, err
-		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+		It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {
+			Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
+				var err error
+				volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
+				return volumeClaims, err
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+		})
 
 		if pkg.IsDevProfile() {
 			It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -12,8 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
@@ -25,57 +25,57 @@ const (
 
 var volumeClaims map[string]*corev1.PersistentVolumeClaim
 
-var _ = ginkgo.Describe("Verify Keycloak configuration", func() {
-	var _ = ginkgo.Context("Verify password policies", func() {
+var _ = Describe("Verify Keycloak configuration", func() {
+	var _ = Context("Verify password policies", func() {
 		isManagedClusterProfile := pkg.IsManagedClusterProfile()
-		ginkgo.It("Verify master realm password policy", func() {
+		It("Verify master realm password policy", func() {
 			if !isManagedClusterProfile {
 				// GIVEN the password policy setup for the master realm during installation
 				// WHEN valid and invalid password changes are attempted
 				// THEN verify valid passwords are accepted and invalid passwords are rejected.
-				gomega.Eventually(verifyKeycloakMasterRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+				Eventually(verifyKeycloakMasterRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(BeTrue())
 			}
 		})
-		ginkgo.It("Verify verrazzano-system realm password policy", func() {
+		It("Verify verrazzano-system realm password policy", func() {
 			if !isManagedClusterProfile {
 				// GIVEN the password policy setup for the verrazzano-system realm during installation
 				// WHEN valid and invalid password changes are attempted
 				// THEN verify valid passwords are accepted and invalid passwords are rejected.
-				gomega.Eventually(verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+				Eventually(verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect, waitTimeout, pollingInterval).Should(BeTrue())
 			}
 		})
 	})
 })
 
-var _ = ginkgo.Describe("Verify MySQL Persistent Volumes based on install profile", func() {
-	var _ = ginkgo.Context("Verify Persistent volumes allocated per install profile", func() {
+var _ = Describe("Verify MySQL Persistent Volumes based on install profile", func() {
+	var _ = Context("Verify Persistent volumes allocated per install profile", func() {
 
 		var err error
 		size := "8Gi" // based on values set in platform-operator/thirdparty/charts/mysql
 
 		var volumeClaims map[string]*corev1.PersistentVolumeClaim
-		gomega.Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
+		Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
 			volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
 			return volumeClaims, err
-		}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 		if pkg.IsDevProfile() {
-			ginkgo.It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {
+			It("Verify persistent volumes in namespace keycloak based on Dev install profile", func() {
 				// There is no Persistent Volume for MySQL in a dev install
-				gomega.Expect(len(volumeClaims)).To(gomega.Equal(0))
+				Expect(len(volumeClaims)).To(Equal(0))
 			})
 		} else if pkg.IsManagedClusterProfile() {
-			ginkgo.It("Verify namespace keycloak doesn't exist based on Managed Cluster install profile", func() {
+			It("Verify namespace keycloak doesn't exist based on Managed Cluster install profile", func() {
 				// There is no keycloak namespace in a managed cluster install
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					_, err := pkg.GetNamespace(keycloakNamespace)
 					return err != nil && errors.IsNotFound(err)
-				}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		} else if pkg.IsProdProfile() {
-			ginkgo.It("Verify persistent volumes in namespace keycloak based on Prod install profile", func() {
+			It("Verify persistent volumes in namespace keycloak based on Prod install profile", func() {
 				// 50 GB Persistent Volume create for MySQL in a prod install
-				gomega.Expect(len(volumeClaims)).To(gomega.Equal(1))
+				Expect(len(volumeClaims)).To(Equal(1))
 				assertPersistentVolume("mysql", size)
 			})
 		}
@@ -145,7 +145,7 @@ func verifyKeycloakRealmPasswordPolicyIsCorrect(realm string) bool {
 }
 
 func assertPersistentVolume(key string, size string) {
-	gomega.Expect(volumeClaims).To(gomega.HaveKey(key))
+	Expect(volumeClaims).To(HaveKey(key))
 	pvc := volumeClaims[key]
-	gomega.Expect(pvc.Spec.Resources.Requests.Storage().String()).To(gomega.Equal(size))
+	Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal(size))
 }

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -6,9 +6,9 @@ package kubernetes_test
 import (
 	"time"
 
-	"github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo"
 	ginkgoExt "github.com/onsi/ginkgo/extensions/table"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,58 +41,58 @@ var expectedNonVMIPodsVerrazzanoSystem = []string{
 //"vmi-system-prometheus",
 //"vmi-system-prometheus-gw"}
 
-var _ = ginkgo.Describe("Kubernetes Cluster",
+var _ = Describe("Kubernetes Cluster",
 	func() {
 		isManagedClusterProfile := pkg.IsManagedClusterProfile()
 		isProdProfile := pkg.IsProdProfile()
 
-		ginkgo.It("has the expected number of nodes", func() {
-			gomega.Eventually(func() (bool, error) {
+		It("has the expected number of nodes", func() {
+			Eventually(func() (bool, error) {
 				nodes, err := pkg.ListNodes()
 				return nodes != nil && len(nodes.Items) >= 1, err
-			}, timeout5Min, pollingInterval).ShouldNot(gomega.BeNil())
+			}, timeout5Min, pollingInterval).ShouldNot(BeNil())
 		})
 
-		ginkgo.It("has the expected namespaces", func() {
+		It("has the expected namespaces", func() {
 			var namespaces *v1.NamespaceList
-			gomega.Eventually(func() (*v1.NamespaceList, error) {
+			Eventually(func() (*v1.NamespaceList, error) {
 				var err error
 				namespaces, err = pkg.ListNamespaces(metav1.ListOptions{})
 				return namespaces, err
-			}, timeout5Min, pollingInterval).ShouldNot(gomega.BeNil())
+			}, timeout5Min, pollingInterval).ShouldNot(BeNil())
 
 			if isManagedClusterProfile {
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeFalse())
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeFalse())
+				Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(BeFalse())
+				Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(BeFalse())
 				// Even though we do not install Rancher on managed clusters, we do create the namespace
 				// so we can create network policies. Rancher will run pods in this namespace once
 				// the managed cluster manifest YAML is applied to the managed cluster.
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
-				gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeFalse())
+				Expect(nsListContains(namespaces.Items, "cattle-system")).To(BeTrue())
+				Expect(nsListContains(namespaces.Items, "local")).To(BeFalse())
 			} else {
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeTrue())
-				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeTrue())
-				gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeTrue())
+				Expect(nsListContains(namespaces.Items, "cattle-system")).To(BeTrue())
+				Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(BeTrue())
+				Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(BeTrue())
+				Expect(nsListContains(namespaces.Items, "local")).To(BeTrue())
 			}
-			gomega.Expect(nsListContains(namespaces.Items, "istio-system")).To(gomega.BeTrue())
-			gomega.Expect(nsListContains(namespaces.Items, "gitlab")).To(gomega.BeFalse())
+			Expect(nsListContains(namespaces.Items, "istio-system")).To(BeTrue())
+			Expect(nsListContains(namespaces.Items, "gitlab")).To(BeFalse())
 			if isManagedClusterProfile {
-				gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.BeFalse())
+				Expect(nsListContains(namespaces.Items, "keycloak")).To(BeFalse())
 			} else {
-				gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.BeTrue())
+				Expect(nsListContains(namespaces.Items, "keycloak")).To(BeTrue())
 			}
-			gomega.Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(gomega.BeTrue())
-			gomega.Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(gomega.BeTrue())
-			gomega.Expect(nsListContains(namespaces.Items, "cert-manager")).To(gomega.BeTrue())
-			gomega.Expect(nsListContains(namespaces.Items, "ingress-nginx")).To(gomega.BeTrue())
+			Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(BeTrue())
+			Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(BeTrue())
+			Expect(nsListContains(namespaces.Items, "cert-manager")).To(BeTrue())
+			Expect(nsListContains(namespaces.Items, "ingress-nginx")).To(BeTrue())
 		})
 
 		ginkgoExt.DescribeTable("deployed Verrazzano components",
 			func(name string, expected bool) {
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return vzComponentPresent(name, "verrazzano-system")
-				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+				}, waitTimeout, pollingInterval).Should(Equal(expected))
 			},
 			ginkgoExt.Entry("includes verrazzano-operator", "verrazzano-operator", true),
 			ginkgoExt.Entry("does not include verrazzano-web", "verrazzano-web", false),
@@ -104,9 +104,9 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed cert-manager components",
 			func(name string, expected bool) {
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return vzComponentPresent(name, "cert-manager")
-				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+				}, waitTimeout, pollingInterval).Should(Equal(expected))
 			},
 			ginkgoExt.Entry("includes cert-manager", "cert-manager", true),
 			ginkgoExt.Entry("does include cert-manager-cainjector", "cert-manager-cainjector", true),
@@ -114,18 +114,18 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed ingress components",
 			func(name string, expected bool) {
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return vzComponentPresent(name, "ingress-nginx")
-				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+				}, waitTimeout, pollingInterval).Should(Equal(expected))
 			},
 			ginkgoExt.Entry("includes ingress-controller-ingress-nginx-controller", "ingress-controller-ingress-nginx-controller", true),
 		)
 
 		ginkgoExt.DescribeTable("keycloak components are not deployed",
 			func(name string, expected bool) {
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return vzComponentPresent(name, "keycloak")
-				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+				}, waitTimeout, pollingInterval).Should(Equal(expected))
 			},
 			ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
 		)
@@ -133,18 +133,18 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 		if isManagedClusterProfile {
 			ginkgoExt.DescribeTable("rancher components are not deployed",
 				func(name string, expected bool) {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return vzComponentPresent(name, "cattle-system")
-					}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+					}, waitTimeout, pollingInterval).Should(Equal(expected))
 				},
 				ginkgoExt.Entry("includes rancher", "rancher", false),
 			)
 		} else {
 			ginkgoExt.DescribeTable("deployed rancher components",
 				func(name string, expected bool) {
-					gomega.Eventually(func() bool {
+					Eventually(func() bool {
 						return vzComponentPresent(name, "cattle-system")
-					}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+					}, waitTimeout, pollingInterval).Should(Equal(expected))
 				},
 				ginkgoExt.Entry("includes rancher", "rancher", true),
 			)
@@ -152,9 +152,9 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed VMI components",
 			func(name string, expected bool) {
-				gomega.Eventually(func() bool {
+				Eventually(func() bool {
 					return vzComponentPresent(name, "verrazzano-system")
-				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+				}, waitTimeout, pollingInterval).Should(Equal(expected))
 			},
 			ginkgoExt.Entry("includes prometheus", "vmi-system-prometheus", true),
 			ginkgoExt.Entry("includes prometheus-gw", "vmi-system-prometheus-gw", false),
@@ -166,33 +166,33 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 			ginkgoExt.Entry("includes verrazzano-console", "verrazzano-console", !isManagedClusterProfile),
 		)
 
-		ginkgo.It("Expected pods are running", func() {
+		It("Expected pods are running", func() {
 			pkg.Concurrently(
 				func() {
 					// Rancher pods do not run on the managed cluster at install time (they do get started later when the managed
 					// cluster is registered)
 					if !isManagedClusterProfile {
-						gomega.Eventually(func() bool { return pkg.PodsRunning("cattle-system", expectedPodsCattleSystem) }, waitTimeout, pollingInterval).
-							Should(gomega.BeTrue())
+						Eventually(func() bool { return pkg.PodsRunning("cattle-system", expectedPodsCattleSystem) }, waitTimeout, pollingInterval).
+							Should(BeTrue())
 					}
 				},
 				func() {
 					if !isManagedClusterProfile {
-						gomega.Eventually(func() bool { return pkg.PodsRunning("keycloak", expectedPodsKeycloak) }, waitTimeout, pollingInterval).
-							Should(gomega.BeTrue())
+						Eventually(func() bool { return pkg.PodsRunning("keycloak", expectedPodsKeycloak) }, waitTimeout, pollingInterval).
+							Should(BeTrue())
 					}
 				},
 				func() {
-					gomega.Eventually(func() bool { return pkg.PodsRunning("cert-manager", expectedPodsCertManager) }, waitTimeout, pollingInterval).
-						Should(gomega.BeTrue())
+					Eventually(func() bool { return pkg.PodsRunning("cert-manager", expectedPodsCertManager) }, waitTimeout, pollingInterval).
+						Should(BeTrue())
 				},
 				func() {
-					gomega.Eventually(func() bool { return pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx) }, waitTimeout, pollingInterval).
-						Should(gomega.BeTrue())
+					Eventually(func() bool { return pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx) }, waitTimeout, pollingInterval).
+						Should(BeTrue())
 				},
 				func() {
-					gomega.Eventually(func() bool { return pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem) }, waitTimeout, pollingInterval).
-						Should(gomega.BeTrue())
+					Eventually(func() bool { return pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem) }, waitTimeout, pollingInterval).
+						Should(BeTrue())
 				},
 			)
 		})

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -4,7 +4,6 @@
 package kubernetes_test
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -47,64 +46,53 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 		isManagedClusterProfile := pkg.IsManagedClusterProfile()
 		isProdProfile := pkg.IsProdProfile()
 
-		ginkgo.It("has the expected number of nodes",
-			func() {
+		ginkgo.It("has the expected number of nodes", func() {
+			gomega.Eventually(func() (bool, error) {
 				nodes, err := pkg.ListNodes()
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Error listing nodes")
-				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">=", 1))
+				return nodes != nil && len(nodes.Items) >= 1, err
+			}, timeout5Min, pollingInterval).ShouldNot(gomega.BeNil())
+		})
 
-				// dump out node data to file
-				logData := ""
-				for i := range nodes.Items {
-					logData = logData + nodes.Items[i].ObjectMeta.Name + "\n"
-				}
-			})
+		ginkgo.It("has the expected namespaces", func() {
+			var namespaces *v1.NamespaceList
+			gomega.Eventually(func() (*v1.NamespaceList, error) {
+				var err error
+				namespaces, err = pkg.ListNamespaces(metav1.ListOptions{})
+				return namespaces, err
+			}, timeout5Min, pollingInterval).ShouldNot(gomega.BeNil())
 
-		ginkgo.It("has the expected namespaces",
-			func() {
-				namespaces, err := pkg.ListNamespaces(metav1.ListOptions{})
-				if err != nil {
-					ginkgo.Fail(fmt.Sprintf("Failed to get namespaces with error: %v", err))
-				}
-				if isManagedClusterProfile {
-					gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeFalse())
-					gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeFalse())
-					// Even though we do not install Rancher on managed clusters, we do create the namespace
-					// so we can create network policies. Rancher will run pods in this namespace once
-					// the managed cluster manifest YAML is applied to the managed cluster.
-					gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
-					gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeFalse())
-				} else {
-					gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
-					gomega.Eventually(func() bool { return nsListContains(namespaces.Items, "cattle-global-data") }, timeout5Min, pollingInterval).
-						Should(gomega.BeTrue())
-					gomega.Eventually(func() bool { return nsListContains(namespaces.Items, "cattle-global-nt") }, timeout5Min, pollingInterval).
-						Should(gomega.BeTrue())
-					gomega.Eventually(func() bool { return nsListContains(namespaces.Items, "local") }, timeout5Min, pollingInterval).
-						Should(gomega.BeTrue())
-				}
-				gomega.Expect(nsListContains(namespaces.Items, "istio-system")).To(gomega.Equal(true))
-				gomega.Expect(nsListContains(namespaces.Items, "gitlab")).To(gomega.Equal(false))
-				if isManagedClusterProfile {
-					gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.Equal(false))
-				} else {
-					gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.Equal(true))
-				}
-				gomega.Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(gomega.Equal(true))
-				gomega.Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(gomega.Equal(true))
-				gomega.Expect(nsListContains(namespaces.Items, "cert-manager")).To(gomega.Equal(true))
-				gomega.Expect(nsListContains(namespaces.Items, "ingress-nginx")).To(gomega.Equal(true))
-
-				// dump out namespace data to file
-				logData := ""
-				for i := range namespaces.Items {
-					logData = logData + namespaces.Items[i].Name + "\n"
-				}
-			})
+			if isManagedClusterProfile {
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeFalse())
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeFalse())
+				// Even though we do not install Rancher on managed clusters, we do create the namespace
+				// so we can create network policies. Rancher will run pods in this namespace once
+				// the managed cluster manifest YAML is applied to the managed cluster.
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
+				gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeFalse())
+			} else {
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-system")).To(gomega.BeTrue())
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(gomega.BeTrue())
+				gomega.Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(gomega.BeTrue())
+				gomega.Expect(nsListContains(namespaces.Items, "local")).To(gomega.BeTrue())
+			}
+			gomega.Expect(nsListContains(namespaces.Items, "istio-system")).To(gomega.BeTrue())
+			gomega.Expect(nsListContains(namespaces.Items, "gitlab")).To(gomega.BeFalse())
+			if isManagedClusterProfile {
+				gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.BeFalse())
+			} else {
+				gomega.Expect(nsListContains(namespaces.Items, "keycloak")).To(gomega.BeTrue())
+			}
+			gomega.Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(gomega.BeTrue())
+			gomega.Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(gomega.BeTrue())
+			gomega.Expect(nsListContains(namespaces.Items, "cert-manager")).To(gomega.BeTrue())
+			gomega.Expect(nsListContains(namespaces.Items, "ingress-nginx")).To(gomega.BeTrue())
+		})
 
 		ginkgoExt.DescribeTable("deployed Verrazzano components",
 			func(name string, expected bool) {
-				gomega.Expect(vzComponentPresent(name, "verrazzano-system")).To(gomega.Equal(expected))
+				gomega.Eventually(func() bool {
+					return vzComponentPresent(name, "verrazzano-system")
+				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 			},
 			ginkgoExt.Entry("includes verrazzano-operator", "verrazzano-operator", true),
 			ginkgoExt.Entry("does not include verrazzano-web", "verrazzano-web", false),
@@ -116,7 +104,9 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed cert-manager components",
 			func(name string, expected bool) {
-				gomega.Expect(vzComponentPresent(name, "cert-manager")).To(gomega.Equal(expected))
+				gomega.Eventually(func() bool {
+					return vzComponentPresent(name, "cert-manager")
+				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 			},
 			ginkgoExt.Entry("includes cert-manager", "cert-manager", true),
 			ginkgoExt.Entry("does include cert-manager-cainjector", "cert-manager-cainjector", true),
@@ -124,38 +114,37 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed ingress components",
 			func(name string, expected bool) {
-				gomega.Expect(vzComponentPresent(name, "ingress-nginx")).To(gomega.Equal(expected))
+				gomega.Eventually(func() bool {
+					return vzComponentPresent(name, "ingress-nginx")
+				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 			},
 			ginkgoExt.Entry("includes ingress-controller-ingress-nginx-controller", "ingress-controller-ingress-nginx-controller", true),
 		)
 
-		if isManagedClusterProfile {
-			ginkgoExt.DescribeTable("keycloak components are not deployed",
-				func(name string, expected bool) {
-					gomega.Expect(vzComponentPresent(name, "keycloak")).To(gomega.BeFalse())
-				},
-				ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
-			)
-		} else {
-			ginkgoExt.DescribeTable("deployed keycloak components",
-				func(name string, expected bool) {
-					gomega.Expect(vzComponentPresent(name, "keycloak")).To(gomega.Equal(expected))
-				},
-				ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
-			)
-		}
+		ginkgoExt.DescribeTable("keycloak components are not deployed",
+			func(name string, expected bool) {
+				gomega.Eventually(func() bool {
+					return vzComponentPresent(name, "keycloak")
+				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
+			},
+			ginkgoExt.Entry("includes ssoproxycontroller", "ssoproxycontroller", false),
+		)
 
 		if isManagedClusterProfile {
 			ginkgoExt.DescribeTable("rancher components are not deployed",
 				func(name string, expected bool) {
-					gomega.Expect(vzComponentPresent(name, "cattle-system")).To(gomega.BeFalse())
+					gomega.Eventually(func() bool {
+						return vzComponentPresent(name, "cattle-system")
+					}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 				},
 				ginkgoExt.Entry("includes rancher", "rancher", false),
 			)
 		} else {
 			ginkgoExt.DescribeTable("deployed rancher components",
 				func(name string, expected bool) {
-					gomega.Expect(vzComponentPresent(name, "cattle-system")).To(gomega.Equal(expected))
+					gomega.Eventually(func() bool {
+						return vzComponentPresent(name, "cattle-system")
+					}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 				},
 				ginkgoExt.Entry("includes rancher", "rancher", true),
 			)
@@ -163,7 +152,9 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 
 		ginkgoExt.DescribeTable("deployed VMI components",
 			func(name string, expected bool) {
-				gomega.Expect(vzComponentPresent(name, "verrazzano-system")).To(gomega.Equal(expected))
+				gomega.Eventually(func() bool {
+					return vzComponentPresent(name, "verrazzano-system")
+				}, waitTimeout, pollingInterval).Should(gomega.Equal(expected))
 			},
 			ginkgoExt.Entry("includes prometheus", "vmi-system-prometheus", true),
 			ginkgoExt.Entry("includes prometheus-gw", "vmi-system-prometheus-gw", false),
@@ -175,37 +166,36 @@ var _ = ginkgo.Describe("Kubernetes Cluster",
 			ginkgoExt.Entry("includes verrazzano-console", "verrazzano-console", !isManagedClusterProfile),
 		)
 
-		ginkgo.It("Expected pods are running",
-			func() {
-				pkg.Concurrently(
-					func() {
-						// Rancher pods do not run on the managed cluster at install time (they do get started later when the managed
-						// cluster is registered)
-						if !isManagedClusterProfile {
-							gomega.Eventually(func() bool { return pkg.PodsRunning("cattle-system", expectedPodsCattleSystem) }, waitTimeout, pollingInterval).
-								Should(gomega.BeTrue())
-						}
-					},
-					func() {
-						if !isManagedClusterProfile {
-							gomega.Eventually(func() bool { return pkg.PodsRunning("keycloak", expectedPodsKeycloak) }, waitTimeout, pollingInterval).
-								Should(gomega.BeTrue())
-						}
-					},
-					func() {
-						gomega.Eventually(func() bool { return pkg.PodsRunning("cert-manager", expectedPodsCertManager) }, waitTimeout, pollingInterval).
+		ginkgo.It("Expected pods are running", func() {
+			pkg.Concurrently(
+				func() {
+					// Rancher pods do not run on the managed cluster at install time (they do get started later when the managed
+					// cluster is registered)
+					if !isManagedClusterProfile {
+						gomega.Eventually(func() bool { return pkg.PodsRunning("cattle-system", expectedPodsCattleSystem) }, waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
-					},
-					func() {
-						gomega.Eventually(func() bool { return pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx) }, waitTimeout, pollingInterval).
+					}
+				},
+				func() {
+					if !isManagedClusterProfile {
+						gomega.Eventually(func() bool { return pkg.PodsRunning("keycloak", expectedPodsKeycloak) }, waitTimeout, pollingInterval).
 							Should(gomega.BeTrue())
-					},
-					func() {
-						gomega.Eventually(func() bool { return pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem) }, waitTimeout, pollingInterval).
-							Should(gomega.BeTrue())
-					},
-				)
-			})
+					}
+				},
+				func() {
+					gomega.Eventually(func() bool { return pkg.PodsRunning("cert-manager", expectedPodsCertManager) }, waitTimeout, pollingInterval).
+						Should(gomega.BeTrue())
+				},
+				func() {
+					gomega.Eventually(func() bool { return pkg.PodsRunning("ingress-nginx", expectedPodsIngressNginx) }, waitTimeout, pollingInterval).
+						Should(gomega.BeTrue())
+				},
+				func() {
+					gomega.Eventually(func() bool { return pkg.PodsRunning("verrazzano-system", expectedNonVMIPodsVerrazzanoSystem) }, waitTimeout, pollingInterval).
+						Should(gomega.BeTrue())
+				},
+			)
+		})
 	})
 
 func nsListContains(list []v1.Namespace, target string) bool {

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -6,9 +6,9 @@ package verrazzano_test
 import (
 	"time"
 
-	"github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo"
 	ginkgoExt "github.com/onsi/ginkgo/extensions/table"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -18,7 +18,7 @@ const (
 	pollingInterval = 5 * time.Second
 )
 
-var _ = ginkgo.Describe("Verrazzano", func() {
+var _ = Describe("Verrazzano", func() {
 
 	vzInstallReadRule := rbacv1.PolicyRule{
 		Verbs:     []string{"get", "list", "watch"},
@@ -78,9 +78,9 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgoExt.DescribeTable("CRD for",
 		func(name string) {
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				return pkg.DoesCRDExist(name)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		},
 		ginkgoExt.Entry("verrazzanos should exist in cluster", "verrazzanos.install.verrazzano.io"),
 		ginkgoExt.Entry("verrazzanomanagedclusters should exist in cluster", "verrazzanomanagedclusters.clusters.verrazzano.io"),
@@ -88,9 +88,9 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgoExt.DescribeTable("ClusterRole",
 		func(name string) {
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				return pkg.DoesClusterRoleExist(name)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		},
 		ginkgoExt.Entry("verrazzano-admin should exist", "verrazzano-admin"),
 		ginkgoExt.Entry("verrazzano-monitor should exist", "verrazzano-monitor"),
@@ -100,36 +100,36 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 
 	ginkgoExt.DescribeTable("ClusterRoleBinding",
 		func(name string) {
-			gomega.Eventually(func() (bool, error) {
+			Eventually(func() (bool, error) {
 				return pkg.DoesClusterRoleBindingExist(name)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		},
 		ginkgoExt.Entry("verrazzano-admin should exist", "verrazzano-admin"),
 		ginkgoExt.Entry("verrazzano-monitor should exist", "verrazzano-monitor"),
 	)
 
-	ginkgo.Describe("ClusterRole verrazzano-admin", func() {
+	Describe("ClusterRole verrazzano-admin", func() {
 		var rules []rbacv1.PolicyRule
 
-		ginkgo.BeforeEach(func() {
+		BeforeEach(func() {
 			var cr *rbacv1.ClusterRole
-			gomega.Eventually(func() (*rbacv1.ClusterRole, error) {
+			Eventually(func() (*rbacv1.ClusterRole, error) {
 				var err error
 				cr, err = pkg.GetClusterRole("verrazzano-admin")
 				return cr, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			rules = cr.Rules
 		})
 
-		ginkgo.It("has correct number of rules", func() {
-			gomega.Expect(len(rules)).To(gomega.Equal(11),
+		It("has correct number of rules", func() {
+			Expect(len(rules)).To(Equal(11),
 				"there should be eleven rules")
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
 			func(rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
+				Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(BeTrue())
 			},
 			ginkgoExt.Entry("vzInstallReadRule should exist", vzInstallReadRule),
 			ginkgoExt.Entry("vzInstallWriteRule should exist", vzInstallWriteRule),
@@ -145,28 +145,28 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		)
 	})
 
-	ginkgo.Describe("ClusterRole verrazzano-monitor", func() {
+	Describe("ClusterRole verrazzano-monitor", func() {
 		var rules []rbacv1.PolicyRule
 
-		ginkgo.BeforeEach(func() {
+		BeforeEach(func() {
 			var cr *rbacv1.ClusterRole
-			gomega.Eventually(func() (*rbacv1.ClusterRole, error) {
+			Eventually(func() (*rbacv1.ClusterRole, error) {
 				var err error
 				cr, err = pkg.GetClusterRole("verrazzano-monitor")
 				return cr, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			rules = cr.Rules
 		})
 
-		ginkgo.It("has correct number of rules", func() {
-			gomega.Expect(len(rules)).To(gomega.Equal(5),
+		It("has correct number of rules", func() {
+			Expect(len(rules)).To(Equal(5),
 				"there should be five rules")
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
 			func(rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
+				Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(BeTrue())
 			},
 			ginkgoExt.Entry("vzSystemReadRule should exist", vzSystemReadRule),
 			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
@@ -176,28 +176,28 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		)
 	})
 
-	ginkgo.Describe("ClusterRole verrazzano-project-admin", func() {
+	Describe("ClusterRole verrazzano-project-admin", func() {
 		var rules []rbacv1.PolicyRule
 
-		ginkgo.BeforeEach(func() {
+		BeforeEach(func() {
 			var cr *rbacv1.ClusterRole
-			gomega.Eventually(func() (*rbacv1.ClusterRole, error) {
+			Eventually(func() (*rbacv1.ClusterRole, error) {
 				var err error
 				cr, err = pkg.GetClusterRole("verrazzano-project-admin")
 				return cr, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			rules = cr.Rules
 		})
 
-		ginkgo.It("has correct number of rules", func() {
-			gomega.Expect(len(rules)).To(gomega.Equal(6),
+		It("has correct number of rules", func() {
+			Expect(len(rules)).To(Equal(6),
 				"there should be six rules")
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
 			func(rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
+				Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(BeTrue())
 			},
 			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
 			ginkgoExt.Entry("vzAppWriteRule should exist", vzAppWriteRule),
@@ -208,28 +208,28 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		)
 	})
 
-	ginkgo.Describe("ClusterRole verrazzano-project-monitor", func() {
+	Describe("ClusterRole verrazzano-project-monitor", func() {
 		var rules []rbacv1.PolicyRule
 
-		ginkgo.BeforeEach(func() {
+		BeforeEach(func() {
 			var cr *rbacv1.ClusterRole
-			gomega.Eventually(func() (*rbacv1.ClusterRole, error) {
+			Eventually(func() (*rbacv1.ClusterRole, error) {
 				var err error
 				cr, err = pkg.GetClusterRole("verrazzano-project-monitor")
 				return cr, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
 			rules = cr.Rules
 		})
 
-		ginkgo.It("has correct number of rules", func() {
-			gomega.Expect(len(rules)).To(gomega.Equal(3),
+		It("has correct number of rules", func() {
+			Expect(len(rules)).To(Equal(3),
 				"there should be three rules")
 		})
 
 		ginkgoExt.DescribeTable("PolicyRule",
 			func(rule rbacv1.PolicyRule) {
-				gomega.Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(gomega.BeTrue())
+				Expect(pkg.SliceContainsPolicyRule(rules, rule)).To(BeTrue())
 			},
 			ginkgoExt.Entry("vzAppReadRule should exist", vzAppReadRule),
 			ginkgoExt.Entry("vzWebLogicReadRule should exist", vzWebLogicReadRule),
@@ -237,114 +237,114 @@ var _ = ginkgo.Describe("Verrazzano", func() {
 		)
 	})
 
-	ginkgo.Describe("ClusterRoleBinding verrazzano-admin", func() {
-		ginkgo.It("has correct subjects and refs", func() {
+	Describe("ClusterRoleBinding verrazzano-admin", func() {
+		It("has correct subjects and refs", func() {
 			var crb *rbacv1.ClusterRoleBinding
-			gomega.Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
+			Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
 				var err error
 				crb, err = pkg.GetClusterRoleBinding("verrazzano-admin")
 				return crb, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(crb.RoleRef.Name == "verrazzano-admin").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Name == "verrazzano-admin").To(BeTrue(),
 				"the roleRef.name should be verrazzano-admin")
-			gomega.Expect(crb.RoleRef.Kind == "ClusterRole").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
 				"the roleRef.kind shoudl be ClusterRole")
 
-			gomega.Expect(len(crb.Subjects) == 1).To(gomega.BeTrue(),
+			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")
 			s := crb.Subjects[0]
-			gomega.Expect(s.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(s.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the subject's apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(s.Kind == "Group").To(gomega.BeTrue(),
+			Expect(s.Kind == "Group").To(BeTrue(),
 				"the subject's kind should be Group")
-			gomega.Expect(s.Name == "verrazzano-admins").To(gomega.BeTrue(),
+			Expect(s.Name == "verrazzano-admins").To(BeTrue(),
 				"the subject's name should be verrazzano-admins")
 		})
 	})
 
-	ginkgo.Describe("ClusterRoleBinding verrazzano-admin-k8s", func() {
-		ginkgo.It("has correct subjects and refs", func() {
+	Describe("ClusterRoleBinding verrazzano-admin-k8s", func() {
+		It("has correct subjects and refs", func() {
 			var crb *rbacv1.ClusterRoleBinding
-			gomega.Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
+			Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
 				var err error
 				crb, err = pkg.GetClusterRoleBinding("verrazzano-admin-k8s")
 				return crb, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(crb.RoleRef.Name == "admin").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Name == "admin").To(BeTrue(),
 				"the roleRef.name should be admin")
-			gomega.Expect(crb.RoleRef.Kind == "ClusterRole").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
 				"the roleRef.kind shoudl be ClusterRole")
 
-			gomega.Expect(len(crb.Subjects) == 1).To(gomega.BeTrue(),
+			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")
 			s := crb.Subjects[0]
-			gomega.Expect(s.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(s.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the subject's apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(s.Kind == "Group").To(gomega.BeTrue(),
+			Expect(s.Kind == "Group").To(BeTrue(),
 				"the subject's kind should be Group")
-			gomega.Expect(s.Name == "verrazzano-admins").To(gomega.BeTrue(),
+			Expect(s.Name == "verrazzano-admins").To(BeTrue(),
 				"the subject's name should be verrazzano-admins")
 		})
 	})
 
-	ginkgo.Describe("ClusterRoleBinding verrazzano-monitor", func() {
-		ginkgo.It("has correct subjects and refs", func() {
+	Describe("ClusterRoleBinding verrazzano-monitor", func() {
+		It("has correct subjects and refs", func() {
 			var crb *rbacv1.ClusterRoleBinding
-			gomega.Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
+			Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
 				var err error
 				crb, err = pkg.GetClusterRoleBinding("verrazzano-monitor")
 				return crb, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(crb.RoleRef.Name == "verrazzano-monitor").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Name == "verrazzano-monitor").To(BeTrue(),
 				"the roleRef.name should be verrazzano-monitor")
-			gomega.Expect(crb.RoleRef.Kind == "ClusterRole").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
 				"the roleRef.kind shoudl be ClusterRole")
 
-			gomega.Expect(len(crb.Subjects) == 1).To(gomega.BeTrue(),
+			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")
 			s := crb.Subjects[0]
-			gomega.Expect(s.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(s.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the subject's apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(s.Kind == "Group").To(gomega.BeTrue(),
+			Expect(s.Kind == "Group").To(BeTrue(),
 				"the subject's kind should be Group")
-			gomega.Expect(s.Name == "verrazzano-monitors").To(gomega.BeTrue(),
+			Expect(s.Name == "verrazzano-monitors").To(BeTrue(),
 				"the subject's name should be verrazzano-monitors")
 		})
 	})
 
-	ginkgo.Describe("ClusterRoleBinding verrazzano-monitor-k8s", func() {
-		ginkgo.It("has correct subjects and refs", func() {
+	Describe("ClusterRoleBinding verrazzano-monitor-k8s", func() {
+		It("has correct subjects and refs", func() {
 			var crb *rbacv1.ClusterRoleBinding
-			gomega.Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
+			Eventually(func() (*rbacv1.ClusterRoleBinding, error) {
 				var err error
 				crb, err = pkg.GetClusterRoleBinding("verrazzano-monitor-k8s")
 				return crb, err
-			}, waitTimeout, pollingInterval).ShouldNot(gomega.BeNil())
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			gomega.Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the roleRef.apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(crb.RoleRef.Name == "view").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Name == "view").To(BeTrue(),
 				"the roleRef.name should be view")
-			gomega.Expect(crb.RoleRef.Kind == "ClusterRole").To(gomega.BeTrue(),
+			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
 				"the roleRef.kind shoudl be ClusterRole")
 
-			gomega.Expect(len(crb.Subjects) == 1).To(gomega.BeTrue(),
+			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")
 			s := crb.Subjects[0]
-			gomega.Expect(s.APIGroup == "rbac.authorization.k8s.io").To(gomega.BeTrue(),
+			Expect(s.APIGroup == "rbac.authorization.k8s.io").To(BeTrue(),
 				"the subject's apiGroup should be rbac.authorization.k8s.io")
-			gomega.Expect(s.Kind == "Group").To(gomega.BeTrue(),
+			Expect(s.Kind == "Group").To(BeTrue(),
 				"the subject's kind should be Group")
-			gomega.Expect(s.Name == "verrazzano-monitors").To(gomega.BeTrue(),
+			Expect(s.Name == "verrazzano-monitors").To(BeTrue(),
 				"the subject's name should be verrazzano-monitors")
 		})
 	})

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -25,27 +25,27 @@ const (
 	pollingInterval = 5 * time.Second
 )
 
-var _ = Describe("Verrazzano Web UI", func() {
-	var ingress *v1beta1.Ingress
-	var consoleUIConfigured bool = false
+var ingress *v1beta1.Ingress
+var consoleUIConfigured bool = false
 
-	It("ingress exist", func() {
-		Eventually(func() (*v1beta1.Ingress, error) {
-			var err error
-			ingress, err = pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-ingress", v1.GetOptions{})
-			return ingress, err
-		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+var _ = BeforeSuite(func() {
+	Eventually(func() (*v1beta1.Ingress, error) {
+		var err error
+		ingress, err = pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-ingress", v1.GetOptions{})
+		return ingress, err
+	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-		Expect(len(ingress.Spec.Rules)).To(Equal(1))
+	Expect(len(ingress.Spec.Rules)).To(Equal(1))
 
-		// Determine if the console UI is configured
-		for _, path := range ingress.Spec.Rules[0].HTTP.Paths {
-			if path.Backend.ServiceName == "verrazzano-console" {
-				consoleUIConfigured = true
-			}
+	// Determine if the console UI is configured
+	for _, path := range ingress.Spec.Rules[0].HTTP.Paths {
+		if path.Backend.ServiceName == "verrazzano-console" {
+			consoleUIConfigured = true
 		}
-	})
+	}
+})
 
+var _ = Describe("Verrazzano Web UI", func() {
 	When("the console UI is configured", func() {
 		var serverURL string
 

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -25,129 +25,128 @@ const (
 	pollingInterval = 5 * time.Second
 )
 
-var _ = Describe("Verrazzano Web UI",
-	func() {
-		var ingress *v1beta1.Ingress
+var _ = Describe("Verrazzano Web UI", func() {
+	var ingress *v1beta1.Ingress
+	var consoleUIConfigured bool = false
 
-		It("ingress exist", func() {
-			Eventually(func() (*v1beta1.Ingress, error) {
-				var err error
-				ingress, err = pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-ingress", v1.GetOptions{})
-				return ingress, err
-			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+	It("ingress exist", func() {
+		Eventually(func() (*v1beta1.Ingress, error) {
+			var err error
+			ingress, err = pkg.GetKubernetesClientset().ExtensionsV1beta1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-ingress", v1.GetOptions{})
+			return ingress, err
+		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
-			Expect(len(ingress.Spec.Rules)).To(Equal(1))
-		})
+		Expect(len(ingress.Spec.Rules)).To(Equal(1))
 
 		// Determine if the console UI is configured
-		consoleUIConfigured := false
 		for _, path := range ingress.Spec.Rules[0].HTTP.Paths {
 			if path.Backend.ServiceName == "verrazzano-console" {
 				consoleUIConfigured = true
 			}
 		}
-
-		if consoleUIConfigured {
-
-			var ingressRules = ingress.Spec.Rules
-			serverURL := fmt.Sprintf("https://%s/", ingressRules[0].Host)
-
-			pkg.Log(pkg.Info, "The Web UI's URL is "+serverURL)
-
-			It("can be accessed", func() {
-				Eventually(func() (*pkg.HTTPResponse, error) {
-					return pkg.GetWebPage(serverURL, "")
-				}, waitTimeout, pollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyNotEmpty(), pkg.BodyDoesNotContain("404")))
-			})
-
-			It("has the correct SSL certificate",
-				func() {
-					var certs []*x509.Certificate
-					Eventually(func() ([]*x509.Certificate, error) {
-						var err error
-						certs, err = pkg.GetCertificates(serverURL)
-						return certs, err
-					}, waitTimeout, pollingInterval).ShouldNot(BeNil())
-
-					// There will normally be several certs, but we only need to check the
-					// first one -- might want to refactor the checks out into a pkg.IsCertValid()
-					// function so we can use it from other test suites too??
-					pkg.Log(pkg.Debug, "Issuer Common Name: "+certs[0].Issuer.CommonName)
-					pkg.Log(pkg.Debug, "Subject Common Name: "+certs[0].Subject.CommonName)
-					pkg.Log(pkg.Debug, "Not Before: "+certs[0].NotBefore.String())
-					pkg.Log(pkg.Debug, "Not After: "+certs[0].NotAfter.String())
-					Expect(time.Now().After(certs[0].NotBefore)).To(BeTrue())
-					Expect(time.Now().Before(certs[0].NotAfter)).To(BeTrue())
-				})
-
-			It("should return no Server header",
-				func() {
-					kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-					httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
-					Expect(err).ShouldNot(HaveOccurred())
-					req, err := retryablehttp.NewRequest("GET", serverURL, nil)
-					Expect(err).ShouldNot(HaveOccurred())
-					resp, err := httpClient.Do(req)
-					Expect(err).ShouldNot(HaveOccurred())
-					ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-					// HTTP Server headers should never be returned.
-					for headerName, headerValues := range resp.Header {
-						Expect(strings.ToLower(headerName)).ToNot(Equal("server"), fmt.Sprintf("Unexpected Server header %v", headerValues))
-					}
-				})
-
-			It("should not return CORS Access-Control-Allow-Origin header when no Origin header is provided",
-				func() {
-					kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-					httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
-					Expect(err).ShouldNot(HaveOccurred())
-					req, err := retryablehttp.NewRequest("GET", serverURL, nil)
-					Expect(err).ShouldNot(HaveOccurred())
-					resp, err := httpClient.Do(req)
-					Expect(err).ShouldNot(HaveOccurred())
-					ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-					// HTTP Access-Control-Allow-Origin header should never be returned.
-					for headerName, headerValues := range resp.Header {
-						Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
-					}
-				})
-
-			It("should not return CORS Access-Control-Allow-Origin header when Origin: * is provided",
-				func() {
-					kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-					httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
-					Expect(err).ShouldNot(HaveOccurred())
-					req, err := retryablehttp.NewRequest("GET", serverURL, nil)
-					req.Header.Add("Origin", "*")
-					Expect(err).ShouldNot(HaveOccurred())
-					resp, err := httpClient.Do(req)
-					Expect(err).ShouldNot(HaveOccurred())
-					ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-					// HTTP Access-Control-Allow-Origin header should never be returned.
-					for headerName, headerValues := range resp.Header {
-						Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
-					}
-				})
-
-			It("should not return CORS Access-Control-Allow-Origin header when Origin: null is provided",
-				func() {
-					kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
-					httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
-					Expect(err).ShouldNot(HaveOccurred())
-					req, err := retryablehttp.NewRequest("GET", serverURL, nil)
-					req.Header.Add("Origin", "null")
-					Expect(err).ShouldNot(HaveOccurred())
-					resp, err := httpClient.Do(req)
-					Expect(err).ShouldNot(HaveOccurred())
-					ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-					// HTTP Access-Control-Allow-Origin header should never be returned.
-					for headerName, headerValues := range resp.Header {
-						Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
-					}
-				})
-		}
 	})
+
+	When("the console UI is configured", func() {
+		var serverURL string
+
+		BeforeEach(func() {
+			if !consoleUIConfigured {
+				Skip("Skipping spec since console UI is not configured")
+			}
+
+			ingressRules := ingress.Spec.Rules
+			serverURL = fmt.Sprintf("https://%s/", ingressRules[0].Host)
+		})
+
+		It("can be accessed", func() {
+			Eventually(func() (*pkg.HTTPResponse, error) {
+				return pkg.GetWebPage(serverURL, "")
+			}, waitTimeout, pollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyNotEmpty(), pkg.BodyDoesNotContain("404")))
+		})
+
+		It("has the correct SSL certificate", func() {
+			var certs []*x509.Certificate
+			Eventually(func() ([]*x509.Certificate, error) {
+				var err error
+				certs, err = pkg.GetCertificates(serverURL)
+				return certs, err
+			}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+
+			// There will normally be several certs, but we only need to check the
+			// first one -- might want to refactor the checks out into a pkg.IsCertValid()
+			// function so we can use it from other test suites too??
+			pkg.Log(pkg.Debug, "Issuer Common Name: "+certs[0].Issuer.CommonName)
+			pkg.Log(pkg.Debug, "Subject Common Name: "+certs[0].Subject.CommonName)
+			pkg.Log(pkg.Debug, "Not Before: "+certs[0].NotBefore.String())
+			pkg.Log(pkg.Debug, "Not After: "+certs[0].NotAfter.String())
+			Expect(time.Now().After(certs[0].NotBefore)).To(BeTrue())
+			Expect(time.Now().Before(certs[0].NotAfter)).To(BeTrue())
+		})
+
+		It("should return no Server header", func() {
+			kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
+			httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			req, err := retryablehttp.NewRequest("GET", serverURL, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			resp, err := httpClient.Do(req)
+			Expect(err).ShouldNot(HaveOccurred())
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			// HTTP Server headers should never be returned.
+			for headerName, headerValues := range resp.Header {
+				Expect(strings.ToLower(headerName)).ToNot(Equal("server"), fmt.Sprintf("Unexpected Server header %v", headerValues))
+			}
+		})
+
+		It("should not return CORS Access-Control-Allow-Origin header when no Origin header is provided", func() {
+			kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
+			httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			req, err := retryablehttp.NewRequest("GET", serverURL, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			resp, err := httpClient.Do(req)
+			Expect(err).ShouldNot(HaveOccurred())
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			// HTTP Access-Control-Allow-Origin header should never be returned.
+			for headerName, headerValues := range resp.Header {
+				Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
+			}
+		})
+
+		It("should not return CORS Access-Control-Allow-Origin header when Origin: * is provided", func() {
+			kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
+			httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			req, err := retryablehttp.NewRequest("GET", serverURL, nil)
+			req.Header.Add("Origin", "*")
+			Expect(err).ShouldNot(HaveOccurred())
+			resp, err := httpClient.Do(req)
+			Expect(err).ShouldNot(HaveOccurred())
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			// HTTP Access-Control-Allow-Origin header should never be returned.
+			for headerName, headerValues := range resp.Header {
+				Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
+			}
+		})
+
+		It("should not return CORS Access-Control-Allow-Origin header when Origin: null is provided", func() {
+			kubeconfigPath := pkg.GetKubeConfigPathFromEnv()
+			httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			req, err := retryablehttp.NewRequest("GET", serverURL, nil)
+			req.Header.Add("Origin", "null")
+			Expect(err).ShouldNot(HaveOccurred())
+			resp, err := httpClient.Do(req)
+			Expect(err).ShouldNot(HaveOccurred())
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			// HTTP Access-Control-Allow-Origin header should never be returned.
+			for headerName, headerValues := range resp.Header {
+				Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
+			}
+		})
+	})
+})


### PR DESCRIPTION
# Description

This PR improves the remaining acceptance tests by:

1. Adding `Eventually` around calls that should be retried
2. Removing `Expect` and `Fail` calls inside `Eventually`
3. Use dot imports for gomega and ginkgo

Note that I put all of the dot import changes into a single commit to make it easier to review the other changes.

This is the final PR for this work to improve the acceptance tests.

Implements VZ-2909

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
