### PR TITLE
Added parameters for LatestPSU and RecommendedPatches to ImageBuildRequest CRD

### DIFF
--- a/image-patch-operator/api/images/v1alpha1/imagebuildrequest_types.go
+++ b/image-patch-operator/api/images/v1alpha1/imagebuildrequest_types.go
@@ -74,6 +74,12 @@ type ImageBuildRequestSpec struct {
 
 	// The version for WebLogic needed by the WebLogic Image Tool
 	WebLogicInstallerVersion string `json:"webLogicInstallerVersion"`
+
+	// Flag to determine whether to find and apply the latest PatchSet Update
+	LatestPSU bool `json:"latestPSU,omitempty"`
+
+	// Flag to determine whether to find and apply the latest PatchSet Update and recommended patches (takes precedence over LatestPSU)
+	RecommendedPatches bool `json:"recommendedPatches,omitempty"`
 }
 
 // Image provides more configuration information to the ImageBuildRequestSpec

--- a/image-patch-operator/helm_config/charts/image-patch-operator/crds/images.verrazzano.io_imagebuildrequests.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/crds/images.verrazzano.io_imagebuildrequests.yaml
@@ -79,6 +79,14 @@ spec:
               jdkInstallerVersion:
                 description: The version for JDK needed by the WebLogic Image Tool
                 type: string
+              latestPSU:
+                description: Flag to determine whether to find and apply the latest
+                  PatchSet Update
+                type: boolean
+              recommendedPatches:
+                description: Flag to determine whether to find and apply the latest
+                  PatchSet Update and recommended patches (takes precedence over LatestPSU)
+                type: boolean
               webLogicInstaller:
                 description: The WebLogic Installer that will be used by the WebLogic
                   Image Tool


### PR DESCRIPTION
# Description

Added parameters for LatestPSU and RecommendedPatches to ImageBuildRequest CRD. These are features supported by WIT: LatestPSU - Find and apply the latest PatchSet Update, RecommendedPatches - Find and apply the latest PatchSet Update and recommended patches (this takes precedence over latestPSU).

Fixes VZ-3186

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
