### PR TITLE
VZ-3498: Enable backport labeling when running verrazzano-helper

### DIFF
--- a/ci/ticket-commits/JenkinsfileCommits
+++ b/ci/ticket-commits/JenkinsfileCommits
@@ -77,7 +77,7 @@ pipeline {
                         echo Processing commits:
                         cat ${tmpfile}; echo
 
-                        verrazzano-helper update ticket-commits --commit-file "${tmpfile}" --token unused --jira-env=prod
+                        verrazzano-helper update ticket-commits --commit-file "${tmpfile}" --backport-labels --token unused --jira-env=prod
                     """
                 }
             }


### PR DESCRIPTION
# Description

This PR enables backport labeling of JIRA tickets when processing commits. Commits on release-* branches with JIRA ticket ids in the commit messages will cause the helper to add a label "bp-<release branch version>" to the tickets.

Implements VZ-3498

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
