### PR TITLE
Use versioned name for Verrazzano tarball generation, generate automatically on release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ def SKIP_ACCEPTANCE_TESTS = false
 def SKIP_TRIGGERED_TESTS = false
 def SUSPECT_LIST = ""
 def SCAN_IMAGE_PATCH_OPERATOR = false
+def VERRAZZANO_DEV_VERSION = ""
 
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 
@@ -475,7 +476,7 @@ pipeline {
             }
         }
         success {
-            storePipelineArtifacts()
+            storePipelineArtifacts(VERRAZZANO_DEV_VERSION)
         }
         cleanup {
             deleteDir()
@@ -493,34 +494,41 @@ def moveContentToGoRepoPath() {
 }
 
 // Called in final post success block of pipeline
-def storePipelineArtifacts() {
-    sh """
-        if [ "${params.GENERATE_TARBALL}" == "true" ]; then
-            mkdir ${WORKSPACE}/tar-files
-            chmod uog+w ${WORKSPACE}/tar-files
-            cp $WORKSPACE/generated-verrazzano-bom.json ${WORKSPACE}/tar-files/verrazzano-bom.json
-            cp tools/scripts/vz-registry-image-helper.sh ${WORKSPACE}/tar-files/vz-registry-image-helper.sh
-            cp tools/scripts/README.md ${WORKSPACE}/tar-files/README.md
-            mkdir -p ${WORKSPACE}/tar-files/charts
-            cp  -r platform-operator/helm_config/charts/verrazzano-platform-operator ${WORKSPACE}/tar-files/charts
-            tools/scripts/generate_tarball.sh ${WORKSPACE}/tar-files/verrazzano-bom.json ${WORKSPACE}/tar-files ${WORKSPACE}/tarball.tar.gz
-            cd ${WORKSPACE}
-            sha256sum tarball.tar.gz > tarball.tar.gz.sha256
-            echo "git-commit=${env.GIT_COMMIT}" > tarball-commit.txt
-            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/tarball-commit.txt --file tarball-commit.txt
-            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/tarball.tar.gz --file tarball.tar.gz
-            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/tarball.tar.gz.sha256 --file tarball.tar.gz.sha256
-       fi
-    """
+def storePipelineArtifacts(version) {
+    script {
+        tarfilePrefix="verrazzano_${version}"
+        tarfile="${tarfilePrefix}.tar.gz"
+        commitFile="${tarfilePrefix}-commit.txt"
+        sha256File="${tarfile}.sha256"
+        sh """
+            if [ "${params.GENERATE_TARBALL}" == "true" ] || [[ ${GIT_BRANCH} == release* ]]; then
+                echo "Generating tar file ${tarfile} (SHA: ${sha256File}), commit file ${commitFile}"
+                mkdir ${WORKSPACE}/tar-files
+                chmod uog+w ${WORKSPACE}/tar-files
+                cp $WORKSPACE/generated-verrazzano-bom.json ${WORKSPACE}/tar-files/verrazzano-bom.json
+                cp tools/scripts/vz-registry-image-helper.sh ${WORKSPACE}/tar-files/vz-registry-image-helper.sh
+                cp tools/scripts/README.md ${WORKSPACE}/tar-files/README.md
+                mkdir -p ${WORKSPACE}/tar-files/charts
+                cp  -r platform-operator/helm_config/charts/verrazzano-platform-operator ${WORKSPACE}/tar-files/charts
+                tools/scripts/generate_tarball.sh ${WORKSPACE}/tar-files/verrazzano-bom.json ${WORKSPACE}/tar-files ${WORKSPACE}/${tarfile}
+                cd ${WORKSPACE}
+                sha256sum ${tarfile} > ${sha256File}
+                echo "git-commit=${env.GIT_COMMIT}" > ${commitFile}
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${commitFile} --file ${commitFile}
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${tarfile} --file ${tarfile}
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${sha256File} --file ${sha256File}
+           fi
+        """
 
-    // If this is master and it was clean, record the commit in object store so the periodic test jobs can run against that rather than the head of master
-    sh """
-        if [ "${env.JOB_NAME}" == "verrazzano/master" ]; then
-            cd ${GO_REPO_PATH}/verrazzano
-            echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-stable-commit.txt
-            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/last-stable-commit.txt --file $WORKSPACE/last-stable-commit.txt
-        fi
-    """
+        // If this is master and it was clean, record the commit in object store so the periodic test jobs can run against that rather than the head of master
+        sh """
+            if [ "${env.JOB_NAME}" == "verrazzano/master" ]; then
+                cd ${GO_REPO_PATH}/verrazzano
+                echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-stable-commit.txt
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/last-stable-commit.txt --file $WORKSPACE/last-stable-commit.txt
+            fi
+        """
+    }
 }
 
 // Called in Stage Integration Tests steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -498,10 +498,11 @@ def storePipelineArtifacts(version) {
     script {
         tarfilePrefix="verrazzano_${version}"
         tarfile="${tarfilePrefix}.tar.gz"
+        zipFile="${tarfilePrefix}.zip"
         commitFile="${tarfilePrefix}-commit.txt"
         sha256File="${tarfile}.sha256"
         sh """
-            if [ "${params.GENERATE_TARBALL}" == "true" ] || [[ ${GIT_BRANCH} == release* ]]; then
+            if [ "${params.GENERATE_TARBALL}" == "true" ] || [[ ${GIT_BRANCH} == release-* ]]; then
                 echo "Generating tar file ${tarfile} (SHA: ${sha256File}), commit file ${commitFile}"
                 mkdir ${WORKSPACE}/tar-files
                 chmod uog+w ${WORKSPACE}/tar-files
@@ -514,9 +515,9 @@ def storePipelineArtifacts(version) {
                 cd ${WORKSPACE}
                 sha256sum ${tarfile} > ${sha256File}
                 echo "git-commit=${env.GIT_COMMIT}" > ${commitFile}
+                zip ${zipFile} ${commitFile} ${sha256File} ${tarfile}
                 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${commitFile} --file ${commitFile}
-                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${tarfile} --file ${tarfile}
-                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${sha256File} --file ${sha256File}
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${zipFile} --file ${zipFile}
            fi
         """
 

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -50,7 +50,7 @@ function create_image_repos_from_archives() {
     local from_repository=$(dirname $from_image | cut -d \/ -f 2-)
 
     local is_public="false"
-    if [ "$from_repository" == "rancher" ] || [ "$from_image" == "verrazzano-platform-operator" ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ]; then
       # Rancher repos must be public
       is_public="true"
     fi

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -50,7 +50,7 @@ function create_image_repos_from_archives() {
     local from_repository=$(dirname $from_image | cut -d \/ -f 2-)
 
     local is_public="false"
-    if [ "$from_repository" == "rancher" ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image" == "verrazzano-platform-operator" ]; then
       # Rancher repos must be public
       is_public="true"
     fi


### PR DESCRIPTION
# Description

Update product tarball/Zip generation for upload to PLS for release

- Create a Zip that combines the image tarball, the commit-file, and the checksum file
- Use a versioned name for the tarball and Zip
- Also generate the tarball in `release*` branches
- Adds a fix for the private registry test to always mark the VPO OCIR repository as public during the test run

Fixes VZ-2141

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
