### PR TITLE
Revert "VZ-3013: Temporarily disable priv reg tests"

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -124,7 +124,7 @@ pipeline {
                                 ], wait: true
                         }
                     }
-                }
+                }*/
                 stage('Private registry tests') {
                     steps {
                         script {
@@ -134,7 +134,7 @@ pipeline {
                                 ], wait: true
                         }
                     }
-                }*/
+                }
             }
         }
     }


### PR DESCRIPTION
Reverts verrazzano/verrazzano#1345

The periodic tests ran successfully and published a new install tarball, so we can revert the change which will re-enable the private registry tests.