### PR TITLE
VZ-3122: Upgrade Coherence Operator to 3.2.0

### DIFF
--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -3,4 +3,4 @@
 
 # NOTE: The image you're looking for isn't here. The coherence-operator image now comes from
 # the bill of materials file (verrazzano-bom.json).
-defaultCoherenceImage: ghcr.io/oracle/coherence-ce:20.12.1
+defaultCoherenceImage: ghcr.io/oracle/coherence-ce:21.06

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -1,12 +1,12 @@
-# Copyright 2020, 2021, Oracle Corporation and/or its affiliates.
+# Copyright 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.1.5
-appVersion: 3.1.5
+version: 3.2.0
+appVersion: 3.2.0
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
@@ -10,19 +10,25 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    name: coherence-operator
-    control-plane: coherence
-    app: coherence-operator
-    version: v3.1.5
-  name: coherence-operator-webhook-service
+  name: coherence-operator-webhook
   namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: coherence
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/instance: coherence-operator-manager
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: coherence-operator
+    app.kubernetes.io/managed-by: helm
 spec:
   ports:
   - port: 443
     targetPort: 9443
   selector:
-    control-plane: coherence
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/instance: coherence-operator-manager
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/component: manager
 ---
 apiVersion: v1
 kind: Service
@@ -31,36 +37,57 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
-    app: coherence-operator
-    version: v3.1.5
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/instance: coherence-operator-rest
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/component: rest
+    app.kubernetes.io/part-of: coherence-operator
+    app.kubernetes.io/managed-by: helm
 spec:
   ports:
     - name: http-rest
       port: 8000
       targetPort: 8000
   selector:
-    control-plane: coherence
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/instance: coherence-operator-manager
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/component: manager
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    control-plane: coherence
-    app: coherence-operator
-    version: v3.1.5
   name: coherence-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: coherence
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/instance: coherence-operator-manager
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/part-of: coherence-operator
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/created-by: controller-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: coherence
+      app.kubernetes.io/name: coherence-operator
+      app.kubernetes.io/instance: coherence-operator-manager
+      app.kubernetes.io/version: "3.2.0"
+      app.kubernetes.io/component: manager
   template:
     metadata:
       labels:
         control-plane: coherence
-        app: coherence-operator
-        version: v3.1.5
+        app.kubernetes.io/name: coherence-operator
+        app.kubernetes.io/instance: coherence-operator-manager
+        app.kubernetes.io/version: "3.2.0"
+        app.kubernetes.io/component: manager
+        app.kubernetes.io/part-of: coherence-operator
+        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/created-by: controller-manager
     spec:
       serviceAccountName: {{ default "coherence-operator" .Values.serviceAccountName }}
       containers:
@@ -83,7 +110,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WEBHOOK_SERVICE
-          value: coherence-operator-webhook-service
+          value: coherence-operator-webhook
         - name: WEBHOOK_SECRET
           value: {{ default "coherence-webhook-server-cert" .Values.webhookCertSecret }}
         - name: SERVICE_NAME

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
@@ -215,3 +215,61 @@ subjects:
 - kind: ServiceAccount
   name: {{ default "coherence-operator" .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+---
+# ---------------------------------------------------------------------
+# This is the Role required by the Coherence Operator
+# during normal operation to perform leader election.
+# ---------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# ---------------------------------------------------------------------
+# This is the Role binding required by the Coherence Operator
+# during normal operation to perform leader election.
+# ---------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ default "coherence-operator" .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -1,17 +1,17 @@
-# Copyright 2020, 2021, Oracle Corporation and/or its affiliates.
+# Copyright 2020 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
 # image is the Coherence Operator image
-image: "ghcr.io/oracle/coherence-operator:3.1.5"
+image: "ghcr.io/oracle/coherence-operator:3.2.0"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
-defaultCoherenceImage: "oraclecoherence/coherence-ce:20.12.1"
+defaultCoherenceImage: "oraclecoherence/coherence-ce:21.06"
 
 # defaultCoherenceUtilsImage is the Coherence Operator utils image that will be used when running
 # Coherence Pods. This image version should typically match the Operator version.
-defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.1.5-utils"
+defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.0-utils"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -381,7 +381,7 @@
           "images": [
             {
               "image": "coherence-operator",
-              "tag": "3.1.5",
+              "tag": "3.2.0",
               "helmFullImageKey": "image"
             }
           ]


### PR DESCRIPTION
# Description

Upgrade Coherence Operator to 3.2.0. The changes:
- Update the Coherence Operator image tag in the bill of materials file
- Update the Coherence Operator helm chart

Note that the copyright headers in the helm files do not include 2021. They are incorrect in the Coherence Operator github repo. I have let that team know and they will fix them.

Fixes VZ-3122

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
