### PR TITLE
Update coherence operator to v3.2.2

### DIFF
--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -3,4 +3,4 @@
 
 # NOTE: The image you're looking for isn't here. The coherence-operator image now comes from
 # the bill of materials file (verrazzano-bom.json).
-defaultCoherenceImage: ghcr.io/oracle/coherence-ce:21.06
+defaultCoherenceImage: ghcr.io/oracle/coherence-ce:21.06.1

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -5,8 +5,8 @@
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.2.1
-appVersion: 3.2.1
+version: 3.2.2
+appVersion: 3.2.2
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020, Oracle Corporation and/or its affiliates.
+# Copyright 2020, 2021 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 

--- a/platform-operator/thirdparty/charts/coherence-operator/LICENSE.txt
+++ b/platform-operator/thirdparty/charts/coherence-operator/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+Copyright (c) 2019, 2021 Oracle and/or its affiliates.  All rights reserved.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.1"
+    app.kubernetes.io/version: "3.2.2"
     app.kubernetes.io/component: webhook
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -28,7 +28,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.1"
+    app.kubernetes.io/version: "3.2.2"
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-rest
-    app.kubernetes.io/version: "3.2.1"
+    app.kubernetes.io/version: "3.2.2"
     app.kubernetes.io/component: rest
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -52,7 +52,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.1"
+    app.kubernetes.io/version: "3.2.2"
     app.kubernetes.io/component: manager
 ---
 apiVersion: apps/v1
@@ -64,7 +64,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.1"
+    app.kubernetes.io/version: "3.2.2"
     app.kubernetes.io/component: manager
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -80,7 +80,7 @@ spec:
         control-plane: coherence
         app.kubernetes.io/name: coherence-operator
         app.kubernetes.io/instance: coherence-operator-manager
-        app.kubernetes.io/version: "3.2.1"
+        app.kubernetes.io/version: "3.2.2"
         app.kubernetes.io/component: manager
         app.kubernetes.io/part-of: coherence-operator
         app.kubernetes.io/managed-by: helm

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -3,15 +3,15 @@
 # http://oss.oracle.com/licenses/upl.
 
 # image is the Coherence Operator image
-image: "ghcr.io/oracle/coherence-operator:3.2.1"
+image: "ghcr.io/oracle/coherence-operator:3.2.2"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
-defaultCoherenceImage: "oraclecoherence/coherence-ce:21.06"
+defaultCoherenceImage: "oraclecoherence/coherence-ce:21.06.1"
 
 # defaultCoherenceUtilsImage is the Coherence Operator utils image that will be used when running
 # Coherence Pods. This image version should typically match the Operator version.
-defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.1-utils"
+defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.2-utils"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -381,7 +381,7 @@
           "images": [
             {
               "image": "coherence-operator",
-              "tag": "3.2.1",
+              "tag": "3.2.2",
               "helmFullImageKey": "image"
             }
           ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,8 +220,8 @@
           "name": "verrazzano",
           "images": [
             {
-              "image": "verrazzano-operator",
-              "tag": "1.1.0-20210721203425-f4d8b23",
+              "image": "verrazzano-operator-jenkins",
+              "tag": "1.1.0-20210906132229-7b9641d",
               "helmFullImageKey": "verrazzanoOperator.imageName",
               "helmTagKey": "verrazzanoOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,8 +220,8 @@
           "name": "verrazzano",
           "images": [
             {
-              "image": "verrazzano-operator-jenkins",
-              "tag": "1.1.0-20210906132229-7b9641d",
+              "image": "verrazzano-operator",
+              "tag": "1.1.0-20210907141728-f037a71",
               "helmFullImageKey": "verrazzanoOperator.imageName",
               "helmTagKey": "verrazzanoOperator.imageVersion"
             },


### PR DESCRIPTION
# Description

Uptake Coherence operator v.3.2.2. As part of this change, verrazzano-operator version is updated to get the Coherence dashboards from v.3.2.2.

Fixes VZ-3482

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
