### PR TITLE
VZ-3422. Fix build error caused by overlapping change

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio_component_test.go
@@ -6,6 +6,7 @@ package component
 import (
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/istio"
 	"go.uber.org/zap"
 	"os/exec"
@@ -36,7 +37,7 @@ func IstioTestGetName(t *testing.T) {
 func IstioTestUpgrade(t *testing.T) {
 	assert := assert.New(t)
 
-	SetUnitTestBomFilePath(testBomFilePath)
+	config.SetDefaultBomFilePath(testBomFilePath)
 	istio.SetCmdRunner(istioFakeRunner{})
 	defer istio.SetDefaultRunner()
 	setIstioUpgradeFunc(fakeIstioUpgrade)


### PR DESCRIPTION
# Description

Fix a unit test build error caused by overlapping changes.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
