### PR TITLE
VZ-3422.  Non-blocking installs of Go components; install state-machine

### DIFF
--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -154,6 +154,7 @@ func (r *Reconciler) createOrUpdateNamespaces(ctx context.Context, vp clustersv1
 			})
 			if err != nil {
 				logger.Error(err, "create or update namespace failed", "namespace", nsTemplate.Metadata.Name, "opResult", opResult)
+				return err
 			}
 
 			if err = r.createOrUpdateRoleBindings(ctx, nsTemplate.Metadata.Name, vp, logger); err != nil {

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -200,6 +200,9 @@ type Condition struct {
 type StateType string
 
 const (
+	// Disabled is the state for when a component is not currently installed
+	Disabled StateType = "Disabled"
+
 	// Installing is the state when an install is in progress
 	Installing StateType = "Installing"
 
@@ -208,6 +211,12 @@ const (
 
 	// Upgrading is the state when an upgrade is in progress
 	Upgrading StateType = "Upgrading"
+
+	// Updating is the state when a component configuration update is being applied
+	Updating StateType = "Updating"
+
+	// Error is the state when a Verrazzano resource has experienced an error that may leave it in an unstable state
+	Error StateType = "Error"
 
 	// Ready is the state when a Verrazzano resource can perform an uninstall or upgrade
 	Ready StateType = "Ready"

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -6,7 +6,10 @@ package appoper
 import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"go.uber.org/zap"
@@ -25,4 +28,12 @@ func AppendApplicationOperatorOverrides(_ *zap.SugaredLogger, _ string, _ string
 	})
 	fmt.Println("Foo")
 	return kvs, nil
+}
+
+// IsApplicationOperatorReady checks if the application operator deployment is ready
+func IsApplicationOperatorReady(log *zap.SugaredLogger, c client.Client, name string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: "verrazzano-application-operator", Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, c, deployments, 1)
 }

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
@@ -4,9 +4,15 @@
 package appoper
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"os"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -36,4 +42,46 @@ func TestAppendAppOperatorOverrides(t *testing.T) {
 	assert.Len(kvs, 1, "AppendApplicationOperatorOverrides returned wrong number of Key:Value pairs")
 	assert.Equalf("image", kvs[0].Key, "Did not get expected image Key")
 	assert.Equalf(customImage, kvs[0].Value, "Did not get expected image Value")
+}
+
+// TestIsApplicationOperatorReady tests the IsApplicationOperatorReady function
+// GIVEN a call to IsApplicationOperatorReady
+//  WHEN the deployment object has enough replicas available
+//  THEN true is returned
+func TestIsApplicationOperatorReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      "verrazzano-application-operator",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, IsApplicationOperatorReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
+}
+
+// TestIsApplicationOperatorNotReady tests the IsApplicationOperatorReady function
+// GIVEN a call to IsApplicationOperatorReady
+//  WHEN the deployment object does NOT have enough replicas available
+//  THEN false is returned
+func TestIsApplicationOperatorNotReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      "verrazzano-application-operator",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 1,
+		},
+	})
+	assert.False(t, IsApplicationOperatorReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
 }

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package coherence
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const coherenceOperatorDeploymentName = "coherence-operator"
+
+// IsCoherenceOperatorReady checks if the COH operator deployment is ready
+func IsCoherenceOperatorReady(log *zap.SugaredLogger, c clipkg.Client, _ string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: coherenceOperatorDeploymentName, Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, c, deployments, 1)
+}

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence_test.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package coherence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestIsCoherenceOperatorReady tests the IsApplicationOperatorReady function
+// GIVEN a call to IsCoherenceOperatorReady
+//  WHEN the deployment object has enough replicas available
+//  THEN true is returned
+func TestIsCoherenceOperatorReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      coherenceOperatorDeploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, IsCoherenceOperatorReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
+}
+
+// TestIsCoherenceOperatorNotReady tests the IsApplicationOperatorReady function
+// GIVEN a call to IsCoherenceOperatorReady
+//  WHEN the deployment object does NOT have enough replicas available
+//  THEN false is returned
+func TestIsCoherenceOperatorNotReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      coherenceOperatorDeploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 1,
+		},
+	})
+	assert.False(t, IsCoherenceOperatorReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
+}

--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package oam
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const oamOperatorDeploymentName = "oam-kubernetes-runtime"
+
+// IsOAMReady checks if the OAM operator deployment is ready
+func IsOAMReady(log *zap.SugaredLogger, c client.Client, _ string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: oamOperatorDeploymentName, Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, c, deployments, 1)
+}

--- a/platform-operator/controllers/verrazzano/component/oam/oam_test.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package oam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestIsOAMOperatorReady tests the IsOAMReady function
+// GIVEN a call to IsOAMReady
+//  WHEN the deployment object has enough replicas available
+//  THEN true is returned
+func TestIsOAMOperatorReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      oamOperatorDeploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       1,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 0,
+		},
+	})
+	assert.True(t, IsOAMReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
+}
+
+// TestIsOAMOperatorNotReady tests the IsOAMReady function
+// GIVEN a call to IsOAMReady
+//  WHEN the deployment object does NOT have enough replicas available
+//  THEN false is returned
+func TestIsOAMOperatorNotReady(t *testing.T) {
+
+	fakeClient := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      oamOperatorDeploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			ReadyReplicas:       0,
+			AvailableReplicas:   0,
+			UnavailableReplicas: 1,
+		},
+	})
+	assert.False(t, IsOAMReady(zap.S(), fakeClient, "", constants.VerrazzanoSystemNamespace))
+}

--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -5,6 +5,10 @@ package registry
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/coherence"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/oam"
+	"path/filepath"
+
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/appoper"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -14,7 +18,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"go.uber.org/zap"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
@@ -111,9 +114,9 @@ func GetComponents() []spi.Component {
 			ChartNamespace:          constants.VerrazzanoSystemNamespace,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			WaitForInstall:          true,
 			ImagePullSecretKeyname:  "imagePullSecrets[0].name",
 			ValuesFile:              filepath.Join(overridesDir, "coherence-values.yaml"),
+			ReadyStatusFunc:         coherence.IsCoherenceOperatorReady,
 		},
 		helm.HelmComponent{
 			ReleaseName:             "weblogic-operator",
@@ -121,12 +124,12 @@ func GetComponents() []spi.Component {
 			ChartNamespace:          constants.VerrazzanoSystemNamespace,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			WaitForInstall:          true,
 			ImagePullSecretKeyname:  "imagePullSecrets[0].name",
 			ValuesFile:              filepath.Join(overridesDir, "weblogic-values.yaml"),
 			PreInstallFunc:          weblogic.WeblogicOperatorPreInstall,
 			AppendOverridesFunc:     weblogic.AppendWeblogicOperatorOverrides,
 			Dependencies:            []string{"istiod"},
+			ReadyStatusFunc:         weblogic.IsWeblogicOperatorReady,
 		},
 		helm.HelmComponent{
 			ReleaseName:             "oam-kubernetes-runtime",
@@ -134,9 +137,9 @@ func GetComponents() []spi.Component {
 			ChartNamespace:          constants.VerrazzanoSystemNamespace,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			WaitForInstall:          true,
 			ValuesFile:              filepath.Join(overridesDir, "oam-kubernetes-runtime-values.yaml"),
 			ImagePullSecretKeyname:  "imagePullSecrets[0].name",
+			ReadyStatusFunc:         oam.IsOAMReady,
 		},
 		helm.HelmComponent{
 			ReleaseName:             "verrazzano-application-operator",
@@ -144,10 +147,11 @@ func GetComponents() []spi.Component {
 			ChartNamespace:          constants.VerrazzanoSystemNamespace,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			WaitForInstall:          true,
 			ValuesFile:              filepath.Join(overridesDir, "verrazzano-application-operator-values.yaml"),
 			AppendOverridesFunc:     appoper.AppendApplicationOperatorOverrides,
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
+			ReadyStatusFunc:         appoper.IsApplicationOperatorReady,
+			Dependencies:            []string{"oam-kubernetes-runtime"},
 		},
 		helm.HelmComponent{
 			ReleaseName:             "mysql",

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
@@ -6,6 +6,7 @@ package weblogic
 import (
 	"context"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const wlsOperatorDeploymentName = "weblogic-operator"
 
 // AppendWeblogicOperatorOverrides appends the WKO-specific helm Value overrides.
 func AppendWeblogicOperatorOverrides(_ *zap.SugaredLogger, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
@@ -64,4 +67,11 @@ func WeblogicOperatorPreInstall(log *zap.SugaredLogger, client clipkg.Client, _ 
 		return []bom.KeyValue{}, err
 	}
 	return []bom.KeyValue{}, nil
+}
+
+func IsWeblogicOperatorReady(log *zap.SugaredLogger, c clipkg.Client, _ string, namespace string) bool {
+	deployments := []types.NamespacedName{
+		{Name: wlsOperatorDeploymentName, Namespace: namespace},
+	}
+	return status.DeploymentsReady(log, c, deployments, 1)
 }

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -4,43 +4,63 @@
 package verrazzano
 
 import (
-	"fmt"
+	"context"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"go.uber.org/zap"
 )
 
-// Reconcile upgrade will install the components as required
-func (r *Reconciler) reconcileInstall(log *zap.SugaredLogger, cr *installv1alpha1.Verrazzano) error {
+// reconcileComponents Reconcile components individually
+func (r *Reconciler) reconcileComponents(_ context.Context, log *zap.SugaredLogger, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
+
+	result := ctrl.Result{}
 
 	// Loop through all of the Verrazzano components and upgrade each one sequentially for now; will parallelize later
 	for _, comp := range registry.GetComponents() {
 		if !comp.IsOperatorInstallSupported() {
 			continue
 		}
-		// If component is enabled -- need to replicate scripts' config merging logic here
-		// If component is in deployed state, continue
-		if comp.IsReady(log, r.Client, cr.Namespace) {
-			log.Infof("Component %s already installed")
-			if err := r.updateComponentStatus(log, cr, comp.Name(), "Update ready status", installv1alpha1.InstallComplete); err != nil {
-				return err
-			}
+		componentState := cr.Status.Components[comp.Name()].State
+		switch componentState {
+		case installv1alpha1.Ready:
+			// For delete, we should look at the VZ resource delete timestamp and shift into Quiescing/Uninstalling state
 			continue
-		}
-		if !registry.ComponentDependenciesMet(log, r.Client, comp) {
-			return fmt.Errorf("Dependencies not met for %s: %v", comp.Name(), comp.GetDependencies())
-		}
-		if err := r.updateComponentStatus(log, cr, comp.Name(), "Install starting", installv1alpha1.InstallStarted); err != nil {
-			return err
-		}
-		// If component is not installed,install it
-		if err := comp.Install(log, r, cr.Namespace, r.DryRun); err != nil {
-			return err
-		}
-		if err := r.updateComponentStatus(log, cr, comp.Name(), "Install complete", installv1alpha1.InstallComplete); err != nil {
-			return err
+		case installv1alpha1.Disabled:
+			r.updateComponentStatus(log, cr, comp.Name(), "Install started", installv1alpha1.InstallStarted)
+			result.Requeue = true
+			continue
+		case installv1alpha1.Installing:
+			// For delete, we should look at the VZ resource delete timestamp and shift into Quiescing/Uninstalling state
+			// If component is enabled -- need to replicate scripts' config merging logic here
+			// If component is in deployed state, continue
+			if comp.IsReady(log, r.Client, cr.Namespace) {
+				log.Infof("Component %s successfully installed")
+				if err := r.updateComponentStatus(log, cr, comp.Name(), "Install complete", installv1alpha1.InstallComplete); err != nil {
+					return ctrl.Result{Requeue: true}, err
+				}
+				result.Requeue = true
+				continue
+			}
+			if !registry.ComponentDependenciesMet(log, r.Client, comp) {
+				log.Infof("Dependencies not met for %s: %v", comp.Name(), comp.GetDependencies())
+				result.Requeue = true
+				continue
+			}
+			if err := r.updateComponentStatus(log, cr, comp.Name(), "Install starting", installv1alpha1.InstallStarted); err != nil {
+				return ctrl.Result{Requeue: true}, err
+			}
+			// If component is not installed,install it
+			if err := comp.Install(log, r, cr.Namespace, r.DryRun); err != nil {
+				return ctrl.Result{Requeue: true}, err
+			}
+			//case installv1alpha1.Failed, installv1alpha1.Error:
+			//case installv1alpha1.Disabled:
+			//case installv1alpha1.Upgrading:
+			//case installv1alpha1.Updating:
+			//case installv1alpha1.Quiescing:
 		}
 	}
-	return nil
+	return result, nil
 }

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -6,7 +6,6 @@ package verrazzano
 import (
 	"context"
 	"fmt"
-	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +19,7 @@ import (
 // so that the admin cluster can manage multi-cluster resources without the need of a VMC.  In the
 // case of a cluster that is used as a managed cluster, this secret will still be created, but not used, and
 // ultimately replaced when the user applies the managed cluster YAML which has the replacement secret.
-func (r *Reconciler) syncLocalRegistrationSecret(vz *installv1alpha1.Verrazzano) error {
+func (r *Reconciler) syncLocalRegistrationSecret() error {
 
 	// If the agent secret exists in verrazzano-system namespace then that means this
 	// is a managed cluster and the user applied the YAML to create all the secrets.
@@ -41,7 +40,7 @@ func (r *Reconciler) syncLocalRegistrationSecret(vz *installv1alpha1.Verrazzano)
 	}
 
 	// create the local registration secret
-	_, err = r.createOrUpdateLocalRegistrationSecret(vz, constants.MCLocalRegistrationSecret, constants.VerrazzanoSystemNamespace)
+	_, err = r.createOrUpdateLocalRegistrationSecret(constants.MCLocalRegistrationSecret, constants.VerrazzanoSystemNamespace)
 	if err != nil {
 		return err
 	}
@@ -50,7 +49,7 @@ func (r *Reconciler) syncLocalRegistrationSecret(vz *installv1alpha1.Verrazzano)
 }
 
 // Create or update the secret
-func (r *Reconciler) createOrUpdateLocalRegistrationSecret(vz *installv1alpha1.Verrazzano, name string, namespace string) (controllerutil.OperationResult, error) {
+func (r *Reconciler) createOrUpdateLocalRegistrationSecret(name string, namespace string) (controllerutil.OperationResult, error) {
 	var secret corev1.Secret
 	secret.Namespace = namespace
 	secret.Name = name


### PR DESCRIPTION
# Description

Allow non-blocking installs of components, validate ready status independently.

Fixes VZ-3422 (partial).

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
