### PR TITLE
Add more debugging for the test that fails on 1.21

### DIFF
--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -329,9 +329,11 @@ var _ = Describe("Test Verrazzano API Service Account", func() {
 		})
 
 		It("Validate the secret of the Service Account of Verrazzano API", func() {
+			GinkgoWriter.Write([]byte("DEBUG - This test fails on 1.21 - extra debugging added\n"))
 			// Get secret for the SA
 			var pods *corev1.PodList
 			saSecret := serviceAccount.Secrets[0]
+			GinkgoWriter.Write([]byte("SA SECRET: " + saSecret.String() + "\n"))
 			var clientset *kubernetes.Clientset
 			Eventually(func() (*kubernetes.Clientset, error) {
 				var err error
@@ -347,9 +349,15 @@ var _ = Describe("Test Verrazzano API Service Account", func() {
 			secretMatched := false
 			for i := range pods.Items {
 				// Get the secret of the API proxy pod
+				GinkgoWriter.Write([]byte("IN RANGE i=" + fmt.Sprint(i) + " POD=" + pods.Items[i].Name + "\n"))
 				if strings.HasPrefix(pods.Items[i].Name, verrazzanoAPI) {
 					apiProxy := pods.Items[i]
 					for j := range apiProxy.Spec.Volumes {
+						if apiProxy.Spec.Volumes[j].Secret != nil {
+							GinkgoWriter.Write([]byte("IN RANGE j=" + fmt.Sprint(j) + " VOLUME= " + apiProxy.Spec.Volumes[j].Name + " SECRET=" + apiProxy.Spec.Volumes[j].Secret.SecretName + "\n"))
+						} else {
+							GinkgoWriter.Write([]byte("IN RANGE j=" + fmt.Sprint(j) + " VOLUME= " + apiProxy.Spec.Volumes[j].Name + " SECRET=NIL\n"))
+						}
 						if apiProxy.Spec.Volumes[j].Secret != nil && apiProxy.Spec.Volumes[j].Secret.SecretName == saSecret.Name {
 							secretMatched = true
 							break


### PR DESCRIPTION
Signed-off-by: Mark Nelson <mark.x.nelson@oracle.com>

# Description

This PR adds some extra debugging to a test that passes on 1.19 and 1.20 but fails on 1.21, so we can try to get more info to help figure out the issue. 

Contributes to VZ-3701

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
