### PR TITLE
Remove redundant call to update_perodic_on_success.sh in post-run steps

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -190,15 +190,7 @@ pipeline {
             }
         }
     }
-
     post {
-        success {
-            sh """
-                if [ "${env.BRANCH_NAME}" == "master" ]; then
-                    ci/scripts/update_periodic_on_success.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH}
-                fi
-            """
-        }
         failure {
             script {
                 if (isAlertingEnabled()) {


### PR DESCRIPTION
# Description

Remove redundant call to update_perodic_on_success.sh in post-run steps.  This is done in the `Private Registry` stage now.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
