### PR TITLE
Created helm chart value - api.proxy.MaxRequestSize

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-api-configmap.yaml
@@ -903,7 +903,7 @@ data:
         #tcp_nopush     on;
 
         # Posts from Fluentd can require more than the default 1m max body size
-        client_max_body_size 65m;
+        client_max_body_size {{ .MaxRequestSize | default "65m" | quote }};
 
         #keepalive_timeout  0;
         keepalive_timeout  65;

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -92,6 +92,7 @@ api:
     OidcCallbackPath: /_authentication_callback
     OidcLogoutCallbackPath: /_logout
     AuthnStateTTL: "300"
+    MaxRequestSize: 65m 
 
 # OCI-related values
 oci:


### PR DESCRIPTION
Fixes VZ-3533
1. Added helm chart value in values.yaml - api.proxy.MaxRequestSize
2. Modified Verrazzano-api-configmap.yaml to fetch the above value

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
