### PR TITLE
Acceptance test fixes

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -278,13 +278,23 @@ var _ = AfterSuite(func() {
 	}
 
 	Eventually(func() error {
+		return pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-app.yaml")
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-comp.yaml")
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
 		return pkg.DeleteNamespace("sockshop")
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
+	pkg.Log(pkg.Info, "Waiting for namespace to be deleted")
 	Eventually(func() bool {
 		_, err := pkg.GetNamespace("sockshop")
 		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+	}, waitTimeout, pollingInterval).Should(BeTrue())
+	pkg.Log(pkg.Info, "Namespace deleted")
 })
 
 // isSockShopServiceReady checks if the service is ready

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -278,14 +278,6 @@ var _ = AfterSuite(func() {
 	}
 
 	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-app.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("examples/sock-shop/sock-shop-comp.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	Eventually(func() error {
 		return pkg.DeleteNamespace("sockshop")
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -285,8 +285,10 @@ var _ = AfterSuite(func() {
 	// capture a cluster dump and hopefully we can figure out what is keeping the namespace
 	// from going away
 	pkg.Log(pkg.Info, "Waiting for namespace to be deleted")
+	var ns *v1.Namespace
+	var err error
 	for i := 0; i < 10; i++ {
-		_, err := pkg.GetNamespace("sockshop")
+		ns, err = pkg.GetNamespace("sockshop")
 		if err != nil && errors.IsNotFound(err) {
 			pkg.Log(pkg.Info, "Namespace deleted")
 			return
@@ -298,6 +300,11 @@ var _ = AfterSuite(func() {
 	}
 
 	pkg.Log(pkg.Error, "Namespace could not be deleted, dumping cluster")
+	if ns != nil {
+		if b, err := json.Marshal(ns); err == nil {
+			pkg.Log(pkg.Info, string(b))
+		}
+	}
 	pkg.ExecuteClusterDumpWithEnvVarConfig()
 	Fail("Unable to delete namespace")
 })

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -338,7 +338,7 @@ func testAccess(fromSelector metav1.LabelSelector, fromNamespace string, toSelec
 			if expectAccess {
 				Eventually(func() bool {
 					return attemptConnection(&fromPod, &toPod, port, 10)
-				}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), fmt.Sprintf("Should be able to access pod %s from pod %s on port %d", toPod.Name, fromPod.Name, port))
+				}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Should be able to access pod %s from pod %s on port %d", toPod.Name, fromPod.Name, port))
 			} else {
 				Consistently(func() bool {
 					return attemptConnection(&fromPod, &toPod, port, 10)


### PR DESCRIPTION
# Description

This PR updates two acceptance tests:

1. Sock shop intermittently fails in `AfterSuite` because the sockshop namespace is not deleting properly. I added calls to delete the test resources, which should not make a difference, but all of the other tests clean up resources they create so I made this consistent. I also added a cluster dump when the namespace doesn't delete, so hopefully when this problem occurs the cluster dump will give us more to go on.
2. The network policy test, when testing access from one pod to another, had two issues:
    - When expecting pod-to-pod access to work, it was only running the check once. A transient network issue could make the check fail, so I wrapped it in `Eventually`.
    - When expecting pod-to-pod access to NOT work, again it was only doing the check once. A transient network issue could cause the test to pass even if pod-to-pod access would otherwise work. I wrapped that check in `Consistently` to help minimize the risk of the test passing by accident.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
