### PR TITLE
Fixes for installing optional components

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -342,7 +342,7 @@ type ConsoleComponent struct {
 
 type RancherComponent struct {
 	// +optional
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // FluentdComponent specifies the Fluentd DaemonSet configuration

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -320,7 +320,7 @@ type KeycloakComponent struct {
 	// +optional
 	MySQL MySQLComponent `json:"mysql,omitempty"`
 	// +optional
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // MySQLComponent specifies the MySQL configuration

--- a/platform-operator/config/samples/install-optional.yaml
+++ b/platform-operator/config/samples/install-optional.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# This install resource uses the "dev" profile to install a minimal footprint for
+# Verrazzano for local development and experimentation.
+#
+# In addition, this configuration disables a number of components as listed below.
+#
+#
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: my-verrazzano
+spec:
+  profile: dev
+  components:
+    elasticsearch:
+      enabled: false
+    kibana:
+      enabled: false
+    prometheus:
+      enabled: false
+    grafana:
+      enabled: false
+    console:
+      enabled: false
+    keycloak:
+      enabled: false
+    rancher:
+      enabled: false

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -474,7 +474,7 @@ func (r *Reconciler) updateStatus(log *zap.SugaredLogger, cr *installv1alpha1.Ve
 	case installv1alpha1.UpgradeStarted:
 		cr.Status.State = installv1alpha1.Upgrading
 	case installv1alpha1.InstallComplete:
-		cr.Status.VerrazzanoInstance = vzinstance.GetInstanceInfo(r.Client)
+		cr.Status.VerrazzanoInstance = vzinstance.GetInstanceInfo(r.Client, cr)
 		fallthrough
 	case installv1alpha1.UninstallComplete, installv1alpha1.UpgradeComplete:
 		cr.Status.State = installv1alpha1.Ready

--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -338,12 +338,16 @@ func getInstallArgs(args []installv1alpha1.InstallArgs) []InstallArg {
 
 func getRancher(rancher *installv1alpha1.RancherComponent) Rancher {
 	if rancher == nil {
-		return Rancher{}
+		return Rancher{Enabled: "true"}
 	}
-	rancherConfig := Rancher{
-		Enabled: strconv.FormatBool(rancher.Enabled),
+
+	var enabled string
+	if rancher.Enabled != nil {
+		enabled = strconv.FormatBool(*rancher.Enabled)
+	} else {
+		enabled = "true"
 	}
-	return rancherConfig
+	return Rancher{Enabled: enabled}
 }
 
 // getKeycloak returns the json representation for the keycloak configuration

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -42,7 +42,7 @@ func TestNipIoInstallDefaults(t *testing.T) {
 //  WHEN I call GetInstallConfig
 //  THEN the nip.io install configuration is created and verified
 func TestNipIoInstallNonDefaults(t *testing.T) {
-	enabled := true
+	enabled := false
 	vz := installv1alpha1.Verrazzano{
 		Spec: installv1alpha1.VerrazzanoSpec{
 			Profile:         "dev",
@@ -136,7 +136,7 @@ func TestNipIoInstallNonDefaults(t *testing.T) {
 	assert.Equalf(t, "customNamespace", config.Certificates.CA.ClusterResourceNamespace, "Expected namespace did not match")
 	assert.Equalf(t, "customSecret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 
-	assert.Equalf(t, "true", config.Rancher.Enabled, "Expected rancher enabled did not match")
+	assert.Equalf(t, "false", config.Rancher.Enabled, "Expected rancher enabled did not match")
 
 	assert.Equalf(t, 1, len(config.Keycloak.KeycloakInstallArgs), "Expected keycloakInstallArgs length did not match")
 	assert.Equalf(t, "keycloak-name", config.Keycloak.KeycloakInstallArgs[0].Name, "Expected keycloakInstallArgs name did not match")
@@ -144,7 +144,7 @@ func TestNipIoInstallNonDefaults(t *testing.T) {
 	assert.Equalf(t, 1, len(config.Keycloak.MySQL.MySQLInstallArgs), "Expected mysqlInstallArgs length did not match")
 	assert.Equalf(t, "mysql-name", config.Keycloak.MySQL.MySQLInstallArgs[0].Name, "Expected mysqlInstallArgs name did not match")
 	assert.Equalf(t, "mysql-value", config.Keycloak.MySQL.MySQLInstallArgs[0].Value, "Expected mysqlInstallArgs value did not match")
-	assert.Equalf(t, "true", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
+	assert.Equalf(t, "false", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
 }
 
 // TestExternalInstall tests the creation of an external install configuration

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -33,7 +33,7 @@ func TestNipIoInstallDefaults(t *testing.T) {
 	assert.Equalf(t, "verrazzano-ca-certificate-secret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 	assert.Equalf(t, 0, len(config.Keycloak.KeycloakInstallArgs), "Expected keycloakInstallArgs length did not match")
 	assert.Equalf(t, 0, len(config.Keycloak.MySQL.MySQLInstallArgs), "Expected mySqlInstallArgs length did not match")
-	assert.Equalf(t, "", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
+	assert.Equalf(t, "true", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
 	assert.Equalf(t, "", config.Rancher.Enabled, "Expected rancher enabled did not match")
 }
 
@@ -42,6 +42,7 @@ func TestNipIoInstallDefaults(t *testing.T) {
 //  WHEN I call GetInstallConfig
 //  THEN the nip.io install configuration is created and verified
 func TestNipIoInstallNonDefaults(t *testing.T) {
+	enabled := true
 	vz := installv1alpha1.Verrazzano{
 		Spec: installv1alpha1.VerrazzanoSpec{
 			Profile:         "dev",
@@ -104,7 +105,7 @@ func TestNipIoInstallNonDefaults(t *testing.T) {
 							},
 						},
 					},
-					Enabled: true,
+					Enabled: &enabled,
 				},
 			},
 		},

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -34,7 +34,7 @@ func TestNipIoInstallDefaults(t *testing.T) {
 	assert.Equalf(t, 0, len(config.Keycloak.KeycloakInstallArgs), "Expected keycloakInstallArgs length did not match")
 	assert.Equalf(t, 0, len(config.Keycloak.MySQL.MySQLInstallArgs), "Expected mySqlInstallArgs length did not match")
 	assert.Equalf(t, "true", config.Keycloak.Enabled, "Expected keycloak enabled did not match")
-	assert.Equalf(t, "", config.Rancher.Enabled, "Expected rancher enabled did not match")
+	assert.Equalf(t, "true", config.Rancher.Enabled, "Expected rancher enabled did not match")
 }
 
 // TestNipIoInstallNonDefaults tests the creation of an nip.io install non-default configuration
@@ -88,7 +88,7 @@ func TestNipIoInstallNonDefaults(t *testing.T) {
 					},
 				},
 				Rancher: &installv1alpha1.RancherComponent{
-					Enabled: true,
+					Enabled: &enabled,
 				},
 				Keycloak: &installv1alpha1.KeycloakComponent{
 					KeycloakInstallArgs: []installv1alpha1.InstallArgs{

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -37,6 +37,7 @@ spec:
       ports:
         - port: 15090
           protocol: TCP
+{{- if .Values.console.enabled }}
 ---
 # Network policy for Verrazzano console
 # Ingress: allow nginx-ingress-controller to connect to port 8000
@@ -74,6 +75,7 @@ spec:
       ports:
         - port: 15090
           protocol: TCP
+{{- end }}
 ---
 # Network policy for Verrazzano operator
 # Ingress: deny all

--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -52,6 +52,7 @@ spec:
           protocol: TCP
         - port: 8000
           protocol: TCP
+{{- if .Values.grafana.enabled}}
 ---
 # Network policy for VMI System Grafana
 # Ingress: allow connect from the ingress controller to oidc port 8775
@@ -89,6 +90,8 @@ spec:
       ports:
         - port: 15090
           protocol: TCP
+{{- end }}
+{{- if .Values.prometheus.enabled}}
 ---
 # Network policy for VMI System Prometheus
 # Ingress: allow connect from the ingress controller to oidc port 8775
@@ -123,6 +126,7 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+{{- end }}
 ---
 # Network policy for Cert Manager
 # Ingress: allow connect from Prometheus for scraping metrics
@@ -273,6 +277,7 @@ spec:
         - port: 15090
           protocol: TCP
 {{- end }}
+{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher cluster agent
 # Ingress: deny all
@@ -288,7 +293,6 @@ spec:
       app: cattle-cluster-agent
   policyTypes:
     - Ingress
-{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher UI/API
 # Ingress: allow nginx ingress

--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -277,7 +277,6 @@ spec:
         - port: 15090
           protocol: TCP
 {{- end }}
-{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher cluster agent
 # Ingress: deny all
@@ -293,6 +292,7 @@ spec:
       app: cattle-cluster-agent
   policyTypes:
     - Ingress
+{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher UI/API
 # Ingress: allow nginx ingress

--- a/platform-operator/internal/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/internal/vzinstance/verrazzano_instance_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -104,7 +105,19 @@ func TestGetInstanceInfo(t *testing.T) {
 			return nil
 		})
 
-	instanceInfo := GetInstanceInfo(mock)
+	vz := &v1alpha1.Verrazzano{
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				Console: &v1alpha1.ConsoleComponent{
+					MonitoringComponent: v1alpha1.MonitoringComponent{
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	instanceInfo := GetInstanceInfo(mock, vz)
 	mocker.Finish()
 	assert.NotNil(t, instanceInfo)
 	assert.Equal(t, "https://"+consoleURL, *instanceInfo.ConsoleURL)
@@ -176,7 +189,7 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 			return nil
 		})
 
-	instanceInfo := GetInstanceInfo(mock)
+	instanceInfo := GetInstanceInfo(mock, &v1alpha1.Verrazzano{})
 	mocker.Finish()
 	assert.NotNil(t, instanceInfo)
 	assert.Equal(t, "https://"+consoleURL, *instanceInfo.ConsoleURL)
@@ -206,7 +219,7 @@ func TestGetInstanceInfoGetError(t *testing.T) {
 			return fmt.Errorf("Test error")
 		})
 
-	info := GetInstanceInfo(mock)
+	info := GetInstanceInfo(mock, &v1alpha1.Verrazzano{})
 	mocker.Finish()
 	assert.Nil(t, info)
 }
@@ -230,7 +243,19 @@ func TestGetInstanceInfoNoIngresses(t *testing.T) {
 			return nil
 		})
 
-	instanceInfo := GetInstanceInfo(mock)
+	vz := &v1alpha1.Verrazzano{
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				Console: &v1alpha1.ConsoleComponent{
+					MonitoringComponent: v1alpha1.MonitoringComponent{
+						Enabled: false,
+					},
+				},
+			},
+		},
+	}
+
+	instanceInfo := GetInstanceInfo(mock, vz)
 	mocker.Finish()
 	assert.Nil(t, instanceInfo)
 }

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -583,10 +583,8 @@ DNS_SUFFIX=$(get_dns_suffix ${INGRESS_IP})
 
 RANCHER_HOSTNAME=rancher.${NAME}.${DNS_SUFFIX}
 
-# Create the cattle-system namespace if rancher if enabled so we can create network policies
-if [ $(is_rancher_enabled) == "true" ]; then
-  action "Creating cattle-system namespace" create_cattle_system_namespace || exit 1
-fi
+# Always create the cattle-system namespace so we can create network policies
+action "Creating cattle-system namespace" create_cattle_system_namespace || exit 1
 
 # Copy the optional global registry secret to the cattle-system namespace for pulling images from a private registry
 if [ "${REGISTRY_SECRET_EXISTS}" == "TRUE" ]; then

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -583,8 +583,10 @@ DNS_SUFFIX=$(get_dns_suffix ${INGRESS_IP})
 
 RANCHER_HOSTNAME=rancher.${NAME}.${DNS_SUFFIX}
 
-# Always create the cattle-system namespace so we can create network policies
-action "Creating cattle-system namespace" create_cattle_system_namespace || exit 1
+# Create the cattle-system namespace if rancher if enabled so we can create network policies
+if [ $(is_rancher_enabled) == "true" ]; then
+  action "Creating cattle-system namespace" create_cattle_system_namespace || exit 1
+fi
 
 # Copy the optional global registry secret to the cattle-system namespace for pulling images from a private registry
 if [ "${REGISTRY_SECRET_EXISTS}" == "TRUE" ]; then

--- a/platform-operator/scripts/install/config.sh
+++ b/platform-operator/scripts/install/config.sh
@@ -450,7 +450,7 @@ function get_console_enabled() {
 
 # Return whether Elasticsearch console is enabled
 function is_elasticsearch_console_enabled() {
-  local es_enabled=$(get_console_enabled 'elasticsearch')
+  local es_enabled=$(get_console_enabled 'elasticSearch')
   echo ${es_enabled}
 }
 

--- a/platform-operator/scripts/install/install-overrides/config.dev.json
+++ b/platform-operator/scripts/install/install-overrides/config.dev.json
@@ -1,8 +1,5 @@
 {
   "rancher": {
     "enabled": true
-  },
-  "keycloak": {
-    "enabled": true
   }
 }

--- a/platform-operator/scripts/install/install-overrides/config.dev.json
+++ b/platform-operator/scripts/install/install-overrides/config.dev.json
@@ -1,5 +1,2 @@
 {
-  "rancher": {
-    "enabled": true
-  }
 }

--- a/platform-operator/scripts/install/install-overrides/config.json
+++ b/platform-operator/scripts/install/install-overrides/config.json
@@ -2,9 +2,6 @@
   "rancher": {
     "enabled": true
   },
-  "keycloak": {
-    "enabled": true
-  },
   "consolesEnabled": {
     "grafana": true,
     "kibana": true,

--- a/platform-operator/scripts/install/install-overrides/config.json
+++ b/platform-operator/scripts/install/install-overrides/config.json
@@ -1,7 +1,4 @@
 {
-  "rancher": {
-    "enabled": true
-  },
   "consolesEnabled": {
     "grafana": true,
     "kibana": true,

--- a/platform-operator/scripts/install/install-overrides/config.json
+++ b/platform-operator/scripts/install/install-overrides/config.json
@@ -5,7 +5,7 @@
   "consolesEnabled": {
     "grafana": true,
     "kibana": true,
-    "elasticsearch": true,
+    "elasticSearch": true,
     "prometheus": true,
     "console": true
   }

--- a/platform-operator/scripts/install/install-overrides/config.managed-cluster.json
+++ b/platform-operator/scripts/install/install-overrides/config.managed-cluster.json
@@ -8,7 +8,7 @@
   "consolesEnabled": {
     "grafana": false,
     "kibana": false,
-    "elasticsearch": false,
+    "elasticSearch": false,
     "prometheus": false,
     "console": false
   }

--- a/platform-operator/scripts/install/install-overrides/config.prod.json
+++ b/platform-operator/scripts/install/install-overrides/config.prod.json
@@ -1,8 +1,5 @@
 {
   "rancher": {
     "enabled": true
-  },
-  "keycloak": {
-    "enabled": true
   }
 }

--- a/platform-operator/scripts/install/install-overrides/config.prod.json
+++ b/platform-operator/scripts/install/install-overrides/config.prod.json
@@ -1,5 +1,2 @@
 {
-  "rancher": {
-    "enabled": true
-  }
 }


### PR DESCRIPTION
# Description

This pull request contains a number of fixes for the Verrazzano install.  The fixes include:

1. The optional install of Keycloak now works when disabling the component in the vz resource
2. The optional install of Rancher now works when disabling the component in the vz resource
3. The optional install of Elasticsearch now works when disabling the component in the vz resource
4. Network policies were being installed if component was disabled. This has been fixed.

Fixes VZ-3010

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
