### PR TITLE
Handle well-known managed cluster CA in api proxy

### DIFF
--- a/pkg/proxy/auth_lua_template.go
+++ b/pkg/proxy/auth_lua_template.go
@@ -744,7 +744,6 @@ const OidcAuthLuaFileTemplate = `local me = {}
         end
 
         local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
-        args.cluster = nil
         ngx.req.set_uri_args(args)
         ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
 
@@ -759,7 +758,7 @@ const OidcAuthLuaFileTemplate = `local me = {}
         end
 
         local secret = me.getSecret(vmc.spec.caSecret)
-        if not(secret) or not(secret.data) or not(secret.data["cacrt"]) then
+        if not(secret) or not(secret.data) or not(secret.data["cacrt"]) or secret.data["cacrt"] == "" then
             me.logJson(ngx.INFO, "Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
@@ -771,6 +770,7 @@ const OidcAuthLuaFileTemplate = `local me = {}
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
+        args.cluster = nil
         local startIndex, _ = string.find(decodedSecret, "-----BEGIN CERTIFICATE-----")
         local _, endIndex = string.find(decodedSecret, "-----END CERTIFICATE-----")
         if startIndex >= 1 and endIndex > startIndex then

--- a/pkg/proxy/auth_lua_template.go
+++ b/pkg/proxy/auth_lua_template.go
@@ -743,22 +743,25 @@ const OidcAuthLuaFileTemplate = `local me = {}
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
+        local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
+        args.cluster = nil
+        ngx.req.set_uri_args(args)
+        ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
+
         -- To access managed cluster api server on self signed certificates, the admin cluster api server needs ca certificates for the managed cluster.
         -- A secret is created in admin cluster during multi cluster setup that contains the ca certificate.
         -- Here we read the name of that secret from vmc spec and retrieve the secret from cluster and read the cacrt field.
         -- The value of cacrt field is decoded to get the ca certificate and is appended to file being pointed to by the proxy_ssl_trusted_certificate variable.
-        local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
+
         if not(vmc.spec) or not(vmc.spec.caSecret) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch ca secret name for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.logJson(ngx.INFO, "ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            do return end
         end
 
         local secret = me.getSecret(vmc.spec.caSecret)
         if not(secret) or not(secret.data) or not(secret.data["cacrt"]) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch ca secret for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.logJson(ngx.INFO, "Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            do return end
         end
 
         local decodedSecret = ngx.decode_base64(secret.data["cacrt"])
@@ -773,10 +776,6 @@ const OidcAuthLuaFileTemplate = `local me = {}
         if startIndex >= 1 and endIndex > startIndex then
             me.write_file("/etc/nginx/upstream.pem", string.sub(decodedSecret, startIndex, endIndex))
         end
-
-        args.cluster = nil
-        ngx.req.set_uri_args(args)
-        ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
     end
 {{ end }}
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -821,7 +821,6 @@ data:
         end
 
         local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
-        args.cluster = nil
         ngx.req.set_uri_args(args)
         ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
 
@@ -836,7 +835,7 @@ data:
         end
 
         local secret = me.getSecret(vmc.spec.caSecret)
-        if not(secret) or not(secret.data) or not(secret.data["cacrt"]) then
+        if not(secret) or not(secret.data) or not(secret.data["cacrt"]) or secret.data["cacrt"] == "" then
             me.logJson(ngx.INFO, "Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
@@ -848,6 +847,7 @@ data:
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
+        args.cluster = nil
         local startIndex, _ = string.find(decodedSecret, "-----BEGIN CERTIFICATE-----")
         local _, endIndex = string.find(decodedSecret, "-----END CERTIFICATE-----")
         if startIndex >= 1 and endIndex > startIndex then

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -820,22 +820,25 @@ data:
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
+        local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
+        args.cluster = nil
+        ngx.req.set_uri_args(args)
+        ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
+
         -- To access managed cluster api server on self signed certificates, the admin cluster api server needs ca certificates for the managed cluster.
         -- A secret is created in admin cluster during multi cluster setup that contains the ca certificate.
         -- Here we read the name of that secret from vmc spec and retrieve the secret from cluster and read the cacrt field.
         -- The value of cacrt field is decoded to get the ca certificate and is appended to file being pointed to by the proxy_ssl_trusted_certificate variable.
-        local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
+
         if not(vmc.spec) or not(vmc.spec.caSecret) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch ca secret name for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.logJson(ngx.INFO, "ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            do return end
         end
 
         local secret = me.getSecret(vmc.spec.caSecret)
         if not(secret) or not(secret.data) or not(secret.data["cacrt"]) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch ca secret for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.logJson(ngx.INFO, "Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            do return end
         end
 
         local decodedSecret = ngx.decode_base64(secret.data["cacrt"])
@@ -850,10 +853,6 @@ data:
         if startIndex >= 1 and endIndex > startIndex then
             me.write_file("/etc/nginx/upstream.pem", string.sub(decodedSecret, startIndex, endIndex))
         end
-
-        args.cluster = nil
-        ngx.req.set_uri_args(args)
-        ngx.var.kubernetes_server_url = serverUrl .. ngx.var.uri
     end
 {{ end }}
 


### PR DESCRIPTION
# Description

Handle well-known managed cluster CA in api proxy lua code when proxying requests to managed cluster. Based on Ravi's branch with some additional fixes, so that UI does not show an error in an OCI DNS multicluster environment with applications deployed.

Fixes VZ-3092

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
