### PR TITLE
default elasticsearchURL and elasticsearchSecret in logging helm

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -508,20 +508,32 @@ spec:
             - name: FLUENT_ELASTICSEARCH_SED_DISABLE
               value: "true"
             - name: ELASTICSEARCH_URL
+  {{- if .Values.logging.elasticsearchURL }}
               value: {{ .Values.logging.elasticsearchURL }}
+  {{- else }}
+              value: http://vmi-system-es-ingest-oidc:8775
+  {{- end }}
             - name: CLUSTER_NAME
               value: local
             - name: ELASTICSEARCH_USER
               valueFrom:
                 secretKeyRef:
                   key: username
+  {{- if .Values.logging.elasticsearchSecret }}
                   name: {{ .Values.logging.elasticsearchSecret }}
+  {{- else }}
+                  name: verrazzano
+  {{- end }}
                   optional: true
             - name: ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: password
+  {{- if .Values.logging.elasticsearchSecret }}
                   name: {{ .Values.logging.elasticsearchSecret }}
+  {{- else }}
+                  name: verrazzano
+  {{- end }}
                   optional: true
             - name: CA_FILE
               value: /fluentd/cacerts/all-ca-certs.pem
@@ -567,7 +579,11 @@ spec:
           emptyDir: {}
         - name: secret-volume
           secret:
+  {{- if .Values.logging.elasticsearchSecret }}
             secretName: {{ .Values.logging.elasticsearchSecret }}
+  {{- else }}
+            secretName: verrazzano
+  {{- end }}
         - configMap:
             name: {{ .Values.logging.name }}-config
           name: {{ .Values.logging.name }}-config

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -68,8 +68,6 @@ monitoringOperator:
 
 logging:
   name: fluentd
-  elasticsearchURL: http://vmi-system-es-ingest-oidc:8775
-  elasticsearchSecret: verrazzano
   # NOTE: The fluentd-kubernetes-daemonset image now comes from the bill of materials file (verrazzano-bom.json).
 
 fluentd:


### PR DESCRIPTION
# Description

When upgrading from 1.0 where elasticsearchURL and elasticsearchSecret are absent, value.yaml won't be fed to helm command either, we need to default them in the logging helm template.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
