### PR TITLE
Fix eventually checker unit test bug, re-enable checker in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -602,7 +602,7 @@ def qualityCheck() {
     sh """
         echo "run all linters"
         cd ${GO_REPO_PATH}/verrazzano
-        make check
+        make check check-tests
 
         echo "copyright scan"
         time make copyright-check

--- a/tools/eventually-checker/check_eventually_test.go
+++ b/tools/eventually-checker/check_eventually_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"go/token"
 	"os"
 	"strings"
 	"testing"
@@ -88,6 +89,10 @@ func TestParseFlags(t *testing.T) {
 // THEN the output contains the files and positions of the bad calls
 func TestDisplayResults(t *testing.T) {
 	assert := assert.New(t)
+
+	// clear the maps from previous analysis run
+	funcMap = make(map[string][]funcCall)
+	eventuallyMap = make(map[token.Pos][]funcCall)
 
 	fset, pkgs, err := loadPackages("./test")
 	if err != nil {


### PR DESCRIPTION
# Description

Fixed a bug in the Eventually checker unit tests. The `TestDisplayResults` test needed to clear the two state maps. The results from the previous scan were still in the maps and the file position numbers were relative to a previous token.FileSet, causing the files/lines to be incorrectly displayed.

I fixed this by clearing the maps before running the test. I have also re-enabled the checker in the Jenkinsfile.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
