### PR TITLE
VZ-3730 proxyv2 image tag update 1.7.3-2

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -124,7 +124,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.7.3",
+              "tag": "1.7.3-2",
               "helmImageKey": "global.proxy.image",
               "helmTagKey": "global.tag"
             }
@@ -136,7 +136,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.7.3",
+              "tag": "1.7.3-2",
               "helmImageKey": "global.proxy.image",
               "helmTagKey": "global.tag"
             }
@@ -148,7 +148,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.7.3",
+              "tag": "1.7.3-2",
               "helmImageKey": "global.proxy.image",
               "helmTagKey": "global.tag"
             }
@@ -238,7 +238,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.7.3",
+              "tag": "1.7.3-2",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {


### PR DESCRIPTION
# Description

A new image update for proxyv2 provided by OLCNE updates. This is an updated version of the original 1.7.3 image tagged 1.7.3-2

Fixes VZ-3730

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
