### PR TITLE
VZ-3584 OLCNE Istio ExternalIP

### DIFF
--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -87,7 +87,9 @@ function install_verrazzano()
   local PROFILE_VALUES_OVERRIDE=" -f ${VZ_CHARTS_DIR}/verrazzano/values.${profile}.yaml"
 
   # Get the endpoint for the Kubernetes API server.  The endpoint returned has the format of IP:PORT
+  # For OLCNE, there is a comma separated list of IP:PORT pairs, so split on the comma
   local ENDPOINT=$(kubectl get endpoints --namespace default kubernetes --no-headers | awk '{ print $2}')
+  ENDPOINT=$(echo $ENDPOINT | tr "," "\n")
   local ENDPOINT_ARRAY=(${ENDPOINT//:/ })
 
   local DNS_TYPE=$(get_config_value ".dns.type")

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -86,12 +86,6 @@ function install_verrazzano()
   fi
   local PROFILE_VALUES_OVERRIDE=" -f ${VZ_CHARTS_DIR}/verrazzano/values.${profile}.yaml"
 
-  # Get the endpoint for the Kubernetes API server.  The endpoint returned has the format of IP:PORT
-  # For OLCNE, there is a comma separated list of IP:PORT pairs, so split on the comma
-  local ENDPOINT=$(kubectl get endpoints --namespace default kubernetes --no-headers | awk '{ print $2}')
-  ENDPOINT=$(echo $ENDPOINT | tr "," "\n")
-  local ENDPOINT_ARRAY=(${ENDPOINT//:/ })
-
   local DNS_TYPE=$(get_config_value ".dns.type")
   local EXTERNAL_DNS_ENABLED=false
   if [ "$DNS_TYPE" == "oci" ]; then
@@ -114,8 +108,6 @@ function install_verrazzano()
         --set config.envName=${ENV_NAME} \
         --set config.dnsSuffix=${DNS_SUFFIX} \
         --set config.enableMonitoringStorage=true \
-        --set kubernetes.service.endpoint.ip=${ENDPOINT_ARRAY[0]} \
-        --set kubernetes.service.endpoint.port=${ENDPOINT_ARRAY[1]} \
         --set externaldns.enabled=${EXTERNAL_DNS_ENABLED} \
         --set keycloak.enabled=$(is_keycloak_enabled) \
         --set rancher.enabled=$(is_rancher_enabled) \

--- a/platform-operator/thirdparty/charts/istio/gateways/istio-ingress/templates/service.yaml
+++ b/platform-operator/thirdparty/charts/istio/gateways/istio-ingress/templates/service.yaml
@@ -23,6 +23,10 @@ spec:
 {{- if $gateway.externalTrafficPolicy }}
   externalTrafficPolicy: {{$gateway.externalTrafficPolicy }}
 {{- end }}
+{{- if $gateway.externalIPs }}
+  externalIPs:
+{{ toYaml $gateway.externalIPs | indent 4 }}
+{{- end }}
   type: {{ $gateway.type }}
   selector:
 {{ $gateway.labels | toYaml | indent 4 }}


### PR DESCRIPTION
This PR has 2 fixes for OLCNE

1). Add the ExternIPs back the Istio chart, it existing in Istio 1.4.6, but was removed in Istio 1.7.3.  This is needed to access the application via the Istio Ingress Gateway

2) Fix a verrazzano script problem where multiple Kubernetes API Server IPs are returned on OLCNE causing the following parsing error:
Error: failed parsing --set data: key map "100" has no value

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
