### PR TITLE
Fix ingress rule for Bob's Books Order Manager

### DIFF
--- a/examples/bobs-books/bobs-books-app.yaml
+++ b/examples/bobs-books/bobs-books-app.yaml
@@ -50,7 +50,7 @@ spec:
                     - path: "/bobs-bookstore-order-manager/orders"
                       pathType: Prefix
                     - path: "/bobs-bookstore-order-manager/books"
-                        pathType: Prefix
+                      pathType: Prefix
     - componentName: bobs-orders-configmap
     - componentName: bobs-mysql-deployment
     - componentName: bobs-mysql-service

--- a/examples/bobs-books/bobs-books-app.yaml
+++ b/examples/bobs-books/bobs-books-app.yaml
@@ -49,6 +49,8 @@ spec:
                 - paths:
                     - path: "/bobs-bookstore-order-manager/orders"
                       pathType: Prefix
+                    - path: "/bobs-bookstore-order-manager/books"
+                        pathType: Prefix
     - componentName: bobs-orders-configmap
     - componentName: bobs-mysql-deployment
     - componentName: bobs-mysql-service


### PR DESCRIPTION
# Description

This change fixes the once broken link to the `/books` path in the Bob's Books Order Manager application.

Fixes VZ-2231

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
