### PR TITLE
Fix controller-gen for verrazzano-application-operator

### DIFF
--- a/application-operator/apis/weblogic/v8/monitoring_exporter_spec.go
+++ b/application-operator/apis/weblogic/v8/monitoring_exporter_spec.go
@@ -3,13 +3,15 @@
 
 package v8
 
+import "encoding/json"
+
 // MonitoringExporterSpec defines the desired state of monitoring exporter sidecar
 // +k8s:openapi-gen=true
 type MonitoringExporterSpec struct {
 	// The configuration for the WebLogic Monitoring Exporter. If WebLogic Server instances are already running and have
 	// the monitoring exporter sidecar container, then changes to this field will be propagated to the exporter without
 	// requiring the restart of the WebLogic Server instances.
-	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	Configuration json.RawMessage `json:"configuration,omitempty"`
 
 	// The WebLogic Monitoring Exporter sidecar container image name.
 	Image string `json:"image,omitempty"`

--- a/application-operator/apis/weblogic/v8/zz_generated.deepcopy.go
+++ b/application-operator/apis/weblogic/v8/zz_generated.deepcopy.go
@@ -8,6 +8,7 @@
 package v8
 
 import (
+	"encoding/json"
 	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -408,10 +409,8 @@ func (in *MonitoringExporterSpec) DeepCopyInto(out *MonitoringExporterSpec) {
 	*out = *in
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration
-		*out = make(map[string]interface{}, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
 	}
 }
 


### PR DESCRIPTION
# Description

In https://github.com/verrazzano/verrazzano/pull/1632, a change was done to change type of `configuration` element in `MonitoringExporterSpec` from `map[string]string` to `map[string]interface{}` but this broke the `controller-gen` and it failed with following

```bash
github.com/verrazzano/verrazzano/application-operator/apis/weblogic/v8:-: name requested for invalid type: interface{}
github.com/verrazzano/verrazzano/application-operator/apis/weblogic/v8:-: invalid map value type: interface{}
Error: not all generators ran successfully
```
because the type `interface{}` is not supported. This PR to change the type to `map[string]json.RawMessage` which produces the same effect and is supported. Have been tested for any regression.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
