### PR TITLE
VZ-3726 VZ-3725 update to OCIR scan cleared ingress nginx images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -27,13 +27,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20210510134749-abc2d2088",
+              "tag": "0.46.0-20211005200943-bd017fde2",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "0.46.0-20210510134749-abc2d2088",
+              "tag": "0.46.0-20211005200943-bd017fde2",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }


### PR DESCRIPTION
# Description

This PR updates both the controller and default-backend images of ingress nginx to images that have no OCIR scan identified HIGH/CRITICAL vulnerabilities.

![Container_Registry___Oracle_Cloud_Infrastructure](https://user-images.githubusercontent.com/67696706/136251912-a1092322-10e9-442f-a09c-ac588a93a2e6.png)

![Container_Registry___Oracle_Cloud_Infrastructure](https://user-images.githubusercontent.com/67696706/136252006-736874e5-d8f0-497e-9357-a10a5f70a39f.png)

Fixes VZ-3725, VZ-3726

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
