### PR TITLE
Added support for DryRun feature of WIT

### DIFF
--- a/image-patch-operator/README.md
+++ b/image-patch-operator/README.md
@@ -71,6 +71,7 @@ NAME                                               READY   STATUS         RESTAR
 verrazzano-image-patch-operator-7477f65ccf-rjmsc   1/1     Running        0          6m42s
 ```
 Please note that the created Deployment will by default set the IBR_DRY_RUN flag to false. If you would like to run an image job as a dry run, then you may edit the Deployment and set the environment variable IBR_DRY_RUN to true. This will result in the WebLogic Image Tool script to print the Dockerfile to stdout instead of building the image.
+
 ### Create a Secret with Credentials for Pushing the Image
 The Secret can be manually created using `kubectl`.<br>
 ```bash

--- a/image-patch-operator/README.md
+++ b/image-patch-operator/README.md
@@ -70,7 +70,7 @@ This will show an output similar to the following:
 NAME                                               READY   STATUS         RESTARTS   AGE
 verrazzano-image-patch-operator-7477f65ccf-rjmsc   1/1     Running        0          6m42s
 ```
-
+Please note that the created Deployment will by default set the IBR_DRY_RUN flag to false. If you would like to run an image job as a dry run, then you may edit the Deployment and set the environment variable IBR_DRY_RUN to true. This will result in the WebLogic Image Tool script to print the Dockerfile to stdout instead of building the image.
 ### Create a Secret with Credentials for Pushing the Image
 The Secret can be manually created using `kubectl`.<br>
 ```bash

--- a/image-patch-operator/README.md
+++ b/image-patch-operator/README.md
@@ -82,7 +82,6 @@ This will show an output similar to the following:
 NAME                                               READY   STATUS         RESTARTS   AGE
 verrazzano-image-patch-operator-7477f65ccf-rjmsc   1/1     Running        0          6m42s
 ```
-Please note that the created Deployment will by default set the IBR_DRY_RUN flag to false. If you would like to run an image job as a dry run, then you may edit the Deployment and set the environment variable IBR_DRY_RUN to true. This will result in the WebLogic Image Tool script to print the Dockerfile to stdout instead of building the image.
 
 ### Create a Secret with Credentials for Pushing the Image
 The Secret can be manually created using `kubectl`.<br>
@@ -146,3 +145,12 @@ To track the progress of your WebLogic Image Tool image, check the logs of this 
 ```bash
 $ kubectl logs -f -n verrazzano-system verrazzano-images-cluster1-XXXXX
 ```
+
+### Troubleshooting
+After creating an ImageBuildRequest, if you encounter problems with the building of your image, you may be able to help diagnose your problem through the use of the WebLogic Image Tool Dry Run feature. Running an ImageJob as a Dry Run will result in the Dockerfile of the image to be printed to stdout - the image will not be built or pushed.
+
+There are two different methods to run an ImageJob as a Dry Run. The first is to edit the Deployment that gets created by the helm install. By default, the "IBR_DRY_RUN" environmental variable of the Deployment will be set to false. You may edit the Deployment and set this variable to true. This will run all future ImageJobs as a Dry Run (you may set this variable back to false to run ImageJobs regularly).
+
+The second method you may use, is to edit the values.yaml file in the helm_config directory. The values.yaml file lists a variable "dryRun" which by default is set to false. Setting this variable to true, and then preforming a helm install will result in future ImageJobs to run as Dry Runs. You may change back to running ImageJobs normally by editing the Deployment and setting the "IBR_DRY_RUN" variable back to false.
+
+To view the output of an ImageJob Dry Run, follow the steps located in the "Check the Status of the Image" section of this document.

--- a/image-patch-operator/api/images/v1alpha1/imagebuildrequest_types.go
+++ b/image-patch-operator/api/images/v1alpha1/imagebuildrequest_types.go
@@ -23,6 +23,15 @@ const (
 
 	// Failed is the state when an ImageBuildRequest has failed
 	Failed StateType = "Failed"
+
+	// DryRunActive is the state when an image job is preforming a DryRun
+	DryRunActive StateType = "DryRunActive"
+
+	// DryRunPrinted is the state after an image job successful preforms a DryRun
+	DryRunPrinted StateType = "DryRunPrinted"
+
+	// DryRunFailure is the state if an image job fails while trying to preform a DryRun
+	DryRunFailure StateType = "DryRunFailure"
 )
 
 // ConditionType identifies the condition of the ImageBuildRequest which can be checked with kubectl wait
@@ -37,6 +46,15 @@ const (
 
 	// BuildFailed means the image build job has failed during execution.
 	BuildFailed ConditionType = "BuildFailed"
+
+	// DryRunStarted means the image job is trying to print the Dockerfile to stdout
+	DryRunStarted ConditionType = "DryRunStarted"
+
+	// DryRunCompleted means the image job printed the Dockerfile to stdout successfully (the image will not be built)
+	DryRunCompleted ConditionType = "DryRunCompleted"
+
+	// DryRunFailed means the image job failed when trying to print the Dockerfile to stdout
+	DryRunFailed ConditionType = "DryRunFailed"
 )
 
 // Condition describes current state of an image build request.

--- a/image-patch-operator/controllers/imagebuildrequest_controller.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller.go
@@ -176,6 +176,12 @@ func (r *ImageBuildRequestReconciler) updateStatus(log *zap.SugaredLogger, cr *i
 		cr.Status.State = imagesv1alpha1.Published
 	case imagesv1alpha1.BuildFailed:
 		cr.Status.State = imagesv1alpha1.Failed
+	case imagesv1alpha1.DryRunStarted:
+		cr.Status.State = imagesv1alpha1.DryRunActive
+	case imagesv1alpha1.DryRunCompleted:
+		cr.Status.State = imagesv1alpha1.DryRunPrinted
+	case imagesv1alpha1.DryRunFailed:
+		cr.Status.State = imagesv1alpha1.DryRunFailure
 	}
 	log.Infof("Setting ImageBuildRequest resource condition and state: %v/%v", condition.Type, cr.Status.State)
 
@@ -195,28 +201,45 @@ func (r *ImageBuildRequestReconciler) setImageBuildCondition(log *zap.SugaredLog
 		for _, condition := range ibr.Status.Conditions {
 			if condition.Type == imagesv1alpha1.BuildCompleted || condition.Type == imagesv1alpha1.BuildFailed {
 				return nil
+			} else if condition.Type == imagesv1alpha1.DryRunCompleted || condition.Type == imagesv1alpha1.DryRunFailed {
+				return nil
 			}
 		}
 		var message string
 		var conditionType imagesv1alpha1.ConditionType
 		if job.Status.Succeeded == 1 {
-			message = "ImageBuildRequest build completed successfully"
-			conditionType = imagesv1alpha1.BuildCompleted
+			if r.DryRun {
+				message = "ImageBuildRequest DryRun completed successfully"
+				conditionType = imagesv1alpha1.DryRunCompleted
+			} else {
+				message = "ImageBuildRequest build completed successfully"
+				conditionType = imagesv1alpha1.BuildCompleted
+			}
 		} else {
-			message = "ImageBuildRequest build failed to complete"
-			conditionType = imagesv1alpha1.BuildFailed
+			if r.DryRun {
+				message = "ImageBuildRequest DryRun failed to complete"
+				conditionType = imagesv1alpha1.DryRunFailed
+			} else {
+				message = "ImageBuildRequest build failed to complete"
+				conditionType = imagesv1alpha1.BuildFailed
+			}
+
 		}
 		return r.updateStatus(log, ibr, message, conditionType)
 	}
 
 	// Add the build started condition if not already added
 	for _, condition := range ibr.Status.Conditions {
-		if condition.Type == imagesv1alpha1.BuildStarted {
+		if condition.Type == imagesv1alpha1.BuildStarted || condition.Type == imagesv1alpha1.DryRunStarted {
 			return nil
 		}
 	}
 
-	return r.updateStatus(log, ibr, "ImageBuildRequest build in progress", imagesv1alpha1.BuildStarted)
+	if r.DryRun {
+		return r.updateStatus(log, ibr, "ImageBuildRequest DryRun in progress", imagesv1alpha1.DryRunStarted)
+	} else {
+		return r.updateStatus(log, ibr, "ImageBuildRequest build in progress", imagesv1alpha1.BuildStarted)
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/image-patch-operator/controllers/imagebuildrequest_controller.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller.go
@@ -237,9 +237,8 @@ func (r *ImageBuildRequestReconciler) setImageBuildCondition(log *zap.SugaredLog
 
 	if r.DryRun {
 		return r.updateStatus(log, ibr, "ImageBuildRequest DryRun in progress", imagesv1alpha1.DryRunStarted)
-	} else {
-		return r.updateStatus(log, ibr, "ImageBuildRequest build in progress", imagesv1alpha1.BuildStarted)
 	}
+	return r.updateStatus(log, ibr, "ImageBuildRequest build in progress", imagesv1alpha1.BuildStarted)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -93,7 +93,7 @@ func TestNewImageBuildRequest(t *testing.T) {
 	assert.NoError(err)
 
 	// Verify the DryRun flag is set to false by default (this value can be changed in the helm config values.yaml file)
-	assert.Equal(reconciler.DryRun, false)
+	assert.Equal(false, reconciler.DryRun)
 
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
@@ -102,9 +102,9 @@ func TestNewImageBuildRequest(t *testing.T) {
 	assert.NoError(err)
 
 	// The status, condition, and message of the IBR should reflect that the ImageJob is in progress
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("Building"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("BuildStarted"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest build in progress")
+	assert.Equal(imagesv1alpha1.StateType("Building"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("BuildStarted"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest build in progress", ibr.Status.Conditions[0].Message)
 
 	jb := &batchv1.Job{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "verrazzano-images-cluster1"}, jb)
@@ -113,24 +113,24 @@ func TestNewImageBuildRequest(t *testing.T) {
 	assert.NoError(err)
 
 	// Verify istio-injection disabled for the job
-	assert.Equal(jb.Labels["sidecar.istio.io/inject"], "false")
+	assert.Equal("false", jb.Labels["sidecar.istio.io/inject"])
 
 	// Testing that the spec fields of the IBR propagate to the environmental variables of the ImageJob
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[0].Value, "test-build")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[1].Value, "test-tag")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[2].Value, "phx.ocir.io")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[3].Value, "myrepo/verrazzano")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[4].Value, "ghcr.io/oracle/oraclelinux:8-slim")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[5].Value, "jdk-8u281-linux-x64.tar.gz")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[6].Value, "8u281")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[7].Value, "fmw_12.2.1.4.0_wls.jar")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[8].Value, "12.2.1.4.0")
+	assert.Equal("test-build", jb.Spec.Template.Spec.Containers[0].Env[0].Value)
+	assert.Equal("test-tag", jb.Spec.Template.Spec.Containers[0].Env[1].Value)
+	assert.Equal("phx.ocir.io", jb.Spec.Template.Spec.Containers[0].Env[2].Value)
+	assert.Equal("myrepo/verrazzano", jb.Spec.Template.Spec.Containers[0].Env[3].Value)
+	assert.Equal("ghcr.io/oracle/oraclelinux:8-slim", jb.Spec.Template.Spec.Containers[0].Env[4].Value)
+	assert.Equal("jdk-8u281-linux-x64.tar.gz", jb.Spec.Template.Spec.Containers[0].Env[5].Value)
+	assert.Equal("8u281", jb.Spec.Template.Spec.Containers[0].Env[6].Value)
+	assert.Equal("fmw_12.2.1.4.0_wls.jar", jb.Spec.Template.Spec.Containers[0].Env[7].Value)
+	assert.Equal("12.2.1.4.0", jb.Spec.Template.Spec.Containers[0].Env[8].Value)
 
 	// Verifying that the PV, PVC, and Volume Mount are present on the created job
-	assert.Equal(jb.Spec.Template.Spec.Volumes[1].Name, "installers-storage")
-	assert.Equal(jb.Spec.Template.Spec.Volumes[1].PersistentVolumeClaim.ClaimName, "installers-storage-claim")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name, "installers-storage")
-	assert.Equal(jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath, "/installers")
+	assert.Equal("installers-storage", jb.Spec.Template.Spec.Volumes[1].Name)
+	assert.Equal("installers-storage-claim", jb.Spec.Template.Spec.Volumes[1].PersistentVolumeClaim.ClaimName)
+	assert.Equal("installers-storage", jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name)
+	assert.Equal("/installers", jb.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath)
 
 }
 
@@ -158,15 +158,15 @@ func TestIBRJobSucceeded(t *testing.T) {
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 	assert.NoError(err)
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("Published"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("BuildCompleted"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest build completed successfully")
+	assert.Equal(imagesv1alpha1.StateType("Published"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("BuildCompleted"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest build completed successfully", ibr.Status.Conditions[0].Message)
 
 	// Verify the job exists in a succeeded state
 	jb := &batchv1.Job{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "verrazzano-images-cluster1"}, jb)
 	assert.NoError(err)
-	assert.Equal(jb.Status.Succeeded, int32(1))
+	assert.Equal(int32(1), jb.Status.Succeeded)
 }
 
 // TestIBRJobFailed tests the Reconcile method for the following:
@@ -193,15 +193,15 @@ func TestIBRJobFailed(t *testing.T) {
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 	assert.NoError(err)
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("Failed"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("BuildFailed"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest build failed to complete")
+	assert.Equal(imagesv1alpha1.StateType("Failed"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("BuildFailed"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest build failed to complete", ibr.Status.Conditions[0].Message)
 
 	// Verify the job exists in a failed state
 	jb := &batchv1.Job{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "verrazzano-images-cluster1"}, jb)
 	assert.NoError(err)
-	assert.Equal(jb.Status.Failed, int32(1))
+	assert.Equal(int32(1), jb.Status.Failed)
 }
 
 // TestIBRDryRun tests the Reconcile method for the following:
@@ -230,9 +230,9 @@ func TestIBRDryRun(t *testing.T) {
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 	assert.NoError(err)
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("DryRunActive"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("DryRunStarted"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest DryRun in progress")
+	assert.Equal(imagesv1alpha1.StateType("DryRunActive"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("DryRunStarted"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest DryRun in progress", ibr.Status.Conditions[0].Message)
 
 	// Verifying a job gets created when DryRun is active
 	jb := &batchv1.Job{}
@@ -267,15 +267,15 @@ func TestIBRDryRunJobSucceeded(t *testing.T) {
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 	assert.NoError(err)
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("DryRunPrinted"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("DryRunCompleted"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest DryRun completed successfully")
+	assert.Equal(imagesv1alpha1.StateType("DryRunPrinted"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("DryRunCompleted"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest DryRun completed successfully", ibr.Status.Conditions[0].Message)
 
 	// Verify the job exists in a succeeded state
 	jb := &batchv1.Job{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "verrazzano-images-cluster1"}, jb)
 	assert.NoError(err)
-	assert.Equal(jb.Status.Succeeded, int32(1))
+	assert.Equal(int32(1), jb.Status.Succeeded)
 }
 
 // TestIBRJobFailed tests the Reconcile method for the following:
@@ -305,15 +305,15 @@ func TestIBRDryRunJobFailed(t *testing.T) {
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 	assert.NoError(err)
-	assert.Equal(ibr.Status.State, imagesv1alpha1.StateType("DryRunFailure"))
-	assert.Equal(ibr.Status.Conditions[0].Type, imagesv1alpha1.ConditionType("DryRunFailed"))
-	assert.Equal(ibr.Status.Conditions[0].Message, "ImageBuildRequest DryRun failed to complete")
+	assert.Equal(imagesv1alpha1.StateType("DryRunFailure"), ibr.Status.State)
+	assert.Equal(imagesv1alpha1.ConditionType("DryRunFailed"), ibr.Status.Conditions[0].Type)
+	assert.Equal("ImageBuildRequest DryRun failed to complete", ibr.Status.Conditions[0].Message)
 
 	// Verify the job exists in a failed state
 	jb := &batchv1.Job{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "verrazzano-images-cluster1"}, jb)
 	assert.NoError(err)
-	assert.Equal(jb.Status.Failed, int32(1))
+	assert.Equal(int32(1), jb.Status.Failed)
 }
 
 // newScheme creates a new scheme that includes this package's object to use for testing

--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -92,6 +92,9 @@ func TestNewImageBuildRequest(t *testing.T) {
 	_, err := reconciler.Reconcile(request)
 	assert.NoError(err)
 
+	// Verify the DryRun flag is set to false by default (this value can be changed in the helm config values.yaml file)
+	assert.Equal(reconciler.DryRun, false)
+
 	ibr := &imagesv1alpha1.ImageBuildRequest{}
 	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cluster1"}, ibr)
 

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -105,6 +105,10 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 								Name:  "WDT_INSTALLER_VERSION",
 								Value: os.Getenv("WDT_INSTALLER_VERSION"),
 							},
+							{
+								Name:  "IBR_DRY_RUN",
+								Value: os.Getenv("IBR_DRY_RUN"),
+							},
 						},
 					}},
 					RestartPolicy:      corev1.RestartPolicyNever,

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
@@ -34,4 +34,6 @@ spec:
               value: {{ .Values.weblogicDeployTool.version }}
             - name: IMAGE_TOOL_NAME
               value: {{ .Values.imageTool.name }}
+            - name: VZ_DRY_RUN
+              value: {{ .Values.dryRun }}
       serviceAccountName: {{ .Values.imagePatchOperator.name }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
@@ -34,6 +34,6 @@ spec:
               value: {{ .Values.weblogicDeployTool.version }}
             - name: IMAGE_TOOL_NAME
               value: {{ .Values.imageTool.name }}
-            - name: VZ_DRY_RUN
+            - name: IBR_DRY_RUN
               value: {{ .Values.dryRun }}
       serviceAccountName: {{ .Values.imagePatchOperator.name }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
@@ -35,5 +35,5 @@ spec:
             - name: IMAGE_TOOL_NAME
               value: {{ .Values.imageTool.name }}
             - name: IBR_DRY_RUN
-              value: {{ .Values.dryRun }}
+              value: {{ .Values.dryRun | quote }}
       serviceAccountName: {{ .Values.imagePatchOperator.name }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -16,6 +16,8 @@ weblogicDeployTool:
   binary: weblogic-deploy.zip
   version: latest
 
+dryRun: false
+
 global:
   imagePullSecrets: []
 

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -16,6 +16,8 @@ weblogicDeployTool:
   binary: weblogic-deploy.zip
   version: latest
 
+# this flag will get passed to the weblogic-imagetool
+# setting dryRun to true will not build the image, but instead print the Dockerfile to stdout
 dryRun: false
 
 global:

--- a/image-patch-operator/main.go
+++ b/image-patch-operator/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	imagesv1alpha1 "github.com/verrazzano/verrazzano/image-patch-operator/api/images/v1alpha1"
 	"github.com/verrazzano/verrazzano/image-patch-operator/controllers"
@@ -65,7 +66,8 @@ func main() {
 	}
 
 	// Setup the reconciler
-	_, dryRun := os.LookupEnv("IBR_DRY_RUN") // If this var is set, the image jobs are no-ops
+	// If dryRun is set to true, then the image job will print the Dockerfile to stdout instead of building the image
+	dryRun, _ := strconv.ParseBool(os.Getenv("IBR_DRY_RUN"))
 	reconciler := controllers.ImageBuildRequestReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/image-patch-operator/main.go
+++ b/image-patch-operator/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Setup the reconciler
-	_, dryRun := os.LookupEnv("VZ_DRY_RUN") // If this var is set, the image jobs are no-ops
+	_, dryRun := os.LookupEnv("IBR_DRY_RUN") // If this var is set, the image jobs are no-ops
 	reconciler := controllers.ImageBuildRequestReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -16,7 +16,7 @@ export WLSIMG_CACHEDIR="/home/verrazzano/cache"
 ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version ${WDT_INSTALLER_VERSION} --path ./installers/${WDT_INSTALLER_BINARY}
 
 # Create the image
-./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION}
+./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION} --dryRun=${IBR_DRY_RUN}
 
 # Tag and push the image to the registry
 podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -18,7 +18,8 @@ export WLSIMG_CACHEDIR="/home/verrazzano/cache"
 # Create the image
 ./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION} --dryRun=${IBR_DRY_RUN}
 
-# Tag and push the image to the registry
-podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
-podman image push ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
-
+# Tag and push the image to the registry (only if we are not in a DryRun)
+if [ "${IBR_DRY_RUN}" == "false" ] ; then
+  podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
+  podman image push ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
+fi


### PR DESCRIPTION
# Description

With this change, the user may now specify if they would like to run the image job as a DryRun. Setting the DryRun flag to true will cause WIT to print the Dockerfile to stdout instead of building the image.

Fixes VZ-3115

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
