### PR TITLE
Disable the Upgrade check for old envoy images

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -916,7 +916,7 @@ def upgradeVerrazzano() {
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
                 # wait for the upgrade to complete
-                kubectl wait --timeout=10m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                kubectl wait --timeout=20m --for=condition=UpgradeComplete verrazzano/my-verrazzano
                             
                 # Get the install job(s) and mke sure the it matches pre-install.  If there is more than 1 job or the job changed, then it won't match
                 kubectl -n verrazzano-install get job -o yaml --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-post-upgrade-job.out

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -4,7 +4,6 @@
 def DOCKER_IMAGE_TAG
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
-def PROXY_IMAGES_VERRAZZANO_SYSTEM
 def PROXY_IMAGES_INGRESS_NGINX
 def PROXY_IMAGES_KEYCLOAK
 def PROXY_IMAGES_SPRINGBOOT
@@ -240,7 +239,6 @@ pipeline {
                     steps {
                         runGinkgoRandomize('verify-install')
                         script {
-                            PROXY_IMAGES_VERRAZZANO_SYSTEM = getProxyImageCount("verrazzano-system")
                             PROXY_IMAGES_INGRESS_NGINX = getProxyImageCount("ingress-nginx")
                             PROXY_IMAGES_KEYCLOAK = getProxyImageCount("keycloak")
                         }
@@ -374,7 +372,7 @@ pipeline {
                     kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
 
                     # wait for the upgrade to complete
-                    kubectl wait --timeout=15m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                    kubectl wait --timeout=20m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                     # Dump the resource to debug
                     kubectl get -o yaml verrazzano/my-verrazzano || true
@@ -432,11 +430,6 @@ pipeline {
                 stage("Validate istiocoredns uninstalled") {
                     steps {
                         validateIstioCoreDNSUninstall()
-                    }
-                }
-                stage("Validate verrazzano-system istio upgrade") {
-                    steps {
-                        validateProxyImageCount("verrazzano-system", PROXY_IMAGES_VERRAZZANO_SYSTEM)
                     }
                 }
                 stage("Validate ingress-nginx istio upgrade") {


### PR DESCRIPTION
Disable the proxy image version check since it doesn't handle the kiali use case where Kiali gets installed after upgrade.  This test will be moved to a go post-upgrade test suite.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
