### PR TITLE
vz-3693 remove CLI tests stage

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -555,33 +555,6 @@ pipeline {
                         }
                     }
                 }
-                stage ('CLI Tests') {
-                    steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            script {
-                                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                                for(int count=2; count<=clusterCount; count++) {
-                                    sh """
-                                        export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
-                                        export MANAGED_CLUSTER_DIR="${KUBECONFIG_DIR}/${count}"
-                                        export MANAGED_CLUSTER_NAME="managed${count-1}"
-                                        export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                                        cd ${GO_REPO_PATH}/verrazzano
-                                        make cli
-                                        ./tools/cli/scripts/cli_test.sh
-                                    """
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        failure {
-                            script {
-                                dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-cli-tests")
-                            }
-                        }
-                    }
-                }
                 stage ('verify deregister') {
                     steps {
                         verifyDeregisterManagedClusters()


### PR DESCRIPTION
# Description

Remove the CLI tests stage.  Errors from this stage are causing master builds to fail.  The decision was to remove them for now because the CLI is not yet part of the product.  

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
