### PR TITLE
VZ-3968.  Use service externalIP field when using external LB

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -763,11 +763,13 @@ func buildDomainNameForWildcard(cli client.Reader, trait *vzapi.IngressTrait, su
 	}
 	var IP string
 	if istio.Spec.Type == corev1.ServiceTypeLoadBalancer {
-		istioIngress := istio.Status.LoadBalancer.Ingress
-		if len(istioIngress) == 0 {
+		if len(istio.Status.LoadBalancer.Ingress) > 0 {
+			IP = istio.Status.LoadBalancer.Ingress[0].IP
+		} else if len(istio.Spec.ExternalIPs) > 0 {
+			IP = istio.Spec.ExternalIPs[0]
+		} else {
 			return "", fmt.Errorf("%s is missing loadbalancer IP", istioIngressGateway)
 		}
-		IP = istioIngress[0].IP
 	} else if istio.Spec.Type == corev1.ServiceTypeNodePort {
 		// Do the equiv of the following command to get the IP
 		// kubectl -n istio-system get pods --selector app=istio-ingressgateway,istio=ingressgateway -o jsonpath='{.items[0].status.hostIP}'


### PR DESCRIPTION
# Description

Fixes case where external LB is used with Wildcard DNS
- Use LB service externalIP value if not auto-assigned by Kubernetes.

Fixes VZ-3968.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
