### PR TITLE
Move install jobs, pods, service accounts, oci secret to verrazzano-install

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -211,8 +211,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${VERRAZZANO_INSTALL_LOGS_DIR}
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -238,8 +238,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                         echo "Verrazzano install logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1106,8 +1106,8 @@ def dumpInstallLogs() {
                 ## dump verrazzano install logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 mkdir -p ${LOG_DIR}
-                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
                 echo "------------------------------------------"
             """
         }

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -330,8 +330,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -387,8 +387,8 @@ pipeline {
                         sh """
                             ## dump out install logs
                             mkdir -p ${WORKSPACE}/platform-operator/scripts/install/build/logs
-                            kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                            kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                            kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                            kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                             echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                             echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                             echo "------------------------------------------"

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -277,8 +277,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -159,8 +159,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -274,8 +274,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"
@@ -412,8 +412,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-reinstall.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-reinstall-job-pod.out"
                         echo "------------------------------------------"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -195,8 +195,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -202,6 +202,7 @@ pipeline {
                                 echo "------------------------------------------"
                             """
                             script {
+                                dumpVerrazzanoPlatformOperatorLogs("before-upgrade")
                                 VZ_TEST_METRIC = metricJobName('')
                                 metricTimerStart("${VZ_TEST_METRIC}")
                             }
@@ -260,7 +261,7 @@ pipeline {
                     }
                     post {
                         always {
-                            dumpVerrazzanoPlatformOperatorLogs()
+                            dumpVerrazzanoPlatformOperatorLogs("after-upgrade")
                         }
                     }
                 }
@@ -348,7 +349,6 @@ pipeline {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
                     dumpNginxIngressControllerLogs()
-                    dumpVerrazzanoPlatformOperatorLogs()
                     dumpVerrazzanoApplicationOperatorLogs()
                     dumpOamKubernetesRuntimeLogs()
                     dumpVerrazzanoApiLogs()
@@ -443,14 +443,12 @@ def dumpNginxIngressControllerLogs() {
     """
 }
 
-def dumpVerrazzanoPlatformOperatorLogs() {
+def dumpVerrazzanoPlatformOperatorLogs(stage) {
     sh """
         ## dump out verrazzano-platform-operator logs
         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        echo "verrazzano-platform-operator logs dumped to verrazzano-platform-operator-pod.log"
-        echo "verrazzano-platform-operator pod description dumped to verrazzano-platform-operator-pod.out"
+        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "------------------------------------------"
     """
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"reflect"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
@@ -26,7 +27,12 @@ func GetCurrentBomVersion() (*semver.SemVersion, error) {
 	if err != nil {
 		return nil, err
 	}
-	return semver.NewSemVersion(fmt.Sprintf("v%s", bom.GetVersion()))
+	v := bom.GetVersion()
+	if v == constants.BomVerrazzanoVersion {
+		// This will only happen during development testing, the value doesn't matter
+		v = "1.0.1"
+	}
+	return semver.NewSemVersion(fmt.Sprintf("v%s", v))
 }
 
 // ValidateVersion check that requestedVersion matches BOM requestedVersion

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"reflect"
 
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/semver"
@@ -133,10 +133,10 @@ func ValidateInProgress(state StateType) error {
 func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
 		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "default"}, secret)
+		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("secret \"%s\" must be created in the default namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret)
+				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoInstallNamespace)
 			}
 			return err
 		}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
@@ -539,7 +540,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = ValidateOciDNSSecret(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "secret \"oci-bad-secret\" must be created in the default namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano for OCI DNS", err.Error())
 }
 
 // TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the verrazzano CR exists
@@ -569,7 +570,7 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oci",
-			Namespace: "default",
+			Namespace: constants.VerrazzanoInstallNamespace,
 		},
 	}
 	err = client.Create(context.TODO(), secret)

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -62,3 +62,5 @@ const VerrazzanoAppOperatorImageEnvVar = "APP_OPERATOR_IMAGE"
 
 // The Kubernetes default namespace
 const DefaultNamespace = "default"
+
+const BomVerrazzanoVersion = "VERRAZZANO_VERSION"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -59,3 +59,6 @@ const ImageRepoOverrideEnvVar = "IMAGE_REPO"
 
 // VerrazzanoAppOperatorImageEnvVar is the environment variable used to override the Verrazzano Application Operator image
 const VerrazzanoAppOperatorImageEnvVar = "APP_OPERATOR_IMAGE"
+
+// The Kubernetes default namespace
+const DefaultNamespace = "default"

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -233,10 +233,10 @@ func (r *Reconciler) createClusterRoleBinding(ctx context.Context, log *zap.Suga
 }
 
 // deleteClusterRoleBinding deletes the cluster role binding
-func (r *Reconciler) deleteClusterRoleBinding(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, namespace string) error {
+func (r *Reconciler) deleteClusterRoleBinding(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	binding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: buildClusterRoleBindingName(namespace, vz.Name),
+			Name: buildClusterRoleBindingName(vz.Namespace, vz.Name),
 		},
 	}
 	err := r.Delete(ctx, binding, &client.DeleteOptions{})
@@ -925,7 +925,7 @@ func (r *Reconciler) procDelete(ctx context.Context, log *zap.SugaredLogger, vz 
 // Cleanup the resources left over from install and uninstall
 func (r *Reconciler) cleanup(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
 	// Delete roleBinding
-	err := r.deleteClusterRoleBinding(ctx, log, vz, getInstallNamespace())
+	err := r.deleteClusterRoleBinding(ctx, log, vz)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -84,8 +84,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// Initial the verrazzano CR
-	result, err := r.initVz(vz, log)
+	// Watch for install/uinstall job events
+	result, err := r.ensureJobWatch(vz, log)
 	if err != nil {
 		log.Errorf("unable to set watch for Job resource: %v", err)
 		return result, err
@@ -1030,9 +1030,9 @@ func (r *Reconciler) watchJobs(namespace string, name string, log *zap.SugaredLo
 	return nil
 }
 
-// Init the Verrazzano resource. Add a watch for each Verrazzano resource so that the reconciler
+// ensureJobWatch adds a watch for each Verrazzano resource so that the reconciler
 // gets called for that resource if an event happens on a job
-func (r *Reconciler) initVz(vz *installv1alpha1.Verrazzano, log *zap.SugaredLogger) (ctrl.Result, error) {
+func (r *Reconciler) ensureJobWatch(vz *installv1alpha1.Verrazzano, log *zap.SugaredLogger) (ctrl.Result, error) {
 	if unitTesting {
 		return ctrl.Result{}, nil
 	}
@@ -1052,4 +1052,9 @@ func (r *Reconciler) initVz(vz *installv1alpha1.Verrazzano, log *zap.SugaredLogg
 	// Update the map indicating the resource is being watched
 	watchSet[vz.Name] = true
 	return ctrl.Result{Requeue: true}, nil
+}
+
+// This is needed for unit testing
+func initUnitTesing() {
+	unitTesting = true
 }

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -20,6 +20,7 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/installjob"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/uninstalljob"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
@@ -159,7 +160,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *Reconciler) doesOCIDNSConfigSecretExist(vz *installv1alpha1.Verrazzano) error {
 	// ensure the secret exists before proceeding
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "default"}, secret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: vz.Spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -381,6 +381,21 @@ func (r *Reconciler) cleanupUninstallJob(jobName string, namespace string, log *
 	return nil
 }
 
+// deleteNamespace deletes a namespace
+func (r *Reconciler) deleteNamespace(ctx context.Context, log *zap.SugaredLogger, namespace string) error {
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+		},
+	}
+	err := r.Delete(ctx, &ns, &client.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		log.Errorf("Failed deleting namespace %s: %v", ns.Name, err)
+		return err
+	}
+	return nil
+}
+
 // SetupWithManager creates a new controller and adds it to the manager
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var err error
@@ -903,11 +918,11 @@ func (r *Reconciler) cleanup(ctx context.Context, log *zap.SugaredLogger, vz *in
 	}
 
 	// Delete the verrazzano-system namespace
-	ns := corev1.Namespace{}
-	err = r.Delete(ctx, &ns, &client.DeleteOptions{})
+	err = r.deleteNamespace(ctx, log, vzconst.VerrazzanoSystemNamespace)
 	if err != nil {
 		return err
 	}
+	
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -951,30 +951,6 @@ func (r *Reconciler) cleanup(ctx context.Context, log *zap.SugaredLogger, vz *in
 	return nil
 }
 
-// cleanupOld deltes the resources that used to be in the default namespace in earlier versions of Verrazzano.  This
-// also includes the ClusterRoleBinding, which is outside the scope of namespace
-func (r *Reconciler) cleanupOld(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) error {
-	// Delete ClusterRoleBinding
-	err := r.deleteClusterRoleBinding(ctx, log, vz, vzconst.DefaultNamespace)
-	if err != nil {
-		return err
-	}
-
-	// Delete install service account
-	err = r.deleteServiceAccount(ctx, log, vz, vzconst.DefaultNamespace)
-	if err != nil {
-		return err
-	}
-
-	// Delete the install config map
-	err = r.deleteConfigMap(ctx, log, vz, vzconst.DefaultNamespace)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Create a new Result that will cause a reconcile requeue after a short delay
 func newRequeueWithDelay() ctrl.Result {
 	var seconds = rand.IntnRange(3, 5)

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -101,6 +101,7 @@ func TestGetInstallJobName(t *testing.T) {
 // WHEN a verrazzano resource has been applied
 // THEN ensure all the objects are already created
 func TestSuccessfulInstall(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -207,6 +208,7 @@ func TestSuccessfulInstall(t *testing.T) {
 // WHEN a verrazzano resource has been created
 // THEN ensure all the objects are created
 func TestCreateVerrazzano(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test1"}
@@ -342,6 +344,7 @@ func TestCreateVerrazzano(t *testing.T) {
 // WHEN a verrazzano resource has been created
 // THEN ensure all the objects are created
 func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test1"}
@@ -505,6 +508,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure all the objects are deleted
 func TestUninstallComplete(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -591,9 +595,6 @@ func TestUninstallComplete(t *testing.T) {
 	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
 	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 	expectDeleteNamespace(mock)
-	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
-	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
-	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -612,6 +613,7 @@ func TestUninstallComplete(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure an unisntall job is started
 func TestUninstallStarted(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -699,6 +701,7 @@ func TestUninstallStarted(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure the error is handled
 func TestUninstallFailed(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -783,9 +786,6 @@ func TestUninstallFailed(t *testing.T) {
 	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
 	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 	expectDeleteNamespace(mock)
-	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
-	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
-	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -804,6 +804,7 @@ func TestUninstallFailed(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure all the objects are deleted
 func TestUninstallSucceeded(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -888,9 +889,6 @@ func TestUninstallSucceeded(t *testing.T) {
 	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
 	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 	expectDeleteNamespace(mock)
-	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
-	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
-	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -909,6 +907,7 @@ func TestUninstallSucceeded(t *testing.T) {
 // WHEN it does not exist
 // THEN ensure the error not found is handled
 func TestVerrazzanoNotFound(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -415,7 +415,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the DNS config secret and return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			data := make(map[string][]byte)
 			data["passphrase"] = []byte("passphraseValue")
@@ -1464,7 +1464,7 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 
 	// Expect a call to get the DNS config secret but return a not found error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Secret"))
 
 	// Create and make the request

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -145,7 +145,7 @@ func TestSuccessfulInstall(t *testing.T) {
 
 	// Expect a call to get the Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -237,14 +237,14 @@ func TestCreateVerrazzano(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
+			asserts.Equalf(getInstallNamespace(), serviceAccount.Namespace, "ServiceAccount namespace did not match")
 			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
@@ -263,20 +263,20 @@ func TestCreateVerrazzano(t *testing.T) {
 			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
 			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
-			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
+			asserts.Equalf(getInstallNamespace(), clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ConfigMap - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
+			asserts.Equalf(getInstallNamespace(), configMap.Namespace, "ConfigMap namespace did not match")
 			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			return nil
@@ -287,14 +287,14 @@ func TestCreateVerrazzano(t *testing.T) {
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
+			asserts.Equalf(getInstallNamespace(), job.Namespace, "Job namespace did not match")
 			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
@@ -304,7 +304,7 @@ func TestCreateVerrazzano(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -380,14 +380,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
+			asserts.Equalf(getInstallNamespace(), serviceAccount.Namespace, "ServiceAccount namespace did not match")
 			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
@@ -406,7 +406,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
 			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
-			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
+			asserts.Equalf(getInstallNamespace(), clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
@@ -430,14 +430,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ConfigMap - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
+			asserts.Equalf(getInstallNamespace(), configMap.Namespace, "ConfigMap namespace did not match")
 			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			asserts.NotNil(configMap.Data["config.json"], "Configuration entry not found")
@@ -450,14 +450,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
+			asserts.Equalf(getInstallNamespace(), job.Namespace, "Job namespace did not match")
 			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
@@ -467,7 +467,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -543,12 +543,12 @@ func TestUninstallComplete(t *testing.T) {
 
 	// Expect a lookup of a running install job
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to get the uninstall Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -579,6 +579,11 @@ func TestUninstallComplete(t *testing.T) {
 			asserts.Len(verrazzano.Status.Conditions, 2)
 			return nil
 		})
+
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+	expectDeleteNamespace(mock)
 
 	// Create and make the request
 	request := newRequest(namespace, name)
@@ -1893,7 +1898,7 @@ func newVerrazzanoReconciler(c client.Client) Reconciler {
 func setupInstallInternalConfigMapExpectations(mock *mocks.MockClient, name string, namespace string) {
 	// Expect a call to get an existing configmap, but return a NotFound error.
 	mock.EXPECT().
-		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: getInstallNamespace()}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
 			return errors.NewNotFound(schema.GroupResource{
 				Group:    vzapi.SchemeGroupVersion.Group,
@@ -1963,7 +1968,7 @@ func expectVerrazzanoSystemNamespaceDoesNotExist(mock *mocks.MockClient, asserts
 func expectConfigMapExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
 	// Expect a call to get the ConfigMap - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
 			configMap.ObjectMeta = cm.ObjectMeta
@@ -1992,7 +1997,7 @@ func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzap
 func expectGetServiceAccountExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, []string{}, labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -2011,6 +2016,36 @@ func expectGetVerrazzanoExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Ver
 			verrazzano.Spec.Components.DNS = verrazzanoToUse.Spec.Components.DNS
 			return nil
 		})
+}
+
+// expectDeleteServiceAccount expects a call to delete the service account used by install
+func expectDeleteServiceAccount(mock *mocks.MockClient, namespace string, name string) {
+	// Expect a call to get the ServiceAccount - return that it exists
+	mock.EXPECT().
+		Delete(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Any()).Return(nil)
+}
+
+
+// expectDeleteConfigMap expects a call to delete the config map used by install
+func expectDeleteConfigMap(mock *mocks.MockClient, namespace string, name string) {
+	// Expect a call to get the ServiceAccount - return that it exists
+	mock.EXPECT().
+		Delete(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Any()).Return(nil)
+}
+
+// expectDeleteNamespace expects a call to delete the verrazzano-system ns
+func expectDeleteNamespace(mock *mocks.MockClient) {
+	// Expect a call to get the ServiceAccount - return that it exists
+	mock.EXPECT().
+		Delete(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoSystemNamespace}, gomock.Any()).Return(nil)
+}
+
+
+// expectDeleteClusterRoleBinding expects a call to delete the ClusterRoleBinding for the Verrazzano with the given
+// namespace and name, and returns that it exists
+func expectDeleteClusterRoleBinding(mock *mocks.MockClient, namespace string, name string) {
+	mock.EXPECT().
+		Delete(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Any()).Return(nil)
 }
 
 // Test_commonPath tests commonPath function

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -1979,7 +1979,7 @@ func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzap
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: clusterRoleBindingName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(&verrazzanoToUse, nsName.Name, buildServiceAccountName(nsName.Name))
+			crb := installjob.NewClusterRoleBinding(&verrazzanoToUse, nsName.Name, getInstallNamespace(), buildServiceAccountName(nsName.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -13,7 +13,7 @@ import (
 // vz - pointer to verrazzano resource
 // name - name of the RoleBinding resource
 // saName - name of ServiceAccount resource
-func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano,rbNname string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
+func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, rbNname string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   rbNname,

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -9,32 +9,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewClusterRoleBinding returns a cluster role binding resource for installing Verrazzano
+// NewClusterRoleBinding returns a RoleBinding resource for installing Verrazzano
 // vz - pointer to verrazzano resource
-// name - name of the clusterrolebinding resource
-// saName - name of service account resource
-func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
+// name - name of the RoleBinding resource
+// saName - name of ServiceAccount resource
+func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano,rbNname string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
+			Name:   rbNname,
 			Labels: vz.Labels,
-			// TODO mackin - delete this in finalizer
-			// Set owner reference here instead of calling controllerutil.SetControllerReference
-			// which does not allow cluster-scoped resources.
-			// This reference will result in the clusterrolebinding resource being deleted
-			// when the verrazzano CR is deleted.
-			//OwnerReferences: []metav1.OwnerReference{
-			//	{
-			//		APIVersion: vz.APIVersion,
-			//		Kind:       vz.Kind,
-			//		Name:       vz.Name,
-			//		UID:        vz.UID,
-			//		Controller: func() *bool {
-			//			flag := true
-			//			return &flag
-			//		}(),
-			//	},
-			//},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -9,9 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewClusterRoleBinding returns a RoleBinding resource for installing Verrazzano
+// NewClusterRoleBinding returns a ClusterRoleBinding resource for installing Verrazzano
 // vz - pointer to verrazzano resource
-// name - name of the RoleBinding resource
+// name - name of the ClusterRoleBinding resource
+// saNamespace - name of ServiceAccount namespace
 // saName - name of ServiceAccount resource
 func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, rbNname string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -13,27 +13,28 @@ import (
 // vz - pointer to verrazzano resource
 // name - name of the clusterrolebinding resource
 // saName - name of service account resource
-func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saName string) *rbacv1.ClusterRoleBinding {
+func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: vz.Labels,
+			// TODO mackin - delete this in finalizer
 			// Set owner reference here instead of calling controllerutil.SetControllerReference
 			// which does not allow cluster-scoped resources.
 			// This reference will result in the clusterrolebinding resource being deleted
 			// when the verrazzano CR is deleted.
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: vz.APIVersion,
-					Kind:       vz.Kind,
-					Name:       vz.Name,
-					UID:        vz.UID,
-					Controller: func() *bool {
-						flag := true
-						return &flag
-					}(),
-				},
-			},
+			//OwnerReferences: []metav1.OwnerReference{
+			//	{
+			//		APIVersion: vz.APIVersion,
+			//		Kind:       vz.Kind,
+			//		Name:       vz.Name,
+			//		UID:        vz.UID,
+			//		Controller: func() *bool {
+			//			flag := true
+			//			return &flag
+			//		}(),
+			//	},
+			//},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -44,7 +45,7 @@ func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saName s
 			{
 				Kind:      "ServiceAccount",
 				Name:      saName,
-				Namespace: vz.Namespace,
+				Namespace: saNamespace,
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
@@ -4,6 +4,7 @@
 package installjob
 
 import (
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestNewClusterRoleBinding(t *testing.T) {
 	name := "test-clusterRoleBinding"
 	saName := "service-account"
 
-	clusterRoleBinding := NewClusterRoleBinding(&vz, name, saName)
+	clusterRoleBinding := NewClusterRoleBinding(&vz, name, constants.VerrazzanoInstallNamespace, saName)
 
 	assert.Equalf(t, "", clusterRoleBinding.Namespace, "Expected namespace did not match")
 	assert.Equalf(t, name, clusterRoleBinding.Name, "Expected clusterRoleBinding name did not match")

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
@@ -4,7 +4,6 @@
 package installjob
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,11 +28,11 @@ func TestNewClusterRoleBinding(t *testing.T) {
 	name := "test-clusterRoleBinding"
 	saName := "service-account"
 
-	clusterRoleBinding := NewClusterRoleBinding(&vz, name, constants.VerrazzanoInstallNamespace, saName)
+	clusterRoleBinding := NewClusterRoleBinding(&vz, name, namespace, saName)
 
 	assert.Equalf(t, "", clusterRoleBinding.Namespace, "Expected namespace did not match")
 	assert.Equalf(t, name, clusterRoleBinding.Name, "Expected clusterRoleBinding name did not match")
-	assert.Equalf(t, 1, len(clusterRoleBinding.OwnerReferences), "Expected length of owner references did not match")
+	assert.Equalf(t, 0, len(clusterRoleBinding.OwnerReferences), "Expected length of owner references did not match")
 	assert.Equalf(t, vz.Labels, clusterRoleBinding.Labels, "Expected labels did not match")
 	assert.Equalf(t, saName, clusterRoleBinding.Subjects[0].Name, "Expected service account name did not match")
 	assert.Equalf(t, "ServiceAccount", clusterRoleBinding.Subjects[0].Kind, "Expected subject kind did not match")

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -11,7 +11,9 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -68,6 +70,21 @@ func (r *Reconciler) mutateLocalRegistrationSecret(secret *corev1.Secret) error 
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
 		clusters.ManagedClusterNameKey: []byte(constants.MCLocalCluster),
+	}
+	return nil
+}
+
+// Delete the local registration secret
+func (r *Reconciler) deleteLocalRegistrationSecret(vz *installv1alpha1.Verrazzano) error {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      constants.MCAgentSecret,
+		},
+	}
+	err := r.Delete(context.TODO(), &secret, &client.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("Failed deleting the local registration secret %s/%s: %v", secret.Namespace, secret.Name, err)
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -11,9 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -70,21 +68,6 @@ func (r *Reconciler) mutateLocalRegistrationSecret(secret *corev1.Secret) error 
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
 		clusters.ManagedClusterNameKey: []byte(constants.MCLocalCluster),
-	}
-	return nil
-}
-
-// Delete the local registration secret
-func (r *Reconciler) deleteLocalRegistrationSecret(vz *installv1alpha1.Verrazzano) error {
-	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: constants.VerrazzanoSystemNamespace,
-			Name:      constants.MCAgentSecret,
-		},
-	}
-	err := r.Delete(context.TODO(), &secret, &client.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failed deleting the local registration secret %s/%s: %v", secret.Namespace, secret.Name, err)
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -4,7 +4,6 @@
 package verrazzano
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -59,10 +58,6 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, req ctrl.Request, 
 	log.Info(msg)
 	cr.Status.Version = targetVersion
 	err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete)
-
-	// Cleanup old resources left around when the install used to be done in the default namespace
-	// This is a best effort attempt, do not fail on errors
-	_ = r.cleanupOld(context.TODO(), log, cr)
 
 	return ctrl.Result{}, err
 }

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -20,8 +20,6 @@ import (
 // The max upgrade failures for a given upgrade attempt is 2
 const failedUpgradeLimit = 2
 
-var deletedOldResources bool
-
 // Reconcile upgrade will upgrade the components as required
 func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, req ctrl.Request, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	// Upgrade version was validated in webhook, see ValidateVersion

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -4,6 +4,7 @@
 package verrazzano
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -58,6 +59,13 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, req ctrl.Request, 
 	log.Info(msg)
 	cr.Status.Version = targetVersion
 	err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete)
+
+	// Cleanup old security
+	err = r.cleanupOld(context.TODO(), log, cr)
+	if err != nil {
+		return newRequeueWithDelay(), err
+	}
+
 	return ctrl.Result{}, err
 }
 

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -42,7 +42,7 @@ type badRunner struct {
 // WHEN a verrazzano version is empty
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeNoVersion(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -98,7 +98,7 @@ func TestUpgradeNoVersion(t *testing.T) {
 // WHEN a verrazzano spec.version is the same as the status.version
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeSameVersion(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -157,7 +157,7 @@ func TestUpgradeSameVersion(t *testing.T) {
 // WHEN upgrade has not been started and spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeStarted is added
 func TestUpgradeStarted(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -230,7 +230,7 @@ func TestUpgradeStarted(t *testing.T) {
 // WHEN the current upgrade failed more than the failure limet
 // THEN ensure that upgrade is not started
 func TestUpgradeTooManyFailures(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -304,7 +304,7 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 // WHEN the total upgrade failures exceed the limit, but the current upgrade is under the limit
 // THEN ensure that upgrade is started
 func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -401,7 +401,7 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 // WHEN the current upgrade failures exceeds the limit, but there was a previous upgrade success
 // THEN ensure that upgrade is not started
 func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -486,7 +486,7 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeCompleted(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -528,6 +528,10 @@ func TestUpgradeCompleted(t *testing.T) {
 			return nil
 		})
 
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+
 	// Expect a call to get the service account
 	expectGetServiceAccountExists(mock, name, nil)
 
@@ -536,10 +540,6 @@ func TestUpgradeCompleted(t *testing.T) {
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
-
-	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
-	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
-	expectDeleteConfigMap(mock, getInstallNamespace(), name)
 
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().
@@ -571,7 +571,7 @@ func TestUpgradeCompleted(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeHelmError(t *testing.T) {
-	unitTesting = true
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -44,6 +44,7 @@ type badRunner struct {
 func TestUpgradeNoVersion(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -73,6 +74,12 @@ func TestUpgradeNoVersion(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -92,6 +99,7 @@ func TestUpgradeNoVersion(t *testing.T) {
 func TestUpgradeSameVersion(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -124,6 +132,12 @@ func TestUpgradeSameVersion(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -143,6 +157,7 @@ func TestUpgradeSameVersion(t *testing.T) {
 func TestUpgradeStarted(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -177,6 +192,12 @@ func TestUpgradeStarted(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
@@ -208,6 +229,7 @@ func TestUpgradeStarted(t *testing.T) {
 func TestUpgradeTooManyFailures(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -255,6 +277,12 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -274,6 +302,7 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -331,6 +360,12 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
@@ -363,6 +398,7 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -421,6 +457,12 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -440,6 +482,7 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 func TestUpgradeCompleted(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	fname, _ := filepath.Abs(unitTestBomFile)
 	component.SetUnitTestBomFilePath(fname)
@@ -478,6 +521,12 @@ func TestUpgradeCompleted(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
@@ -513,6 +562,7 @@ func TestUpgradeCompleted(t *testing.T) {
 func TestUpgradeHelmError(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -549,6 +599,12 @@ func TestUpgradeHelmError(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -42,6 +42,7 @@ type badRunner struct {
 // WHEN a verrazzano version is empty
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeNoVersion(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -97,6 +98,7 @@ func TestUpgradeNoVersion(t *testing.T) {
 // WHEN a verrazzano spec.version is the same as the status.version
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeSameVersion(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -155,6 +157,7 @@ func TestUpgradeSameVersion(t *testing.T) {
 // WHEN upgrade has not been started and spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeStarted is added
 func TestUpgradeStarted(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -227,6 +230,7 @@ func TestUpgradeStarted(t *testing.T) {
 // WHEN the current upgrade failed more than the failure limet
 // THEN ensure that upgrade is not started
 func TestUpgradeTooManyFailures(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -300,6 +304,7 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 // WHEN the total upgrade failures exceed the limit, but the current upgrade is under the limit
 // THEN ensure that upgrade is started
 func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -396,6 +401,7 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 // WHEN the current upgrade failures exceeds the limit, but there was a previous upgrade success
 // THEN ensure that upgrade is not started
 func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -480,6 +486,7 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeCompleted(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano
@@ -530,6 +537,10 @@ func TestUpgradeCompleted(t *testing.T) {
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -560,6 +571,7 @@ func TestUpgradeCompleted(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeHelmError(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	var verrazzanoToUse vzapi.Verrazzano

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -528,10 +528,6 @@ func TestUpgradeCompleted(t *testing.T) {
 			return nil
 		})
 
-	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
-	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
-	expectDeleteConfigMap(mock, getInstallNamespace(), name)
-
 	// Expect a call to get the service account
 	expectGetServiceAccountExists(mock, name, nil)
 

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"flag"
-	"os"
-
 	"github.com/verrazzano/verrazzano/pkg/log"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -16,16 +14,14 @@ import (
 	config2 "github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/netpolicy"
 	"go.uber.org/zap"
-	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -138,13 +134,6 @@ func main() {
 	}
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Errorf("unable to create controller: %v", err)
-		os.Exit(1)
-	}
-
-	// Watch for the secondary resource (Job).
-	if err := reconciler.Controller.Watch(&source.Kind{Type: &batchv1.Job{}},
-		&handler.EnqueueRequestForOwner{OwnerType: &installv1alpha1.Verrazzano{}, IsController: true}); err != nil {
-		setupLog.Errorf("unable to set watch for Job resource: %v", err)
 		os.Exit(1)
 	}
 

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -838,7 +838,7 @@ fi
 if [ $(is_oci_dns) == "true" ]; then
   secret_name=$(get_config_value ".dns.oci.ociConfigSecret")
   consoleout
-  consoleout "NOTE: The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
+  consoleout "NOTE: The secret \"${secret_name}\" created in the \"verrazzano-install\" namespace prior to installation is only used during the actual installation."
   consoleout "You may delete it now.  DO NOT delete the secret of the same name in the cert-manager namespace."
   consoleout
 fi

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -65,6 +65,7 @@ OCI_CONFIG_FILE=~/.oci/config
 SECTION=DEFAULT
 OCI_CONFIG_SECRET_NAME=oci
 K8SCONTEXT=""
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 while getopts c:o:s:k:h flag
 do
@@ -93,16 +94,16 @@ if [[ ! -z "$pass_phrase" ]]; then
   echo "  passphrase: $pass_phrase" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
+# create the secret in verrazzano-install namespace
 create_secret=true
 
-kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n default > /dev/null 2>&1
+kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
-  echo "Secret $OCI_CONFIG_SECRET_NAME already exists.  Please delete then try again."
+  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace. Please delete that and try again."
   exit 1
 fi
-kubectl ${K8SCONTEXT} create secret -n default  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
 
 
 

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -10,6 +10,7 @@ TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
 OCI_CONFIG_SECRET_NAME=oci
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 # Validate expected environment variables exist
 if [ -z "${OCI_CLI_REGION}" ]; then
@@ -47,5 +48,9 @@ if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
   echo "  passphrase: ${OCI_PRIVATE_KEY_PASSPHRASE}" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+# create the secret in verrazzano-install namespace
+if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
+  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and try again."
+  exit 1
+fi
+kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE


### PR DESCRIPTION
Move the following resources to the verrazzano-install namespace from the default namespace
- service account
- config map
- install/uninstall jobs
- install/uninstall pods
- OCI secret (created by user)

In addition
- Cleanup old resources in default namespace from previous install
- Fix Jenkins files to look in verrazzano-install for the pod logs
- This includes Bhat's OCI DNS secret change from  pabhat/oci-secret-vz-nsg (required for this change)

I tried to use a RoleBinding instead of a ClusterRoleBinding but got an error since our install gets nodes, which is cluster level. Also, I had to add a different type of watch for jobs, since the VZ CR no longer owns the jobs because they are in a different namespace.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
