### PR TITLE
VZ-3144.  Update private registry tests, run automatically from release branches

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -3,6 +3,9 @@
 
 def GIT_COMMIT_TO_USE
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def TESTS_FAILED = false
+def tarfilePrefix="verrazzano_periodic"
+def storeLocation=""
 
 pipeline {
     options {
@@ -67,11 +70,12 @@ pipeline {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
+                    storeLocation="${env.BRANCH_NAME}-last-clean-periodic-test/${tarfilePrefix}.zip"
                 }
             }
         }
 
-        stage ('Kick off parallel tests') {
+        stage ('Periodic Test Suites') {
             parallel {
                 stage('Kind Acceptance Tests on 1.19 Non-Calico') {
                     steps {
@@ -83,6 +87,13 @@ pipeline {
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false)
                                 ], wait: true
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                TESTS_FAILED = true
+                            }
                         }
                     }
                 }
@@ -98,6 +109,13 @@ pipeline {
                                 ], wait: true
                         }
                     }
+                    post {
+                        failure {
+                            script {
+                                TESTS_FAILED = true
+                            }
+                        }
+                    }
                 }
                 stage('OCI DNS/ACME-Staging Tests') {
                     steps {
@@ -109,6 +127,13 @@ pipeline {
                                     string(name: 'ACME_ENVIRONMENT', value: "staging"),
                                     booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false)
                                 ], wait: true
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                TESTS_FAILED = true
+                            }
                         }
                     }
                 }
@@ -125,13 +150,39 @@ pipeline {
                                 ], wait: true
                         }
                     }
+                    post {
+                        failure {
+                            script {
+                                TESTS_FAILED = true
+                            }
+                        }
+                    }
                 }*/
-                stage('Private registry tests') {
+            }
+        }
+        stage("Private Registry") {
+            when {
+                allOf {
+                    expression {TESTS_FAILED == false}
+                }
+            }
+            stages {
+                stage("Upload Periodic Run Artifacts") {
+                    steps {
+                        sh """
+                            if [ "${env.BRANCH_NAME}" == "master" ]; then
+                                ci/scripts/update_periodic_on_success.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH} ${tarfilePrefix}
+                            fi
+                        """
+                    }
+                }
+                stage('Private Registry Tests') {
                     steps {
                         script {
                             build job: "verrazzano-private-registry/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
+                                    string(name: 'ZIPFILE_LOCATION', value: storeLocation)
                                 ], wait: true
                         }
                     }
@@ -141,13 +192,6 @@ pipeline {
     }
 
     post {
-        success {
-            sh """
-                if [ "${env.BRANCH_NAME}" == "master" ]; then
-                    ci/scripts/update_periodic_on_success.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH}
-                fi
-            """
-        }
         cleanup {
             deleteDir()
         }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -39,6 +39,10 @@ pipeline {
                 description: 'This is the wildcard DNS domain',
                 // 1st choice is the default value
                 choices: [ "nip.io", "sslip.io"])
+        string (name: 'ZIPFILE_LOCATION',
+                        defaultValue: 'master-last-clean-periodic-test/verrazzano_full.zip',
+                        description: 'The bucket location to use for the Zip file download',
+                        trim: true)
         booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
         booleanParam (description: 'Whether to include the slow tests in the acceptance tests', name: 'RUN_SLOW_TESTS', defaultValue: false)
@@ -210,12 +214,32 @@ pipeline {
 
         stage('Download and extract Tarball') {
             steps {
-                sh """
-                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/tarball.tar.gz --file ${WORKSPACE}/vz-latest-tarball.tar.gz
-                    mkdir ${TARBALL_DIR} || true
-                    cd ${TARBALL_DIR}
-                    tar xvf ${WORKSPACE}/vz-latest-tarball.tar.gz
-                """
+                script {
+                    downloadLocation = "${WORKSPACE}/${params.ZIPFILE_LOCATION}"
+                    baseFilename = sh (
+                        script: "basename ${params.ZIPFILE_LOCATION} .zip",
+                        returnStdout: true
+                        ).trim()
+                    tarfileName = "${baseFilename}.tar.gz"
+                    checksumFile = "${tarfileName}.sha256"
+                    echo "base name: $baseFilename, tar name: $tarfileName"
+
+                    zipDir = sh (
+                        script: "dirname $downloadLocation",
+                        returnStdout: true
+                        ).trim()
+
+                    sh """
+                        mkdir -p $zipDir || true
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${params.ZIPFILE_LOCATION} --file ${downloadLocation}
+                    """
+
+                    dir(env.TARBALL_DIR) {
+                        unzip zipFile: downloadLocation
+                        sh "sha256sum -c $checksumFile"
+                        sh "tar xvf $tarfileName"
+                        }
+                }
             }
         }
         stage('Upload Verrazzano Images') {

--- a/ci/scripts/generate_product_zip.sh
+++ b/ci/scripts/generate_product_zip.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+if [ -z "$1" ]; then
+  echo "GIT commit must be specified"
+  exit 1
+fi
+GIT_COMMIT_USED="$1"
+
+if [ -z "$2" ]; then
+  echo "Short commit hash must be specified"
+  exit 1
+fi
+SHORT_COMMIT_HASH_ENV="$2"
+
+if [ -z "$3" ]; then
+  echo "Bucket label for zip must be specified"
+  exit 1
+fi
+BUCKET_LABEL="$3"
+
+if [ -z "$4" ]; then
+  echo "The tar/Zip file prefix must be specified"
+  exit 1
+fi
+ZIPFILE_PREFIX="$4"
+
+if [ -z "$5" ]; then
+  echo "Path to the generated BOM file must be specified"
+  exit 1
+fi
+GENERATED_BOM_FILE="$5"
+
+if [ -z "$JENKINS_URL" ] || [ -z "$WORKSPACE" ] || [ -z "$OCI_OS_NAMESPACE" ] || [ -z "$OCI_OS_BUCKET" ]; then
+  echo "This script must only be called from Jenkins and requires a number of environment variables are set"
+  exit 1
+fi
+
+mkdir ${WORKSPACE}/tar-files
+chmod uog+w ${WORKSPACE}/tar-files
+cp $GENERATED_BOM_FILE ${WORKSPACE}/tar-files/verrazzano-bom.json
+cp tools/scripts/vz-registry-image-helper.sh ${WORKSPACE}/tar-files/vz-registry-image-helper.sh
+cp tools/scripts/README.md ${WORKSPACE}/tar-files/README.md
+mkdir -p ${WORKSPACE}/tar-files/charts
+cp  -r platform-operator/helm_config/charts/verrazzano-platform-operator ${WORKSPACE}/tar-files/charts
+
+tarfile="${ZIPFILE_PREFIX}.tar.gz"
+commitFile="${ZIPFILE_PREFIX}-commit.txt"
+sha256File="${tarfile}.sha256"
+zipFile="${ZIPFILE_PREFIX}.zip"
+
+tools/scripts/generate_tarball.sh ${WORKSPACE}/tar-files/verrazzano-bom.json ${WORKSPACE}/tar-files ${WORKSPACE}/${tarfile}
+cd ${WORKSPACE}
+sha256sum ${tarfile} > ${sha256File}
+echo "git-commit=${GIT_COMMIT_USED}" > ${commitFile}
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BUCKET_LABEL}/${commitFile} --file ${commitFile}
+zip ${zipFile} ${commitFile} ${sha256File} ${tarfile}
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BUCKET_LABEL}/${zipFile} --file ${zipFile}

--- a/ci/scripts/update_periodic_on_success.sh
+++ b/ci/scripts/update_periodic_on_success.sh
@@ -16,25 +16,17 @@ if [ -z "$2" ]; then
 fi
 SHORT_COMMIT_HASH_ENV="$2"
 
+if [ -z "$3" ]; then
+  echo "The tar/Zip file prefix must be specified"
+  exit 1
+fi
+ZIPFILE_PREFIX="$3"
+
 if [ -z "$JENKINS_URL" ] || [ -z "$WORKSPACE" ] || [ -z "$OCI_OS_NAMESPACE" ] || [ -z "$OCI_OS_BUCKET" ]; then
   echo "This script must only be called from Jenkins and requires a number of environment variables are set"
   exit 1
 fi
 
-mkdir ${WORKSPACE}/tar-files
-chmod uog+w ${WORKSPACE}/tar-files
-oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/${SHORT_COMMIT_HASH_ENV}/generated-verrazzano-bom.json --file ${WORKSPACE}/tar-files/verrazzano-bom.json
-cp tools/scripts/vz-registry-image-helper.sh ${WORKSPACE}/tar-files/vz-registry-image-helper.sh
-cp tools/scripts/README.md ${WORKSPACE}/tar-files/README.md
-mkdir -p ${WORKSPACE}/tar-files/charts
-cp  -r platform-operator/helm_config/charts/verrazzano-platform-operator ${WORKSPACE}/tar-files/charts
-tools/scripts/generate_tarball.sh ${WORKSPACE}/tar-files/verrazzano-bom.json ${WORKSPACE}/tar-files ${WORKSPACE}/tarball.tar.gz
-cd ${WORKSPACE}
-sha256sum tarball.tar.gz > tarball.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/tarball.tar.gz --file tarball.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/tarball.tar.gz.sha256 --file tarball.tar.gz.sha256
-echo "git-commit=${GIT_COMMIT_USED}" > tarball-commit.txt
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/tarball-commit.txt --file tarball-commit.txt
 oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/${SHORT_COMMIT_HASH_ENV}/operator.yaml --file operator.yaml
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/operator.yaml --file operator.yaml
 oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/${SHORT_COMMIT_HASH_ENV}/k8s-dump-cluster.sh --file k8s-dump-cluster.sh
@@ -49,3 +41,10 @@ oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} 
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/verrazzano-analysis-linux-amd64.tar.gz.sha256 --file verrazzano-analysis-linux-amd64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/verrazzano-analysis-darwin-amd64.tar.gz --file verrazzano-analysis-darwin-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master-last-clean-periodic-test/verrazzano-analysis-darwin-amd64.tar.gz.sha256 --file verrazzano-analysis-darwin-amd64.tar.gz.sha256
+
+# Generate a Verrazzano full Zip for private registry testing
+
+# Get the latest stable generated BOM file
+oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name master/${SHORT_COMMIT_HASH_ENV}/generated-verrazzano-bom.json --file ${WORKSPACE}/tar-files/verrazzano-bom.json
+# Call the script to generate and publish the BOM
+ci/scripts/generate_product_zip.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH} master-last-clean-periodic-test ${ZIPFILE_PREFIX} ${WORKSPACE}/tar-files/verrazzano-bom.json


### PR DESCRIPTION

# Description

This updates the main Jenkins run, periodic tests, and private registry tests to use the new Zip format for PLS
* Always run the Zip generation and private registry tests from the main build in `release-*` branches, or when `GENERATE_TARBALL==true`
* Refactors the tarball/Zip generation into a shared script between the periodic tests and main Jenkins run 
* Updates the periodic tests to do the Zip generation and private registry test run to validate that zip in a separate stage after the main test runs
* Also adds a checksum-check of the expanded tarball before testing

Fixes VZ-3144.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
