### PR TITLE
Copy oci secret from verrazzano-install namespace to cert-manager namespace

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -202,6 +202,7 @@ pipeline {
                                 echo "------------------------------------------"
                             """
                             script {
+                                dumpVerrazzanoPlatformOperatorLogs("before-upgrade")
                                 VZ_TEST_METRIC = metricJobName('')
                                 metricTimerStart("${VZ_TEST_METRIC}")
                             }
@@ -260,7 +261,7 @@ pipeline {
                     }
                     post {
                         always {
-                            dumpVerrazzanoPlatformOperatorLogs()
+                            dumpVerrazzanoPlatformOperatorLogs("after-upgrade")
                         }
                     }
                 }
@@ -348,7 +349,6 @@ pipeline {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
                     dumpNginxIngressControllerLogs()
-                    dumpVerrazzanoPlatformOperatorLogs()
                     dumpVerrazzanoApplicationOperatorLogs()
                     dumpOamKubernetesRuntimeLogs()
                     dumpVerrazzanoApiLogs()
@@ -443,14 +443,12 @@ def dumpNginxIngressControllerLogs() {
     """
 }
 
-def dumpVerrazzanoPlatformOperatorLogs() {
+def dumpVerrazzanoPlatformOperatorLogs(stage) {
     sh """
         ## dump out verrazzano-platform-operator logs
         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        echo "verrazzano-platform-operator logs dumped to verrazzano-platform-operator-pod.log"
-        echo "verrazzano-platform-operator pod description dumped to verrazzano-platform-operator-pod.out"
+        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "------------------------------------------"
     """
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -127,10 +127,10 @@ func ValidateInProgress(state StateType) error {
 func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
 		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "default"}, secret)
+		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "verrazzano-system"}, secret)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("secret \"%s\" must be created in the default namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret)
+				return fmt.Errorf("secret \"%s\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret)
 			}
 			return err
 		}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/semver"
 
@@ -127,10 +128,10 @@ func ValidateInProgress(state StateType) error {
 func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
 		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "verrazzano-system"}, secret)
+		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoSystemNamespace}, secret)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("secret \"%s\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret)
+				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoSystemNamespace)
 			}
 			return err
 		}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -128,10 +128,10 @@ func ValidateInProgress(state StateType) error {
 func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
 		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoSystemNamespace}, secret)
+		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoSystemNamespace)
+				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoInstallNamespace)
 			}
 			return err
 		}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/semver"
 

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -539,7 +539,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = ValidateOciDNSSecret(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "secret \"oci-bad-secret\" must be created in the default namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "secret \"oci-bad-secret\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", err.Error())
 }
 
 // TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the verrazzano CR exists
@@ -569,7 +569,7 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oci",
-			Namespace: "default",
+			Namespace: "verrazzano-system",
 		},
 	}
 	err = client.Create(context.TODO(), secret)

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
@@ -539,7 +540,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = ValidateOciDNSSecret(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano for OCI DNS", err.Error())
 }
 
 // TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the verrazzano CR exists
@@ -569,7 +570,7 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oci",
-			Namespace: "verrazzano-system",
+			Namespace: constants.VerrazzanoInstallNamespace,
 		},
 	}
 	err = client.Create(context.TODO(), secret)

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -539,7 +539,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = ValidateOciDNSSecret(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "secret \"oci-bad-secret\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-system namespace before installing Verrrazzano for OCI DNS", err.Error())
 }
 
 // TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the verrazzano CR exists

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -52,7 +52,6 @@ func (v *Verrazzano) ValidateCreate() error {
 	}
 
 	// Validate that the OCI DNS secret required by install exists
-	log.Info("Check for validating oci secret as part in ValidateCreate")
 	if err := ValidateOciDNSSecret(client, &v.Spec); err != nil {
 		return err
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -52,6 +52,7 @@ func (v *Verrazzano) ValidateCreate() error {
 	}
 
 	// Validate that the OCI DNS secret required by install exists
+	log.Info("Check for validating oci secret as part in ValidateCreate")
 	if err := ValidateOciDNSSecret(client, &v.Spec); err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/installjob"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/uninstalljob"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *Reconciler) doesOCIDNSConfigSecretExist(vz *installv1alpha1.Verrazzano) error {
 	// ensure the secret exists before proceeding
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "verrazzano-system"}, secret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoSystemNamespace}, secret)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *Reconciler) doesOCIDNSConfigSecretExist(vz *installv1alpha1.Verrazzano) error {
 	// ensure the secret exists before proceeding
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "default"}, secret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "verrazzano-system"}, secret)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -104,7 +104,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(vz.Status) {
-		log.Info("Verrazzano is already installed, check if upgrade is needed.")
 		// If the version is specified and different than the current version of the installation
 		// then proceed with upgrade
 		if len(vz.Spec.Version) > 0 && vz.Spec.Version != vz.Status.Version {
@@ -122,7 +121,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	log.Info("Check oci secret in Reconciler")
 	// if an OCI DNS installation, make sure the secret required exists before proceeding
 	if vz.Spec.Components.DNS != nil && vz.Spec.Components.DNS.OCI != nil {
 		err := r.doesOCIDNSConfigSecretExist(vz)

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -104,6 +104,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(vz.Status) {
+		log.Info("Verrazzano is already installed, check if upgrade is needed.")
 		// If the version is specified and different than the current version of the installation
 		// then proceed with upgrade
 		if len(vz.Spec.Version) > 0 && vz.Spec.Version != vz.Status.Version {
@@ -121,6 +122,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
+	log.Info("Check oci secret in Reconciler")
 	// if an OCI DNS installation, make sure the secret required exists before proceeding
 	if vz.Spec.Components.DNS != nil && vz.Spec.Components.DNS.OCI != nil {
 		err := r.doesOCIDNSConfigSecretExist(vz)
@@ -163,7 +165,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *Reconciler) doesOCIDNSConfigSecretExist(vz *installv1alpha1.Verrazzano) error {
 	// ensure the secret exists before proceeding
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoSystemNamespace}, secret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -412,7 +412,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the DNS config secret and return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			data := make(map[string][]byte)
 			data["passphrase"] = []byte("passphraseValue")
@@ -1413,7 +1413,7 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the DNS config secret but return a not found error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Secret"))
 
 	// Create and make the request

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -412,7 +412,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the DNS config secret and return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			data := make(map[string][]byte)
 			data["passphrase"] = []byte("passphraseValue")
@@ -1413,7 +1413,7 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the DNS config secret but return a not found error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Secret"))
 
 	// Create and make the request

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -94,7 +94,7 @@ function setup_cluster_issuer() {
     local OCI_DNS_ZONE_NAME=$(get_config_value ".dns.oci.dnsZoneName")
 
     if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n $VERRAZZANO_INSTALL_NS ; then
-        fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist"
+        fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist in the namespace $VERRAZZANO_INSTALL_NS"
     fi
 
     acmeURL="https://acme-v02.api.letsencrypt.org/directory"

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -14,7 +14,7 @@ set -eu
 
 VERRAZZANO_DEFAULT_SECRET_NAMESPACE="cert-manager"
 VERRAZZANO_DEFAULT_SECRET_NAME="verrazzano-ca-certificate-secret"
-VERRAZZANO_NS=verrazzano-system
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 function install_nginx_ingress_controller()
 {
@@ -93,7 +93,7 @@ function setup_cluster_issuer() {
     local OCI_DNS_ZONE_OCID=$(get_config_value ".dns.oci.dnsZoneOcid")
     local OCI_DNS_ZONE_NAME=$(get_config_value ".dns.oci.dnsZoneName")
 
-    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n verrazzano-system ; then
+    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n $VERRAZZANO_INSTALL_NS ; then
         fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist"
     fi
 
@@ -230,11 +230,11 @@ function install_external_dns()
   local externalDNSNamespace=cert-manager
 
   if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n ${externalDNSNamespace} ; then
-    # secret does not exist, so copy the configured oci config secret from verrazzano-system namespace.
-    # Operator has already checked for existence of secret in verrazzano-system namespace
+    # secret does not exist, so copy the configured oci config secret from verrazzano-install namespace.
+    # Operator has already checked for existence of secret in verrazzano-install namespace
     # The DNS zone compartment will get appended to secret generated for cert external dns
     local dns_compartment=$(get_config_value ".dns.oci.dnsZoneCompartmentOcid")
-    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n ${VERRAZZANO_NS} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
+    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n ${VERRAZZANO_INSTALL_NS} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
         | sed '/^$/d' > $TMP_DIR/oci.yaml
     echo "compartment: $dns_compartment" >> $TMP_DIR/oci.yaml
     kubectl create secret generic $OCI_DNS_CONFIG_SECRET --from-file=$TMP_DIR/oci.yaml -n ${externalDNSNamespace}

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -92,7 +92,7 @@ function setup_cluster_issuer() {
     local OCI_DNS_ZONE_OCID=$(get_config_value ".dns.oci.dnsZoneOcid")
     local OCI_DNS_ZONE_NAME=$(get_config_value ".dns.oci.dnsZoneName")
 
-    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET ; then
+    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n verrazzano-system ; then
         fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist"
     fi
 
@@ -233,7 +233,7 @@ function install_external_dns()
     # Operator has already checked for existence of secret in default namespace
     # The DNS zone compartment will get appended to secret generated for cert external dns
     local dns_compartment=$(get_config_value ".dns.oci.dnsZoneCompartmentOcid")
-    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
+    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n verrazzano-system -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
         | sed '/^$/d' > $TMP_DIR/oci.yaml
     echo "compartment: $dns_compartment" >> $TMP_DIR/oci.yaml
     kubectl create secret generic $OCI_DNS_CONFIG_SECRET --from-file=$TMP_DIR/oci.yaml -n ${externalDNSNamespace}

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -14,6 +14,7 @@ set -eu
 
 VERRAZZANO_DEFAULT_SECRET_NAMESPACE="cert-manager"
 VERRAZZANO_DEFAULT_SECRET_NAME="verrazzano-ca-certificate-secret"
+VERRAZZANO_NS=verrazzano-system
 
 function install_nginx_ingress_controller()
 {
@@ -229,11 +230,11 @@ function install_external_dns()
   local externalDNSNamespace=cert-manager
 
   if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n ${externalDNSNamespace} ; then
-    # secret does not exist, so copy the configured oci config secret from default namespace.
-    # Operator has already checked for existence of secret in default namespace
+    # secret does not exist, so copy the configured oci config secret from verrazzano-system namespace.
+    # Operator has already checked for existence of secret in verrazzano-system namespace
     # The DNS zone compartment will get appended to secret generated for cert external dns
     local dns_compartment=$(get_config_value ".dns.oci.dnsZoneCompartmentOcid")
-    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n verrazzano-system -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
+    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n ${VERRAZZANO_NS} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
         | sed '/^$/d' > $TMP_DIR/oci.yaml
     echo "compartment: $dns_compartment" >> $TMP_DIR/oci.yaml
     kubectl create secret generic $OCI_DNS_CONFIG_SECRET --from-file=$TMP_DIR/oci.yaml -n ${externalDNSNamespace}

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -838,7 +838,7 @@ fi
 if [ $(is_oci_dns) == "true" ]; then
   secret_name=$(get_config_value ".dns.oci.ociConfigSecret")
   consoleout
-  consoleout "NOTE: The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
+  consoleout "NOTE: The secret \"${secret_name}\" created in the \"verrazzano-install\" namespace prior to installation is only used during the actual installation."
   consoleout "You may delete it now.  DO NOT delete the secret of the same name in the cert-manager namespace."
   consoleout
 fi

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -100,7 +100,7 @@ create_secret=true
 kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
-  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace. Please delete that and then try again."
+  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace. Please delete that and try again."
   exit 1
 fi
 kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -65,6 +65,7 @@ OCI_CONFIG_FILE=~/.oci/config
 SECTION=DEFAULT
 OCI_CONFIG_SECRET_NAME=oci
 K8SCONTEXT=""
+VERRAZZANO_SYSTEM_NS=verrazzano-system
 
 while getopts c:o:s:k:h flag
 do
@@ -93,16 +94,16 @@ if [[ ! -z "$pass_phrase" ]]; then
   echo "  passphrase: $pass_phrase" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
+# create the secret in verrazzano-system namespace
 create_secret=true
 
-kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n default > /dev/null 2>&1
+kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_SYSTEM_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
-  echo "Secret $OCI_CONFIG_SECRET_NAME already exists.  Please delete then try again."
+  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_SYSTEM_NS} namespace. Please delete that and then try again."
   exit 1
 fi
-kubectl ${K8SCONTEXT} create secret -n default  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_SYSTEM_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
 
 
 

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -65,7 +65,7 @@ OCI_CONFIG_FILE=~/.oci/config
 SECTION=DEFAULT
 OCI_CONFIG_SECRET_NAME=oci
 K8SCONTEXT=""
-VERRAZZANO_SYSTEM_NS=verrazzano-system
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 while getopts c:o:s:k:h flag
 do
@@ -94,16 +94,16 @@ if [[ ! -z "$pass_phrase" ]]; then
   echo "  passphrase: $pass_phrase" >> $OUTPUT_FILE
 fi
 
-# create the secret in verrazzano-system namespace
+# create the secret in verrazzano-install namespace
 create_secret=true
 
-kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_SYSTEM_NS > /dev/null 2>&1
+kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
-  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_SYSTEM_NS} namespace. Please delete that and then try again."
+  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace. Please delete that and then try again."
   exit 1
 fi
-kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_SYSTEM_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
 
 
 

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -10,7 +10,7 @@ TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
 OCI_CONFIG_SECRET_NAME=oci
-VERRAZZANO_NS=verrazzano-system
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 # Validate expected environment variables exist
 if [ -z "${OCI_CLI_REGION}" ]; then
@@ -48,6 +48,9 @@ if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
   echo "  passphrase: ${OCI_PRIVATE_KEY_PASSPHRASE}" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
-kubectl create namespace $VERRAZZANO_NS
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_NS --from-file=$OUTPUT_FILE
+# create the secret in verrazzano-install namespace
+if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
+  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and then try again."
+  exit 1
+fi
+kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -50,7 +50,7 @@ fi
 
 # create the secret in verrazzano-install namespace
 if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
-  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and then try again."
+  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and try again."
   exit 1
 fi
 kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -48,4 +48,5 @@ if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
 fi
 
 # create the secret in default namespace
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+kubectl create namespace verrazzano-system
+kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n verrazzano-system --from-file=$OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -10,6 +10,7 @@ TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
 OCI_CONFIG_SECRET_NAME=oci
+VERRAZZANO_NS=verrazzano-system
 
 # Validate expected environment variables exist
 if [ -z "${OCI_CLI_REGION}" ]; then
@@ -48,5 +49,5 @@ if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
 fi
 
 # create the secret in default namespace
-kubectl create namespace verrazzano-system
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n verrazzano-system --from-file=$OUTPUT_FILE
+kubectl create namespace $VERRAZZANO_NS
+kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_NS --from-file=$OUTPUT_FILE


### PR DESCRIPTION
# Description

This PR includes the change to copy the oci secret from verrazzano-install namespace, instead of default, to cert-manager namespace during the Verrazzano installation using OCI DNS.

Contributes to VZ-3319

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
