### PR TITLE
VZ-2522 backport for disallow Mcxxxx resources that are not in a VerrazzanoProject

### DIFF
--- a/application-operator/controllers/webhooks/multicluster_validation.go
+++ b/application-operator/controllers/webhooks/multicluster_validation.go
@@ -6,13 +6,13 @@ package webhooks
 import (
 	"context"
 	"fmt"
+
 	clusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	clusterutil "github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -71,4 +71,29 @@ func translateErrorToResponse(err error) admission.Response {
 		return admission.Allowed("")
 	}
 	return admission.Denied(err.Error())
+}
+
+// Validate that the namespace of a multiclusterXXX resource is part of a verrazzanoproject
+func validateNamespaceInProject(c client.Client, namespace string) error {
+	vzProjects := clusters.VerrazzanoProjectList{}
+	err := c.List(context.TODO(), &vzProjects)
+	if err != nil {
+		return err
+	}
+
+	if len(vzProjects.Items) == 0 {
+		return fmt.Errorf("namespace %s not specified in any verrazzanoproject resources - no verrazzanoproject resources found", namespace)
+	}
+
+	// Check verrazzanoProjects for a matching namespace
+	for _, proj := range vzProjects.Items {
+		for _, ns := range proj.Spec.Template.Namespaces {
+			if ns.Metadata.Name == namespace {
+				return nil
+			}
+		}
+	}
+
+	// No matching namespace found so return error
+	return fmt.Errorf("namespace %s not specified in any verrazzanoproject resources", namespace)
 }

--- a/application-operator/controllers/webhooks/multicluster_validation_test.go
+++ b/application-operator/controllers/webhooks/multicluster_validation_test.go
@@ -4,8 +4,11 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1alpha12 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
@@ -102,4 +105,71 @@ func newScheme() *runtime.Scheme {
 	}, &corev1.Secret{})
 	v1alpha1.AddToScheme(scheme)
 	return scheme
+}
+
+// TestValidateNamespaceInProject tests the function validateNamespaceInProject
+// GIVEN a call to validateNamespaceInProject
+// WHEN called with various namespaces
+// THEN the validation should succeed or fail based on what is found in created verrazzanoproject resources
+func TestValidateNamespaceInProject(t *testing.T) {
+	asrt := assert.New(t)
+	v := newMultiClusterApplicationConfigurationValidator()
+
+	// No verrazzanoproject resources exist so failure is expected
+	err := validateNamespaceInProject(v.client, "application-ns")
+	asrt.EqualError(err, "namespace application-ns not specified in any verrazzanoproject resources - no verrazzanoproject resources found")
+
+	// Create a verrazzanoproject resource with namespaces application-ns1 and application-ns2
+	vp1 := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name1",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns1",
+						},
+					},
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns2",
+						},
+					},
+				},
+			},
+		},
+	}
+	asrt.NoError(v.client.Create(context.TODO(), &vp1))
+
+	// Create a verrazzanoproject resource with namespace application-ns3
+	vp2 := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name2",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns3",
+						},
+					},
+				},
+			},
+		},
+	}
+	asrt.NoError(v.client.Create(context.TODO(), &vp2))
+
+	// Namespace does not exist in a verrazzanoproject so failure is expected
+	err = validateNamespaceInProject(v.client, "application-ns")
+	asrt.EqualError(err, "namespace application-ns not specified in any verrazzanoproject resources")
+
+	// Namespaces are found in a verrazzanoproject so success is expected
+	asrt.NoError(validateNamespaceInProject(v.client, "application-ns1"))
+	asrt.NoError(validateNamespaceInProject(v.client, "application-ns2"))
+	asrt.NoError(validateNamespaceInProject(v.client, "application-ns3"))
 }

--- a/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook.go
+++ b/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook.go
@@ -5,9 +5,9 @@ package webhooks
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"net/http"
 
+	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	k8sadmission "k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -42,7 +42,14 @@ func (v *MultiClusterApplicationConfigurationValidator) Handle(ctx context.Conte
 	if mcac.ObjectMeta.DeletionTimestamp.IsZero() {
 		switch req.Operation {
 		case k8sadmission.Create, k8sadmission.Update:
-			return translateErrorToResponse(validateMultiClusterResource(v.client, mcac))
+			err = validateMultiClusterResource(v.client, mcac)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
+			err = validateNamespaceInProject(v.client, mcac.Namespace)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
 	}
 	return admission.Allowed("")

--- a/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook_test.go
@@ -104,10 +104,10 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationTargeti
 			ServiceAccount:               "test-service-account",
 		},
 	}
-	mcc := v1alpha12.MultiClusterApplicationConfiguration{
+	mcac := v1alpha12.MultiClusterApplicationConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcapplicationconfiguration-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterApplicationConfigurationSpec{
 			Placement: v1alpha12.Placement{
@@ -115,13 +115,32 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationTargeti
 			},
 		},
 	}
-	asrt.NoError(v.client.Create(context.TODO(), &mc))
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
 
-	req := newAdmissionRequest(admissionv1beta1.Create, mcc)
+	asrt.NoError(v.client.Create(context.TODO(), &mc))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
+
+	req := newAdmissionRequest(admissionv1beta1.Create, mcac)
 	res := v.Handle(context.TODO(), req)
 	asrt.True(res.Allowed, "Expected multi-cluster application configuration create validation to succeed.")
 
-	req = newAdmissionRequest(admissionv1beta1.Update, mcc)
+	req = newAdmissionRequest(admissionv1beta1.Update, mcac)
 	res = v.Handle(context.TODO(), req)
 	asrt.True(res.Allowed, "Expected multi-cluster application configuration update validation to succeed.")
 }
@@ -141,10 +160,10 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationWithout
 			Namespace: constants.VerrazzanoSystemNamespace,
 		},
 	}
-	mcc := v1alpha12.MultiClusterApplicationConfiguration{
+	mcac := v1alpha12.MultiClusterApplicationConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcapplicationconfiguration-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterApplicationConfigurationSpec{
 			Placement: v1alpha12.Placement{
@@ -152,13 +171,32 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationWithout
 			},
 		},
 	}
-	asrt.NoError(v.client.Create(context.TODO(), &s))
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
 
-	req := newAdmissionRequest(admissionv1beta1.Create, mcc)
+	asrt.NoError(v.client.Create(context.TODO(), &s))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
+
+	req := newAdmissionRequest(admissionv1beta1.Create, mcac)
 	res := v.Handle(context.TODO(), req)
 	asrt.True(res.Allowed, "Expected multi-cluster application configuration validation to succeed with missing placement information on managed cluster.")
 
-	req = newAdmissionRequest(admissionv1beta1.Update, mcc)
+	req = newAdmissionRequest(admissionv1beta1.Update, mcac)
 	res = v.Handle(context.TODO(), req)
 	asrt.True(res.Allowed, "Expected multi-cluster application configuration validation to succeed with missing placement information on managed cluster.")
 }

--- a/application-operator/controllers/webhooks/multiclustercomponent_webhook.go
+++ b/application-operator/controllers/webhooks/multiclustercomponent_webhook.go
@@ -5,9 +5,9 @@ package webhooks
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"net/http"
 
+	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	k8sadmission "k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -42,7 +42,14 @@ func (v *MultiClusterComponentValidator) Handle(ctx context.Context, req admissi
 	if mcc.ObjectMeta.DeletionTimestamp.IsZero() {
 		switch req.Operation {
 		case k8sadmission.Create, k8sadmission.Update:
-			return translateErrorToResponse(validateMultiClusterResource(v.client, mcc))
+			err = validateMultiClusterResource(v.client, mcc)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
+			err = validateNamespaceInProject(v.client, mcc.Namespace)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
 	}
 	return admission.Allowed("")

--- a/application-operator/controllers/webhooks/multiclustercomponent_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclustercomponent_webhook_test.go
@@ -107,7 +107,7 @@ func TestValidationSuccessForMultiClusterComponentCreationTargetingExistingManag
 	mcc := v1alpha12.MultiClusterComponent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mccomponent-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterComponentSpec{
 			Placement: v1alpha12.Placement{
@@ -115,7 +115,26 @@ func TestValidationSuccessForMultiClusterComponentCreationTargetingExistingManag
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &mc))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, mcc)
 	res := v.Handle(context.TODO(), req)
@@ -144,7 +163,7 @@ func TestValidationSuccessForMultiClusterComponentCreationWithoutTargetClustersO
 	mcc := v1alpha12.MultiClusterComponent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mccomponent-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterComponentSpec{
 			Placement: v1alpha12.Placement{
@@ -152,7 +171,26 @@ func TestValidationSuccessForMultiClusterComponentCreationWithoutTargetClustersO
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &s))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, mcc)
 	res := v.Handle(context.TODO(), req)

--- a/application-operator/controllers/webhooks/multiclusterconfigmap_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclusterconfigmap_webhook_test.go
@@ -107,7 +107,7 @@ func TestValidationSuccessForMultiClusterConfigMapCreationTargetingExistingManag
 	p := v1alpha12.MultiClusterConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcconfigmap-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterConfigMapSpec{
 			Placement: v1alpha12.Placement{
@@ -115,7 +115,26 @@ func TestValidationSuccessForMultiClusterConfigMapCreationTargetingExistingManag
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &c))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, p)
 	res := v.Handle(context.TODO(), req)
@@ -144,7 +163,7 @@ func TestValidationSuccessForMultiClusterConfigMapCreationWithoutTargetClustersO
 	p := v1alpha12.MultiClusterConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcconfigmap-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterConfigMapSpec{
 			Placement: v1alpha12.Placement{
@@ -152,7 +171,26 @@ func TestValidationSuccessForMultiClusterConfigMapCreationWithoutTargetClustersO
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &s))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, p)
 	res := v.Handle(context.TODO(), req)

--- a/application-operator/controllers/webhooks/multiclustersecret_webhook.go
+++ b/application-operator/controllers/webhooks/multiclustersecret_webhook.go
@@ -5,9 +5,9 @@ package webhooks
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"net/http"
 
+	"github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	k8sadmission "k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -42,7 +42,14 @@ func (v *MultiClusterSecretValidator) Handle(ctx context.Context, req admission.
 	if mcs.ObjectMeta.DeletionTimestamp.IsZero() {
 		switch req.Operation {
 		case k8sadmission.Create, k8sadmission.Update:
-			return translateErrorToResponse(validateMultiClusterResource(v.client, mcs))
+			err = validateMultiClusterResource(v.client, mcs)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
+			err = validateNamespaceInProject(v.client, mcs.Namespace)
+			if err != nil {
+				return admission.Denied(err.Error())
+			}
 		}
 	}
 	return admission.Allowed("")

--- a/application-operator/controllers/webhooks/multiclustersecret_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclustersecret_webhook_test.go
@@ -107,7 +107,7 @@ func TestValidationSuccessForMultiClusterSecretCreationTargetingExistingManagedC
 	p := v1alpha12.MultiClusterSecret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcsecret-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterSecretSpec{
 			Placement: v1alpha12.Placement{
@@ -115,7 +115,26 @@ func TestValidationSuccessForMultiClusterSecretCreationTargetingExistingManagedC
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &c))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, p)
 	res := v.Handle(context.TODO(), req)
@@ -144,7 +163,7 @@ func TestValidationSuccessForMultiClusterSecretCreationWithoutTargetClustersOnMa
 	p := v1alpha12.MultiClusterSecret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcsecret-name",
-			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Namespace: "application-ns",
 		},
 		Spec: v1alpha12.MultiClusterSecretSpec{
 			Placement: v1alpha12.Placement{
@@ -152,7 +171,26 @@ func TestValidationSuccessForMultiClusterSecretCreationWithoutTargetClustersOnMa
 			},
 		},
 	}
+	vp := v1alpha12.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-verrazzanoproject-name",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: v1alpha12.VerrazzanoProjectSpec{
+			Template: v1alpha12.ProjectTemplate{
+				Namespaces: []v1alpha12.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	asrt.NoError(v.client.Create(context.TODO(), &s))
+	asrt.NoError(v.client.Create(context.TODO(), &vp))
 
 	req := newAdmissionRequest(admissionv1beta1.Create, p)
 	res := v.Handle(context.TODO(), req)

--- a/application-operator/test/integ/multi_cluster_test.go
+++ b/application-operator/test/integ/multi_cluster_test.go
@@ -85,7 +85,9 @@ var _ = ginkgo.Describe("Testing Multi-Cluster CRDs", func() {
 
 var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 	ginkgo.It("Apply MultiClusterConfigMap creates a ConfigMap ", func() {
-		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/multicluster_configmap_sample.yaml")
+		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_sample.yaml")
+		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be created successfully")
+		_, stderr = util.Kubectl("apply -f testdata/multi-cluster/multicluster_configmap_sample.yaml")
 		gomega.Expect(stderr).To(gomega.Equal(""))
 		mcConfigMap, err := K8sClient.GetMultiClusterConfigMap(multiclusterTestNamespace, "mymcconfigmap")
 		gomega.Expect(err).To(gomega.BeNil())
@@ -103,7 +105,9 @@ var _ = ginkgo.Describe("Testing MultiClusterConfigMap", func() {
 		}, timeout, pollInterval).Should(gomega.BeTrue())
 	})
 	ginkgo.It("Apply Invalid MultiClusterConfigMap results in Failed Status", func() {
-		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/multicluster_configmap_INVALID.yaml")
+		_, stderr := util.Kubectl("apply -f testdata/multi-cluster/verrazzanoproject_sample.yaml")
+		gomega.Expect(stderr).To(gomega.Equal(""), "VerrazzanoProject should be created successfully")
+		_, stderr = util.Kubectl("apply -f testdata/multi-cluster/multicluster_configmap_INVALID.yaml")
 		gomega.Expect(stderr).To(gomega.Equal(""))
 		gomega.Eventually(func() bool {
 			// Expecting a failed state value in the MultiClusterConfigMap since creation of


### PR DESCRIPTION
# Description

This pull request validates that the namespace of a Mcxxx resource is specified in a VerrazzanoProject resource.
The validation is via a validating webhook and addresses:
- MultiClusterApplicationConfigurations
- MultiClusterComponents
- MultiClusterConfigMaps
- MultiClusterSecrets

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
