### PR TITLE
VZ-3329 cattle-cluster-agent failure to connect to Rancher on the admin cluster

### DIFF
--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -367,9 +367,19 @@ function install_rancher()
         if [ $(get_config_value ".certificates.ca.secretName") == "$VERRAZZANO_DEFAULT_SECRET_NAME" ] &&
            [ $(get_config_value ".certificates.ca.clusterResourceNamespace") == "$VERRAZZANO_DEFAULT_SECRET_NAMESPACE" ]; then
           EXTRA_RANCHER_ARGUMENTS="--set privateCA=true"
+          echo "Waiting for secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE to be created."
+          retries=0
+          until [ "$retries" -ge 60 ]
+          do
+            kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${TMP_DIR}/cacerts.pem && break
+            retries=$(($retries+1))
+            sleep 1
+          done
+          if [ "$retries" -ge 60 ]; then
+            fail "Failed to get secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE.";
+          fi
           echo "Copy CA certificate which is used by the Rancher Agent to validate the connection to the server."
-          kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${TMP_DIR}/cacerts.pem
-          kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem=${TMP_DIR}/cacerts.pem
+          kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem=${TMP_DIR}/cacerts.pem || return $?
         fi
         RANCHER_PATCH_DATA="{\"metadata\":{\"annotations\":{\"kubernetes.io/tls-acme\":\"true\",\"nginx.ingress.kubernetes.io/auth-realm\":\"${NAME}.${DNS_SUFFIX} auth\",\"cert-manager.io/cluster-issuer\":\"verrazzano-cluster-issuer\"}}}"
       else

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -367,18 +367,23 @@ function install_rancher()
         if [ $(get_config_value ".certificates.ca.secretName") == "$VERRAZZANO_DEFAULT_SECRET_NAME" ] &&
            [ $(get_config_value ".certificates.ca.clusterResourceNamespace") == "$VERRAZZANO_DEFAULT_SECRET_NAMESPACE" ]; then
           EXTRA_RANCHER_ARGUMENTS="--set privateCA=true"
-          echo "Waiting for secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE to be created."
-          retries=0
-          until [ "$retries" -ge 60 ]
+          log "Waiting for secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE to be created."
+          local retries=0
+          local max_retries=60
+          until [ "$retries" -ge "$max_retries" ]
           do
-            kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${TMP_DIR}/cacerts.pem && break
+            kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}'
+            if [ $? -eq 0 ]; then
+              kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${TMP_DIR}/cacerts.pem || return $?
+              break
+            fi
             retries=$(($retries+1))
             sleep 1
           done
-          if [ "$retries" -ge 60 ]; then
+          if [ "$retries" -ge "$max_retries" ]; then
             fail "Failed to get secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE.";
           fi
-          echo "Copy CA certificate which is used by the Rancher Agent to validate the connection to the server."
+          log "Copy CA certificate which is used by the Rancher Agent to validate the connection to the server."
           kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem=${TMP_DIR}/cacerts.pem || return $?
         fi
         RANCHER_PATCH_DATA="{\"metadata\":{\"annotations\":{\"kubernetes.io/tls-acme\":\"true\",\"nginx.ingress.kubernetes.io/auth-realm\":\"${NAME}.${DNS_SUFFIX} auth\",\"cert-manager.io/cluster-issuer\":\"verrazzano-cluster-issuer\"}}}"

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -367,13 +367,12 @@ function install_rancher()
         if [ $(get_config_value ".certificates.ca.secretName") == "$VERRAZZANO_DEFAULT_SECRET_NAME" ] &&
            [ $(get_config_value ".certificates.ca.clusterResourceNamespace") == "$VERRAZZANO_DEFAULT_SECRET_NAMESPACE" ]; then
           EXTRA_RANCHER_ARGUMENTS="--set privateCA=true"
-          log "Waiting for secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE to be created."
           local retries=0
           local max_retries=60
           until [ "$retries" -ge "$max_retries" ]
           do
-            kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}'
-            if [ $? -eq 0 ]; then
+            log "Waiting for secret $VERRAZZANO_DEFAULT_SECRET_NAME in namespace $VERRAZZANO_DEFAULT_SECRET_NAMESPACE to be created."
+            if kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME >/dev/null 2>&1 ; then
               kubectl -n $VERRAZZANO_DEFAULT_SECRET_NAMESPACE get secret $VERRAZZANO_DEFAULT_SECRET_NAME -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${TMP_DIR}/cacerts.pem || return $?
               break
             fi


### PR DESCRIPTION
# Description

This pull request fixes a failure of the cattle-cluster-agent on a manged cluster to connect to Rancher on the admin cluster.  The result of the failure was a crashloopbackoff of the cattle-cluster-agent pod.  The failure was intermittent and was caused by a bug in the install scripts.  The install scripts were creating the tls-ca secret n the cattle-system namespace with an empty cacerts.pem value.  The cacerts.pem value comes from the cert-manager secret verrazzano-ca-certificate-secret.  The install script was changed to wait for the cert-manager secret verrazzano-ca-certificate-secret before setting the tls-ca secret.

Fixes VZ-3329

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
