### PR TITLE
VZ-3013: Temporarily disable priv reg tests

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -124,7 +124,7 @@ pipeline {
                                 ], wait: true
                         }
                     }
-                }*/
+                }
                 stage('Private registry tests') {
                     steps {
                         script {
@@ -134,7 +134,7 @@ pipeline {
                                 ], wait: true
                         }
                     }
-                }
+                }*/
             }
         }
     }


### PR DESCRIPTION
# Description

There is a chicken & egg problem with the periodic triggered tests and the private registry tests. The private registry tests install from the last good tarball generated by the periodic tests, but the periodic tests fail because the private registry tests fail. They are running tests from master and require a matching platform operator.

This PR temporarily disables the private reg tests so we can get a good tarball published, and then we will re-enable the tests. This is a stop-gap solution until we can fix this issue longer term.

Fixes VZ-3013

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
