### PR TITLE
Add a label to provide an incremental build number with trailing zeroes, to the metrics from CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -825,18 +825,22 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    statusLabel = "F"
-    echo "Status $status"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
+    echo "Status $status Status"
+    echo "StatusLabel $statusLabel StatusLabel"
     if (status.equals("SUCCESS")) {
+        echo "I am here inside SUCCESS"
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        echo "I am here inside FAILURE"
+        metricValue = "0"
+    } else {
+        echo "I am here in else"
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -798,7 +798,9 @@ def metricTimerStart(metricName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\"'
     return labels

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -798,8 +798,7 @@ def metricTimerStart(metricName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\"'
     return labels
@@ -831,7 +830,8 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
-    def statusLabel = "F"
+    statusLabel = "F"
+    echo "Status $status"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
         statusLabel = "S"
@@ -842,6 +842,7 @@ def metricBuildDuration() {
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
         labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
+        echo "Labels $labels"
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.GIT_BRANCH} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -800,7 +800,7 @@ def metricTimerStart(metricName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\"'
     return labels

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -831,22 +831,17 @@ def metricBuildDuration() {
     testMetric = metricJobName('')
     def metricValue = "-1"
     statusLabel = status.substring(0,1)
-    echo "Status $status Status"
-    echo "StatusLabel $statusLabel StatusLabel"
     if (status.equals("SUCCESS")) {
-        echo "I am here inside SUCCESS"
         metricValue = "1"
     } else if (status.equals("FAILURE")) {
-        echo "I am here inside FAILURE"
         metricValue = "0"
     } else {
-        echo "I am here in else"
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
         labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
-        echo "Labels $labels"
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.GIT_BRANCH} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -687,6 +687,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +
@@ -725,14 +726,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -686,8 +686,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +
@@ -721,17 +720,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -688,7 +688,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -686,7 +686,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -568,7 +568,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -567,6 +567,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -605,14 +606,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels =  getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -566,8 +566,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -601,17 +600,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -566,7 +566,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1169,7 +1169,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + kube_ver + '\\",' +

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1167,8 +1167,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + kube_ver + '\\",' +

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1168,8 +1168,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + kube_ver + '\\",' +
@@ -1204,17 +1203,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1167,6 +1167,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
+    def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
              'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1169,6 +1169,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + kube_ver + '\\",' +
@@ -1208,14 +1209,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -849,8 +849,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -891,17 +890,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -849,7 +849,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -850,6 +850,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -895,14 +896,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -851,7 +851,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -672,7 +672,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -670,8 +670,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -705,17 +704,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -670,7 +670,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -671,6 +671,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.OKE_CLUSTER_VERSION}"+'\\",' +
@@ -709,14 +710,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -517,7 +517,7 @@ def metricJobName(stageName) {
 def getMetricLabels() {
     def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
     labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -516,6 +516,7 @@ def metricJobName(stageName) {
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
     labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +
@@ -554,14 +555,17 @@ def metricBuildDuration() {
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
     def metricValue = "0"
+    def statusLabel = "F"
     if (status.equals("SUCCESS")) {
         metricValue = "1"
+        statusLabel = "S"
     } else if (status.equals("ABORTED")) {
         metricValue = "-1"
+        statusLabel = "A"
     }
     if (params.EMIT_METRICS) {
         labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${status}"+'\\"'
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -515,8 +515,7 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +
@@ -550,17 +549,18 @@ def metricTimerEnd(metricName, status) {
 
 // Emit the metrics indicating the duration and result of the build
 def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}"
+    def status = "${currentBuild.currentResult}".trim()
     long duration = "${currentBuild.duration}" as long;
     long durationInSec = (duration/1000)
     testMetric = metricJobName('')
-    def metricValue = "0"
-    def statusLabel = "F"
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
     if (status.equals("SUCCESS")) {
         metricValue = "1"
-        statusLabel = "S"
-    } else if (status.equals("ABORTED")) {
-        metricValue = "-1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
         statusLabel = "A"
     }
     if (params.EMIT_METRICS) {

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -515,7 +515,9 @@ def metricJobName(stageName) {
 
 // Construct the set of labels/dimensions for the metrics
 def getMetricLabels() {
-    labels = 'build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
              'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
              'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
              'kubernetes_version=\\"' + "${params.KUBERNETES_CLUSTER_VERSION}"+'\\",' +


### PR DESCRIPTION
Renamed label "number" to "jenkins_build_number" in metrics published from CI pipeline. Also added a new label build_number, to get the metrics in the order in which they are published (that is also order by the label indicating the build number). Without this change, when the X-axis displays the metrics in Series mode in a Grafana panel, the data will be sorted based on the Git commit id. This is nothing but the order in which the Prometheus query returns the result, sorts by the label in the order. With the introduction of the new label "build_number" (which comes before label commit_sha), the result of the prometheus query will be sorted in the order of build number.

The value for the label indicating the status is changed to the first character of the ${currentBuild.currentResult} so that the same can be displayed in legends without consuming too much space, which is required to select a particular color for the metrics based on the status of the build.

Contributes to VZ-3054

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
