### PR TITLE
No JIRA.  Use the fn pointer reference for GetComponents for the unit…

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -42,7 +42,7 @@ func ResetGetComponentsFn() {
 // GetComponents returns the list of components that are installable and upgradeable.
 // The components will be processed in the order items in the array
 func GetComponents() []spi.Component {
-	return getComponents()
+	return getComponentsFn()
 }
 
 // getComponents is the internal impl function for GetComponents, to allow overriding it for testing purposes


### PR DESCRIPTION

# Description

Fix registry.go to use the fn pointer variable for GetComponents so the unit-test overrides work.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
