### PR TITLE
Specify the release-1.0 pinned RUNNER_DOCKER_IMAGE/ARGS and agent VMs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def VERRAZZANO_DEV_VERSION = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 pipeline {
     options {
@@ -19,8 +19,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {
@@ -12,8 +12,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/looping-test/Jenkinsfile
+++ b/ci/looping-test/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
         }

--- a/ci/looping-test/JenkinsfileCreateCluster
+++ b/ci/looping-test/JenkinsfileCreateCluster
@@ -15,8 +15,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
         }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -19,7 +19,6 @@ installerFileName = "install-verrazzano.yaml"
 pipeline {
     options {
         skipDefaultCheckout true
-        timestamps ()
     }
 
     agent {
@@ -52,10 +51,6 @@ pipeline {
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
                 choices: [ "1.19", "1.18", "1.17", "1.20" ])
-        string (name: 'VERSION_FOR_INSTALL',
-                defaultValue: 'v1.0.0',
-                description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',
-                trim: true)
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
@@ -78,19 +73,6 @@ pipeline {
                 choices: [ "nip.io", "sslip.io"])
         booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
-        booleanParam (description: 'Whether to emit metrics from the pipeline', name: 'EMIT_METRICS', defaultValue: true)
-        string (name: 'TAGGED_TESTS',
-                defaultValue: '',
-                description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
-                trim: true)
-        string (name: 'INCLUDED_TESTS',
-                defaultValue: '.*',
-                description: 'A regex matching any fully qualified test file that should be executed (e.g. examples/helidon/). Default: .*',
-                trim: true)
-        string (name: 'EXCLUDED_TESTS',
-                defaultValue: '_excluded_test',
-                description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
-                trim: true)
     }
 
     environment {
@@ -165,18 +147,6 @@ pipeline {
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
-
-        // used for console artifact capture on failure
-        JENKINS_READ = credentials('jenkins-auditor')
-        OCI_CLI_AUTH="instance_principal"
-        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-        OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
-        OCI_OS_BUCKET="verrazzano-builds"
-
-        // used to emit metrics
-        PROMETHEUS_GW_URL = credentials('v8o-dev-sauron-prometheus-url')
-        TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION}"
     }
 
     stages {
@@ -270,7 +240,7 @@ pipeline {
             }
         }
 
-        stage('Install and Configure') {
+        stage('Acceptance Tests') {
             when {
                 allOf {
                     not { buildingTag() }
@@ -318,7 +288,7 @@ pipeline {
                                     }
                                     steps {
                                         script {
-                                            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                                            int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
                                             for(int count=1; count<=clusterCount; count++) {
                                                 sh """
                                                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
@@ -358,31 +328,48 @@ pipeline {
                     }
                 }
                 stage ('Install Verrazzano') {
+                    environment {
+                        OCI_CLI_AUTH="instance_principal"
+                        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+                        OCI_OS_BUCKET="verrazzano-builds"
+                    }
                     steps {
                         script {
-                            VZ_INSTALL_METRIC = metricJobName('install_v8o')
-                            metricTimerStart("${VZ_INSTALL_METRIC}")
-                            getVerrazzanoOperatorYaml()
-                         }
-                        installVerrazzano()
+                            // Either download the latest platform operator YAML from the master bucket, or create one
+                            // using the specific operator image provided by the user.
+                            sh """
+                                echo "Platform Operator Configuration"
+                                cd ${GO_REPO_PATH}/verrazzano
+                                if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
+                                    echo "Using the latest master branch operator.yaml from object storage"
+                                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
+                                    cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+                                else
+                                    echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
+                                    env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
+                                fi
+                            """
+                        }
+                        script {
+                            // Create a dictionary of Verrazzano install steps to be executed in parallel
+                            // - the first one will always be the Admin cluster
+                            // - clusters 2-max are managed clusters
+                            def verrazzanoInstallStages = [:]
+                            int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+                            for(int count=1; count<=clusterCount; count++) {
+                                def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                                def key = "vz-mgd-${count-1}"
+                                if (count == 1) {
+                                    key = "vz-admin"
+                                }
+                                verrazzanoInstallStages["${key}"] = installVerrazzano(count, installerPath)
+                            }
+                            parallel verrazzanoInstallStages
+                        }
                     }
                     post {
                         always {
-                            script {
-                                dumpInstallLogs()
-                                VZ_TEST_METRIC = metricJobName('')
-                                metricTimerStart("${VZ_TEST_METRIC}")
-                            }
-                        }
-                        failure {
-                            script {
-                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
-                            }
-                        }
-                        success {
-                            script {
-                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
-                            }
+                            dumpInstallLogs()
                         }
                     }
                 }
@@ -428,6 +415,42 @@ pipeline {
                         }
                     }
                 }
+                stage ('CLI Tests') {
+                    stages {
+                        stage ('Verify Install') {
+                            steps {
+                                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                    script {
+                                        int count = params.TOTAL_CLUSTERS.toInteger() + 1
+                                        sh """
+                                            export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                                            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                                            ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor verify-install/...
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        stage ('Run commands') {
+                            steps {
+                                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                    script {
+                                        int count = params.TOTAL_CLUSTERS.toInteger() + 1
+                                        sh """
+                                            export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+                                            export MANAGED_CLUSTER_DIR="${KUBECONFIG_DIR}/${count}"
+                                            export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                            export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                                            cd ${GO_REPO_PATH}/verrazzano
+                                            make cli
+                                            ./tools/cli/scripts/cli_test.sh
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 stage ('Register managed clusters') {
                     steps {
                         registerManagedClusters()
@@ -435,12 +458,37 @@ pipeline {
                 }
                 stage ('Verify Register') {
                     steps {
-                        verifyRegisterManagedClusters()
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            script {
+                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                                for(int count=2; count<=clusterCount; count++) {
+                                    sh """
+                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                                        ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor multicluster/verify-register/...
+                                    """
+                                }
+                            }
+                        }
                     }
                 }
                 stage ('Verify Managed Cluster Permissions') {
                     steps {
-                        verifyManagedClusterPermissions()
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            script {
+                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                                for(int count=2; count<=clusterCount; count++) {
+                                    sh """
+                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                                        export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
+                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                                        ginkgo -v -stream -keepGoing --noColor multicluster/verify-permissions/...
+                                    """
+                                }
+                            }
+                        }
                     }
                 }
                 stage ('Verify Metrics') {
@@ -448,56 +496,6 @@ pipeline {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
-                stage("upgrade-platform-operator") {
-                    steps {
-                        upgradePlatformOperator()
-                    }
-                }
-                stage("upgrade-verrazzano") {
-                    steps {
-                        upgradeVerrazzano()
-                    }
-                }
-            }
-            post {
-                failure {
-                    script {
-                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-install")
-                    }
-                }
-            }
-        }
-
-        stage('Verify Upgrade') {
-            // Rerun some stages to verify the upgrade
-            parallel {
-                stage ('Verify Register') {
-                    steps {
-                        verifyRegisterManagedClusters()
-                    }
-                }
-                stage ('Verify Managed Cluster Permissions') {
-                    steps {
-                        verifyManagedClusterPermissions()
-                    }
-                }
-                stage ('Verify Metrics') {
-                    steps {
-                        runGinkgoRandomize('metrics/syscomponents')
-                    }
-                }
-            }
-            post {
-                failure {
-                    script {
-                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-verify-upgrade")
-                    }
-                }
-            }
-        }
-
-        stage('Acceptance Tests') {
-            stages {
                 stage ('Example apps') {
                     parallel {
                         stage ('Examples Helidon') {
@@ -511,7 +509,7 @@ pipeline {
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
                                         export DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon"
-                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/examples/helidon/...
+                                        ginkgo -v -keepGoing --noColor multicluster/examples/helidon/...
                                     """
                                 }
                             }
@@ -531,7 +529,7 @@ pipeline {
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
                                         export DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon-ns-ops"
-                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/examples/helidon-ns-ops/...
+                                        ginkgo -v -keepGoing --noColor multicluster/examples/helidon-ns-ops/...
                                     """
                                 }
                             }
@@ -548,7 +546,7 @@ pipeline {
                                         export MANAGED_CLUSTER_NAME="managed${count-1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-api/...
+                                        ginkgo -v -keepGoing --noColor multicluster/verify-api/...
                                     """
                                 }
                             }
@@ -558,32 +556,6 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
-                            }
-                        }
-                    }
-                }
-                stage ('CLI Tests') {
-                    steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                // Running the CLI tests for only one managed cluster for now
-                                int count = params.TOTAL_CLUSTERS.toInteger()
-                                sh """
-                                    export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
-                                    export MANAGED_CLUSTER_DIR="${KUBECONFIG_DIR}/${count}"
-                                    export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                    cd ${GO_REPO_PATH}/verrazzano
-                                    make cli
-                                    ./tools/cli/scripts/cli_test.sh
-                                """
-                            }
-                        }
-                    }
-                    post {
-                        failure {
-                            script {
-                                dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-cli-failed")
                             }
                         }
                     }
@@ -631,19 +603,16 @@ pipeline {
             post {
                 failure {
                     script {
-                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
-                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
                     script {
-                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                         }
@@ -654,15 +623,7 @@ pipeline {
     }
     post {
         failure {
-            sh """
-                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
-            """
             archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
-            sh """
-                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
-                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
-                rm archive.zip
-            """
         }
         always {
             script {
@@ -677,19 +638,10 @@ pipeline {
                 }
                 dumpUninstallLogs()
             }
-            archiveArtifacts artifacts: '**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
-
             script {
-                if (params.EMIT_METRICS) {
-                    withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
-                        sh """
-                            ${GO_REPO_PATH}/verrazzano/ci/scripts/dashboard/emit_metrics.sh "${GO_REPO_PATH}/verrazzano/tests/e2e" "${SAURON_CREDENTIALS}" || echo "Emit metrics failed, continuing with other post actions"
-                        """
-                    }
-                }
-
-                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
                 if (env.TEST_ENV == "kind") {
                     for(int count=1; count<=clusterCount; count++) {
                         sh """
@@ -719,7 +671,6 @@ pipeline {
             }
         }
         cleanup {
-            metricBuildDuration()
             deleteDir()
         }
     }
@@ -769,47 +720,10 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
         }
 }
 
-// Either download the specified release of the platform operator YAML, or create one
-// using the specific operator image provided by the user.
-def getVerrazzanoOperatorYaml() {
-    sh """
-        echo "Platform Operator Configuration"
-        cd ${GO_REPO_PATH}/verrazzano
-        if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
-            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-        else
-            echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
-            env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
-        fi
-    """
-}
-
-// Install Verrazzano on each of the clusters
-def installVerrazzano() {
-    script {
-        // Create a dictionary of Verrazzano install steps to be executed in parallel
-        // - the first one will always be the Admin cluster
-        // - clusters 2-max are managed clusters
-        def verrazzanoInstallStages = [:]
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-        for(int count=1; count<=clusterCount; count++) {
-            def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-            def key = "vz-mgd-${count-1}"
-            if (count == 1) {
-                key = "vz-admin"
-            }
-            verrazzanoInstallStages["${key}"] = installVerrazzanoOnCluster(count, installerPath)
-        }
-        parallel verrazzanoInstallStages
-    }
-}
-
 // Install Verrazzano on a target cluster
 // - count is the cluster index into the $KUBECONFIG_DIR
 // - verrazzanoConfig is the Verrazzano CR to use to install VZ on the cluster
-def installVerrazzanoOnCluster(count, verrazzanoConfig) {
+def installVerrazzano(count, verrazzanoConfig) {
     // For parallel execution, wrap this in a Groovy enclosure {}
     return {
         script {
@@ -845,65 +759,6 @@ def installVerrazzanoOnCluster(count, verrazzanoConfig) {
 
                 # wait for Verrazzano install to complete
                 ./tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-            """
-        }
-    }
-}
-
-// Upgrade the verrazzano-platform-operator
-def upgradePlatformOperator() {
-    script {
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-        for (int count = 1; count <= clusterCount; count++) {
-            def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
-            sh """
-                export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
-
-                echo "Upgrading the Verrazzano platform operator"
-                # Download the operator.yaml for the target version that we are upgrading to
-                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${upgradeOperatorFile}
-                kubectl apply -f ${upgradeOperatorFile}
-
-                # need to sleep since the old operator needs to transition to terminating state
-                sleep 15
-
-                # ensure operator pod is up
-                kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-            """
-        }
-    }
-}
-
-// Upgrade Verrazzano
-def upgradeVerrazzano() {
-    script {
-        // Download the bom for the target version that we are upgrading to, then extract the version
-        // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
-        VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
-
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-        for(int count=1; count<=clusterCount; count++) {
-            def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-            def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
-            sh """
-                export KUBECONFIG=${KUBECONFIG_DIR}/${count}/kube_config
-
-                echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
-                # Modify the version field in the verrazzano CR file to be this new verrazzano version
-                cd ${GO_REPO_PATH}/verrazzano
-                cp ${v8oInstallFile} ${v8oUpgradeFile}
-                ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
-                # Do the upgrade
-                echo "Following is the verrazano CR file with the new version:"
-                cat ${v8oUpgradeFile}
-                kubectl apply -f ${v8oUpgradeFile}
-                # wait for the upgrade to complete
-                kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
-
-                # ideally we don't need to wait here
-                sleep 15
-                echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
-                helm list -A
             """
         }
     }
@@ -958,42 +813,6 @@ def registerManagedClusters() {
     }
 }
 
-// Verify the register of the managed clusters
-def verifyRegisterManagedClusters() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for(int count=2; count<=clusterCount; count++) {
-                sh """
-                    export MANAGED_CLUSTER_NAME="managed${count-1}"
-                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
-                """
-            }
-        }
-    }
-}
-
-// Verify the managed cluster permissions
-def verifyManagedClusterPermissions() {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            for(int count=2; count<=clusterCount; count++) {
-                sh """
-                    export MANAGED_CLUSTER_NAME="managed${count-1}"
-                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                    export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
-                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -v -stream -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-permissions/...
-                """
-            }
-        }
-    }
-}
-
-
 // Run a test suite against all clusters
 def runGinkgoRandomize(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -1012,7 +831,7 @@ def runGinkgoRandomize(testSuitePath) {
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true ${testSuitePath}/...
+                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor ${testSuitePath}/...
                 """
             }
         }
@@ -1026,7 +845,7 @@ def runGinkgo(testSuitePath, kubeConfig, clusterCount) {
             export KUBECONFIG="${kubeConfig}"
             export CLUSTER_COUNT="${clusterCount}"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true ${testSuitePath}/...
+            ginkgo -v -keepGoing --noColor ${testSuitePath}/...
         """
     }
 }
@@ -1038,7 +857,7 @@ def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript
         String allArgs = ""
         extraArgs.each { allArgs += it + " " }
 
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
         for(int count=1; count<=clusterCount; count++) {
             def destinationPath = "${env.KUBECONFIG_DIR}/${count}/${installerFileName}"
             def installProfile = env.MANAGED_CLUSTER_PROFILE
@@ -1076,13 +895,16 @@ def createKindClusters() {
 
         // Can these for now, but eventually we should be able to build this based on
         // inspecting the Docker bridge network CIDR and splitting up a range based on
-        // the cluster count.
+        // the cluster count
 
-        def addressRanges = [ "172.18.0.231-172.18.0.238", "172.18.0.239-172.18.0.246", "172.18.0.247-172.18.0.254"]
+        // Create an extra cluster for CLI Tests
+        // This cluster will be deleted at the post action stage along with other clusters
+
+        def addressRanges = [ "172.18.0.231-172.18.0.238", "172.18.0.239-172.18.0.246", "172.18.0.247-172.18.0.254", "172.18.0.255-172.18.0.262" ]
         def clusterInstallStages = [:]
         boolean cleanupKindContainers = true
         boolean connectJenkinsRunnerToNetwork = true
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
         for(int count=1; count<=clusterCount; count++) {
             string metallbAddressRange = addressRanges.get(count-1)
             def deployStep = "cluster-${count}"
@@ -1099,17 +921,18 @@ def createKindClusters() {
 }
 
 // Invoke the OKE cluster creation script for the desired number of clusters
+// One extra cluster for CLI Test
 def createOKEClusters(clusterPrefix) {
     script {
         sh """
             echo "tests will execute" > ${TESTS_EXECUTED_FILE}
         """
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
         sh """
             mkdir -p ${KUBECONFIG_DIR}
             echo "Create OKE cluster"
             cd ${TEST_SCRIPTS_DIR}
-            TF_VAR_label_prefix=${clusterPrefix} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}" ${params.CREATE_CLUSTER_USE_CALICO}
+            TF_VAR_label_prefix=${clusterPrefix} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}" ${CREATE_CLUSTER_USE_CALICO}
         """
     }
 }
@@ -1253,23 +1076,18 @@ def dumpVerrazzanoApiLogs() {
     }
 }
 
+// Also dump install logs for cluster used in CLI tests
 def dumpInstallLogs() {
     script {
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
         for(int count=1; count<=clusterCount; count++) {
             LOG_DIR="${VERRAZZANO_INSTALL_LOGS_DIR}/cluster-$count"
-
-            // This function may run on older versions of Verrazzano that have the logs stored in the default namespace
-            def namespace = "verrazzano-install"
-            if (params.VERSION_FOR_INSTALL.startsWith("v1.0.0") || params.VERSION_FOR_INSTALL.startsWith("v1.0.1")) {
-                namespace = "default"
-            }
             sh """
                 ## dump verrazzano install logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 mkdir -p ${LOG_DIR}
-                kubectl -n ${namespace} logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                kubectl -n ${namespace} describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
                 echo "------------------------------------------"
             """
         }
@@ -1300,77 +1118,4 @@ def getEffectiveDumpOnSuccess() {
         echo "Forcing dump on success based on global override setting"
     }
     return effectiveValue
-}
-
-def metricJobName(stageName) {
-    job = env.JOB_NAME.split("/")[0]
-    job = '_' + job.replaceAll('-','_')
-    if (stageName) {
-        job = job + '_' + stageName
-    }
-    return job
-}
-
-// Construct the set of labels/dimensions for the metrics
-def getMetricLabels() {
-    def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
-    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
-    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
-             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
-             'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
-             'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
-             'kubernetes_version=\\"' + kube_ver + '\\",' +
-             'test_env=\\"' + "${params.TEST_ENV}" + '\\"'
-    return labels
-}
-
-// Construct the set of labels/dimensions for the metrics
-def metricTimerStart(metricName) {
-    def timerStartName = "${metricName}_START"
-    env."${timerStartName}" = sh(returnStdout: true, script: "date +%s").trim()
-}
-
-def metricTimerEnd(metricName, status) {
-    def timerStartName = "${metricName}_START"
-    def timerEndName   = "${metricName}_END"
-    env."${timerEndName}" = sh(returnStdout: true, script: "date +%s").trim()
-    if (params.EMIT_METRICS) {
-        long x = env."${timerStartName}" as long;
-        long y = env."${timerEndName}" as long;
-        def dur = (y-x)
-        labels = getMetricLabels()
-        withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
-            EMIT = sh(returnStdout: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${metricName} ${env.BRANCH_NAME} $labels ${status} ${dur}")
-            echo "emit prometheus metrics: $EMIT"
-            return EMIT
-        }
-    } else {
-        return ''
-    }
-}
-
-// Emit the metrics indicating the duration and result of the build
-def metricBuildDuration() {
-    def status = "${currentBuild.currentResult}".trim()
-    long duration = "${currentBuild.duration}" as long;
-    long durationInSec = (duration/1000)
-    testMetric = metricJobName('')
-    def metricValue = "-1"
-    statusLabel = status.substring(0,1)
-    if (status.equals("SUCCESS")) {
-        metricValue = "1"
-    } else if (status.equals("FAILURE")) {
-        metricValue = "0"
-    } else {
-        // Consider every other status as a single label
-        statusLabel = "A"
-    }
-    if (params.EMIT_METRICS) {
-        labels = getMetricLabels()
-        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
-        withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
-            METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
-            echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"
-        }
-    }
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -12,19 +12,20 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 installerFileName = "install-verrazzano.yaml"
 
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"
@@ -51,6 +52,10 @@ pipeline {
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
                 choices: [ "1.19", "1.18", "1.17", "1.20" ])
+        string (name: 'VERSION_FOR_INSTALL',
+                defaultValue: 'v1.0.0',
+                description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',
+                trim: true)
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',
@@ -73,6 +78,19 @@ pipeline {
                 choices: [ "nip.io", "sslip.io"])
         booleanParam (description: 'Whether to create the cluster with Calico for AT testing', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', description: 'Whether to dump k8s cluster on success (off by default, can be useful to capture for comparing to failed cluster)', defaultValue: false)
+        booleanParam (description: 'Whether to emit metrics from the pipeline', name: 'EMIT_METRICS', defaultValue: true)
+        string (name: 'TAGGED_TESTS',
+                defaultValue: '',
+                description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
+                trim: true)
+        string (name: 'INCLUDED_TESTS',
+                defaultValue: '.*',
+                description: 'A regex matching any fully qualified test file that should be executed (e.g. examples/helidon/). Default: .*',
+                trim: true)
+        string (name: 'EXCLUDED_TESTS',
+                defaultValue: '_excluded_test',
+                description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
+                trim: true)
     }
 
     environment {
@@ -147,6 +165,18 @@ pipeline {
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
+
+        // used for console artifact capture on failure
+        JENKINS_READ = credentials('jenkins-auditor')
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
+        OCI_OS_BUCKET="verrazzano-builds"
+
+        // used to emit metrics
+        PROMETHEUS_GW_URL = credentials('v8o-dev-sauron-prometheus-url')
+        TEST_ENV_LABEL = "${params.TEST_ENV}"
+        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION}"
     }
 
     stages {
@@ -240,7 +270,7 @@ pipeline {
             }
         }
 
-        stage('Acceptance Tests') {
+        stage('Install and Configure') {
             when {
                 allOf {
                     not { buildingTag() }
@@ -288,7 +318,7 @@ pipeline {
                                     }
                                     steps {
                                         script {
-                                            int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+                                            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
                                             for(int count=1; count<=clusterCount; count++) {
                                                 sh """
                                                     export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
@@ -328,48 +358,31 @@ pipeline {
                     }
                 }
                 stage ('Install Verrazzano') {
-                    environment {
-                        OCI_CLI_AUTH="instance_principal"
-                        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-                        OCI_OS_BUCKET="verrazzano-builds"
-                    }
                     steps {
                         script {
-                            // Either download the latest platform operator YAML from the master bucket, or create one
-                            // using the specific operator image provided by the user.
-                            sh """
-                                echo "Platform Operator Configuration"
-                                cd ${GO_REPO_PATH}/verrazzano
-                                if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-                                    echo "Using the latest master branch operator.yaml from object storage"
-                                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-                                    cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-                                else
-                                    echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
-                                    env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
-                                fi
-                            """
-                        }
-                        script {
-                            // Create a dictionary of Verrazzano install steps to be executed in parallel
-                            // - the first one will always be the Admin cluster
-                            // - clusters 2-max are managed clusters
-                            def verrazzanoInstallStages = [:]
-                            int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
-                            for(int count=1; count<=clusterCount; count++) {
-                                def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                                def key = "vz-mgd-${count-1}"
-                                if (count == 1) {
-                                    key = "vz-admin"
-                                }
-                                verrazzanoInstallStages["${key}"] = installVerrazzano(count, installerPath)
-                            }
-                            parallel verrazzanoInstallStages
-                        }
+                            VZ_INSTALL_METRIC = metricJobName('install_v8o')
+                            metricTimerStart("${VZ_INSTALL_METRIC}")
+                            getVerrazzanoOperatorYaml()
+                         }
+                        installVerrazzano()
                     }
                     post {
                         always {
-                            dumpInstallLogs()
+                            script {
+                                dumpInstallLogs()
+                                VZ_TEST_METRIC = metricJobName('')
+                                metricTimerStart("${VZ_TEST_METRIC}")
+                            }
+                        }
+                        failure {
+                            script {
+                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
+                            }
+                        }
+                        success {
+                            script {
+                                INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '1')
+                            }
                         }
                     }
                 }
@@ -415,42 +428,6 @@ pipeline {
                         }
                     }
                 }
-                stage ('CLI Tests') {
-                    stages {
-                        stage ('Verify Install') {
-                            steps {
-                                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                                    script {
-                                        int count = params.TOTAL_CLUSTERS.toInteger() + 1
-                                        sh """
-                                            export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                            ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor verify-install/...
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                        stage ('Run commands') {
-                            steps {
-                                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                                    script {
-                                        int count = params.TOTAL_CLUSTERS.toInteger() + 1
-                                        sh """
-                                            export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
-                                            export MANAGED_CLUSTER_DIR="${KUBECONFIG_DIR}/${count}"
-                                            export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                            export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                            cd ${GO_REPO_PATH}/verrazzano
-                                            make cli
-                                            ./tools/cli/scripts/cli_test.sh
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
                 stage ('Register managed clusters') {
                     steps {
                         registerManagedClusters()
@@ -458,37 +435,12 @@ pipeline {
                 }
                 stage ('Verify Register') {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor multicluster/verify-register/...
-                                    """
-                                }
-                            }
-                        }
+                        verifyRegisterManagedClusters()
                     }
                 }
                 stage ('Verify Managed Cluster Permissions') {
                     steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                        export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
-                                        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -v -stream -keepGoing --noColor multicluster/verify-permissions/...
-                                    """
-                                }
-                            }
-                        }
+                        verifyManagedClusterPermissions()
                     }
                 }
                 stage ('Verify Metrics') {
@@ -496,6 +448,56 @@ pipeline {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
+                stage("upgrade-platform-operator") {
+                    steps {
+                        upgradePlatformOperator()
+                    }
+                }
+                stage("upgrade-verrazzano") {
+                    steps {
+                        upgradeVerrazzano()
+                    }
+                }
+            }
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-install")
+                    }
+                }
+            }
+        }
+
+        stage('Verify Upgrade') {
+            // Rerun some stages to verify the upgrade
+            parallel {
+                stage ('Verify Register') {
+                    steps {
+                        verifyRegisterManagedClusters()
+                    }
+                }
+                stage ('Verify Managed Cluster Permissions') {
+                    steps {
+                        verifyManagedClusterPermissions()
+                    }
+                }
+                stage ('Verify Metrics') {
+                    steps {
+                        runGinkgoRandomize('metrics/syscomponents')
+                    }
+                }
+            }
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-verify-upgrade")
+                    }
+                }
+            }
+        }
+
+        stage('Acceptance Tests') {
+            stages {
                 stage ('Example apps') {
                     parallel {
                         stage ('Examples Helidon') {
@@ -509,7 +511,7 @@ pipeline {
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
                                         export DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon"
-                                        ginkgo -v -keepGoing --noColor multicluster/examples/helidon/...
+                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/examples/helidon/...
                                     """
                                 }
                             }
@@ -529,7 +531,7 @@ pipeline {
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                                         export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
                                         export DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon-ns-ops"
-                                        ginkgo -v -keepGoing --noColor multicluster/examples/helidon-ns-ops/...
+                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/examples/helidon-ns-ops/...
                                     """
                                 }
                             }
@@ -546,7 +548,7 @@ pipeline {
                                         export MANAGED_CLUSTER_NAME="managed${count-1}"
                                         export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                                         cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                                        ginkgo -v -keepGoing --noColor multicluster/verify-api/...
+                                        ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-api/...
                                     """
                                 }
                             }
@@ -556,6 +558,32 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
+                            }
+                        }
+                    }
+                }
+                stage ('CLI Tests') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            script {
+                                // Running the CLI tests for only one managed cluster for now
+                                int count = params.TOTAL_CLUSTERS.toInteger()
+                                sh """
+                                    export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+                                    export MANAGED_CLUSTER_DIR="${KUBECONFIG_DIR}/${count}"
+                                    export MANAGED_CLUSTER_NAME="managed${count-1}"
+                                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                                    cd ${GO_REPO_PATH}/verrazzano
+                                    make cli
+                                    ./tools/cli/scripts/cli_test.sh
+                                """
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            script {
+                                dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-cli-failed")
                             }
                         }
                     }
@@ -603,16 +631,19 @@ pipeline {
             post {
                 failure {
                     script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
                     script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                         }
@@ -623,7 +654,15 @@ pipeline {
     }
     post {
         failure {
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
+            """
             archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
+            sh """
+                curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
+                oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+                rm archive.zip
+            """
         }
         always {
             script {
@@ -638,10 +677,19 @@ pipeline {
                 }
                 dumpUninstallLogs()
             }
-            archiveArtifacts artifacts: '**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
+
             script {
-                int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+                if (params.EMIT_METRICS) {
+                    withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
+                        sh """
+                            ${GO_REPO_PATH}/verrazzano/ci/scripts/dashboard/emit_metrics.sh "${GO_REPO_PATH}/verrazzano/tests/e2e" "${SAURON_CREDENTIALS}" || echo "Emit metrics failed, continuing with other post actions"
+                        """
+                    }
+                }
+
+                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
                 if (env.TEST_ENV == "kind") {
                     for(int count=1; count<=clusterCount; count++) {
                         sh """
@@ -671,6 +719,7 @@ pipeline {
             }
         }
         cleanup {
+            metricBuildDuration()
             deleteDir()
         }
     }
@@ -720,10 +769,47 @@ def installKindCluster(count, metallbAddressRange, cleanupKindContainers, connec
         }
 }
 
+// Either download the specified release of the platform operator YAML, or create one
+// using the specific operator image provided by the user.
+def getVerrazzanoOperatorYaml() {
+    sh """
+        echo "Platform Operator Configuration"
+        cd ${GO_REPO_PATH}/verrazzano
+        if [ "NONE" = "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
+            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
+            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
+            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
+        else
+            echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
+            env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
+        fi
+    """
+}
+
+// Install Verrazzano on each of the clusters
+def installVerrazzano() {
+    script {
+        // Create a dictionary of Verrazzano install steps to be executed in parallel
+        // - the first one will always be the Admin cluster
+        // - clusters 2-max are managed clusters
+        def verrazzanoInstallStages = [:]
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            def installerPath="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+            def key = "vz-mgd-${count-1}"
+            if (count == 1) {
+                key = "vz-admin"
+            }
+            verrazzanoInstallStages["${key}"] = installVerrazzanoOnCluster(count, installerPath)
+        }
+        parallel verrazzanoInstallStages
+    }
+}
+
 // Install Verrazzano on a target cluster
 // - count is the cluster index into the $KUBECONFIG_DIR
 // - verrazzanoConfig is the Verrazzano CR to use to install VZ on the cluster
-def installVerrazzano(count, verrazzanoConfig) {
+def installVerrazzanoOnCluster(count, verrazzanoConfig) {
     // For parallel execution, wrap this in a Groovy enclosure {}
     return {
         script {
@@ -759,6 +845,65 @@ def installVerrazzano(count, verrazzanoConfig) {
 
                 # wait for Verrazzano install to complete
                 ./tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+            """
+        }
+    }
+}
+
+// Upgrade the verrazzano-platform-operator
+def upgradePlatformOperator() {
+    script {
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for (int count = 1; count <= clusterCount; count++) {
+            def upgradeOperatorFile="${KUBECONFIG_DIR}/${count}/upgrade-operator.yaml"
+            sh """
+                export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
+
+                echo "Upgrading the Verrazzano platform operator"
+                # Download the operator.yaml for the target version that we are upgrading to
+                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${upgradeOperatorFile}
+                kubectl apply -f ${upgradeOperatorFile}
+
+                # need to sleep since the old operator needs to transition to terminating state
+                sleep 15
+
+                # ensure operator pod is up
+                kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+            """
+        }
+    }
+}
+
+// Upgrade Verrazzano
+def upgradeVerrazzano() {
+    script {
+        // Download the bom for the target version that we are upgrading to, then extract the version
+        // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
+        VERRAZZANO_DEV_VERSION = sh(returnStdout: true, script: "curl https://objectstorage.us-phoenix-1.oraclecloud.com/n/stevengreenberginc/b/verrazzano-builds/o/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/generated-verrazzano-bom.json | jq -r '.version'").trim()
+
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for(int count=1; count<=clusterCount; count++) {
+            def v8oInstallFile="${KUBECONFIG_DIR}/${count}/${installerFileName}"
+            def v8oUpgradeFile="${KUBECONFIG_DIR}/${count}/verrazzano-upgrade-cr.yaml"
+            sh """
+                export KUBECONFIG=${KUBECONFIG_DIR}/${count}/kube_config
+
+                echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
+                # Modify the version field in the verrazzano CR file to be this new verrazzano version
+                cd ${GO_REPO_PATH}/verrazzano
+                cp ${v8oInstallFile} ${v8oUpgradeFile}
+                ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
+                # Do the upgrade
+                echo "Following is the verrazano CR file with the new version:"
+                cat ${v8oUpgradeFile}
+                kubectl apply -f ${v8oUpgradeFile}
+                # wait for the upgrade to complete
+                kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+
+                # ideally we don't need to wait here
+                sleep 15
+                echo "helm list : releases across all namespaces, after upgrading Verrazzano installation ..."
+                helm list -A
             """
         }
     }
@@ -813,6 +958,42 @@ def registerManagedClusters() {
     }
 }
 
+// Verify the register of the managed clusters
+def verifyRegisterManagedClusters() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                    export MANAGED_CLUSTER_NAME="managed${count-1}"
+                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-register/...
+                """
+            }
+        }
+    }
+}
+
+// Verify the managed cluster permissions
+def verifyManagedClusterPermissions() {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            for(int count=2; count<=clusterCount; count++) {
+                sh """
+                    export MANAGED_CLUSTER_NAME="managed${count-1}"
+                    export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    export MANAGED_ACCESS_KUBECONFIG="${KUBECONFIG_DIR}/${count}/managed_kube_config"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -v -stream -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true multicluster/verify-permissions/...
+                """
+            }
+        }
+    }
+}
+
+
 // Run a test suite against all clusters
 def runGinkgoRandomize(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -831,7 +1012,7 @@ def runGinkgoRandomize(testSuitePath) {
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor ${testSuitePath}/...
+                    ginkgo -p --randomizeAllSpecs -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true ${testSuitePath}/...
                 """
             }
         }
@@ -845,7 +1026,7 @@ def runGinkgo(testSuitePath, kubeConfig, clusterCount) {
             export KUBECONFIG="${kubeConfig}"
             export CLUSTER_COUNT="${clusterCount}"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v -keepGoing --noColor ${testSuitePath}/...
+            ginkgo -v -keepGoing --noColor -tags="${params.TAGGED_TESTS}" --focus="${params.INCLUDED_TESTS}" --skip="${params.EXCLUDED_TESTS}" --regexScansFilePath=true ${testSuitePath}/...
         """
     }
 }
@@ -857,7 +1038,7 @@ def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript
         String allArgs = ""
         extraArgs.each { allArgs += it + " " }
 
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
             def destinationPath = "${env.KUBECONFIG_DIR}/${count}/${installerFileName}"
             def installProfile = env.MANAGED_CLUSTER_PROFILE
@@ -895,16 +1076,13 @@ def createKindClusters() {
 
         // Can these for now, but eventually we should be able to build this based on
         // inspecting the Docker bridge network CIDR and splitting up a range based on
-        // the cluster count
+        // the cluster count.
 
-        // Create an extra cluster for CLI Tests
-        // This cluster will be deleted at the post action stage along with other clusters
-
-        def addressRanges = [ "172.18.0.231-172.18.0.238", "172.18.0.239-172.18.0.246", "172.18.0.247-172.18.0.254", "172.18.0.255-172.18.0.262" ]
+        def addressRanges = [ "172.18.0.231-172.18.0.238", "172.18.0.239-172.18.0.246", "172.18.0.247-172.18.0.254"]
         def clusterInstallStages = [:]
         boolean cleanupKindContainers = true
         boolean connectJenkinsRunnerToNetwork = true
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
             string metallbAddressRange = addressRanges.get(count-1)
             def deployStep = "cluster-${count}"
@@ -921,18 +1099,17 @@ def createKindClusters() {
 }
 
 // Invoke the OKE cluster creation script for the desired number of clusters
-// One extra cluster for CLI Test
 def createOKEClusters(clusterPrefix) {
     script {
         sh """
             echo "tests will execute" > ${TESTS_EXECUTED_FILE}
         """
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         sh """
             mkdir -p ${KUBECONFIG_DIR}
             echo "Create OKE cluster"
             cd ${TEST_SCRIPTS_DIR}
-            TF_VAR_label_prefix=${clusterPrefix} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}" ${CREATE_CLUSTER_USE_CALICO}
+            TF_VAR_label_prefix=${clusterPrefix} TF_VAR_state_name=multicluster-${env.BUILD_NUMBER}-${env.BRANCH_NAME} ./create_oke_multi_cluster.sh "$clusterCount" "${KUBECONFIG_DIR}" ${params.CREATE_CLUSTER_USE_CALICO}
         """
     }
 }
@@ -1076,18 +1253,23 @@ def dumpVerrazzanoApiLogs() {
     }
 }
 
-// Also dump install logs for cluster used in CLI tests
 def dumpInstallLogs() {
     script {
-        int clusterCount = params.TOTAL_CLUSTERS.toInteger() + 1
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
         for(int count=1; count<=clusterCount; count++) {
             LOG_DIR="${VERRAZZANO_INSTALL_LOGS_DIR}/cluster-$count"
+
+            // This function may run on older versions of Verrazzano that have the logs stored in the default namespace
+            def namespace = "verrazzano-install"
+            if (params.VERSION_FOR_INSTALL.startsWith("v1.0.0") || params.VERSION_FOR_INSTALL.startsWith("v1.0.1")) {
+                namespace = "default"
+            }
             sh """
                 ## dump verrazzano install logs
                 export KUBECONFIG=${KUBECONFIG_DIR}/$count/kube_config
                 mkdir -p ${LOG_DIR}
-                kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
-                kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
+                kubectl -n ${namespace} logs --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/${VERRAZZANO_INSTALL_LOG} --tail -1
+                kubectl -n ${namespace} describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${LOG_DIR}/verrazzano-install-job-pod.out
                 echo "------------------------------------------"
             """
         }
@@ -1118,4 +1300,77 @@ def getEffectiveDumpOnSuccess() {
         echo "Forcing dump on success based on global override setting"
     }
     return effectiveValue
+}
+
+def metricJobName(stageName) {
+    job = env.JOB_NAME.split("/")[0]
+    job = '_' + job.replaceAll('-','_')
+    if (stageName) {
+        job = job + '_' + stageName
+    }
+    return job
+}
+
+// Construct the set of labels/dimensions for the metrics
+def getMetricLabels() {
+    def kube_ver = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION }"
+    def buildNumber = String.format("%010d", env.BUILD_NUMBER.toInteger())
+    labels = 'build_number=\\"' + "${buildNumber}"+'\\",' +
+             'jenkins_build_number=\\"' + "${env.BUILD_NUMBER}"+'\\",' +
+             'jenkins_job=\\"' + "${env.JOB_NAME}".replace("%2F","/") + '\\",' +
+             'commit_sha=\\"' + "${env.GIT_COMMIT}"+'\\",' +
+             'kubernetes_version=\\"' + kube_ver + '\\",' +
+             'test_env=\\"' + "${params.TEST_ENV}" + '\\"'
+    return labels
+}
+
+// Construct the set of labels/dimensions for the metrics
+def metricTimerStart(metricName) {
+    def timerStartName = "${metricName}_START"
+    env."${timerStartName}" = sh(returnStdout: true, script: "date +%s").trim()
+}
+
+def metricTimerEnd(metricName, status) {
+    def timerStartName = "${metricName}_START"
+    def timerEndName   = "${metricName}_END"
+    env."${timerEndName}" = sh(returnStdout: true, script: "date +%s").trim()
+    if (params.EMIT_METRICS) {
+        long x = env."${timerStartName}" as long;
+        long y = env."${timerEndName}" as long;
+        def dur = (y-x)
+        labels = getMetricLabels()
+        withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
+            EMIT = sh(returnStdout: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${metricName} ${env.BRANCH_NAME} $labels ${status} ${dur}")
+            echo "emit prometheus metrics: $EMIT"
+            return EMIT
+        }
+    } else {
+        return ''
+    }
+}
+
+// Emit the metrics indicating the duration and result of the build
+def metricBuildDuration() {
+    def status = "${currentBuild.currentResult}".trim()
+    long duration = "${currentBuild.duration}" as long;
+    long durationInSec = (duration/1000)
+    testMetric = metricJobName('')
+    def metricValue = "-1"
+    statusLabel = status.substring(0,1)
+    if (status.equals("SUCCESS")) {
+        metricValue = "1"
+    } else if (status.equals("FAILURE")) {
+        metricValue = "0"
+    } else {
+        // Consider every other status as a single label
+        statusLabel = "A"
+    }
+    if (params.EMIT_METRICS) {
+        labels = getMetricLabels()
+        labels = labels + ',result=\\"' + "${statusLabel}"+'\\"'
+        withCredentials([usernameColonPassword(credentialsId: 'verrazzano-sauron', variable: 'SAURON_CREDENTIALS')]) {
+            METRIC_STATUS = sh(returnStdout: true, returnStatus: true, script: "ci/scripts/metric_emit.sh ${PROMETHEUS_GW_URL} ${SAURON_CREDENTIALS} ${testMetric}_job ${env.BRANCH_NAME} $labels ${metricValue} ${durationInSec}")
+            echo "Publishing the metrics for build duration and status returned status code $METRIC_STATUS"
+        }
+    }
 }

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 pipeline {
     options {
@@ -19,8 +19,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 def availableRegions = [  "us-ashburn-1", "ap-chuncheon-1", "ap-hyderabad-1", "ap-melbourne-1", "ap-osaka-1", "ap-seoul-1", "ap-sydney-1",
                           "ap-tokyo-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",
@@ -34,8 +34,8 @@ pipeline {
 
     agent {
         docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS} --cap-add=NET_ADMIN"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0} --cap-add=NET_ADMIN"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             label "${agentLabel}"
         }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -4,8 +4,8 @@
 def DOCKER_IMAGE_TAG
 // Pin to PHX for now for testing; tarball is located only in PHX at present, and takes 15+ mins to download to LHR at runtime
 // - at some point, we can either enable bucket replication or have the pipeline push it to more regions
-//def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
-def agentLabel = "phxlarge"
+//def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
+def agentLabel = "phxlarge_1_0"
 def ocirRegion = "phx"
 def ocirRegistry = "${ocirRegion}.ocir.io"
 def imageRepoSubPath=""
@@ -18,8 +18,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -3,7 +3,7 @@
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 pipeline {
     options {
@@ -12,8 +12,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
         }

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8_1_0"
 
 pipeline {
     options {
@@ -11,8 +11,8 @@ pipeline {
 
     agent {
         docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_0}"
+            args "${RUNNER_DOCKER_ARGS_1_0}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"


### PR DESCRIPTION
# Description

No JIRA.

Recent changes for golang version, and k8s version support in master require that we start implementing the tool branching strategy for the release-1.0 branch.

This pins the tooling in release-1.0 to images which support the CI for that release.

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
