### PR TITLE
VZ-3358 cherry pick into release-1.0

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -196,8 +196,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${VERRAZZANO_INSTALL_LOGS_DIR}
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -231,8 +231,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                         echo "Verrazzano install logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1086,8 +1086,8 @@ def dumpInstallLogs() {
                 ## dump verrazzano install logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 mkdir -p ${LOG_DIR}
-                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
                 echo "------------------------------------------"
             """
         }

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -330,8 +330,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -378,8 +378,6 @@ pipeline {
                             echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                             echo "------------------------------------------"
                         """
-                        VZ_TEST_METRIC = metricJobName('')
-                        metricTimerStart("${VZ_TEST_METRIC}")
                     }
                 }
             }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -368,15 +368,19 @@ pipeline {
             }
             post {
                 always {
-                    sh """
-                        ## dump out install logs
-                        mkdir -p ${WORKSPACE}/platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
-                        echo "Verrazzano Installation logs dumped to verrazzano-install.log"
-                        echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
-                        echo "------------------------------------------"
-                    """
+                    script {
+                        sh """
+                            ## dump out install logs
+                            mkdir -p ${WORKSPACE}/platform-operator/scripts/install/build/logs
+                            kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                            kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                            echo "Verrazzano Installation logs dumped to verrazzano-install.log"
+                            echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
+                            echo "------------------------------------------"
+                        """
+                        VZ_TEST_METRIC = metricJobName('')
+                        metricTimerStart("${VZ_TEST_METRIC}")
+                    }
                 }
             }
         }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -277,8 +277,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -159,8 +159,8 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -263,8 +263,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"
@@ -397,8 +397,8 @@ pipeline {
                     sh """
                         ## dump out install logs
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs
-                        kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
-                        kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
+                        kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall.log --tail -1
+                        kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/verrazzano-reinstall-job-pod.out
                         echo "Verrazzano Installation logs dumped to verrazzano-reinstall.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-reinstall-job-pod.out"
                         echo "------------------------------------------"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -194,12 +194,17 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
-                                kubectl describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                                 echo "------------------------------------------"
                             """
+                            script {
+                                dumpVerrazzanoPlatformOperatorLogs("before-upgrade")
+                                VZ_TEST_METRIC = metricJobName('')
+                                metricTimerStart("${VZ_TEST_METRIC}")
+                            }
                         }
                     }
                 }
@@ -252,7 +257,7 @@ pipeline {
                     }
                     post {
                         always {
-                            dumpVerrazzanoPlatformOperatorLogs()
+                            dumpVerrazzanoPlatformOperatorLogs("after-upgrade")
                         }
                     }
                 }
@@ -338,7 +343,6 @@ pipeline {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
                     dumpNginxIngressControllerLogs()
-                    dumpVerrazzanoPlatformOperatorLogs()
                     dumpVerrazzanoApplicationOperatorLogs()
                     dumpOamKubernetesRuntimeLogs()
                     dumpVerrazzanoApiLogs()
@@ -430,14 +434,12 @@ def dumpNginxIngressControllerLogs() {
     """
 }
 
-def dumpVerrazzanoPlatformOperatorLogs() {
+def dumpVerrazzanoPlatformOperatorLogs(stage) {
     sh """
         ## dump out verrazzano-platform-operator logs
         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        echo "verrazzano-platform-operator logs dumped to verrazzano-platform-operator-pod.log"
-        echo "verrazzano-platform-operator pod description dumped to verrazzano-platform-operator-pod.out"
+        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "------------------------------------------"
     """
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/util/semver"
@@ -26,7 +27,12 @@ func GetCurrentBomVersion() (*semver.SemVersion, error) {
 	if err != nil {
 		return nil, err
 	}
-	return semver.NewSemVersion(fmt.Sprintf("v%s", bom.GetVersion()))
+	v := bom.GetVersion()
+	if v == constants.BomVerrazzanoVersion {
+		// This will only happen during development testing, the value doesn't matter
+		v = "1.0.1"
+	}
+	return semver.NewSemVersion(fmt.Sprintf("v%s", v))
 }
 
 // ValidateVersion check that requestedVersion matches chart requestedVersion
@@ -127,10 +133,10 @@ func ValidateInProgress(state StateType) error {
 func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
 		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: "default"}, secret)
+		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("secret \"%s\" must be created in the default namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret)
+				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoInstallNamespace)
 			}
 			return err
 		}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component"
@@ -539,7 +540,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = ValidateOciDNSSecret(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "secret \"oci-bad-secret\" must be created in the default namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano for OCI DNS", err.Error())
 }
 
 // TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the verrazzano CR exists
@@ -569,7 +570,7 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oci",
-			Namespace: "default",
+			Namespace: constants.VerrazzanoInstallNamespace,
 		},
 	}
 	err = client.Create(context.TODO(), secret)

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -60,6 +60,11 @@ const ImageRepoOverrideEnvVar = "IMAGE_REPO"
 // VerrazzanoAppOperatorImageEnvVar is the environment variable used to override the Verrazzano Application Operator image
 const VerrazzanoAppOperatorImageEnvVar = "APP_OPERATOR_IMAGE"
 
+// The Kubernetes default namespace
+const DefaultNamespace = "default"
+
+const BomVerrazzanoVersion = "VERRAZZANO_VERSION"
+
 // ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
 const ClusterNameData = "managed-cluster-name"
 

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -101,6 +101,7 @@ func TestGetInstallJobName(t *testing.T) {
 // WHEN a verrazzano resource has been applied
 // THEN ensure all the objects are already created
 func TestSuccessfulInstall(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
@@ -132,20 +133,20 @@ func TestSuccessfulInstall(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap
-	expectConfigMapExists(mock, namespace, name, labels)
+	expectConfigMapExists(mock, name, labels)
 
 	// Expect a call to get the verrazzano system namespace (return exists)
 	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -207,6 +208,7 @@ func TestSuccessfulInstall(t *testing.T) {
 // WHEN a verrazzano resource has been created
 // THEN ensure all the objects are created
 func TestCreateVerrazzano(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test1"}
@@ -237,14 +239,14 @@ func TestCreateVerrazzano(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
+			asserts.Equalf(getInstallNamespace(), serviceAccount.Namespace, "ServiceAccount namespace did not match")
 			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
@@ -263,20 +265,20 @@ func TestCreateVerrazzano(t *testing.T) {
 			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
 			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
-			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
+			asserts.Equalf(getInstallNamespace(), clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ConfigMap - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
+			asserts.Equalf(getInstallNamespace(), configMap.Namespace, "ConfigMap namespace did not match")
 			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			return nil
@@ -287,14 +289,14 @@ func TestCreateVerrazzano(t *testing.T) {
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
+			asserts.Equalf(getInstallNamespace(), job.Namespace, "Job namespace did not match")
 			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
@@ -304,7 +306,7 @@ func TestCreateVerrazzano(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -342,6 +344,7 @@ func TestCreateVerrazzano(t *testing.T) {
 // WHEN a verrazzano resource has been created
 // THEN ensure all the objects are created
 func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test1"}
@@ -380,14 +383,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ServiceAccount - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, serviceAccount.Namespace, "ServiceAccount namespace did not match")
+			asserts.Equalf(getInstallNamespace(), serviceAccount.Namespace, "ServiceAccount namespace did not match")
 			asserts.Equalf(buildServiceAccountName(name), serviceAccount.Name, "ServiceAccount name did not match")
 			asserts.Equalf(labels, serviceAccount.Labels, "ServiceAccount labels did not match")
 			return nil
@@ -406,13 +409,13 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 			asserts.Equalf(buildClusterRoleBindingName(namespace, name), clusterRoleBinding.Name, "ClusterRoleBinding name did not match")
 			asserts.Equalf(labels, clusterRoleBinding.Labels, "ClusterRoleBinding labels did not match")
 			asserts.Equalf(buildServiceAccountName(name), clusterRoleBinding.Subjects[0].Name, "ClusterRoleBinding Subjects name did not match")
-			asserts.Equalf(namespace, clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
+			asserts.Equalf(getInstallNamespace(), clusterRoleBinding.Subjects[0].Namespace, "ClusterRoleBinding Subjects namespace did not match")
 			return nil
 		})
 
 	// Expect a call to get the DNS config secret and return it
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			data := make(map[string][]byte)
 			data["passphrase"] = []byte("passphraseValue")
@@ -430,14 +433,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the ConfigMap - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, buildServiceAccountName(name)))
 
 	// Expect a call to create the ConfigMap - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, configMap.Namespace, "ConfigMap namespace did not match")
+			asserts.Equalf(getInstallNamespace(), configMap.Namespace, "ConfigMap namespace did not match")
 			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
 			asserts.NotNil(configMap.Data["config.json"], "Configuration entry not found")
@@ -450,14 +453,14 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 
 	// Expect a call to get the Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to create the Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
+			asserts.Equalf(getInstallNamespace(), job.Namespace, "Job namespace did not match")
 			asserts.Equalf(buildInstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
@@ -467,7 +470,7 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
+	mock.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Any()).Return(nil)
 
 	// Expect a call to delete a stale uninstall job resource
 	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -505,9 +508,11 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure all the objects are deleted
 func TestUninstallComplete(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
+	var verrazzanoToUse vzapi.Verrazzano
 
 	deleteTime := metav1.Time{
 		Time: time.Now(),
@@ -541,14 +546,20 @@ func TestUninstallComplete(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a lookup of a running install job
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to get the uninstall Job - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -580,6 +591,11 @@ func TestUninstallComplete(t *testing.T) {
 			return nil
 		})
 
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+	expectDeleteNamespace(mock)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -597,9 +613,11 @@ func TestUninstallComplete(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure an unisntall job is started
 func TestUninstallStarted(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
+	var verrazzanoToUse vzapi.Verrazzano
 
 	deleteTime := metav1.Time{
 		Time: time.Now(),
@@ -634,21 +652,27 @@ func TestUninstallStarted(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a lookup of a running install job
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to get the uninstall Job - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildUninstallJobName(name)))
 
 	// Expect a call to create the uninstall Job - return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, job *batchv1.Job, opts ...client.CreateOption) error {
-			asserts.Equalf(namespace, job.Namespace, "Job namespace did not match")
+			asserts.Equalf(getInstallNamespace(), job.Namespace, "Job namespace did not match")
 			asserts.Equalf(buildUninstallJobName(name), job.Name, "Job name did not match")
 			asserts.Equalf(labels, job.Labels, "Job labels did not match")
 			return nil
@@ -677,9 +701,11 @@ func TestUninstallStarted(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure the error is handled
 func TestUninstallFailed(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
+	var verrazzanoToUse vzapi.Verrazzano
 
 	deleteTime := metav1.Time{
 		Time: time.Now(),
@@ -690,11 +716,6 @@ func TestUninstallFailed(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
-
-	// Expect a lookup of a running install job
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to get the verrazzano resource.  Return resource with deleted timestamp.
 	mock.EXPECT().
@@ -711,9 +732,20 @@ func TestUninstallFailed(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Expect a lookup of a running install job
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
+
 	// Expect a call to get the uninstall Job - return that it exists and the job failed
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -750,6 +782,11 @@ func TestUninstallFailed(t *testing.T) {
 			return nil
 		})
 
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+	expectDeleteNamespace(mock)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -767,9 +804,11 @@ func TestUninstallFailed(t *testing.T) {
 // WHEN a verrazzano resource has been deleted
 // THEN ensure all the objects are deleted
 func TestUninstallSucceeded(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 	labels := map[string]string{"label1": "test"}
+	var verrazzanoToUse vzapi.Verrazzano
 
 	deleteTime := metav1.Time{
 		Time: time.Now(),
@@ -780,11 +819,6 @@ func TestUninstallSucceeded(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
-
-	// Expect a lookup of a running install job
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
 
 	// Expect a call to get the verrazzano resource.  Return resource with deleted timestamp.
 	mock.EXPECT().
@@ -801,9 +835,20 @@ func TestUninstallSucceeded(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Expect a lookup of a running install job
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, buildInstallJobName(name)))
+
 	// Expect a call to get the uninstall Job - return that it exists and the job succeeded
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildUninstallJobName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, job *batchv1.Job) error {
 			newJob := installjob.NewJob(&installjob.JobConfig{
 				JobConfigCommon: k8s.JobConfigCommon{
@@ -840,6 +885,11 @@ func TestUninstallSucceeded(t *testing.T) {
 			return nil
 		})
 
+	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
+	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
+	expectDeleteConfigMap(mock, getInstallNamespace(), name)
+	expectDeleteNamespace(mock)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -857,6 +907,7 @@ func TestUninstallSucceeded(t *testing.T) {
 // WHEN it does not exist
 // THEN ensure the error not found is handled
 func TestVerrazzanoNotFound(t *testing.T) {
+	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
 
@@ -942,7 +993,7 @@ func TestServiceAccountGetError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get ServiceAccount"))
 
 	// Create and make the request
@@ -953,8 +1004,8 @@ func TestServiceAccountGetError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to get ServiceAccount")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestServiceAccountCreateError tests the Reconcile method for the following use case
@@ -985,7 +1036,7 @@ func TestServiceAccountCreateError(t *testing.T) {
 
 	// Expect a call to get the ServiceAccount - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ServiceAccount"}, name))
 
 	// Expect a call to create the ServiceAccount - return failure
@@ -1001,8 +1052,8 @@ func TestServiceAccountCreateError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to create ServiceAccount")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestClusterRoleBindingGetError tests the Reconcile method for the following use case
@@ -1032,7 +1083,7 @@ func TestClusterRoleBindingGetError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the ServiceAccount - return that it exists
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding - return a failure error
 	mock.EXPECT().
@@ -1047,8 +1098,8 @@ func TestClusterRoleBindingGetError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to get ClusterRoleBinding")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestClusterRoleBindingCreateError tests the Reconcile method for the following use case
@@ -1078,7 +1129,7 @@ func TestClusterRoleBindingCreateError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the ServiceAccount - return that it exists
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding - return not found
 	mock.EXPECT().
@@ -1098,8 +1149,8 @@ func TestClusterRoleBindingCreateError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to create ClusterRoleBinding")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestConfigMapGetError tests the Reconcile method for the following use case
@@ -1129,14 +1180,14 @@ func TestConfigMapGetError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get ConfigMap"))
 
 	// Create and make the request
@@ -1147,8 +1198,8 @@ func TestConfigMapGetError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to get ConfigMap")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestConfigMapCreateError tests the Reconcile method for the following use case
@@ -1178,14 +1229,14 @@ func TestConfigMapCreateError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "ConfigMap"}, name))
 
 	// Expect a call to create the ConfigMap - return failure
@@ -1201,8 +1252,8 @@ func TestConfigMapCreateError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to create ConfigMap")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestVZSystemNamespaceGetError tests the Reconcile method for the following use case
@@ -1232,13 +1283,13 @@ func TestVZSystemNamespaceGetError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap
-	expectConfigMapExists(mock, namespace, name, labels)
+	expectConfigMapExists(mock, name, labels)
 
 	errMsg := "get vz system namespace error"
 	// Expect a call to get the verrazzano system namespace - return a failure error
@@ -1254,8 +1305,8 @@ func TestVZSystemNamespaceGetError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, errMsg)
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestVZSystemNamespaceCreateError tests the Reconcile method for the following use case
@@ -1285,13 +1336,13 @@ func TestVZSystemNamespaceCreateError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap
-	expectConfigMapExists(mock, namespace, name, labels)
+	expectConfigMapExists(mock, name, labels)
 
 	errMsg := "create vz system namespace error"
 	// Expect a call to get the verrazzano system namespace - return an IsNotFound
@@ -1312,8 +1363,8 @@ func TestVZSystemNamespaceCreateError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, errMsg)
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestJobGetError tests the Reconcile method for the following use case
@@ -1343,20 +1394,20 @@ func TestJobGetError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap
-	expectConfigMapExists(mock, namespace, name, labels)
+	expectConfigMapExists(mock, name, labels)
 
 	// Expect a call to get the verrazzano system namespace (return exists)
 	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return a failure error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Job"))
 
 	// Create and make the request
@@ -1367,8 +1418,8 @@ func TestJobGetError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to get Job")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestGetOCIConfigSecretError tests the Reconcile method for the following use case
@@ -1406,14 +1457,14 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the DNS config secret but return a not found error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: "test-oci-config-secret"}, gomock.Not(gomock.Nil())).
 		Return(errors.NewBadRequest("failed to get Secret"))
 
 	// Create and make the request
@@ -1424,8 +1475,8 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to get Secret")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestJobCreateError tests the Reconcile method for the following use case
@@ -1455,20 +1506,20 @@ func TestJobCreateError(t *testing.T) {
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
 
 	// Expect a call to get the service account
-	expectGetServiceAccountExists(mock, namespace, name, labels)
+	expectGetServiceAccountExists(mock, name, labels)
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the ConfigMap
-	expectConfigMapExists(mock, namespace, name, labels)
+	expectConfigMapExists(mock, name, labels)
 
 	// Expect a call to get the verrazzano system namespace (return exists)
 	expectGetVerrazzanoSystemNamespaceExists(mock, asserts)
 
 	// Expect a call to get the Job - return not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildInstallJobName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: namespace, Resource: "Job"}, name))
 
 	// Expect a call to create the Job - return failure
@@ -1484,8 +1535,8 @@ func TestJobCreateError(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.EqualError(err, "failed to create Job")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestCreateInternalConfigMapReturnsError tests the saveVerrazzanoSpec error condition on create
@@ -1511,7 +1562,7 @@ func TestCreateInternalConfigMapReturnsError(t *testing.T) {
 
 	// Expect a call to get an existing configmap, but return a NotFound error.
 	mock.EXPECT().
-		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: getInstallNamespace()}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
 			return errors.NewNotFound(schema.GroupResource{
 				Group:    vzapi.SchemeGroupVersion.Group,
@@ -1564,8 +1615,8 @@ func TestUpdateInternalConfigMap(t *testing.T) {
 	returnMap := corev1.ConfigMap{
 		Data: savedMap,
 	}
-	// Expect a call to get a stale uninstall job resource
-	mock.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Any()).
+	// Expect a call to get a ConfigMap
+	mock.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: getInstallNamespace()}, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
 			assert.NotNil(t, configMap)
 			configMap.Data = returnMap.Data
@@ -1893,7 +1944,7 @@ func newVerrazzanoReconciler(c client.Client) Reconciler {
 func setupInstallInternalConfigMapExpectations(mock *mocks.MockClient, name string, namespace string) {
 	// Expect a call to get an existing configmap, but return a NotFound error.
 	mock.EXPECT().
-		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: namespace}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), client.ObjectKey{Name: buildInternalConfigMapName(name), Namespace: getInstallNamespace()}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name client.ObjectKey, configMap *corev1.ConfigMap) error {
 			return errors.NewNotFound(schema.GroupResource{
 				Group:    vzapi.SchemeGroupVersion.Group,
@@ -1960,10 +2011,10 @@ func expectVerrazzanoSystemNamespaceDoesNotExist(mock *mocks.MockClient, asserts
 
 // expectConfigMapExists expects a call to get the config map for the Verrazzano with the given namespace and name,
 // and returns that it exists
-func expectConfigMapExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
+func expectConfigMapExists(mock *mocks.MockClient, name string, labels map[string]string) {
 	// Expect a call to get the ConfigMap - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildConfigMapName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
 			cm := installjob.NewConfigMap(name.Namespace, name.Name, labels)
 			configMap.ObjectMeta = cm.ObjectMeta
@@ -1979,7 +2030,7 @@ func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzap
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: clusterRoleBindingName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-			crb := installjob.NewClusterRoleBinding(&verrazzanoToUse, nsName.Name, buildServiceAccountName(nsName.Name))
+			crb := installjob.NewClusterRoleBinding(&verrazzanoToUse, nsName.Name, getInstallNamespace(), buildServiceAccountName(nsName.Name))
 			clusterRoleBinding.ObjectMeta = crb.ObjectMeta
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
@@ -1989,10 +2040,10 @@ func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzap
 
 // expectGetServiceAccountExists expects a call to get the service account for the Verrazzano with the given
 // namespace and name, and returns that it exists
-func expectGetServiceAccountExists(mock *mocks.MockClient, namespace string, name string, labels map[string]string) {
+func expectGetServiceAccountExists(mock *mocks.MockClient, name string, labels map[string]string) {
 	// Expect a call to get the ServiceAccount - return that it exists
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: getInstallNamespace(), Name: buildServiceAccountName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, serviceAccount *corev1.ServiceAccount) error {
 			newSA := installjob.NewServiceAccount(name.Namespace, name.Name, []string{}, labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
@@ -2011,6 +2062,38 @@ func expectGetVerrazzanoExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Ver
 			verrazzano.Spec.Components.DNS = verrazzanoToUse.Spec.Components.DNS
 			return nil
 		})
+}
+
+// expectDeleteServiceAccount expects a call to delete the service account used by install
+func expectDeleteServiceAccount(mock *mocks.MockClient, namespace string, name string) {
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// Expect a call to get the ServiceAccount - return that it exists
+	// mock.EXPECT().Delete(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildServiceAccountName(name)}, gomock.Any()).Return(nil)
+}
+
+// expectDeleteConfigMap expects a call to delete the config map used by install
+func expectDeleteConfigMap(mock *mocks.MockClient, namespace string, name string) {
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// Expect a call to get the ServiceAccount - return that it exists
+	// mock.EXPECT().Delete(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: buildConfigMapName(name)}, gomock.Any()).Return(nil)
+}
+
+// expectDeleteNamespace expects a call to delete the verrazzano-system ns
+func expectDeleteNamespace(mock *mocks.MockClient) {
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// Expect a call to get the ServiceAccount - return that it exists
+	// mock.EXPECT().Delete(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoSystemNamespace}, gomock.Any()).Return(nil)
+}
+
+// expectDeleteClusterRoleBinding expects a call to delete the ClusterRoleBinding for the Verrazzano with the given
+// namespace and name, and returns that it exists
+func expectDeleteClusterRoleBinding(mock *mocks.MockClient, namespace string, name string) {
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	//	mock.EXPECT().Delete(gomock.Any(), types.NamespacedName{Namespace: "", Name: buildClusterRoleBindingName(namespace, name)}, gomock.Any()).Return(nil)
 }
 
 // Test_commonPath tests commonPath function

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding.go
@@ -9,31 +9,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewClusterRoleBinding returns a cluster role binding resource for installing Verrazzano
+// NewClusterRoleBinding returns a ClusterRoleBinding resource for installing Verrazzano
 // vz - pointer to verrazzano resource
-// name - name of the clusterrolebinding resource
-// saName - name of service account resource
-func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saName string) *rbacv1.ClusterRoleBinding {
+// name - name of the ClusterRoleBinding resource
+// saNamespace - name of ServiceAccount namespace
+// saName - name of ServiceAccount resource
+func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, rbNname string, saNamespace string, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
+			Name:   rbNname,
 			Labels: vz.Labels,
-			// Set owner reference here instead of calling controllerutil.SetControllerReference
-			// which does not allow cluster-scoped resources.
-			// This reference will result in the clusterrolebinding resource being deleted
-			// when the verrazzano CR is deleted.
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: vz.APIVersion,
-					Kind:       vz.Kind,
-					Name:       vz.Name,
-					UID:        vz.UID,
-					Controller: func() *bool {
-						flag := true
-						return &flag
-					}(),
-				},
-			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -44,7 +29,7 @@ func NewClusterRoleBinding(vz *installv1alpha1.Verrazzano, name string, saName s
 			{
 				Kind:      "ServiceAccount",
 				Name:      saName,
-				Namespace: vz.Namespace,
+				Namespace: saNamespace,
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/clusterrolebinding_test.go
@@ -28,11 +28,11 @@ func TestNewClusterRoleBinding(t *testing.T) {
 	name := "test-clusterRoleBinding"
 	saName := "service-account"
 
-	clusterRoleBinding := NewClusterRoleBinding(&vz, name, saName)
+	clusterRoleBinding := NewClusterRoleBinding(&vz, name, namespace, saName)
 
 	assert.Equalf(t, "", clusterRoleBinding.Namespace, "Expected namespace did not match")
 	assert.Equalf(t, name, clusterRoleBinding.Name, "Expected clusterRoleBinding name did not match")
-	assert.Equalf(t, 1, len(clusterRoleBinding.OwnerReferences), "Expected length of owner references did not match")
+	assert.Equalf(t, 0, len(clusterRoleBinding.OwnerReferences), "Expected length of owner references did not match")
 	assert.Equalf(t, vz.Labels, clusterRoleBinding.Labels, "Expected labels did not match")
 	assert.Equalf(t, saName, clusterRoleBinding.Subjects[0].Name, "Expected service account name did not match")
 	assert.Equalf(t, "ServiceAccount", clusterRoleBinding.Subjects[0].Kind, "Expected subject kind did not match")

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -56,6 +56,7 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, req ctrl.Request, 
 	log.Info(msg)
 	cr.Status.Version = targetVersion
 	err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete)
+
 	return ctrl.Result{}, err
 }
 

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -42,8 +42,10 @@ type badRunner struct {
 // WHEN a verrazzano version is empty
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeNoVersion(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -73,6 +75,12 @@ func TestUpgradeNoVersion(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -90,8 +98,10 @@ func TestUpgradeNoVersion(t *testing.T) {
 // WHEN a verrazzano spec.version is the same as the status.version
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeSameVersion(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -124,6 +134,12 @@ func TestUpgradeSameVersion(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -141,8 +157,10 @@ func TestUpgradeSameVersion(t *testing.T) {
 // WHEN upgrade has not been started and spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeStarted is added
 func TestUpgradeStarted(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -177,6 +195,12 @@ func TestUpgradeStarted(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
@@ -206,8 +230,10 @@ func TestUpgradeStarted(t *testing.T) {
 // WHEN the current upgrade failed more than the failure limet
 // THEN ensure that upgrade is not started
 func TestUpgradeTooManyFailures(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -255,6 +281,12 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -272,8 +304,10 @@ func TestUpgradeTooManyFailures(t *testing.T) {
 // WHEN the total upgrade failures exceed the limit, but the current upgrade is under the limit
 // THEN ensure that upgrade is started
 func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -331,6 +365,12 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
@@ -361,8 +401,10 @@ func TestUpgradeStartedWhenPrevFailures(t *testing.T) {
 // WHEN the current upgrade failures exceeds the limit, but there was a previous upgrade success
 // THEN ensure that upgrade is not started
 func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -421,6 +463,12 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
@@ -438,8 +486,10 @@ func TestUpgradeNotStartedWhenPrevFailures(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeCompleted(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	fname, _ := filepath.Abs(unitTestBomFile)
 	component.SetUnitTestBomFilePath(fname)
@@ -478,6 +528,12 @@ func TestUpgradeCompleted(t *testing.T) {
 			return nil
 		})
 
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
@@ -511,8 +567,10 @@ func TestUpgradeCompleted(t *testing.T) {
 // WHEN spec.version doesn't match status.version
 // THEN ensure a condition with type UpgradeCompleted is added
 func TestUpgradeHelmError(t *testing.T) {
+	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
 
 	component.SetUnitTestBomFilePath(unitTestBomFile)
 	asserts := assert.New(t)
@@ -549,6 +607,12 @@ func TestUpgradeHelmError(t *testing.T) {
 			}
 			return nil
 		})
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"flag"
-	"os"
-
 	"github.com/verrazzano/verrazzano/pkg/log"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -16,16 +14,14 @@ import (
 	config2 "github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/netpolicy"
 	"go.uber.org/zap"
-	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -138,13 +134,6 @@ func main() {
 	}
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Errorf("unable to create controller: %v", err)
-		os.Exit(1)
-	}
-
-	// Watch for the secondary resource (Job).
-	if err := reconciler.Controller.Watch(&source.Kind{Type: &batchv1.Job{}},
-		&handler.EnqueueRequestForOwner{OwnerType: &installv1alpha1.Verrazzano{}, IsController: true}); err != nil {
-		setupLog.Errorf("unable to set watch for Job resource: %v", err)
 		os.Exit(1)
 	}
 

--- a/platform-operator/scripts/install/2-install-system-components.sh
+++ b/platform-operator/scripts/install/2-install-system-components.sh
@@ -14,6 +14,7 @@ set -eu
 
 VERRAZZANO_DEFAULT_SECRET_NAMESPACE="cert-manager"
 VERRAZZANO_DEFAULT_SECRET_NAME="verrazzano-ca-certificate-secret"
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 function install_nginx_ingress_controller()
 {
@@ -94,8 +95,8 @@ function setup_cluster_issuer() {
     local OCI_DNS_ZONE_OCID=$(get_config_value ".dns.oci.dnsZoneOcid")
     local OCI_DNS_ZONE_NAME=$(get_config_value ".dns.oci.dnsZoneName")
 
-    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET ; then
-        fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist"
+    if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n $VERRAZZANO_INSTALL_NS ; then
+        fail "The OCI Configuration Secret $OCI_DNS_CONFIG_SECRET does not exist in the namespace $VERRAZZANO_INSTALL_NS"
     fi
 
     acmeURL="https://acme-v02.api.letsencrypt.org/directory"
@@ -228,11 +229,11 @@ function install_external_dns()
   local externalDNSNamespace=cert-manager
 
   if ! kubectl get secret $OCI_DNS_CONFIG_SECRET -n ${externalDNSNamespace} ; then
-    # secret does not exist, so copy the configured oci config secret from default namespace.
-    # Operator has already checked for existence of secret in default namespace
+    # secret does not exist, so copy the configured oci config secret from verrazzano-install namespace.
+    # Operator has already checked for existence of secret in verrazzano-install namespace
     # The DNS zone compartment will get appended to secret generated for cert external dns
     local dns_compartment=$(get_config_value ".dns.oci.dnsZoneCompartmentOcid")
-    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
+    kubectl get secret ${OCI_DNS_CONFIG_SECRET} -n ${VERRAZZANO_INSTALL_NS} -o go-template='{{range $k,$v := .data}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}' \
         | sed '/^$/d' > $TMP_DIR/oci.yaml
     echo "compartment: $dns_compartment" >> $TMP_DIR/oci.yaml
     kubectl create secret generic $OCI_DNS_CONFIG_SECRET --from-file=$TMP_DIR/oci.yaml -n ${externalDNSNamespace}

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -645,7 +645,7 @@ fi
 if [ $(is_oci_dns) == "true" ]; then
   secret_name=$(get_config_value ".dns.oci.ociConfigSecret")
   consoleout
-  consoleout "NOTE: The secret \"${secret_name}\" created in the \"default\" namespace prior to installation is only used during the actual installation."
+  consoleout "NOTE: The secret \"${secret_name}\" created in the \"verrazzano-install\" namespace prior to installation is only used during the actual installation."
   consoleout "You may delete it now.  DO NOT delete the secret of the same name in the cert-manager namespace."
   consoleout
 fi

--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -64,6 +64,9 @@ OCI_CONFIG_FILE=~/.oci/config
 SECTION=DEFAULT
 OCI_CONFIG_SECRET_NAME=oci
 
+K8SCONTEXT=""
+VERRAZZANO_INSTALL_NS=verrazzano-install
+
 while getopts o:s:k:h flag
 do
     case "${flag}" in
@@ -90,17 +93,17 @@ if [[ ! -z "$pass_phrase" ]]; then
   echo "  passphrase: $pass_phrase" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
+# create the secret in verrazzano-install namespace
 create_secret=true
 
-kubectl get secret $OCI_CONFIG_SECRET_NAME -n default > /dev/null 2>&1
+kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
-  echo "Secret $OCI_CONFIG_SECRET_NAME already exists.  Please delete then try again."
+  echo "Secret $OCI_CONFIG_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace. Please delete that and try again."
   exit 1
 fi
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
 
+kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
 
 
 

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -10,6 +10,7 @@ TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
 OCI_CONFIG_SECRET_NAME=oci
+VERRAZZANO_INSTALL_NS=verrazzano-install
 
 # Validate expected environment variables exist
 if [ -z "${OCI_CLI_REGION}" ]; then
@@ -47,5 +48,9 @@ if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
   echo "  passphrase: ${OCI_PRIVATE_KEY_PASSPHRASE}" >> $OUTPUT_FILE
 fi
 
-# create the secret in default namespace
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
+# create the secret in verrazzano-install namespace
+if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
+  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and try again."
+  exit 1
+fi
+kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE


### PR DESCRIPTION
Cherry pick change for VZ-3358, this uses verrazzano-install namespace instead of the default namespace for the install/uninstall jobs and pods plus the service account.  It also includes the change where the OCI secret is now created in the verrazzano-install namespace. 

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
