### PR TITLE
Revert rancher images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -165,13 +165,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20211103183518-ec72f6a2f",
+              "tag": "v2.5.9-20211013170111-ec72f6a2f",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20211103183518-ec72f6a2f"
+              "tag": "v2.5.9-20211013170111-ec72f6a2f"
             }
           ]
         },


### PR DESCRIPTION
# Description

I had updated the BOM to pick up new build versions (just rebuild no code changes) of the rancher and rancher-agent images, but somehow that resulted in rancher pulling in newer, unexpected versions of the additional rancher images that get installed in the background. That caused the private registry tests to fail because the images were not present in the registry.

Revert to using the previous image tags.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
