### PR TITLE
VZ-3889: backport to release-1.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
         booleanParam (description: 'Whether to generate a tarball', name: 'GENERATE_TARBALL', defaultValue: false)
         booleanParam (description: 'Whether to push images to OCIR', name: 'PUSH_TO_OCIR', defaultValue: false)
         booleanParam (description: 'Whether to fail the Integration Tests to test failure handling', name: 'SIMULATE_FAILURE', defaultValue: false)
+        booleanParam (description: 'Whether to wait for triggered tests or not. This defaults to false, this setting is useful for things like release automation that require everything to complete successfully', name: 'WAIT_FOR_TRIGGERED', defaultValue: false)
         choice (name: 'WILDCARD_DNS_DOMAIN',
                 description: 'Wildcard DNS Domain',
                 // 1st choice is the default value

--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -180,12 +180,13 @@ pipeline {
 
                         retry(count: env.BUILD_RETRIES) {
                             script {
-                                echo "Triggering Verrazzano build for release"
+                                echo "Triggering Verrazzano build for release, this will wait for triggered tests to finish"
                                 releaseBuild = build job: "${RELEASE_JOB_NAME}",
                                     parameters: [
                                         booleanParam(name: 'RUN_ACCEPTANCE_TESTS', value: true),
                                         booleanParam(name: 'RUN_SLOW_TESTS', value: true),
                                         booleanParam(name: 'TRIGGER_FULL_TESTS', value: true),
+                                        booleanParam(name: 'WAIT_FOR_TRIGGERED', value: true),
                                         booleanParam(name: 'GENERATE_TARBALL', value: true),
                                         booleanParam(name: 'GENERATE_TOOL', value: true),
                                         booleanParam(name: 'PUSH_TO_OCIR', value: true)


### PR DESCRIPTION
# Description

Backport the new parameter to the release-1.0 line, this really is just for aligning the parameters in that pipeline so the parameter exists there (and so the release automation pipeline can be more consistent between master/release-1.0). The release-1.0 line currently only will wait for completion, so the new parameter will be ignored when specified. If the other disconnected behaviour gets backported for some reason this will work as it does in master (and when we cut new release branches).

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
