### PR TITLE
Tvlatas/update dumps saving

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,7 @@ pipeline {
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // Needed by ToDoList example test
         DATABASE_PSW = credentials('todo-mysql-password') // Needed by ToDoList example test
 
+        // used for console artifact capture on failure
         JENKINS_READ = credentials('jenkins-auditor')
 
         OCI_CLI_AUTH="instance_principal"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -462,7 +462,7 @@ pipeline {
             archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
             sh """
                 curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
-                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
                 rm archive.zip
             """
             mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -416,6 +416,15 @@ pipeline {
             deleteCluster()
         }
         failure {
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
+            """
+            archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                rm archive.zip
+            """
             mail to: "${env.BUILD_NOTIFICATION_TO_EMAIL}", from: "${env.BUILD_NOTIFICATION_FROM_EMAIL}",
             subject: "Verrazzano: ${env.JOB_NAME} - Failed",
             body: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}"

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -88,6 +88,10 @@ pipeline {
 
         // used for console artifact capture on failure
         JENKINS_READ = credentials('jenkins-auditor')
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
+        OCI_OS_BUCKET="verrazzano-builds"
     }
 
     stages {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -86,6 +86,8 @@ pipeline {
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
 
+        // used for console artifact capture on failure
+        JENKINS_READ = credentials('jenkins-auditor')
     }
 
     stages {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -148,6 +148,9 @@ pipeline {
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
+
+        // used for console artifact capture on failure
+        JENKINS_READ = credentials('jenkins-auditor')
     }
 
     stages {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -151,6 +151,10 @@ pipeline {
 
         // used for console artifact capture on failure
         JENKINS_READ = credentials('jenkins-auditor')
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
+        OCI_OS_BUCKET="verrazzano-builds"
     }
 
     stages {
@@ -332,11 +336,6 @@ pipeline {
                     }
                 }
                 stage ('Install Verrazzano') {
-                    environment {
-                        OCI_CLI_AUTH="instance_principal"
-                        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-                        OCI_OS_BUCKET="verrazzano-builds"
-                    }
                     steps {
                         script {
                             // Either download the latest platform operator YAML from the master bucket, or create one

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -607,7 +607,15 @@ pipeline {
     }
     post {
         failure {
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
+            """
             archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                rm archive.zip
+            """
         }
         always {
             script {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -143,7 +143,6 @@ pipeline {
 
         // used for console artifact capture on failure
         JENKINS_READ = credentials('jenkins-auditor')
-        OCI_CLI_AUTH="instance_principal"
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_BUCKET="verrazzano-builds"
@@ -257,6 +256,9 @@ pipeline {
         }
 
         stage("install-platform-operator") {
+            environment {
+                OCI_CLI_AUTH="instance_principal"
+            }
             steps {
                 sh """
                     echo "Install Platform Operator"
@@ -579,7 +581,7 @@ pipeline {
             archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
             sh """
                 curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
-                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                OCI_CLI_AUTH="instance_principal" oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
                 rm archive.zip
             """
             script {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -571,6 +571,15 @@ pipeline {
             """
        }
        failure {
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
+            """
+            archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                rm archive.zip
+            """
             script {
                 if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME == "verrazzano/develop") {
                     emailext recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']],

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -143,6 +143,10 @@ pipeline {
 
         // used for console artifact capture on failure
         JENKINS_READ = credentials('jenkins-auditor')
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
+        OCI_OS_BUCKET="verrazzano-builds"
     }
 
     stages {
@@ -253,11 +257,6 @@ pipeline {
         }
 
         stage("install-platform-operator") {
-            environment {
-                OCI_CLI_AUTH="instance_principal"
-                OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-                OCI_OS_BUCKET="verrazzano-builds"
-            }
             steps {
                 sh """
                     echo "Install Platform Operator"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -140,6 +140,9 @@ pipeline {
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
+
+        // used for console artifact capture on failure
+        JENKINS_READ = credentials('jenkins-auditor')
     }
 
     stages {

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -32,7 +32,7 @@ func vmiIngressURLs() (map[string]string, error) {
 		return nil, err
 	}
 	ingressList, err := clientset.ExtensionsV1beta1().Ingresses(verrazzanoNamespace).List(context.TODO(), v1.ListOptions{})
-	if err == nil {  // TEPMORARY FORCE FAILURE TO TEST ARTIFACT CAPTURE
+	if err == nil {
 		return nil, err
 	}
 

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -32,7 +32,7 @@ func vmiIngressURLs() (map[string]string, error) {
 		return nil, err
 	}
 	ingressList, err := clientset.ExtensionsV1beta1().Ingresses(verrazzanoNamespace).List(context.TODO(), v1.ListOptions{})
-	if err == nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -32,7 +32,7 @@ func vmiIngressURLs() (map[string]string, error) {
 		return nil, err
 	}
 	ingressList, err := clientset.ExtensionsV1beta1().Ingresses(verrazzanoNamespace).List(context.TODO(), v1.ListOptions{})
-	if err != nil {
+	if err == nil {  // TEPMORARY FORCE FAILURE TO TEST ARTIFACT CAPTURE
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

We moved the Kind ATs out of the main verrazzano job, but saving failed artifacts to object storage only was happening for the main verrazzano job.

This will save failed run artifacts for the Kind AT jobs, OCI DNS, and Multi-Cluster tests (we can add more later). This changes up the location to include the job name now at the top level as we are saving from multiple jobs.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
