### PR TITLE
VZ-3380: Perform an update in the multicluster acceptance tests

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -368,6 +368,7 @@ pipeline {
                     }
                     post {
                         always {
+                            archiveArtifacts artifacts: '${WORKSPACE}/acceptance-test-operator.yaml', allowEmptyArchive: true
                             script {
                                 dumpInstallLogs()
                                 VZ_TEST_METRIC = metricJobName('')
@@ -1228,7 +1229,7 @@ def getVerrazzanoOperatorYaml() {
         cd ${GO_REPO_PATH}/verrazzano
         if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
             echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-            curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
+            curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
             cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
         else
             echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1229,7 +1229,7 @@ def getVerrazzanoOperatorYaml() {
         cd ${GO_REPO_PATH}/verrazzano
         if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
             echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-            curl -k -u ${GITHUB_RELEASE_USERID_USR}:${GITHUB_RELEASE_USERID_PSW} "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
+            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
             cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
         else
             echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -369,7 +369,8 @@ pipeline {
                                 cd ${GO_REPO_PATH}/verrazzano
                                 if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
                                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-                                    curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" > ${WORKSPACE}/acceptance-test-operator.yaml
+                                    curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
+                                    cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
                                 else
                                     echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
                                     env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -460,6 +460,14 @@ pipeline {
                 }
             }
         }
+        post {
+            failure {
+                script {
+                    dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-install")
+                }
+            }
+        }
+
         stage('Verify Upgrade') {
             // Rerun some stages to verify the upgrade
             parallel {
@@ -480,6 +488,14 @@ pipeline {
                 }
             }
         }
+        post {
+            failure {
+                script {
+                    dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-verify-upgrade")
+                }
+            }
+        }
+
         stage('Acceptance Tests') {
             stages {
                 stage ('Example apps') {
@@ -833,14 +849,14 @@ def upgradePlatformOperator() {
         script {
             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
             for (int count = 2; count <= clusterCount; count++) {
+                def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
                 sh """
                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
 
                     echo "Upgrading the Verrazzano platform operator"
                     # Download the operator.yaml for the target version that we are upgrading to
-                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/upgrade-operator.yaml
-                    cp ${WORKSPACE}/upgrade-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                    kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
+                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${upgradeOperatorFile}
+                    kubectl apply -f ${upgradeOperatorFile}
 
                     # need to sleep since the old operator needs to transition to terminating state
                     sleep 15

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -362,37 +362,9 @@ pipeline {
                         script {
                             VZ_INSTALL_METRIC = metricJobName('install_v8o')
                             metricTimerStart("${VZ_INSTALL_METRIC}")
-                            // Either download the specified release of the platform operator YAML, or create one
-                            // using the specific operator image provided by the user.
-                            sh """
-                                echo "Platform Operator Configuration"
-                                cd ${GO_REPO_PATH}/verrazzano
-                                if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-                                    echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-                                    curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
-                                    cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                                else
-                                    echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
-                                    env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
-                                fi
-                            """
-                        }
-                        script {
-                            // Create a dictionary of Verrazzano install steps to be executed in parallel
-                            // - the first one will always be the Admin cluster
-                            // - clusters 2-max are managed clusters
-                            def verrazzanoInstallStages = [:]
-                            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                            for(int count=1; count<=clusterCount; count++) {
-                                def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                                def key = "vz-mgd-${count-1}"
-                                if (count == 1) {
-                                    key = "vz-admin"
-                                }
-                                verrazzanoInstallStages["${key}"] = installVerrazzano(count, installerPath)
-                            }
-                            parallel verrazzanoInstallStages
-                        }
+                            getVerrazzanoOperatorYaml()
+                         }
+                        installVerrazzano()
                     }
                     post {
                         always {
@@ -1244,6 +1216,44 @@ def metricBuildDuration() {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"
         }
+    }
+}
+
+
+// Either download the specified release of the platform operator YAML, or create one
+// using the specific operator image provided by the user.
+def getVerrazzanoOperatorYaml() {
+    sh """
+        echo "Platform Operator Configuration"
+        cd ${GO_REPO_PATH}/verrazzano
+        if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
+            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
+            curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
+            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+        else
+            echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
+            env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
+        fi
+    """
+}
+
+// Install Verrazzano on each of the clusters
+def installVerrazzano() {
+    script {
+        // Create a dictionary of Verrazzano install steps to be executed in parallel
+        // - the first one will always be the Admin cluster
+        // - clusters 2-max are managed clusters
+        def verrazzanoInstallStages = [:]
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+            def key = "vz-mgd-${count-1}"
+            if (count == 1) {
+                key = "vz-admin"
+            }
+            verrazzanoInstallStages["${key}"] = installVerrazzano(count, installerPath)
+        }
+        parallel verrazzanoInstallStages
     }
 }
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -270,13 +270,13 @@ pipeline {
             }
         }
 
-        stage('Acceptance Tests') {
+        stage('Install and Configure') {
             when {
                 allOf {
                     not { buildingTag() }
                     anyOf {
                         branch 'master';
-                        expression {SKIP_ACCEPTANCE_TESTS == false};
+                        expression { SKIP_ACCEPTANCE_TESTS == false };
                     }
                 }
             }
@@ -505,13 +505,14 @@ pipeline {
                         upgradePlatformOperator()
                     }
                 }
-
                 stage("upgrade-verrazzano") {
                     steps {
                         upgradeVerrazzano()
                     }
                 }
             }
+        }
+        stage('Acceptance Tests') {
             stages {
                 stage ('Example apps') {
                     parallel {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -368,7 +368,6 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: '**/*-operator.yaml', allowEmptyArchive: true
                             script {
                                 dumpInstallLogs()
                                 VZ_TEST_METRIC = metricJobName('')
@@ -660,7 +659,7 @@ pipeline {
                 }
                 dumpUninstallLogs()
             }
-            archiveArtifacts artifacts: '**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
 
             script {
@@ -752,10 +751,47 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
         }
 }
 
+// Either download the specified release of the platform operator YAML, or create one
+// using the specific operator image provided by the user.
+def getVerrazzanoOperatorYaml() {
+    sh """
+        echo "Platform Operator Configuration"
+        cd ${GO_REPO_PATH}/verrazzano
+        if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
+            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
+            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
+            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+        else
+            echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
+            env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
+        fi
+    """
+}
+
+// Install Verrazzano on each of the clusters
+def installVerrazzano() {
+    script {
+        // Create a dictionary of Verrazzano install steps to be executed in parallel
+        // - the first one will always be the Admin cluster
+        // - clusters 2-max are managed clusters
+        def verrazzanoInstallStages = [:]
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+            def key = "vz-mgd-${count-1}"
+            if (count == 1) {
+                key = "vz-admin"
+            }
+            verrazzanoInstallStages["${key}"] = installVerrazzanoOnCluster(count, installerPath)
+        }
+        parallel verrazzanoInstallStages
+    }
+}
+
 // Install Verrazzano on a target cluster
 // - count is the cluster index into the $KUBECONFIG_DIR
 // - verrazzanoConfig is the Verrazzano CR to use to install VZ on the cluster
-def installVerrazzano(count, verrazzanoConfig) {
+def installVerrazzanoOnCluster(count, verrazzanoConfig) {
     // For parallel execution, wrap this in a Groovy enclosure {}
     return {
         script {
@@ -792,6 +828,69 @@ def installVerrazzano(count, verrazzanoConfig) {
                 # wait for Verrazzano install to complete
                 ./tests/e2e/config/scripts/wait-for-verrazzano-install.sh
             """
+        }
+    }
+}
+
+// Upgrade the verrazzano-platform-operator
+def upgradePlatformOperator() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for (int count = 2; count <= clusterCount; count++) {
+                sh """
+                    export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                    echo "Upgrading the Verrazzano platform operator"
+                    # Download the operator.yaml for the target version that we are upgrading to
+                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/upgrade-operator.yaml
+                    cp ${WORKSPACE}/upgrade-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+                    kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
+
+                    # need to sleep since the old operator needs to transition to terminating state
+                    sleep 15
+
+                    # ensure operator pod is up
+                    kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+                """
+            }
+        }
+    }
+}
+
+// Upgrade Verrazzano
+def upgradeVerrazzano() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            // Download the bom for the target version that we are upgrading to, then extract the version
+            // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
+            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
+
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                    export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+                    export V8O_INSTALL_FILE=${KUBECONFIG_DIR}/${count}/${installerFileName}
+                    export V8O_UPGRADE_FILE=${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml
+
+                    echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
+                    # Modify the version field in the verrazzano CR file to be this new verrazzano version
+                    cd ${GO_REPO_PATH}/verrazzano
+                    cp ${V8O_INSTALL_FILE} ${V8O_UPGRADE_FILE}
+                    ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${V8O_UPGRADE_FILE}
+                    # Do the upgrade
+                    echo "Following is the verrazano CR file with the new version:"
+                    cat ${V8O_UPGRADE_FILE}
+                    kubectl apply -f ${V8O_UPGRADE_FILE}
+                    # wait for the upgrade to complete
+                    kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+
+                    # ideally we don't need to wait here
+                    sleep 15
+                    echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
+                    helm list -A
+                """
+            }
         }
     }
 }
@@ -1216,105 +1315,6 @@ def metricBuildDuration() {
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"
-        }
-    }
-}
-
-
-// Either download the specified release of the platform operator YAML, or create one
-// using the specific operator image provided by the user.
-def getVerrazzanoOperatorYaml() {
-    sh """
-        echo "Platform Operator Configuration"
-        cd ${GO_REPO_PATH}/verrazzano
-        if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
-            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-        else
-            echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
-            env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
-        fi
-    """
-}
-
-// Install Verrazzano on each of the clusters
-def installVerrazzano() {
-    script {
-        // Create a dictionary of Verrazzano install steps to be executed in parallel
-        // - the first one will always be the Admin cluster
-        // - clusters 2-max are managed clusters
-        def verrazzanoInstallStages = [:]
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-        for(int count=1; count<=clusterCount; count++) {
-            def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-            def key = "vz-mgd-${count-1}"
-            if (count == 1) {
-                key = "vz-admin"
-            }
-            verrazzanoInstallStages["${key}"] = installVerrazzano(count, installerPath)
-        }
-        parallel verrazzanoInstallStages
-    }
-}
-
-// Upgrade the verrazzano-platform-operator
-def upgradePlatformOperator() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for (int count = 2; count <= clusterCount; count++) {
-                sh """
-                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-
-                                        echo "Upgrading the Verrazzano platform operator"
-                                        # Download the operator.yaml for the target version that we are upgrading to
-                                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-                                        cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                                        kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
-                
-                                        # need to sleep since the old operator needs to transition to terminating state
-                                        sleep 15
-                
-                                        # ensure operator pod is up
-                                        kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-                                    """
-            }
-        }
-    }
-}
-
-// Upgrade Verrazzano
-def upgradeVerrazzano() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            // Download the bom for the target version that we are upgrading to, then extract the version
-            // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
-            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
-
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for(int count=2; count<=clusterCount; count++) {
-                sh """
-                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-
-                                        echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
-                                        # Modify the version field in the verrazzano CR file to be this new verrazzano version
-                                        cd ${GO_REPO_PATH}/verrazzano
-                                        cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        # Do the upgrade
-                                        echo "Following is the verrazano CR file with the new version:"
-                                        cat ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        # wait for the upgrade to complete
-                                        kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
-            
-                                        # ideally we don't need to wait here
-                                        sleep 15
-                                        echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
-                                        helm list -A
-                                    """
-            }
         }
     }
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -290,7 +290,7 @@ pipeline {
                             }
                         }
                         stage('Create OKE Clusters') {
-                            when { expression { return params.TEST_ENV == 'ocidns_oke' || params.TEST_ENV == 'magicdns_oke'} }
+                            when { expression { return params.TEST_ENV == 'ocidns_oke' || params.TEST_ENV == 'magicdns_oke' } }
                             steps {
                                 echo "OKE Cluster Prefix: ${OKE_CLUSTER_PREFIX}"
                                 createOKEClusters("${OKE_CLUSTER_PREFIX}")
@@ -319,7 +319,7 @@ pipeline {
                                     steps {
                                         script {
                                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                            for(int count=1; count<=clusterCount; count++) {
+                                            for (int count = 1; count <= clusterCount; count++) {
                                                 sh """
                                                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                                                     cd ${GO_REPO_PATH}/verrazzano
@@ -346,7 +346,7 @@ pipeline {
                         stage("Configure KinD") {
                             when { expression { return params.TEST_ENV == 'kind' } }
                             steps {
-                                configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_KIND,"./tests/e2e/config/scripts/process_kind_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
+                                configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_KIND, "./tests/e2e/config/scripts/process_kind_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
                             }
                         }
                         stage("Configure OKE/MagicDNS") {
@@ -357,23 +357,22 @@ pipeline {
                         }
                     }
                 }
-                stage ('Install Verrazzano') {
+                stage('Install Verrazzano') {
                     steps {
                         script {
                             VZ_INSTALL_METRIC = metricJobName('install_v8o')
                             metricTimerStart("${VZ_INSTALL_METRIC}")
-                            // Either download the latest platform operator YAML from the master bucket, or create one
+                            // Either download the specified release of the platform operator YAML, or create one
                             // using the specific operator image provided by the user.
                             sh """
                                 echo "Platform Operator Configuration"
                                 cd ${GO_REPO_PATH}/verrazzano
                                 if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-                                    echo "Using the latest master branch operator.yaml from object storage"
-                                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-                                    cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                                else
                                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                                     curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" > ${WORKSPACE}/acceptance-test-operator.yaml
+                                else
+                                    echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
+                                    env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
                                 fi
                             """
                         }
@@ -383,9 +382,9 @@ pipeline {
                             // - clusters 2-max are managed clusters
                             def verrazzanoInstallStages = [:]
                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                            for(int count=1; count<=clusterCount; count++) {
-                                def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                                def key = "vz-mgd-${count-1}"
+                            for (int count = 1; count <= clusterCount; count++) {
+                                def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                                def key = "vz-mgd-${count - 1}"
                                 if (count == 1) {
                                     key = "vz-admin"
                                 }
@@ -404,21 +403,21 @@ pipeline {
                         }
                         failure {
                             script {
-                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
+                                INSTALL_METRICS_PUSHED = metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
                             }
                         }
                         success {
                             script {
-                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
+                                INSTALL_METRICS_PUSHED = metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
                             }
                         }
                     }
                 }
-                stage ('Verify Install') {
+                stage('Verify Install') {
                     // NOTE: The stages are executed in parallel, however the tests themselves are executed against
                     //       each cluster in sequence. If possible, we should parallelize that as well.
                     parallel {
-                        stage ('multicluster/verify-install') {
+                        stage('multicluster/verify-install') {
                             steps {
                                 runGinkgoRandomize('multicluster/verify-install')
                             }
@@ -456,19 +455,19 @@ pipeline {
                         }
                     }
                 }
-                stage ('Register managed clusters') {
+                stage('Register managed clusters') {
                     steps {
                         registerManagedClusters()
                     }
                 }
-                stage ('Verify Register') {
+                stage('Verify Register') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
                                 int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
+                                for (int count = 2; count <= clusterCount; count++) {
                                     sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                        export MANAGED_CLUSTER_NAME="managed${count - 1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
@@ -478,14 +477,14 @@ pipeline {
                         }
                     }
                 }
-                stage ('Verify Managed Cluster Permissions') {
+                stage('Verify Managed Cluster Permissions') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
                                 int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
+                                for (int count = 2; count <= clusterCount; count++) {
                                     sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                        export MANAGED_CLUSTER_NAME="managed${count - 1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
@@ -496,23 +495,24 @@ pipeline {
                         }
                     }
                 }
-                stage ('Verify Metrics') {
+                stage('Verify Metrics') {
                     steps {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
                 stage("upgrade-platform-operator") {
                     steps {
-                            upgradePlatformOperator()
-                        }
+                        upgradePlatformOperator()
                     }
+                }
 
                 stage("upgrade-verrazzano") {
                     steps {
                         upgradeVerrazzano()
                     }
                 }
-                
+            }
+            stages {
                 stage ('Example apps') {
                     parallel {
                         stage ('Examples Helidon') {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -435,19 +435,7 @@ pipeline {
                 }
                 stage ('Verify Register') {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
-                                    """
-                                }
-                            }
-                        }
+                        verifyRegisterManagedClusters()
                     }
                 }
                 stage ('Verify Managed Cluster Permissions') {
@@ -938,6 +926,23 @@ def registerManagedClusters() {
                     export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     cd ${GO_REPO_PATH}/verrazzano
                     ./tests/e2e/config/scripts/register_managed_cluster.sh
+                """
+            }
+        }
+    }
+}
+
+// Verify the register of the managed clusters
+def verifyRegisterManagedClusters() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                    export MANAGED_CLUSTER_NAME="managed${count-1}"
+                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
                 """
             }
         }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -868,20 +868,20 @@ def upgradeVerrazzano() {
 
             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
             for(int count=2; count<=clusterCount; count++) {
+                def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
                 sh """
-                    export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-                    export V8O_INSTALL_FILE="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                    export V8O_UPGRADE_FILE="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
+                    export KUBECONFIG=${KUBECONFIG_DIR}/${count}/kube_config
 
                     echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
                     # Modify the version field in the verrazzano CR file to be this new verrazzano version
                     cd ${GO_REPO_PATH}/verrazzano
-                    cp ${V8O_INSTALL_FILE} ${V8O_UPGRADE_FILE}
-                    ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${V8O_UPGRADE_FILE}
+                    cp ${v8oInstallFile} ${v8oUpgradeFile}
+                    ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
                     # Do the upgrade
                     echo "Following is the verrazano CR file with the new version:"
-                    cat ${V8O_UPGRADE_FILE}
-                    kubectl apply -f ${V8O_UPGRADE_FILE}
+                    cat ${v8oUpgradeFile}
+                    kubectl apply -f ${v8oUpgradeFile}
                     # wait for the upgrade to complete
                     kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -368,7 +368,7 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: '${WORKSPACE}/acceptance-test-operator.yaml', allowEmptyArchive: true
+                            archiveArtifacts artifacts: '**/*-operator.yaml', allowEmptyArchive: true
                             script {
                                 dumpInstallLogs()
                                 VZ_TEST_METRIC = metricJobName('')

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -440,20 +440,7 @@ pipeline {
                 }
                 stage ('Verify Managed Cluster Permissions') {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                        export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
-                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -v -stream -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-permissions/...
-                                    """
-                                }
-                            }
-                        }
+                        verifyManagedClusterPermissions()
                     }
                 }
                 stage ('Verify Metrics') {
@@ -469,6 +456,26 @@ pipeline {
                 stage("upgrade-verrazzano") {
                     steps {
                         upgradeVerrazzano()
+                    }
+                }
+            }
+        }
+        stage('Verify Upgrade') {
+            // Rerun some stages to verify the upgrade
+            parallel {
+                stage ('Verify Register') {
+                    steps {
+                        verifyRegisterManagedClusters()
+                    }
+                }
+                stage ('Verify Managed Cluster Permissions') {
+                    steps {
+                        verifyManagedClusterPermissions()
+                    }
+                }
+                stage ('Verify Metrics') {
+                    steps {
+                        runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
             }
@@ -948,6 +955,25 @@ def verifyRegisterManagedClusters() {
         }
     }
 }
+
+// Verify the managed cluster permissions
+def verifyManagedClusterPermissions() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                    export MANAGED_CLUSTER_NAME="managed${count-1}"
+                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -v -stream -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-permissions/...
+                """
+            }
+        }
+    }
+}
+
 
 // Run a test suite against all clusters
 def runGinkgoRandomize(testSuitePath) {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -848,7 +848,7 @@ def upgradePlatformOperator() {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         script {
             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for (int count = 2; count <= clusterCount; count++) {
+            for (int count = 1; count <= clusterCount; count++) {
                 def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
                 sh """
                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
@@ -878,7 +878,7 @@ def upgradeVerrazzano() {
             VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
 
             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for(int count=2; count<=clusterCount; count++) {
+            for(int count=1; count<=clusterCount; count++) {
                 def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
                 def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
                 sh """

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -870,8 +870,8 @@ def upgradeVerrazzano() {
             for(int count=2; count<=clusterCount; count++) {
                 sh """
                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-                    export V8O_INSTALL_FILE=${KUBECONFIG_DIR}/${count}/${installerFileName}
-                    export V8O_UPGRADE_FILE=${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml
+                    export V8O_INSTALL_FILE="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                    export V8O_UPGRADE_FILE="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
 
                     echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
                     # Modify the version field in the verrazzano CR file to be this new verrazzano version

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -459,11 +459,11 @@ pipeline {
                     }
                 }
             }
-        }
-        post {
-            failure {
-                script {
-                    dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-install")
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-install")
+                    }
                 }
             }
         }
@@ -487,11 +487,11 @@ pipeline {
                     }
                 }
             }
-        }
-        post {
-            failure {
-                script {
-                    dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-verify-upgrade")
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-verify-upgrade")
+                    }
                 }
             }
         }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
                     not { buildingTag() }
                     anyOf {
                         branch 'master';
-                        expression { SKIP_ACCEPTANCE_TESTS == false };
+                        expression {SKIP_ACCEPTANCE_TESTS == false};
                     }
                 }
             }
@@ -290,7 +290,7 @@ pipeline {
                             }
                         }
                         stage('Create OKE Clusters') {
-                            when { expression { return params.TEST_ENV == 'ocidns_oke' || params.TEST_ENV == 'magicdns_oke' } }
+                            when { expression { return params.TEST_ENV == 'ocidns_oke' || params.TEST_ENV == 'magicdns_oke'} }
                             steps {
                                 echo "OKE Cluster Prefix: ${OKE_CLUSTER_PREFIX}"
                                 createOKEClusters("${OKE_CLUSTER_PREFIX}")
@@ -319,7 +319,7 @@ pipeline {
                                     steps {
                                         script {
                                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                            for (int count = 1; count <= clusterCount; count++) {
+                                            for(int count=1; count<=clusterCount; count++) {
                                                 sh """
                                                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                                                     cd ${GO_REPO_PATH}/verrazzano
@@ -346,7 +346,7 @@ pipeline {
                         stage("Configure KinD") {
                             when { expression { return params.TEST_ENV == 'kind' } }
                             steps {
-                                configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_KIND, "./tests/e2e/config/scripts/process_kind_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
+                                configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_KIND,"./tests/e2e/config/scripts/process_kind_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
                             }
                         }
                         stage("Configure OKE/MagicDNS") {
@@ -357,7 +357,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Install Verrazzano') {
+                stage ('Install Verrazzano') {
                     steps {
                         script {
                             VZ_INSTALL_METRIC = metricJobName('install_v8o')
@@ -382,9 +382,9 @@ pipeline {
                             // - clusters 2-max are managed clusters
                             def verrazzanoInstallStages = [:]
                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                            for (int count = 1; count <= clusterCount; count++) {
-                                def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                                def key = "vz-mgd-${count - 1}"
+                            for(int count=1; count<=clusterCount; count++) {
+                                def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                                def key = "vz-mgd-${count-1}"
                                 if (count == 1) {
                                     key = "vz-admin"
                                 }
@@ -403,21 +403,21 @@ pipeline {
                         }
                         failure {
                             script {
-                                INSTALL_METRICS_PUSHED = metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
+                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
                             }
                         }
                         success {
                             script {
-                                INSTALL_METRICS_PUSHED = metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
+                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
                             }
                         }
                     }
                 }
-                stage('Verify Install') {
+                stage ('Verify Install') {
                     // NOTE: The stages are executed in parallel, however the tests themselves are executed against
                     //       each cluster in sequence. If possible, we should parallelize that as well.
                     parallel {
-                        stage('multicluster/verify-install') {
+                        stage ('multicluster/verify-install') {
                             steps {
                                 runGinkgoRandomize('multicluster/verify-install')
                             }
@@ -455,19 +455,19 @@ pipeline {
                         }
                     }
                 }
-                stage('Register managed clusters') {
+                stage ('Register managed clusters') {
                     steps {
                         registerManagedClusters()
                     }
                 }
-                stage('Verify Register') {
+                stage ('Verify Register') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
                                 int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for (int count = 2; count <= clusterCount; count++) {
+                                for(int count=2; count<=clusterCount; count++) {
                                     sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count - 1}"
+                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
@@ -477,14 +477,14 @@ pipeline {
                         }
                     }
                 }
-                stage('Verify Managed Cluster Permissions') {
+                stage ('Verify Managed Cluster Permissions') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             script {
                                 int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for (int count = 2; count <= clusterCount; count++) {
+                                for(int count=2; count<=clusterCount; count++) {
                                     sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count - 1}"
+                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
@@ -495,7 +495,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Verify Metrics') {
+                stage ('Verify Metrics') {
                     steps {
                         runGinkgoRandomize('metrics/syscomponents')
                     }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -52,6 +52,10 @@ pipeline {
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
                 choices: [ "1.19", "1.18", "1.17", "1.20" ])
+        string (name: 'VERSION_FOR_INSTALL',
+                defaultValue: 'v1.0.0',
+                description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',
+                trim: true)
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
@@ -368,8 +372,8 @@ pipeline {
                                     oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
                                     cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
                                 else
-                                    echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
-                                    env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
+                                    echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
+                                    curl "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" > ${WORKSPACE}/acceptance-test-operator.yaml
                                 fi
                             """
                         }
@@ -497,6 +501,69 @@ pipeline {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
+                stage("upgrade-platform-operator") {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            script {
+                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                                for(int count=2; count<=clusterCount; count++) {
+                                    sh """
+                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                                        echo "Upgrading the Verrazzano platform operator"
+                                        # Download the operator.yaml for the target version that we are upgrading to
+                                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
+                                        cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+                                        kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
+                
+                                        # need to sleep since the old operator needs to transition to terminating state
+                                        sleep 15
+                
+                                        # ensure operator pod is up
+                                        kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+                                    """
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage("upgrade-verrazzano") {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            script {
+                                // Download the bom for the target version that we are upgrading to, then extract the version
+                                // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
+                                VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
+
+                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                                for(int count=2; count<=clusterCount; count++) {
+                                    sh """
+                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                                        echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
+                                        # Modify the version field in the verrazzano CR file to be this new verrazzano version
+                                        cd ${GO_REPO_PATH}/verrazzano
+                                        cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        # Do the upgrade
+                                        echo "Following is the verrazano CR file with the new version:"
+                                        cat ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        # wait for the upgrade to complete
+                                        kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+            
+                                        # ideally we don't need to wait here
+                                        sleep 15
+                                        echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
+                                        helm list -A
+                                    """
+                                }
+                            }
+                        }
+                    }
+                }
+                
                 stage ('Example apps') {
                     parallel {
                         stage ('Examples Helidon') {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -503,64 +503,13 @@ pipeline {
                 }
                 stage("upgrade-platform-operator") {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-
-                                        echo "Upgrading the Verrazzano platform operator"
-                                        # Download the operator.yaml for the target version that we are upgrading to
-                                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-                                        cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                                        kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
-                
-                                        # need to sleep since the old operator needs to transition to terminating state
-                                        sleep 15
-                
-                                        # ensure operator pod is up
-                                        kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-                                    """
-                                }
-                            }
+                            upgradePlatformOperator()
                         }
                     }
-                }
 
                 stage("upgrade-verrazzano") {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                // Download the bom for the target version that we are upgrading to, then extract the version
-                                // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
-                                VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
-
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-
-                                        echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
-                                        # Modify the version field in the verrazzano CR file to be this new verrazzano version
-                                        cd ${GO_REPO_PATH}/verrazzano
-                                        cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        # Do the upgrade
-                                        echo "Following is the verrazano CR file with the new version:"
-                                        cat ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
-                                        # wait for the upgrade to complete
-                                        kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
-            
-                                        # ideally we don't need to wait here
-                                        sleep 15
-                                        echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
-                                        helm list -A
-                                    """
-                                }
-                            }
-                        }
+                        upgradeVerrazzano()
                     }
                 }
                 
@@ -1292,6 +1241,67 @@ def metricBuildDuration() {
         withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
             METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
             echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"
+        }
+    }
+}
+
+// Upgrade the verrazzano-platform-operator
+def upgradePlatformOperator() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for (int count = 2; count <= clusterCount; count++) {
+                sh """
+                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                                        echo "Upgrading the Verrazzano platform operator"
+                                        # Download the operator.yaml for the target version that we are upgrading to
+                                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
+                                        cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+                                        kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
+                
+                                        # need to sleep since the old operator needs to transition to terminating state
+                                        sleep 15
+                
+                                        # ensure operator pod is up
+                                        kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+                                    """
+            }
+        }
+    }
+}
+
+// Upgrade Verrazzano
+def upgradeVerrazzano() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            // Download the bom for the target version that we are upgrading to, then extract the version
+            // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
+            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
+
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                                        export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                                        echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
+                                        # Modify the version field in the verrazzano CR file to be this new verrazzano version
+                                        cd ${GO_REPO_PATH}/verrazzano
+                                        cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        # Do the upgrade
+                                        echo "Following is the verrazano CR file with the new version:"
+                                        cat ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                                        # wait for the upgrade to complete
+                                        kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+            
+                                        # ideally we don't need to wait here
+                                        sleep 15
+                                        echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
+                                        helm list -A
+                                    """
+            }
         }
     }
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -845,63 +845,59 @@ def installVerrazzanoOnCluster(count, verrazzanoConfig) {
 
 // Upgrade the verrazzano-platform-operator
 def upgradePlatformOperator() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for (int count = 1; count <= clusterCount; count++) {
-                def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
-                sh """
-                    export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+    script {
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for (int count = 1; count <= clusterCount; count++) {
+            def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
+            sh """
+                export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
 
-                    echo "Upgrading the Verrazzano platform operator"
-                    # Download the operator.yaml for the target version that we are upgrading to
-                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${upgradeOperatorFile}
-                    kubectl apply -f ${upgradeOperatorFile}
+                echo "Upgrading the Verrazzano platform operator"
+                # Download the operator.yaml for the target version that we are upgrading to
+                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${upgradeOperatorFile}
+                kubectl apply -f ${upgradeOperatorFile}
 
-                    # need to sleep since the old operator needs to transition to terminating state
-                    sleep 15
+                # need to sleep since the old operator needs to transition to terminating state
+                sleep 15
 
-                    # ensure operator pod is up
-                    kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-                """
-            }
+                # ensure operator pod is up
+                kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+            """
         }
     }
 }
 
 // Upgrade Verrazzano
 def upgradeVerrazzano() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            // Download the bom for the target version that we are upgrading to, then extract the version
-            // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
-            VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
+    script {
+        // Download the bom for the target version that we are upgrading to, then extract the version
+        // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
+        VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
 
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for(int count=1; count<=clusterCount; count++) {
-                def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
-                sh """
-                    export KUBECONFIG=${KUBECONFIG_DIR}/${count}/kube_config
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+            def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
+            sh """
+                export KUBECONFIG=${KUBECONFIG_DIR}/${count}/kube_config
 
-                    echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
-                    # Modify the version field in the verrazzano CR file to be this new verrazzano version
-                    cd ${GO_REPO_PATH}/verrazzano
-                    cp ${v8oInstallFile} ${v8oUpgradeFile}
-                    ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
-                    # Do the upgrade
-                    echo "Following is the verrazano CR file with the new version:"
-                    cat ${v8oUpgradeFile}
-                    kubectl apply -f ${v8oUpgradeFile}
-                    # wait for the upgrade to complete
-                    kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
+                # Modify the version field in the verrazzano CR file to be this new verrazzano version
+                cd ${GO_REPO_PATH}/verrazzano
+                cp ${v8oInstallFile} ${v8oUpgradeFile}
+                ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
+                # Do the upgrade
+                echo "Following is the verrazano CR file with the new version:"
+                cat ${v8oUpgradeFile}
+                kubectl apply -f ${v8oUpgradeFile}
+                # wait for the upgrade to complete
+                kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
-                    # ideally we don't need to wait here
-                    sleep 15
-                    echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
-                    helm list -A
-                """
-            }
+                # ideally we don't need to wait here
+                sleep 15
+                echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
+                helm list -A
+            """
         }
     }
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1229,7 +1229,7 @@ def getVerrazzanoOperatorYaml() {
         cd ${GO_REPO_PATH}/verrazzano
         if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
             echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-            curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
+            curl -k -u ${GITHUB_RELEASE_USERID_USR}:${GITHUB_RELEASE_USERID_PSW} "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -o ${WORKSPACE}/downloaded-release-operator.yaml
             cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
         else
             echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"


### PR DESCRIPTION
# Description

Change the multicluster acceptance test suite to do the following:

- Install verrazzano v1.0.0 (by default, but can override with parameter)
- Configure multicluster environment and verify the install
- Upgrade the admin and managed clusters to the version of verrazzano on the branch
- Verify the upgrade
- Run the acceptance tests

Fixes VZ-3380

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
