### PR TITLE
VZ-3578 - Change dump of logs to be aware of what version of Verrazzano was installed

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1251,12 +1251,18 @@ def dumpInstallLogs() {
         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
             LOG_DIR="${VERRAZZANO_INSTALL_LOGS_DIR}/cluster-$count"
+
+            // This function may run on older versions of Verrazzano that have the logs stored in the default namespace
+            def namespace = "verrazzano-install"
+            if (params.VERSION_FOR_INSTALL.startsWith("v1.0.0") || params.VERSION_FOR_INSTALL.startsWith("v1.0.1")) {
+                namespace = "default"
+            }
             sh """
                 ## dump verrazzano install logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 mkdir -p ${LOG_DIR}
-                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                kubectl -n ${namespace} logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+                kubectl -n ${namespace} describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
                 echo "------------------------------------------"
             """
         }

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package installscript_test
 
 import (
@@ -54,6 +52,9 @@ var _ = BeforeSuite(func() {
 	}
 })
 
+// This test checks that the console output at the end of an install does not show a
+// user URL's that do not exist for that installation platform.  For example, a managed
+// cluster install would not have console URLs.
 var _ = Describe("Verify Verrazzano install scripts", func() {
 
 	Context("Verify Console URLs in the install log", func() {

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+// +build unstable_test
+
 package installscript_test
 
 import (


### PR DESCRIPTION
# Description

The dump of The Verrazzano install logs in the multicluster test pipeline is currently being done for a v1.0 install (and then upgrading later).  The location of the log files has changed from the "default" namespace to the "verrazzano-install" namespace.  This change is to have the test suite choose the source location of the logs based on the Version of verrazzano installed.  For version 1.0.0 and 1.0.1 the default namespace is used, otherwise verrazzano-system is used.

Fixes VZ-3578

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
