### PR TITLE
VZ-4070. Improve install script waits for istiod and nginx availability, extend max timeout

### DIFF
--- a/platform-operator/scripts/install/1-install-init.sh
+++ b/platform-operator/scripts/install/1-install-init.sh
@@ -54,23 +54,7 @@ function wait_for_nodes_to_exist {
 }
 
 function wait_for_istio {
-  for iter in {1..60}; do
-    if ! kubectl  get ns istio-system 2>&1 > /dev/null; then
-      echo "Waiting for istio-sytem namespace..."
-      sleep 5s
-    else
-      break
-    fi
-  done
-  for iter in {1..60}; do
-    if ! kubectl  get deployment istiod -n istio-system 2>&1 > /dev/null; then
-      echo "Waiting for istiod deployement..."
-      sleep 5s
-    else
-      break
-    fi
-  done
-  kubectl  wait --for=condition=available deployment -n istio-system istiod --timeout=7m
+  wait_for_deployment istio-system istiod
   return $?
 }
 

--- a/platform-operator/scripts/install/common.sh
+++ b/platform-operator/scripts/install/common.sh
@@ -51,30 +51,58 @@ function wait_for_ingress_ip() {
   fi
 }
 
-# Wait for a deployment to become available in target namespace
+function execute_wait {
+  fn=$1
+  shift
+  for iter in {1..60}; do
+    if ${fn} $* 2>&1 > /dev/null; then
+      return 0
+    fi
+    log "Waiting..."
+    sleep 10s
+  done
+  return 1
+}
+
+function get_ns {
+  kubectl get namespace ${1}
+}
+
+function get_deployment {
+  kubectl get -n $1  deployment $2
+}
+
+# Wait for a deployment to become available in target namespace up to 20m max
 # - scaffolding support while we move some things to the platform operator; some components have dependencies
 #   on others during install at present
 function wait_for_deployment {
   local ns=$1
   local deployment=$2
-  for iter in {1..60}; do
-    if ! kubectl get namespace ${ns} 2>&1 > /dev/null; then
-      echo Waiting for namespace ${ns}...
-      sleep 5s
-    else
-      break
+  # Wait up 5 min for the ns to appear
+  log "Waiting for namespace $ns to be created..."
+  execute_wait get_ns $ns
+  # Wait up 5 min for the deployment to appear
+  log "Waiting for deployment ${deployment} in namespace $ns to be created..."
+  execute_wait get_deployment $ns ${deployment}
+
+  # Wait for a max of up to 20 mins for the deployment
+  intervalWaitSeconds=60
+  intervalsMax=20
+  for ((iter=1; iter < $intervalsMax; iter++)); do
+    log "Waiting for deployment ${deployment} in namespace $ns to become available..."
+    if kubectl  wait --for=condition=available deployment ${deployment} -n ${ns}  --timeout=${intervalWaitSeconds}s 2>&1 > /dev/null; then
+      log "Wait for deployment ${deployment} completed"
+      return 0
     fi
-  done
-  for iter in {1..60}; do
-    if ! kubectl get -n ${ns}  deployment ${deployment} 2>&1 > /dev/null; then
-      echo Waiting for deployment ${deployment}...
-      sleep 5s
-    else
-      break
+    if [[ $iter -gt 2 ]] && [[ $(($iter % 2)) -eq 0 ]]; then
+      log "Waited for ${deployment} for $(( ${iter}*${intervalWaitSeconds} )) seconds, checking for slow image pulls in namespace $ns"
+      check_for_slow_image_pulls $ns || true  # eat the failure error code, we want to keep checking
     fi
+    log "Waiting for deployment ${deployment}..."
   done
-  kubectl  wait --for=condition=available deployment ${deployment} -n ${ns}  --timeout=7m
-  return $?
+  log "Wait for deployment ${deployment} FAILED, deployment ${ns}/${deployment} state:"
+  kubectl  describe deployment -n ${ns} ${deployment} || true
+  return 1
 }
 
 function get_rancher_access_token {
@@ -414,7 +442,7 @@ function check_for_slow_image_pulls() {
     return 0
   fi
 
-  log "Slow image pulls detected for namepace $1 after install failure"
+  log "Slow image pulls detected for namepace $1"
   return 1
 }
 

--- a/platform-operator/scripts/install/common.sh
+++ b/platform-operator/scripts/install/common.sh
@@ -98,7 +98,6 @@ function wait_for_deployment {
       log "Waited for ${deployment} for $(( ${iter}*${intervalWaitSeconds} )) seconds, checking for slow image pulls in namespace $ns"
       check_for_slow_image_pulls $ns || true  # eat the failure error code, we want to keep checking
     fi
-    log "Waiting for deployment ${deployment}..."
   done
   log "Wait for deployment ${deployment} FAILED, deployment ${ns}/${deployment} state:"
   kubectl  describe deployment -n ${ns} ${deployment} || true


### PR DESCRIPTION
# Description

NGINX and Istio installs have been moved to the platform operator as part of a larger effort to move all components there and remove the install job.  The components that are still installed by the scripts depend on Istio and NGINX being available, so some timed-waits were added to the scripts to delay execution until those services are available.  The timeouts are currently not long enough to account for slow image pulls or other performance degradations during install that can delay availability of those services.

This change extends install script max timeouts for istiod and nginx availability and improves diagnostics a little when the timeouts are exceeded.
- Check for slow image pulls and report them
- Add more descriptive output
- dump deployment object on failure

Fixes VZ-4070.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
