### PR TITLE
VZ-3909: [release-1.0] use same version of the nginx-ingress-controller images (#1879)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -273,7 +273,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20210510134749-abc2d2088",
+              "tag": "0.46.0-20211005200943-bd017fde2",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             },
             {
@@ -289,7 +289,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20210510134749-abc2d2088",
+              "tag": "0.46.0-20211005200943-bd017fde2",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             }


### PR DESCRIPTION
This pull request backports changes to use the same version of the nginx-ingress-controller image in the Verrazzano BOM. This change was a straight cherry-pick from master.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
