### PR TITLE
VZ-3504: use restart annotations to restart the apps

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -452,6 +452,16 @@ pipeline {
                         validateProxyImageCount("hello-helidon", PROXY_IMAGES_HELIDON)
                     }
                 }
+                stage("Validate todo-list istio upgrade") {
+                    steps {
+                        validateProxyImageCount("todo-list", PROXY_IMAGES_TODO)
+                    }
+                }
+                stage("Validate bobs-books istio upgrade") {
+                    steps {
+                        validateProxyImageCount("bobs-books", PROXY_IMAGES_BOBSBOOKS)
+                    }
+                }
                 stage("Istioctl verify install") {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -472,7 +482,7 @@ pipeline {
                 }
                 success {
                     script {
-                        if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                        if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('validate-upgrade-success-cluster-dump')
                         }
                     }
@@ -523,6 +533,11 @@ pipeline {
                 stage('examples todo') {
                     steps {
                         runGinkgo('examples/todo', "true", "false")
+                    }
+                }
+                stage('examples bobs-books') {
+                    steps {
+                        runGinkgo('examples/bobsbooks', "true", "false")
                     }
                 }
             }
@@ -941,10 +956,14 @@ def validateIstioCoreDNSUninstall() {
 
 def restartExampleApps() {
     sh """
-        kubectl rollout restart deployment -n springboot
+        kubectl -n verrazzano-system rollout status deployment/verrazzano-application-operator
+        sleep 60
 
-        kubectl rollout restart deployment -n hello-helidon
-    """
+        kubectl annotate appconfig hello-helidon-appconf -n hello-helidon verrazzano.io/restart-version="aaa" --overwrite
+        kubectl annotate appconfig springboot-appconf -n springboot verrazzano.io/restart-version="aaa" --overwrite
+        kubectl annotate appconfig todo-appconf -n todo-list verrazzano.io/restart-version="aaa" --overwrite
+        kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="aaa" --overwrite
+       """
 }
 
 def getProxyImageCount(namespace)  {
@@ -962,5 +981,6 @@ def validateProxyImageCount(namespace, count) {
         sleep(15)
     }
     echo "Incorrect number of new istio proxy images in namespace ${namespace} after upgrade, found ${upgraded_proxy_images} but expected ${count}"
+    sh """kubectl get pods -n ${namespace} -o jsonpath={.items[*].spec.containers[*].image}"""
     exit 1
 }

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -971,7 +971,7 @@ def restartExampleApps() {
         kubectl get verrazzanoweblogicworkloads.oam.verrazzano.io -n todo-list todo-domain -o yaml | grep "verrazzano.io/restart-version: aaa"
 
         kubectl get verrazzanocoherenceworkloads.oam.verrazzano.io -n bobs-books bobby-coh -o yaml | grep "verrazzano.io/restart-version: aaa"
-        kubectl get verrazzanocoherenceworkloads.oam.verrazzano.io -n bobs-books robert-coh-o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanocoherenceworkloads.oam.verrazzano.io -n bobs-books robert-coh -o yaml | grep "verrazzano.io/restart-version: aaa"
 
         kubectl get verrazzanohelidonworkloads.oam.verrazzano.io -n bobs-books bobbys-helidon-stock-application -o yaml | grep "verrazzano.io/restart-version: aaa"
         kubectl get verrazzanohelidonworkloads.oam.verrazzano.io -n bobs-books robert-helidon -o yaml | grep "verrazzano.io/restart-version: aaa"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -963,7 +963,22 @@ def restartExampleApps() {
         kubectl annotate appconfig springboot-appconf -n springboot verrazzano.io/restart-version="aaa" --overwrite
         kubectl annotate appconfig todo-appconf -n todo-list verrazzano.io/restart-version="aaa" --overwrite
         kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="aaa" --overwrite
-       """
+
+        sleep 10
+
+        kubectl get verrazzanoweblogicworkloads.oam.verrazzano.io -n bobs-books bobby-wls -o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanoweblogicworkloads.oam.verrazzano.io -n bobs-books bobs-orders-wls -o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanoweblogicworkloads.oam.verrazzano.io -n todo-list todo-domain -o yaml | grep "verrazzano.io/restart-version: aaa"
+
+        kubectl get verrazzanocoherenceworkloads.oam.verrazzano.io -n bobs-books bobby-coh -o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanocoherenceworkloads.oam.verrazzano.io -n bobs-books robert-coh-o yaml | grep "verrazzano.io/restart-version: aaa"
+
+        kubectl get verrazzanohelidonworkloads.oam.verrazzano.io -n bobs-books bobbys-helidon-stock-application -o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanohelidonworkloads.oam.verrazzano.io -n bobs-books robert-helidon -o yaml | grep "verrazzano.io/restart-version: aaa"
+        kubectl get verrazzanohelidonworkloads.oam.verrazzano.io -n hello-helidon hello-helidon-workload -o yaml | grep "verrazzano.io/restart-version: aaa"
+
+        kubectl get containerizedworkloads.core.oam.dev -n springboot springboot-workload -o yaml | grep "verrazzano.io/restart-version: aaa"
+    """
 }
 
 def getProxyImageCount(namespace)  {


### PR DESCRIPTION
Fixes VZ-3804
These changes use the _verrazzano.io/restart-version_ annotation on the app configs to restart the example apps in the pipeline. They also add tests for bobs-books back in and check to make sure the annotation gets filtered down to the workloads.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
