### PR TITLE
VZ-3497: Initial pass at pre-release validation scripts

### DIFF
--- a/release/scripts/check_versions.sh
+++ b/release/scripts/check_versions.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# Checks the Verrazzano development and Chart.yaml versions to make sure they are accurate
+
+usage() {
+    cat <<EOM
+  Checks .verrazzano-development-version and Chart.yaml files to make sure the versions are correct.
+
+  Usage:
+    $(basename $0) <version to release>
+
+  Example:
+    $(basename $0) 1.0.2
+
+  This script should be run from the git repository containing the bits to release.
+EOM
+    exit 0
+}
+
+[ -z "$1" -o "$1" == "-h" ] && { usage; }
+
+VERSION=$1
+PASS=true
+SCRIPT_DIR=$(dirname "$0")
+
+# Check .verrazzano-development-version
+
+VER=$(grep verrazzano-development-version $SCRIPT_DIR/../../.verrazzano-development-version | cut -d= -f 2)
+
+[[ "$VERSION" != "$VER" ]] && { echo "FAILED: .verrazzano-development-version has incorrect version"; PASS=false; }
+
+# Check Chart.yaml versions
+
+for f in $(find $SCRIPT_DIR/../../platform-operator/helm_config/charts/ -name Chart.yaml)
+do
+    VER=$(grep 'version:' $f | cut -d: -f 2 | xargs echo -n)
+    [[ "$VERSION" != "$VER" ]] && { echo "FAILED: $f has incorrect version"; PASS=false; }
+
+    VER=$(grep 'appVersion:' $f | cut -d: -f 2 | xargs echo -n)
+    [[ "$VERSION" != "$VER" ]] && { echo "FAILED: $f has incorrect appVersion"; PASS=false; }
+done
+
+[[ "$PASS" == "true" ]] && { echo "All version checks passed"; exit 0; } || exit 1;

--- a/release/scripts/compare_crds.sh
+++ b/release/scripts/compare_crds.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# Compare all CRD differences between two commits, tags, etc.
+
+usage() {
+    cat <<EOM
+  Shows all CRD differences between two git tags, commits, etc.
+
+  Usage:
+    $(basename $0) <from> <to>
+
+  Example:
+    $(basename $0) v1.0.0 HEAD
+
+  This script should be run from the git repository containing the bits to release. "from" and "to" can be tags, commits, etc.
+  "from" defaults to the most recent version tag and "to" defaults to HEAD.
+EOM
+    exit 0
+}
+
+[ "$1" == "-h" ] && { usage; }
+
+FROM=$1
+TO=${2:-HEAD}
+
+# Default to the latest tag
+if [[ -z "$FROM" ]]; then
+   git fetch --tags
+   FROM=$(git tag --sort=taggerdate | tail -1)
+fi
+
+echo "Showing all CRD differences between $FROM and $TO"
+echo ""
+
+SCRIPT_DIR=$(dirname "$0")
+git --no-pager diff --exit-code $FROM $TO -- `find $SCRIPT_DIR/../.. -type f -path '*/crds/*.yaml'`

--- a/release/scripts/prerelease_validation.sh
+++ b/release/scripts/prerelease_validation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# Run prerelease validation checks
+
+usage() {
+    cat <<EOM
+  Performs pre-release validation checks.
+
+  Usage:
+    $(basename $0) <version to release>
+
+  Example:
+    $(basename $0) 1.0.2
+
+  This script depends on git and verrazzano-helper and should be run from the git repository containing the bits to release.
+EOM
+    exit 0
+}
+
+[ -z "$1" -o "$1" == "-h" ] && { usage; }
+
+VERSION=$1
+SCRIPT_DIR=$(dirname "$0")
+
+# Check for CRD changes
+
+echo "Checking for CRD changes... you should visually inspect for potential backward incompatibilities"
+$SCRIPT_DIR/compare_crds.sh
+EXIT_CODE=$?
+echo ""
+
+# Check .verrazzano-development-version and Chart.yaml versions
+
+echo "Checking versions..."
+$SCRIPT_DIR/check_versions.sh $VERSION
+((EXIT_CODE |= $?))
+echo ""
+
+# If this is a patch release, check for any tickets that don't have backported commits
+
+if [[ "$VERSION" == *.0 ]]; then
+    echo "Not a patch release, skipping backported commits check"
+else
+    if ! command -v verrazzano-helper &> /dev/null
+    then
+      echo "verrazzano-helper must be in path"
+      exit 1
+    fi
+
+    echo "Checking for missing backport commits..."
+    verrazzano-helper get ticket-backports $VERSION --jira-env prod --token unused
+    ((EXIT_CODE |= $?))
+fi
+
+# If the IGNORE_FAILURES environment variable is set, always exit with zero
+
+[[ -n "$IGNORE_FAILURES" ]] && exit 0 || exit $EXIT_CODE


### PR DESCRIPTION
# Description

Automation scripts for pre-release validation. The scripts currently show/check:

- CRD differences
- Versions in .verrazzano-development-version and Chart.yaml files
- JIRA tickets missing backports (for patch releases)

If any of the checks fail, the pre-release validation script exits with a non-zero code. Setting the `IGNORE_FAILURES` environment variable overrides that and the script will always exit with a zero code.

Implements VZ-3497

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
