### PR TITLE
Add logout endpoint in auth proxy

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -18,11 +18,11 @@ data:
     end
     local ingressUri = 'https://'..ingressHost
     local callbackPath = "{{ .OidcCallbackPath }}"
-    local logoutCallbackPath = "{{ .OidcLogoutCallbackPath }}"
+    local logoutPath = "/_logout"
 
     local auth = require("auth").config({
         callbackUri = ingressUri..callbackPath,
-        logoutCallbackUri = ingressUri..logoutCallbackPath
+        consoleUrl = ingressUri
     })
 
     -- TODO: is this needed here? Is it better done via/at ingress?
@@ -43,6 +43,10 @@ data:
     local backendUrl = auth.getBackendServerUrlFromName(backend)
 
     auth.info("Processing request for backend '"..ingressHost.."'")
+    if auth.requestUriMatches(ngx.var.request_uri, logoutPath) then
+       -- logout was triggered
+       auth.logout()
+    end
 
     local authHeader = ngx.req.get_headers()["authorization"]
     local token = nil
@@ -61,9 +65,6 @@ data:
             -- we initiated authentication via pkce, and OP is delivering the code
             -- will redirect to target url, where token will be found in cookie
             auth.oidcHandleCallback()
-        elseif auth.requestUriMatches(ngx.var.request_uri, logoutCallbackPath) then
-            -- logout was triggered, and OP (always?) is calling our logout URL
-            auth.oidcHandleLogoutCallback()
         end
         -- no token yet, and the request is not progressing an OIDC flow.
         -- check if caller has an existing session with a valid token.
@@ -210,8 +211,7 @@ data:
     end
 
     function me.unauthorized(msg, err)
-        me.deleteCookie("vz_authn")
-        me.deleteCookie("vz_userinfo")
+        me.deleteCookies("vz_authn", "vz_userinfo")
         me.logJson(ngx.ERR, msg, err)
         ngx.status = ngx.HTTP_UNAUTHORIZED
         ngx.say("401 Unauthorized")
@@ -234,10 +234,22 @@ data:
 
     function me.logout()
         local redirectArgs = ngx.encode_args({
-            redirect_uri = me.logoutCallbackUri
+            redirect_uri = me.consoleUrl
         })
-        local redirectURL = me.oidcProviderUri.."/protocol/openid-connect/logout?"..redirectArgs
-        ngx.redirect(redirectURL)
+        local ck = me.readCookie("vz_authn")
+        if ck then
+            local rft = ck.rt
+            ngx.req.set_header("Content-Type","application/x-www-form-urlencoded")
+            ngx.req.set_method(ngx.HTTP_POST)
+            local redirectURL = me.getOidcProviderUri().."/protocol/openid-connect/logout?"..redirectArgs
+            local postArgs = ngx.encode_args({refresh_token = ck.rt,
+            redirect_uri = redirectURL,
+            client_id = oidcClient})
+            ngx.req.read_body()
+            ngx.req.set_body_data(postArgs)
+            me.deleteCookies("vz_authn", "vz_userinfo")
+            ngx.redirect(redirectURL)
+        end
     end
 
     function me.randomBase64(size)
@@ -476,7 +488,7 @@ data:
         if not cookie then
             me.unauthorized("Missing state cookie")
         end
-        me.deleteCookie("vz_state")
+        me.deleteCookies("vz_state")
         local stateCk = cookie.state
         -- local nonceCk = cookie.nonce
         local request_uri = cookie.request_uri
@@ -498,10 +510,6 @@ data:
             end
             me.unauthorized("Failed to obtain token with code")
         end
-    end
-
-    function me.oidcHandleLogoutCallback()
-        me.unauthorized("User logged out")
     end
 
     function me.oidcTokenRequest(formArgs)
@@ -671,8 +679,7 @@ data:
             end
         end
         -- no valid token found, delete cookie
-        me.deleteCookie("vz_authn")
-        me.deleteCookie("vz_userinfo")
+        me.deleteCookies("vz_authn", "vz_userinfo")
         return nil
     end
 
@@ -738,8 +745,13 @@ data:
         cookie:set({key=ckName, value=ckValue, path="/", secure=true, httponly=httponly, expires=expires})
     end
 
-    function me.deleteCookie(ckName)
-        ngx.header["Set-Cookie"] = ckName..'=; Path=/; Secure; HttpOnly; Expires=Thu, 01 Jan 1970 00:00:00 UTC;'
+     function me.deleteCookies(...)
+        local cookies = {}
+        local arg = {...}
+        for i,v in ipairs(arg) do
+            cookies[i] = tostring(v)..'=; Path=/; Secure; HttpOnly; Expires=Thu, 01 Jan 1970 00:00:00 UTC;'
+        end
+        ngx.header["Set-Cookie"] = cookies
     end
 
     function me.readCookie(ckName)

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -18,7 +18,7 @@ data:
     end
     local ingressUri = 'https://'..ingressHost
     local callbackPath = "{{ .OidcCallbackPath }}"
-    local logoutPath = "/_logout"
+    local logoutPath = "{{ .OidcLogoutCallbackPath }}"
 
     local auth = require("auth").config({
         callbackUri = ingressUri..callbackPath,

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -161,5 +161,11 @@ var _ = Describe("Verrazzano Web UI", func() {
 				Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
 			}
 		})
+
+		It("can be logged out", func() {
+			Eventually(func() (*pkg.HTTPResponse, error) {
+				return pkg.GetWebPage(fmt.Sprintf("%s/%s",serverURL,"_logout"), "")
+			}, waitTimeout, pollingInterval).Should(And(pkg.HasStatus(http.StatusFound)))
+		})
 	})
 })


### PR DESCRIPTION
# Description

Adds an __logout_  endpoint in auth proxy that will perform session logout from keycloak

Fixes VZ-3591

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
