### PR TITLE
Do not add JIRA comment if PR is being updated (release 1-.0 branch)

### DIFF
--- a/ci/ticket-commits/JenkinsfilePullRequests
+++ b/ci/ticket-commits/JenkinsfilePullRequests
@@ -45,9 +45,14 @@ pipeline {
             }
             steps {
                 script {
-                    sh """
-                        verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.CHANGE_TITLE}" --token unused --jira-env=prod
-                    """
+                    // Do not add a comment to the JIRA if an existing pull request is being updated
+                    if (currentBuild.changeSets.size() == 0) {
+                        sh """
+                            verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.CHANGE_TITLE}" --pr-target "${env.CHANGE_TARGET}" --token unused --jira-env=prod
+                        """
+                    } else {
+                        echo "Existing pull request updated, skipping update of JIRA ticket"
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

Backport of a change to not add a PR comment to a JIRA if an existing PR is being updated.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
