### PR TITLE
Use persistence overrides with dev profile for upgrade test stability.

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -120,7 +120,6 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
-        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-kind.yaml"
 
         TEST_ENV = "${params.TEST_ENV}"
         MANAGED_CLUSTER_PROFILE = "${params.MANAGED_CLUSTER_PROFILE}"
@@ -148,6 +147,7 @@ pipeline {
         OCI_CLI_REGION = "${params.OKE_CLUSTER_REGION}"
         OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING = 'True'
 
+        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml"
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-nipio.yaml"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -384,12 +384,7 @@ func GetEffectiveKeyCloakPersistenceOverride() (*corev1.PersistentVolumeClaimSpe
 }
 
 // GetEffectiveVMIPersistenceOverride returns the effective PVC override for the VMI components, if it exists
-func GetEffectiveVMIPersistenceOverride() (*corev1.PersistentVolumeClaimSpec, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return nil, err
-	}
+func GetEffectiveVMIPersistenceOverride(kubeconfigPath string) (*corev1.PersistentVolumeClaimSpec, error) {
 	verrazzano, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if err != nil {
 		return nil, err

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -356,12 +356,7 @@ func GetNamespace(name string) (*corev1.Namespace, error) {
 }
 
 // GetEffectiveKeyCloakPersistenceOverride returns the effective PVC override for Keycloak, if it exists
-func GetEffectiveKeyCloakPersistenceOverride() (*corev1.PersistentVolumeClaimSpec, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return nil, err
-	}
+func GetEffectiveKeyCloakPersistenceOverride(kubeconfigPath string) (*v1alpha1.VolumeClaimSpecTemplate, error) {
 	verrazzano, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if err != nil {
 		return nil, err
@@ -377,7 +372,7 @@ func GetEffectiveKeyCloakPersistenceOverride() (*corev1.PersistentVolumeClaimSpe
 	}
 	for _, template := range verrazzano.Spec.VolumeClaimSpecTemplates {
 		if template.Name == mysqlVolSource.PersistentVolumeClaim.ClaimName {
-			return &template.Spec, nil
+			return &template, nil
 		}
 	}
 	return nil, fmt.Errorf("Did not find matching PVC template for %s", mysqlVolSource.PersistentVolumeClaim.ClaimName)

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -384,7 +384,7 @@ func GetEffectiveKeyCloakPersistenceOverride() (*corev1.PersistentVolumeClaimSpe
 }
 
 // GetEffectiveVMIPersistenceOverride returns the effective PVC override for the VMI components, if it exists
-func GetEffectiveVMIPersistenceOverride(kubeconfigPath string) (*corev1.PersistentVolumeClaimSpec, error) {
+func GetEffectiveVMIPersistenceOverride(kubeconfigPath string) (*v1alpha1.VolumeClaimSpecTemplate, error) {
 	verrazzano, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if err != nil {
 		return nil, err
@@ -397,7 +397,7 @@ func GetEffectiveVMIPersistenceOverride(kubeconfigPath string) (*corev1.Persiste
 	}
 	for _, template := range verrazzano.Spec.VolumeClaimSpecTemplates {
 		if template.Name == volumeOverride.PersistentVolumeClaim.ClaimName {
-			return &template.Spec, nil
+			return &template, nil
 		}
 	}
 	return nil, fmt.Errorf("Did not find matching PVC template for %s", volumeOverride.PersistentVolumeClaim.ClaimName)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -250,16 +250,11 @@ var _ = Describe("VMI", func() {
 	// If there are persistence overrides at the global level, that will cause persistent
 	// volumes to be created for the VMI components that use them (ES, Kibana, and Prometheus)
 	// At some point we may need to check for individual VMI overrides.
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	override, err := pkg.GetEffectiveVMIPersistenceOverride(kubeconfigPath)
+	kubeconfigPath, _ := k8sutil.GetKubeConfigLocation()
+	override, _ := pkg.GetEffectiveVMIPersistenceOverride(kubeconfigPath)
 	if override != nil {
 		size = override.Spec.Resources.Requests.Storage().String()
 	}
-
-	It("Check for errors getting persistent volume overrides", func() {
-		Expect(err).Should(BeNil(), fmt.Sprintf("Unexpected error getting default kubeconfig path: %s", err))
-		Expect(err).Should(BeNil(), fmt.Sprintf("Unexpected error getting VMI persistence overrides: %s", err))
-	})
 
 	if pkg.IsDevProfile() {
 		It("Check persistent volumes for dev profile", func() {
@@ -267,7 +262,7 @@ var _ = Describe("VMI", func() {
 			if override != nil {
 				expectedVolumes = 3
 			}
-			Expect(len(volumeClaims), err).To(Equal(expectedVolumes))
+			Expect(len(volumeClaims)).To(Equal(expectedVolumes))
 			if expectedVolumes > 0 {
 				assertPersistentVolume("vmi-system-prometheus", size)
 				assertPersistentVolume("vmi-system-grafana", size)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -253,13 +253,15 @@ var _ = Describe("VMI", func() {
 			kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 			Expect(err).Should(BeNil(), fmt.Sprintf("Unexpected error getting default kubeconfig path: %s", err))
 			override, err := pkg.GetEffectiveVMIPersistenceOverride(kubeconfigPath)
+			Expect(err).Should(BeNil(), fmt.Sprintf("Unexpected error getting VMI persistence overrides: %s", err))
 			// If there are persistence overrides at the global level, that will cause persistent
 			// volumes to be created for the VMI components that use them (ES, Kibana, and Prometheus)
 			// At some point we may need to check for individual VMI overrides.
 			if override != nil {
 				expectedVolumes = 3
+				size = override.Spec.Resources.Requests.Storage().String()
+				pkg.Log(pkg.Info, fmt.Sprintf("Found persistent override \"%s\" for VMI in dev profile, size: %s", override.Name, size))
 			}
-			Expect(err).Should(BeNil(), fmt.Sprintf("Unexpected error getting VMI persistence overrides: %s", err))
 			Expect(len(volumeClaims), err).To(Equal(expectedVolumes))
 			if expectedVolumes > 0 {
 				assertPersistentVolume("vmi-system-prometheus", size)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -248,8 +248,18 @@ var _ = Describe("VMI", func() {
 
 	size := "50Gi"
 	if pkg.IsDevProfile() {
+		expectedVolumes := 0
+		override, err := pkg.GetEffectiveVMIPersistenceOverride()
+		assertNotNil(err)
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Error checking VMI volume overrides: %v", err))
+			return
+		}
+		if override != nil {
+			expectedVolumes = 3
+		}
 		It("Check persistent volumes for dev profile", func() {
-			Expect(len(volumeClaims)).To(Equal(0))
+			Expect(len(volumeClaims)).To(Equal(expectedVolumes))
 		})
 	} else if isManagedClusterProfile {
 		It("Check persistent volumes for managed cluster profile", func() {


### PR DESCRIPTION
# Description

Add persistence overrides to the `dev` profile for the Multicluster tests, to provide more stability around pod restarts while still leveraging the minimal `dev` profile resource usage.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
