### PR TITLE
Fix upgrade of fluentd daemonset on a managed cluster

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -59,3 +59,16 @@ const ImageRepoOverrideEnvVar = "IMAGE_REPO"
 
 // VerrazzanoAppOperatorImageEnvVar is the environment variable used to override the Verrazzano Application Operator image
 const VerrazzanoAppOperatorImageEnvVar = "APP_OPERATOR_IMAGE"
+
+// ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
+const ClusterNameData = "managed-cluster-name"
+
+// ElasticsearchURLData - the field name in MCRegistrationSecret that contains the admin cluster's
+// Elasticsearch endpoint's URL
+const ElasticsearchURLData = "es-url"
+
+// ClusterNameEnvVar is the environment variable used to identify the managed cluster for fluentd
+const ClusterNameEnvVar = "CLUSTER_NAME"
+
+// ElasticsearchURLEnvVar is the environment variable used to identify the admin clusters Elasticsearch URL
+const ElasticsearchURLEnvVar = "ELASTICSEARCH_URL"

--- a/platform-operator/controllers/verrazzano/component/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm_component.go
@@ -102,6 +102,7 @@ func (h helmComponent) Upgrade(log *zap.SugaredLogger, client clipkg.Client, ns 
 
 	// Do the preUpgrade if the function is defined
 	if h.preUpgradeFunc != nil && UpgradePrehooksEnabled {
+		log.Infof("Running preUpgrade function for %s", h.releaseName)
 		err := h.preUpgradeFunc(log, client, h.releaseName, namespace, h.chartDir)
 		if err != nil {
 			return err

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -91,6 +91,7 @@ func GetComponents() []Component {
 			chartNamespace:          constants.VerrazzanoSystemNamespace,
 			ignoreNamespaceOverride: true,
 			resolveNamespaceFunc:    resolveVerrazzanoNamespace,
+			preUpgradeFunc:          verrazzanoPreUpgrade,
 		},
 		helmComponent{
 			releaseName:             "coherence-operator",

--- a/platform-operator/controllers/verrazzano/component/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano.go
@@ -63,11 +63,11 @@ func fixupFluentdDaemonset(log *zap.SugaredLogger, client client.Client, namespa
 	clusterNameIndex := -1
 	elasticURLIndex := -1
 	for i, env := range daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env {
-		if env.Name == "CLUSTER_NAME" && env.ValueFrom != nil {
+		if env.Name == constants.ClusterNameEnvVar && env.ValueFrom != nil {
 			clusterNameIndex = i
 			continue
 		}
-		if env.Name == "ELASTICSEARCH_URL" && env.ValueFrom != nil {
+		if env.Name == constants.ElasticsearchURLEnvVar && env.ValueFrom != nil {
 			elasticURLIndex = i
 		}
 	}
@@ -86,15 +86,15 @@ func fixupFluentdDaemonset(log *zap.SugaredLogger, client client.Client, namespa
 	}
 
 	// The secret must contain a cluster name
-	clusterName, ok := secret.Data["managed-cluster-name"]
+	clusterName, ok := secret.Data[constants.ClusterNameData]
 	if !ok {
-		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, "managed-cluster-name")
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, constants.ClusterNameData)
 	}
 
 	// The secret must contain the Elasticsearch endpoint's URL
-	elasticsearchURL, ok := secret.Data["es-url"]
+	elasticsearchURL, ok := secret.Data[constants.ElasticsearchURLData]
 	if !ok {
-		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, "es-url")
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, constants.ElasticsearchURLData)
 	}
 
 	// Update the daemonset to use a value instead of the valueFrom

--- a/platform-operator/controllers/verrazzano/component/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano.go
@@ -26,7 +26,7 @@ func resolveVerrazzanoNamespace(ns string) string {
 }
 
 // verrazzanoPreUpgrade contains code that is run prior to helm upgrade for the verrazzano helm chart
-func verrazzanoPreUpgrade(log *zap.SugaredLogger, client client.Client, release string, namespace string, chartDir string) error {
+func verrazzanoPreUpgrade(log *zap.SugaredLogger, client client.Client, _ string, namespace string, _ string) error {
 	return fixupFluentdDaemonset(log, client, namespace)
 }
 

--- a/platform-operator/controllers/verrazzano/component/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano.go
@@ -3,6 +3,19 @@
 
 package component
 
+import (
+	"context"
+	"fmt"
+
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 // resolveNamesapce will return the default verrzzano system namespace unless the namespace
 // is specified
 func resolveVerrazzanoNamespace(ns string) string {
@@ -10,4 +23,90 @@ func resolveVerrazzanoNamespace(ns string) string {
 		return ns
 	}
 	return vzDefaultNamespace
+}
+
+// verrazzanoPreUpgrade contains code that is run prior to helm upgrade for the verrazzano helm chart
+func verrazzanoPreUpgrade(log *zap.SugaredLogger, client client.Client, release string, namespace string, chartDir string) error {
+	return fixupFluentdDaemonset(log, client, namespace)
+}
+
+// This function is used to fixup the fluentd daemonset on a managed cluster so that helm upgrade of verrazzano does
+// not fail.  Prior to Verrazzano v1.0.1, the mcagent would change the environment variables CLUSTER_NAME and
+// ELASTICSEARCH_URL on a managed cluster to use valueFrom (from a secret) instead of using a value. The helm chart
+// template for the fluentd daemonset expects a value.
+func fixupFluentdDaemonset(log *zap.SugaredLogger, client client.Client, namespace string) error {
+	// Get the fluentd daemonset resource
+	fluentdNamespacedName := types.NamespacedName{Name: "fluentd", Namespace: namespace}
+	daemonSet := appsv1.DaemonSet{}
+	err := client.Get(context.TODO(), fluentdNamespacedName, &daemonSet)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		log.Errorf("Failed to find the fluentd DaemonSet %s, %v", daemonSet.Name, err)
+		return err
+	}
+
+	// Find the fluent container and save it's container index
+	fluentdIndex := -1
+	for i, container := range daemonSet.Spec.Template.Spec.Containers {
+		if container.Name == "fluentd" {
+			fluentdIndex = i
+		}
+	}
+	if fluentdIndex == -1 {
+		return fmt.Errorf("fluentd container not found in fluentd daemonset: %s", daemonSet.Name)
+	}
+
+	// Check if env variables CLUSTER_NAME and ELASTICSEARCH_URL are using valueFrom.
+	clusterNameIndex := -1
+	elasticURLIndex := -1
+	for i, env := range daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env {
+		if env.Name == "CLUSTER_NAME" && env.ValueFrom != nil {
+			clusterNameIndex = i
+			continue
+		}
+		if env.Name == "ELASTICSEARCH_URL" && env.ValueFrom != nil {
+			elasticURLIndex = i
+		}
+	}
+
+	// If valueFrom is not being used then we do not need to fix the env variables
+	if clusterNameIndex == -1 && elasticURLIndex == -1 {
+		return nil
+	}
+
+	// Get the secret containing managed cluster name and Elasticsearch URL
+	secretNamespacedName := types.NamespacedName{Name: constants.MCRegistrationSecret, Namespace: namespace}
+	secret := corev1.Secret{}
+	err = client.Get(context.TODO(), secretNamespacedName, &secret)
+	if err != nil {
+		return err
+	}
+
+	// The secret must contain a cluster name
+	clusterName, ok := secret.Data["managed-cluster-name"]
+	if !ok {
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, "managed-cluster-name")
+	}
+
+	// The secret must contain the Elasticsearch endpoint's URL
+	elasticsearchURL, ok := secret.Data["es-url"]
+	if !ok {
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, "es-url")
+	}
+
+	// Update the daemonset to use a value instead of the valueFrom
+	if clusterNameIndex != -1 {
+		daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env[clusterNameIndex].Value = string(clusterName)
+		daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env[clusterNameIndex].ValueFrom = nil
+	}
+	if elasticURLIndex != -1 {
+		daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env[elasticURLIndex].Value = string(elasticsearchURL)
+		daemonSet.Spec.Template.Spec.Containers[fluentdIndex].Env[elasticURLIndex].ValueFrom = nil
+	}
+	log.Infof("Updating fluentd daemonset to use valueFrom instead of value for CLUSTER_NAME and ELASTICSEARCH_URL environment variables")
+	err = client.Update(context.TODO(), &daemonSet)
+
+	return err
 }

--- a/platform-operator/controllers/verrazzano/component/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano.go
@@ -52,6 +52,7 @@ func fixupFluentdDaemonset(log *zap.SugaredLogger, client client.Client, namespa
 	for i, container := range daemonSet.Spec.Template.Spec.Containers {
 		if container.Name == "fluentd" {
 			fluentdIndex = i
+			break
 		}
 	}
 	if fluentdIndex == -1 {

--- a/platform-operator/controllers/verrazzano/component/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,11 +71,11 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 							Name: "wrong-name",
 							Env: []corev1.EnvVar{
 								{
-									Name:  "CLUSTER_NAME",
-									Value: "admin",
+									Name:  constants.ClusterNameEnvVar,
+									Value: "managed1",
 								},
 								{
-									Name:  "ELASTICSEARCH_URL",
+									Name:  constants.ElasticsearchURLEnvVar,
 									Value: "some-url",
 								},
 							},
@@ -102,8 +102,8 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 
 	// create a secret with needed keys
 	data := make(map[string][]byte)
-	data["managed-cluster-name"] = []byte("managed1")
-	data["es-url"] = []byte("some-url")
+	data[constants.ClusterNameData] = []byte("managed1")
+	data[constants.ElasticsearchURLData] = []byte("some-url")
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: defNs,
@@ -120,7 +120,7 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: constants.MCRegistrationSecret,
 			},
-			Key: "managed-cluster-name",
+			Key: constants.ClusterNameData,
 		},
 	}
 	esURLRef := corev1.EnvVarSource{
@@ -128,7 +128,7 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: constants.MCRegistrationSecret,
 			},
-			Key: "es-url",
+			Key: constants.ElasticsearchURLData,
 		},
 	}
 	daemonSet.Spec.Template.Spec.Containers[0].Env[0].Value = ""

--- a/platform-operator/controllers/verrazzano/component/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano_test.go
@@ -4,10 +4,18 @@
 package component
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestVzResolveNamespace tests the Verrazzano component name
@@ -23,4 +31,124 @@ func TestVzResolveNamespace(t *testing.T) {
 	assert.Equal(defNs, ns, "Wrong namespace resolved for verrazzano when using default namespace")
 	ns = resolveVerrazzanoNamespace("custom")
 	assert.Equal("custom", ns, "Wrong namespace resolved for verrazzano when using custom namesapce")
+}
+
+// TestFixupFluentdDaemonset tests calls to fixupFluentdDaemonset
+func TestFixupFluentdDaemonset(t *testing.T) {
+	const defNs = constants.VerrazzanoSystemNamespace
+	assert := assert.New(t)
+	scheme := runtime.NewScheme()
+	appsv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	client := fake.NewFakeClientWithScheme(scheme)
+	logger, _ := zap.NewProduction()
+	log := logger.Sugar()
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defNs,
+		},
+	}
+	err := client.Create(context.TODO(), &ns)
+	assert.NoError(err)
+
+	// Should return with no error since the fluentd daemonset does not exist.
+	// This is valid case when fluentd is not installed.
+	err = fixupFluentdDaemonset(log, client, defNs)
+	assert.NoError(err)
+
+	// Create a fluentd daemonset for test purposes
+	daemonSet := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defNs,
+			Name:      "fluentd",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "wrong-name",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "CLUSTER_NAME",
+									Value: "admin",
+								},
+								{
+									Name:  "ELASTICSEARCH_URL",
+									Value: "some-url",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = client.Create(context.TODO(), &daemonSet)
+	assert.NoError(err)
+
+	// should return error that fluentd container is missing
+	err = fixupFluentdDaemonset(log, client, defNs)
+	assert.EqualError(err, "fluentd container not found in fluentd daemonset: fluentd")
+
+	daemonSet.Spec.Template.Spec.Containers[0].Name = "fluentd"
+	err = client.Update(context.TODO(), &daemonSet)
+	assert.NoError(err)
+
+	// should return no error since the env variables don't need fixing up
+	err = fixupFluentdDaemonset(log, client, defNs)
+	assert.NoError(err)
+
+	// create a secret with needed keys
+	data := make(map[string][]byte)
+	data["managed-cluster-name"] = []byte("managed1")
+	data["es-url"] = []byte("some-url")
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defNs,
+			Name:      constants.MCRegistrationSecret,
+		},
+		Data: data,
+	}
+	err = client.Create(context.TODO(), &secret)
+	assert.NoError(err)
+
+	// Update env variables to use ValueFrom instead of Value
+	clusterNameRef := corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: constants.MCRegistrationSecret,
+			},
+			Key: "managed-cluster-name",
+		},
+	}
+	esURLRef := corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: constants.MCRegistrationSecret,
+			},
+			Key: "es-url",
+		},
+	}
+	daemonSet.Spec.Template.Spec.Containers[0].Env[0].Value = ""
+	daemonSet.Spec.Template.Spec.Containers[0].Env[0].ValueFrom = &clusterNameRef
+	daemonSet.Spec.Template.Spec.Containers[0].Env[1].Value = ""
+	daemonSet.Spec.Template.Spec.Containers[0].Env[1].ValueFrom = &esURLRef
+	err = client.Update(context.TODO(), &daemonSet)
+	assert.NoError(err)
+
+	// should return no error
+	err = fixupFluentdDaemonset(log, client, defNs)
+	assert.NoError(err)
+
+	// env variables should be fixed up to use Value instead of ValueFrom
+	fluentdNamespacedName := types.NamespacedName{Name: "fluentd", Namespace: defNs}
+	updatedDaemonSet := appsv1.DaemonSet{}
+	err = client.Get(context.TODO(), fluentdNamespacedName, &updatedDaemonSet)
+	assert.NoError(err)
+	assert.Equal("managed1", updatedDaemonSet.Spec.Template.Spec.Containers[0].Env[0].Value)
+	assert.Nil(updatedDaemonSet.Spec.Template.Spec.Containers[0].Env[0].ValueFrom)
+	assert.Equal("some-url", updatedDaemonSet.Spec.Template.Spec.Containers[0].Env[1].Value)
+	assert.Nil(updatedDaemonSet.Spec.Template.Spec.Containers[0].Env[1].ValueFrom)
 }


### PR DESCRIPTION
# Description

This pull request fixes the upgrade on a managed cluster when moving to v1.0.1. 

The problem was that the daemonset for fluentd contains a couple of environment variables that are defined as "value" in the helm template.  However, on the managed cluster, the registration process changes those variables to be "valueFrom" in order to obtain the values from the cluster registration secret.  The upgrade was failing because this difference.

Fixes VZ-3378

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
