### PR TITLE
Allow BOM subcomponent to override the global registry setting

### DIFF
--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -62,6 +62,9 @@ type BomSubComponent struct {
 	// where ghci.io is the registry and verrazzano is the repository name.
 	Repository string `json:"repository"`
 
+	// Override the registry within a subcomponent
+	Registry string `json:"registry"`
+
 	// Images is the array of images for this subcomponent
 	Images []BomImage `json:"images"`
 }
@@ -264,6 +267,9 @@ func (b *Bom) ResolveRegistry(sc *BomSubComponent) string {
 	registry := os.Getenv(constants.RegistryOverrideEnvVar)
 	if registry == "" {
 		registry = b.bomDoc.Registry
+		if len(sc.Registry) > 0 {
+			registry = sc.Registry
+		}
 	}
 	return registry
 }

--- a/pkg/bom/bom_test.go
+++ b/pkg/bom/bom_test.go
@@ -166,6 +166,7 @@ var testSubcomponetHelmKeyValues = map[string]*testSubComponent{
 // This is the real BOM file path needed for unit tests
 const realBomFilePath = "testdata/verrazzano-bom.json"
 const testBomFilePath = "testdata/test_bom.json"
+const testBomSubcomponentOverridesPath = "testdata/test_bom_sc_overrides.json"
 
 // TestFakeBom tests loading a fake bom json into a struct
 // GIVEN a json file
@@ -224,4 +225,30 @@ func validateImages(assert *assert.Assertions, bom *Bom, checkImageVal bool) {
 			}
 		}
 	}
+}
+
+// TestBomSubcomponentOverrides the ability to override registry and repo settings at the subcomponent level
+// GIVEN a json file where a subcomponent overrides the registry and repository location of its images
+// WHEN I load it and check those settings
+// THEN the correct overrides are present without affecting the global registry setting
+func TestBomSubcomponentOverrides(t *testing.T) {
+	assert := assert.New(t)
+	bom, err := NewBom(testBomSubcomponentOverridesPath)
+
+	assert.Equal("ghcr.io", bom.GetRegistry(), "Global registry not correct")
+
+	nginxSubcomponent, err := bom.GetSubcomponent("ingress-controller")
+	assert.NotNil(t, nginxSubcomponent)
+	assert.NoError(err)
+
+	assert.Equal("ghcr.io", bom.GetRegistry(), "Global registry not correct")
+	assert.Equal("myreg.io", bom.ResolveRegistry(nginxSubcomponent), "NGINX subcomponent registry not correct")
+	assert.Equal("myrepoprefix/testnginx", bom.ResolveRepo(nginxSubcomponent), "NGINX subcomponent repo not correct")
+
+	vpoSubcomponent, err := bom.GetSubcomponent("verrazzano-platform-operator")
+	assert.NotNil(t, vpoSubcomponent)
+	assert.NoError(err)
+
+	assert.Equal("ghcr.io", bom.ResolveRegistry(vpoSubcomponent), "VPO subcomponent registry not correct")
+	assert.Equal("verrazzano", bom.ResolveRepo(vpoSubcomponent), "VPO subcomponent repo not correct")
 }

--- a/pkg/bom/bom_test.go
+++ b/pkg/bom/bom_test.go
@@ -236,7 +236,7 @@ func TestBomSubcomponentOverrides(t *testing.T) {
 	bom, err := NewBom(testBomSubcomponentOverridesPath)
 	assert.Equal("ghcr.io", bom.GetRegistry(), "Global registry not correct")
 	assert.NoError(err)
-	
+
 	nginxSubcomponent, err := bom.GetSubcomponent("ingress-controller")
 	assert.NotNil(t, nginxSubcomponent)
 	assert.NoError(err)

--- a/pkg/bom/bom_test.go
+++ b/pkg/bom/bom_test.go
@@ -234,9 +234,9 @@ func validateImages(assert *assert.Assertions, bom *Bom, checkImageVal bool) {
 func TestBomSubcomponentOverrides(t *testing.T) {
 	assert := assert.New(t)
 	bom, err := NewBom(testBomSubcomponentOverridesPath)
-
 	assert.Equal("ghcr.io", bom.GetRegistry(), "Global registry not correct")
-
+	assert.NoError(err)
+	
 	nginxSubcomponent, err := bom.GetSubcomponent("ingress-controller")
 	assert.NotNil(t, nginxSubcomponent)
 	assert.NoError(err)

--- a/pkg/bom/testdata/test_bom_sc_overrides.json
+++ b/pkg/bom/testdata/test_bom_sc_overrides.json
@@ -1,0 +1,46 @@
+{
+  "registry": "ghcr.io",
+  "version": "0.17.0",
+  "components": [
+    {
+      "name": "verrazzano-platform-operator",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "verrazzano-platform-operator",
+          "images": [
+            {
+              "image": "VERRAZZANO_PLATFORM_OPERATOR_IMAGE",
+              "tag": "VERRAZZANO_PLATFORM_OPERATOR_TAG",
+              "helmFullImageKey": "image"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ingress-nginx",
+      "subcomponents": [
+        {
+          "repository": "myrepoprefix/testnginx",
+          "registry": "myreg.io",
+          "name": "ingress-controller",
+          "images": [
+            {
+              "image": "nginx-ingress-controller",
+              "tag": "0.46.0-20210510134749-abc2d2088",
+              "helmFullImageKey": "controller.image.repository",
+              "helmTagKey": "controller.image.tag"
+            },
+            {
+              "image": "nginx-ingress-default-backend",
+              "tag": "0.46.0-20210510134749-abc2d2088",
+              "helmFullImageKey": "defaultBackend.image.repository",
+              "helmTagKey": "defaultBackend.image.tag"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Allow a subcomponent in the BOM to override the global registry location.  This is to facilitate testing one-off images in developer scenarios.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
