### PR TITLE
VZ-3568.  Upgrade/upgrade-test fixes

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -206,7 +206,7 @@ pipeline {
                             sh """
                                 ## dump out install logs
                                 mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
-                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log --tail -1
+                                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano --tail -1 > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log
                                 kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
                                 echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                                 echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
@@ -235,11 +235,11 @@ pipeline {
                         cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
                         kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
 
-                        # need to sleep since the old operator needs to transition to terminating state
-                        sleep 15
-
                         # ensure operator pod is up
                         kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+
+                        # need to sleep since the old operator needs to transition to terminating state
+                        sleep 15
                     """
                     }
                 }
@@ -257,12 +257,17 @@ pipeline {
                             cd ${GO_REPO_PATH}/verrazzano
                             cp ${TEST_SCRIPTS_DIR}/install-verrazzano-kind.yaml ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                             ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+
                             # Do the upgrade
                             echo "Following is the verrazano CR file with the new version:"
                             cat ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                             kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+
                             # wait for the upgrade to complete
                             kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+
+                            # Dump the resource to debug
+                            kubectl get -o yaml verrazzano/my-verrazzano || true
 
                             # ideally we don't need to wait here
                             sleep 15
@@ -337,7 +342,7 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sCluster('upgrade-failure-post-run-cluster-dump')
                         }
                     }
                 }
@@ -345,7 +350,7 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sCluster('upgrade-success-post-run-cluster-dump')
                         }
                     }
                 }
@@ -466,7 +471,7 @@ def dumpVerrazzanoPlatformOperatorLogs(stage) {
     sh """
         ## dump out verrazzano-platform-operator logs
         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-        kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
         kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "------------------------------------------"
     """
@@ -476,7 +481,7 @@ def dumpVerrazzanoApplicationOperatorLogs() {
     sh """
         ## dump out verrazzano-application-operator logs
         mkdir -p ${WORKSPACE}/verrazzano-application-operator/logs
-        kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator --tail -1 > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
         kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "verrazzano-application-operator logs dumped to verrazzano-application-operator-pod.log"
         echo "verrazzano-application-operator pod description dumped to verrazzano-application-operator-pod.out"
@@ -488,7 +493,7 @@ def dumpOamKubernetesRuntimeLogs() {
     sh """
         ## dump out oam-kubernetes-runtime logs
         mkdir -p ${WORKSPACE}/oam-kubernetes-runtime/logs
-        kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/oam-kubernetes-runtime/logs/oam-kubernetes-runtime-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime --tail -1 > ${WORKSPACE}/oam-kubernetes-runtime/logs/oam-kubernetes-runtime-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
         kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/verrazzano-application-operator/logs/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "verrazzano-application-operator logs dumped to oam-kubernetes-runtime-pod.log"
         echo "verrazzano-application-operator pod description dumped to oam-kubernetes-runtime-pod.out"

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -120,8 +120,7 @@ func (h HelmComponent) IsInstalled(_ *zap.SugaredLogger, _ clipkg.Client, namesp
 // IsReady Indicates whether or not a component is available and ready
 func (h HelmComponent) IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool {
 	ns := resolveNamespace(h, namespace)
-	installed, _ := helm.IsReleaseDeployed(h.ReleaseName, resolveNamespace(h, namespace))
-	if installed {
+	if deployed, _ := helm.IsReleaseDeployed(h.ReleaseName, resolveNamespace(h, namespace)); deployed {
 		if h.ReadyStatusFunc != nil {
 			return h.ReadyStatusFunc(log, client, h.ReleaseName, ns)
 		}

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -120,7 +120,7 @@ func (h HelmComponent) IsInstalled(_ *zap.SugaredLogger, _ clipkg.Client, namesp
 // IsReady Indicates whether or not a component is available and ready
 func (h HelmComponent) IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool {
 	ns := resolveNamespace(h, namespace)
-	installed, _ := helm.IsReleaseInstalled(h.ReleaseName, resolveNamespace(h, namespace))
+	installed, _ := helm.IsReleaseDeployed(h.ReleaseName, resolveNamespace(h, namespace))
 	if installed {
 		if h.ReadyStatusFunc != nil {
 			return h.ReadyStatusFunc(log, client, h.ReleaseName, ns)

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -33,6 +33,18 @@ type helmFakeRunner struct {
 
 const testBomFilePath = "../../testdata/test_bom.json"
 
+// genericHelmTestRunner is used to run generic OS commands with expected results
+type genericHelmTestRunner struct {
+	stdOut []byte
+	stdErr []byte
+	err    error
+}
+
+// Run genericHelmTestRunner executor
+func (r genericHelmTestRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
+	return r.stdOut, r.stdErr, r.err
+}
+
 // TestGetName tests the component name
 // GIVEN a Verrazzano component
 //  WHEN I call Name
@@ -91,10 +103,14 @@ func TestUpgradeIsInstalledUnexpectedError(t *testing.T) {
 		return nil, nil, nil
 	})
 	defer setDefaultUpgradeFunc()
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return "", fmt.Errorf("Unexpected error")
+
+	helm.SetCmdRunner(genericHelmTestRunner{
+		stdOut: []byte(""),
+		stdErr: []byte("What happened?"),
+		err:    fmt.Errorf("Unexpected error"),
 	})
-	defer helm.SetDefaultChartStatusFunction()
+	defer helm.SetDefaultRunner()
+
 	err := comp.Upgrade(zap.S(), nil, "", false)
 	assert.Error(err)
 }
@@ -111,11 +127,11 @@ func TestUpgradeReleaseNotInstalled(t *testing.T) {
 	setUpgradeFunc(func(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides string, overrideFiles ...string) (stdout []byte, stderr []byte, err error) {
 		return nil, nil, nil
 	})
-	defer setDefaultUpgradeFunc()
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartNotFound, nil
-	})
-	defer helm.SetDefaultChartStatusFunction()
+	helm.SetCmdRunner(helmFakeRunner{})
+	defer helm.SetDefaultRunner()
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer config.SetDefaultBomFilePath("")
+
 	err := comp.Upgrade(zap.S(), nil, "", false)
 	assert.NoError(err)
 }
@@ -335,12 +351,19 @@ func TestIsInstalled(t *testing.T) {
 	defer helm.SetDefaultChartStatusFunction()
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
 
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
+	helm.SetCmdRunner(genericHelmTestRunner{
+		stdOut: []byte(""),
+		stdErr: []byte(""),
+		err:    nil,
 	})
+	defer helm.SetDefaultRunner()
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer config.SetDefaultBomFilePath("")
 	assert.True(comp.IsInstalled(zap.S(), client, "default"))
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartNotFound, nil
+	helm.SetCmdRunner(genericHelmTestRunner{
+		stdOut: []byte(""),
+		stdErr: []byte(""),
+		err:    fmt.Errorf("Not installed"),
 	})
 	assert.False(comp.IsInstalled(zap.S(), client, "default"))
 }

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -52,7 +52,7 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, cr *installv1alpha
 	log.Info(msg)
 	cr.Status.Version = targetVersion
 	if err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete); err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return newRequeueWithDelay(), err
 	}
 
 	return ctrl.Result{}, nil

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -51,9 +51,11 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, cr *installv1alpha
 	msg := fmt.Sprintf("Verrazzano upgraded to version %s successfully", cr.Spec.Version)
 	log.Info(msg)
 	cr.Status.Version = targetVersion
-	err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete)
+	if err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete); err != nil {
+		return ctrl.Result{Requeue: true}, err
+	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 // Return true if verrazzano is installed

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: {{ .Values.name }}
     spec:
+      terminationGracePeriodSeconds: 0
       initContainers:
         - name: webhook-init
           image: {{ .Values.image }}

--- a/platform-operator/internal/helm/helmcli.go
+++ b/platform-operator/internal/helm/helmcli.go
@@ -172,7 +172,7 @@ func IsReleaseFailed(releaseName string, namespace string) (bool, error) {
 	return releaseStatus == ChartStatusFailed, nil
 }
 
-// IsReleaseDeployed returns true if the release is installed
+// IsReleaseDeployed returns true if the release is deployed
 func IsReleaseDeployed(releaseName string, namespace string) (found bool, err error) {
 	log := zap.S()
 	releaseStatus, err := chartStatusFn(releaseName, namespace)

--- a/platform-operator/internal/helm/helmcli_test.go
+++ b/platform-operator/internal/helm/helmcli_test.go
@@ -141,10 +141,6 @@ func TestIsReleaseInstalled(t *testing.T) {
 	assert := assert.New(t)
 	SetCmdRunner(foundRunner{t: t})
 	defer SetDefaultRunner()
-	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return ChartStatusDeployed, nil
-	})
-	defer SetDefaultChartStatusFunction()
 
 	found, err := IsReleaseInstalled(release, ns)
 	assert.NoError(err, "IsReleaseInstalled returned an error")
@@ -159,10 +155,6 @@ func TestIsReleaseNotInstalled(t *testing.T) {
 	assert := assert.New(t)
 	SetCmdRunner(foundRunner{t: t})
 	defer SetDefaultRunner()
-	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return ChartNotFound, nil
-	})
-	defer SetDefaultChartStatusFunction()
 
 	found, err := IsReleaseInstalled(missingRelease, ns)
 	assert.NoError(err, "IsReleaseInstalled returned an error")
@@ -180,6 +172,42 @@ func TestIsReleaseInstalledFailed(t *testing.T) {
 
 	found, err := IsReleaseInstalled("", ns)
 	assert.Error(err, "IsReleaseInstalled should have returned an error")
+	assert.False(found, "Release should not be found")
+}
+
+// TestIsReleaseDeployed tests checking if a Helm release is installed
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseDeployed
+//  THEN the function returns success and found equal true
+func TestIsReleaseDeployed(t *testing.T) {
+	assert := assert.New(t)
+	SetCmdRunner(foundRunner{t: t})
+	defer SetDefaultRunner()
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartStatusDeployed, nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	found, err := IsReleaseDeployed(release, ns)
+	assert.NoError(err, "IsReleaseInstalled returned an error")
+	assert.True(found, "Release not found")
+}
+
+// TestIsReleaseNotDeployed tests checking if a Helm release is not installed
+// GIVEN a release name and namespace
+//  WHEN I call IsReleaseDeployed
+//  THEN the function returns success and the correct found status
+func TestIsReleaseNotDeployed(t *testing.T) {
+	assert := assert.New(t)
+	SetCmdRunner(foundRunner{t: t})
+	defer SetDefaultRunner()
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartNotFound, nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	found, err := IsReleaseDeployed(missingRelease, ns)
+	assert.NoError(err, "IsReleaseInstalled returned an error")
 	assert.False(found, "Release should not be found")
 }
 

--- a/tests/e2e/config/scripts/wait-for-verrazzano-upgrade.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-upgrade.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+resourceName=${1:-my-verrazzano}
+resPath=verrazzano/${resourceName}
+
+if ! kubectl get ${resPath}; then
+  echo "Verrazzano resource ${resPath} not found"
+  exit 1
+fi
+
+echo "Starting wait for upgrade operation at $(date)"
+
+SECONDS=0
+retval_success=1
+retval_failed=1
+while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]; do
+  sleep 5
+  output=$(kubectl wait --for=condition=UpgradeFailed ${resPath} --timeout=0 2>&1)
+  retval_failed=$?
+  output=$(kubectl wait --for=condition=UpgradeComplete ${resPath} --timeout=0 2>&1)
+  retval_success=$?
+done
+
+if [ $retval_failed -eq 0 ]; then
+    echo "Upgrade Failed"
+    exit 1
+fi
+
+echo "Upgrade completed successfully at $(date).  Wait time: $SECONDS seconds"


### PR DESCRIPTION
# Description

Upgrade/upgrade-test fixes.
- Revert impl for IsReleaseInstalled to previous impl that doesn't do fine-grained status checks
- Separate out new impl into new fn, IsReleaseDeployed for now, will debug and consolidate later if possible
- Set terminationGracePeriodSeconds to 0 on the platform operator deployment
- Handle error where setting UpgradeComplete status returns an error, and requeue for re-processing
- Fix up delays/waits in upgrade test pipeline
- Add unit test case for status update error on UpgradeComplete

Fixes VZ-3568.  

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
