### PR TITLE
Release automation fixes (master port)

### DIFF
--- a/release/builds/JenkinsfilePostPRT
+++ b/release/builds/JenkinsfilePostPRT
@@ -125,7 +125,7 @@ pipeline {
                 SCANNER_ARCHIVE_FILE = credentials('scanner-archive-file')
 
                 // The minimum required scopes for the token are: "repo", "read:org".
-                GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-assets')
+                GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-process')
                 NO_PROXY_SUFFIX = credentials('cdn-no-proxy')
             }
             steps {

--- a/release/builds/JenkinsfilePostPRT
+++ b/release/builds/JenkinsfilePostPRT
@@ -125,13 +125,14 @@ pipeline {
                 SCANNER_ARCHIVE_FILE = credentials('scanner-archive-file')
 
                 // The minimum required scopes for the token are: "repo", "read:org".
-                GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-process')
+                GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-assets')
                 NO_PROXY_SUFFIX = credentials('cdn-no-proxy')
             }
             steps {
                 script {
                   sh """
-                    export GITHUB_TOKEN=
+                    echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
+
                     cd ${WORKSPACE}/release/scripts
                     ./create_github_release.sh ${params.RELEASE_VERSION} ${params.RELEASE_COMMIT} ${RELEASE_BINARIES_DIR} ${TEST_RUN}
                   """

--- a/release/scripts/create_github_release.sh
+++ b/release/scripts/create_github_release.sh
@@ -17,7 +17,7 @@ usage() {
     $(basename $0) <new version for the release> <hash of commit to release> <directory containing the release binaries> <a boolean to indicate test run, defaults to true>
 
   Example:
-    $(basename $0) v.1.0.1 aa94949a4e8e9b50bc0674035898f2579f2519cb ~/go/src/github.com/verrazzano/verrazzano/release
+    $(basename $0) v1.0.1 aa94949a4e8e9b50bc0674035898f2579f2519cb ~/go/src/github.com/verrazzano/verrazzano/release
 
   The script assumes Github CLI is installed and login is performed to authenticate the Github account.
 
@@ -32,37 +32,7 @@ RELEASE_COMMIT=${2}
 RELEASE_BINARIES_DIR=${3}
 TEST_RUN=${4:-true}
 
-function verify_released_artifacts() {
-  local releaseVersionDir=$RELEASE_BINARIES_DIR/release
-  mkdir -p $releaseVersionDir
-  cd $releaseVersionDir
-
-  # Iterate the array containing the release artifacts and download all of them
-  for i in "${releaseArtifacts[@]}"
-  do
-    wget -O $i https://github.com/verrazzano/verrazzano/releases/download/v$VERSION/$i
-  done
-  sha256sum -c k8s-dump-cluster.sh.sha256
-  sha256sum -c verrazzano-analysis-darwin-amd64.tar.gz.sha256
-  sha256sum -c verrazzano-analysis-linux-amd64.tar.gz.sha256
-
-  # Latest tag is automatic, do we really need to check ? If required, better compare the files from the two directories
-  local latestVersionDir=$RELEASE_BINARIES_DIR/latest
-  mkdir -p $latestVersionDir
-  cd $latestVersionDir
-
-  # Iterate the array containing the release artifacts and download all of them
-  for i in "${releaseArtifacts[@]}"
-  do
-    wget -O $i https://github.com/verrazzano/verrazzano/releases/latest/download/$i
-  done
-  sha256sum -c k8s-dump-cluster.sh.sha256
-  sha256sum -c verrazzano-analysis-darwin-amd64.tar.gz.sha256
-  sha256sum -c verrazzano-analysis-linux-amd64.tar.gz.sha256
-}
-
 function verify_release_binaries_exist() {
-  cd ${RELEASE_BINARIES_DIR}
   for i in "${releaseArtifacts[@]}"
   do
     if [ ! -f $i ];then
@@ -81,11 +51,15 @@ verify_release_binaries_exist || exit 1
 # Validate Github CLI
 validate_github_cli || exit 1
 
-# Login to github cli
-echo ${GITHUB_ACCESS_TOKEN}|gh auth login --with-token
-
 if [ $TEST_RUN == true ] ; then
-    echo "TEST_RUN is set to true, not doing a github release."
+    echo "TEST_RUN is set to true, NOT doing a github release. This is the command that would be executed:"
+    echo ""
+    echo gh release create \"${VERSION}\" \
+      --draft \
+      --target \"${RELEASE_COMMIT}\" \
+      --notes \"\" \
+      --title \"Verrazzano release ${VERSION}\" \
+    ${releaseArtifacts[*]}
 else
     echo "TEST_RUN is set to false, doing a github release now."
     # Setting an empty string for notes, as the release notes will be prepared separately
@@ -95,6 +69,4 @@ else
       --notes "" \
       --title "Verrazzano release ${VERSION}" \
     ${releaseArtifacts[*]}
-    verify_released_artifacts || exit 1
 fi
-

--- a/release/scripts/verify_github_release.sh
+++ b/release/scripts/verify_github_release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Verifies GitHub release artifacts.
+set -e
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+. $SCRIPT_DIR/common.sh
+
+usage() {
+    cat <<EOM
+  Downloads the release artifacts from GitHub and checks the SHA256 hash.
+
+  Usage:
+    $(basename $0) <release version to verify>
+
+  Example:
+    $(basename $0) v1.0.1
+EOM
+    exit 0
+}
+
+[ -z "$1" ] || [ "$1" == "-h" ] && { usage; }
+
+VERSION=${1}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -r "${TMPDIR}"' exit
+
+# Configure sha command based on platform
+SHA_CMD="sha256sum -c"
+
+if [ "$(uname)" == "Darwin" ]; then
+    SHA_CMD="shasum -a 256 -c"
+fi
+
+function verify_released_artifacts() {
+  local releaseVersionDir=${TMPDIR}/release
+  mkdir -p $releaseVersionDir
+  cd $releaseVersionDir
+
+  # Iterate the array containing the release artifacts and download all of them
+  echo "Downloading release artifacts for ${VERSION}"
+  for i in "${releaseArtifacts[@]}"
+  do
+    local url="https://github.com/verrazzano/verrazzano/releases/download/$VERSION/$i"
+    curl -Ss -L --show-error --fail -o $i ${url} || { echo "Unable to download ${url}"; exit; }
+  done
+  ${SHA_CMD} k8s-dump-cluster.sh.sha256
+  ${SHA_CMD} verrazzano-analysis-darwin-amd64.tar.gz.sha256
+  ${SHA_CMD} verrazzano-analysis-linux-amd64.tar.gz.sha256
+
+  # Latest tag is automatic, do we really need to check ? If required, better compare the files from the two directories
+  local latestVersionDir=${TMPDIR}}/latest
+  mkdir -p $latestVersionDir
+  cd $latestVersionDir
+
+  # Iterate the array containing the release artifacts and download all of them
+  echo "Downloading release artifacts for latest"
+  for i in "${releaseArtifacts[@]}"
+  do
+    local url="https://github.com/verrazzano/verrazzano/releases/latest/download/$i"
+    curl -Ss -L --show-error --fail -o $i ${url} || { echo "Unable to download ${url}"; exit; }
+  done
+  ${SHA_CMD} k8s-dump-cluster.sh.sha256
+  ${SHA_CMD} verrazzano-analysis-darwin-amd64.tar.gz.sha256
+  ${SHA_CMD} verrazzano-analysis-linux-amd64.tar.gz.sha256
+}
+
+verify_released_artifacts


### PR DESCRIPTION
# Description

Port of release automation fixes to master.

Updates to the release automation scripts for creating and verifying a GitHub release. I had to separate the release artifact verification script because creating a GitHub release using "--draft" means the artifacts aren't available for public download. The script always failed as a result.

I also made fixes and enhancements based on my experience performing the last release. For example, I enhanced the verification script so that it can be run on mac or linux.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
