### PR TITLE
Update to use Rancher 2.5.9

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -155,6 +155,8 @@ function delete_rancher() {
   do
     delete_k8s_resources rolebinding ":metadata.name" "Could not delete RoleBindings from Rancher in namespace ${namespace}" '/clusterrolebinding-/' "${namespace}" \
       || return $? # return on pipefail
+    delete_k8s_resources rolebinding ":metadata.name" "Could not delete RoleBindings from Rancher in namespace ${namespace}" '/^rb-/' "${namespace}" \
+      || return $? # return on pipefail
   done
 
   # delete configmap in kube-system
@@ -208,6 +210,10 @@ function delete_rancher() {
     | awk '/controller.cattle.io/ {print $1}' \
     | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || err_return $? "Could not remove Rancher finalizers from all namespaces" || return $? # return on pipefail
+
+  log "Removing Rancher MutatingWebhookConfiguration"
+  kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io rancher.cattle.io --ignore-not-found \
+    || err_return $? "Failed to delete MutatingWebhookConfiguration rancher.cattle.io"
 }
 
 action "Deleting Rancher Components" delete_rancher || exit 1

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -165,13 +165,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.7-20210407205410-1c7b39d0c",
+              "tag": "v2.5.9-20210716224636-3e2504adb",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.7-20210407205410-1c7b39d0c"
+              "tag": "v2.5.9-20210716224636-3e2504adb"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -207,7 +207,7 @@
             {
               "image": "local-path-provisioner",
               "tag": "v0.0.14"
-            },
+            }
           ]
         }
       ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -186,24 +186,28 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.0-beta9"
+              "tag": "v0.1.1"
             },
             {
               "image": "fleet-agent",
-              "tag": "v0.3.4"
+              "tag": "v0.3.5"
             },
             {
               "image": "fleet",
-              "tag": "v0.3.4"
+              "tag": "v0.3.5"
             },
             {
               "image": "gitjob",
-              "tag": "v0.1.13"
+              "tag": "v0.1.15"
             },
             {
               "image": "rancher-operator",
-              "tag": "v0.1.3"
-            }
+              "tag": "v0.1.4"
+            },
+            {
+              "image": "local-path-provisioner",
+              "tag": "v0.0.14"
+            },
           ]
         }
       ]


### PR DESCRIPTION
# Description

Update verrazzano-bom to use Rancher 2.5.9. Also update additional_rancher images in the bom file for private registry install. Fix uninstall to clean up additional rolebindings and mutating webhook added in this version of Rancher.

Fixes VZ-3085

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
