### PR TITLE
VZ-2996: nginx bug

### DIFF
--- a/pkg/proxy/auth_lua_template.go
+++ b/pkg/proxy/auth_lua_template.go
@@ -140,14 +140,16 @@ const OidcAuthLuaFileTemplate = `local me = {}
 
     function me.unauthorized(msg, err)
         me.deleteCookie("authn")
-        ngx.status = ngx.HTTP_UNAUTHORIZED
         me.logJson(ngx.ERR, msg, err)
+        ngx.status = ngx.HTTP_UNAUTHORIZED
+        ngx.say("401 Unauthorized")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     function me.forbidden(msg, err)
-        ngx.status = ngx.HTTP_FORBIDDEN
         me.logJson(ngx.ERR, msg, err)
+        ngx.status = ngx.HTTP_FORBIDDEN
+        ngx.say("403 Forbidden")
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
@@ -638,9 +640,7 @@ const OidcAuthLuaFileTemplate = `local me = {}
       me.logJson(ngx.INFO, "Read service account token.")
       local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token")
       if not (serviceAccountToken) then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "No service account token present in pod.")
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("No service account token present in pod.")
       end
       return serviceAccountToken
     end
@@ -695,14 +695,10 @@ const OidcAuthLuaFileTemplate = `local me = {}
           },
       })
       if err then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "Error accessing vz api", err)
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("Error accessing vz api", err)
       end
       if not(res) or not (res.body) then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "Unable to get k8s resource.")
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("Unable to get k8s resource.")
       end
       local cjson = require "cjson"
       return cjson.decode(res.body)
@@ -738,9 +734,7 @@ const OidcAuthLuaFileTemplate = `local me = {}
         me.logJson(ngx.INFO, "Read vmc resource for " .. args.cluster)
         local vmc = me.getVMC(args.cluster)
         if not(vmc) or not(vmc.status) or not(vmc.status.apiUrl) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch vmc api url for vmc " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.unauthorized("Unable to fetch vmc api url for vmc " .. args.cluster)
         end
 
         local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
@@ -765,9 +759,7 @@ const OidcAuthLuaFileTemplate = `local me = {}
 
         local decodedSecret = ngx.decode_base64(secret.data["cacrt"])
         if not(decodedSecret) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to decode ca secret for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.unauthorized("Unable to decode ca secret for vmc to access api server of managed cluster " .. args.cluster)
         end
 
         args.cluster = nil

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -217,14 +217,16 @@ data:
 
     function me.unauthorized(msg, err)
         me.deleteCookie("authn")
-        ngx.status = ngx.HTTP_UNAUTHORIZED
         me.logJson(ngx.ERR, msg, err)
+        ngx.status = ngx.HTTP_UNAUTHORIZED
+        ngx.say("401 Unauthorized")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     function me.forbidden(msg, err)
-        ngx.status = ngx.HTTP_FORBIDDEN
         me.logJson(ngx.ERR, msg, err)
+        ngx.status = ngx.HTTP_FORBIDDEN
+        ngx.say("403 Forbidden")
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
@@ -715,9 +717,7 @@ data:
       me.logJson(ngx.INFO, "Read service account token.")
       local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token")
       if not (serviceAccountToken) then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "No service account token present in pod.")
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("No service account token present in pod.")
       end
       return serviceAccountToken
     end
@@ -772,14 +772,10 @@ data:
           },
       })
       if err then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "Error accessing vz api", err)
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("Error accessing vz api", err)
       end
       if not(res) or not (res.body) then
-        ngx.status = 401
-        me.logJson(ngx.ERR, "Unable to get k8s resource.")
-        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        me.unauthorized("Unable to get k8s resource.")
       end
       local cjson = require "cjson"
       return cjson.decode(res.body)
@@ -815,9 +811,7 @@ data:
         me.logJson(ngx.INFO, "Read vmc resource for " .. args.cluster)
         local vmc = me.getVMC(args.cluster)
         if not(vmc) or not(vmc.status) or not(vmc.status.apiUrl) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to fetch vmc api url for vmc " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.unauthorized("Unable to fetch vmc api url for vmc " .. args.cluster)
         end
 
         local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion
@@ -842,9 +836,7 @@ data:
 
         local decodedSecret = ngx.decode_base64(secret.data["cacrt"])
         if not(decodedSecret) then
-            ngx.status = 401
-            me.logJson(ngx.ERR, "Unable to decode ca secret for vmc to access api server of managed cluster " .. args.cluster)
-            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+            me.unauthorized("Unable to decode ca secret for vmc to access api server of managed cluster " .. args.cluster)
         end
 
         args.cluster = nil


### PR DESCRIPTION
# Description

Return specific messages with errors, so that nginx doesn't default to sending server name/version.
Ensure all error returns use wrappers that say the messages.

Fixes VZ-2996

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
