### PR TITLE
VZ-3266: Acceptance test fix to use Eventually around PodsNotRunning

### DIFF
--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -166,9 +166,9 @@ func undeployFooApplication() {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/foo/springboot-frontend.yaml")
 	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
-	notRunning := pkg.PodsNotRunning(fooNamespace, expectedPodsFoo)
-	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
+	Eventually(func() (bool, error) {
+		return pkg.PodsNotRunning(fooNamespace, expectedPodsFoo)
+	}, waitTimeout, shortPollingInterval).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", fooNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
 	Eventually(func() error {
@@ -201,9 +201,9 @@ func undeployBarApplication() {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/bar/springboot-frontend.yaml")
 	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
-	notRunning := pkg.PodsNotRunning(barNamespace, expectedPodsBar)
-	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
+	Eventually(func() (bool, error) {
+		return pkg.PodsNotRunning(barNamespace, expectedPodsBar)
+	}, waitTimeout, shortPollingInterval).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", barNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
 	Eventually(func() error {
@@ -236,9 +236,9 @@ func undeployNoIstioApplication() {
 		return pkg.DeleteResourceFromFile("testdata/istio/authz/noistio/springboot-frontend.yaml")
 	}, waitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	// NOTE: This function does wait for the pods to terminate even though it's not using Eventually
-	notRunning := pkg.PodsNotRunning(noIstioNamespace, expectedPodsBar)
-	Expect(notRunning).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
+	Eventually(func() (bool, error) {
+		return pkg.PodsNotRunning(noIstioNamespace, expectedPodsBar)
+	}, waitTimeout, shortPollingInterval).Should(BeTrue(), fmt.Sprintf("Pods in namespace %s stuck terminating!", noIstioNamespace))
 
 	pkg.Log(pkg.Info, "Delete namespace")
 	Eventually(func() error {

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -132,41 +132,26 @@ func PodsRunningInCluster(namespace string, namePrefixes []string, kubeconfigPat
 	return len(missing) == 0
 }
 
-// PodsNotRunning waits for all the pods in namePrefixes to be terminated
-func PodsNotRunning(namespace string, namePrefixes []string) bool {
+// PodsNotRunning returns true if all pods in namePrefixes are not running
+func PodsNotRunning(namespace string, namePrefixes []string) (bool, error) {
 	clientset, err := GetKubernetesClientset()
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error getting clientset, error: %v", err))
-		return false
+		return false, err
 	}
 	allPods, err := ListPodsInCluster(namespace, clientset)
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error listing pods in cluster for namespace: %s, error: %v", namespace, err))
-		return false
+		return false, err
 	}
 	terminatedPods := notRunning(allPods.Items, namePrefixes...)
-	var i int = 0
-	for len(terminatedPods) != len(namePrefixes) {
-		Log(Info, fmt.Sprintf("Pods %v were TERMINATED in %v", terminatedPods, namespace))
-		time.Sleep(15 * time.Second)
-		pods, err := ListPodsInCluster(namespace, clientset)
-		if err != nil {
-			Log(Error, fmt.Sprintf("Error listing pods in cluster for namespace: %s, error: %v", namespace, err))
-			return false
-		}
-		terminatedPods = notRunning(pods.Items, namePrefixes...)
-		i++
-		if i > 10 {
-			break
-		}
-	}
 	if len(terminatedPods) != len(namePrefixes) {
 		runningPods := areRunning(allPods.Items, namePrefixes...)
 		Log(Info, fmt.Sprintf("Pods %v were RUNNING in %v", runningPods, namespace))
-		return false
+		return false, nil
 	}
 	Log(Info, fmt.Sprintf("ALL pods %v were TERMINATED in %v", terminatedPods, namespace))
-	return true
+	return true, nil
 }
 
 // notRunning finds the pods not running

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -123,17 +123,23 @@ var _ = Describe("VMI", func() {
 	if isManagedClusterProfile {
 		It("Elasticsearch should NOT be present", func() {
 			// Verify ES not present
-			Expect(pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-es"})).To(BeTrue())
+			Eventually(func() (bool, error) {
+				return pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-es"})
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 			Expect(elasticTLSSecret()).To(BeTrue())
 			Expect(elastic.CheckIngress()).To(BeFalse())
 			Expect(ingressURLs).NotTo(HaveKey("vmi-system-es-ingest"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
 
 			// Verify Kibana not present
-			Expect(pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-kibana"})).To(BeTrue())
+			Eventually(func() (bool, error) {
+				return pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-kibana"})
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 			Expect(ingressURLs).NotTo(HaveKey("vmi-system-kibana"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
 
 			// Verify Grafana not present
-			Expect(pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-grafana"})).To(BeTrue())
+			Eventually(func() (bool, error) {
+				return pkg.PodsNotRunning(verrazzanoNamespace, []string{"vmi-system-grafana"})
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 			Expect(ingressURLs).NotTo(HaveKey("vmi-system-grafana"), fmt.Sprintf("Ingress %s not found", "vmi-system-grafana"))
 		})
 	} else {


### PR DESCRIPTION
# Description

There is a common `PodsNotRunning` function that checks to make sure pods with specific prefixes are not running in a namespace. That function could fail with no retries.

I fixed the `PodsNotRunning` function to:
1. Return an error in addition to the boolean
2. Remove the loop with sleep

I also changed the tests that call that function to use Eventually. Now the call will be retried if it returns an error or if it returns `false`.

Fixes VZ-3266

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
