### PR TITLE
Implements CLI namespace commands

### DIFF
--- a/tools/cli/vz/cmd/namespace/create.go
+++ b/tools/cli/vz/cmd/namespace/create.go
@@ -1,0 +1,100 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/pkg/helpers"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var projectName []string
+var description []string
+var projectDeclared bool
+
+type NamespaceCreateOptions struct {
+	args []string
+	genericclioptions.IOStreams
+}
+
+func NewNamespaceCreateOptions(streams genericclioptions.IOStreams) *NamespaceCreateOptions {
+	return &NamespaceCreateOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdNamespaceCreate(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create namespace",
+		Short: "Create a namespace",
+		Long:  "Create a namespace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := createNamespace(streams, args, kubernetesInterface); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&description, "description", []string{}, "Description about the namespace")
+	cmd.Flags().StringSliceVarP(&projectName, "project-name", "p", []string{""}, "Name of project this namespace belongs to")
+	// checking if project-name flag is passed.
+	projectDeclared = cmd.Flags().Changed("project-name")
+	return cmd
+}
+
+func createNamespace(streams genericclioptions.IOStreams, args []string, kubernetesInterface helpers.Kubernetes) error {
+	nsName := args[0]
+	// adding label to register namespace as verrazzano namespace
+	vzLabel := make(map[string]string)
+	vzLabel["verrazzano-managed"] = "true"
+
+	// if project flag is passed
+	if projectDeclared {
+		projectClientset, err := kubernetesInterface.NewProjectClientSet()
+		project, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), projectName[0], metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+
+		// preparing the namespace
+		vzLabel["verrazzano/projectName"] = projectName[0]
+		newNsTemplate := v1alpha1.NamespaceTemplate{
+			Metadata: metav1.ObjectMeta{
+				Name:              nsName,
+				CreationTimestamp: metav1.Now(),
+				Labels:            vzLabel,
+			},
+		}
+		// adding the namespace to the project
+		project.Spec.Template.Namespaces = append(project.Spec.Template.Namespaces, newNsTemplate)
+		if _, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), project, metav1.UpdateOptions{}); err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+	} else {
+		// preparing the namespace object
+		newNamespace := v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              nsName,
+				CreationTimestamp: metav1.Now(),
+				Labels:            vzLabel,
+			},
+		}
+
+		// fetching the clientsets
+		clustersClientset := kubernetesInterface.NewClientSet()
+		_, err := clustersClientset.CoreV1().Namespaces().Create(context.Background(), &newNamespace, metav1.CreateOptions{})
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+	}
+
+	fmt.Fprintln(streams.Out, "namespace/"+nsName+" created")
+	return nil
+}

--- a/tools/cli/vz/cmd/namespace/create.go
+++ b/tools/cli/vz/cmd/namespace/create.go
@@ -28,7 +28,7 @@ func NewNamespaceCreateOptions(streams genericclioptions.IOStreams) *NamespaceCr
 
 func NewCmdNamespaceCreate(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create namespace",
+		Use:   "create NAMESPACE",
 		Short: "Create a namespace",
 		Long:  "Create a namespace",
 		Args:  cobra.ExactArgs(1),

--- a/tools/cli/vz/cmd/namespace/create.go
+++ b/tools/cli/vz/cmd/namespace/create.go
@@ -42,7 +42,6 @@ func NewCmdNamespaceCreate(streams genericclioptions.IOStreams, kubernetesInterf
 			return nil
 		},
 	}
-	cmd.Flags().StringSliceVar(&description, "description", []string{}, "Description about the namespace")
 	cmd.Flags().StringSliceVarP(&projectName, "project-name", "p", []string{""}, "Name of project this namespace belongs to")
 	// checking if project-name flag is passed.
 	projectDeclared = cmd.Flags().Changed("project-name")

--- a/tools/cli/vz/cmd/namespace/create.go
+++ b/tools/cli/vz/cmd/namespace/create.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
 
 import (

--- a/tools/cli/vz/cmd/namespace/create.go
+++ b/tools/cli/vz/cmd/namespace/create.go
@@ -15,7 +15,6 @@ import (
 )
 
 var projectName []string
-var description []string
 var projectDeclared bool
 
 type NamespaceCreateOptions struct {
@@ -57,6 +56,10 @@ func createNamespace(streams genericclioptions.IOStreams, args []string, kuberne
 	// if project flag is passed
 	if projectDeclared {
 		projectClientset, err := kubernetesInterface.NewProjectClientSet()
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
 		project, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), projectName[0], metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintln(streams.ErrOut, err)

--- a/tools/cli/vz/cmd/namespace/create_test.go
+++ b/tools/cli/vz/cmd/namespace/create_test.go
@@ -12,10 +12,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"strconv"
-
-	//"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"strconv"
 	"testing"
 )
 

--- a/tools/cli/vz/cmd/namespace/create_test.go
+++ b/tools/cli/vz/cmd/namespace/create_test.go
@@ -69,7 +69,7 @@ func TestNewCmdNamespaceCreateArguments(t *testing.T) {
 	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
 	streams, _, outBuffer, errBuffer := genericclioptions.NewTestIOStreams()
 	testCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
-	//deleteCmd := NewCmdNamespaceDelete(streams, fakeKubernetes)
+	deleteCmd := NewCmdNamespaceDelete(streams, fakeKubernetes)
 
 	// Calling with no arguments should throw an error
 	asserts.EqualError(testCmd.Execute(), "accepts 1 arg(s), received 0")
@@ -88,6 +88,8 @@ func TestNewCmdNamespaceCreateArguments(t *testing.T) {
 		testCmd.SetArgs([]string{n})
 		asserts.NoError(testCmd.Execute())
 		asserts.Equal(outBuffer.String(), `namespace/`+n+" created\n")
+		deleteCmd.SetArgs([]string{n})
+		deleteCmd.Execute()
 		outBuffer.Reset()
 	}
 }

--- a/tools/cli/vz/cmd/namespace/create_test.go
+++ b/tools/cli/vz/cmd/namespace/create_test.go
@@ -69,7 +69,7 @@ func TestNewCmdNamespaceCreateArguments(t *testing.T) {
 	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
 	streams, _, outBuffer, errBuffer := genericclioptions.NewTestIOStreams()
 	testCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
-	deleteCmd := NewCmdNamespaceDelete(streams, fakeKubernetes)
+
 
 	// Calling with no arguments should throw an error
 	asserts.EqualError(testCmd.Execute(), "accepts 1 arg(s), received 0")
@@ -81,16 +81,6 @@ func TestNewCmdNamespaceCreateArguments(t *testing.T) {
 		testCmd.SetArgs(ns)
 		asserts.EqualError(testCmd.Execute(), `accepts 1 arg(s), received `+strconv.Itoa(len(ns)))
 		errBuffer.Reset()
-	}
-
-	// Calling with 1 namespace should not throw an error
-	for _, n := range singleNs {
-		testCmd.SetArgs([]string{n})
-		asserts.NoError(testCmd.Execute())
-		asserts.Equal(outBuffer.String(), `namespace/`+n+" created\n")
-		deleteCmd.SetArgs([]string{n})
-		deleteCmd.Execute()
-		outBuffer.Reset()
 	}
 }
 

--- a/tools/cli/vz/cmd/namespace/create_test.go
+++ b/tools/cli/vz/cmd/namespace/create_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package namespace
+
+import (
+	"github.com/stretchr/testify/assert"
+	projectclientset "github.com/verrazzano/verrazzano/application-operator/clients/clusters/clientset/versioned"
+	"github.com/verrazzano/verrazzano/application-operator/clients/clusters/clientset/versioned/fake"
+	clustersclientset "github.com/verrazzano/verrazzano/platform-operator/clients/clusters/clientset/versioned"
+	verrazzanoclientset "github.com/verrazzano/verrazzano/platform-operator/clients/verrazzano/clientset/versioned"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"strconv"
+
+	//"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"testing"
+)
+
+var singleNs = [...]string{"ns1", "ns2", "ns3", "ns4"}
+var mutipleNs = [...][]string{
+	{"ns1", "ns2"},
+	{"ns3", "ns4", "ns5"},
+	{"ns6", "ns7", "ns8"},
+}
+
+type TestKubernetes struct {
+	fakeProjectClient  projectclientset.Interface
+	fakeClustersClient clustersclientset.Interface
+	fakek8sClient      kubernetes.Interface
+	fakev8oClient      verrazzanoclientset.Interface
+}
+
+func (o *TestKubernetes) NewVerrazzanoClientSet() (verrazzanoclientset.Interface, error) {
+	return o.fakev8oClient, nil
+}
+
+func (o *TestKubernetes) GetKubeConfig() *rest.Config {
+	config := &rest.Config{
+		Host: "https://1.2.3.4:1234",
+	}
+	return config
+}
+
+func (o *TestKubernetes) NewClustersClientSet() (clustersclientset.Interface, error) {
+	return o.fakeClustersClient, nil
+}
+
+func (o *TestKubernetes) NewProjectClientSet() (projectclientset.Interface, error) {
+	return o.fakeProjectClient, nil
+}
+
+func (o *TestKubernetes) NewClientSet() kubernetes.Interface {
+	return o.fakek8sClient
+}
+
+// unit test for finding arguments passed.
+// unit test for creating duplicate (verrazzano & non-verrazzano) namespaces
+
+func TestNewCmdNamespaceCreateArguments(t *testing.T) {
+	asserts := assert.New(t)
+	fakeKubernetes := &TestKubernetes{
+		fakeProjectClient: fake.NewSimpleClientset(),
+		fakek8sClient:     k8sfake.NewSimpleClientset(),
+	}
+
+	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+	streams, _, outBuffer, errBuffer := genericclioptions.NewTestIOStreams()
+	testCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
+	//deleteCmd := NewCmdNamespaceDelete(streams, fakeKubernetes)
+
+	// Calling with no arguments should throw an error
+	asserts.EqualError(testCmd.Execute(), "accepts 1 arg(s), received 0")
+	outBuffer.Reset()
+	errBuffer.Reset()
+
+	// Calling with more than 1 namespace as argument should throw an error
+	for _, ns := range mutipleNs {
+		testCmd.SetArgs(ns)
+		asserts.EqualError(testCmd.Execute(), `accepts 1 arg(s), received `+strconv.Itoa(len(ns)))
+		errBuffer.Reset()
+	}
+
+	// Calling with 1 namespace should not throw an error
+	for _, n := range singleNs {
+		testCmd.SetArgs([]string{n})
+		asserts.NoError(testCmd.Execute())
+		asserts.Equal(outBuffer.String(), `namespace/`+n+" created\n")
+		outBuffer.Reset()
+	}
+}

--- a/tools/cli/vz/cmd/namespace/create_test.go
+++ b/tools/cli/vz/cmd/namespace/create_test.go
@@ -70,7 +70,6 @@ func TestNewCmdNamespaceCreateArguments(t *testing.T) {
 	streams, _, outBuffer, errBuffer := genericclioptions.NewTestIOStreams()
 	testCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
 
-
 	// Calling with no arguments should throw an error
 	asserts.EqualError(testCmd.Execute(), "accepts 1 arg(s), received 0")
 	outBuffer.Reset()

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -85,6 +85,6 @@ func deleteNamespace(streams genericclioptions.IOStreams, args []string, kuberne
 		return err
 	}
 
-	fmt.Fprintln(streams.Out, "namepspace "+`"`+nsName+`"`+" deleted")
+	fmt.Fprintln(streams.Out, "namespace "+`"`+nsName+`"`+" deleted")
 	return nil
 }

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -82,7 +82,6 @@ func deleteNamespace(streams genericclioptions.IOStreams, args []string, kuberne
 	}
 
 	// deleting namespace from kubernetes API incase it had no associated projects
-	// TODO : Check if project associated namesapces will throw an error
 	err = clientset.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
 	if err != nil {
 		fmt.Fprintln(streams.ErrOut, err)

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
 
 import (

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -22,7 +22,7 @@ func NewNamespaceDeleteOptions(streams genericclioptions.IOStreams) *NamespaceDe
 
 func NewCmdNamespaceDelete(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete NAMESPACE",
 		Short: "delete namespace",
 		Long:  "delete namespace",
 		Args:  cobra.ExactArgs(1),

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -1,0 +1,87 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/pkg/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type NamespaceDeleteOptions struct {
+	args []string
+	genericclioptions.IOStreams
+}
+
+func NewNamespaceDeleteOptions(streams genericclioptions.IOStreams) *NamespaceDeleteOptions {
+	return &NamespaceDeleteOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdNamespaceDelete(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete namespace",
+		Long:  "delete namespace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := deleteNamespace(streams, args, kubernetesInterface); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func deleteNamespace(streams genericclioptions.IOStreams, args []string, kubernetesInterface helpers.Kubernetes) error {
+	nsName := args[0]
+
+	// deleting namespace from associated projects.
+	projectClientset, err := kubernetesInterface.NewProjectClientSet()
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+
+	projects, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").List(context.Background(), metav1.ListOptions{})
+	for _, project := range projects.Items {
+		for i, namespace := range project.Spec.Template.Namespaces {
+			if namespace.Metadata.Name == nsName {
+				project.Spec.Template.Namespaces = append(project.Spec.Template.Namespaces[:i], project.Spec.Template.Namespaces[i+1:]...)
+			}
+		}
+
+		_, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), &project, metav1.UpdateOptions{})
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+	}
+
+	clientset := kubernetesInterface.NewClientSet()
+
+	// verifying if namespace is a vz namespace before deleting it from kubernetes API
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+	if ns.Labels["verrazzano-managed"] != "true" {
+		fmt.Fprintln(streams.Out, `"`+nsName+`" is not a verrazzano namespace`)
+		return nil
+	}
+
+	// deleting namespace from kubernetes API incase it had no associated projects
+	// TODO : Check if project associated namesapces will throw an error
+	err = clientset.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+
+	fmt.Fprintln(streams.Out, "namepspace "+`"`+nsName+`"`+" deleted")
+	return nil
+}

--- a/tools/cli/vz/cmd/namespace/delete.go
+++ b/tools/cli/vz/cmd/namespace/delete.go
@@ -50,6 +50,10 @@ func deleteNamespace(streams genericclioptions.IOStreams, args []string, kuberne
 	}
 
 	projects, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
 	for _, project := range projects.Items {
 		for i, namespace := range project.Spec.Template.Namespaces {
 			if namespace.Metadata.Name == nsName {

--- a/tools/cli/vz/cmd/namespace/delete_test.go
+++ b/tools/cli/vz/cmd/namespace/delete_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
-// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package namespace
 

--- a/tools/cli/vz/cmd/namespace/delete_test.go
+++ b/tools/cli/vz/cmd/namespace/delete_test.go
@@ -14,7 +14,6 @@ import (
 
 // unit test for checking arguments
 // unit test for deleting non-existent namespaces
-// unit test for ensuring namespace is deleted i.e by calling namespace command repeatedly.
 
 func TestNewCmdNamespaceDeleteArgument(t *testing.T) {
 	asserts := assert.New(t)
@@ -49,5 +48,25 @@ func TestNewCmdNamespaceDeleteArgument(t *testing.T) {
 		asserts.NoError(testCmd.Execute())
 		asserts.Equal(outBuffer.String(), `namespace "`+n+`"`+" deleted\n")
 		outBuffer.Reset()
+	}
+}
+
+func TestNewCmdNamespaceDeleteDNE(t *testing.T) {
+	asserts := assert.New(t)
+	fakeKubernetes := &TestKubernetes{
+		fakeProjectClient: fake.NewSimpleClientset(),
+		fakek8sClient:     k8sfake.NewSimpleClientset(),
+	}
+
+	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+	streams, _, _, errBuffer := genericclioptions.NewTestIOStreams()
+	testCmd := NewCmdNamespaceDelete(streams, fakeKubernetes)
+
+	// Calling with 1 namespace should not throw an error
+	for _, n := range singleNs {
+		testCmd.SetArgs([]string{n})
+		asserts.Error(testCmd.Execute())
+		asserts.Equal(errBuffer.String(), `namespaces "`+n+`"`+" not found\n")
+		errBuffer.Reset()
 	}
 }

--- a/tools/cli/vz/cmd/namespace/delete_test.go
+++ b/tools/cli/vz/cmd/namespace/delete_test.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+package namespace
+
+// unit test for checking arguments
+// unit test for deleting non-existent namespaces
+// unit test for ensuring namespace is deleted i.e by calling namespace command repeatedly.

--- a/tools/cli/vz/cmd/namespace/list.go
+++ b/tools/cli/vz/cmd/namespace/list.go
@@ -65,7 +65,6 @@ func listNamespace(o *NamespaceListOptions, streams genericclioptions.IOStreams,
 			Version: "v1",
 			Kind:    "namespaces",
 		})
-		// TODO : how to find group?
 		printer, err := o.PrintFlags.ToPrinter()
 		if err != nil {
 			fmt.Fprintln(streams.ErrOut, "Did not get a printer object")

--- a/tools/cli/vz/cmd/namespace/list.go
+++ b/tools/cli/vz/cmd/namespace/list.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/pkg/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type NamespaceListOptions struct {
+	args []string
+	genericclioptions.IOStreams
+	PrintFlags *helpers.PrintFlags
+}
+
+func NewNamespaceListOptions(streams genericclioptions.IOStreams) *NamespaceListOptions {
+	return &NamespaceListOptions{
+		IOStreams:  streams,
+		PrintFlags: helpers.NewGetPrintFlags(),
+	}
+}
+
+func NewCmdNamespaceList(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
+	o := NewNamespaceListOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List namespaces",
+		Long:    "List namespaces",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := listNamespace(o, streams, args, kubernetesInterface); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	o.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func listNamespace(o *NamespaceListOptions, streams genericclioptions.IOStreams, args []string, kubernetesInterface helpers.Kubernetes) error {
+	clientset := kubernetesInterface.NewClientSet()
+	collection, err := clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+	})
+	if err != nil {
+		fmt.Fprintln(streams.Out, err)
+		return err
+	}
+
+	// Output options was specified
+	if len(*o.PrintFlags.OutputFormat) != 0 {
+		// Set the Version and Kind before passing it as runtime object
+		collection.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+			Version: "v1",
+			Kind:    "namespaces",
+		})
+		// TODO : how to find group?
+		printer, err := o.PrintFlags.ToPrinter()
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, "Did not get a printer object")
+			return err
+		}
+		err = printer.PrintObj(collection, o.Out)
+		return err
+	}
+
+	// how to get description
+	headings := []string{"NAME", "STATE", "PROJECT", "AGE"}
+	data := [][]string{}
+	for _, ns := range collection.Items {
+		var projectName string
+		isVzns := false
+		labels := ns.GetLabels()
+		for s, s2 := range labels {
+			if s == "verrazzano-managed" && s2 == "true" {
+				isVzns = true
+				projectName = labels["verrazzano/projectName"]
+			}
+
+		}
+		// if namespace is an verrazzano namespace, display this namespace.
+		if isVzns {
+			rowData := []string{
+				ns.Name,
+				string(ns.Status.Phase),
+				projectName,
+				helpers.Age(ns.CreationTimestamp),
+			}
+			data = append(data, rowData)
+		}
+	}
+	if len(data)==0{
+		fmt.Fprintln(streams.Out,"no namespaces present")
+		return nil
+	}else{
+		err = helpers.PrintTable(headings, data, streams.Out)
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut,err)
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/cli/vz/cmd/namespace/list.go
+++ b/tools/cli/vz/cmd/namespace/list.go
@@ -80,33 +80,28 @@ func listNamespace(o *NamespaceListOptions, streams genericclioptions.IOStreams,
 	data := [][]string{}
 	for _, ns := range collection.Items {
 		var projectName string
-		isVzns := false
 		labels := ns.GetLabels()
+		// if namespace is a verrazzano namespace, display namespace
 		for s, s2 := range labels {
 			if s == "verrazzano-managed" && s2 == "true" {
-				isVzns = true
 				projectName = labels["verrazzano/projectName"]
+				rowData := []string{
+					ns.Name,
+					string(ns.Status.Phase),
+					projectName,
+					helpers.Age(ns.CreationTimestamp),
+				}
+				data = append(data, rowData)
 			}
-
-		}
-		// if namespace is an verrazzano namespace, display this namespace.
-		if isVzns {
-			rowData := []string{
-				ns.Name,
-				string(ns.Status.Phase),
-				projectName,
-				helpers.Age(ns.CreationTimestamp),
-			}
-			data = append(data, rowData)
 		}
 	}
-	if len(data)==0{
-		fmt.Fprintln(streams.Out,"no namespaces present")
+	if len(data) == 0 {
+		fmt.Fprintln(streams.Out, "no verrazzano namespaces exist")
 		return nil
-	}else{
+	} else {
 		err = helpers.PrintTable(headings, data, streams.Out)
 		if err != nil {
-			fmt.Fprintln(streams.ErrOut,err)
+			fmt.Fprintln(streams.ErrOut, err)
 			return err
 		}
 	}

--- a/tools/cli/vz/cmd/namespace/list.go
+++ b/tools/cli/vz/cmd/namespace/list.go
@@ -98,12 +98,12 @@ func listNamespace(o *NamespaceListOptions, streams genericclioptions.IOStreams,
 	if len(data) == 0 {
 		fmt.Fprintln(streams.Out, "no verrazzano namespaces exist")
 		return nil
-	} else {
-		err = helpers.PrintTable(headings, data, streams.Out)
-		if err != nil {
-			fmt.Fprintln(streams.ErrOut, err)
-			return err
-		}
 	}
+	err = helpers.PrintTable(headings, data, streams.Out)
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+
 	return nil
 }

--- a/tools/cli/vz/cmd/namespace/list_test.go
+++ b/tools/cli/vz/cmd/namespace/list_test.go
@@ -1,0 +1,1 @@
+package namespace

--- a/tools/cli/vz/cmd/namespace/list_test.go
+++ b/tools/cli/vz/cmd/namespace/list_test.go
@@ -32,7 +32,7 @@ func TestNewCmdNamespaceListOutput(t *testing.T) {
 	outBuffer.Reset()
 	errBuffer.Reset()
 
-	actual :=`NAME   STATE   PROJECT   AGE   
+	actual := `NAME   STATE   PROJECT   AGE   
 ns1                      0s    
 ns2                      0s    
 ns3                      0s    
@@ -41,5 +41,5 @@ ns4                      0s
 `
 	// verify output
 	asserts.NoError(testCmd.Execute())
-	asserts.Equal(outBuffer.String(),actual)
+	asserts.Equal(outBuffer.String(), actual)
 }

--- a/tools/cli/vz/cmd/namespace/list_test.go
+++ b/tools/cli/vz/cmd/namespace/list_test.go
@@ -1,1 +1,38 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/clients/clusters/clientset/versioned/fake"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+// unit test for checking output
+func TestNewCmdNamespaceListOutput(t *testing.T) {
+	asserts := assert.New(t)
+	fakeKubernetes := &TestKubernetes{
+		fakeProjectClient: fake.NewSimpleClientset(),
+		fakek8sClient:     k8sfake.NewSimpleClientset(),
+	}
+
+	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+	streams, _, outBuffer, errBuffer := genericclioptions.NewTestIOStreams()
+	testCmd := NewCmdNamespaceList(streams, fakeKubernetes)
+	createCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
+
+	// Creating ns
+	for _, n := range singleNs {
+		createCmd.SetArgs([]string{n})
+		asserts.NoError(createCmd.Execute())
+	}
+	outBuffer.Reset()
+	errBuffer.Reset()
+
+	// verify output
+	asserts.NoError(testCmd.Execute())
+	asserts.Equal(outBuffer.String(),"")
+}

--- a/tools/cli/vz/cmd/namespace/list_test.go
+++ b/tools/cli/vz/cmd/namespace/list_test.go
@@ -32,7 +32,14 @@ func TestNewCmdNamespaceListOutput(t *testing.T) {
 	outBuffer.Reset()
 	errBuffer.Reset()
 
+	actual :=`NAME   STATE   PROJECT   AGE   
+ns1                      0s    
+ns2                      0s    
+ns3                      0s    
+ns4                      0s    
+
+`
 	// verify output
 	asserts.NoError(testCmd.Execute())
-	asserts.Equal(outBuffer.String(),"")
+	asserts.Equal(outBuffer.String(),actual)
 }

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -1,0 +1,1 @@
+package namespace

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -64,14 +64,14 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 
 	// making namespace a verrazzano namespace
 	nsLabels := namespace.GetLabels()
-	if len(nsLabels)==0{
+	if len(nsLabels) == 0 {
 		nsLabels = make(map[string]string)
 	}
-		nsLabels["verrazzano-managed"] = "true"
+	nsLabels["verrazzano-managed"] = "true"
 	namespace.SetLabels(nsLabels)
 
 	// if namespace is already existing in a vz project
-	if nsLabels["verrazzano/projectName"]!="" {
+	if nsLabels["verrazzano/projectName"] != "" {
 		srcProjectName := nsLabels["verrazzano/projectName"]
 		// remove namespace from srcProject
 		srcProject, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), srcProjectName, metav1.GetOptions{})
@@ -94,7 +94,7 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 		// updating the project.
 		srcProject, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), srcProject, metav1.UpdateOptions{})
 		if err != nil {
-		//	fmt.Fprintln(streams.ErrOut, err)
+			//	fmt.Fprintln(streams.ErrOut, err)
 			return err
 		}
 	}
@@ -116,6 +116,6 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 		fmt.Fprintln(streams.ErrOut, err)
 		return err
 	}
-	fmt.Fprintln(streams.Out,`"`+nsName+`" namespace moved to "`+destProject.GetName()+`" project`)
+	fmt.Fprintln(streams.Out, `"`+nsName+`" namespace moved to "`+destProject.GetName()+`" project`)
 	return nil
 }

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -94,7 +94,7 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 		// updating the project.
 		srcProject, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), srcProject, metav1.UpdateOptions{})
 		if err != nil {
-			//	fmt.Fprintln(streams.ErrOut, err)
+			fmt.Fprintln(streams.ErrOut, err)
 			return err
 		}
 	}

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
 
 import (

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -1,1 +1,115 @@
 package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/pkg/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type NamespaceMoveOptions struct {
+	args []string
+	genericclioptions.IOStreams
+}
+
+func NewNamespaceMoveOptions(streams genericclioptions.IOStreams) *NamespaceMoveOptions {
+	return &NamespaceMoveOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdNamespaceMove(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "move NAMESPACE PROJECT",
+		Short: "move namespace to a project",
+		Long:  "move a namespace to a different project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := moveNamespace(streams, args, kubernetesInterface); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernetesInterface helpers.Kubernetes) error {
+	nsName := args[0]
+	projectName := args[1]
+
+	projectClientset, err := kubernetesInterface.NewProjectClientSet()
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+	clustersClientset := kubernetesInterface.NewClientSet()
+
+	destProject, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), projectName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+	namespace, err := clustersClientset.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+
+	// making namespace a verrazzano namespace
+	nsLabels := namespace.GetLabels()
+	nsLabels["verrazzano-managed"] = "true"
+	namespace.SetLabels(nsLabels)
+
+	// if namespace is already existing in a vz project
+	if nsLabels["verrazzano/projectName"] != "" {
+		srcProjectName := nsLabels["verrazzano/projectName"]
+		// remove namespace from srcProject
+		srcProject, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), srcProjectName, metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+		delIndex := 0
+		// finding index of namespace to delete in the source project file
+		for i, nsTemplate := range srcProject.Spec.Template.Namespaces {
+			if nsTemplate.Metadata.Name == nsName {
+				delIndex = i
+				break
+			}
+		}
+
+		// deleting namespace from source project file
+		srcProject.Spec.Template.Namespaces = append(srcProject.Spec.Template.Namespaces[:delIndex], srcProject.Spec.Template.Namespaces[delIndex+1:]...)
+
+		// updating the project.
+		_, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), srcProject, metav1.UpdateOptions{})
+		if err != nil {
+			fmt.Fprintln(streams.ErrOut, err)
+			return err
+		}
+	}
+
+	nsLabels["verrazzano/projectName"] = destProject.GetName()
+	namespace.SetLabels(nsLabels)
+
+	// add namespace to destProject
+	nsTemplate := v1alpha1.NamespaceTemplate{
+		Metadata: metav1.ObjectMeta{
+			Name:              namespace.GetName(),
+			CreationTimestamp: namespace.GetCreationTimestamp(),
+			Labels:            namespace.GetLabels(),
+		},
+	}
+	destProject.Spec.Template.Namespaces = append(destProject.Spec.Template.Namespaces, nsTemplate)
+	_, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), destProject, metav1.UpdateOptions{})
+	if err != nil {
+		fmt.Fprintln(streams.ErrOut, err)
+		return err
+	}
+
+	return nil
+}

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -64,7 +64,10 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 
 	// making namespace a verrazzano namespace
 	nsLabels := namespace.GetLabels()
-	nsLabels["verrazzano-managed"] = "true"
+	if len(nsLabels)==0{
+		nsLabels = make(map[string]string)
+	}
+		nsLabels["verrazzano-managed"] = "true"
 	namespace.SetLabels(nsLabels)
 
 	// if namespace is already existing in a vz project
@@ -113,6 +116,6 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 		fmt.Fprintln(streams.ErrOut, err)
 		return err
 	}
-
+	fmt.Fprintln(streams.Out,`"`+nsName+`" namespace moved to "`+destProject.GetName()+`" project`)
 	return nil
 }

--- a/tools/cli/vz/cmd/namespace/move.go
+++ b/tools/cli/vz/cmd/namespace/move.go
@@ -68,7 +68,7 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 	namespace.SetLabels(nsLabels)
 
 	// if namespace is already existing in a vz project
-	if nsLabels["verrazzano/projectName"] != "" {
+	if nsLabels["verrazzano/projectName"]!="" {
 		srcProjectName := nsLabels["verrazzano/projectName"]
 		// remove namespace from srcProject
 		srcProject, err := projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Get(context.Background(), srcProjectName, metav1.GetOptions{})
@@ -89,9 +89,9 @@ func moveNamespace(streams genericclioptions.IOStreams, args []string, kubernete
 		srcProject.Spec.Template.Namespaces = append(srcProject.Spec.Template.Namespaces[:delIndex], srcProject.Spec.Template.Namespaces[delIndex+1:]...)
 
 		// updating the project.
-		_, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), srcProject, metav1.UpdateOptions{})
+		srcProject, err = projectClientset.ClustersV1alpha1().VerrazzanoProjects("verrazzano-mc").Update(context.Background(), srcProject, metav1.UpdateOptions{})
 		if err != nil {
-			fmt.Fprintln(streams.ErrOut, err)
+		//	fmt.Fprintln(streams.ErrOut, err)
 			return err
 		}
 	}

--- a/tools/cli/vz/cmd/namespace/move_test.go
+++ b/tools/cli/vz/cmd/namespace/move_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 )
 
-var projectNs = []string{"project1","project2","project3"}
-var moveData = [][]string{{"ns1","project2"},{"ns2","project3"},{"ns3","project1"}}
+var projectNs = []string{"project1", "project2", "project3"}
+var moveData = [][]string{{"ns1", "project2"}, {"ns2", "project3"}, {"ns3", "project1"}}
 
 // Unit test for moving a verrazzano namespace to a project
 func TestNewCmdNamespaceMoveDefault(t *testing.T) {
@@ -24,10 +24,10 @@ func TestNewCmdNamespaceMoveDefault(t *testing.T) {
 	}
 
 	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
-	streams, _, outBuffer, _:= genericclioptions.NewTestIOStreams()
+	streams, _, outBuffer, _ := genericclioptions.NewTestIOStreams()
 	testCmd := NewCmdNamespaceMove(streams, fakeKubernetes)
-	createCmd := NewCmdNamespaceCreate(streams,fakeKubernetes)
-	projectaddCmd := project.NewCmdProjectAdd(streams,fakeKubernetes)
+	createCmd := NewCmdNamespaceCreate(streams, fakeKubernetes)
+	projectaddCmd := project.NewCmdProjectAdd(streams, fakeKubernetes)
 
 	for _, ns := range singleNs {
 		createCmd.SetArgs([]string{ns})
@@ -44,9 +44,9 @@ func TestNewCmdNamespaceMoveDefault(t *testing.T) {
 		testCmd.SetArgs(args)
 		asserts.NoError(testCmd.Execute())
 	}
-	actual :=`"ns1" namespace moved to "project2" project
+	actual := `"ns1" namespace moved to "project2" project
 "ns2" namespace moved to "project3" project
 "ns3" namespace moved to "project1" project
 `
-	asserts.Equal(outBuffer.String(),actual)
+	asserts.Equal(outBuffer.String(), actual)
 }

--- a/tools/cli/vz/cmd/namespace/move_test.go
+++ b/tools/cli/vz/cmd/namespace/move_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package namespace
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/clients/clusters/clientset/versioned/fake"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/cmd/project"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+var projectNs = []string{"project1","project2","project3"}
+var moveData = [][]string{{"ns1","project2"},{"ns2","project3"},{"ns3","project1"}}
+
+// Unit test for moving a verrazzano namespace to a project
+func TestNewCmdNamespaceMoveDefault(t *testing.T) {
+	asserts := assert.New(t)
+	fakeKubernetes := &TestKubernetes{
+		fakeProjectClient: fake.NewSimpleClientset(),
+		fakek8sClient:     k8sfake.NewSimpleClientset(),
+	}
+
+	// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+	streams, _, outBuffer, _:= genericclioptions.NewTestIOStreams()
+	testCmd := NewCmdNamespaceMove(streams, fakeKubernetes)
+	createCmd := NewCmdNamespaceCreate(streams,fakeKubernetes)
+	projectaddCmd := project.NewCmdProjectAdd(streams,fakeKubernetes)
+
+	for _, ns := range singleNs {
+		createCmd.SetArgs([]string{ns})
+		createCmd.Execute()
+	}
+	for _, args := range projectNs {
+		projectaddCmd.SetArgs([]string{args})
+		asserts.NoError(projectaddCmd.Execute())
+		projectaddCmd.Execute()
+	}
+	outBuffer.Reset()
+
+	for _, args := range moveData {
+		testCmd.SetArgs(args)
+		asserts.NoError(testCmd.Execute())
+	}
+	actual :=`"ns1" namespace moved to "project2" project
+"ns2" namespace moved to "project3" project
+"ns3" namespace moved to "project1" project
+`
+	asserts.Equal(outBuffer.String(),actual)
+}

--- a/tools/cli/vz/cmd/namespace/namespace.go
+++ b/tools/cli/vz/cmd/namespace/namespace.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
 
 import (
@@ -26,7 +29,7 @@ func NewCmdNamespace(streams genericclioptions.IOStreams, kubernetesInterface he
 		// TODO : Description needs to be rewritten
 	}
 	cmd.AddCommand(NewCmdNamespaceCreate(streams, kubernetesInterface))
-	//cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
+	cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
 	cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
 	cmd.AddCommand(NewCmdNamespaceDelete(streams, kubernetesInterface))
 	return cmd

--- a/tools/cli/vz/cmd/namespace/namespace.go
+++ b/tools/cli/vz/cmd/namespace/namespace.go
@@ -26,8 +26,8 @@ func NewCmdNamespace(streams genericclioptions.IOStreams, kubernetesInterface he
 		// TODO : Description needs to be rewritten
 	}
 	cmd.AddCommand(NewCmdNamespaceCreate(streams, kubernetesInterface))
-	cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
-	cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
+	//cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
+	//cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
 	cmd.AddCommand(NewCmdNamespaceDelete(streams, kubernetesInterface))
 	return cmd
 }

--- a/tools/cli/vz/cmd/namespace/namespace.go
+++ b/tools/cli/vz/cmd/namespace/namespace.go
@@ -27,7 +27,7 @@ func NewCmdNamespace(streams genericclioptions.IOStreams, kubernetesInterface he
 	}
 	cmd.AddCommand(NewCmdNamespaceCreate(streams, kubernetesInterface))
 	//cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
-	//cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
+	cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
 	cmd.AddCommand(NewCmdNamespaceDelete(streams, kubernetesInterface))
 	return cmd
 }

--- a/tools/cli/vz/cmd/namespace/namespace.go
+++ b/tools/cli/vz/cmd/namespace/namespace.go
@@ -1,0 +1,33 @@
+package namespace
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/pkg/helpers"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type NamespaceOptions struct {
+	args []string
+	genericclioptions.IOStreams
+}
+
+func NewNamespaceOptions(streams genericclioptions.IOStreams) *NamespaceOptions {
+	return &NamespaceOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdNamespace(streams genericclioptions.IOStreams, kubernetesInterface helpers.Kubernetes) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "namespace",
+		Short:   "Work with namespaces",
+		Long:    "Work with namespaces",
+		Aliases: []string{"ns"},
+		// TODO : Description needs to be rewritten
+	}
+	cmd.AddCommand(NewCmdNamespaceCreate(streams, kubernetesInterface))
+	cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))
+	cmd.AddCommand(NewCmdNamespaceMove(streams, kubernetesInterface))
+	cmd.AddCommand(NewCmdNamespaceDelete(streams, kubernetesInterface))
+	return cmd
+}

--- a/tools/cli/vz/cmd/namespace/namespace.go
+++ b/tools/cli/vz/cmd/namespace/namespace.go
@@ -26,7 +26,6 @@ func NewCmdNamespace(streams genericclioptions.IOStreams, kubernetesInterface he
 		Short:   "Work with namespaces",
 		Long:    "Work with namespaces",
 		Aliases: []string{"ns"},
-		// TODO : Description needs to be rewritten
 	}
 	cmd.AddCommand(NewCmdNamespaceCreate(streams, kubernetesInterface))
 	cmd.AddCommand(NewCmdNamespaceList(streams, kubernetesInterface))

--- a/tools/cli/vz/cmd/project/add.go
+++ b/tools/cli/vz/cmd/project/add.go
@@ -42,11 +42,6 @@ func NewCmdProjectAdd(streams genericclioptions.IOStreams, kubernetesInterface h
 	}
 	cmd.Flags().StringSliceVarP(&projectNamespaces, "namespaces", "n", []string{}, "List of namespaces to include in the project")
 	cmd.Flags().StringSliceVarP(&projectPlacement, "placement", "p", []string{"local"}, "List of clusters this project will be placed in")
-	err := cmd.MarkFlagRequired("namespaces")
-	if err != nil {
-		fmt.Fprintln(streams.ErrOut, "namespace flag is mandatory")
-		return nil
-	}
 	return cmd
 }
 
@@ -55,9 +50,9 @@ func addProject(streams genericclioptions.IOStreams, args []string, kubernetesIn
 
 	// if no namespace was provided, default to a single namespace
 	// with the same name as the project itself
-	/*if len(projectNamespaces) == 0 {
+	if len(projectNamespaces) == 0 {
 		projectNamespaces = []string{projectName}
-	}*/
+	}
 
 	nsLabel := make(map[string]string)
 	nsLabel["verrazzano/projectName"] = projectName

--- a/tools/cli/vz/cmd/root.go
+++ b/tools/cli/vz/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tools/cli/vz/cmd/app"
 	"github.com/verrazzano/verrazzano/tools/cli/vz/cmd/cluster"
+	"github.com/verrazzano/verrazzano/tools/cli/vz/cmd/namespace"
 	"github.com/verrazzano/verrazzano/tools/cli/vz/cmd/project"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -64,5 +65,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(project.NewCmdProject(streams, o))
 	cmd.AddCommand(cluster.NewCmdCluster(streams, o))
 	cmd.AddCommand(app.NewCmdApp(streams))
+	cmd.AddCommand(namespace.NewCmdNamespace(streams,o))
 	return cmd
 }

--- a/tools/cli/vz/cmd/root.go
+++ b/tools/cli/vz/cmd/root.go
@@ -65,6 +65,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(project.NewCmdProject(streams, o))
 	cmd.AddCommand(cluster.NewCmdCluster(streams, o))
 	cmd.AddCommand(app.NewCmdApp(streams))
-	cmd.AddCommand(namespace.NewCmdNamespace(streams,o))
+	cmd.AddCommand(namespace.NewCmdNamespace(streams, o))
 	return cmd
 }


### PR DESCRIPTION
# Description

This PR contains the code+unit tests for the following `namespace` commands :

1. `namespace create` → creates a verrazzano namespace.
2. `namespace delete` → deletes a verrazzano namespace.
3. `namespace list` → lists all verrazzano namespaces available.
4. `namespace move `→ moves a namespace to a specified verrazzano project.

The change added in `project add`.go file is for appending metadata to the namespaces defined when a project is created - to bind a project & it's namespaces together.

Fixes VZ-3037.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
