### PR TITLE
JIRA:VZ-2954 add timestamps to jenkins build logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -7,6 +7,7 @@ def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -8,6 +8,7 @@ def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -19,6 +19,7 @@ installerFileName = "install-verrazzano.yaml"
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
     options {
         skipDefaultCheckout true
         copyArtifactPermission('*');
+        timestamps ()
     }
 
     agent {


### PR DESCRIPTION
# Description

The timestamps allow for better correlation with other logs and metrics to diagnose issues.

Helps with VZ-2954

An image of what the build logs look like with this enabled:

![verrazzano_»_jmaron_VZ-2954__1_Console__Jenkins_](https://user-images.githubusercontent.com/67696706/125705983-c00691f8-afff-44ca-8f2a-a9a277f349fa.png)

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
