### PR TITLE
Force --wait on helm upgrade commands

### DIFF
--- a/platform-operator/internal/util/helm/helmcli.go
+++ b/platform-operator/internal/util/helm/helmcli.go
@@ -48,6 +48,7 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 		args = append(args, "--namespace")
 		args = append(args, namespace)
 	}
+	args = append(args, "--wait")
 
 	// Do not pass the --reuse-values arg to 'helm upgrade'.  Instead, pass the
 	// values retrieved from 'helm get values' with the -f arg to 'helm upgrade'. This is a workaround to avoid


### PR DESCRIPTION
# Description

Force a `--wait` on helm upgrade commands during a VZ upgrade.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
