### PR TITLE
VZ-3604 - add wait for VMC to be deleted in CLI tests

### DIFF
--- a/tools/cli/scripts/cli_test.sh
+++ b/tools/cli/scripts/cli_test.sh
@@ -37,6 +37,23 @@ fi
 echo "vz cluster deregister ${MANAGED_CLUSTER_NAME}"
 vz cluster deregister ${MANAGED_CLUSTER_NAME}
 
+# wait for the VMC to be deleted
+retries=0
+echo "wait for VMC ${MANAGED_CLUSTER_NAME} to be deleted"
+until [ "$retries" -ge 10 ]
+do
+  kubectl --kubeconfig ${ADMIN_KUBECONFIG} get vmc ${MANAGED_CLUSTER_NAME} -n verrazzano-mc
+  if [ $? -eq 1 ]; then
+    break
+  fi
+  retries=$(($retries+1))
+  sleep 5
+done
+if [ "$retries" -ge 10 ] ; then
+  echo "failed to delete VMC ${MANAGED_CLUSTER_NAME}"
+  exit 1
+fi
+
 #create VerrazzanoMangedCLuster on admin
 echo "vz cluster register ${MANAGED_CLUSTER_NAME}"
 vz cluster register ${MANAGED_CLUSTER_NAME} -d "VerrazzanoManagedCluster object for ${MANAGED_CLUSTER_NAME}" -c "ca-secret-${MANAGED_CLUSTER_NAME}"

--- a/tools/cli/scripts/cli_test.sh
+++ b/tools/cli/scripts/cli_test.sh
@@ -44,7 +44,7 @@ set +e
 until [ "$retries" -ge 10 ]
 do
   kubectl --kubeconfig ${ADMIN_KUBECONFIG} get vmc ${MANAGED_CLUSTER_NAME} -n verrazzano-mc
-  if [ $? -eq 1 ]; then
+  if [ $? -ne 0 ]; then
     break
   fi
   retries=$(($retries+1))

--- a/tools/cli/scripts/cli_test.sh
+++ b/tools/cli/scripts/cli_test.sh
@@ -40,6 +40,7 @@ vz cluster deregister ${MANAGED_CLUSTER_NAME}
 # wait for the VMC to be deleted
 retries=0
 echo "wait for VMC ${MANAGED_CLUSTER_NAME} to be deleted"
+set +e
 until [ "$retries" -ge 10 ]
 do
   kubectl --kubeconfig ${ADMIN_KUBECONFIG} get vmc ${MANAGED_CLUSTER_NAME} -n verrazzano-mc
@@ -49,6 +50,7 @@ do
   retries=$(($retries+1))
   sleep 5
 done
+set -e
 if [ "$retries" -ge 10 ] ; then
   echo "failed to delete VMC ${MANAGED_CLUSTER_NAME}"
   exit 1


### PR DESCRIPTION
# Description

The CLI tests are failing intermittently.  We believe the failure is a timing condition due to not waiting for the VMC to be deleted during de-register.

Fixes VZ-3604

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
