### PR TITLE
Default log level header instead of calling ginkgo.Fail

### DIFF
--- a/tests/e2e/pkg/logging.go
+++ b/tests/e2e/pkg/logging.go
@@ -5,7 +5,6 @@ package pkg
 
 import (
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -56,7 +55,7 @@ func Log(level LogLevel, message string) {
 		case Debug:
 			levelHeader = "[DEBUG]"
 		default:
-			ginkgo.Fail("Bad (non-existent) error level requested: " + strconv.Itoa(int(level)))
+			levelHeader = "[INFO]"
 		}
 		ginkgo.GinkgoWriter.Write([]byte(levelHeader + " " + time.Now().Format("2020-01-02 15:04:05.000000") + " " + message + "\n"))
 	}


### PR DESCRIPTION
# Description

Change to default the log level header string instead of calling `ginkgo.Fail`. This cleans up a bunch of linter complaints.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
