### PR TITLE
ImagePatchOperator supports LatestPSU and RecommendedPatches parameters

### DIFF
--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -82,6 +82,8 @@ func TestNewImageBuildRequest(t *testing.T) {
 		"JDK_INSTALLER_VERSION": "8u281",
 		"WLS_INSTALLER_VERSION": "12.2.1.4.0",
 		"IBR_NAME":              "cluster1",
+		"LATEST_PSU":            "false",
+		"RECOMMENDED_PATCHES":   "true",
 	}
 
 	// Creating an ImageBuildRequest resource
@@ -122,6 +124,8 @@ func TestNewImageBuildRequest(t *testing.T) {
 	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[6].Value, "8u281")
 	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[7].Value, "fmw_12.2.1.4.0_wls.jar")
 	assert.Equal(jb.Spec.Template.Spec.Containers[0].Env[8].Value, "12.2.1.4.0")
+	assert.Equal("false", jb.Spec.Template.Spec.Containers[0].Env[11].Value)
+	assert.Equal("true", jb.Spec.Template.Spec.Containers[0].Env[12].Value)
 
 	// Verifying that the PV, PVC, and Volume Mount are present on the created job
 	assert.Equal(jb.Spec.Template.Spec.Volumes[1].Name, "installers-storage")

--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -82,8 +82,6 @@ func TestNewImageBuildRequest(t *testing.T) {
 		"JDK_INSTALLER_VERSION": "8u281",
 		"WLS_INSTALLER_VERSION": "12.2.1.4.0",
 		"IBR_NAME":              "cluster1",
-		"LATEST_PSU":            "false",
-		"RECOMMENDED_PATCHES":   "true",
 	}
 
 	// Creating an ImageBuildRequest resource

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -110,6 +110,14 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 								Name:  "WDT_INSTALLER_VERSION",
 								Value: os.Getenv("WDT_INSTALLER_VERSION"),
 							},
+							{
+								Name:  "LATEST_PSU",
+								Value: strconv.FormatBool(jobConfig.IBR.Spec.LatestPSU),
+							},
+							{
+								Name:  "RECOMMENDED_PATCHES",
+								Value: strconv.FormatBool(jobConfig.IBR.Spec.RecommendedPatches),
+							},
 						},
 					}},
 					RestartPolicy:      corev1.RestartPolicyNever,

--- a/image-patch-operator/test/templates/imagebuildrequest_instance.yaml
+++ b/image-patch-operator/test/templates/imagebuildrequest_instance.yaml
@@ -16,3 +16,5 @@ spec:
     repository: {{.IMAGE_REPOSITORY}}
   jdkInstallerVersion: {{.JDK_INSTALLER_VERSION}}
   webLogicInstallerVersion: {{.WLS_INSTALLER_VERSION}}
+  latestPSU: {{.LATEST_PSU}}
+  recommendedPatches: {{.RECOMMENDED_PATCHES}}

--- a/image-patch-operator/test/templates/imagebuildrequest_instance.yaml
+++ b/image-patch-operator/test/templates/imagebuildrequest_instance.yaml
@@ -16,5 +16,5 @@ spec:
     repository: {{.IMAGE_REPOSITORY}}
   jdkInstallerVersion: {{.JDK_INSTALLER_VERSION}}
   webLogicInstallerVersion: {{.WLS_INSTALLER_VERSION}}
-  latestPSU: {{.LATEST_PSU}}
-  recommendedPatches: {{.RECOMMENDED_PATCHES}}
+  latestPSU: false
+  recommendedPatches: true


### PR DESCRIPTION
# Description

The image job gets passed parameters for LatestPSU and RecommendedPatches options. Added unit tests to verify this functionality.

Fixes VZ-3188

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
