### PR TITLE
Backport fix for VZ-3125 to release-1.0 branch

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -3,9 +3,6 @@
 
 package constants
 
-// VerrazzanoClustersGroup - clusters group
-const VerrazzanoClustersGroup = "clusters.verrazzano.io"
-
 // VerrazzanoSystemNamespace is the system namespace for verrazzano
 const VerrazzanoSystemNamespace = "verrazzano-system"
 
@@ -41,9 +38,14 @@ const ElasticsearchUsernameData = "username"
 // cluster's Elasticsearch password
 const ElasticsearchPasswordData = "password"
 
-// ElasticsearchCABundleData - the field name in MCRegistrationSecret that contains the admin
-// cluster's Elasticsearch CA bundle
-const ElasticsearchCABundleData = "ca-bundle"
+// CaBundleKey is the CA cert key in a secret
+const CaBundleKey = "ca-bundle"
+
+// CaFileDefault is the default value for the CA_FILE environment variable
+const CaFileDefault = "/etc/ssl/certs/ca-bundle.crt"
+
+// CaFileOverride is the location when the registration secret contains a ca-bundle
+const CaFileOverride = "/fluentd/secret/ca-bundle"
 
 // LabelVerrazzanoManaged - constant for a Kubernetes label that is applied by Verrazzano
 const LabelVerrazzanoManaged = "verrazzano-managed"

--- a/application-operator/controllers/logging/fluentd.go
+++ b/application-operator/controllers/logging/fluentd.go
@@ -4,20 +4,17 @@
 package logging
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,8 +30,6 @@ const (
 	elasticSearchURLEnv  = "ELASTICSEARCH_URL"
 	elasticSearchUserEnv = "ELASTICSEARCH_USER"
 	elasticSearchPwdEnv  = "ELASTICSEARCH_PASSWORD"
-
-	CAFileConfig = "\n  ca_file /fluentd/secret/ca-bundle"
 )
 
 // DefaultFluentdImage holds the default FLUENTD image that will be used if it is not specified in the logging logInfo
@@ -195,29 +190,6 @@ func (f *Fluentd) createFluentdConfigMap(namespace string) *v1.ConfigMap {
 			return data
 		}(),
 	}
-}
-
-func GetFluentdConfiguration(templateConfig string, requiresCABundle bool) string {
-	tmpl, err := template.New("fluentdContainer").Parse(templateConfig)
-	if err != nil {
-		return ""
-	}
-
-	caFile := ""
-	if requiresCABundle {
-		caFile = CAFileConfig
-	}
-	data := struct {
-		CAFile string
-	}{caFile}
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, data)
-	if err != nil {
-		return ""
-	}
-
-	return buf.String()
 }
 
 // removeFluentdContainer removes FLUENTD container

--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /secret/ca-bundle;
+        lua_ssl_trusted_certificate /etc/nginx/all-ca-certs.pem;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/startup_sh_template.go
+++ b/pkg/proxy/startup_sh_template.go
@@ -32,6 +32,12 @@ const OidcStartupFileTemplate = `#!/bin/bash
 
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
+{{- else if eq .Mode "oauth-proxy" }}
+    # Create a pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret.
+    # It is valid for ca-bundle to be empty.
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/all-ca-certs.pem
+    cat /secret/ca-bundle >> /etc/nginx/all-ca-certs.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -902,7 +902,7 @@ data:
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /secret/ca-bundle;
+        lua_ssl_trusted_certificate /etc/nginx/all-ca-certs.pem;
 {{- end }}
 
         upstream http_backend {
@@ -979,6 +979,12 @@ data:
 
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
+{{- else if eq .Mode "oauth-proxy" }}
+    # Create a pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret.
+    # It is valid for ca-bundle to be empty.
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/all-ca-certs.pem
+    cat /secret/ca-bundle >> /etc/nginx/all-ca-certs.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -321,7 +321,7 @@ data:
       slow_flush_log_threshold 120s
 
       hosts "#{ENV['ELASTICSEARCH_URL']}"
-      ca_file /fluentd/secret/ca-bundle
+      ca_file "#{ENV['CA_FILE']}"
       # ssl_version TLSv1_2
       user "#{ENV['ELASTICSEARCH_USER']}"
       password "#{ENV['ELASTICSEARCH_PASSWORD']}"
@@ -474,6 +474,8 @@ spec:
                   key: password
                   name: verrazzano
                   optional: true
+            - name: CA_FILE
+              value: /etc/ssl/certs/ca-bundle.crt
           image: {{ .Values.logging.fluentdImage }}
           imagePullPolicy: IfNotPresent
           name: {{ .Values.logging.name }}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -232,7 +232,7 @@
             },
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "0.17.0-20210701165333-7d6ab12",
+              "tag": "1.1.0-20210816150650-1ff4223",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },
@@ -258,7 +258,7 @@
             },
             {
               "image": "verrazzano-monitoring-instance-eswait",
-              "tag": "0.15.0-20210527135645-9046e4b",
+              "tag": "1.1.0-20210816150650-1ff4223",
               "helmFullImageKey": "monitoringOperator.esWaitImage"
             },
             {


### PR DESCRIPTION
# Description

Backport the fix for VZ-3125 (logs and metrics not working for multicluster when configured with OCIDNS)

Fixes VZ-3125

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
