### PR TITLE
VZ-3570 Delete OAM Components when an application is deleted

### DIFF
--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -5,10 +5,12 @@ package mcagent
 
 import (
 	"fmt"
+	"strings"
 
 	oamv1alpha2 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,7 +62,12 @@ func (s *Syncer) syncMCApplicationConfigurationObjects(namespace string) error {
 		if !s.appConfigPlacedOnCluster(&allAdminMCAppConfigs, mcAppConfig.Name, mcAppConfig.Namespace) {
 			err := s.LocalClient.Delete(s.Context, &allLocalMCAppConfigs.Items[i])
 			if err != nil {
-				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterApplicationConfiguration with name %q and namespace %q", mcAppConfig.Name, mcAppConfig.Namespace))
+				s.Log.Error(err, fmt.Sprintf("failed to delete MultiClusterApplicationConfiguration with name %q in namespace %q", mcAppConfig.Name, mcAppConfig.Namespace))
+			}
+			// Delete the OAM components listed in application
+			err = s.deleteComponentList(mcAppConfig)
+			if err != nil {
+				s.Log.Error(err, fmt.Sprintf("error deleting the OAM Components listed in the MultiClusterApplicationConfiguration with name %q in namespace %q", mcAppConfig.Name, mcAppConfig.Namespace))
 			}
 		}
 	}
@@ -110,6 +117,8 @@ func (s *Syncer) updateMultiClusterAppConfigStatus(name types.NamespacedName, ne
 
 // syncComponentList - Synchronize the list of OAM Components contained in the MultiClusterApplicationConfiguration
 func (s *Syncer) syncComponentList(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfiguration) error {
+	var errorStrings []string
+
 	// Loop through the component list and get them one at a time.
 	for _, component := range mcAppConfig.Spec.Template.Spec.Components {
 		objectKey := types.NamespacedName{Name: component.ComponentName, Namespace: mcAppConfig.Namespace}
@@ -118,28 +127,93 @@ func (s *Syncer) syncComponentList(mcAppConfig clustersv1alpha1.MultiClusterAppl
 		if err != nil {
 			return err
 		}
-		_, err = s.createOrUpdateComponent(*oamComp)
+		_, err = s.createOrUpdateComponent(*oamComp, mcAppConfig.Name)
 		if err != nil {
-			return err
+			errorStrings = append(errorStrings, err.Error())
 		}
+	}
+
+	// Check if any errors were collected while processing the list
+	if len(errorStrings) > 0 {
+		return fmt.Errorf(strings.Join(errorStrings, "\n"))
 	}
 	return nil
 }
 
-func (s *Syncer) createOrUpdateComponent(srcComp oamv1alpha2.Component) (controllerutil.OperationResult, error) {
+// deleteComponentList - Delete the list of OAM Components contained in the MultiClusterApplicationConfiguration
+//                       that is being deleted.
+func (s *Syncer) deleteComponentList(mcAppConfig clustersv1alpha1.MultiClusterApplicationConfiguration) error {
+	var errorStrings []string
+
+	// Get list of OAM Applications from the local client
+	listOptions := &client.ListOptions{Namespace: mcAppConfig.Namespace}
+	appList := clustersv1alpha1.MultiClusterApplicationConfigurationList{}
+	err := s.LocalClient.List(s.Context, &appList, listOptions)
+	if err != nil {
+		return err
+	}
+
+	// Loop through the component list and get them one at a time.
+	for _, component := range mcAppConfig.Spec.Template.Spec.Components {
+		// Get the OAM component
+		oamComp := oamv1alpha2.Component{}
+		err := s.LocalClient.Get(s.Context, types.NamespacedName{Name: component.ComponentName, Namespace: mcAppConfig.Namespace}, &oamComp)
+		if err != nil {
+			errorStrings = append(errorStrings, err.Error())
+			continue
+		}
+
+		// Remove this MultiClusterApplicationConfiguration from the label list
+		newLabels := vzstring.RemoveFromCommaSeparatedString(oamComp.Labels[mcAppConfigsLabel], mcAppConfig.Name)
+		if newLabels == "" {
+			// Ok to delete this component because it is not shared by another MultiClusterApplicationConfiguration
+			err := s.LocalClient.Delete(s.Context, &oamComp)
+			if err != nil {
+				errorStrings = append(errorStrings, err.Error())
+			}
+		} else {
+			// Update the OAM Component labels to remove the name of the MultiClusterApplicationConfiguration that is deleted
+			oamComp.Labels[mcAppConfigsLabel] = newLabels
+			err := s.LocalClient.Update(s.Context, &oamComp)
+			if err != nil {
+				errorStrings = append(errorStrings, err.Error())
+			}
+		}
+	}
+
+	// Check if any errors were collected while processing the list
+	if len(errorStrings) > 0 {
+		return fmt.Errorf(strings.Join(errorStrings, "\n"))
+	}
+	return nil
+}
+
+// createOrUpdateComponent - create or update an OAM Component
+func (s *Syncer) createOrUpdateComponent(srcComp oamv1alpha2.Component, mcAppConfigName string) (controllerutil.OperationResult, error) {
 	var oamComp oamv1alpha2.Component
 	oamComp.Namespace = srcComp.Namespace
 	oamComp.Name = srcComp.Name
 
 	return controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &oamComp, func() error {
-		s.mutateComponent(srcComp, &oamComp)
+		s.mutateComponent(s.ManagedClusterName, mcAppConfigName, srcComp, &oamComp)
 		return nil
 	})
 }
 
 // mutateComponent mutates the OAM component to reflect the contents of the parent MultiClusterComponent
-func (s *Syncer) mutateComponent(srcComp oamv1alpha2.Component, localComp *oamv1alpha2.Component) {
-	localComp.Spec = srcComp.Spec
-	localComp.Labels = srcComp.Labels
-	localComp.Annotations = srcComp.Annotations
+func (s *Syncer) mutateComponent(managedClusterName string, mcAppConfigName string, component oamv1alpha2.Component, componentNew *oamv1alpha2.Component) {
+	// Initialize the labels field
+	if componentNew.Labels == nil {
+		componentNew.Labels = make(map[string]string)
+		if component.Labels != nil {
+			componentNew.Labels = component.Labels
+		}
+	}
+
+	// Add the name of this MultiClusterApplicationConfiguration to the label list
+	componentNew.Labels[mcAppConfigsLabel] = vzstring.AppendToCommaSeparatedString(componentNew.Labels[mcAppConfigsLabel], mcAppConfigName)
+
+	componentNew.Labels[managedClusterLabel] = managedClusterName
+	componentNew.Spec = component.Spec
+	componentNew.Annotations = component.Annotations
 }

--- a/application-operator/mcagent/mcagent_appconfig.go
+++ b/application-operator/mcagent/mcagent_appconfig.go
@@ -260,7 +260,7 @@ func (s *Syncer) deleteOrphanedComponents() error {
 	}
 
 	// Process the list of OAM Components checking to see if they are part of any MultiClusterApplicationConfiguration
-	for _, oamComp := range oamCompList.Items {
+	for i, oamComp := range oamCompList.Items {
 		found := false
 		// Loop through the MultiClusterApplicationConfiguration objects checking for a reference
 		for _, mcAppConfig := range mcAppConfigList.Items {
@@ -279,7 +279,7 @@ func (s *Syncer) deleteOrphanedComponents() error {
 		if !found {
 			// Delete the orphaned OAM Component
 			s.Log.Info(fmt.Sprintf("Deleting orphaned OAM Component %s in namespace %s", oamComp.Name, oamComp.Namespace))
-			err = s.LocalClient.Delete(s.Context, &oamComp)
+			err = s.LocalClient.Delete(s.Context, &oamCompList.Items[i])
 			if err != nil {
 				return err
 			}

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -126,11 +126,13 @@ func TestUpdateMCAppConfig(t *testing.T) {
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testComponent1.Name, Namespace: testComponent1.Namespace}, component1)
 	assert.NoError(err)
 	assert.Equal(s.ManagedClusterName, component1.Labels[managedClusterLabel])
+	assert.Equal(testMCAppConfig.Name, component1.Labels[mcAppConfigsLabel])
 
 	component2 := &oamv1alpha2.Component{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testComponent2.Name, Namespace: testComponent2.Namespace}, component2)
 	assert.NoError(err)
 	assert.Equal(s.ManagedClusterName, component2.Labels[managedClusterLabel])
+	assert.Equal(testMCAppConfig.Name, component2.Labels[mcAppConfigsLabel])
 }
 
 // TestDeleteMCAppConfig tests the synchronization method for the following use case.

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -171,9 +171,10 @@ func VerifyAppDeleted(kubeconfigPath string, namespace string) bool {
 
 func verifyMCResourcesDeleted(kubeconfigPath string, namespace string, projectName string) bool {
 	appConfExists := mcAppConfExists(kubeconfigPath, namespace)
-	compExists := mcComponentExists(kubeconfigPath, namespace)
+	mcCompExists := mcComponentExists(kubeconfigPath, namespace)
 	projExists := projectExists(kubeconfigPath, projectName)
-	return !appConfExists && !compExists && !projExists
+	compExists := componentExists(kubeconfigPath, namespace)
+	return !appConfExists && !compExists && !projExists && !mcCompExists
 }
 
 // HelidonNamespaceExists - returns true if the hello-helidon namespace exists in the given cluster
@@ -205,6 +206,15 @@ func mcComponentExists(kubeconfigPath string, namespace string) bool {
 		Group:    clustersv1alpha1.SchemeGroupVersion.Group,
 		Version:  clustersv1alpha1.SchemeGroupVersion.Version,
 		Resource: "multiclustercomponents",
+	}
+	return resourceExists(gvr, namespace, componentName, kubeconfigPath)
+}
+
+func componentExists(kubeconfigPath string, namespace string) bool {
+	gvr := schema.GroupVersionResource{
+		Group:    oamv1alpha1.SchemeGroupVersion.Group,
+		Version:  oamv1alpha1.SchemeGroupVersion.Version,
+		Resource: "components",
 	}
 	return resourceExists(gvr, namespace, componentName, kubeconfigPath)
 }


### PR DESCRIPTION
# Description

When an MultiClusterApplicationConfiguration is deleted from a managed cluster, also delete the OAM components that were synced for the application.  Since OAM components can be shared between applications, ensure the delete only occurs when no application is still sharing it.

Fixes VZ-3570

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
