### PR TITLE
Backport: Uptake Console 1.0.1 fixes for VZ-3155 into Verrazzano helm chart

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -283,7 +283,7 @@
             },
             {
               "image": "console",
-              "tag": "0.17.0-20210629214513-a686730",
+              "tag": "1.0.1-20210820153900-ee396d6",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
# Description

Backport: Uptake Console 1.0.1 fixes into Verrazzano helm chart (From VZ-3155)

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
