### PR TITLE
Eventually linter bug fix and enable build gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,9 @@ copyright-check-branch: copyright-check
 .PHONY: check-tests
 check-tests: check-eventually
 
-# using "-report" here displays results but does not exit with a non-zero code, doing this until we address all of the existing complaints
 .PHONY: check-eventually
 check-eventually: check-eventually-test
-	go run tools/eventually-checker/check_eventually.go -report tests/e2e
+	go run tools/eventually-checker/check_eventually.go tests/e2e
 
 .PHONY: check-eventually-test
 check-eventually-test:

--- a/tools/eventually-checker/test/main.go
+++ b/tools/eventually-checker/test/main.go
@@ -39,3 +39,10 @@ func unusedFunc() { //nolint
 
 func localFunc() {
 }
+
+// this common Ginkgo pattern is here to test a bug fix... prior to the fix, the "Fail"
+// here would be associated with the preceding function declaration ("localFunc" in this
+// case) and it would cause a false positive
+var _ = Describe("Generic decl bug fix", func() {
+	Fail("This is not in an eventually")
+})


### PR DESCRIPTION
# Description

This PR fixes a bug in the Eventually linter that resulted in false positives. The problem occurred when the parser encountered generic decls after a function decl, and the calls inside the generic decl were incorrectly associated with the previous function decl. For example:

```
func foo() {
 ...
}

var _ = Describe("Tests", func() {
   It("aSpec", func() {
      Expect(...)
   })
})
```

Prior to the fix, the `Expect` was incorrectly associated with the `foo` function.

To fix the bug, I first added a generic decl to the test `main.go` and reproduced the false positive. The fix is to keep track of the token end position of the current function decl. Once the parser encounters a node after that end position, it resets the current func decl name and end position. Then we only record the function calls when the current function decl is defined.

This PR also removes the `-report` flag when running the linter so that builds are now gated on a clean linter run.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
