### PR TITLE
VZ-4003 Replace interface list with command due to Kiali timing issues

### DIFF
--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -575,10 +575,6 @@ if [ "$(is_elasticsearch_console_enabled)" == "true" ]; then
   consoleArr+=("Elasticsearch - https://elasticsearch.vmi.system.${ENV_NAME}.${DNS_SUFFIX}")
 fi
 
-if [ -n "$(kubectl get vz -o jsonpath='{.items[0].status.instance.kialiUrl}')" ]; then
-  consoleArr+=("Kiali - https://kiali.vmi.system.${ENV_NAME}.${DNS_SUFFIX}")
-fi
-
 if [[ "$(is_vz_console_enabled)" == "true" ]]; then
   consoleArr+=("Verrazzano Console - https://verrazzano.${ENV_NAME}.${DNS_SUFFIX}")
 fi

--- a/platform-operator/scripts/install/4-install-keycloak.sh
+++ b/platform-operator/scripts/install/4-install-keycloak.sh
@@ -589,15 +589,13 @@ if [ $console_count -gt 0 ];then
   display_warning_for_secret="true"
   consoleout
   if [ $console_count -eq 1 ];then
-    consoleout "Verrazzano provides the following user interface."
+    consoleout "Verrazzano provides one user interface."
   else
     consoleout "Verrazzano provides various user interfaces."
   fi
   consoleout
-  for consoleValue in "${consoleArr[@]}"
-  do
-    consoleout "$consoleValue"
-  done
+  consoleout "To get the URL for each Verrazzano interface, run the following command:"
+  consoleout "kubectl get vz -o jsonpath={.items[].status.instance} | jq ."
   consoleout
   if [ $console_count -eq 1 ];then
     consoleout "You will need the credentials to access the preceding user interface. The user interface can be accessed by the username/password."


### PR DESCRIPTION
# Description

Because the KialiUrl status cannot be guaranteed by install time, we need to give users the command to access the interface URLs rather than the URLs themselves

Fixes VZ-4003

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
