### PR TITLE
Fix Istio CR installArgs handling

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
@@ -60,11 +60,6 @@ spec:
 {{.ExternalIps}}
 `
 
-// templateValuesIstioHelm is needed for template rendering of helm values
-type templateValuesIstioHelm struct {
-	Values string
-}
-
 // templateValuesExternalIPs needed for template rendering of external IPs.
 type templateValuesExternalIPs struct {
 	ExternalIps string

--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
@@ -28,6 +28,10 @@ var cr1 = vzapi.IstioComponent{
 			Value: "3",
 		},
 		{
+			Name:  "pilot.resources.requests.memory",
+			Value: "128Mi",
+		},
+		{
 			Name:  ExternalIPArg,
 			Value: "1.2.3.4",
 		},
@@ -57,6 +61,10 @@ spec:
     global:
       defaultPodDisruptionBudget:
         enabled: false
+    pilot:
+      resources:
+        requests:
+          memory: 128Mi
     gateways:
       istio-ingressgateway:
         serviceAnnotations:

--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
@@ -10,8 +10,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 )
 
-const argShape = `
-gateways.istio-ingressgateway.serviceAnnotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"`
+const argShape = `gateways.istio-ingressgateway.serviceAnnotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"`
 
 // Specify the install args
 var cr1 = vzapi.IstioComponent{
@@ -19,6 +18,14 @@ var cr1 = vzapi.IstioComponent{
 		{
 			Name:  argShape,
 			Value: "10Mbps",
+		},
+		{
+			Name:  "global.defaultPodDisruptionBudget.enabled",
+			Value: "false",
+		},
+		{
+			Name:  "gateways.istio-ingressgateway.replicaCount",
+			Value: "3",
 		},
 		{
 			Name:  ExternalIPArg,
@@ -48,10 +55,13 @@ spec:
   # Please keep this in sync with manifests/charts/global.yaml
   values:
     global:
-      gateways:
-        istio-ingressgateway:
-          serviceAnnotations:
-            service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+      defaultPodDisruptionBudget:
+        enabled: false
+    gateways:
+      istio-ingressgateway:
+        serviceAnnotations:
+          service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+        replicaCount: 3
 `
 
 // TestBuildIstioOperatorYaml tests the BuildIstioOperatorYaml function


### PR DESCRIPTION
# Description

Fixes an issue for `istioInstallArgs` handling in the VZ CR for Istio
- generates a separate YAML snippet for each Istio installArg
- merges those with the ExternalIPs snippet and the egress snippet

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
