### PR TITLE
VZ-3093: Initial commit of acceptance test Eventually checker tool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -602,7 +602,7 @@ def qualityCheck() {
     sh """
         echo "run all linters"
         cd ${GO_REPO_PATH}/verrazzano
-        make check
+        make check check-tests
 
         echo "copyright scan"
         time make copyright-check

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,21 @@ copyright-check-branch: copyright-check
 	go run tools/copyright/copyright.go --verbose --enforce-current $(shell git diff --name-only ${PARENT_BRANCH})
 
 #
+# Quality checks on acceptance tests
+#
+.PHONY: check-tests
+check-tests: check-eventually
+
+# using "-report" here displays results but does not exit with a non-zero code, doing this until we address all of the existing complaints
+.PHONY: check-eventually
+check-eventually: check-eventually-test
+	go run tools/eventually-checker/check_eventually.go -report tests/e2e
+
+.PHONY: check-eventually-test
+check-eventually-test:
+	(cd tools/eventually-checker; go test .)
+
+#
 # CLI
 #
 cli:

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1912,6 +1912,38 @@ shall terminate as of the date such litigation is filed.
 
 
 -------- Dependency
+golang.org/x/mod
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
 golang.org/x/net
 -------- Copyrights
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -2079,6 +2111,61 @@ shall terminate as of the date such litigation is filed.
 
 
 -------- Dependency
+golang.org/x/tools
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.  All rights reserved.
+Copyright 2013 The Go Authors.  All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors.  All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright © 1994-1999 Lucent Technologies Inc.  All rights reserved.
+Portions Copyright © 1995-1997 C H Forsyth (forsyth@terzarima.net)
+Portions Copyright © 1997-1999 Vita Nuova Limited
+Portions Copyright © 2000-2007 Vita Nuova Holdings Limited (www.vitanuova.com)
+Portions Copyright © 2004,2006 Bruce Ellis
+Portions Copyright © 2005-2007 C H Forsyth (forsyth@terzarima.net)
+Revisions Copyright © 2000-2007 Lucent Technologies Inc. and others
+Portions Copyright © 2009 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors.  All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+const license = `// Copyright 2013 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
 golang.org/x/xerrors
 -------- Copyrights
 Copyright (c) 2019 The Go Authors. All rights reserved.
@@ -2162,11 +2249,13 @@ github.com/imdario/mergo
 github.com/liggitt/tabwriter
 github.com/spf13/pflag
 golang.org/x/crypto
+golang.org/x/mod
 golang.org/x/net
 golang.org/x/oauth2
 golang.org/x/sys
 golang.org/x/text
 golang.org/x/time
+golang.org/x/tools
 golang.org/x/xerrors
 google.golang.org/protobuf
 gopkg.in/inf.v0
@@ -2496,4 +2585,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: a91634d9e30946768f6696a3b14d23ed
+License file based on go.mod with md5 sum: 875e563f2b867b895a80b2625fcf1828

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
+	golang.org/x/tools v0.0.0-20200630223951-c138986dd9b9
 	istio.io/api v0.0.0-20200911191701-0dc35ad5c478
 	istio.io/client-go v0.0.0-20200807182027-d287a5abb594
 	k8s.io/api v0.21.1

--- a/tools/eventually-checker/README.md
+++ b/tools/eventually-checker/README.md
@@ -1,0 +1,33 @@
+# Eventually Checker
+
+This tool is used to scan tests that use the gomega and ginkgo packages and checks for calls that will force `gomega.Eventually` calls to exit prematurely. Specifically, it looks for `ginkgo.Fail` and `gomega.Expect` calls in call trees rooted by `gomega.Eventually`.
+
+## Usage
+
+```shell
+go run check_eventually.go [options] path
+
+Options:
+  -report   report on problems but always exits with a zero status code
+```
+
+## Running the Checker
+
+The tool is integrated into the Verrazzano top-level Makefile in the `check-tests` target. Use `make check-tests` or run the tool manually. For example, to run the tool against the acceptance tests:
+
+```shell
+$ go run tools/eventually-checker/check_eventually.go tests/e2e
+```
+If the tool finds suspect calls, it displays the locations of those calls along with the locations of the `Eventually` calls. For example:
+
+```shell
+$ go run tools/eventually-checker/check_eventually.go tools/eventually-checker/test/
+
+eventuallyChecker: Fail/Expect at /go/src/github.com/verrazzano/verrazzano/tools/eventually-checker/test/internal/helper.go:12:2
+    called from Eventually at:
+        /go/src/github.com/verrazzano/verrazzano/tools/eventually-checker/test/main.go:14:3
+
+eventuallyChecker: Fail/Expect at /go/src/github.com/verrazzano/verrazzano/tools/eventually-checker/test/main.go:32:2
+    called from Eventually at:
+        /go/src/github.com/verrazzano/verrazzano/tools/eventually-checker/test/main.go:23:3
+```

--- a/tools/eventually-checker/check_eventually.go
+++ b/tools/eventually-checker/check_eventually.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const mode packages.LoadMode = packages.NeedName |
+	packages.NeedTypes |
+	packages.NeedSyntax |
+	packages.NeedTypesInfo
+
+// funcCall contains information about a function call, including the function name and its position in a file
+type funcCall struct {
+	name string
+	pos  token.Pos
+}
+
+// funcMap is a map of function names to functions called directly by the function
+var funcMap = make(map[string][]funcCall)
+
+// eventuallyMap is a map of locations of Eventually calls and the functions called directly by those Eventually calls
+var eventuallyMap = make(map[token.Pos][]funcCall)
+
+// if reportOnly is true, we always return a zero exit code
+var reportOnly bool
+
+// parseFlags sets up command line arg and flag parsing
+func parseFlags() {
+	flag.Usage = func() {
+		help := "Usage of %s: [options] path\nScans all packages in path and outputs function calls that cause Eventually to exit prematurely\n\n"
+		fmt.Fprintf(flag.CommandLine.Output(), help, os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.BoolVar(&reportOnly, "report", false, "report on problems but always exits with a zero status code")
+	flag.Parse()
+}
+
+// main loads the packages from the specified directories, analyzes the file sets, and displays information about
+// calls that should not be called from Eventually
+func main() {
+	parseFlags()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// load all packages from the specified directory
+	fset, pkgs, err := loadPackages(flag.Args()[0])
+	if err != nil {
+		fmt.Fprintln(flag.CommandLine.Output(), err)
+		os.Exit(1)
+	}
+
+	// analyze each package
+	for _, pkg := range pkgs {
+		analyze(pkg.Syntax)
+	}
+
+	// check for calls that should not be in Eventually blocks and display results
+	results := checkForBadCalls()
+	displayResults(results, fset, flag.CommandLine.Output())
+
+	if len(results) > 0 && !reportOnly {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+// loadPackages loads the packages from the specified path and returns the FileSet, the slice of packages,
+// and an error
+func loadPackages(path string) (*token.FileSet, []*packages.Package, error) {
+	fset := token.NewFileSet()
+	cfg := &packages.Config{Tests: true, Fset: fset, Mode: mode, Dir: path}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		return nil, nil, err
+	}
+	return fset, pkgs, nil
+}
+
+// analyze analyzes all of the files in the file set, looking for calls to Fail & Expect inside of Eventually.
+// We use ast.Inspect to walk the abstract syntax tree, searching for function declarations and function calls.
+// If we find a call to Eventually, we record it in the map of Eventually calls, otherwise we record the
+// call in funcMap.
+func analyze(files []*ast.File) {
+	for _, file := range files {
+		var currentFuncDecl string
+		ast.Inspect(file, func(n ast.Node) bool {
+			pkg := file.Name.Name
+			switch x := n.(type) {
+			case *ast.FuncDecl:
+				currentFuncDecl = fmt.Sprintf("%s.%s", pkg, x.Name.Name)
+			case *ast.CallExpr:
+				name, pos := getNameAndPosFromCallExpr(x, file.Name.Name)
+
+				if name != "" {
+					if strings.HasSuffix(name, ".Eventually") {
+						f, isAnonFunc := getEventuallyFuncName(pkg, x.Args)
+						if isAnonFunc {
+							inspectEventuallyAnonFunc(pos, x.Args[0], pkg, currentFuncDecl)
+							// returning false tells the inspector there's no need to continue walking this
+							// part of the tree
+							return false
+						}
+						addCallToEventuallyMap(pos, f, pos)
+					} else {
+						if _, ok := funcMap[currentFuncDecl]; !ok {
+							funcMap[currentFuncDecl] = make([]funcCall, 0)
+						}
+						funcMap[currentFuncDecl] = append(funcMap[currentFuncDecl], funcCall{name: name, pos: pos})
+					}
+				}
+			}
+			return true
+		})
+	}
+}
+
+// inspectEventuallyAnonFunc finds all function calls in an anonymous function passed to Eventually
+func inspectEventuallyAnonFunc(eventuallyPos token.Pos, node ast.Node, pkgName string, parent string) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.CallExpr:
+			name, pos := getNameAndPosFromCallExpr(x, pkgName)
+			addCallToEventuallyMap(eventuallyPos, name, pos)
+		}
+		return true
+	})
+}
+
+// addCallToEventuallyMap adds a function name at the given position to the map of Eventually calls
+func addCallToEventuallyMap(eventuallyPos token.Pos, funcName string, pos token.Pos) {
+	if _, ok := eventuallyMap[eventuallyPos]; !ok {
+		eventuallyMap[eventuallyPos] = make([]funcCall, 0)
+	}
+	eventuallyMap[eventuallyPos] = append(eventuallyMap[eventuallyPos], funcCall{name: funcName, pos: pos})
+}
+
+// getNameAndPosFromCallExpr gets the function name and position from an ast.CallExpr
+func getNameAndPosFromCallExpr(expr *ast.CallExpr, pkgName string) (string, token.Pos) {
+	switch x := expr.Fun.(type) {
+	case *ast.Ident:
+		// ast.Ident means the call is in the same package as the enclosing function declaration, so use the
+		// package from the func decl
+		name := pkgName + "." + x.Name
+		pos := x.NamePos
+		return name, pos
+	case *ast.SelectorExpr:
+		var pkg string
+		var pos token.Pos
+		if ident, ok := x.X.(*ast.Ident); ok {
+			pkg = ident.Name + "."
+			pos = ident.NamePos
+		}
+		name := pkg + x.Sel.Name
+		return name, pos
+	default:
+		// ignore other function call types
+		return "", 0
+	}
+}
+
+// getEventuallyFuncName returns the name of the function (prefixed with package name) passed to
+// Eventually and a boolean that will be true if an anonymous function is passed to Eventually
+func getEventuallyFuncName(pkg string, args []ast.Expr) (string, bool) {
+	if len(args) == 0 {
+		panic("No args passed to Eventually call")
+	}
+
+	switch x := args[0].(type) {
+	case *ast.FuncLit:
+		return "", true
+	case *ast.Ident:
+		return pkg + "." + x.Name, false
+	case *ast.SelectorExpr:
+		var p string = pkg + "."
+		if ident, ok := x.X.(*ast.Ident); ok {
+			p = ident.Name + "."
+		}
+		return p + x.Sel.Name, false
+	default:
+		panic(fmt.Sprintf("Unexpected AST node type found: %s", x))
+	}
+}
+
+// checkForBadCalls searchs all functions called by Eventually functions looking for bad calls and
+// returns a map of results, where the key has the position of the bad call and the values contains
+// a slice with all of the positions of Eventually calls that call the function (directly or indirectly)
+func checkForBadCalls() map[token.Pos][]token.Pos {
+	var resultsMap = make(map[token.Pos][]token.Pos)
+
+	for key, val := range eventuallyMap {
+		for _, eventuallyFuncCall := range val {
+			if fc := findBadCall(&eventuallyFuncCall, 0); fc != nil {
+				if _, ok := resultsMap[fc.pos]; !ok {
+					resultsMap[fc.pos] = make([]token.Pos, 0)
+				}
+				resultsMap[fc.pos] = append(resultsMap[fc.pos], key)
+			}
+		}
+	}
+
+	return resultsMap
+}
+
+// findBadCall does a depth-first search of function calls looking for calls to Fail or Expect - it returns
+// nil if no bad calls are found, or information describing the call (name and file position) if a bad call is found
+func findBadCall(fc *funcCall, depth int) *funcCall {
+	// if there are any cycles in the call graph due to recursion, use depth value to prevent running forever
+	if depth > 30 {
+		return nil
+	}
+
+	if strings.HasSuffix(fc.name, ".Fail") || strings.HasSuffix(fc.name, ".Expect") {
+		return fc
+	}
+
+	for _, child := range funcMap[fc.name] {
+		if childFuncCall := findBadCall(&child, depth+1); childFuncCall != nil {
+			return childFuncCall
+		}
+	}
+
+	return nil
+}
+
+// displayResults outputs the analysis results
+func displayResults(results map[token.Pos][]token.Pos, fset *token.FileSet, out io.Writer) {
+	for key, val := range results {
+		fmt.Fprintf(out, "eventuallyChecker: Fail/Expect at %s\n    called from Eventually at:\n", fset.PositionFor(key, true))
+		for _, calls := range val {
+			fmt.Fprintf(out, "        %s\n", fset.PositionFor(calls, true))
+		}
+		fmt.Fprintln(out)
+	}
+}

--- a/tools/eventually-checker/check_eventually_test.go
+++ b/tools/eventually-checker/check_eventually_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAnalyzePackages tests analyzing packages and finds bad calls inside gomega.Eventually.
+// GIVEN test source code that calls gomega.Eventually and ginkgo.Fail and gomega.Expect
+// WHEN the packages are analyzed
+// THEN the checker correctly identifies Fail and Expect calls that are called by Eventually (directly or indirectly)
+func TestAnalyzePackages(t *testing.T) {
+	assert := assert.New(t)
+
+	// load the packages from the unit test data directory
+	fset, pkgs, err := loadPackages("./test")
+	if err != nil {
+		assert.NoError(err)
+	}
+
+	// should be two packages
+	assert.Len(pkgs, 2)
+
+	// analyze the packages
+	for _, pkg := range pkgs {
+		analyze(pkg.Syntax)
+	}
+
+	// check for bad calls, we should get 2
+	results := checkForBadCalls()
+	assert.Len(results, 2)
+
+	for key, val := range results {
+		// convert the failed call position to a string of the form "filename:row:column"
+		failedCallPos := fset.PositionFor(key, true).String()
+
+		if strings.HasSuffix(failedCallPos, "/internal/helper.go:12:2") {
+			// expect this bad call from Eventually in main.go
+			assert.Len(val, 1)
+			eventuallyPos := fset.PositionFor(val[0], true).String()
+			assert.True(strings.HasSuffix(eventuallyPos, "/main.go:14:3"))
+		} else if strings.HasSuffix(failedCallPos, "/main.go:32:2") {
+			// expect this bad call from Eventually in main.go
+			assert.Len(val, 1)
+			eventuallyPos := fset.PositionFor(val[0], true).String()
+			assert.True(strings.HasSuffix(eventuallyPos, "/main.go:23:3"))
+		} else {
+			t.Errorf("Found unexpected Fail/Expect call at: %s", failedCallPos)
+		}
+	}
+}
+
+// TestParseFlags tests command line flag parsing
+// GIVEN command line arguments
+// WHEN the command line arguments are parsed
+// THEN validate that the flags are set correctly and positional arguments are correct
+func TestParseFlags(t *testing.T) {
+	assert := assert.New(t)
+	path := "/unit/test/path"
+
+	os.Args = []string{"cmd_exe", "-report", path}
+
+	parseFlags()
+	assert.True(reportOnly)
+	assert.Equal(path, flag.Args()[0])
+
+	// reset flag parsing
+	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError)
+
+	os.Args = []string{"cmd_exe", path}
+
+	parseFlags()
+	assert.False(reportOnly)
+	assert.Equal(path, flag.Args()[0])
+}
+
+// TestDisplayResults tests output of checker results
+// GIVEN test source code that calls gomega.Eventually and ginkgo.Fail and gomega.Expect
+// WHEN the packages are analyzed
+// AND results are displayed
+// THEN the output contains the files and positions of the bad calls
+func TestDisplayResults(t *testing.T) {
+	assert := assert.New(t)
+
+	fset, pkgs, err := loadPackages("./test")
+	if err != nil {
+		assert.NoError(err)
+	}
+
+	for _, pkg := range pkgs {
+		analyze(pkg.Syntax)
+	}
+
+	results := checkForBadCalls()
+
+	var b bytes.Buffer
+	displayResults(results, fset, &b)
+	assert.Contains(b.String(), "main.go:32:2")
+	assert.Contains(b.String(), "main.go:23:3")
+	assert.Contains(b.String(), "helper.go:12:2")
+	assert.Contains(b.String(), "main.go:14:3")
+}

--- a/tools/eventually-checker/test/internal/helper.go
+++ b/tools/eventually-checker/test/internal/helper.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package internal
+
+import . "github.com/onsi/gomega" //nolint
+
+func DoSomething() (bool, error) {
+	return someNestedFunc(), nil
+}
+
+func someNestedFunc() bool {
+	Expect(false).To(BeTrue())
+	return true
+}
+
+func AnotherFunc() bool {
+	return false
+}

--- a/tools/eventually-checker/test/main.go
+++ b/tools/eventually-checker/test/main.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"github.com/verrazzano/verrazzano/tools/eventually-checker/test/internal"
+
+	. "github.com/onsi/ginkgo" //nolint
+	. "github.com/onsi/gomega" //nolint
+)
+
+func main() {
+	It("Test 1", func() {
+		Eventually(func() (bool, error) {
+			localFunc()
+			return internal.DoSomething()
+		})
+
+		Expect(false).To(BeTrue())
+	})
+
+	It("Test 2", func() {
+		Eventually(eventuallyFunc)
+	})
+
+	It("Test 3", func() {
+		Eventually(internal.AnotherFunc)
+	})
+}
+
+func eventuallyFunc() bool {
+	Fail("FAIL!")
+	return true
+}
+
+func unusedFunc() { //nolint
+	internal.DoSomething()
+}
+
+func localFunc() {
+}


### PR DESCRIPTION
# Description

This PR introduces the acceptance test Eventually checker into the build. The checker looks for `Fail` and `Expect` calls that can result in an `Eventually` exiting prematurely.

**NOTE**: The checker is currently configured in report mode, so it displays problems but it does not exit with a non-zero code, thus it will not gate the build. Once we have cleaned up all of the existing complaints, we can remove the "-report" flag and the build will be gated on the check.

@markxnelson I'm not exactly sure that my updates to the third party license file are correct. I didn't expect the addition of golang.org/x/mod but I left it in. Let me know if I need to fix anything in there.

Implements VZ-3093

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
