### PR TITLE
VZ-3240.  Move WKO install to platform operator.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/component.go
+++ b/platform-operator/controllers/verrazzano/component/component.go
@@ -24,5 +24,11 @@ type Component interface {
 	IsOperatorInstallSupported() bool
 
 	// IsInstalled Indicates whether or not the component is installed
-	IsInstalled() bool
+	IsInstalled(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool
+
+	// IsReady Indicates whether or not a component is available and ready
+	IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool
+
+	// GetDependencies returns the dependencies of this component
+	GetDependencies() []string
 }

--- a/platform-operator/controllers/verrazzano/component/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm_component.go
@@ -49,6 +49,9 @@ type helmComponent struct {
 	// appendOverridesFunc is an optional function get additional override values
 	appendOverridesFunc appendOverridesSig
 
+	// readyStatusFunc is an optional function override to do deeper checks on a component's ready state
+	readyStatusFunc readyStatusFuncSig
+
 	// resolveNamespaceFunc is an optional function to process the namespace name
 	resolveNamespaceFunc resolveNamespaceSig
 
@@ -60,6 +63,9 @@ type helmComponent struct {
 
 	// imagePullSecretKeyname is the Helm value key for the image pull secret for a chart
 	imagePullSecretKeyname string
+
+	// dependencies is a list of dependencies for this component, by component/release name
+	dependencies []string
 }
 
 // Verify that helmComponent implements Component
@@ -80,6 +86,9 @@ type resolveNamespaceSig func(ns string) string
 // upgradeFuncSig is a function needed for unit test override
 type upgradeFuncSig func(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides string, overrideFiles ...string) (stdout []byte, stderr []byte, err error)
 
+// readyStatusFuncSig describes the function signature for doing deeper checks on a component's ready state
+type readyStatusFuncSig func(log *zap.SugaredLogger, client clipkg.Client, releaseName string, namespace string) bool
+
 // upgradeFunc is the default upgrade function
 var upgradeFunc upgradeFuncSig = helm.Upgrade
 
@@ -91,20 +100,39 @@ func (h helmComponent) Name() string {
 	return h.releaseName
 }
 
+// GetDependencies returns the dependencies of this component
+func (h helmComponent) GetDependencies() []string {
+	return h.dependencies
+}
+
 // IsOperatorInstallSupported Returns true if the component supports direct install via the operator
 func (h helmComponent) IsOperatorInstallSupported() bool {
 	return h.supportsOperatorInstall
 }
 
-func (h helmComponent) IsInstalled() bool {
-	installed, _ := helm.IsReleaseInstalled(h.releaseName, h.chartNamespace)
+// IsInstalled Indicates whether or not the component is installed
+func (h helmComponent) IsInstalled(_ *zap.SugaredLogger, _ clipkg.Client, namespace string) bool {
+	installed, _ := helm.IsReleaseInstalled(h.releaseName, resolveNamespace(h, namespace))
 	return installed
+}
+
+// IsReady Indicates whether or not a component is available and ready
+func (h helmComponent) IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool {
+	ns := resolveNamespace(h, namespace)
+	installed, _ := helm.IsReleaseInstalled(h.releaseName, resolveNamespace(h, namespace))
+	if installed {
+		if h.readyStatusFunc != nil {
+			return h.readyStatusFunc(log, client, h.releaseName, ns)
+		}
+		return true
+	}
+	return false
 }
 
 func (h helmComponent) Install(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
 
 	// Resolve the namespace
-	resolvedNamespace := h.resolveNamespace(namespace)
+	resolvedNamespace := resolveNamespace(h, namespace)
 
 	failed, err := helm.IsReleaseFailed(h.releaseName, resolvedNamespace)
 	if err != nil {
@@ -148,7 +176,7 @@ func (h helmComponent) Install(log *zap.SugaredLogger, client clipkg.Client, nam
 // BOM json file.  Each component also has the ability to add additional override parameters.
 func (h helmComponent) Upgrade(log *zap.SugaredLogger, client clipkg.Client, ns string, dryRun bool) error {
 	// Resolve the namespace
-	namespace := h.resolveNamespace(ns)
+	namespace := resolveNamespace(h, ns)
 
 	// Check if the component is installed before trying to upgrade
 	found, err := helm.IsReleaseInstalled(h.releaseName, namespace)
@@ -206,7 +234,7 @@ func (h helmComponent) Upgrade(log *zap.SugaredLogger, client clipkg.Client, ns 
 	return err
 }
 
-func (h helmComponent) buildOverridesString(log *zap.SugaredLogger, client clipkg.Client, namespace string, additionalValues ...keyValue) (string, error) {
+func (h helmComponent) buildOverridesString(log *zap.SugaredLogger, _ clipkg.Client, namespace string, additionalValues ...keyValue) (string, error) {
 	// Optionally create a second override file.  This will contain both image overridesString and any additional
 	// overridesString required by a component.
 	// Get image overridesString unless opt out
@@ -252,7 +280,7 @@ func (h helmComponent) buildOverridesString(log *zap.SugaredLogger, client clipk
 //
 // The need for this stems from an issue with the Verrazzano component and the fact
 // that component charts underneath VZ component need to have the ns overridden
-func (h helmComponent) resolveNamespace(ns string) string {
+func resolveNamespace(h helmComponent, ns string) string {
 	namespace := ns
 	if h.resolveNamespaceFunc != nil {
 		namespace = h.resolveNamespaceFunc(namespace)

--- a/platform-operator/controllers/verrazzano/component/image_pull_secret.go
+++ b/platform-operator/controllers/verrazzano/component/image_pull_secret.go
@@ -17,17 +17,13 @@ import (
 // true if the image pull secret exists and was copied successfully.
 func checkImagePullSecret(client client.Client, targetNamespace string) (bool, error) {
 	var targetSecret v1.Secret
-	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: targetNamespace, Name: constants.GlobalImagePullSecName}, &targetSecret); err != nil {
-		if errors.IsAlreadyExists(err) {
-			// Global secret exists and was already copied to the target namespace
-			return true, nil
-		}
-		if !errors.IsNotFound(err) {
-			// Unexpected error
-			return false, err
-		}
+	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: targetNamespace, Name: constants.GlobalImagePullSecName}, &targetSecret); err == nil {
+		return true, nil
+	} else if !errors.IsNotFound(err) {
+		// Unexpected error
+		return false, err
 	}
-	// check for global image pull secret in default ns
+	// Did not find the secret in the target ns, check for global image pull secret in default ns to copy
 	var secret v1.Secret
 	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: constants.GlobalImagePullSecName}, &secret); err != nil {
 		if errors.IsNotFound(err) {

--- a/platform-operator/controllers/verrazzano/component/image_pull_secret_test.go
+++ b/platform-operator/controllers/verrazzano/component/image_pull_secret_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package component
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestCopyPullSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the secret does not exist in the target namespace
+// THEN true is returned
+func TestCopyPullSecret(t *testing.T) {
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.True(t, copied)
+}
+
+// TestCopyGlobalPullSecretDoesNotExist tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the source secret does not exist in the default namespace
+// THEN false is returned
+func TestCopyGlobalPullSecretDoesNotExist(t *testing.T) {
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.False(t, copied)
+}
+
+// TestTargetPullSecretAlreadyExists tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the pull secret already exists in the target namespace
+// THEN true is returned
+func TestTargetPullSecretAlreadyExists(t *testing.T) {
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.True(t, copied)
+}
+
+// TestUnexpectedErrorGetTargetSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the target namespace check
+// THEN false and an error are returned
+func TestUnexpectedErrorGetTargetSecret(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+
+	// Expect a call to get an existing configmap, but return a NotFound error.
+	mock.EXPECT().
+		Get(gomock.Any(), name, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, _ client.ObjectKey, _ *corev1.Secret) error {
+			return fmt.Errorf("Unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestUnexpectedErrorOnCreate tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the create target secret operation
+// THEN false and an error are returned
+func TestUnexpectedErrorOnCreate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	defaultName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)
+		})
+	// Expect a call to get the default ns secret.
+	mock.EXPECT().
+		Get(gomock.Any(), defaultName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			secret.ObjectMeta.Namespace = defaultName.Namespace
+			secret.ObjectMeta.Name = defaultName.Name
+			secret.Type = "kubernetes.io/dockerconfigjson"
+			return nil
+		})
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, secret *corev1.Secret) error {
+			return fmt.Errorf("Unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestUnexpectedErrorGetSourceSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the get source secret operation
+// THEN false and an error are returned
+func TestUnexpectedErrorGetSourceSecret(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	defaultName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)
+		})
+	// Expect a call to get the default ns secret.
+	mock.EXPECT().
+		Get(gomock.Any(), defaultName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return fmt.Errorf("unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestAddImagePullSecretUnexpectedError tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN an unexpected error is returned from checkImagePullSecret
+// THEN an error is returned and the key/value pairs are unmodified
+func TestAddImagePullSecretUnexpectedError(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return fmt.Errorf("unexpected error")
+		})
+
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), mock, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.NotNil(t, err)
+	assert.Equal(t, kvs, retKVs)
+}
+
+// TestAddImagePullSecretTargetSecretAlreadyExists tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN the target secret already exists
+// THEN no error is returned and the target secret helm key/value pair have been added to the key/value list
+func TestAddImagePullSecretTargetSecretAlreadyExists(t *testing.T) {
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), client, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.Nil(t, err)
+	assert.Lenf(t, retKVs, 3, "Unexpected number of key/value pairs: %s", len(retKVs))
+	for _, kv := range retKVs {
+		assert.Containsf(t, []string{"key1", "key2", "helmKey"}, kv.key, "Did not have key %s", kv.key)
+		assert.Containsf(t, []string{"value1", "value2", constants.GlobalImagePullSecName}, kv.value, "Did not have value", kv.value)
+	}
+}
+
+// TestAddImagePullSecretTargetSecretCopied tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN the target secret is successfully copied
+// THEN no error is returned and the target secret helm key/value pair have been added to the key/value list
+func TestAddImagePullSecretTargetSecretCopied(t *testing.T) {
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), client, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.Nil(t, err)
+	assert.Lenf(t, retKVs, 3, "Unexpected number of key/value pairs: %s", len(retKVs))
+	for _, kv := range retKVs {
+		assert.Containsf(t, []string{"key1", "key2", "helmKey"}, kv.key, "Did not have key %s", kv.key)
+		assert.Containsf(t, []string{"value1", "value2", constants.GlobalImagePullSecName}, kv.value, "Did not have value", kv.value)
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/istio.go
+++ b/platform-operator/controllers/verrazzano/component/istio.go
@@ -4,7 +4,10 @@
 package component
 
 import (
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const istioGlobalHubKey = "global.hub"
@@ -37,4 +40,12 @@ func appendIstioOverrides(_ *zap.SugaredLogger, releaseName string, _ string, _ 
 	}
 
 	return kvs, nil
+}
+
+// istiodReadyCheck Determines if istiod is up and has a minimum number of available replicas
+func istiodReadyCheck(log *zap.SugaredLogger, client clipkg.Client, _ string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: "istiod", Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, client, deployments, 1)
 }

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -4,7 +4,10 @@
 package component
 
 import (
+	"fmt"
+	"go.uber.org/zap"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -32,6 +35,7 @@ func GetComponents() []Component {
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "istio-values.yaml"),
 			appendOverridesFunc:     appendIstioOverrides,
+			readyStatusFunc:         istiodReadyCheck,
 		},
 		helmComponent{
 			releaseName:             "istio-ingress",
@@ -114,6 +118,7 @@ func GetComponents() []Component {
 			valuesFile:              filepath.Join(overridesDir, "weblogic-values.yaml"),
 			preInstallFunc:          weblogicOperatorPreInstall,
 			appendOverridesFunc:     appendWeblogicOperatorOverrides,
+			dependencies:            []string{"istiod"},
 		},
 		helmComponent{
 			releaseName:             "oam-kubernetes-runtime",
@@ -152,4 +157,57 @@ func GetComponents() []Component {
 			appendOverridesFunc:     appendKeycloakOverrides,
 		},
 	}
+}
+
+func FindComponent(releaseName string) (bool, Component) {
+	for _, comp := range GetComponents() {
+		if comp.Name() == releaseName {
+			return true, comp
+		}
+	}
+	return false, &helmComponent{}
+}
+
+// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available
+func ComponentDependenciesMet(log *zap.SugaredLogger, client client.Client, c Component) bool {
+	trace, err := checkDependencies(log, client, c, nil)
+	if err != nil {
+		log.Error(err.Error())
+		return false
+	}
+	if trace == nil {
+		log.Infof("No dependencies declared for %s", c.Name())
+		return true
+	}
+	log.Infof("Trace results for %s: %v", c.Name(), trace)
+	for _, value := range trace {
+		if !value {
+			return false
+		}
+	}
+	return true
+}
+
+// checkDependencies Check the ready state of any dependencies and check for cycles
+func checkDependencies(log *zap.SugaredLogger, client client.Client, c Component, trace map[string]bool) (map[string]bool, error) {
+	for _, dependencyName := range c.GetDependencies() {
+		if trace == nil {
+			trace = make(map[string]bool)
+		}
+		if _, ok := trace[dependencyName]; ok {
+			return trace, fmt.Errorf("Illegal state, dependency cycle found for %s: %s", c.Name(), dependencyName)
+		}
+		found, dependency := FindComponent(dependencyName)
+		if !found {
+			return trace, fmt.Errorf("Illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
+		}
+		if trace, err := checkDependencies(log, client, dependency, trace); err != nil {
+			return trace, err
+		}
+		if !dependency.IsReady(log, client, dependencyName) {
+			trace[dependencyName] = false // dependency is not ready
+		}
+		trace[dependencyName] = true // dependency is ready
+	}
+	return trace, nil
 }

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -108,7 +108,12 @@ func GetComponents() []Component {
 			chartDir:                filepath.Join(thirdPartyChartsDir, "weblogic-operator"),
 			chartNamespace:          constants.VerrazzanoSystemNamespace,
 			ignoreNamespaceOverride: true,
+			supportsOperatorInstall: true,
+			waitForInstall:          true,
+			imagePullSecretKeyname:  "imagePullSecrets[0].name",
 			valuesFile:              filepath.Join(overridesDir, "weblogic-values.yaml"),
+			preInstallFunc:          weblogicOperatorPreInstall,
+			appendOverridesFunc:     appendWeblogicOperatorOverrides,
 		},
 		helmComponent{
 			releaseName:             "oam-kubernetes-runtime",

--- a/platform-operator/controllers/verrazzano/component/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic_operator.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package component
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// appendWeblogicOperatorOverrides appends the WKO-specific helm value overrides.
+func appendWeblogicOperatorOverrides(_ *zap.SugaredLogger, releaseName string, _ string, _ string, kvs []keyValue) ([]keyValue, error) {
+	keyValueOverrides := []keyValue{
+		{
+			key:   "serviceAccount",
+			value: "weblogic-operator-sa",
+		},
+		{
+			key:   "domainNamespaceSelectionStrategy",
+			value: "LabelSelector",
+		},
+		{
+			key:   "domainNamespaceLabelSelector",
+			value: "verrazzano-managed",
+		},
+		{
+			key:   "enableClusterRoleBinding",
+			value: "true",
+		},
+	}
+
+	kvs = append(kvs, keyValueOverrides...)
+
+	return kvs, nil
+}
+
+func weblogicOperatorPreInstall(log *zap.SugaredLogger, client clipkg.Client, _ string, namespace string, _ string) ([]keyValue, error) {
+	var serviceAccount corev1.ServiceAccount
+	const accountName = "weblogic-operator-sa"
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: accountName, Namespace: namespace}, &serviceAccount); err != nil {
+		if errors.IsAlreadyExists(err) {
+			// Service account already exists in the target namespace
+			return []keyValue{}, nil
+		}
+		if !errors.IsNotFound(err) {
+			// Unexpected error
+			return []keyValue{}, err
+		}
+	}
+	serviceAccount = corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      accountName,
+			Namespace: namespace,
+		},
+	}
+	if err := client.Create(context.TODO(), &serviceAccount); err != nil {
+		return []keyValue{}, err
+	}
+	return []keyValue{}, nil
+}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -60,6 +60,12 @@ const configDataKey = "spec"
 // initializedSet is needed to keep track of which Verrazzano CRs have been initialized
 var initializedSet = make(map[string]bool)
 
+// systemNamespaceLabels the verrazzano-system namespace labels required
+var systemNamespaceLabels = map[string]string{
+	"istio-injection":         "enabled",
+	"verrazzano.io/namespace": vzconst.VerrazzanoSystemNamespace,
+}
+
 // Set to true during unit testing
 var unitTesting bool
 
@@ -789,8 +795,7 @@ func (r *Reconciler) createVerrazzanoSystemNamespace(ctx context.Context, log *z
 			return err
 		}
 		vzSystemNS.Name = vzconst.VerrazzanoSystemNamespace
-		vzSystemNS.Labels = make(map[string]string)
-		vzSystemNS.Labels["istio-injection"] = "enabled"
+		vzSystemNS.Labels, _ = mergeMaps(nil, systemNamespaceLabels)
 		if err := r.Create(ctx, &vzSystemNS); err != nil {
 			return err
 		}
@@ -798,16 +803,31 @@ func (r *Reconciler) createVerrazzanoSystemNamespace(ctx context.Context, log *z
 		return nil
 	}
 	// Namespace exists, see if we need to add the label
-	if vzSystemNS.Labels == nil {
-		vzSystemNS.Labels = make(map[string]string)
+	var updated bool
+	vzSystemNS.Labels, updated = mergeMaps(vzSystemNS.Labels, systemNamespaceLabels)
+	if !updated {
+		return nil
 	}
-	if _, ok := vzSystemNS.Labels["istio-injection"]; !ok {
-		vzSystemNS.Labels["istio-injection"] = "enabled"
-		if err := r.Update(ctx, &vzSystemNS); err != nil {
-			return err
-		}
+	if err := r.Update(ctx, &vzSystemNS); err != nil {
+		return err
 	}
 	return nil
+}
+
+// mergeMaps Merge one map into another, creating new one if necessary; returns the updated map and true if it was modified
+func mergeMaps(to map[string]string, from map[string]string) (map[string]string, bool) {
+	mergedMap := to
+	if mergedMap == nil {
+		mergedMap = make(map[string]string)
+	}
+	var updated bool
+	for k, v := range from {
+		if _, ok := mergedMap[k]; !ok {
+			mergedMap[k] = v
+			updated = true
+		}
+	}
+	return mergedMap, updated
 }
 
 // containsString checks for a string in a slice of strings

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"testing"
 	"time"
 
@@ -185,7 +184,7 @@ func TestSuccessfulInstall(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
 			asserts.Len(verrazzano.Status.Conditions, 1)
 			return nil
-		}).Times(4)
+		}).Times(5)
 
 	// Expect a call to get the verrazzano resource.
 	mock.EXPECT().
@@ -194,19 +193,6 @@ func TestSuccessfulInstall(t *testing.T) {
 			ingressList.Items = []extv1beta1.Ingress{}
 			return nil
 		})
-
-	// Expect a call to restart the WKO deployment
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-system", Name: "weblogic-operator"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, dep *appsv1.Deployment) error {
-			dep.Name = "weblogic-operator"
-			dep.Namespace = "verrazzano-system"
-			return nil
-		}).Times(1)
-	mock.EXPECT().Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, _ *appsv1.Deployment, opts ...client.UpdateOption) error {
-			return nil
-		}).Times(1)
 
 	setupInstallInternalConfigMapExpectations(mock, name, namespace)
 
@@ -349,7 +335,7 @@ func TestCreateVerrazzano(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
 			asserts.Len(verrazzano.Status.Conditions, 1)
 			return nil
-		}).Times(4)
+		}).Times(5)
 
 	setupInstallInternalConfigMapExpectations(mock, name, namespace)
 
@@ -544,7 +530,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
 			asserts.Len(verrazzano.Status.Conditions, 1)
 			return nil
-		}).Times(4)
+		}).Times(5)
 
 	setupInstallInternalConfigMapExpectations(mock, name, namespace)
 
@@ -2051,6 +2037,8 @@ func expectGetVerrazzanoSystemNamespaceExists(mock *mocks.MockClient, asserts *a
 		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			ns.Name = constants.VerrazzanoSystemNamespace
+			ns.Labels = make(map[string]string)
+			ns.Labels["istio-injection"] = "enabled"
 			return nil
 		})
 }

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -2037,8 +2037,7 @@ func expectGetVerrazzanoSystemNamespaceExists(mock *mocks.MockClient, asserts *a
 		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoSystemNamespace}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			ns.Name = constants.VerrazzanoSystemNamespace
-			ns.Labels = make(map[string]string)
-			ns.Labels["istio-injection"] = "enabled"
+			ns.Labels = systemNamespaceLabels
 			return nil
 		})
 }
@@ -2366,6 +2365,119 @@ func Test_addFluentdExtraVolumeMounts(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMergeMapsNilSourceMap tests mergeMaps function
+// GIVEN an empty source map and a non-empty map to merge
+// WHEN the mergeMaps function is called
+// THEN true is returned and a new map with the merged values is created
+func TestMergeMapsNilSourceMap(t *testing.T) {
+	var mymap map[string]string
+	systemNamespaceLabels := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+	newMap, updated := mergeMaps(mymap, systemNamespaceLabels)
+	t.Logf("Merged map: %v", newMap)
+	assert.True(t, updated)
+	assert.Equal(t, systemNamespaceLabels, newMap)
+}
+
+// TestMergeNestedEmptyMap tests mergeMaps function
+// GIVEN an empty source map nested in a struct and a non-empty map to merge
+// WHEN the mergeMaps function is called
+// THEN true is returned and a new map with the merged values is created
+func TestMergeNestedEmptyMap(t *testing.T) {
+	type mytype struct {
+		MyMap map[string]string
+	}
+	systemNamespaceLabels := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+	var updated bool
+	myInstance := mytype{}
+	myInstance.MyMap, updated = mergeMaps(myInstance.MyMap, systemNamespaceLabels)
+	t.Logf("Merged map: %v", myInstance.MyMap)
+	assert.True(t, updated)
+	assert.Equal(t, systemNamespaceLabels, myInstance.MyMap)
+}
+
+// TestMergeNestedMapEntriesExist tests mergeMaps function
+// GIVEN an two maps are merged with the same values
+// WHEN the mergeMaps function is called
+// THEN false is returned the map is unchanged
+func TestMergeNestedMapEntriesExist(t *testing.T) {
+	type mytype struct {
+		MyMap map[string]string
+	}
+	systemNamespaceLabels := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+	var updated bool
+	myInstance := mytype{}
+	myInstance.MyMap = map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+
+	myInstance.MyMap, updated = mergeMaps(myInstance.MyMap, systemNamespaceLabels)
+	assert.False(t, updated)
+	assert.Equal(t, systemNamespaceLabels, myInstance.MyMap)
+}
+
+// TestPartialMergeNestedMap tests mergeMaps function
+// GIVEN source map contains a subset of the map to merge
+// WHEN the mergeMaps function is called
+// THEN true is returned the new map has all expected values
+func TestPartialMergeNestedMap(t *testing.T) {
+	type mytype struct {
+		MyMap map[string]string
+	}
+	systemNamespaceLabels := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+	var updated bool
+	myInstance := mytype{}
+	myInstance.MyMap = map[string]string {
+		"istio-injection": "enabled",
+	}
+
+	myInstance.MyMap, updated = mergeMaps(myInstance.MyMap, systemNamespaceLabels)
+	assert.True(t, updated)
+	assert.Equal(t, systemNamespaceLabels, myInstance.MyMap)
+}
+
+// TestNonIntersectingMergeNestedMap tests mergeMaps function
+// GIVEN source map and map to merge contain non-intersecting values
+// WHEN the mergeMaps function is called
+// THEN true is returned the new map is a union of all values
+func TestNonIntersectingMergeNestedMap(t *testing.T) {
+	type mytype struct {
+		MyMap map[string]string
+	}
+	systemNamespaceLabels := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+	}
+	var updated bool
+	myInstance := mytype{}
+	myInstance.MyMap = map[string]string {
+		"mylabel": "someValue",
+	}
+
+	expectedMap := map[string]string {
+		"istio-injection": "enabled",
+		"verrazzano.io/namespace": constants.VerrazzanoSystemNamespace,
+		"mylabel": "someValue",
+	}
+
+	myInstance.MyMap, updated = mergeMaps(myInstance.MyMap, systemNamespaceLabels)
+	assert.True(t, updated)
+	assert.Len(t, myInstance.MyMap, 3)
+	assert.Equal(t, expectedMap, myInstance.MyMap)
 }
 
 func collectVolumeMounts(vz *vzapi.Verrazzano) []string {

--- a/platform-operator/internal/helm/helmcli.go
+++ b/platform-operator/internal/helm/helmcli.go
@@ -105,7 +105,7 @@ func Uninstall(log *zap.SugaredLogger, releaseName string, namespace string, wai
 	// overrides that we used during the install.
 	args := []string{}
 
-	stdout, stderr, err = runHelm(log, releaseName, namespace, "", "uninstall", false, args, dryRun)
+	stdout, stderr, err = runHelm(log, releaseName, namespace, "", "uninstall", true, args, dryRun)
 	if err != nil {
 		return stdout, stderr, err
 	}

--- a/platform-operator/internal/helm/helmcli.go
+++ b/platform-operator/internal/helm/helmcli.go
@@ -105,7 +105,7 @@ func Uninstall(log *zap.SugaredLogger, releaseName string, namespace string, wai
 	// overrides that we used during the install.
 	args := []string{}
 
-	stdout, stderr, err = runHelm(log, releaseName, namespace, "", "uninstall", true, args, dryRun)
+	stdout, stderr, err = runHelm(log, releaseName, namespace, "", "uninstall", false, args, dryRun)
 	if err != nil {
 		return stdout, stderr, err
 	}

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package status
+
+import (
+	"context"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeploymentsReady Check that the named deployments have the minimum number of specified replicas ready and available
+func DeploymentsReady(log *zap.SugaredLogger, client clipkg.Client, deployments []types.NamespacedName, expectedReplicas int32) bool {
+	for _, namespacedName := range deployments {
+		deployment := appsv1.Deployment{}
+		if err := client.Get(context.TODO(), namespacedName, &deployment); err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("%v deployment not found", namespacedName)
+				// Deployment not found
+				return false
+			}
+			log.Errorf("Unexpected error checking %v status: %v", namespacedName, err)
+			return false
+		}
+		if deployment.Status.AvailableReplicas < expectedReplicas {
+			log.Infof("Not enough available replicas for the %v deployment yet", namespacedName)
+			return false
+		}
+	}
+	return true
+}

--- a/platform-operator/internal/k8s/status/deployment_ready_test.go
+++ b/platform-operator/internal/k8s/status/deployment_ready_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestDeploymentsReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object has a minimum of desired available replicas
+// THEN true is returned
+func TestDeploymentsReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleReplicasReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has met the minimum of desired available replicas > 1
+// THEN true is returned
+func TestMultipleReplicasReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       3,
+			AvailableReplicas:   3,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 3))
+}
+
+// TestMultipleReplicasReadyAboveThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has more than the minimum desired replicas available
+// THEN true is returned
+func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       3,
+			AvailableReplicas:   3,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 2))
+}
+
+// TestDeploymentsNotAvailableOrReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object does not have a minimium number of desired available replicas
+// THEN false is returned
+func TestDeploymentsNotAvailableOrReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleReplicasReadyBelowThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has less than the minimum desired replicas available
+// THEN false is returned
+func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 2,
+		},
+	})
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 2))
+}
+
+// TestDeploymentsReadyDeploymentNotFound tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object is not found
+// THEN false is returned
+func TestDeploymentsReadyDeploymentNotFound(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleDeploymentsReplicasReadyBelowThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica for multiple deployments
+// WHEN the one of the target Deployment objects has less than the minimum desired replicas available
+// THEN false is returned
+func TestMultipleDeploymentsReplicasReadyBelowThreshold(t *testing.T) {
+	name1 := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	name2 := types.NamespacedName{Name: "thud", Namespace: "bar"}
+	name3 := types.NamespacedName{Name: "thud", Namespace: "thwack"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name1.Namespace,
+				Name:      name1.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name2.Namespace,
+				Name:      name2.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       1,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 2,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name3.Namespace,
+				Name:      name3.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+	)
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name1, name2, name3}, 2))
+}
+
+// TestMultipleDeploymentsReplicasReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica for multiple deployments
+// WHEN the all of the target Deployment objects meet the minimum desired replicas available threshold
+// THEN true is returned
+func TestMultipleDeploymentsReplicasReady(t *testing.T) {
+	name1 := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	name2 := types.NamespacedName{Name: "thud", Namespace: "bar"}
+	name3 := types.NamespacedName{Name: "thud", Namespace: "thwack"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name1.Namespace,
+				Name:      name1.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name2.Namespace,
+				Name:      name2.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name3.Namespace,
+				Name:      name3.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+	)
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name1, name2, name3}, 2))
+}

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -326,6 +326,6 @@ fi
 
 action "Installing Verrazzano system components" install_verrazzano || exit 1
 platform_operator_install_message "Coherence Kubernetes operator"
-action "Installing WebLogic Kubernetes operator" install_weblogic_operator || exit 1
+platform_operator_install_message "WebLogic Kubernetes operator"
 platform_operator_install_message "OAM Kubernetes operator"
 platform_operator_install_message "Verrazzano Application Kubernetes operator"


### PR DESCRIPTION
# Description

Move the WKO install to the platform operator.
- Added hooks for pre-install fn for a `helmComponent`, and added a WKO impl to set up the pre-reqs for that service
- Added the ability to declare dependencies between components in the registry, and validate that those dependencies are `Ready` before allowing install
- Declared dependency on Istio from WKO, and added Istio ready check fn
- Added/updated the unit tests

Fixes VZ-3240.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
