### PR TITLE
vz-3480 reduce verbosity of logging in reconcile loop

### DIFF
--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -78,7 +78,7 @@ var rancherHTTPClient requestSender = &httpRequestSender{}
 // registerManagedClusterWithRancher registers a managed cluster with Rancher and returns a chunk of YAML that
 // must be applied on the managed cluster to complete the registration.
 func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, log *zap.SugaredLogger) (string, error) {
-	log.Infof("Registering managed cluster in Rancher with name: %s", clusterName)
+	log.Debugf("Registering managed cluster in Rancher with name: %s", clusterName)
 
 	rc := &rancherConfig{baseURL: "https://" + nginxIngressHostName}
 

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -88,35 +88,35 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 	}
 
 	// Sync the service account
-	log.Infof("Syncing the ServiceAccount for VMC %s", vmc.Name)
+	log.Debugf("Syncing the ServiceAccount for VMC %s", vmc.Name)
 	err = r.syncServiceAccount(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the ServiceAccount", err, log)
 		return ctrl.Result{}, err
 	}
 
-	log.Infof("Syncing the RoleBinding for VMC %s", vmc.Name)
+	log.Debugf("Syncing the RoleBinding for VMC %s", vmc.Name)
 	_, err = r.syncManagedRoleBinding(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the RoleBinding", err, log)
 		return ctrl.Result{}, err
 	}
 
-	log.Infof("Syncing the Agent secret for VMC %s", vmc.Name)
+	log.Debugf("Syncing the Agent secret for VMC %s", vmc.Name)
 	err = r.syncAgentSecret(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the agent secret", err, log)
 		return ctrl.Result{}, err
 	}
 
-	log.Infof("Syncing the Registration secret for VMC %s", vmc.Name)
+	log.Debugf("Syncing the Registration secret for VMC %s", vmc.Name)
 	err = r.syncRegistrationSecret(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the registration secret", err, log)
 		return ctrl.Result{}, err
 	}
 
-	log.Infof("Syncing the Manifest secret for VMC %s", vmc.Name)
+	log.Debugf("Syncing the Manifest secret for VMC %s", vmc.Name)
 	err = r.syncManifestSecret(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the Manifest secret", err, log)
@@ -133,7 +133,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	log.Infof("Syncing the prometheus scraper for VMC %s", vmc.Name)
+	log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
 	err = r.syncPrometheusScraper(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)


### PR DESCRIPTION
# Description

Reduce the logging output of the reconcile loop.  Every minute a block of redundant messages was being output to the log.

Fixes VZ-3480

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
