### PR TITLE
VZ-3573.  Upgrade fails with chart stuck in pending-upgrade status

### DIFF
--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -39,7 +39,7 @@ type Component interface {
 	PostInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error
 
 	// IsInstalled Indicates whether or not the component is installed
-	IsInstalled(log *zap.SugaredLogger, client clipkg.Client, namespace string) (bool, error)
+	IsInstalled(log *zap.SugaredLogger, client clipkg.Client, namespace string) (installed bool, err error)
 
 	// IsReady Indicates whether or not a component is available and ready
 	IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -731,6 +731,12 @@ func TestUpgradeHelmError(t *testing.T) {
 	// Inject a bad cmd runner to the real helm is not called
 	helm.SetCmdRunner(badRunner{})
 
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
 	// Create and make the request
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)

--- a/platform-operator/internal/helm/helmcli_test.go
+++ b/platform-operator/internal/helm/helmcli_test.go
@@ -353,8 +353,8 @@ func Test_getReleaseStateChartNotFound(t *testing.T) {
 	assert.Equalf(t, "", state, "unpexected state: %s", state)
 }
 
-// Test_getChartStatusDeployed tests the getChartStatus fn
-// GIVEN a call to getChartStatus
+// Test_getChartStatusDeployed tests the GetChartStatus fn
+// GIVEN a call to GetChartStatus
 //  WHEN Helm returns a deployed state
 //  THEN the function returns "deployed" and no error
 func Test_getChartStatusDeployed(t *testing.T) {
@@ -395,13 +395,13 @@ func Test_getChartStatusDeployed(t *testing.T) {
 		err:    nil,
 	})
 	defer SetDefaultRunner()
-	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	state, err := GetChartStatus("weblogic-operator", "verrazzano-system")
 	assert.NoError(t, err)
 	assert.Equalf(t, ChartStatusDeployed, state, "unpexected state: %s", state)
 }
 
-// Test_getChartStatusNotFound tests the getChartStatus fn
-// GIVEN a call to getChartStatus
+// Test_getChartStatusNotFound tests the GetChartStatus fn
+// GIVEN a call to GetChartStatus
 //  WHEN the json structure does not have an status filed in the info section
 //  THEN the function returns an error
 func Test_getChartStatusNotFound(t *testing.T) {
@@ -441,13 +441,13 @@ func Test_getChartStatusNotFound(t *testing.T) {
 		err:    nil,
 	})
 	defer SetDefaultRunner()
-	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	state, err := GetChartStatus("weblogic-operator", "verrazzano-system")
 	assert.Error(t, err)
 	assert.Empty(t, state)
 }
 
-// Test_getChartStatusChartNotFound tests the getChartStatus fn
-// GIVEN a call to getChartStatus
+// Test_getChartStatusChartNotFound tests the GetChartStatus fn
+// GIVEN a call to GetChartStatus
 //  WHEN the Chart is not found
 //  THEN the function returns chart not found and no error
 func Test_getChartStatusChartNotFound(t *testing.T) {
@@ -460,13 +460,13 @@ func Test_getChartStatusChartNotFound(t *testing.T) {
 		err:    fmt.Errorf("Error running status command"),
 	})
 	defer SetDefaultRunner()
-	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	state, err := GetChartStatus("weblogic-operator", "verrazzano-system")
 	assert.NoError(t, err)
 	assert.Equalf(t, ChartNotFound, state, "unpexected state: %s", state)
 }
 
-// Test_getChartStatusUnexpectedHelmError tests the getChartStatus fn
-// GIVEN a call to getChartStatus
+// Test_getChartStatusUnexpectedHelmError tests the GetChartStatus fn
+// GIVEN a call to GetChartStatus
 //  WHEN Helm returns an error
 //  THEN the function returns an error
 func Test_getChartStatusUnexpectedHelmError(t *testing.T) {
@@ -479,13 +479,13 @@ func Test_getChartStatusUnexpectedHelmError(t *testing.T) {
 		err:    fmt.Errorf("Unexpected error running status command"),
 	})
 	defer SetDefaultRunner()
-	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	state, err := GetChartStatus("weblogic-operator", "verrazzano-system")
 	assert.Error(t, err)
 	assert.Equalf(t, "", state, "unpexected state: %s", state)
 }
 
-// Test_getChartInfoNotFound tests the getChartStatus fn
-// GIVEN a call to getChartStatus
+// Test_getChartInfoNotFound tests the GetChartStatus fn
+// GIVEN a call to GetChartStatus
 //  WHEN the json structure does not have an info section
 //  THEN the function returns an error
 func Test_getChartInfoNotFound(t *testing.T) {
@@ -519,7 +519,7 @@ func Test_getChartInfoNotFound(t *testing.T) {
 		err:    nil,
 	})
 	defer SetDefaultRunner()
-	state, err := getChartStatus("weblogic-operator", "verrazzano-system")
+	state, err := GetChartStatus("weblogic-operator", "verrazzano-system")
 	assert.Error(t, err)
 	assert.Empty(t, state)
 }


### PR DESCRIPTION
# Description

Before upgrading, check if a helm-component's chart is stuck in `pending-upgrade` status.  It seems like this can happen when a helm command is interrupted before completing.

Fixes VZ-3573.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
