### PR TITLE
Adiforluls/vz 3302

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -44,7 +44,7 @@ pipeline {
     }
 
     environment {
-        KUBERNETES_VERSION = '1.17,1.19,1.20'
+        KUBERNETES_VERSION = '1.17,1.19,1.18'
     }
 
     stages {
@@ -153,12 +153,12 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.19') {
+                stage('Kind Acceptance Tests on 1.18') {
                     steps {
                         script {
                             build job: "/verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
-                                    string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.19'),
+                                    string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.18'),
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
@@ -167,12 +167,12 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.20') {
+                stage('Kind Acceptance Tests on 1.19') {
                     steps {
                         script {
                             build job: "/verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                                 parameters: [
-                                    string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.20'),
+                                    string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.19'),
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.18", "1.19", "1.20", "1.17" ])
+                choices: [ "1.20", "1.19", "1.18", "1.17" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',


### PR DESCRIPTION
# Description

The task was to change the default k8s version we test on from 1.18 to 1.20. Changed the default k8s version for kind tests. Turned 1.20 as default k8s version in ci/kind/Jenkinsfile and in ci/JenkinsfileTestTrigge removed v1.20 and included v1.18 for kind acceptance tests.

Fixes VZ-3302

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
