### PR TITLE
istio disruption budget

### DIFF
--- a/platform-operator/helm_config/overrides/istio-values.yaml
+++ b/platform-operator/helm_config/overrides/istio-values.yaml
@@ -16,6 +16,11 @@ global:
   imagePullPolicy: IfNotPresent
   proxy:
     readinessFailureThreshold: 90
+  # enable pod disruption budget for the control plane, which is used to ensure Istio control plane
+  # components are gradually upgraded or recovered.
+  # pod disruption budget(pdb) is disabled to allow upgrading worker nodes without violating pdb
+  defaultPodDisruptionBudget:
+    enabled: false
 
 pilot:
   autoscaleEnabled: false


### PR DESCRIPTION
# Description

Disable Istio pod disruption budget(pdb) to allow node upgrade or draining without violating pdb. 

To upgrade worker nodes, istio pdb and following default rolling policy would require scaling up istiod, istiocoredns, and istio-ingressgateway to 4 replicas:
```
  autoscaleMin: 1
  rollingMaxUnavailable: 25%
```
In order to drain the worker nodes the istio pods are scheduled on, the istio deployments must be scaled up to 4 replicas to satisfy disruption budget so that one (25%) of the 4 replicas can be evicted.

Fixes VZ-3310

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
