### PR TITLE
Add authorization header when making managed cluster api call

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -840,6 +840,9 @@ data:
         ngx.req.set_uri_args(args)
         local serverUrl = vmc.status.apiUrl .. "/" .. vzApiVersion .. ngx.var.uri
 
+        -- propagate the user's token as a bearer token, remote cluster won't have access to the session.
+        ngx.req.set_header("Authorization", "Bearer "..token)
+
         -- To access managed cluster api server on self signed certificates, the admin cluster api server needs ca certificates for the managed cluster.
         -- A secret is created in admin cluster during multi cluster setup that contains the ca certificate.
         -- Here we read the name of that secret from vmc spec and retrieve the secret from cluster and read the cacrt field.


### PR DESCRIPTION
# Description

Console API calls will rely on the session/session cookie for authN once the console changes are in, but the session won't be available to the authproxy in the remote cluster. To avoid the cost of re-authenticating and acquiring tokens on the managed cluster side, pass the ID token as a bearer token.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
