### PR TITLE
Add missing SERVICE_KEY creds

### DIFF
--- a/ci/JenkinsfileFlakyTests
+++ b/ci/JenkinsfileFlakyTests
@@ -43,6 +43,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_BUCKET="verrazzano-builds"
         BRANCH_NAME="master"
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
     }
 
     // This job runs against the latest stable master commit. That is defined as the last clean master build and test run whose

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -43,6 +43,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_BUCKET="verrazzano-builds"
         BRANCH_NAME="master"
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
     }
 
     // This job runs against the latest stable master commit. That is defined as the last clean master build and test run whose

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -63,6 +63,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_BUCKET="verrazzano-builds"
         PROMETHEUS_GW_URL = credentials('v8o-dev-sauron-prometheus-url')
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
     }
 
     stages {


### PR DESCRIPTION
# Description

The de-coupling and new notification changes missed adding the SERVICE_KEY creds in the jobs where notifications were added (this is needed for pagerduty)

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
