### PR TITLE
JIRA:VZ-3324 make txt owner unique for external dns installation

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -256,8 +256,8 @@ function install_external_dns()
         ${HELM_IMAGE_ARGS} \
         --set domainFilters[0]=${DNS_SUFFIX} \
         --set zoneIdFilters[0]=$(get_config_value ".dns.oci.dnsZoneOcid") \
-        --set txtOwnerId=v8o-local-${NAME} \
-        --set txtPrefix=_v8o-local-${NAME}_ \
+        --set txtOwnerId=v8o-local-${NAME}-${TIMESTAMP} \
+        --set txtPrefix=_v8o-local-${NAME}-${TIMESTAMP}_ \
         --set extraVolumes[0].name=config \
         --set extraVolumes[0].secret.secretName=$OCI_DNS_CONFIG_SECRET \
         --set extraVolumeMounts[0].name=config \
@@ -574,6 +574,7 @@ REGISTRY_SECRET_EXISTS=$(check_registry_secret_exists)
 
 OCI_DNS_CONFIG_SECRET=$(get_config_value ".dns.oci.ociConfigSecret")
 NAME=$(get_config_value ".environmentName")
+TIMESTAMP=$(date +%s)
 DNS_TYPE=$(get_config_value ".dns.type")
 CERT_ISSUER_TYPE=$(get_config_value ".certificates.issuerType")
 


### PR DESCRIPTION
# Description

Adding a timestamp to the txtOwner fields to ensure specific record ownership for a given installation.  This will hopefully prevent the overwriting of DNS records by a cluster with the same env name in the same DNS zone.

Fixes VZ-3324

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
