### PR TITLE
VZ-3102: Set helm upgrade timeout during install

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -215,6 +215,7 @@ function install_cert_manager()
         ${HELM_IMAGE_ARGS} \
         ${EXTRA_CERT_MANAGER_ARGUMENTS} \
         --wait \
+        --timeout 10m0s \
         || return $?
 
     kubectl -n cert-manager rollout status -w deploy/cert-manager


### PR DESCRIPTION
# Description

Add --timeout to the certificate manager helm install command.

Fixes VZ-3102

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
