### PR TITLE
Disable eventually checker until unit test failure is fixed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -602,7 +602,7 @@ def qualityCheck() {
     sh """
         echo "run all linters"
         cd ${GO_REPO_PATH}/verrazzano
-        make check check-tests
+        make check
 
         echo "copyright scan"
         time make copyright-check


### PR DESCRIPTION
# Description

One of the master runs failed because the eventually checker unit tests failed. The failure happened in one of four runs. I'm temporarily disabling the checker in Jenkins until I can figure out why the unit tests failed, but the tool can still be run manually.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
