### PR TITLE
VZ-3899.  Update fluend sidecar configmap if necessary

### DIFF
--- a/application-operator/controllers/logging/fluentd.go
+++ b/application-operator/controllers/logging/fluentd.go
@@ -165,12 +165,10 @@ func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
 		return err
 	}
 
-	if !configMapExists {
-		if err = f.Create(f.Context, f.createFluentdConfigMap(namespace), &k8sclient.CreateOptions{}); err != nil {
-			return err
-		}
+	if configMapExists {
+		return f.Update(f.Context, f.createFluentdConfigMap(namespace), &k8sclient.UpdateOptions{})
 	}
-	return err
+	return f.Create(f.Context, f.createFluentdConfigMap(namespace), &k8sclient.CreateOptions{})
 }
 
 // createFluentdConfigMap creates the FLUENTD configmap per given namespace.

--- a/application-operator/controllers/logging/fluentd_test.go
+++ b/application-operator/controllers/logging/fluentd_test.go
@@ -98,6 +98,13 @@ func TestFluentdApplyForUpdate(t *testing.T) {
 
 			return nil
 		})
+	mockClient.EXPECT().
+		Update(fluentd.Context, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, configMap *v1.ConfigMap, options *client.UpdateOptions) error {
+			asserts.Equal(t, *fluentd.createFluentdConfigMap(testNamespace), *configMap)
+			asserts.Equal(t, client.UpdateOptions{}, *options)
+			return nil
+		})
 
 	// invoke method being tested
 	changesMade, err := fluentd.Apply(logInfo, resource, fluentdPod)

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -336,42 +336,45 @@ var _ = Describe("Verify ToDo List example application.", func() {
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
 			},
-			/*func() {
-				It("Verify recent fluentd-stdout-sidecar server log record exists", func() {
-					Eventually(func() bool {
-						return pkg.FindLog(indexName,
-							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "wls_log_stream", Value: "server_log"},
-								{Key: "stream", Value: "stdout"}},
-							[]pkg.Match{})
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent server log record")
-				})
+			func() {
+				pkg.MinVersionSpec("Verify recent fluentd-stdout-sidecar server log record exists", "1.1.0",
+					func() {
+						Eventually(func() bool {
+							return pkg.FindLog(indexName,
+								[]pkg.Match{
+									{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+									{Key: "wls_log_stream", Value: "server_log"},
+									{Key: "stream", Value: "stdout"}},
+								[]pkg.Match{})
+						}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent server log record")
+					})
 			},
 			func() {
-				It("Verify recent fluentd-stdout-sidecar domain log record exists", func() {
-					Eventually(func() bool {
-						return pkg.FindLog(indexName,
-							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "wls_log_stream", Value: "domain_log"},
-								{Key: "stream", Value: "stdout"}},
-							[]pkg.Match{})
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent domain log record")
-				})
+				pkg.MinVersionSpec("Verify recent fluentd-stdout-sidecar server log record exists", "1.1.0",
+					func() {
+						Eventually(func() bool {
+							return pkg.FindLog(indexName,
+								[]pkg.Match{
+									{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+									{Key: "wls_log_stream", Value: "domain_log"},
+									{Key: "stream", Value: "stdout"}},
+								[]pkg.Match{})
+						}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent domain log record")
+					})
 			},
 			func() {
-				It("Verify recent fluentd-stdout-sidecar server nodemanager log record exists", func() {
-					Eventually(func() bool {
-						return pkg.FindLog(indexName,
-							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "wls_log_stream", Value: "server_nodemanager_log"},
-								{Key: "stream", Value: "stdout"}},
-							[]pkg.Match{})
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent server nodemanager log record")
-				})
-			},*/
+				pkg.MinVersionSpec("Verify recent fluentd-stdout-sidecar server log record exists", "1.1.0",
+					func() {
+						Eventually(func() bool {
+							return pkg.FindLog(indexName,
+								[]pkg.Match{
+									{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+									{Key: "wls_log_stream", Value: "server_nodemanager_log"},
+									{Key: "stream", Value: "stdout"}},
+								[]pkg.Match{})
+						}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent server nodemanager log record")
+					})
+			},
 			// GIVEN a WebLogic application with logging enabled
 			// WHEN the log records are retrieved from the Elasticsearch index
 			// THEN verify that a recent pattern-matched log record of tododomain-adminserver stdout is found

--- a/tests/e2e/pkg/conditional_spec.go
+++ b/tests/e2e/pkg/conditional_spec.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package pkg
+
+import (
+	"fmt"
+	"github.com/onsi/ginkgo"
+)
+
+// ConditionalCheckFunc Test function for conditional specs
+type ConditionalCheckFunc func() (bool, error)
+
+// ConditionalSpec Executes the specified test spec/func when the condition function passes without error
+func ConditionalSpec(description string, skipMessage string, condition ConditionalCheckFunc, specFunc interface{}) {
+	checkPassed, err := condition()
+	if err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	// Only run the target test function when the minimum version criteria is met
+	if checkPassed {
+		ginkgo.It(description, specFunc)
+	} else {
+		Log(Info, fmt.Sprintf("Skipping spec '%s', %s", description, skipMessage))
+	}
+}
+
+// MinVersionSpec Executes the specified test spec/func when the Verrazzano version meets the minimum specified version
+func MinVersionSpec(description string, minVersion string, specFunc interface{}) {
+	ConditionalSpec(description, fmt.Sprintf("Min version not met: %s", minVersion), func() (bool, error) {
+		return IsVerrazzanoMinVersion(minVersion)
+	}, specFunc)
+}


### PR DESCRIPTION
# Description

In the 1.1 release the fluentd sidecar parse rules for WLS have been updated to accommodate additional log file types that might be available in the server container (nodemanager, access, and domain logs, in addition to the server log).  On upgrade, however, the configmap is not updated.  If the configmap has not changed, the resultant update will be a no-op.  

Also
- renabled the new WLS logging tests, conditionalized for 1.1+
- Added a general utility for conditional execution of a test spec

Fixes VZ-3899.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
