### PR TITLE
VZ-3938: Jenkins support for processing scan results

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -1,0 +1,70 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+pipeline {
+    options {
+        timestamps ()
+    }
+
+    agent {
+       docker {
+            image "${RUNNER_DOCKER_IMAGE}"
+            args "${RUNNER_DOCKER_ARGS}"
+            label "VM.Standard2.8"
+            registryCredentialsId 'ocir-pull-and-push-account'
+        }
+    }
+
+    environment {
+        OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
+        OCI_CLI_USER = credentials('oci-dev-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-dev-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-dev-api-key-file')
+        OCI_CLI_REGION = "us-ashburn-1"
+        OCI_REGION = "${env.OCI_CLI_REGION}"
+
+        OCIR_COMPARTMENT_ID = "ocid1.compartment.oc1..aaaaaaaab5ygayr7tg3xw24pu24zz5bg6laejdkz7hyutrbltkfnfsy644qa"
+        OCIR_SCAN_REGISTRY = credentials('ocir-scan-registry')
+        OCIR_REPOSITORY_BASE = credentials('ocir-scan-repository-path')
+        OCIR_PATH_FILTER = ".*"
+        DOCKER_SCAN_CREDS = credentials('v8odev-ocir')
+
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_BUCKET = "verrazzano-builds"
+
+        GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-process')
+    }
+
+    stages {
+        stage('Fetch Scan Results') {
+            steps {
+                script {
+                    try {
+                        sh """
+                            echo "${DOCKER_SCAN_CREDS_PSW}" | docker login ${env.OCIR_SCAN_REGISTRY} -u ${DOCKER_SCAN_CREDS_USR} --password-stdin
+                        """
+                    } catch(error) {
+                        echo "docker login failed, retrying after sleep"
+                        retry(4) {
+                            sleep(30)
+                            sh """
+                            echo "${DOCKER_SCAN_CREDS_PSW}" | docker login ${env.OCIR_SCAN_REGISTRY} -u ${DOCKER_SCAN_CREDS_USR} --password-stdin
+                            """
+                        }
+                    }
+
+                    sh """
+                        echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
+                        echo "Fetching scan results for branch: ${env.BRANCH_NAME}"
+                        ci/scripts/get_branch_scan_results.sh
+                    """
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'boms/**,scan-results/**', allowEmptyArchive: true
+                }
+            }
+        }
+    }
+}

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         OCI_CLI_REGION = "us-ashburn-1"
         OCI_REGION = "${env.OCI_CLI_REGION}"
 
-        OCIR_COMPARTMENT_ID = "ocid1.compartment.oc1..aaaaaaaab5ygayr7tg3xw24pu24zz5bg6laejdkz7hyutrbltkfnfsy644qa"
+        OCIR_COMPARTMENT_ID = credentials('ocir-scan-compartment')
         OCIR_SCAN_REGISTRY = credentials('ocir-scan-registry')
         OCIR_REPOSITORY_BASE = credentials('ocir-scan-repository-path')
         OCIR_PATH_FILTER = ".*"

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# NOTE: This script assumes that:
+#
+#   1) "docker login" has been done for the image registry
+#   2) OCI credentials have been configured to allow the OCI CLI to fetch scan results from OCIR
+#   3) "gh auth login" has been done to allow the github CLI to list releases and fetch release artifacts
+#
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+RELEASE_SCRIPT_DIR=${SCRIPT_DIR}/../../release/scripts
+
+if [ -z "$JENKINS_URL" ] || [ -z "$WORKSPACE" ] || [ -z "$OCI_OS_NAMESPACE" ] || [ -z "$OCI_OS_BUCKET" ] || [ -z "$BRANCH_NAME" ]; then
+  echo "This script must only be called from Jenkins and requires a number of environment variables are set"
+  exit 1
+fi
+
+# Hack to get the generated BOM from a release by pulling down the operator.yaml from the release artifacts
+# and copying the BOM from the platform operator image
+function get_bom_from_release() {
+    local releaseTag=$1
+    local outputFile=$2
+    local tmpDir=$(mktemp -d)
+
+    # Download the operator.yaml for the release and get the platform-operator image and tag
+    gh release download ${releaseTag} -p 'operator.yaml' -D ${tmpDir}
+    local image=$(grep "verrazzano-platform-operator:" ${tmpDir}/operator.yaml | grep "image:" -m 1 | xargs | cut -d' ' -f 2)
+
+    # Create a container from the image and copy the BOM from the container
+    local containerId=$(docker create ${image})
+    docker cp ${containerId}:/verrazzano/platform-operator/verrazzano-bom.json ${outputFile}
+
+    rm -fr ${tmpDir}
+}
+
+BOM_DIR=${WORKSPACE}/boms
+mkdir -p ${BOM_DIR}
+SCAN_RESULTS_BASE_DIR=${WORKSPACE}/scan-results
+export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/latest
+mkdir -p ${SCAN_RESULTS_DIR}
+
+# Get the last pushed BOM for the tip of the branch
+BRANCH_NAME=release-1.0
+echo "Attempting to fetch BOM from object storage for branch: ${BRANCH_NAME}"
+export SCAN_BOM_FILE=${BOM_DIR}/last-ocir-pushed-verrazzano-bom.json
+
+oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/last-ocir-pushed-verrazzano-bom.json --file ${SCAN_BOM_FILE}
+if [ $? -eq 0 ]; then
+  echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
+  ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh
+fi
+
+if [[ "${BRANCH_NAME}" == release-* ]]; then
+  # Get the list of matching releases, for example, on branch "release-1.0" the matching releases are "v1.0.0", "v1.0.1", ...
+  echo "Attempting to fetch BOMs for released versions on branch: ${BRANCH_NAME}"
+
+  MAJOR_MINOR_VERSION=${BRANCH_NAME:8}
+  VERSIONS=$(gh release list | cut -f 3 | grep v${MAJOR_MINOR_VERSION})
+
+  # For now get the results for all versions, at some point we should ignore versions that we no longer support
+  for VERSION in ${VERSIONS}
+  do
+    echo "Fetching BOM for ${VERSION}"
+    export SCAN_BOM_FILE=${BOM_DIR}/${VERSION}-bom.json
+    get_bom_from_release ${VERSION} ${SCAN_BOM_FILE}
+
+    export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/${VERSION}
+    mkdir -p ${SCAN_RESULTS_DIR}
+
+    echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
+    ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh
+  done
+fi

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -32,6 +32,7 @@ function get_bom_from_release() {
     # Create a container from the image and copy the BOM from the container
     local containerId=$(docker create ${image})
     docker cp ${containerId}:/verrazzano/platform-operator/verrazzano-bom.json ${outputFile}
+    docker rm ${containerId}
 
     rm -fr ${tmpDir}
 }

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -43,7 +43,6 @@ export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/latest
 mkdir -p ${SCAN_RESULTS_DIR}
 
 # Get the last pushed BOM for the tip of the branch
-BRANCH_NAME=release-1.0
 echo "Attempting to fetch BOM from object storage for branch: ${BRANCH_NAME}"
 export SCAN_BOM_FILE=${BOM_DIR}/last-ocir-pushed-verrazzano-bom.json
 


### PR DESCRIPTION
# Description

Jenkinsfile and shell script that process scan results per branch. The pipeline is set up to run on master and release-* branches. For release-* branches, we fetch the scan results for all images for all releases associated with the branch, as well as the tip of the branch.

Implements VZ-3938

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
