### PR TITLE
JIRA:VZ-3023 (release-1.0 back port) ensure configmaps are deleted during uninstall (#1436)

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -75,6 +75,14 @@ function finalize() {
   delete_k8s_resources clusterrole ":metadata.name" "Could not delete ClusterRoles" '/verrazzano/ && ! /verrazzano-managed-cluster/' \
     || return $? # return on pipefail
 
+  log "Deleting configmap istio-ca-root-cert from all namespaces"
+  IFS=$'\n' read -r -d '' -a namespaces < <( kubectl get namespaces --no-headers -o custom-columns=":metadata.name" && printf '\0' )
+  for ns in "${namespaces[@]}" ; do
+    if kubectl get configmap istio-ca-root-cert > /dev/null 2>&1 ; then
+      kubectl delete configmap istio-ca-root-cert --namespace ${ns} --ignore-not-found=true
+    fi
+  done
+
   # Grab all leftover Helm repos and delete resources
   log "Deleting Helm repos"
   local helm_ls
@@ -85,6 +93,7 @@ function finalize() {
       | xargsr -I name helm repo remove name \
       || err_return $? "Could delete Helm Repos" || return $? # return on pipefail
   fi
+
 }
 
 action "Deleting Istio Components" uninstall_istio || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -70,6 +70,10 @@ function delete_cert_manager() {
   patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespace cert-manager" '/cert-manager/ {print $1}' '{"metadata":{"finalizers":null}}' \
     || return $? # return on pipefail
 
+  # delete cainjector config map
+  log "Deleting cainjector leader election configmap"
+  kubectl delete configmap cert-manager-cainjector-leader-election -n kube-system --ignore-not-found=true || err_return $? "Could not delete ConfigMap from kube-system" || return $?
+
   # delete namespace
   log "Deleting cert-manager namespace"
   kubectl delete namespace cert-manager --ignore-not-found=true || err_return $? "Could not delete namespace cert-manager" || return $?


### PR DESCRIPTION
# Description

- added code to remove the cainjector ConfigMap
- moved code removing istio configmaps prior to helm repo deletion to ensure the code is executed regardless of any helm related issues

Fixes VZ-3023

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
