### PR TITLE
VZ-3420. Move WKO install to platform operator.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/component.go
+++ b/platform-operator/controllers/verrazzano/component/component.go
@@ -24,5 +24,11 @@ type Component interface {
 	IsOperatorInstallSupported() bool
 
 	// IsInstalled Indicates whether or not the component is installed
-	IsInstalled() bool
+	IsInstalled(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool
+
+	// IsReady Indicates whether or not a component is available and ready
+	IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool
+
+	// GetDependencies returns the dependencies of this component
+	GetDependencies() []string
 }

--- a/platform-operator/controllers/verrazzano/component/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm_component.go
@@ -143,7 +143,7 @@ func (h helmComponent) Install(log *zap.SugaredLogger, client clipkg.Client, nam
 		// NOTE: we'll likely have to put in some more logic akin to what we do for the scripts, see
 		//       reset_chart() in the common.sh script.  Recovering chart state can be a bit difficult, we
 		//       may need to draw on both the 'ls' and 'status' output for that.
-		helm.Uninstall(log, h.releaseName, resolvedNamespace, h.waitForInstall, dryRun)
+		helm.Uninstall(log, h.releaseName, resolvedNamespace, dryRun)
 	}
 
 	var kvs []keyValue

--- a/platform-operator/controllers/verrazzano/component/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm_component.go
@@ -146,14 +146,15 @@ func (h helmComponent) Install(log *zap.SugaredLogger, client clipkg.Client, nam
 		helm.Uninstall(log, h.releaseName, resolvedNamespace, h.waitForInstall, dryRun)
 	}
 
+	var kvs []keyValue
 	if h.preInstallFunc != nil {
-		_, err := h.preInstallFunc(log, client, h.releaseName, resolvedNamespace, h.chartDir)
+		preInstallValues, err := h.preInstallFunc(log, client, h.releaseName, resolvedNamespace, h.chartDir)
 		if err != nil {
 			return err
 		}
+		kvs = append(kvs, preInstallValues...)
 	}
 	// check for global image pull secret
-	var kvs []keyValue
 	kvs, err = addGlobalImagePullSecretHelmOverride(log, client, resolvedNamespace, kvs, h.imagePullSecretKeyname)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/image_pull_secret.go
+++ b/platform-operator/controllers/verrazzano/component/image_pull_secret.go
@@ -17,17 +17,13 @@ import (
 // true if the image pull secret exists and was copied successfully.
 func checkImagePullSecret(client client.Client, targetNamespace string) (bool, error) {
 	var targetSecret v1.Secret
-	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: targetNamespace, Name: constants.GlobalImagePullSecName}, &targetSecret); err != nil {
-		if errors.IsAlreadyExists(err) {
-			// Global secret exists and was already copied to the target namespace
-			return true, nil
-		}
-		if !errors.IsNotFound(err) {
-			// Unexpected error
-			return false, err
-		}
+	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: targetNamespace, Name: constants.GlobalImagePullSecName}, &targetSecret); err == nil {
+		return true, nil
+	} else if !errors.IsNotFound(err) {
+		// Unexpected error
+		return false, err
 	}
-	// check for global image pull secret in default ns
+	// Did not find the secret in the target ns, check for global image pull secret in default ns to copy
 	var secret v1.Secret
 	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: constants.GlobalImagePullSecName}, &secret); err != nil {
 		if errors.IsNotFound(err) {

--- a/platform-operator/controllers/verrazzano/component/image_pull_secret_test.go
+++ b/platform-operator/controllers/verrazzano/component/image_pull_secret_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package component
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestCopyPullSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the secret does not exist in the target namespace
+// THEN true is returned
+func TestCopyPullSecret(t *testing.T) {
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.True(t, copied)
+}
+
+// TestCopyGlobalPullSecretDoesNotExist tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the source secret does not exist in the default namespace
+// THEN false is returned
+func TestCopyGlobalPullSecretDoesNotExist(t *testing.T) {
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.False(t, copied)
+}
+
+// TestTargetPullSecretAlreadyExists tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN the pull secret already exists in the target namespace
+// THEN true is returned
+func TestTargetPullSecretAlreadyExists(t *testing.T) {
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	copied, err := checkImagePullSecret(client, constants.VerrazzanoSystemNamespace)
+	assert.NoError(t, err)
+	assert.True(t, copied)
+}
+
+// TestUnexpectedErrorGetTargetSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the target namespace check
+// THEN false and an error are returned
+func TestUnexpectedErrorGetTargetSecret(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+
+	// Expect a call to get an existing configmap, but return a NotFound error.
+	mock.EXPECT().
+		Get(gomock.Any(), name, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, _ client.ObjectKey, _ *corev1.Secret) error {
+			return fmt.Errorf("Unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestUnexpectedErrorOnCreate tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the create target secret operation
+// THEN false and an error are returned
+func TestUnexpectedErrorOnCreate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	defaultName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)
+		})
+	// Expect a call to get the default ns secret.
+	mock.EXPECT().
+		Get(gomock.Any(), defaultName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			secret.ObjectMeta.Namespace = defaultName.Namespace
+			secret.ObjectMeta.Name = defaultName.Name
+			secret.Type = "kubernetes.io/dockerconfigjson"
+			return nil
+		})
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, secret *corev1.Secret) error {
+			return fmt.Errorf("Unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestUnexpectedErrorGetSourceSecret tests a deployment ready status check
+// GIVEN a call to checkImagePullSecret
+// WHEN an unexpected error is returned on the get source secret operation
+// THEN false and an error are returned
+func TestUnexpectedErrorGetSourceSecret(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	defaultName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)
+		})
+	// Expect a call to get the default ns secret.
+	mock.EXPECT().
+		Get(gomock.Any(), defaultName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return fmt.Errorf("unexpected error")
+		})
+	copied, err := checkImagePullSecret(mock, constants.VerrazzanoSystemNamespace)
+	assert.NotNil(t, err)
+	assert.False(t, copied)
+}
+
+// TestAddImagePullSecretUnexpectedError tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN an unexpected error is returned from checkImagePullSecret
+// THEN an error is returned and the key/value pairs are unmodified
+func TestAddImagePullSecretUnexpectedError(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+
+	// Expect a call to get the target ns secret first, return not found
+	mock.EXPECT().
+		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
+			return fmt.Errorf("unexpected error")
+		})
+
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), mock, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.NotNil(t, err)
+	assert.Equal(t, kvs, retKVs)
+}
+
+// TestAddImagePullSecretTargetSecretAlreadyExists tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN the target secret already exists
+// THEN no error is returned and the target secret helm key/value pair have been added to the key/value list
+func TestAddImagePullSecretTargetSecretAlreadyExists(t *testing.T) {
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), client, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.Nil(t, err)
+	assert.Lenf(t, retKVs, 3, "Unexpected number of key/value pairs: %s", len(retKVs))
+	for _, kv := range retKVs {
+		assert.Containsf(t, []string{"key1", "key2", "helmKey"}, kv.key, "Did not have key %s", kv.key)
+		assert.Containsf(t, []string{"value1", "value2", constants.GlobalImagePullSecName}, kv.value, "Did not have value", kv.value)
+	}
+}
+
+// TestAddImagePullSecretTargetSecretCopied tests a deployment ready status check
+// GIVEN a call to addGlobalImagePullSecretHelmOverride
+// WHEN the target secret is successfully copied
+// THEN no error is returned and the target secret helm key/value pair have been added to the key/value list
+func TestAddImagePullSecretTargetSecretCopied(t *testing.T) {
+
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+	},
+	)
+	kvs := []keyValue{
+		{key: "key1", value: "value1"},
+		{key: "key2", value: "value2"},
+	}
+	retKVs, err := addGlobalImagePullSecretHelmOverride(zap.S(), client, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
+	assert.Nil(t, err)
+	assert.Lenf(t, retKVs, 3, "Unexpected number of key/value pairs: %s", len(retKVs))
+	for _, kv := range retKVs {
+		assert.Containsf(t, []string{"key1", "key2", "helmKey"}, kv.key, "Did not have key %s", kv.key)
+		assert.Containsf(t, []string{"value1", "value2", constants.GlobalImagePullSecName}, kv.value, "Did not have value", kv.value)
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/istio.go
+++ b/platform-operator/controllers/verrazzano/component/istio.go
@@ -4,7 +4,10 @@
 package component
 
 import (
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const istioGlobalHubKey = "global.hub"
@@ -37,4 +40,12 @@ func appendIstioOverrides(_ *zap.SugaredLogger, releaseName string, _ string, _ 
 	}
 
 	return kvs, nil
+}
+
+// istiodReadyCheck Determines if istiod is up and has a minimum number of available replicas
+func istiodReadyCheck(log *zap.SugaredLogger, client clipkg.Client, _ string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: "istiod", Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, client, deployments, 1)
 }

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -4,7 +4,10 @@
 package component
 
 import (
+	"fmt"
+	"go.uber.org/zap"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -32,6 +35,7 @@ func GetComponents() []Component {
 			ignoreNamespaceOverride: true,
 			valuesFile:              filepath.Join(overridesDir, "istio-values.yaml"),
 			appendOverridesFunc:     appendIstioOverrides,
+			readyStatusFunc:         istiodReadyCheck,
 		},
 		helmComponent{
 			releaseName:             "istio-ingress",
@@ -108,7 +112,13 @@ func GetComponents() []Component {
 			chartDir:                filepath.Join(thirdPartyChartsDir, "weblogic-operator"),
 			chartNamespace:          constants.VerrazzanoSystemNamespace,
 			ignoreNamespaceOverride: true,
+			supportsOperatorInstall: true,
+			waitForInstall:          true,
+			imagePullSecretKeyname:  "imagePullSecrets[0].name",
 			valuesFile:              filepath.Join(overridesDir, "weblogic-values.yaml"),
+			preInstallFunc:          weblogicOperatorPreInstall,
+			appendOverridesFunc:     appendWeblogicOperatorOverrides,
+			dependencies:            []string{"istiod"},
 		},
 		helmComponent{
 			releaseName:             "oam-kubernetes-runtime",
@@ -147,4 +157,57 @@ func GetComponents() []Component {
 			appendOverridesFunc:     appendKeycloakOverrides,
 		},
 	}
+}
+
+func FindComponent(releaseName string) (bool, Component) {
+	for _, comp := range GetComponents() {
+		if comp.Name() == releaseName {
+			return true, comp
+		}
+	}
+	return false, &helmComponent{}
+}
+
+// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available
+func ComponentDependenciesMet(log *zap.SugaredLogger, client client.Client, c Component) bool {
+	trace, err := checkDependencies(log, client, c, nil)
+	if err != nil {
+		log.Error(err.Error())
+		return false
+	}
+	if trace == nil {
+		log.Infof("No dependencies declared for %s", c.Name())
+		return true
+	}
+	log.Infof("Trace results for %s: %v", c.Name(), trace)
+	for _, value := range trace {
+		if !value {
+			return false
+		}
+	}
+	return true
+}
+
+// checkDependencies Check the ready state of any dependencies and check for cycles
+func checkDependencies(log *zap.SugaredLogger, client client.Client, c Component, trace map[string]bool) (map[string]bool, error) {
+	for _, dependencyName := range c.GetDependencies() {
+		if trace == nil {
+			trace = make(map[string]bool)
+		}
+		if _, ok := trace[dependencyName]; ok {
+			return trace, fmt.Errorf("Illegal state, dependency cycle found for %s: %s", c.Name(), dependencyName)
+		}
+		found, dependency := FindComponent(dependencyName)
+		if !found {
+			return trace, fmt.Errorf("Illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
+		}
+		if trace, err := checkDependencies(log, client, dependency, trace); err != nil {
+			return trace, err
+		}
+		if !dependency.IsReady(log, client, dependencyName) {
+			trace[dependencyName] = false // dependency is not ready
+		}
+		trace[dependencyName] = true // dependency is ready
+	}
+	return trace, nil
 }

--- a/platform-operator/controllers/verrazzano/component/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry.go
@@ -175,7 +175,7 @@ func ComponentDependenciesMet(log *zap.SugaredLogger, client client.Client, c Co
 		log.Error(err.Error())
 		return false
 	}
-	if trace == nil {
+	if len(trace) == 0 {
 		log.Infof("No dependencies declared for %s", c.Name())
 		return true
 	}
@@ -206,6 +206,7 @@ func checkDependencies(log *zap.SugaredLogger, client client.Client, c Component
 		}
 		if !dependency.IsReady(log, client, dependencyName) {
 			trace[dependencyName] = false // dependency is not ready
+			continue
 		}
 		trace[dependencyName] = true // dependency is ready
 	}

--- a/platform-operator/controllers/verrazzano/component/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry_test.go
@@ -4,6 +4,12 @@
 package component
 
 import (
+	"github.com/verrazzano/verrazzano/platform-operator/internal/helm"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,4 +40,222 @@ func TestGetComponents(t *testing.T) {
 	assert.Equal(comps[13].Name(), "verrazzano-application-operator")
 	assert.Equal(comps[14].Name(), "mysql")
 	assert.Equal(comps[15].Name(), "keycloak")
+}
+
+// TestFindComponent tests FindComponent
+// GIVEN a component
+//  WHEN I call FindComponent
+//  THEN the true and the component are returned, false and an empty comp otherwise
+func TestFindComponent(t *testing.T) {
+	found, comp := FindComponent("istiod")
+	assert.True(t, found)
+	assert.NotNil(t, comp)
+	assert.Equal(t, "istiod", comp.Name())
+}
+
+// TestComponentDependenciesMet tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN the true is returned if all depdencies are met
+func TestComponentDependenciesMet(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "istio-system",
+			Name:      "istiod",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.True(t, ready)
+}
+
+// TestComponentDependenciesNotMet tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN the false is returned if any depdencies are not met
+func TestComponentDependenciesNotMet(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "istio-system",
+			Name:      "istiod",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 1,
+		},
+	})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.False(t, ready)
+}
+
+// TestComponentDependenciesDependencyChartNotInstalled tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN the false is returned if the dependent chart isn't installed
+func TestComponentDependenciesDependencyChartNotInstalled(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	//	ObjectMeta: metav1.ObjectMeta{
+	//		Namespace: "istio-system",
+	//		Name:      "istiod",
+	//	},
+	//	Status: appsv1.DeploymentStatus{
+	//		Replicas:            1,
+	//		ReadyReplicas:       0,
+	//		AvailableReplicas:   0,
+	//		UnavailableReplicas: 1,
+	//	},
+	//})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusPendingInstall, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.False(t, ready)
+}
+
+// TestComponentMultipleDependenciesPartiallyMet tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN the false is returned if any depdencies are not met
+func TestComponentMultipleDependenciesPartiallyMet(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod", "cert-manager"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "istio-system",
+			Name:      "istiod",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 1,
+		},
+	})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.False(t, ready)
+}
+
+// TestComponentMultipleDependenciesMet tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN the true is returned if all depdencies are met
+func TestComponentMultipleDependenciesMet(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod", "cert-manager"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "istio-system",
+			Name:      "istiod",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.True(t, ready)
+}
+
+// TestComponentDependenciesCycle tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN it returns false if there's a cycle in the dependencies
+func TestComponentDependenciesCycle(t *testing.T) {
+	comp := helmComponent{
+		releaseName:     "foo",
+		chartDir:        "chartDir",
+		chartNamespace:  "bar",
+		readyStatusFunc: nil,
+		dependencies:    []string{"istiod", "cert-manager", "istiod"},
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "istio-system",
+			Name:      "istiod",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.False(t, ready)
+}
+
+// TestNoComponentDependencies tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN it returns true if there are no dependencies
+func TestNoComponentDependencies(t *testing.T) {
+	comp := helmComponent{
+		releaseName:    "foo",
+		chartDir:       "chartDir",
+		chartNamespace: "bar",
+	}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	assert.True(t, ready)
 }

--- a/platform-operator/controllers/verrazzano/component/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic_operator.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package component
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// appendWeblogicOperatorOverrides appends the WKO-specific helm value overrides.
+func appendWeblogicOperatorOverrides(_ *zap.SugaredLogger, releaseName string, _ string, _ string, kvs []keyValue) ([]keyValue, error) {
+	keyValueOverrides := []keyValue{
+		{
+			key:   "serviceAccount",
+			value: "weblogic-operator-sa",
+		},
+		{
+			key:   "domainNamespaceSelectionStrategy",
+			value: "LabelSelector",
+		},
+		{
+			key:   "domainNamespaceLabelSelector",
+			value: "verrazzano-managed",
+		},
+		{
+			key:   "enableClusterRoleBinding",
+			value: "true",
+		},
+	}
+
+	kvs = append(kvs, keyValueOverrides...)
+
+	return kvs, nil
+}
+
+func weblogicOperatorPreInstall(log *zap.SugaredLogger, client clipkg.Client, _ string, namespace string, _ string) ([]keyValue, error) {
+	var serviceAccount corev1.ServiceAccount
+	const accountName = "weblogic-operator-sa"
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: accountName, Namespace: namespace}, &serviceAccount); err != nil {
+		if errors.IsAlreadyExists(err) {
+			// Service account already exists in the target namespace
+			return []keyValue{}, nil
+		}
+		if !errors.IsNotFound(err) {
+			// Unexpected error
+			return []keyValue{}, err
+		}
+	}
+	serviceAccount = corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      accountName,
+			Namespace: namespace,
+		},
+	}
+	if err := client.Create(context.TODO(), &serviceAccount); err != nil {
+		return []keyValue{}, err
+	}
+	return []keyValue{}, nil
+}

--- a/platform-operator/controllers/verrazzano/component/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic_operator.go
@@ -15,7 +15,7 @@ import (
 )
 
 // appendWeblogicOperatorOverrides appends the WKO-specific helm value overrides.
-func appendWeblogicOperatorOverrides(_ *zap.SugaredLogger, releaseName string, _ string, _ string, kvs []keyValue) ([]keyValue, error) {
+func appendWeblogicOperatorOverrides(_ *zap.SugaredLogger, _ string, _ string, _ string, kvs []keyValue) ([]keyValue, error) {
 	keyValueOverrides := []keyValue{
 		{
 			key:   "serviceAccount",

--- a/platform-operator/controllers/verrazzano/component/weblogic_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic_operator_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package component
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+// Test_appendWeblogicOperatorOverridesExtraKVs tests the appendWeblogicOperatorOverrides fn
+// GIVEN a call to appendWeblogicOperatorOverrides
+//  WHEN I call with no extra kvs
+//  THEN the correct number of keyValue objects are returned and no errors occur
+func Test_appendWeblogicOperatorOverrides(t *testing.T) {
+	kvs, err := appendWeblogicOperatorOverrides(zap.S(), "weblogic-operator", "verrazzano-system", "", []keyValue{})
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 4)
+}
+
+// Test_appendWeblogicOperatorOverridesExtraKVs tests the appendWeblogicOperatorOverrides fn
+// GIVEN a call to appendWeblogicOperatorOverrides
+//  WHEN I pass in a keyValue list
+//  THEN the values passed in are preserved and no errors occur
+func Test_appendWeblogicOperatorOverridesExtraKVs(t *testing.T) {
+	kvs := []keyValue{
+		{key: "key", value: "value"},
+	}
+	var err error
+	kvs, err = appendWeblogicOperatorOverrides(zap.S(), "weblogic-operator", "verrazzano-system", "", kvs)
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 5)
+}
+
+// Test_weblogicOperatorPreInstall tests the weblogicOperatorPreInstall fn
+// GIVEN a call to this fn
+//  WHEN I call weblogicOperatorPreInstall
+//  THEN no errors are returned
+func Test_weblogicOperatorPreInstall(t *testing.T) {
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	kvs, err := weblogicOperatorPreInstall(zap.S(), client, "weblogic-operator", "verrazzano-system", "")
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 0)
+}

--- a/platform-operator/internal/helm/helmcli.go
+++ b/platform-operator/internal/helm/helmcli.go
@@ -26,23 +26,29 @@ type ChartStatusFnType func(releaseName string, namespace string) (string, error
 
 var chartStatusFn ChartStatusFnType = getChartStatus
 
+// SetChartStatusFunction Override the chart status function for unit testing
 func SetChartStatusFunction(f ChartStatusFnType) {
 	chartStatusFn = f
 }
+
+// SetDefaultChartStatusFunction Reset the chart status function
 func SetDefaultChartStatusFunction() {
 	chartStatusFn = getChartStatus
 }
 
 // Package-level var and functions to allow overriding getReleaseState for unit test purposes
-type ReleaseStateFnType func(releaseName string, namespace string) (string, error)
+type releaseStateFnType func(releaseName string, namespace string) (string, error)
 
-var ReleaseStateFn ReleaseStateFnType = getReleaseState
+var releaseStateFn releaseStateFnType = getReleaseState
 
-func SetChartStateFunction(f ReleaseStateFnType) {
-	ReleaseStateFn = f
+// SetChartStateFunction Override the chart state function for unit testing
+func SetChartStateFunction(f releaseStateFnType) {
+	releaseStateFn = f
 }
+
+// SetDefaultChartStateFunction Reset the chart state function
 func SetDefaultChartStateFunction() {
-	ReleaseStateFn = getChartStatus
+	releaseStateFn = getChartStatus
 }
 
 // GetValues will run 'helm get values' command and return the output from the command.
@@ -157,7 +163,7 @@ func runHelm(log *zap.SugaredLogger, releaseName string, namespace string, chart
 // IsReleaseFailed Returns true if the chart release state is marked 'failed'
 func IsReleaseFailed(releaseName string, namespace string) (bool, error) {
 	log := zap.S()
-	releaseStatus, err := getReleaseState(releaseName, namespace)
+	releaseStatus, err := releaseStateFn(releaseName, namespace)
 	if err != nil {
 		log.Errorf("Getting status for chart %s/%s failed with stderr: %v\n", namespace, releaseName, err)
 		return false, err

--- a/platform-operator/internal/helm/helmcli_test.go
+++ b/platform-operator/internal/helm/helmcli_test.go
@@ -5,6 +5,7 @@ package helm
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -36,6 +37,18 @@ type badRunner struct {
 // foundRunner is used to test helm status command
 type foundRunner struct {
 	t *testing.T
+}
+
+// genericTestRunner is used to run generic OS commands with expected results
+type genericTestRunner struct {
+	stdOut []byte
+	stdErr []byte
+	err    error
+}
+
+// Run genericTestRunner executor
+func (r genericTestRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
+	return r.stdOut, r.stdErr, r.err
 }
 
 // TestGetValues tests the Helm get values command
@@ -82,6 +95,42 @@ func TestUpgradeFail(t *testing.T) {
 	assert.Error(err, "Upgrade should have returned an error")
 	assert.Len(stdout, 0, "Upgrade stdout should be empty")
 	assert.NotZero(stderr, "Upgrade stderr should not be empty")
+}
+
+// TestUninstall tests the Helm Uninstall fn
+// GIVEN a call to Uninstall
+//  WHEN the command executes successfully
+//  THEN the function returns no error
+func TestUninstall(t *testing.T) {
+	stdout := []byte{}
+	stdErr := []byte{}
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: stdout,
+		stdErr: stdErr,
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	_, _, err := Uninstall(zap.S(), "weblogic-operator", "verrazzano-system", false)
+	assert.NoError(t, err)
+}
+
+// TestUninstallError tests the Helm Uninstall fn
+// GIVEN a call to Uninstall
+//  WHEN the command executes and returns an error
+//  THEN the function returns an error
+func TestUninstallError(t *testing.T) {
+	stdout := []byte{}
+	stdErr := []byte{}
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: stdout,
+		stdErr: stdErr,
+		err:    fmt.Errorf("Unexpected uninstall error"),
+	})
+	defer SetDefaultRunner()
+	_, _, err := Uninstall(zap.S(), "weblogic-operator", "verrazzano-system", false)
+	assert.Error(t, err)
 }
 
 // TestIsReleaseInstalled tests checking if a Helm release is installed
@@ -132,6 +181,287 @@ func TestIsReleaseInstalledFailed(t *testing.T) {
 	found, err := IsReleaseInstalled("", ns)
 	assert.Error(err, "IsReleaseInstalled should have returned an error")
 	assert.False(found, "Release should not be found")
+}
+
+// TestIsReleaseFailedChartNotFound tests checking if a Helm release is in a failed state
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseFailed and the status is ChartNotFound
+//  THEN the function returns false and no error
+func TestIsReleaseFailedChartNotFound(t *testing.T) {
+	assert := assert.New(t)
+	SetChartStateFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartNotFound, nil
+	})
+	defer SetDefaultChartStateFunction()
+
+	failed, err := IsReleaseFailed("foo", "bar")
+	assert.NoError(err, "IsReleaseInstalled returned an error")
+	assert.False(failed, "ReleaseFailed should be false")
+}
+
+// TestIsReleaseFailedChartNotFound tests checking if a Helm release is in a failed state
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseFailed and the status is deployed
+//  THEN the function returns false and no error
+func TestIsReleaseFailedChartDeployed(t *testing.T) {
+	assert := assert.New(t)
+	SetChartStateFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartStatusDeployed, nil
+	})
+	defer SetDefaultChartStateFunction()
+
+	failed, err := IsReleaseFailed("foo", "bar")
+	assert.NoError(err, "IsReleaseInstalled returned an error")
+	assert.False(failed, "ReleaseFailed should be false")
+}
+
+// TestIsReleaseFailed tests checking if a Helm release is in a failed state
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseFailed and the status is failed
+//  THEN the function returns false and no error
+func TestIsReleaseFailed(t *testing.T) {
+	assert := assert.New(t)
+	SetChartStateFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartStatusFailed, nil
+	})
+	defer SetDefaultChartStateFunction()
+
+	failed, err := IsReleaseFailed("foo", "bar")
+	assert.NoError(err, "IsReleaseInstalled returned an error")
+	assert.True(failed, "ReleaseFailed should be true")
+}
+
+// TestIsReleaseFailedError tests checking if a Helm release is in a failed state
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseFailed and the an error is returned by the state function
+//  THEN the function returns false and an error
+func TestIsReleaseFailedError(t *testing.T) {
+	assert := assert.New(t)
+	SetChartStateFunction(func(releaseName string, namespace string) (string, error) {
+		return "", fmt.Errorf("Unexpected error")
+	})
+	defer SetDefaultChartStateFunction()
+
+	failed, err := IsReleaseFailed("foo", "bar")
+	assert.Error(err, "IsReleaseInstalled returned an error")
+	assert.False(failed)
+}
+
+func Test_getReleaseStateDeployed(t *testing.T) {
+	jsonOut := []byte(`
+[
+  {
+    "name": "weblogic-operator",
+    "namespace": "verrazzano-system",
+    "revision": "1",
+    "updated": "2021-09-08 17:15:01.516374225 +0000 UTC",
+    "status": "deployed",
+    "chart": "weblogic-operator-3.3.0",
+    "app_version": "3.3.0"
+  }
+]
+`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getReleaseState("weblogic-operator", "verrazzano-system")
+	assert.NoError(t, err)
+	assert.Equalf(t, ChartStatusDeployed, state, "unpexected state: %s", state)
+}
+
+func Test_getReleaseStatePendingInstall(t *testing.T) {
+	jsonOut := []byte(`
+[
+  {
+    "name": "weblogic-operator",
+    "namespace": "verrazzano-system",
+    "revision": "1",
+    "updated": "2021-09-08 17:15:01.516374225 +0000 UTC",
+    "status": "pending-install",
+    "chart": "weblogic-operator-3.3.0",
+    "app_version": "3.3.0"
+  }
+]
+`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getReleaseState("weblogic-operator", "verrazzano-system")
+	assert.NoError(t, err)
+	assert.Equalf(t, ChartStatusPendingInstall, state, "unpexected state: %s", state)
+}
+
+func Test_getReleaseStateChartNotFound(t *testing.T) {
+	jsonOut := []byte(`[]`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getReleaseState("weblogic-operator", "verrazzano-system")
+	assert.NoError(t, err)
+	assert.Equalf(t, "", state, "unpexected state: %s", state)
+}
+
+func Test_getChartStatusDeployed(t *testing.T) {
+	jsonOut := []byte(`
+{
+  "name": "weblogic-operator",
+  "info": {
+    "first_deployed": "2021-09-08T17:15:01.516374225Z",
+    "last_deployed": "2021-09-08T17:15:01.516374225Z",
+    "deleted": "",
+    "description": "Install complete",
+    "status": "deployed"
+  },
+  "config": {
+    "annotations": {
+      "traffic.sidecar.istio.io/excludeOutboundPorts": "443"
+    },
+    "domainNamespaceLabelSelector": "verrazzano-managed",
+    "domainNamespaceSelectionStrategy": "LabelSelector",
+    "enableClusterRoleBinding": true,
+    "image": "ghcr.io/oracle/weblogic-kubernetes-operator:3.3.0",
+    "imagePullSecrets": [
+      {
+        "name": "verrazzano-container-registry"
+      }
+    ],
+    "serviceAccount": "weblogic-operator-sa"
+  },
+  "manifest": "manifest-text",
+  "version": 1,
+  "namespace": "verrazzano-system"
+}
+`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	assert.NoError(t, err)
+	assert.Equalf(t, ChartStatusDeployed, state, "unpexected state: %s", state)
+}
+
+func Test_getChartStatusNotFound(t *testing.T) {
+	jsonOut := []byte(`
+{
+  "name": "weblogic-operator",
+  "info": {
+    "first_deployed": "2021-09-08T17:15:01.516374225Z",
+    "last_deployed": "2021-09-08T17:15:01.516374225Z",
+    "deleted": "",
+    "description": "Install complete",
+  },
+  "config": {
+    "annotations": {
+      "traffic.sidecar.istio.io/excludeOutboundPorts": "443"
+    },
+    "domainNamespaceLabelSelector": "verrazzano-managed",
+    "domainNamespaceSelectionStrategy": "LabelSelector",
+    "enableClusterRoleBinding": true,
+    "image": "ghcr.io/oracle/weblogic-kubernetes-operator:3.3.0",
+    "imagePullSecrets": [
+      {
+        "name": "verrazzano-container-registry"
+      }
+    ],
+    "serviceAccount": "weblogic-operator-sa"
+  },
+  "manifest": "manifest-text",
+  "version": 1,
+  "namespace": "verrazzano-system"
+}
+`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	assert.Error(t, err)
+	assert.Empty(t, state)
+}
+
+func Test_getChartStatusChartNotFound(t *testing.T) {
+	stdout := []byte{}
+	stdErr := []byte("Error: release: not found")
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: stdout,
+		stdErr: stdErr,
+		err:    fmt.Errorf("Error running status command"),
+	})
+	defer SetDefaultRunner()
+	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	assert.NoError(t, err)
+	assert.Equalf(t, ChartNotFound, state, "unpexected state: %s", state)
+}
+
+func Test_getChartStatusUnexpectedHelmError(t *testing.T) {
+	stdout := []byte{}
+	stdErr := []byte("Some unknown helm status error")
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: stdout,
+		stdErr: stdErr,
+		err:    fmt.Errorf("Unexpected error running status command"),
+	})
+	defer SetDefaultRunner()
+	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	assert.Error(t, err)
+	assert.Equalf(t, "", state, "unpexected state: %s", state)
+}
+
+func Test_getChartInfoNotFound(t *testing.T) {
+	jsonOut := []byte(`
+{
+  "name": "weblogic-operator",
+  "config": {
+    "annotations": {
+      "traffic.sidecar.istio.io/excludeOutboundPorts": "443"
+    },
+    "domainNamespaceLabelSelector": "verrazzano-managed",
+    "domainNamespaceSelectionStrategy": "LabelSelector",
+    "enableClusterRoleBinding": true,
+    "image": "ghcr.io/oracle/weblogic-kubernetes-operator:3.3.0",
+    "imagePullSecrets": [
+      {
+        "name": "verrazzano-container-registry"
+      }
+    ],
+    "serviceAccount": "weblogic-operator-sa"
+  },
+  "manifest": "manifest-text",
+  "version": 1,
+  "namespace": "verrazzano-system"
+}
+`)
+
+	SetCmdRunner(genericTestRunner{
+		stdOut: jsonOut,
+		stdErr: []byte{},
+		err:    nil,
+	})
+	defer SetDefaultRunner()
+	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	assert.Error(t, err)
+	assert.Empty(t, state)
 }
 
 // Run should assert the command parameters are correct then return a success with stdout contents

--- a/platform-operator/internal/helm/helmcli_test.go
+++ b/platform-operator/internal/helm/helmcli_test.go
@@ -247,6 +247,10 @@ func TestIsReleaseFailedError(t *testing.T) {
 	assert.False(failed)
 }
 
+// Test_getReleaseStateDeployed tests the getReleaseState fn
+// GIVEN a call to getReleaseState
+//  WHEN the chart state is deployed
+//  THEN the function returns ChartStatusDeployed and no error
 func Test_getReleaseStateDeployed(t *testing.T) {
 	jsonOut := []byte(`
 [
@@ -273,6 +277,10 @@ func Test_getReleaseStateDeployed(t *testing.T) {
 	assert.Equalf(t, ChartStatusDeployed, state, "unpexected state: %s", state)
 }
 
+// Test_getReleaseStateDeployed tests the getReleaseState fn
+// GIVEN a call to getReleaseState
+//  WHEN the chart state is pending-install
+//  THEN the function returns ChartStatusPendingInstall and no error
 func Test_getReleaseStatePendingInstall(t *testing.T) {
 	jsonOut := []byte(`
 [
@@ -299,6 +307,10 @@ func Test_getReleaseStatePendingInstall(t *testing.T) {
 	assert.Equalf(t, ChartStatusPendingInstall, state, "unpexected state: %s", state)
 }
 
+// Test_getReleaseStateChartNotFound tests the getReleaseState fn
+// GIVEN a call to getReleaseState
+//  WHEN the chart/release can not be found
+//  THEN the function returns "" and no error
 func Test_getReleaseStateChartNotFound(t *testing.T) {
 	jsonOut := []byte(`[]`)
 
@@ -313,6 +325,10 @@ func Test_getReleaseStateChartNotFound(t *testing.T) {
 	assert.Equalf(t, "", state, "unpexected state: %s", state)
 }
 
+// Test_getChartStatusDeployed tests the getChartStatus fn
+// GIVEN a call to getChartStatus
+//  WHEN Helm returns a deployed state
+//  THEN the function returns "deployed" and no error
 func Test_getChartStatusDeployed(t *testing.T) {
 	jsonOut := []byte(`
 {
@@ -356,6 +372,10 @@ func Test_getChartStatusDeployed(t *testing.T) {
 	assert.Equalf(t, ChartStatusDeployed, state, "unpexected state: %s", state)
 }
 
+// Test_getChartStatusNotFound tests the getChartStatus fn
+// GIVEN a call to getChartStatus
+//  WHEN the json structure does not have an status filed in the info section
+//  THEN the function returns an error
 func Test_getChartStatusNotFound(t *testing.T) {
 	jsonOut := []byte(`
 {
@@ -398,6 +418,10 @@ func Test_getChartStatusNotFound(t *testing.T) {
 	assert.Empty(t, state)
 }
 
+// Test_getChartStatusChartNotFound tests the getChartStatus fn
+// GIVEN a call to getChartStatus
+//  WHEN the Chart is not found
+//  THEN the function returns chart not found and no error
 func Test_getChartStatusChartNotFound(t *testing.T) {
 	stdout := []byte{}
 	stdErr := []byte("Error: release: not found")
@@ -413,6 +437,10 @@ func Test_getChartStatusChartNotFound(t *testing.T) {
 	assert.Equalf(t, ChartNotFound, state, "unpexected state: %s", state)
 }
 
+// Test_getChartStatusUnexpectedHelmError tests the getChartStatus fn
+// GIVEN a call to getChartStatus
+//  WHEN Helm returns an error
+//  THEN the function returns an error
 func Test_getChartStatusUnexpectedHelmError(t *testing.T) {
 	stdout := []byte{}
 	stdErr := []byte("Some unknown helm status error")
@@ -428,6 +456,10 @@ func Test_getChartStatusUnexpectedHelmError(t *testing.T) {
 	assert.Equalf(t, "", state, "unpexected state: %s", state)
 }
 
+// Test_getChartInfoNotFound tests the getChartStatus fn
+// GIVEN a call to getChartStatus
+//  WHEN the json structure does not have an info section
+//  THEN the function returns an error
 func Test_getChartInfoNotFound(t *testing.T) {
 	jsonOut := []byte(`
 {

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package status
+
+import (
+	"context"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeploymentsReady Check that the named deployments have the minimum number of specified replicas ready and available
+func DeploymentsReady(log *zap.SugaredLogger, client clipkg.Client, deployments []types.NamespacedName, expectedReplicas int32) bool {
+	for _, namespacedName := range deployments {
+		deployment := appsv1.Deployment{}
+		if err := client.Get(context.TODO(), namespacedName, &deployment); err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("%v deployment not found", namespacedName)
+				// Deployment not found
+				return false
+			}
+			log.Errorf("Unexpected error checking %v status: %v", namespacedName, err)
+			return false
+		}
+		if deployment.Status.AvailableReplicas < expectedReplicas {
+			log.Infof("Not enough available replicas for the %v deployment yet", namespacedName)
+			return false
+		}
+	}
+	return true
+}

--- a/platform-operator/internal/k8s/status/deployment_ready_test.go
+++ b/platform-operator/internal/k8s/status/deployment_ready_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestDeploymentsReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object has a minimum of desired available replicas
+// THEN true is returned
+func TestDeploymentsReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleReplicasReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has met the minimum of desired available replicas > 1
+// THEN true is returned
+func TestMultipleReplicasReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       3,
+			AvailableReplicas:   3,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 3))
+}
+
+// TestMultipleReplicasReadyAboveThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has more than the minimum desired replicas available
+// THEN true is returned
+func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       3,
+			AvailableReplicas:   3,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 2))
+}
+
+// TestDeploymentsNotAvailableOrReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object does not have a minimium number of desired available replicas
+// THEN false is returned
+func TestDeploymentsNotAvailableOrReady(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleReplicasReadyBelowThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica
+// WHEN the target Deployment object has less than the minimum desired replicas available
+// THEN false is returned
+func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            3,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 2,
+		},
+	})
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 2))
+}
+
+// TestDeploymentsReadyDeploymentNotFound tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady
+// WHEN the target Deployment object is not found
+// THEN false is returned
+func TestDeploymentsReadyDeploymentNotFound(t *testing.T) {
+	name := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name}, 1))
+}
+
+// TestMultipleDeploymentsReplicasReadyBelowThreshold tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica for multiple deployments
+// WHEN the one of the target Deployment objects has less than the minimum desired replicas available
+// THEN false is returned
+func TestMultipleDeploymentsReplicasReadyBelowThreshold(t *testing.T) {
+	name1 := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	name2 := types.NamespacedName{Name: "thud", Namespace: "bar"}
+	name3 := types.NamespacedName{Name: "thud", Namespace: "thwack"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name1.Namespace,
+				Name:      name1.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name2.Namespace,
+				Name:      name2.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       1,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 2,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name3.Namespace,
+				Name:      name3.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+	)
+	assert.False(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name1, name2, name3}, 2))
+}
+
+// TestMultipleDeploymentsReplicasReady tests a deployment ready status check
+// GIVEN a call validate DeploymentsReady for more than one replica for multiple deployments
+// WHEN the all of the target Deployment objects meet the minimum desired replicas available threshold
+// THEN true is returned
+func TestMultipleDeploymentsReplicasReady(t *testing.T) {
+	name1 := types.NamespacedName{Name: "foo", Namespace: "bar"}
+	name2 := types.NamespacedName{Name: "thud", Namespace: "bar"}
+	name3 := types.NamespacedName{Name: "thud", Namespace: "thwack"}
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name1.Namespace,
+				Name:      name1.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name2.Namespace,
+				Name:      name2.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: name3.Namespace,
+				Name:      name3.Name,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:            3,
+				ReadyReplicas:       3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+			},
+		},
+	)
+	assert.True(t, DeploymentsReady(zap.S(), client, []types.NamespacedName{name1, name2, name3}, 2))
+}

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -326,6 +326,6 @@ fi
 
 action "Installing Verrazzano system components" install_verrazzano || exit 1
 platform_operator_install_message "Coherence Kubernetes operator"
-action "Installing WebLogic Kubernetes operator" install_weblogic_operator || exit 1
+platform_operator_install_message "WebLogic Kubernetes operator"
 platform_operator_install_message "OAM Kubernetes operator"
 platform_operator_install_message "Verrazzano Application Kubernetes operator"


### PR DESCRIPTION
# Description

Move the WKO install to the platform operator.
- Added hooks for pre-install fn for a `helmComponent`, and added a WKO impl to set up the pre-reqs for that service
- Added the ability to declare dependencies between components in the registry, and validate that those dependencies are `Ready` before allowing install
- Declared dependency on Istio from WKO, and added Istio ready check fn
- Add the correct labels to the `verrazzano-system` namespace
- Added/updated the unit tests

Fixes VZ-3240.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
