### PR TITLE
JIRA:VZ-3314 disable horizontal pod autoscaler to eliminate continuous warning messages from istio components

### DIFF
--- a/platform-operator/helm_config/overrides/istio-values.yaml
+++ b/platform-operator/helm_config/overrides/istio-values.yaml
@@ -17,16 +17,23 @@ global:
   proxy:
     readinessFailureThreshold: 90
 
+pilot:
+  autoscaleEnabled: false
+
 gateways:
   istio-egressgateway:
     env:
       # Needed to route traffic via egress gateway if desired.
       ISTIO_META_REQUESTED_NETWORK_VIEW: "external"
+    autoscaleEnabled: false
+  istio-ingressgateway:
+    autoscaleEnabled: false
 
 istiocoredns:
   enabled: true
   # NOTE: The image you're looking for isn't here. The istio coredns images now come from
   # the bill of materials file (verrazzano-bom.json).
+  autoscaleEnabled: false
 
 meshConfig:
   enablePrometheusMerge: false


### PR DESCRIPTION

# Description

- Currently the HPA components running enabled in some istio components are generating a large number of warnings due to the inability to query for certain pod runtime metrics (no metrics server running in the cluster)
- Since we are not currently using the HPA this PR disables it to prevent the generation of these messages in the event log, elastic search, etc.

Fixes VZ-3314

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
