### PR TITLE
Include updated VMO images and fix issue of logs and metrics not being collected for MC when using OCIDNS

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -3,9 +3,6 @@
 
 package constants
 
-// VerrazzanoClustersGroup - clusters group
-const VerrazzanoClustersGroup = "clusters.verrazzano.io"
-
 // VerrazzanoSystemNamespace is the system namespace for verrazzano
 const VerrazzanoSystemNamespace = "verrazzano-system"
 
@@ -41,9 +38,8 @@ const ElasticsearchUsernameData = "username"
 // cluster's Elasticsearch password
 const ElasticsearchPasswordData = "password"
 
-// ElasticsearchCABundleData - the field name in MCRegistrationSecret that contains the admin
-// cluster's Elasticsearch CA bundle
-const ElasticsearchCABundleData = "ca-bundle"
+// CaBundleKey is the CA cert key in a secret
+const CaBundleKey = "ca-bundle"
 
 // LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -41,6 +41,12 @@ const ElasticsearchPasswordData = "password"
 // CaBundleKey is the CA cert key in a secret
 const CaBundleKey = "ca-bundle"
 
+// CaFileDefault is the default value for the CA_FILE environment variable
+const CaFileDefault = "/etc/nginx/all-ca-certs.pem"
+
+// CaFileOverride is the location when the registration secret contains a ca-bundle
+const CaFileOverride = "/fluentd/secret/ca-bundle"
+
 // LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"
 

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -42,7 +42,7 @@ const ElasticsearchPasswordData = "password"
 const CaBundleKey = "ca-bundle"
 
 // CaFileDefault is the default value for the CA_FILE environment variable
-const CaFileDefault = "/etc/nginx/all-ca-certs.pem"
+const CaFileDefault = "/etc/ssl/certs/ca-bundle.crt"
 
 // CaFileOverride is the location when the registration secret contains a ca-bundle
 const CaFileOverride = "/fluentd/secret/ca-bundle"

--- a/application-operator/controllers/logging/fluentd.go
+++ b/application-operator/controllers/logging/fluentd.go
@@ -4,20 +4,17 @@
 package logging
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,8 +30,6 @@ const (
 	elasticSearchURLEnv  = "ELASTICSEARCH_URL"
 	elasticSearchUserEnv = "ELASTICSEARCH_USER"
 	elasticSearchPwdEnv  = "ELASTICSEARCH_PASSWORD"
-
-	CAFileConfig = "\n  ca_file /fluentd/secret/ca-bundle"
 )
 
 // DefaultFluentdImage holds the default FLUENTD image that will be used if it is not specified in the logging logInfo
@@ -195,29 +190,6 @@ func (f *Fluentd) createFluentdConfigMap(namespace string) *v1.ConfigMap {
 			return data
 		}(),
 	}
-}
-
-func GetFluentdConfiguration(templateConfig string, requiresCABundle bool) string {
-	tmpl, err := template.New("fluentdContainer").Parse(templateConfig)
-	if err != nil {
-		return ""
-	}
-
-	caFile := ""
-	if requiresCABundle {
-		caFile = CAFileConfig
-	}
-	data := struct {
-		CAFile string
-	}{caFile}
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, data)
-	if err != nil {
-		return ""
-	}
-
-	return buf.String()
 }
 
 // removeFluentdContainer removes FLUENTD container

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -289,7 +289,7 @@ func (s *Syncer) configureLogging() {
 	}
 	secretVersionEnv := getEnvValue(&daemonSet.Spec.Template.Spec.Containers, registrationSecretVersion)
 	// CreateOrUpdate updates the deployment if cluster name or es secret version changed
-	caBundle := string(regSecret.Data[constants.ElasticsearchCABundleData])
+	caBundle := string(regSecret.Data[constants.CaBundleKey])
 	if secretVersionEnv != secretVersion && len(caBundle) > 0 {
 		controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &daemonSet, func() error {
 			s.Log.Info(fmt.Sprintf("Update the DaemonSet %s, registration secret version from %q to %q", loggingName, secretVersionEnv, secretVersion))

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -312,6 +312,8 @@ func updateLoggingDaemonSet(newSecret, secretVersion string, ds *appsv1.DaemonSe
 			ds.Spec.Template.Spec.Containers[i].Env = updateEnv(newSecret, secretVersion, ds.Spec.Template.Spec.Containers[i].Env)
 			ds.Spec.Template.Spec.Containers[i].Env = updateEnvValue(ds.Spec.Template.Spec.Containers[i].Env,
 				registrationSecretVersion, secretVersion)
+			ds.Spec.Template.Spec.Containers[i].Env = updateEnvValue(ds.Spec.Template.Spec.Containers[i].Env,
+				"CA_FILE", "/fluentd/secret/ca-bundle")
 		}
 	}
 	return ds

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -284,7 +284,8 @@ func (s *Syncer) configureLogging() {
 	}
 	secretVersionEnv := getEnvValue(&daemonSet.Spec.Template.Spec.Containers, registrationSecretVersion)
 	// CreateOrUpdate updates the deployment if cluster name or es secret version changed
-	if secretVersionEnv != secretVersion {
+	caBundle := string(regSecret.Data[constants.ElasticsearchCABundleData])
+	if secretVersionEnv != secretVersion && len(caBundle) > 0 {
 		controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &daemonSet, func() error {
 			s.Log.Info(fmt.Sprintf("Update the DaemonSet %s, registration secret version from %q to %q", loggingName, secretVersionEnv, secretVersion))
 			daemonSet = *updateLoggingDaemonSet(constants.MCRegistrationSecret, secretVersion, &daemonSet)

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -10,25 +10,30 @@ import (
 	"os"
 	"time"
 
-	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	"github.com/go-logr/logr"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // ENV VAR for registration secret version
 const registrationSecretVersion = "REGISTRATION_SECRET_VERSION"
+
+// ENV VAR for ca file
+const caFile = "CA_FILE"
+
+// ca_file location when the registration secret contains a ca-bundle
+const caBundle = "/fluentd/secret/ca-bundle"
 
 // StartAgent - start the agent thread for syncing multi-cluster objects
 func StartAgent(client client.Client, statusUpdateChannel chan clusters.StatusUpdateMessage, log logr.Logger) {
@@ -313,7 +318,7 @@ func updateLoggingDaemonSet(newSecret, secretVersion string, ds *appsv1.DaemonSe
 			ds.Spec.Template.Spec.Containers[i].Env = updateEnvValue(ds.Spec.Template.Spec.Containers[i].Env,
 				registrationSecretVersion, secretVersion)
 			ds.Spec.Template.Spec.Containers[i].Env = updateEnvValue(ds.Spec.Template.Spec.Containers[i].Env,
-				"CA_FILE", "/fluentd/secret/ca-bundle")
+				caFile, caBundle)
 		}
 	}
 	return ds

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -563,7 +563,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 					secret.ResourceVersion = newVersion
 					if tt.fields.expectDaemonsetUpdate {
 						secret.Data = map[string][]byte{}
-						secret.Data["ca-bundle"] = []byte("test ca-bundle data")
+						secret.Data[constants.CaBundleKey] = []byte("test ca-bundle data")
 					}
 					return nil
 				})

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -501,7 +501,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "",
 				newSecretVersion: "version1",
-				expectCaFile:     caBundle,
+				expectCaFile:     constants.CaFileOverride,
 			},
 		},
 		{
@@ -509,7 +509,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "",
 				newSecretVersion: "version1",
-				expectCaFile:     caFileDefault,
+				expectCaFile:     constants.CaFileDefault,
 			},
 		},
 		{
@@ -517,7 +517,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "version1",
 				newSecretVersion: "",
-				expectCaFile:     caBundle,
+				expectCaFile:     constants.CaFileOverride,
 			},
 		},
 		{
@@ -525,7 +525,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "version1",
 				newSecretVersion: "version2",
-				expectCaFile:     caBundle,
+				expectCaFile:     constants.CaFileOverride,
 			},
 		},
 		{
@@ -533,7 +533,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "",
 				newSecretVersion: "",
-				expectCaFile:     caBundle,
+				expectCaFile:     constants.CaFileOverride,
 			},
 		},
 		{
@@ -541,7 +541,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 			fields: fields{
 				oldSecretVersion: "version1",
 				newSecretVersion: "version1",
-				expectCaFile:     caBundle,
+				expectCaFile:     constants.CaFileOverride,
 			},
 		},
 	}
@@ -561,9 +561,9 @@ func TestSyncer_configureLogging(t *testing.T) {
 					secret.Name = constants.MCRegistrationSecret
 					secret.Namespace = constants.VerrazzanoSystemNamespace
 					secret.ResourceVersion = newVersion
-					if tt.fields.expectCaFile == caBundle {
+					if tt.fields.expectCaFile == constants.CaFileOverride {
 						secret.Data = map[string][]byte{}
-						secret.Data[constants.CaBundleKey] = []byte(caBundle)
+						secret.Data[constants.CaBundleKey] = []byte("test")
 					}
 					return nil
 				})

--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /secret/ca-bundle;
+        lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;
+        lua_ssl_trusted_certificate /etc/nginx/all-ca-certs.pem;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/startup_sh_template.go
+++ b/pkg/proxy/startup_sh_template.go
@@ -32,6 +32,12 @@ const OidcStartupFileTemplate = `#!/bin/bash
 
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
+{{- else if eq .Mode "oauth-proxy" }}
+    # Create a pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret.
+    # It is valid for ca-bundle to be empty.
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/all-ca-certs.pem
+    cat /secret/ca-bundle >> /etc/nginx/all-ca-certs.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -901,7 +901,7 @@ data:
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /secret/ca-bundle;
+        lua_ssl_trusted_certificate /etc/nginx/all-ca-certs.pem;
 {{- end }}
 
         upstream http_backend {
@@ -978,6 +978,12 @@ data:
 
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
+{{- else if eq .Mode "oauth-proxy" }}
+    # Create a pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret.
+    # It is valid for ca-bundle to be empty.
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/all-ca-certs.pem
+    cat /secret/ca-bundle >> /etc/nginx/all-ca-certs.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -323,7 +323,7 @@ data:
       slow_flush_log_threshold 120s
 
       hosts "#{ENV['ELASTICSEARCH_URL']}"
-      ca_file /fluentd/secret/ca-bundle
+      ca_file "#{ENV['CA_FILE']}"
       # ssl_version TLSv1_2
       user "#{ENV['ELASTICSEARCH_USER']}"
       password "#{ENV['ELASTICSEARCH_PASSWORD']}"
@@ -476,6 +476,8 @@ spec:
                   key: password
                   name: verrazzano
                   optional: true
+            - name: CA_FILE
+              value: /etc/ssl/certs/ca-bundle.crt
           image: {{ .Values.logging.fluentdImage }}
           imagePullPolicy: IfNotPresent
           name: {{ .Values.logging.name }}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -231,8 +231,8 @@
               "helmFullImageKey": "verrazzanoOperator.nodeExporterImage"
             },
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "1.1.0-20210721203422-1c9c3b4",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "1.1.0-20210812121707-9d95cae",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -231,8 +231,8 @@
               "helmFullImageKey": "verrazzanoOperator.nodeExporterImage"
             },
             {
-              "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "1.1.0-20210812121707-9d95cae",
+              "image": "verrazzano-monitoring-operator",
+              "tag": "1.1.0-20210816150650-1ff4223",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },
@@ -258,7 +258,7 @@
             },
             {
               "image": "verrazzano-monitoring-instance-eswait",
-              "tag": "0.15.0-20210527135645-9046e4b",
+              "tag": "1.1.0-20210816150650-1ff4223",
               "helmFullImageKey": "monitoringOperator.esWaitImage"
             },
             {

--- a/tests/e2e/config/scripts/terraform/cluster/multi_cluster_main_tf_template
+++ b/tests/e2e/config/scripts/terraform/cluster/multi_cluster_main_tf_template
@@ -3,7 +3,7 @@
 
 module "MODULE_NAME" {
   source = "oracle-terraform-modules/oke/oci"
-  version = "3.3.0"
+  version = "3.2.0"
 
   tenancy_id = var.tenancy_id
   user_id = var.user_id

--- a/tests/e2e/config/scripts/terraform/cluster/multi_cluster_main_tf_template
+++ b/tests/e2e/config/scripts/terraform/cluster/multi_cluster_main_tf_template
@@ -3,7 +3,7 @@
 
 module "MODULE_NAME" {
   source = "oracle-terraform-modules/oke/oci"
-  version = "3.2.0"
+  version = "3.3.0"
 
   tenancy_id = var.tenancy_id
   user_id = var.user_id


### PR DESCRIPTION
# Description

- Pick up VMO changes that resolve issue of admin cluster being able scrape metrics from a managed cluster when using well known certs.
- Fix issue of managed cluster being able to send logs to the admin cluster when using well known certs
- Updated unit tests to handle cases of ca-bundle being present and being empty
- Copied over Lua changes for new VMO and regenerated the helm chart

Fixes VZ-3125

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
