### PR TITLE
Backport ea4133d0ea281075275fadd6beaa27815289a8d9 to release-1.0

### DIFF
--- a/examples/multicluster/todo-list/todo-list-components.yaml
+++ b/examples/multicluster/todo-list/todo-list-components.yaml
@@ -87,7 +87,7 @@ spec:
                       TestFrequencySeconds: 10
                     JDBCDriverParams:
                       # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server
-                      URL: "jdbc:mysql://mysql.todo-list.svc.cluster.local:3306/tododb"
+                      URL: "jdbc:mysql://mysql.mc-todo-list.svc.cluster.local:3306/tododb"
                       PasswordEncrypted: '@@SECRET:tododomain-jdbc-tododb:password@@'
                       DriverName: com.mysql.cj.jdbc.Driver
                       Properties:


### PR DESCRIPTION
This is a cherry-pick of ea4133d0ea281075275fadd6beaa27815289a8d9 into release-1.0.  This commit fixes a ToDo List MC bug where the MySQL URL had the wrong namespace name.

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
