### PR TITLE
Fix upgrade test

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -229,8 +229,7 @@ pipeline {
                 stage("upgrade-verrazzano") {
                     steps {
                         script {
-                            def props = readProperties file: '.verrazzano-development-version'
-                            VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "cat ${GO_REPO_PATH}/verrazzano/platform-operator/verrazzano-bom.json | jq -r '.version'").trim()
                         }
                         sh """
                             echo "Upgrading the Verrazzano installation"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -229,7 +229,7 @@ pipeline {
                 stage("upgrade-verrazzano") {
                     steps {
                         script {
-                            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/master/generated-verrazzano-bom.json | jq -r '.version'").trim()
+                            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/generated-verrazzano-bom.json | jq -r '.version'").trim()
                         }
                         sh """
                             echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -229,10 +229,10 @@ pipeline {
                 stage("upgrade-verrazzano") {
                     steps {
                         script {
-                            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "cat ${GO_REPO_PATH}/verrazzano/platform-operator/verrazzano-bom.json | jq -r '.version'").trim()
+                            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/master/generated-verrazzano-bom.json | jq -r '.version'").trim()
                         }
                         sh """
-                            echo "Upgrading the Verrazzano installation"
+                            echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
                             # Modify the version field in the verrazzano CR file to be this new verrazzano version
                             cd ${GO_REPO_PATH}/verrazzano
                             cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml

--- a/platform-operator/internal/util/helm/helmcli.go
+++ b/platform-operator/internal/util/helm/helmcli.go
@@ -66,10 +66,12 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 		args = append(args, "--set")
 		args = append(args, overrides)
 	}
-	const maxRetry = 3
+	// Try to upgrade several times.  Sometimes upgrade fails with "already exists" or "no deployed release".
+	// We have seen from tests that doing a retry will eventually sucssed if these 2 errors occur.
+	const maxRetry = 5
 	for i := 1; i <= maxRetry; i++ {
 		cmd := exec.Command("helm", args...)
-		log.Infof("Running command: %s", i, cmd.String())
+		log.Infof("Running command: %s", cmd.String())
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {
 			break

--- a/platform-operator/internal/util/helm/helmcli.go
+++ b/platform-operator/internal/util/helm/helmcli.go
@@ -40,7 +40,7 @@ func GetValues(log *zap.SugaredLogger, releaseName string, namespace string) ([]
 
 // Upgrade will upgrade a Helm release with the specified charts.  The overrideFiles array
 // are in order with the first files in the array have lower precedence than latter files.
-func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, overrideFile string, overrides string, getValuesFile string) (stdout []byte, stderr []byte, err error) {
+func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, overrideFile string, overrides string, existingValuesFile string) (stdout []byte, stderr []byte, err error) {
 	// Helm upgrade command will apply the new chart, but use all the existing
 	// overrides that we used during the install.
 	args := []string{"upgrade", releaseName, chartDir}
@@ -54,7 +54,7 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 	// a failed helm upgrade that results from a nil reference.  The nil reference occurs when a default value
 	// is added to a new chart and new chart references the new value.
 	args = append(args, "-f")
-	args = append(args, getValuesFile)
+	args = append(args, existingValuesFile)
 
 	// Add the override files
 	if len(overrideFile) > 0 {

--- a/platform-operator/internal/util/helm/helmcli.go
+++ b/platform-operator/internal/util/helm/helmcli.go
@@ -66,10 +66,10 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 		args = append(args, "--set")
 		args = append(args, overrides)
 	}
-	cmd := exec.Command("helm", args...)
-	log.Infof("Running command: %s", cmd.String())
 	const maxRetry = 3
 	for i := 1; i <= maxRetry; i++ {
+		cmd := exec.Command("helm", args...)
+		log.Infof("Running command: %s", i, cmd.String())
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {
 			break
@@ -78,7 +78,7 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 		if i == maxRetry {
 			return stdout, stderr, err
 		}
-		log.Errorf("retry %v for upgrade", i)
+		log.Infof("Retrying upgrade, attempt %v", i+1)
 	}
 
 	//  Log upgrade output


### PR DESCRIPTION
The upgrade test was failing for 2 reasons:
1) The helm upgrade command intermittently fails.   Use a retry loop to fix this.
2) Use the BOM version for the upgrade target, instead of the verrazzano-development-version file.  This is because, the BOM version has a version suffix that is appended during each build.  During upgrade, the version field that we put in the Verrazzano CR must match that BOM version.

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
