### PR TITLE
VZ-3280. Internal word linter

### DIFF
--- a/make/quality.mk
+++ b/make/quality.mk
@@ -26,7 +26,7 @@ endif
 .PHONY: word-linter
 word-linter:
 	words=$(curl -L https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)')
-	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker ./../*
+	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker *
 
 .PHONY: coverage
 coverage:

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -23,10 +23,12 @@ else
 endif
 
 # search for internal words that should not be in the repo
+# check fails if res from http req is not successful (200)
 # the actual command being executed in bash is "curl -sL https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)' | ..."
 # additional "$" is to escape literal value in makefile
 .PHONY: word-linter
 word-linter:
+	curl -sL -o /dev/null -w "%{http_code}" https://bit.ly/3iIUcdL | grep -q '200'
 	! curl -sL https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$$\)' | grep -f /dev/stdin -r *
 
 .PHONY: coverage

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -23,6 +23,8 @@ else
 endif
 
 # search for internal words that should not be in the repo
+# the actual command being executed in bash is "curl -sL https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)' | ..."
+# additional "$" is to escape literal value in makefile
 .PHONY: word-linter
 word-linter:
 	! curl -sL https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$$\)' | grep -f /dev/stdin -r *

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -9,7 +9,7 @@ GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.b
 #
 
 .PHONY: check
-check: install-linter
+check: install-linter word-linter
 	$(LINTER) run
 
 # find or download golangci-lint
@@ -21,6 +21,12 @@ ifeq (, $(shell command -v golangci-lint))
 else
 	$(eval LINTER=$(shell command -v golangci-lint))
 endif
+
+# search for "bad" words in repo
+.PHONY: word-linter
+word-linter:
+	words=$(curl -L https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)')
+	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker ./../*
 
 .PHONY: coverage
 coverage:

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -22,11 +22,10 @@ else
 	$(eval LINTER=$(shell command -v golangci-lint))
 endif
 
-# search for "bad" words in repo
+# search for internal words that should not be in the repo
 .PHONY: word-linter
 word-linter:
-	words=$(curl -L https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$\)')
-	grep $words -r --exclude-dir=vendor --exclude-dir=word-checker *
+	! curl -sL https://bit.ly/3iIUcdL | grep -v '^\s*\(#\|$$\)' | grep -f /dev/stdin -r *
 
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
# Description

Adds a "linter" to "make check" to look for forbidden/bad words. Fails build if any target words are detected or if curl command does return status=200. The list of words can be updated by modifying the file in object store.

Changes were validated by placing "bad words" in different files at various directory levels to ensure the build failed when the words were present.

Fixes VZ-3280

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
