### PR TITLE
VZ-3747 Part 2 - Uptake dashboard changes to add cluster drop down, remove old managed_cluster label, update tests

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -21,6 +22,7 @@ import (
 )
 
 // For unit testing
+const actualBomFilePath = "../../../verrazzano-bom.json"
 const testBomFilePath = "../../../controllers//verrazzano/testdata/test_bom.json"
 const invalidTestBomFilePath = "../../../controllers//verrazzano/testdata/invalid_test_bom.json"
 const invalidPathTestBomFilePath = "../../../controllers//verrazzano/testdata/invalid_test_bom_path.json"
@@ -403,6 +405,20 @@ func TestGetCurrentBomVersion(t *testing.T) {
 	version, err := GetCurrentBomVersion()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedVersion, version)
+}
+
+// TestActualBomFile Tests GetCurrentBomVersion with the actual verrazzano-bom.json that is in this
+// code repo to ensure the file can at least be parsed
+func TestActualBomFile(t *testing.T) {
+	// repeat the test with the _actual_ bom file in the code repository
+	// to make sure it can at least be parsed without an error
+	config.SetDefaultBomFilePath(actualBomFilePath)
+	_, err := GetCurrentBomVersion()
+	absPath, err2 := filepath.Abs(actualBomFilePath)
+	if err2 != nil {
+		absPath = actualBomFilePath
+	}
+	assert.NoError(t, err, "Could not get BOM version from file %s", absPath)
 }
 
 // TestGetCurrentBomVersionFileReadError Tests  getBomVersion() when there is an error reading the BOM file

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -47,7 +47,6 @@ static_configs:
 - targets:
   - ##HOST##
   labels: # add the labels if not already present on managed cluster (this will no op if present)
-    managed_cluster: '##CLUSTER_NAME##'
     verrazzano_cluster: '##CLUSTER_NAME##'
 basic_auth:
   username: verrazzano-prom-internal

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -110,10 +110,7 @@ func TestCreateVMC(t *testing.T) {
 		asserts.NotEmpty(scrapeConfig.Search("basic_auth", "password").Data(), "No password")
 		asserts.Equal(prometheusConfigBasePath+"ca-test",
 			scrapeConfig.Search("tls_config", "ca_file").Data(), "Wrong cert path")
-		// assert that BOTH managed_cluster and verrazzano_cluster labels are added in the static config
-		asserts.Equal(testManagedCluster, scrapeConfig.Search(
-			"static_configs", "0", "labels", "managed_cluster").Data(),
-			"Label managed_cluster not set correctly in static_configs")
+		// assert that the verrazzano_cluster label is added in the static config
 		asserts.Equal(testManagedCluster, scrapeConfig.Search(
 			"static_configs", "0", "labels", "verrazzano_cluster").Data(),
 			"Label verrazzano_cluster not set correctly in static_configs")

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -181,7 +181,7 @@
           "images": [
             {
               "image": "verrazzano-operator",
-              "tag": "1.1.0-20211102132834-225ffc1",
+              "tag": "1.1.0-20211103193921-f3b3db2",
               "helmFullImageKey": "verrazzanoOperator.imageName",
               "helmTagKey": "verrazzanoOperator.imageVersion"
             },
@@ -192,7 +192,7 @@
             },
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "1.1.0-20211101174500-1998b28",
+              "tag": "1.1.0-20211102141650-ff61e2c",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -52,7 +52,7 @@ var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
 
 // ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+var clusterNameMetricsLabel
 
 var adminKubeConfig string
 var isManagedClusterProfile bool
@@ -96,6 +96,7 @@ var _ = BeforeSuite(func() {
 			Fail(err.Error())
 		}
 	}
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 })
 
 var _ = Describe("Prometheus Metrics", func() {

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -50,6 +50,7 @@ const (
 
 var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
+
 // ignore error getting the metric label - we'll just use the default value returned
 var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -51,8 +51,8 @@ const (
 var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
 
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel
+// will be initialized in BeforeSuite so that any log messages during init are available
+var clusterNameMetricsLabel = ""
 
 var adminKubeConfig string
 var isManagedClusterProfile bool
@@ -96,6 +96,7 @@ var _ = BeforeSuite(func() {
 			Fail(err.Error())
 		}
 	}
+	// ignore error getting the metric label - we'll just use the default value returned
 	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 })
 

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -50,9 +50,6 @@ const (
 
 var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
-
-// will be initialized in BeforeSuite so that any log messages during init are available
-var clusterNameMetricsLabel = ""
 var isMinVersion110 bool
 
 var adminKubeConfig string
@@ -170,7 +167,8 @@ var _ = Describe("Prometheus Metrics", func() {
 
 // Validate the Istio envoy stats for the pods in the namespaces defined in envoyStatsNamespaces
 func verifyEnvoyStats(metricName string) bool {
-	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), getClusterNameForPromQuery())
+	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, getClusterNameForPromQuery())
 	if err != nil {
 		return false
 	}
@@ -211,38 +209,27 @@ func verifyEnvoyStats(metricName string) bool {
 	return true
 }
 
-func getClusterNameMetricLabel() string {
-	if clusterNameMetricsLabel == "" {
-		// ignore error getting the metric label - we'll just use the default value returned
-		lbl, err := pkg.GetClusterNameMetricLabel()
-		if err != nil {
-			pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
-		}
-		clusterNameMetricsLabel = lbl
-	}
-	return clusterNameMetricsLabel
-}
-
 // Assert the existence of labels for namespace and pod in the envoyStatsMetric
 func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
+	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 	metrics := pkg.JTq(envoyStatsMetric, "data", "result").([]interface{})
 	for _, metric := range metrics {
 		if pkg.Jq(metric, "metric", namespace) == ns && pkg.Jq(metric, "metric", podName) == pod {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
+				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the value "local" when version 1.1 or higher.
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
 						return true
 					}
 				}
@@ -255,8 +242,9 @@ func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 // Validate the metrics contain the labels with values specified as key-value pairs of the map
 func metricsContainLabels(metricName string, kv map[string]string) bool {
 	clusterNameValue := getClusterNameForPromQuery()
-	pkg.Log(pkg.Debug, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, getClusterNameMetricLabel(), clusterNameValue))
-	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), clusterNameValue)
+	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+	pkg.Log(pkg.Debug, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, clusterNameMetricsLabel, clusterNameValue))
+	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, clusterNameValue)
 	if err != nil {
 		return false
 	}
@@ -274,18 +262,18 @@ func metricsContainLabels(metricName string, kv map[string]string) bool {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
+				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the local cluster as its value when version 1.1 or higher
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
 						return true
 					}
 				}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -271,10 +271,6 @@ func metricsContainLabels(metricName string, kv map[string]string) bool {
 		}
 
 		if metricFound {
-			// the verrazzano_cluster label should be found on all clusters
-			if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
-				return false
-			}
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
@@ -284,8 +280,14 @@ func metricsContainLabels(metricName string, kv map[string]string) bool {
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the local cluster as its value
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
-					return true
+				if isMinVersion110 {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
+						return true
+					}
+				} else {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
+						return true
+					}
 				}
 			}
 		}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -52,7 +52,7 @@ var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
 
 // will be initialized in BeforeSuite so that any log messages during init are available
-var clusterNameMetricsLabel = ""
+var clusterNameMetricsLabel string
 var isMinVersion110 bool
 
 var adminKubeConfig string
@@ -81,6 +81,9 @@ var excludePodsIstio = []string{
 }
 
 var _ = BeforeSuite(func() {
+	// ignore error getting the metric label - we'll just use the default value returned
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+
 	present := false
 	var err error
 	adminKubeConfig, present = os.LookupEnv("ADMIN_KUBECONFIG")
@@ -170,7 +173,7 @@ var _ = Describe("Prometheus Metrics", func() {
 
 // Validate the Istio envoy stats for the pods in the namespaces defined in envoyStatsNamespaces
 func verifyEnvoyStats(metricName string) bool {
-	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), getClusterNameForPromQuery())
+	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, getClusterNameForPromQuery())
 	if err != nil {
 		return false
 	}
@@ -211,18 +214,6 @@ func verifyEnvoyStats(metricName string) bool {
 	return true
 }
 
-func getClusterNameMetricLabel() string {
-	if clusterNameMetricsLabel == "" {
-		// ignore error getting the metric label - we'll just use the default value returned
-		lbl, err := pkg.GetClusterNameMetricLabel()
-		if err != nil {
-			pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
-		}
-		clusterNameMetricsLabel = lbl
-	}
-	return clusterNameMetricsLabel
-}
-
 // Assert the existence of labels for namespace and pod in the envoyStatsMetric
 func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 	metrics := pkg.JTq(envoyStatsMetric, "data", "result").([]interface{})
@@ -231,18 +222,18 @@ func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
+				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the value "local"
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
 						return true
 					}
 				}
@@ -255,8 +246,8 @@ func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 // Validate the metrics contain the labels with values specified as key-value pairs of the map
 func metricsContainLabels(metricName string, kv map[string]string) bool {
 	clusterNameValue := getClusterNameForPromQuery()
-	pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, getClusterNameMetricLabel(), clusterNameValue))
-	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), clusterNameValue)
+	pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, clusterNameMetricsLabel, clusterNameValue))
+	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, clusterNameValue)
 	if err != nil {
 		return false
 	}
@@ -274,18 +265,18 @@ func metricsContainLabels(metricName string, kv map[string]string) bool {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
+				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the local cluster as its value
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
+					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
 						return true
 					}
 				}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -230,7 +230,9 @@ func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 
 // Validate the metrics contain the labels with values specified as key-value pairs of the map
 func metricsContainLabels(metricName string, kv map[string]string) bool {
-	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, getClusterNameForPromQuery())
+	clusterNameValue := getClusterNameForPromQuery()
+	pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, clusterNameMetricsLabel, clusterNameValue))
+	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, clusterNameValue)
 	if err != nil {
 		return false
 	}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -50,6 +50,9 @@ const (
 
 var clusterName = os.Getenv("CLUSTER_NAME")
 var kubeConfig = os.Getenv("KUBECONFIG")
+
+// will be initialized in BeforeSuite so that any log messages during init are available
+var clusterNameMetricsLabel = ""
 var isMinVersion110 bool
 
 var adminKubeConfig string
@@ -167,8 +170,7 @@ var _ = Describe("Prometheus Metrics", func() {
 
 // Validate the Istio envoy stats for the pods in the namespaces defined in envoyStatsNamespaces
 func verifyEnvoyStats(metricName string) bool {
-	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
-	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, getClusterNameForPromQuery())
+	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), getClusterNameForPromQuery())
 	if err != nil {
 		return false
 	}
@@ -209,27 +211,38 @@ func verifyEnvoyStats(metricName string) bool {
 	return true
 }
 
+func getClusterNameMetricLabel() string {
+	if clusterNameMetricsLabel == "" {
+		// ignore error getting the metric label - we'll just use the default value returned
+		lbl, err := pkg.GetClusterNameMetricLabel()
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
+		}
+		clusterNameMetricsLabel = lbl
+	}
+	return clusterNameMetricsLabel
+}
+
 // Assert the existence of labels for namespace and pod in the envoyStatsMetric
 func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
-	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 	metrics := pkg.JTq(envoyStatsMetric, "data", "result").([]interface{})
 	for _, metric := range metrics {
 		if pkg.Jq(metric, "metric", namespace) == ns && pkg.Jq(metric, "metric", podName) == pod {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
+				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the value "local" when version 1.1 or higher.
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
 						return true
 					}
 				}
@@ -242,9 +255,8 @@ func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
 // Validate the metrics contain the labels with values specified as key-value pairs of the map
 func metricsContainLabels(metricName string, kv map[string]string) bool {
 	clusterNameValue := getClusterNameForPromQuery()
-	clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
-	pkg.Log(pkg.Debug, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, clusterNameMetricsLabel, clusterNameValue))
-	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, clusterNameMetricsLabel, clusterNameValue)
+	pkg.Log(pkg.Debug, fmt.Sprintf("Looking for metric name %s with label %s = %s", metricName, getClusterNameMetricLabel(), clusterNameValue))
+	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), clusterNameValue)
 	if err != nil {
 		return false
 	}
@@ -262,18 +274,18 @@ func metricsContainLabels(metricName string, kv map[string]string) bool {
 			if isManagedClusterProfile {
 				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
 				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == clusterName {
+				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
 					return true
 				}
 			} else {
 				// the metrics for the admin cluster or in the single cluster installation should contain the label
 				// verrazzano_cluster with the local cluster as its value when version 1.1 or higher
 				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == "local" {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
 						return true
 					}
 				} else {
-					if pkg.Jq(metric, "metric", clusterNameMetricsLabel) == nil {
+					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
 						return true
 					}
 				}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -310,5 +310,8 @@ func getClusterNameForPromQuery() string {
 	if isManagedClusterProfile {
 		return clusterName
 	}
+	if isMinVersion110 {
+		return "local"
+	}
 	return ""
 }

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -33,7 +33,6 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -45,9 +44,6 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
-	// ignore error getting the metric label - we'll just use the default value returned
-	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
-
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFileInCluster(projectfile, adminKubeconfig)
@@ -167,6 +163,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 	// THEN expect Prometheus metrics for the app to exist in Prometheus on the admin cluster
 	Context("Metrics", func() {
 		It("Verify Prometheus metrics exist on admin cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				var m = map[string]string{clusterNameMetricsLabel: clusterName}
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -33,6 +33,8 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+// ignore error getting the metric label - we'll just use the default value returned
+var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -164,7 +166,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 	Context("Metrics", func() {
 		It("Verify Prometheus metrics exist on admin cluster", func() {
 			Eventually(func() bool {
-				var m = map[string]string{"verrazzano_cluster": clusterName}
+				var m = map[string]string{clusterNameMetricsLabel: clusterName}
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -33,8 +33,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -46,6 +45,9 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
+	// ignore error getting the metric label - we'll just use the default value returned
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return pkg.CreateOrUpdateResourceFromFileInCluster(projectfile, adminKubeconfig)

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 	Context("Metrics", func() {
 		It("Verify Prometheus metrics exist on admin cluster", func() {
 			Eventually(func() bool {
-				var m = map[string]string{"managed_cluster": clusterName}
+				var m = map[string]string{"verrazzano_cluster": clusterName}
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -42,7 +42,6 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
-
 	// ignore error getting the metric label - we'll just use the default value returned
 	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -30,6 +30,8 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+// ignore error getting the metric label - we'll just use the default value returned
+var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -159,7 +161,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -168,7 +170,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testNamespace
-				m["verrazzano_cluster"] = "DNE"
+				m[clusterNameMetricsLabel] = "DNE"
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -177,7 +179,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("vendor_requests_count_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find vendor_requests_count_total metric")
 		})
@@ -186,7 +188,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -30,7 +30,6 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -42,9 +41,6 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
-	// ignore error getting the metric label - we'll just use the default value returned
-	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
-
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return examples.DeployHelloHelidonProject(adminKubeconfig, sourceDir)
@@ -159,6 +155,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 	Context("Prometheus Metrics", func() {
 
 		It("Verify base_jvm_uptime_seconds metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
@@ -168,6 +165,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 		})
 
 		It("Verify DNE base_jvm_uptime_seconds metrics does not exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testNamespace
@@ -177,6 +175,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 		})
 
 		It("Verify vendor_requests_count_total metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
@@ -186,6 +185,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 		})
 
 		It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -30,8 +30,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -43,6 +42,9 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
+
+	// ignore error getting the metric label - we'll just use the default value returned
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 	// deploy the VerrazzanoProject
 	Eventually(func() error {

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -168,7 +168,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testNamespace
-				m["managed_cluster"] = "DNE"
+				m["verrazzano_cluster"] = "DNE"
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -177,7 +177,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("vendor_requests_count_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find vendor_requests_count_total metric")
 		})
@@ -186,7 +186,7 @@ var _ = Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -29,6 +29,8 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+// ignore error getting the metric label - we'll just use the default value returned
+var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -145,7 +147,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -154,7 +156,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["verrazzano_cluster"] = "DNE"
+				m[clusterNameMetricsLabel] = "DNE"
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -163,7 +165,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("vendor_requests_count_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find vendor_requests_count_total metric")
 		})
@@ -172,7 +174,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -29,8 +29,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -42,6 +41,9 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
+	// ignore error getting the metric label - we'll just use the default value returned
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return DeploySockShopProject(adminKubeconfig, sourceDir)

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -29,7 +29,6 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -41,9 +40,6 @@ var _ = AfterEach(func() {
 
 // set the kubeconfig to use the admin cluster kubeconfig and deploy the example resources
 var _ = BeforeSuite(func() {
-	// ignore error getting the metric label - we'll just use the default value returned
-	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
-
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return DeploySockShopProject(adminKubeconfig, sourceDir)
@@ -146,6 +142,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 	PContext("Prometheus Metrics", func() {
 
 		It("Verify base_jvm_uptime_seconds metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -155,6 +152,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 		})
 
 		It("Verify DNE base_jvm_uptime_seconds metrics does not exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -164,6 +162,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 		})
 
 		It("Verify vendor_requests_count_total metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -173,6 +172,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 		})
 
 		It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -154,7 +154,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["managed_cluster"] = "DNE"
+				m["verrazzano_cluster"] = "DNE"
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -163,7 +163,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("vendor_requests_count_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find vendor_requests_count_total metric")
 		})
@@ -172,7 +172,7 @@ var _ = Describe("Multi-cluster verify sock-shop", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -32,7 +32,6 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -42,9 +41,6 @@ var _ = AfterEach(func() {
 })
 
 var _ = BeforeSuite(func() {
-	// ignore error getting the metric label - we'll just use the default value returned
-	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
-
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return DeployTodoListProject(adminKubeconfig, sourceDir)
@@ -210,6 +206,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 	Context("Prometheus Metrics", func() {
 
 		It("Verify scrape_duration_seconds metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
@@ -219,6 +216,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 		})
 
 		It("Verify DNE scrape_duration_seconds metrics does not exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
@@ -228,6 +226,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 		})
 
 		It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -218,7 +218,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["managed_cluster"] = "DNE"
+				m["verrazzano_cluster"] = "DNE"
 				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -227,7 +227,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["managed_cluster"] = clusterName
+				m["verrazzano_cluster"] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -32,8 +32,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+var clusterNameMetricsLabel string
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -43,6 +42,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = BeforeSuite(func() {
+	// ignore error getting the metric label - we'll just use the default value returned
+	clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
+
 	// deploy the VerrazzanoProject
 	Eventually(func() error {
 		return DeployTodoListProject(adminKubeconfig, sourceDir)

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -32,6 +32,8 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+// ignore error getting the metric label - we'll just use the default value returned
+var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -209,7 +211,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
@@ -218,7 +220,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["verrazzano_cluster"] = "DNE"
+				m[clusterNameMetricsLabel] = "DNE"
 				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
@@ -227,7 +229,7 @@ var _ = Describe("Multi-cluster verify todo-list", func() {
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
-				m["verrazzano_cluster"] = clusterName
+				m[clusterNameMetricsLabel] = clusterName
 				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Multi Cluster Verify Register", func() {
 
 		It("admin cluster has the expected metrics from managed cluster", func() {
 			Eventually(func() bool {
-				return pkg.MetricsExist("up", "managed_cluster", managedClusterName)
+				return pkg.MetricsExist("up", "verrazzano_cluster", managedClusterName)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a metrics from managed cluster")
 		})
 

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -34,6 +34,8 @@ const verrazzanoSystemNamespace = "verrazzano-system"
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var vmiEsIngressURL = getVmiEsIngressURL()
 var externalEsURL = pkg.GetExternalElasticSearchURL(os.Getenv("ADMIN_KUBECONFIG"))
+// ignore error getting the metric label - we'll just use the default value returned
+var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 
 var _ = Describe("Multi Cluster Verify Register", func() {
 	Context("Admin Cluster", func() {
@@ -157,7 +159,7 @@ var _ = Describe("Multi Cluster Verify Register", func() {
 
 		It("admin cluster has the expected metrics from managed cluster", func() {
 			Eventually(func() bool {
-				return pkg.MetricsExist("up", "verrazzano_cluster", managedClusterName)
+				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a metrics from managed cluster")
 		})
 

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Multi Cluster Verify Register", func() {
 		})
 
 		It("admin cluster has the expected metrics from managed cluster", func() {
+			pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric with label %s with value %s", clusterNameMetricsLabel, managedClusterName))
 			Eventually(func() bool {
 				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a metrics from managed cluster")

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -35,9 +35,6 @@ var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var vmiEsIngressURL = getVmiEsIngressURL()
 var externalEsURL = pkg.GetExternalElasticSearchURL(os.Getenv("ADMIN_KUBECONFIG"))
 
-// ignore error getting the metric label - we'll just use the default value returned
-var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
-
 var _ = Describe("Multi Cluster Verify Register", func() {
 	Context("Admin Cluster", func() {
 		BeforeEach(func() {
@@ -159,6 +156,7 @@ var _ = Describe("Multi Cluster Verify Register", func() {
 		})
 
 		It("admin cluster has the expected metrics from managed cluster", func() {
+			clusterNameMetricsLabel := getClusterNameMetricLabel()
 			pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric with label %s with value %s", clusterNameMetricsLabel, managedClusterName))
 			Eventually(func() bool {
 				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName)
@@ -346,4 +344,13 @@ func assertRegistrationSecret() {
 
 func getVmiEsIngressURL() string {
 	return fmt.Sprintf("%s:443", pkg.GetSystemElasticSearchIngressURL(os.Getenv("ADMIN_KUBECONFIG")))
+}
+
+func getClusterNameMetricLabel() string {
+	// ignore error getting the metric label - we'll just use the default value returned
+	lbl, err := pkg.GetClusterNameMetricLabel()
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
+	}
+	return lbl
 }

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -34,6 +34,7 @@ const verrazzanoSystemNamespace = "verrazzano-system"
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var vmiEsIngressURL = getVmiEsIngressURL()
 var externalEsURL = pkg.GetExternalElasticSearchURL(os.Getenv("ADMIN_KUBECONFIG"))
+
 // ignore error getting the metric label - we'll just use the default value returned
 var clusterNameMetricsLabel, _ = pkg.GetClusterNameMetricLabel()
 

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -6,7 +6,6 @@ package pkg
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -263,79 +262,6 @@ func GetRetryPolicy() func(ctx context.Context, resp *http.Response, err error) 
 		}
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
-}
-
-// findMetric parses a Prometheus response to find a specified set of metric values
-func findMetric(metrics []interface{}, keyMap map[string]string) bool {
-	for _, metric := range metrics {
-
-		// allExist only remains true if all metrics are found in a given JSON response
-		allExist := true
-
-		for key, value := range keyMap {
-			exists := false
-			if Jq(metric, "metric", key) == value {
-				// exists is true if the specific key-value pair is found in a given JSON response
-				exists = true
-			}
-			allExist = exists && allExist
-		}
-		if allExist {
-			return true
-		}
-	}
-	return false
-}
-
-// MetricsExist is identical to MetricsExistInCluster, except that it uses the cluster specified in the environment
-func MetricsExist(metricsName, key, value string) bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return false
-	}
-
-	// map with single key-value pair
-	m := make(map[string]string)
-	m[key] = value
-
-	return MetricsExistInCluster(metricsName, m, kubeconfigPath)
-}
-
-// MetricsExist validates the availability of a given metric in the given cluster
-func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
-	metric, err := QueryMetric(metricsName, kubeconfigPath)
-	if err != nil {
-		return false
-	}
-	metrics := JTq(metric, "data", "result").([]interface{})
-	if metrics != nil {
-		return findMetric(metrics, keyMap)
-	}
-	return false
-}
-
-// JTq queries JSON text with a JSON path
-func JTq(jtext string, path ...string) interface{} {
-	var j map[string]interface{}
-	json.Unmarshal([]byte(jtext), &j)
-	return Jq(j, path...)
-}
-
-// Jq queries JSON nodes with a JSON path
-func Jq(node interface{}, path ...string) interface{} {
-	for _, p := range path {
-		if node == nil {
-			return nil
-		}
-		var nodeMap, ok = node.(map[string]interface{})
-		if ok {
-			node = nodeMap[p]
-		} else {
-			return nil
-		}
-	}
-	return node
 }
 
 // SliceContainsString checks if the input slice (an array of strings)

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -303,17 +303,21 @@ func GetVerrazzanoVersion() (string, error) {
 func IsVerrazzanoMinVersion(minVersion string) (bool, error) {
 	vzVersion, err := GetVerrazzanoVersion()
 	if err != nil {
+		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to get Verrazzano version. %s", err.Error()))
 		return false, err
 	}
+	Log(Info, fmt.Sprintf("IsVerrazzanoMinVersion - Got Verrazzano version %s to compare to minVersion %s", vzVersion, minVersion))
 	if len(vzVersion) == 0 {
 		return false, nil
 	}
 	vzSemver, err := semver.NewSemVersion(vzVersion)
 	if err != nil {
+		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to create semVer from Verrazzano version %s - error %s", vzVersion, err.Error()))
 		return false, err
 	}
 	minSemver, err := semver.NewSemVersion(minVersion)
 	if err != nil {
+		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to create semVer from min version %s - error %s", minVersion, err.Error()))
 		return false, err
 	}
 	return !vzSemver.IsLessThan(minSemver), nil

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -292,7 +292,11 @@ func GetVerrazzanoVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return vz.Status.Version, nil
+	vzVer := vz.Spec.Version
+	if vzVer == "" {
+		vzVer = vz.Status.Version
+	}
+	return vzVer, nil
 }
 
 // IsVerrazzanoMinVersion returns true if the Verrazzano version >= minVersion

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -303,21 +303,17 @@ func GetVerrazzanoVersion() (string, error) {
 func IsVerrazzanoMinVersion(minVersion string) (bool, error) {
 	vzVersion, err := GetVerrazzanoVersion()
 	if err != nil {
-		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to get Verrazzano version. %s", err.Error()))
 		return false, err
 	}
-	Log(Info, fmt.Sprintf("IsVerrazzanoMinVersion - Got Verrazzano version %s to compare to minVersion %s", vzVersion, minVersion))
 	if len(vzVersion) == 0 {
 		return false, nil
 	}
 	vzSemver, err := semver.NewSemVersion(vzVersion)
 	if err != nil {
-		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to create semVer from Verrazzano version %s - error %s", vzVersion, err.Error()))
 		return false, err
 	}
 	minSemver, err := semver.NewSemVersion(minVersion)
 	if err != nil {
-		Log(Error, fmt.Sprintf("IsVerrazzanoMinVersion - Failed to create semVer from min version %s - error %s", minVersion, err.Error()))
 		return false, err
 	}
 	return !vzSemver.IsLessThan(minSemver), nil

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -89,6 +89,7 @@ func GetClusterNameMetricLabel() (string, error) {
 	}
 	return "verrazzano_cluster", nil
 }
+
 // JTq queries JSON text with a JSON path
 func JTq(jtext string, path ...string) interface{} {
 	var j map[string]interface{}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -79,7 +79,7 @@ func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubecon
 // GetClusterNameMetricLabel returns the label name used for labeling metrics with the Verrazzano cluster
 // This is different in pre-1.1 VZ releases versus later releases
 func GetClusterNameMetricLabel() (string, error) {
-	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1")
+	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1.0")
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error checking Verrazzano min version == 1.1: %t", err))
 		return "verrazzano_cluster", err //callers can choose to ignore the error

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -5,9 +5,11 @@ package pkg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,4 +61,90 @@ func getPrometheusIngressHost(kubeconfigPath string) string {
 		}
 	}
 	return ""
+}
+
+// MetricsExist validates the availability of a given metric in the given cluster
+func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
+	metric, err := QueryMetric(metricsName, kubeconfigPath)
+	if err != nil {
+		return false
+	}
+	metrics := JTq(metric, "data", "result").([]interface{})
+	if metrics != nil {
+		return findMetric(metrics, keyMap)
+	}
+	return false
+}
+
+// GetClusterNameMetricLabel returns the label name used for labeling metrics with the Verrazzano cluster
+// This is different in pre-1.1 VZ releases versus later releases
+func GetClusterNameMetricLabel() (string, error) {
+	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1")
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error checking Verrazzano min version == 1.1: %t", err))
+		return "verrazzano_cluster", err //callers can choose to ignore the error
+	} else if !isVz11OrGreater {
+		// versions < 1.1 use the managed_cluster label not the verrazzano_cluster label
+		return "managed_cluster", nil
+	}
+	return "verrazzano_cluster", nil
+}
+// JTq queries JSON text with a JSON path
+func JTq(jtext string, path ...string) interface{} {
+	var j map[string]interface{}
+	json.Unmarshal([]byte(jtext), &j)
+	return Jq(j, path...)
+}
+
+// findMetric parses a Prometheus response to find a specified set of metric values
+func findMetric(metrics []interface{}, keyMap map[string]string) bool {
+	for _, metric := range metrics {
+
+		// allExist only remains true if all metrics are found in a given JSON response
+		allExist := true
+
+		for key, value := range keyMap {
+			exists := false
+			if Jq(metric, "metric", key) == value {
+				// exists is true if the specific key-value pair is found in a given JSON response
+				exists = true
+			}
+			allExist = exists && allExist
+		}
+		if allExist {
+			return true
+		}
+	}
+	return false
+}
+
+// MetricsExist is identical to MetricsExistInCluster, except that it uses the cluster specified in the environment
+func MetricsExist(metricsName, key, value string) bool {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
+		return false
+	}
+
+	// map with single key-value pair
+	m := make(map[string]string)
+	m[key] = value
+
+	return MetricsExistInCluster(metricsName, m, kubeconfigPath)
+}
+
+// Jq queries JSON nodes with a JSON path
+func Jq(node interface{}, path ...string) interface{} {
+	for _, p := range path {
+		if node == nil {
+			return nil
+		}
+		var nodeMap, ok = node.(map[string]interface{})
+		if ok {
+			node = nodeMap[p]
+		} else {
+			return nil
+		}
+	}
+	return node
 }

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -84,9 +84,11 @@ func GetClusterNameMetricLabel() (string, error) {
 		Log(Error, fmt.Sprintf("Error checking Verrazzano min version == 1.1: %t", err))
 		return "verrazzano_cluster", err //callers can choose to ignore the error
 	} else if !isVz11OrGreater {
+		Log(Info, "GetClusterNameMetricsLabel: version is less than 1.1.0")
 		// versions < 1.1 use the managed_cluster label not the verrazzano_cluster label
 		return "managed_cluster", nil
 	}
+	Log(Info, "GetClusterNameMetricsLabel: version is greater than or equal to 1.1.0")
 	return "verrazzano_cluster", nil
 }
 


### PR DESCRIPTION
# Description

VZ-3747 Part 2 - Uptake dashboard changes to add cluster drop down, remove old managed_cluster label, update tests

Fixes VZ-3747

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
