### PR TITLE
VZ- 3977: changes for supporting new security model of secrets in multicluster

### DIFF
--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -228,7 +228,10 @@ func (r *Reconciler) createOrUpdateRoleBindings(ctx context.Context, namespace s
 
 	// create role binding for each managed cluster to limit resource access to admin cluster
 	for _, cluster := range vp.Spec.Placement.Clusters {
-		newRoleBindingManagedCluster(namespace, cluster.Name)
+		rb := newRoleBindingManagedCluster(namespace, cluster.Name)
+		if err := r.createOrUpdateRoleBinding(ctx, rb, logger); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -6,6 +6,7 @@ package verrazzanoproject
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
@@ -33,6 +34,7 @@ const (
 	finalizerName               = "project.verrazzano.io"
 	keyPolicyName               = "policy-name"
 	keyNamespace                = "namespace"
+	managedClusterRole          = "verrazzano-managed-cluster"
 )
 
 // Reconciler reconciles a VerrazzanoProject object
@@ -211,6 +213,7 @@ func (r *Reconciler) createOrUpdateRoleBindings(ctx context.Context, namespace s
 			return err
 		}
 	}
+
 	// create two role bindings, one for the project monitor role and one for the k8s monitor role
 	if len(monitorSubjects) > 0 {
 		rb := newRoleBinding(namespace, projectMonitorRole, monitorSubjects)
@@ -221,6 +224,11 @@ func (r *Reconciler) createOrUpdateRoleBindings(ctx context.Context, namespace s
 		if err := r.createOrUpdateRoleBinding(ctx, rb, logger); err != nil {
 			return err
 		}
+	}
+
+	// create role binding for each managed cluster to limit resource access to admin cluster
+	for _, cluster := range vp.Spec.Placement.Clusters {
+		newRoleBindingManagedCluster(namespace, cluster.Name)
 	}
 	return nil
 }
@@ -267,6 +275,28 @@ func newRoleBinding(namespace string, roleName string, subjects []rbacv1.Subject
 			Name:     roleName,
 		},
 		Subjects: subjects,
+	}
+}
+
+// newRoleBinding returns a populated RoleBinding struct for a given managed cluster
+func newRoleBindingManagedCluster(namespace string, name string) *rbacv1.RoleBinding {
+	clusterNameRef := fmt.Sprintf("verrazzano-cluster-%s", name)
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      clusterNameRef,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     managedClusterRole,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      clusterNameRef,
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		},
 	}
 }
 

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -283,7 +283,7 @@ func newRoleBinding(namespace string, roleName string, subjects []rbacv1.Subject
 
 // newRoleBinding returns a populated RoleBinding struct for a given managed cluster
 func newRoleBindingManagedCluster(namespace string, name string) *rbacv1.RoleBinding {
-	clusterNameRef := fmt.Sprintf("verrazzano-cluster-%s", name)
+	clusterNameRef := generateRoleBindingManagedClusterRef(name)
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -301,6 +301,9 @@ func newRoleBindingManagedCluster(namespace string, name string) *rbacv1.RoleBin
 		},
 		},
 	}
+}
+func generateRoleBindingManagedClusterRef(name string) string {
+	return fmt.Sprintf("verrazzano-cluster-%s", name)
 }
 
 // getDefaultRoleBindingSubjects returns the default binding subjects for project admin/monitor roles

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1235,18 +1235,18 @@ func fakeGetConfig() (*rest.Config, error) {
 func expectSyncRoleBinding(t *testing.T, mock *mocks.MockClient, name string, succeed bool) {
 	asserts := assert.New(t)
 
-	// Expect a call to get the ClusterRoleBinding - return that it does not exist
+	// Expect a call to get the RoleBinding - return that it does not exist
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: generateManagedResourceName(name)}, gomock.Not(gomock.Nil())).
-		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ServiceAccount"}, generateManagedResourceName(name)))
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: generateManagedResourceName(name)}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "RoleBinding"}, generateManagedResourceName(name)))
 
-	// Expect a call to create the ClusterRoleBinding - return success or failure based on the succeed argument
+	// Expect a call to create the RoleBinding - return success or failure based on the succeed argument
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, binding *rbacv1.ClusterRoleBinding, opts ...client.CreateOption) error {
+		DoAndReturn(func(ctx context.Context, binding *rbacv1.RoleBinding, opts ...client.CreateOption) error {
 			if succeed {
-				asserts.Equalf(generateManagedResourceName(name), binding.Name, "ClusterRoleBinding testManagedCluster did not match")
-				asserts.Equalf(constants.MCClusterRole, binding.RoleRef.Name, "ClusterRoleBinding roleref did not match")
+				asserts.Equalf(generateManagedResourceName(name), binding.Name, "RoleBinding testManagedCluster did not match")
+				asserts.Equalf(constants.MCClusterRole, binding.RoleRef.Name, "RoleBinding roleref did not match")
 				asserts.Equalf(generateManagedResourceName(name), binding.Subjects[0].Name, "Subject did not match")
 				asserts.Equalf(constants.VerrazzanoMultiClusterNamespace, binding.Subjects[0].Namespace, "Subject namespace did not match")
 				return nil

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Multi Cluster Verify Kubeconfig Permissions", func() {
 			// TODO VZ-3971: Expect failure when namespace is no longer placed on the managed cluster
 			Eventually(func() (bool, error) {
 				return findSecret(permissionTest2Namespace, "mysecret")
-			}, waitTimeout, pollingInterval).Should(BeFalse(), "Expected to get a forbidden error")
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to get a forbidden error")
 		})
 
 		// VZ-2336: NOT be able to update or delete any VerrazzanoManagedCluster resources

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Multi Cluster Verify Kubeconfig Permissions", func() {
 			// TODO VZ-3971: Expect failure when namespace is no longer placed on the managed cluster
 			Eventually(func() (bool, error) {
 				return findSecret(permissionTest2Namespace, "mysecret")
-			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to get a forbidden error")
+			}, waitTimeout, pollingInterval).Should(BeFalse(), "Expected to get a forbidden error")
 		})
 
 		// VZ-2336: NOT be able to update or delete any VerrazzanoManagedCluster resources


### PR DESCRIPTION
# Description

This pull request includes changes for supporting a new security model of secrets in multicluster.  Instead of a clusterrolebinding, rolebindings are used to access admin cluster resources from a managed cluster.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
