### PR TITLE
DRAFT: Word linter

### DIFF
--- a/make/quality.mk
+++ b/make/quality.mk
@@ -26,7 +26,7 @@ endif
 .PHONY: word-linter
 word-linter:
 	words=$(curl -L https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)')
-	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker ./../*
+	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker *
 
 .PHONY: coverage
 coverage:

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -9,7 +9,7 @@ GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.b
 #
 
 .PHONY: check
-check: install-linter
+check: install-linter word-linter
 	$(LINTER) run
 
 # find or download golangci-lint
@@ -21,6 +21,12 @@ ifeq (, $(shell command -v golangci-lint))
 else
 	$(eval LINTER=$(shell command -v golangci-lint))
 endif
+
+# search for "bad" words in repo
+.PHONY: word-linter
+word-linter:
+	words=$(curl -L https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)')
+	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker ./../*
 
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
# Description

This updates the Make file built by `quality.mk`, verifying that no disallowed internal words are published when `make check` is executed. 

Fixes VZ-3280

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
