### PR TITLE
VZ-2912 added  content-type to access-control-allow-headers

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -952,7 +952,7 @@ data:
                     if h and h ~= "*" and  h ~= "null" then
                         ngx.header["Access-Control-Allow-Origin"] = h
                     end
-                    ngx.header["Access-Control-Allow-Headers"] = "authorization"
+                    ngx.header["Access-Control-Allow-Headers"] = "authorization, content-type"
                 }
 {{- end }}
             }


### PR DESCRIPTION
# Description
Fixes VZ-9999
VZ-2912 added  content-type to access-control-allow-headers

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
