### PR TITLE
Pass base image to Image Tool

### DIFF
--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -22,6 +22,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	k8score "k8s.io/api/core/v1"
 	k8net "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -114,6 +115,20 @@ func TestNewImageBuildRequest(t *testing.T) {
 
 	// Verify istio-injection disabled for the job
 	assert.Equal("false", jb.Labels["sidecar.istio.io/inject"])
+
+	// Default values for resource limits and requests
+	cpuValue := resource.NewMilliQuantity(1100, resource.DecimalSI)
+	memoryValue := resource.NewQuantity(1*1024*1024*1024, resource.BinarySI)
+
+	// Verify that the Job has the expected values for resource limits and requests
+	cpuLimit := jb.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"]
+	memoryLimit := jb.Spec.Template.Spec.Containers[0].Resources.Limits["memory"]
+	cpuRequest := jb.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"]
+	memoryRequest := jb.Spec.Template.Spec.Containers[0].Resources.Requests["memory"]
+	assert.Zero(cpuLimit.Cmp(*cpuValue))
+	assert.Zero(memoryLimit.Cmp(*memoryValue))
+	assert.Zero(cpuRequest.Cmp(*cpuValue))
+	assert.Zero(memoryRequest.Cmp(*memoryValue))
 
 	// Testing that the spec fields of the IBR propagate to the environmental variables of the ImageJob
 	assert.Equal("test-build", jb.Spec.Template.Spec.Containers[0].Env[0].Value)

--- a/image-patch-operator/controllers/imagebuildrequest_controller_test.go
+++ b/image-patch-operator/controllers/imagebuildrequest_controller_test.go
@@ -128,17 +128,11 @@ func TestNewImageBuildRequest(t *testing.T) {
 	cpuValue, _ := resource.ParseQuantity(cpuValueString)
 	memoryValue, _ := resource.ParseQuantity(memoryValueString)
 
-	// Get resource limits and requests on the Pod
-	cpuLimit := jb.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"]
-	memoryLimit := jb.Spec.Template.Spec.Containers[0].Resources.Limits["memory"]
-	cpuRequest := jb.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"]
-	memoryRequest := jb.Spec.Template.Spec.Containers[0].Resources.Requests["memory"]
-
 	// Verify that the resource limits and requests are the expected test values
-	assert.Zero(cpuLimit.Cmp(cpuValue))
-	assert.Zero(memoryLimit.Cmp(memoryValue))
-	assert.Zero(cpuRequest.Cmp(cpuValue))
-	assert.Zero(memoryRequest.Cmp(memoryValue))
+	assert.Equal(cpuValue, jb.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"])
+	assert.Equal(memoryValue, jb.Spec.Template.Spec.Containers[0].Resources.Limits["memory"])
+	assert.Equal(cpuValue, jb.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"])
+	assert.Equal(memoryValue, jb.Spec.Template.Spec.Containers[0].Resources.Requests["memory"])
 
 	// Testing that the spec fields of the IBR propagate to the environmental variables of the ImageJob
 	assert.Equal("test-build", jb.Spec.Template.Spec.Containers[0].Env[0].Value)

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -31,11 +31,10 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 		annotations[k8s.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
 	}
 
-	cpuLimit, err := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_CPU"))
-	memoryLimit, err := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_MEMORY"))
-	cpuRequest, err := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU"))
-	memoryRequest, err := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY"))
-	_ = err // TODO: what to do in the case of an error
+	cpuLimit, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_CPU"))
+	memoryLimit, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_MEMORY"))
+	cpuRequest, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU"))
+	memoryRequest, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY"))
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -31,6 +31,22 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 		annotations[k8s.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
 	}
 
+	// If resource limit and request environment variables are not set, then use some default values
+	for _, envVar := range [2]string{"WIT_POD_RESOURCE_LIMIT_CPU", "WIT_POD_RESOURCE_REQUEST_CPU"} {
+		_, present := os.LookupEnv(envVar)
+		if !present {
+			defaultValue := "1100m"
+			os.Setenv(envVar, defaultValue)
+		}
+	}
+	for _, envVar := range [2]string{"WIT_POD_RESOURCE_LIMIT_MEMORY", "WIT_POD_RESOURCE_REQUEST_MEMORY"} {
+		_, present := os.LookupEnv(envVar)
+		if !present {
+			defaultValue := "1Gi"
+			os.Setenv(envVar, defaultValue)
+		}
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobConfig.JobName,

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -37,6 +37,10 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 	cpuRequest, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU"))
 	memoryRequest, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY"))
 
+	// Convert memory values to Gibibytes
+	memoryLimit *= 1024 * 1024 * 1024
+	memoryRequest *= 1024 * 1024 * 1024
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobConfig.JobName,

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -11,7 +11,6 @@ import (
 	"github.com/verrazzano/verrazzano/image-patch-operator/internal/k8s"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,11 +29,6 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 		annotations = make(map[string]string, 1)
 		annotations[k8s.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
 	}
-
-	cpuLimit, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_CPU"))
-	memoryLimit, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_LIMIT_MEMORY"))
-	cpuRequest, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU"))
-	memoryRequest, _ := resource.ParseQuantity(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY"))
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -56,12 +50,12 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 					Containers: []corev1.Container{{
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
-								"cpu":    cpuLimit,
-								"memory": memoryLimit,
+								"cpu":    jobConfig.CPULimit,
+								"memory": jobConfig.MemoryLimit,
 							},
 							Requests: corev1.ResourceList{
-								"cpu":    cpuRequest,
-								"memory": memoryRequest,
+								"cpu":    jobConfig.CPURequest,
+								"memory": jobConfig.MemoryRequest,
 							},
 						},
 						Name:            "image-build-request",

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -31,16 +31,6 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 		annotations[k8s.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)
 	}
 
-	// Convert resource limits from strings to integers
-	cpuLimit, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_LIMIT_CPU"))
-	memoryLimit, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_LIMIT_MEMORY"))
-	cpuRequest, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU"))
-	memoryRequest, _ := strconv.Atoi(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY"))
-
-	// Convert memory values to Gibibytes
-	memoryLimit *= 1024 * 1024 * 1024
-	memoryRequest *= 1024 * 1024 * 1024
-
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobConfig.JobName,
@@ -61,12 +51,12 @@ func NewJob(jobConfig *JobConfig) *batchv1.Job {
 					Containers: []corev1.Container{{
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
-								"cpu":    *resource.NewMilliQuantity(int64(cpuLimit), resource.DecimalSI),
-								"memory": *resource.NewQuantity(int64(memoryLimit), resource.BinarySI),
+								"cpu":    resource.MustParse(os.Getenv("WIT_POD_RESOURCE_LIMIT_CPU")),
+								"memory": resource.MustParse(os.Getenv("WIT_POD_RESOURCE_LIMIT_MEMORY")),
 							},
 							Requests: corev1.ResourceList{
-								"cpu":    *resource.NewMilliQuantity(int64(cpuRequest), resource.DecimalSI),
-								"memory": *resource.NewQuantity(int64(memoryRequest), resource.BinarySI),
+								"cpu":    resource.MustParse(os.Getenv("WIT_POD_RESOURCE_REQUEST_CPU")),
+								"memory": resource.MustParse(os.Getenv("WIT_POD_RESOURCE_REQUEST_MEMORY")),
 							},
 						},
 						Name:            "image-build-request",

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
@@ -36,4 +36,12 @@ spec:
               value: {{ .Values.imageTool.name }}
             - name: IBR_DRY_RUN
               value: {{ .Values.dryRun | quote }}
+            - name: WIT_POD_RESOURCE_LIMIT_CPU
+              value: {{ .Values.imageTool.resourceLimits.cpu }}
+            - name: WIT_POD_RESOURCE_LIMIT_MEMORY
+              value: {{ .Values.imageTool.resourceLimits.memory }}
+            - name: WIT_POD_RESOURCE_REQUEST_CPU
+              value: {{ .Values.imageTool.resourceRequests.cpu }}
+            - name: WIT_POD_RESOURCE_REQUEST_MEMORY
+              value: {{ .Values.imageTool.resourceRequests.memory }}
       serviceAccountName: {{ .Values.imagePatchOperator.name }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/templates/deployment.yaml
@@ -37,11 +37,11 @@ spec:
             - name: IBR_DRY_RUN
               value: {{ .Values.dryRun | quote }}
             - name: WIT_POD_RESOURCE_LIMIT_CPU
-              value: {{ .Values.imageTool.resourceLimits.cpu }}
+              value: {{ .Values.imageTool.resourceLimits.cpu | quote }}
             - name: WIT_POD_RESOURCE_LIMIT_MEMORY
-              value: {{ .Values.imageTool.resourceLimits.memory }}
+              value: {{ .Values.imageTool.resourceLimits.memory | quote }}
             - name: WIT_POD_RESOURCE_REQUEST_CPU
-              value: {{ .Values.imageTool.resourceRequests.cpu }}
+              value: {{ .Values.imageTool.resourceRequests.cpu | quote }}
             - name: WIT_POD_RESOURCE_REQUEST_MEMORY
-              value: {{ .Values.imageTool.resourceRequests.memory }}
+              value: {{ .Values.imageTool.resourceRequests.memory | quote }}
       serviceAccountName: {{ .Values.imagePatchOperator.name }}

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -11,6 +11,12 @@ imageTool:
   name: verrazzano-image-build-job
   # image value will be filled in during the build pipeline
   image:
+  resourceLimits:
+    cpu: 1100
+    memory: 1073741824 # = 2^30
+  resourceRequests:
+    cpu: 1100
+    memory: 1073741824 # = 2^30
 
 weblogicDeployTool:
   binary: weblogic-deploy.zip

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -14,11 +14,11 @@ imageTool:
   # Specifies the resource limits for the Pod running WebLogic Image Tool
   resourceLimits:
     cpu: "1100" # Units: millicores
-    memory: "1073741824" # = 2^30. Units: Gibibytes
+    memory: "1" # Units: Gibibytes
   # Specifies the resource requests for the Pod running WebLogic Image Tool
   resourceRequests:
     cpu: "1100" # Units: millicores
-    memory: "1073741824" # = 2^30. Units: Gibibytes
+    memory: "1" # Units: Gibibytes
 
 weblogicDeployTool:
   binary: weblogic-deploy.zip

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -13,12 +13,12 @@ imageTool:
   image:
   # Specifies the resource limits for the Pod running WebLogic Image Tool
   resourceLimits:
-    cpu: "1100" # Units: millicores
-    memory: "1" # Units: Gibibytes
+    cpu: "1100m"
+    memory: "1Gi"
   # Specifies the resource requests for the Pod running WebLogic Image Tool
   resourceRequests:
-    cpu: "1100" # Units: millicores
-    memory: "1" # Units: Gibibytes
+    cpu: "1100m"
+    memory: "1Gi"
 
 weblogicDeployTool:
   binary: weblogic-deploy.zip

--- a/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
+++ b/image-patch-operator/helm_config/charts/image-patch-operator/values.yaml
@@ -11,12 +11,14 @@ imageTool:
   name: verrazzano-image-build-job
   # image value will be filled in during the build pipeline
   image:
+  # Specifies the resource limits for the Pod running WebLogic Image Tool
   resourceLimits:
-    cpu: 1100
-    memory: 1073741824 # = 2^30
+    cpu: "1100" # Units: millicores
+    memory: "1073741824" # = 2^30. Units: Gibibytes
+  # Specifies the resource requests for the Pod running WebLogic Image Tool
   resourceRequests:
-    cpu: 1100
-    memory: 1073741824 # = 2^30
+    cpu: "1100" # Units: millicores
+    memory: "1073741824" # = 2^30. Units: Gibibytes
 
 weblogicDeployTool:
   binary: weblogic-deploy.zip

--- a/image-patch-operator/internal/k8s/job.go
+++ b/image-patch-operator/internal/k8s/job.go
@@ -8,6 +8,7 @@ import (
 
 	imagesv1alpha1 "github.com/verrazzano/verrazzano/image-patch-operator/api/images/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +23,10 @@ type JobConfigCommon struct {
 	JobImage           string                            // Image name/tag for the job
 	DryRun             bool                              // Perform the job as a dry-run/no-op, for testing purposes
 	IBR                *imagesv1alpha1.ImageBuildRequest // ImageBuildRequest carrying job environmental variables
+	CPULimit           resource.Quantity                 // Pod's resource limit for the CPU
+	MemoryLimit        resource.Quantity                 // Pod's resource limit for memory
+	CPURequest         resource.Quantity                 // Pod's resource request for CPU
+	MemoryRequest      resource.Quantity                 // Pod's resource request for memory
 }
 
 // NoOpMode value for MODE variable for no-op (test) jobs

--- a/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
+++ b/image-patch-operator/weblogic-imagetool/v8o-imagetool.sh
@@ -16,7 +16,13 @@ export WLSIMG_CACHEDIR="/home/verrazzano/cache"
 ./imagetool/bin/imagetool.sh cache addInstaller --type wdt --version ${WDT_INSTALLER_VERSION} --path /installers/${WDT_INSTALLER_BINARY}
 
 # Create the image
-./imagetool/bin/imagetool.sh create --tag ${IMAGE_NAME}:${IMAGE_TAG} --builder podman --jdkVersion ${JDK_INSTALLER_VERSION} --version ${WEBLOGIC_INSTALLER_VERSION} --dryRun=${IBR_DRY_RUN}
+./imagetool/bin/imagetool.sh create \
+  --tag ${IMAGE_NAME}:${IMAGE_TAG} \
+  --builder podman \
+  --jdkVersion ${JDK_INSTALLER_VERSION} \
+  --version ${WEBLOGIC_INSTALLER_VERSION} \
+  --dryRun=${IBR_DRY_RUN} \
+  --fromImage ${BASE_IMAGE}
 
 # Tag and push the image to the registry (only if we are not in a DryRun)
 if [ "${IBR_DRY_RUN}" == "false" ] ; then


### PR DESCRIPTION
# Description

Image Patch Service.
Includes the `--fromImage` parameter to specify the base image in the call to `imagetool create`.
Adds resource limits and requests to the Pod running the Image Tool in order for this to work. Values for the resource limits and requests are specified as Helm values.

Fixes VZ-3185
# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
