### PR TITLE
VZ-2528 Fix the number of replicas in elasticsearch

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -390,7 +390,9 @@ data:
       "settings" : {
         "index.refresh_interval" : "5s",
         "index.mapping.total_fields.limit" : "2000",
-        "number_of_shards": 5
+        "number_of_shards": 5,
+        "index.number_of_replicas" : 0,
+        "index.auto_expand_replicas" : "0-all"
       },
       "mappings" : {
         "dynamic_templates" : [ {

--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/verrazzano/verrazzano/pkg/httputil"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
@@ -54,23 +55,33 @@ func (e *Elastic) PodsRunning() bool {
 	return running
 }
 
-// Connect checks if the elasticsearch cluster can be connected
-func (e *Elastic) Connect() bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+// getResponseBody gets the response body for the specified path from elasticsearch cluster
+func (e *Elastic) getResponseBody(path string) ([]byte, error) {
+	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting kubeconfig: %v", err))
-		return false
+		return nil, err
 	}
 
-	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+	api, err := pkg.GetAPIEndpoint(kubeConfigPath)
 	if err != nil {
-		return false
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting API endpoint: %v", err))
+		return nil, err
 	}
+
 	esURL, err := api.GetElasticURL()
 	if err != nil {
-		return false
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Elasticsearch URL: %v", err))
+		return nil, err
 	}
-	body, err := e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath), kubeconfigPath)
+
+	esURL = esURL + path
+	return e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeConfigPath), kubeConfigPath)
+}
+
+// Connect checks if the elasticsearch cluster can be connected
+func (e *Elastic) Connect() bool {
+	body, err := e.getResponseBody("/")
 	if err != nil {
 		return false
 	}
@@ -122,32 +133,17 @@ func (e *Elastic) getVmiHTTPClient(kubeconfigPath string) (*retryablehttp.Client
 // ListIndices lists elasticsearch indices
 func (e *Elastic) ListIndices() []string {
 	idx := []string{}
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Error getting kubeconfig: %v", err))
-		return nil
-	}
-
-	for i := range e.getIndices(kubeconfigPath) {
+	for i := range e.getIndices() {
 		idx = append(idx, i)
 	}
 	return idx
 }
 
 // getIndices gets index metadata (aliases, mappings, and settings) of all elasticsearch indices in the given cluster
-func (e *Elastic) getIndices(kubeconfigPath string) map[string]interface{} {
-	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+func (e *Elastic) getIndices() map[string]interface{} {
+	body, err := e.getResponseBody("/_all")
 	if err != nil {
-		return nil
-	}
-	esURL, err := api.GetElasticURL()
-	if err != nil {
-		return nil
-	}
-	esURL = esURL + "/_all"
-	body, err := e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath), kubeconfigPath)
-	if err != nil {
-		pkg.Log(pkg.Info, fmt.Sprintf("Error ListIndices %v error: %v", esURL, err))
+		pkg.Log(pkg.Info, fmt.Sprintf("Error ListIndices error: %v", err))
 		return nil
 	}
 	var indices map[string]interface{}
@@ -159,6 +155,57 @@ func (e *Elastic) getIndices(kubeconfigPath string) map[string]interface{} {
 func (e *Elastic) CheckTLSSecret() bool {
 	secretName := fmt.Sprintf("%v-tls", e.binding)
 	return pkg.SecretsCreated("verrazzano-system", secretName)
+}
+
+// CheckHealth checks the health status of Elasticsearch cluster
+// Returns true if the health status is green otherwise false
+func (e *Elastic) CheckHealth() bool {
+	body, err := e.getResponseBody("/_cluster/health")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster health: %v", err))
+		return false
+	}
+	status, err := httputil.ExtractFieldFromResponseBodyOrReturnError(string(body), "status", "unable to find status in Elasticsearch health response")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error extracting health status from response body %v: %v", string(body), err))
+		return false
+	}
+	if status == "green" {
+		pkg.Log(pkg.Info, "Elasticsearch cluster health status is green")
+		return true
+	}
+	pkg.Log(pkg.Error, fmt.Sprintf("Elasticsearch cluster health status is %v instead of green", status))
+	return false
+}
+
+// CheckIndicesHealth checks the health status of indices in a cluster
+// Returns true if the health status of all the indices is green otherwise false
+func (e *Elastic) CheckIndicesHealth() bool {
+	body, err := e.getResponseBody("/_cat/indices?format=json")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster indices: %v", err))
+		return false
+	}
+	var indices []map[string]interface{}
+	if err := json.Unmarshal(body, &indices); err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error unmarshalling indices response body: %v", err))
+		return false
+	}
+
+	for _, index := range indices {
+		pkg.Log(pkg.Debug, fmt.Sprintf("Index details: %v", index))
+		val, found := index["health"]
+		if !found {
+			pkg.Log(pkg.Error, fmt.Sprintf("Not able to find the health of the index: %v", index))
+			return false
+		}
+		if val.(string) != "green" {
+			pkg.Log(pkg.Error, fmt.Sprintf("Current index health status %v is not green", val))
+			return false
+		}
+	}
+	pkg.Log(pkg.Info, "The health status of all the indices is green")
+	return true
 }
 
 ////Check the Elasticsearch certificate

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -190,6 +190,11 @@ var _ = Describe("VMI", func() {
 			)
 		})
 
+		It("Elasticsearch health should be green", func() {
+			Eventually(elasticHealth, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "cluster health status not green")
+			Eventually(elasticIndicesHealth, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "indices health status not green")
+		})
+
 		It("Elasticsearch systemd journal Index should be accessible", func() {
 			Eventually(func() bool {
 				return pkg.FindAnyLog("verrazzano-systemd-journal",
@@ -362,6 +367,14 @@ func elasticIndicesCreated() bool {
 
 func elasticConnected() bool {
 	return elastic.Connect()
+}
+
+func elasticHealth() bool {
+	return elastic.CheckHealth()
+}
+
+func elasticIndicesHealth() bool {
+	return elastic.CheckIndicesHealth()
 }
 
 func elasticTLSSecret() bool {


### PR DESCRIPTION
- Set index.number_of_replicas to 0 by default
- Enable auto expand replicas setting by configuring "index.auto_expand_replicas" to "0-all"

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [X] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [X] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
