### PR TITLE
VZ-4047: Release automation updates

### DIFF
--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
         string (description: 'The target version (major.minor.patch format, e.g. 1.0.1)', name: 'TARGET_VERSION', defaultValue: 'NONE', trim: true)
         string (description: 'Number of times to retry a failed triggered build', name: 'BUILD_RETRIES', defaultValue: '1', trim: true)
         booleanParam (description: 'Ignore pre-release validation failures', name: 'IGNORE_PRE_RELEASE_VALIDATION_FAILURES', defaultValue: false)
+        booleanParam (description: 'Only create release branch (skips release validation, build, and image push)', name: 'CREATE_BRANCH_ONLY', defaultValue: false)
         booleanParam (description: 'Indicate whether this is a test run', name: 'TEST_RUN', defaultValue: false)
     }
 
@@ -93,8 +94,8 @@ pipeline {
         stage('Pipeline inputs validation') {
             steps {
                 script {
-                    // major or minor release should be leveraging master branch and have a target version that ends in 0
-                    if ((params.TEST_RUN || env.BRANCH_NAME.equals('master')) && params.TARGET_VERSION =~ /^\d+\.\d+\.0$/) {
+                    // major or minor release has a target version that ends in 0
+                    if (params.TARGET_VERSION =~ /^\d+\.\d+\.0$/) {
                         echo "major/minor release detected. test=${params.TEST_RUN}"
                         IS_PATCH_RELEASE = 'false'
                     // patch should be using a "release-#.#" branch and have a version ending in a digit other than 0
@@ -114,6 +115,9 @@ pipeline {
         }
 
         stage('Pre-release validation') {
+            when {
+                expression { !params.CREATE_BRANCH_ONLY }
+            }
             environment {
                 IGNORE_FAILURES = "${params.IGNORE_PRE_RELEASE_VALIDATION_FAILURES}"
                 JIRA_USERNAME = credentials('jira-username')
@@ -151,6 +155,9 @@ pipeline {
                 }
 
                 stage('Verrazzano Build') {
+                    when {
+                        expression { !params.CREATE_BRANCH_ONLY }
+                    }
                     steps {
                         script {
                             if (IS_PATCH_RELEASE == 'true') {
@@ -208,7 +215,10 @@ pipeline {
 
         stage('Push images to OCR') {
             when {
-                expression { !params.TEST_RUN }
+                allOf {
+                    expression { !params.TEST_RUN }
+                    expression { !params.CREATE_BRANCH_ONLY }
+                }
             }
             steps {
                 retry(count: env.BUILD_RETRIES) {

--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -109,6 +109,11 @@ pipeline {
                         error "Invalid source branch ${env.GIT_BRANCH} or a mismatch between source branch and the specified target version ${params.TARGET_VERSION}"
                     }
 
+                    // if CREATE_BRANCH_ONLY is checked, make sure the source branch is master
+                    if (!params.TEST_RUN && params.CREATE_BRANCH_ONLY && env.BRANCH_NAME != "master") {
+                        error "Release branch must be created from master, ${env.BRANCH_NAME} is an invalid source branch"
+                    }
+
                     echo "Patch release? ${IS_PATCH_RELEASE}"
                 }
             }


### PR DESCRIPTION
# Description

I added a bool param to the Jenkinsfile that allows us to run the stage 1 release pipeline and have it only create the branch. This can be used when creating a major/minor version branch in advance of actually performing a release.

I also removed the check for "master" so that the subsequent release run won't fail when the branch is created ahead of time.

The create_branch.sh script already handles the case where the release branch already exists, so no changes needed there to support this.

Implements VZ-4047

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
