### PR TITLE
Persistent Volume hosts installers for weblogic-image tool

### DIFF
--- a/image-patch-operator/README.md
+++ b/image-patch-operator/README.md
@@ -29,6 +29,8 @@ If you don't already have these installers, you may download them locally using 
 - [WLS](https://www.oracle.com/middleware/technologies/weblogic-server-downloads.html)
 - [WIT](https://github.com/oracle/weblogic-image-tool/releases)
 
+Additionally, please add the JDK installer to the image-patch-operator/weblogic-imagetool/installers directory.
+
 ```bash
 # Create the cluster
 $ kind create cluster --config - <<EOF

--- a/image-patch-operator/README.md
+++ b/image-patch-operator/README.md
@@ -22,6 +22,13 @@ verrazzano-weblogic-image-tool-dev    local-00bf9bd7   d975a2f4b85a   4 minutes 
 verrazzano-image-patch-operator-dev   local-00bf9bd7   a0865a3d3e16   5 days ago      187MB
 ```
 Now, create a Kubernetes cluster, and load these two images into your cluster. For example, if you are using a Kind cluster, run the following commands.
+
+Make sure you fill out the hostPath field with a local path to a directory containing the installers for the JDK, WLS, and Weblogic Image Tool.
+If you don't already have these installers, you may download them locally using the links below
+- [JDK](https://www.oracle.com/java/technologies/javase-jdk16-downloads.html)
+- [WLS](https://www.oracle.com/middleware/technologies/weblogic-server-downloads.html)
+- [WIT](https://github.com/oracle/weblogic-image-tool/releases)
+
 ```bash
 # Create the cluster
 $ kind create cluster --config - <<EOF
@@ -36,6 +43,9 @@ nodes:
           extraArgs:
             "service-account-issuer": "kubernetes.default.svc"
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+    extraMounts:
+      - hostPath: <path-to-installers>
+        containerPath: /installers
 EOF
 
 # Load the images

--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -120,6 +120,12 @@ func TestNewImageBuildRequest(t *testing.T) {
 	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[7].Value, "fmw_12.2.1.4.0_wls.jar")
 	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[8].Value, "12.2.1.4.0")
 
+	// Verifying that the PV, PVC, and Volume Mount are present on the created job
+	assert.Equal(jb.Spec.Template.Spec.Volumes[1].Name, "installers-storage")
+	assert.Equal(jb.Spec.Template.Spec.Volumes[1].PersistentVolumeClaim.ClaimName, "installers-storage-claim")
+	assert.Equal(jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name, "installers-storage")
+	assert.Equal(jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath, "/installers")
+
 }
 
 // TestIBRJobSucceeded tests the Reconcile method for the following:

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -59,6 +59,11 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 								MountPath: "/registry-creds",
 								ReadOnly:  true,
 							},
+							{
+								Name:      "installers-storage",
+								MountPath: "/installers",
+								ReadOnly:  true,
+							},
 						},
 						Env: []corev1.EnvVar{
 							{
@@ -116,6 +121,12 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: constants.ImageJobSecretName,
 								},
+							},
+						},
+						{
+							Name: "installers-storage",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "installers-storage-claim"},
 							},
 						},
 					},

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolume.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolume.yaml
@@ -8,9 +8,9 @@ metadata:
     type: local
 spec:
   capacity:
-    storage: {{ .Values.persistentVolume.storage }}
+    storage: {{ .Values.installersVolume.storage }}
   accessModes:
     - ReadOnlyMany
-  storageClassName: {{ .Values.persistentVolume.storageClassName }}
+  storageClassName: {{ .Values.installersVolume.storageClassName }}
   hostPath:
     path: /installers

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolume.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolume.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: installers-storage
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolume.storage }}
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: {{ .Values.persistentVolume.storageClassName }}
+  hostPath:
+    path: /installers

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolumeclaim.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolumeclaim.yaml
@@ -10,5 +10,5 @@ spec:
     - ReadOnlyMany
   resources:
     requests:
-      storage: {{ .Values.persistentVolumeClaim.storage }}
-  storageClassName: {{ .Values.persistentVolumeClaim.storageClassName }}
+      storage: {{ .Values.installersVolumeClaim.storage }}
+  storageClassName: {{ .Values.installersVolumeClaim.storageClassName }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolumeclaim.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: installers-storage-claim
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumeClaim.storage }}
+  storageClassName: {{ .Values.persistentVolumeClaim.storageClassName }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -16,11 +16,11 @@ weblogicDeployTool:
   binary: weblogic-deploy.zip
   version: latest
 
-persistentVolume:
+installersVolume:
   storage: 5Gi
   storageClassName: local-storage
 
-persistentVolumeClaim:
+installersVolumeClaim:
   storage: 3Gi
   storageClassName: local-storage
 

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -16,6 +16,14 @@ weblogicDeployTool:
   binary: weblogic-deploy.zip
   version: latest
 
+persistentVolume:
+  storage: 5Gi
+  storageClassName: local-storage
+
+persistentVolumeClaim:
+  storage: 3Gi
+  storageClassName: local-storage
+
 global:
   imagePullSecrets: []
 

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -41,10 +41,6 @@ RUN microdnf update -y \
 
 WORKDIR /home/verrazzano
 
-ARG JDK_INSTALLER_BINARY
-ARG WEBLOGIC_INSTALLER_BINARY="${WEBLOGIC_INSTALLER_BINARY:-fmw_12.2.1.4.0_wls.jar}"
-ARG WDT_INSTALLER_BINARY="${WDT_INSTALLER_BINARY:-weblogic-deploy.zip}"
-
 RUN groupadd -r verrazzano && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
     && mkdir -p /home/verrazzano/cache \
     && chown -R 1000:verrazzano /home/verrazzano \

--- a/image-patch-operator/weblogic-imagetool/Dockerfile
+++ b/image-patch-operator/weblogic-imagetool/Dockerfile
@@ -62,16 +62,8 @@ COPY --from=build_base --chown=verrazzano:verrazzano /imagetool ./imagetool
 COPY --chown=verrazzano:verrazzano ./v8o-imagetool.sh .
 RUN chmod +x ./v8o-imagetool.sh
 
-# Copy over installers
-COPY --chown=verrazzano:verrazzano \
-    ./installers/${JDK_INSTALLER_BINARY} \
-    ./installers/${WEBLOGIC_INSTALLER_BINARY} \
-    ./installers/${WDT_INSTALLER_BINARY} \
-    ./installers/
-
 COPY THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 
 ENTRYPOINT ["./v8o-imagetool.sh"]
-

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -60,7 +60,7 @@ get-installers:
 	cd ./installers; \
 	export OCI_CLI_REGION=${OCI_CLI_REGION}; \
 	(test -f "weblogic-deploy.zip" || wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip); \
-	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}); \
+	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE});
 
 .PHONY: docker-clean
 docker-clean:

--- a/image-patch-operator/weblogic-imagetool/Makefile
+++ b/image-patch-operator/weblogic-imagetool/Makefile
@@ -61,7 +61,6 @@ get-installers:
 	export OCI_CLI_REGION=${OCI_CLI_REGION}; \
 	(test -f "weblogic-deploy.zip" || wget https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.15/weblogic-deploy.zip); \
 	(test -f ${JDK8_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${JDK8_BUNDLE} --name ${JDK8_BUNDLE}); \
-	(test -f ${WEBLOGIC_BUNDLE} || oci os object get -bn ${BUCKET_NAME} --file ${WEBLOGIC_BUNDLE} --name ${WEBLOGIC_BUNDLE})
 
 .PHONY: docker-clean
 docker-clean:

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# This script wiill fail if any line fails
+# This script will fail if any line fails
 set -e
 
 # Log into the registry
@@ -20,12 +20,8 @@ export WLSIMG_CACHEDIR="/home/verrazzano/cache"
 
 # Tag and push the image to the registry
 
-start_time = `date +%s`
+echo time=$(date +"%Y-%m-%dT%TZ") podman tag
 podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
-end_time = `date +%s`
-echo execution time was `expr $end_time - $start_time` s
 
-start_time = `date +%s`
+echo time=$(date +"%Y-%m-%dT%TZ") podman image push
 podman image push ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
-end_time = `date +%s`
-echo execution time was `expr $end_time - $start_time` s

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -19,6 +19,13 @@ export WLSIMG_CACHEDIR="/home/verrazzano/cache"
 ./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION}
 
 # Tag and push the image to the registry
-podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
-podman image push ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
 
+start_time = `date +%s`
+podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
+end_time = `date +%s`
+echo execution time was `expr $end_time - $start_time` s
+
+start_time = `date +%s`
+podman image push ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
+end_time = `date +%s`
+echo execution time was `expr $end_time - $start_time` s

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -11,9 +11,9 @@ cat /registry-creds/password | podman login $(cat /registry-creds/registry) --us
 
 # Add installers to the imagetool cache
 export WLSIMG_CACHEDIR="/home/verrazzano/cache"
-./imagetool/bin/imagetool.sh cache addInstaller --type wls --version ${WEBLOGIC_INSTALLER_VERSION} --path ./installers/${WEBLOGIC_INSTALLER_BINARY}
-./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version ${JDK_INSTALLER_VERSION} --path ./installers/${JDK_INSTALLER_BINARY}
-./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version ${WDT_INSTALLER_VERSION} --path ./installers/${WDT_INSTALLER_BINARY}
+./imagetool/bin/imagetool.sh cache addInstaller --type wls --version ${WEBLOGIC_INSTALLER_VERSION} --path /installers/${WEBLOGIC_INSTALLER_BINARY}
+./imagetool/bin/imagetool.sh cache addInstaller --type jdk --version ${JDK_INSTALLER_VERSION} --path /installers/${JDK_INSTALLER_BINARY}
+./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version ${WDT_INSTALLER_VERSION} --path /installers/${WDT_INSTALLER_BINARY}
 
 # Create the image
 ./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION}


### PR DESCRIPTION
# Description

The initial POC of the verrazzano-weblogic-image-tool image has the installers built into the image. With this change, the image build job will now access the installers from a mounted volume at runtime.

Fixes VZ-3114

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
