### PR TITLE
VZ-3235: Upgrade versions of external-dns and cert-manager images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -50,24 +50,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "1.2.0-20210818141206-02769bea4",
+              "tag": "1.2.0-20210818200209-6bbae6645",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "1.2.0-20210818141202-02769bea4",
+              "tag": "1.2.0-20210818200159-6bbae6645",
               "helmFullImageKey": "extraArgs[0]=--acme-http01-solver-image"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "1.2.0-20210818141206-02769bea4",
+              "tag": "1.2.0-20210818200209-6bbae6645",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "1.2.0-20210818141206-02769bea4",
+              "tag": "1.2.0-20210818200209-6bbae6645",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -50,24 +50,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "1.2.0-20210602163405-aac6bdf62",
+              "tag": "1.2.0-20210818141206-02769bea4",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "1.2.0-20210510185040-aac6bdf62",
+              "tag": "1.2.0-20210818141202-02769bea4",
               "helmFullImageKey": "extraArgs[0]=--acme-http01-solver-image"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "1.2.0-20210602163405-aac6bdf62",
+              "tag": "1.2.0-20210818141206-02769bea4",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "1.2.0-20210602163405-aac6bdf62",
+              "tag": "1.2.0-20210818141206-02769bea4",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }
@@ -84,7 +84,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.7.1-20201016205338-516bc8b2",
+              "tag": "v0.7.1-20210817193218-4d353845",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
# Description

This PR upgrades the versions of external-dns and cert-manager in the Verrazzano bill of materials file. Those images contain a bug fix for parsing private keys used in OCI. With this fix, Verrazzano now accepts PKCS1 and PKCS8 keys for making OCI API calls.

There is also another related fix in this PR that was needed to make this work. The Rancher installation was broken when using LetsEncrypt due to a recent change to add `-wait` to the helm install of Rancher. The secret containing additional CA certs needed by Rancher was being created after the helm install of Rancher. That happened to work when we were not waiting on the Rancher install, but now that we do wait, it was broken. The fix was to move the secret creation before the helm install.

Fixes VZ-3235

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
