### PR TITLE
Introduce ComponentContext to Component interface

### DIFF
--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -118,27 +117,35 @@ func (h HelmComponent) IsOperatorInstallSupported() bool {
 }
 
 // IsInstalled Indicates whether or not the component is installed
-func (h HelmComponent) IsInstalled(_ *zap.SugaredLogger, _ clipkg.Client, namespace string) (bool, error) {
-	installed, _ := helm.IsReleaseInstalled(h.ReleaseName, resolveNamespace(h, namespace))
+func (h HelmComponent) IsInstalled(context spi.ComponentContext) (bool, error) {
+	if context.IsDryRun() {
+		context.Log().Infof("IsInstalled() dry run for %s", h.ReleaseName)
+		return true, nil
+	}
+	installed, _ := helm.IsReleaseInstalled(h.ReleaseName, h.resolveNamespace(context.GetEffectiveCR().Namespace))
 	return installed, nil
 }
 
 // IsReady Indicates whether or not a component is available and ready
-func (h HelmComponent) IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool {
-	ns := resolveNamespace(h, namespace)
-	if deployed, _ := helm.IsReleaseDeployed(h.ReleaseName, resolveNamespace(h, namespace)); deployed {
+func (h HelmComponent) IsReady(context spi.ComponentContext) bool {
+	if context.IsDryRun() {
+		context.Log().Infof("IsReady() dry run for %s", h.ReleaseName)
+		return true
+	}
+	ns := h.resolveNamespace(context.GetEffectiveCR().Namespace)
+	if deployed, _ := helm.IsReleaseDeployed(h.ReleaseName, ns); deployed {
 		if h.ReadyStatusFunc != nil {
-			return h.ReadyStatusFunc(log, client, h.ReleaseName, ns)
+			return h.ReadyStatusFunc(context.Log(), context.GetClient(), h.ReleaseName, ns)
 		}
 		return true
 	}
 	return false
 }
 
-func (h HelmComponent) Install(log *zap.SugaredLogger, _ *installv1alpha1.Verrazzano, client clipkg.Client, namespace string, dryRun bool) error {
+func (h HelmComponent) Install(context spi.ComponentContext) error {
 
 	// Resolve the namespace
-	resolvedNamespace := resolveNamespace(h, namespace)
+	resolvedNamespace := h.resolveNamespace(context.GetEffectiveCR().Namespace)
 
 	failed, err := helm.IsReleaseFailed(h.ReleaseName, resolvedNamespace)
 	if err != nil {
@@ -149,39 +156,39 @@ func (h HelmComponent) Install(log *zap.SugaredLogger, _ *installv1alpha1.Verraz
 		// NOTE: we'll likely have to put in some more logic akin to what we do for the scripts, see
 		//       reset_chart() in the common.sh script.  Recovering chart state can be a bit difficult, we
 		//       may need to draw on both the 'ls' and 'status' output for that.
-		helm.Uninstall(log, h.ReleaseName, resolvedNamespace, dryRun)
+		helm.Uninstall(context.Log(), h.ReleaseName, resolvedNamespace, context.IsDryRun())
 	}
 
 	var kvs []bom.KeyValue
 	if h.PreInstallFunc != nil {
-		preInstallValues, err := h.PreInstallFunc(log, client, h.ReleaseName, resolvedNamespace, h.ChartDir)
+		preInstallValues, err := h.PreInstallFunc(context.Log(), context.GetClient(), h.ReleaseName, resolvedNamespace, h.ChartDir)
 		if err != nil {
 			return err
 		}
 		kvs = append(kvs, preInstallValues...)
 	}
 	// check for global image pull secret
-	kvs, err = secret.AddGlobalImagePullSecretHelmOverride(log, client, resolvedNamespace, kvs, h.ImagePullSecretKeyname)
+	kvs, err = secret.AddGlobalImagePullSecretHelmOverride(context.Log(), context.GetClient(), resolvedNamespace, kvs, h.ImagePullSecretKeyname)
 	if err != nil {
 		return err
 	}
 
 	// vz-specific chart overrides file
-	overridesString, err := h.buildOverridesString(log, client, resolvedNamespace, kvs...)
+	overridesString, err := h.buildOverridesString(context.Log(), context.GetClient(), resolvedNamespace, kvs...)
 	if err != nil {
 		return err
 	}
 
 	// Perform a helm upgrade --install
-	_, _, err = upgradeFunc(log, h.ReleaseName, resolvedNamespace, h.ChartDir, h.WaitForInstall, dryRun, overridesString, h.ValuesFile)
+	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, resolvedNamespace, h.ChartDir, h.WaitForInstall, context.IsDryRun(), overridesString, h.ValuesFile)
 	return err
 }
 
-func (h HelmComponent) PreInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (h HelmComponent) PreInstall(context spi.ComponentContext) error {
 	return nil
 }
 
-func (h HelmComponent) PostInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (h HelmComponent) PostInstall(context spi.ComponentContext) error {
 	return nil
 }
 
@@ -189,9 +196,9 @@ func (h HelmComponent) PostInstall(log *zap.SugaredLogger, client clipkg.Client,
 // that is included in the operator image, while retaining any helm Value overrides that were applied during
 // install. Along with the override files in helm_config, we need to generate image overrides using the
 // BOM json file.  Each component also has the ability to add additional override parameters.
-func (h HelmComponent) Upgrade(log *zap.SugaredLogger, _ *installv1alpha1.Verrazzano, client clipkg.Client, ns string, dryRun bool) error {
+func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Resolve the namespace
-	namespace := resolveNamespace(h, ns)
+	namespace := h.resolveNamespace(context.GetEffectiveCR().Namespace)
 
 	// Check if the component is installed before trying to upgrade
 	found, err := helm.IsReleaseInstalled(h.ReleaseName, namespace)
@@ -199,25 +206,25 @@ func (h HelmComponent) Upgrade(log *zap.SugaredLogger, _ *installv1alpha1.Verraz
 		return err
 	}
 	if !found {
-		log.Infof("Skipping upgrade of component %s since it is not installed", h.ReleaseName)
+		context.Log().Infof("Skipping upgrade of component %s since it is not installed", h.ReleaseName)
 		return nil
 	}
 
 	// Do the preUpgrade if the function is defined
 	if h.PreUpgradeFunc != nil && UpgradePrehooksEnabled {
-		log.Infof("Running preUpgrade function for %s", h.ReleaseName)
-		err := h.PreUpgradeFunc(log, client, h.ReleaseName, namespace, h.ChartDir)
+		context.Log().Infof("Running preUpgrade function for %s", h.ReleaseName)
+		err := h.PreUpgradeFunc(context.Log(), context.GetClient(), h.ReleaseName, namespace, h.ChartDir)
 		if err != nil {
 			return err
 		}
 	}
 
-	overridesString, err := h.buildOverridesString(log, client, namespace)
+	overridesString, err := h.buildOverridesString(context.Log(), context.GetClient(), namespace)
 	if err != nil {
 		return err
 	}
 
-	stdout, err := helm.GetValues(log, h.ReleaseName, namespace)
+	stdout, err := helm.GetValues(context.Log(), h.ReleaseName, namespace)
 	if err != nil {
 		return err
 	}
@@ -225,35 +232,35 @@ func (h HelmComponent) Upgrade(log *zap.SugaredLogger, _ *installv1alpha1.Verraz
 	var tmpFile *os.File
 	tmpFile, err = ioutil.TempFile(os.TempDir(), "values-*.yaml")
 	if err != nil {
-		log.Errorf("Failed to create temporary file: %v", err)
+		context.Log().Errorf("Failed to create temporary file: %v", err)
 		return err
 	}
 
 	defer os.Remove(tmpFile.Name())
 
 	if _, err = tmpFile.Write(stdout); err != nil {
-		log.Errorf("Failed to write to temporary file: %v", err)
+		context.Log().Errorf("Failed to write to temporary file: %v", err)
 		return err
 	}
 
 	// Close the file
 	if err := tmpFile.Close(); err != nil {
-		log.Errorf("Failed to close temporary file: %v", err)
+		context.Log().Errorf("Failed to close temporary file: %v", err)
 		return err
 	}
 
-	log.Infof("Created values file: %s", tmpFile.Name())
+	context.Log().Infof("Created values file: %s", tmpFile.Name())
 
 	// Perform a helm upgrade --install
-	_, _, err = upgradeFunc(log, h.ReleaseName, namespace, h.ChartDir, true, dryRun, overridesString, h.ValuesFile, tmpFile.Name())
+	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, namespace, h.ChartDir, true, context.IsDryRun(), overridesString, h.ValuesFile, tmpFile.Name())
 	return err
 }
 
-func (h HelmComponent) PreUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (h HelmComponent) PreUpgrade(context spi.ComponentContext) error {
 	return nil
 }
 
-func (h HelmComponent) PostUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (h HelmComponent) PostUpgrade(context spi.ComponentContext) error {
 	return nil
 }
 
@@ -303,7 +310,7 @@ func (h HelmComponent) buildOverridesString(log *zap.SugaredLogger, _ clipkg.Cli
 //
 // The need for this stems from an issue with the Verrazzano component and the fact
 // that component charts underneath VZ component need to have the ns overridden
-func resolveNamespace(h HelmComponent, ns string) string {
+func (h HelmComponent) resolveNamespace(ns string) string {
 	namespace := ns
 	if h.ResolveNamespaceFunc != nil {
 		namespace = h.ResolveNamespaceFunc(namespace)

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -94,7 +94,7 @@ func (i IstioComponent) Upgrade(context spi.ComponentContext) error {
 		return err
 	}
 
-	vz := context.GetEffectiveCR()
+	vz := context.EffectiveCR()
 	defer os.Remove(tmpFile.Name())
 	if vz.Spec.Components.Istio != nil {
 		istioOperatorYaml, err := BuildIstioOperatorYaml(vz.Spec.Components.Istio)
@@ -128,7 +128,7 @@ func (i IstioComponent) Upgrade(context spi.ComponentContext) error {
 		return err
 	}
 
-	err = restartComponentsFn(log, err, i, context.GetClient())
+	err = restartComponentsFn(log, err, i, context.Client())
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/istio"
@@ -75,15 +74,18 @@ func (i IstioComponent) IsOperatorInstallSupported() bool {
 	return false
 }
 
-func (i IstioComponent) IsInstalled(_ *zap.SugaredLogger, _ clipkg.Client, _ string) (bool, error) {
+func (i IstioComponent) IsInstalled(_ spi.ComponentContext) (bool, error) {
 	return false, nil
 }
 
-func (i IstioComponent) Install(log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, _ clipkg.Client, _ string, _ bool) error {
+func (i IstioComponent) Install(_ spi.ComponentContext) error {
 	return nil
 }
 
-func (i IstioComponent) Upgrade(log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, client clipkg.Client, _ string, _ bool) error {
+func (i IstioComponent) Upgrade(context spi.ComponentContext) error {
+
+	log := context.Log()
+
 	// temp file to contain override values from istio install args
 	var tmpFile *os.File
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "values-*.yaml")
@@ -92,6 +94,7 @@ func (i IstioComponent) Upgrade(log *zap.SugaredLogger, vz *installv1alpha1.Verr
 		return err
 	}
 
+	vz := context.GetEffectiveCR()
 	defer os.Remove(tmpFile.Name())
 	if vz.Spec.Components.Istio != nil {
 		istioOperatorYaml, err := BuildIstioOperatorYaml(vz.Spec.Components.Istio)
@@ -125,7 +128,7 @@ func (i IstioComponent) Upgrade(log *zap.SugaredLogger, vz *installv1alpha1.Verr
 		return err
 	}
 
-	err = restartComponentsFn(log, err, i, client)
+	err = restartComponentsFn(log, err, i, context.GetClient())
 	if err != nil {
 		return err
 	}
@@ -141,7 +144,7 @@ func setDefaultUpgradeFunc() {
 	upgradeFunc = istio.Upgrade
 }
 
-func (i IstioComponent) IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool {
+func (i IstioComponent) IsReady(_ spi.ComponentContext) bool {
 	return true
 }
 
@@ -150,19 +153,19 @@ func (i IstioComponent) GetDependencies() []string {
 	return []string{}
 }
 
-func (i IstioComponent) PreUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (i IstioComponent) PreUpgrade(_ spi.ComponentContext) error {
 	return nil
 }
 
-func (i IstioComponent) PostUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (i IstioComponent) PostUpgrade(_ spi.ComponentContext) error {
 	return nil
 }
 
-func (i IstioComponent) PreInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (i IstioComponent) PreInstall(_ spi.ComponentContext) error {
 	return nil
 }
 
-func (i IstioComponent) PostInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error {
+func (i IstioComponent) PostInstall(_ spi.ComponentContext) error {
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
@@ -68,7 +69,7 @@ func TestUpgrade(t *testing.T) {
 	defer istio.SetDefaultRunner()
 	setUpgradeFunc(fakeUpgrade)
 	defer setDefaultUpgradeFunc()
-	err := comp.Upgrade(zap.S(), vz, getMock(t), "", false)
+	err := comp.Upgrade(spi.NewContext(zap.S(), getMock(t), vz, false))
 	assert.NoError(err, "Upgrade returned an error")
 }
 

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -4,7 +4,9 @@
 package registry
 
 import (
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	helm2 "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/helm"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -83,7 +85,7 @@ func TestComponentDependenciesMet(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}, false))
 	assert.True(t, ready)
 }
 
@@ -115,7 +117,7 @@ func TestComponentDependenciesNotMet(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.False(t, ready)
 }
 
@@ -132,22 +134,11 @@ func TestComponentDependenciesDependencyChartNotInstalled(t *testing.T) {
 		Dependencies:    []string{"istiod"},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
-	//	ObjectMeta: metav1.ObjectMeta{
-	//		Namespace: "istio-system",
-	//		Name:      "istiod",
-	//	},
-	//	Status: appsv1.DeploymentStatus{
-	//		Replicas:            1,
-	//		ReadyReplicas:       0,
-	//		AvailableReplicas:   0,
-	//		UnavailableReplicas: 1,
-	//	},
-	//})
 	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
 		return helm.ChartStatusPendingInstall, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.False(t, ready)
 }
 
@@ -179,7 +170,7 @@ func TestComponentMultipleDependenciesPartiallyMet(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.False(t, ready)
 }
 
@@ -211,7 +202,7 @@ func TestComponentMultipleDependenciesMet(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.True(t, ready)
 }
 
@@ -243,7 +234,7 @@ func TestComponentDependenciesCycle(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.False(t, ready)
 }
 
@@ -258,6 +249,6 @@ func TestNoComponentDependencies(t *testing.T) {
 		ChartNamespace: "bar",
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
-	ready := ComponentDependenciesMet(zap.S(), client, comp)
+	ready := ComponentDependenciesMet(comp, spi.NewContext(zap.S(), client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.True(t, ready)
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -14,11 +14,11 @@ type ComponentContext interface {
 	// Log returns the logger for the context
 	Log() *zap.SugaredLogger
 	// GetClient returns the controller client for the context
-	GetClient() clipkg.Client
-	// GetCR returns the actual Verrazzano resource
-	GetCR() *vzapi.Verrazzano
-	// GetEffectiveCR returns the effective merged Verrazzano CR
-	GetEffectiveCR() *vzapi.Verrazzano
+	Client() clipkg.Client
+	// ActualCR returns the actual unmerged Verrazzano resource
+	ActualCR() *vzapi.Verrazzano
+	// EffectiveCR returns the effective merged Verrazzano CR
+	EffectiveCR() *vzapi.Verrazzano
 	// IsDryRun indicates the component context is in DryRun mode
 	IsDryRun() bool
 	// Copy returns a copy of the current context
@@ -29,9 +29,6 @@ type ComponentContext interface {
 type ComponentInfo interface {
 	// Name returns the name of the Verrazzano component
 	Name() string
-	// IsOperatorInstallSupported Returns true if the component supports install directly via the platform operator
-	// - scaffolding while we move components from the scripts to the operator
-	IsOperatorInstallSupported() bool
 	// GetDependencies returns the dependencies of this component
 	GetDependencies() []string
 	// IsReady Indicates whether or not a component is available and ready
@@ -40,6 +37,9 @@ type ComponentInfo interface {
 
 // InstallComponent interface defines installs operations for components that support it
 type InstallComponent interface {
+	// IsOperatorInstallSupported Returns true if the component supports install directly via the platform operator
+	// - scaffolding while we move components from the scripts to the operator
+	IsOperatorInstallSupported() bool
 	// IsInstalled Indicates whether or not the component is installed
 	IsInstalled(context ComponentContext) (bool, error)
 	// PreInstall allows components to perform any pre-processing required prior to initial install
@@ -59,6 +59,7 @@ type UpgradeComponent interface {
 	// PostUpgrade allows components to perform any post-processing required after upgrading
 	PostUpgrade(context ComponentContext) error
 	// GetSkipUpgrade returns the value of the SkipUpgrade field
+	// - Scaffolding for now during the Istio 1.10.2 upgrade process
 	GetSkipUpgrade() bool
 }
 

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -4,47 +4,67 @@
 package spi
 
 import (
-	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"go.uber.org/zap"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Component interface defines the methods implemented by components
-type Component interface {
+// ComponentContext Defines the context objects required for Component operations
+type ComponentContext interface {
+	// Log returns the logger for the context
+	Log() *zap.SugaredLogger
+	// GetClient returns the controller client for the context
+	GetClient() clipkg.Client
+	// GetCR returns the actual Verrazzano resource
+	GetCR() *vzapi.Verrazzano
+	// GetEffectiveCR returns the effective merged Verrazzano CR
+	GetEffectiveCR() *vzapi.Verrazzano
+	// IsDryRun indicates the component context is in DryRun mode
+	IsDryRun() bool
+	// Copy returns a copy of the current context
+	Copy() ComponentContext
+}
+
+// ComponentInfo interface defines common information and metadata about components
+type ComponentInfo interface {
 	// Name returns the name of the Verrazzano component
 	Name() string
-
 	// IsOperatorInstallSupported Returns true if the component supports install directly via the platform operator
 	// - scaffolding while we move components from the scripts to the operator
 	IsOperatorInstallSupported() bool
-
 	// GetDependencies returns the dependencies of this component
 	GetDependencies() []string
+	// IsReady Indicates whether or not a component is available and ready
+	IsReady(context ComponentContext) bool
+}
 
+// InstallComponent interface defines installs operations for components that support it
+type InstallComponent interface {
+	// IsInstalled Indicates whether or not the component is installed
+	IsInstalled(context ComponentContext) (bool, error)
+	// PreInstall allows components to perform any pre-processing required prior to initial install
+	PreInstall(context ComponentContext) error
+	// Install performs the initial install of a component
+	Install(context ComponentContext) error
+	// PostInstall allows components to perform any post-processing required after initial install
+	PostInstall(context ComponentContext) error
+}
+
+// UpgradeComponent interface defines upgrade operations for components that support it
+type UpgradeComponent interface {
+	// PreUpgrade allows components to perform any pre-processing required prior to upgrading
+	PreUpgrade(context ComponentContext) error
+	// Upgrade will upgrade the Verrazzano component specified in the CR.Version field
+	Upgrade(context ComponentContext) error
+	// PostUpgrade allows components to perform any post-processing required after upgrading
+	PostUpgrade(context ComponentContext) error
 	// GetSkipUpgrade returns the value of the SkipUpgrade field
 	GetSkipUpgrade() bool
+}
 
-	// PreUpgrade allows components to perform any pre-processing required prior to upgrading
-	PreUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error
-
-	// Upgrade will upgrade the Verrazzano component specified in the CR.Version field
-	Upgrade(log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, client clipkg.Client, namespace string, dryRun bool) error
-
-	// PostUpgrade allows components to perform any post-processing required after upgrading
-	PostUpgrade(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error
-
-	// PreInstall allows components to perform any pre-processing required prior to initial install
-	PreInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error
-
-	// Install performs the initial install of a component
-	Install(log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano, client clipkg.Client, namespace string, dryRun bool) error
-
-	// PostInstall allows components to perform any post-processing required after initial install
-	PostInstall(log *zap.SugaredLogger, client clipkg.Client, namespace string, dryRun bool) error
-
-	// IsInstalled Indicates whether or not the component is installed
-	IsInstalled(log *zap.SugaredLogger, client clipkg.Client, namespace string) (bool, error)
-
-	// IsReady Indicates whether or not a component is available and ready
-	IsReady(log *zap.SugaredLogger, client clipkg.Client, namespace string) bool
+// Component interface defines the methods implemented by components
+type Component interface {
+	ComponentInfo
+	InstallComponent
+	UpgradeComponent
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -35,8 +35,8 @@ type ComponentInfo interface {
 	IsReady(context ComponentContext) bool
 }
 
-// InstallComponent interface defines installs operations for components that support it
-type InstallComponent interface {
+// ComponentInstaller interface defines installs operations for components that support it
+type ComponentInstaller interface {
 	// IsOperatorInstallSupported Returns true if the component supports install directly via the platform operator
 	// - scaffolding while we move components from the scripts to the operator
 	IsOperatorInstallSupported() bool
@@ -50,8 +50,8 @@ type InstallComponent interface {
 	PostInstall(context ComponentContext) error
 }
 
-// UpgradeComponent interface defines upgrade operations for components that support it
-type UpgradeComponent interface {
+// ComponentUpgrader interface defines upgrade operations for components that support it
+type ComponentUpgrader interface {
 	// PreUpgrade allows components to perform any pre-processing required prior to upgrading
 	PreUpgrade(context ComponentContext) error
 	// Upgrade will upgrade the Verrazzano component specified in the CR.Version field
@@ -66,6 +66,6 @@ type UpgradeComponent interface {
 // Component interface defines the methods implemented by components
 type Component interface {
 	ComponentInfo
-	InstallComponent
-	UpgradeComponent
+	ComponentInstaller
+	ComponentUpgrader
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -38,7 +38,7 @@ func (c componentContext) Log() *zap.SugaredLogger {
 	return c.log
 }
 
-func (c componentContext) GetClient() clipkg.Client {
+func (c componentContext) Client() clipkg.Client {
 	return c.client
 }
 
@@ -46,11 +46,11 @@ func (c componentContext) IsDryRun() bool {
 	return c.dryRun
 }
 
-func (c componentContext) GetCR() *vzapi.Verrazzano {
+func (c componentContext) ActualCR() *vzapi.Verrazzano {
 	return c.cr
 }
 
-func (c componentContext) GetEffectiveCR() *vzapi.Verrazzano {
+func (c componentContext) EffectiveCR() *vzapi.Verrazzano {
 	return c.effectiveCR
 }
 

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package spi
+
+// Default implementation of the ComponentContext interface
+
+import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"go.uber.org/zap"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewContext creates a ComponentContext from a raw CR
+func NewContext(log *zap.SugaredLogger, c clipkg.Client, cr *vzapi.Verrazzano, dryRun bool) ComponentContext {
+	return componentContext{
+		log:         log,
+		client:      c,
+		dryRun:      dryRun,
+		cr:          cr,
+		effectiveCR: cr, // Eventually we will compute the merged effective CR
+	}
+}
+
+type componentContext struct {
+	// log logger for the execution context
+	log *zap.SugaredLogger
+	// client Kubernetes client
+	client clipkg.Client
+	// dryRun If true, do a dry run of operations
+	dryRun bool
+	// cr Represents the current Verrazzano object state in the cluster
+	cr *vzapi.Verrazzano
+	// effectiveCR Represents the configuration resulting from any named profiles used and any configured overrides in the CR
+	effectiveCR *vzapi.Verrazzano
+}
+
+func (c componentContext) Log() *zap.SugaredLogger {
+	return c.log
+}
+
+func (c componentContext) GetClient() clipkg.Client {
+	return c.client
+}
+
+func (c componentContext) IsDryRun() bool {
+	return c.dryRun
+}
+
+func (c componentContext) GetCR() *vzapi.Verrazzano {
+	return c.cr
+}
+
+func (c componentContext) GetEffectiveCR() *vzapi.Verrazzano {
+	return c.effectiveCR
+}
+
+func (c componentContext) Copy() ComponentContext {
+	return componentContext{
+		log:         c.log,
+		client:      c.client,
+		dryRun:      c.dryRun,
+		cr:          c.cr,
+		effectiveCR: c.effectiveCR,
+	}
+}

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"testing"
 	"time"
@@ -129,14 +130,14 @@ func TestSuccessfulInstall(t *testing.T) {
 
 	// Sample bom file for version validation functions
 	config.SetDefaultBomFilePath(testBomFilePath)
-	defer func() {
-		config.SetDefaultBomFilePath("")
-	}()
-	// Stubout the call to check the chart status
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
+	defer config.SetDefaultBomFilePath("")
+
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
+		}
 	})
-	defer helm.SetDefaultChartStatusFunction()
+	defer registry.ResetGetComponentsFn()
 
 	// Expect a call to get the verrazzano resource.
 	expectGetVerrazzanoExists(mock, verrazzanoToUse, namespace, name, labels)
@@ -632,8 +633,8 @@ func TestCreateVerrazzanoWithOCIDNS(t *testing.T) {
 			asserts.Equalf(getInstallNamespace(), configMap.Namespace, "ConfigMap namespace did not match")
 			asserts.Equalf(buildConfigMapName(name), configMap.Name, "ConfigMap name did not match")
 			asserts.Equalf(labels, configMap.Labels, "ConfigMap labels did not match")
-			asserts.NotNil(configMap.Data["config.json"], "Configuration entry not found")
-			asserts.NotNil(configMap.Data[vzapi.OciPrivateKeyFileName], "OCI Config entry not found")
+			asserts.NotNil(configMap.Data["config.json"], "CR entry not found")
+			asserts.NotNil(configMap.Data[vzapi.OciPrivateKeyFileName], "OCI CR entry not found")
 			return nil
 		})
 
@@ -1652,7 +1653,7 @@ func TestJobGetError(t *testing.T) {
 
 // TestGetOCIConfigSecretError tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an verrazzano resource
-// WHEN a there is an error getting the OCI Config secret
+// WHEN a there is an error getting the OCI CR secret
 // THEN return error
 func TestGetOCIConfigSecretError(t *testing.T) {
 	unitTesting = true

--- a/platform-operator/controllers/verrazzano/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/fake_component_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package verrazzano
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+)
+
+// fakeComponent allows for using dummy Component implementations for controller testing
+type fakeComponent struct{}
+
+func (f fakeComponent) Name() string {
+	return "fake"
+}
+
+func (f fakeComponent) GetSkipUpgrade() bool {
+	return false
+}
+
+func (f fakeComponent) IsOperatorInstallSupported() bool {
+	return false
+}
+
+func (f fakeComponent) GetDependencies() []string {
+	return []string{}
+}
+
+func (f fakeComponent) PreUpgrade(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) Upgrade(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) PostUpgrade(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) PreInstall(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) Install(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) PostInstall(_ spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) IsInstalled(_ spi.ComponentContext) (bool, error) {
+	return true, nil
+}
+
+func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
+	return true
+}

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -8,6 +8,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/coherence"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -24,6 +25,8 @@ import (
 func (r *Reconciler) reconcileComponents(_ context.Context, log *zap.SugaredLogger, cr *vzapi.Verrazzano) (ctrl.Result, error) {
 
 	var requeue bool
+
+	compContext := spi.NewContext(log, r, cr, r.DryRun)
 
 	// Loop through all of the Verrazzano components and upgrade each one sequentially for now; will parallelize later
 	for _, comp := range registry.GetComponents() {
@@ -47,18 +50,18 @@ func (r *Reconciler) reconcileComponents(_ context.Context, log *zap.SugaredLogg
 
 		case vzapi.PreInstalling:
 			log.Infof("PreInstalling component %s", comp.Name())
-			if !registry.ComponentDependenciesMet(log, r.Client, comp) {
+			if !registry.ComponentDependenciesMet(comp, compContext) {
 				log.Infof("Dependencies not met for %s: %v", comp.Name(), comp.GetDependencies())
 				requeue = true
 				continue
 			}
-			if err := comp.PreInstall(log, r, cr.Namespace, r.DryRun); err != nil {
+			if err := comp.PreInstall(compContext); err != nil {
 				log.Errorf("Error calling comp.PreInstall for component %s: %v", comp.Name(), err.Error())
 				requeue = true
 				continue
 			}
 			// If component is not installed,install it
-			if err := comp.Install(log, cr, r, cr.Namespace, r.DryRun); err != nil {
+			if err := comp.Install(compContext); err != nil {
 				log.Errorf("Error calling comp.Install for component %s: %v", comp.Name(), err.Error())
 				requeue = true
 				continue
@@ -72,8 +75,8 @@ func (r *Reconciler) reconcileComponents(_ context.Context, log *zap.SugaredLogg
 			// For delete, we should look at the VZ resource delete timestamp and shift into Quiescing/Uninstalling state
 			// If component is enabled -- need to replicate scripts' config merging logic here
 			// If component is in deployed state, continue
-			if comp.IsReady(log, r.Client, cr.Namespace) {
-				if err := comp.PostInstall(log, r, cr.Namespace, r.DryRun); err != nil {
+			if comp.IsReady(compContext) {
+				if err := comp.PostInstall(compContext); err != nil {
 					return newRequeueWithDelay(), err
 				}
 				log.Infof("Component %s successfully installed", comp.Name())

--- a/platform-operator/internal/helm/helmcli.go
+++ b/platform-operator/internal/helm/helmcli.go
@@ -88,6 +88,10 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 	// a failed helm upgrade that results from a nil reference.  The nil reference occurs when a default value
 	// is added to a new chart and new chart references the new value.
 	for _, overridesFileName := range overridesFiles {
+		if len(overridesFileName) == 0 {
+			log.Debugf("Empty overrides file name for release %s", releaseName)
+			continue
+		}
 		args = append(args, "-f")
 		args = append(args, overridesFileName)
 	}


### PR DESCRIPTION
# Description

Refactor Component interface calls around new ComponentContext interface
- Collect parameters into a single object to avoid proliferation of parameters
- Context object will eventually own construction of effective (merged) CR
- Update impls and unit tests
- Unrelated, skip empty values files passed into helm upgrade
- Use fake component impls for controller testing

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
