### PR TITLE
VZ-4021 Introspect interface arguments and check that they are functions

### DIFF
--- a/pkg/framework/ginkgo_wrapper.go
+++ b/pkg/framework/ginkgo_wrapper.go
@@ -5,39 +5,49 @@ package framework
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/onsi/ginkgo"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
 // VzBeforeSuite - wrapper function for ginkgo BeforeSuite
-func VzBeforeSuite(body func(), timeout ...float64) bool {
+func VzBeforeSuite(body interface{}, timeout ...float64) bool {
 	pkg.Log(pkg.Debug, "VzBeforeSuite wrapper")
+	if !isBodyFunc(body) {
+		ginkgo.Fail("Unsupported body type - expected function")
+	}
 	ginkgo.BeforeSuite(func() {
 		pkg.Log(pkg.Info, "BeforeSuite started - placeholder for making API call to emit test related metric(s)")
-		body()
+		reflect.ValueOf(body).Call([]reflect.Value{})
 		pkg.Log(pkg.Info, "BeforeSuite ended - placeholder for making API call to emit test related metric(s)")
 	}, timeout...)
 	return true
 }
 
 // VzAfterSuite - wrapper function for ginkgo AfterSuite
-func VzAfterSuite(body func(), timeout ...float64) bool {
+func VzAfterSuite(body interface{}, timeout ...float64) bool {
 	pkg.Log(pkg.Debug, "VzAfterSuite wrapper")
+	if !isBodyFunc(body) {
+		ginkgo.Fail("Unsupported body type - expected function")
+	}
 	ginkgo.AfterSuite(func() {
 		pkg.Log(pkg.Info, "AfterSuite started - placeholder for making API call to emit test related metric(s)")
-		body()
+		reflect.ValueOf(body).Call([]reflect.Value{})
 		pkg.Log(pkg.Info, "AfterSuite ended - placeholder for making API call to emit test related metric(s)")
 	}, timeout...)
 	return true
 }
 
 // VzIt - wrapper function for ginkgo It
-func VzIt(text string, body func(), timeout ...float64) bool {
+func VzIt(text string, body interface{}, timeout ...float64) bool {
 	pkg.Log(pkg.Debug, "VzIt wrapper")
+	if !isBodyFunc(body) {
+		ginkgo.Fail("Unsupported body type - expected function")
+	}
 	ginkgo.It(text, func() {
 		pkg.Log(pkg.Info, fmt.Sprintf("It block %q started - placeholder for making API call to emit test related metric(s)", ginkgo.CurrentGinkgoTestDescription().TestText))
-		body()
+		reflect.ValueOf(body).Call([]reflect.Value{})
 		pkg.Log(pkg.Info, fmt.Sprintf("It block %q ended - placeholder for making API call to emit test related metric(s)", ginkgo.CurrentGinkgoTestDescription().TestText))
 	}, timeout...)
 	return true

--- a/pkg/framework/ginkgo_wrapper_util.go
+++ b/pkg/framework/ginkgo_wrapper_util.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package framework
+
+import "reflect"
+
+// isBodyFunc - return boolean indicating if the interface is a function
+func isBodyFunc(body interface{}) bool {
+	bodyType := reflect.TypeOf(body)
+	return bodyType.Kind() == reflect.Func
+}

--- a/pkg/framework/ginkgo_wrapper_util_test.go
+++ b/pkg/framework/ginkgo_wrapper_util_test.go
@@ -1,0 +1,33 @@
+package framework
+
+import "testing"
+
+// TestIsBodyFunc - test function for introspecting an interface value
+func TestIsBodyFunc(t *testing.T) {
+	type args struct {
+		body interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test using a function",
+			args: args{body: func() {}},
+			want: true,
+		},
+		{
+			name: "Test using a struct",
+			args: args{body: args{}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBodyFunc(tt.args.body); got != tt.want {
+				t.Errorf("isBodyFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/framework/ginkgo_wrapper_util_test.go
+++ b/pkg/framework/ginkgo_wrapper_util_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package framework
 
 import "testing"

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/verrazzano/verrazzano/pkg/framework"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
@@ -37,18 +37,18 @@ var waitTimeout = 10 * time.Minute
 var pollingInterval = 30 * time.Second
 var shortPollingInterval = 10 * time.Second
 
-var _ = framework.VzBeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	deployFooApplication()
 	deployBarApplication()
 	deployNoIstioApplication()
 })
 
 var failed = false
-var _ = framework.VzAfterEach(func() {
-	failed = failed || framework.VzCurrentGinkgoTestDescription().Failed
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
 })
 
-var _ = framework.VzAfterSuite(func() {
+var _ = AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
@@ -252,29 +252,29 @@ func undeployNoIstioApplication() {
 	}, waitTimeout, shortPollingInterval).Should(BeTrue())
 }
 
-var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
+var _ = Describe("Verify AuthPolicy Applications", func() {
 	// Verify springboot-workload pod is running
 	// GIVEN springboot app is deployed
 	// WHEN the component and appconfig are created
 	// THEN the expected pod must be running in the test namespace
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(fooNamespace, expectedPodsFoo)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
 		})
 	})
 
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(barNamespace, expectedPodsBar)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
 		})
 	})
 
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(noIstioNamespace, expectedPodsBar)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
@@ -283,7 +283,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 
 	var fooHost = ""
 	var err error
-	framework.VzIt("Get foo host from gateway.", func() {
+	It("Get foo host from gateway.", func() {
 		Eventually(func() (string, error) {
 			fooHost, err = k8sutil.GetHostnameFromGateway(fooNamespace, "")
 			return fooHost, err
@@ -291,7 +291,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	})
 
 	var barHost = ""
-	framework.VzIt("Get bar host from gateway.", func() {
+	It("Get bar host from gateway.", func() {
 		Eventually(func() (string, error) {
 			barHost, err = k8sutil.GetHostnameFromGateway(barNamespace, "")
 			return barHost, err
@@ -299,7 +299,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	})
 
 	var noIstioHost = ""
-	framework.VzIt("Get noistio host from gateway.", func() {
+	It("Get noistio host from gateway.", func() {
 		Eventually(func() (string, error) {
 			noIstioHost, err = k8sutil.GetHostnameFromGateway(noIstioNamespace, "")
 			return noIstioHost, err
@@ -310,7 +310,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	framework.VzIt("Verify welcome page of Foo Spring Boot FrontEnd is working.", func() {
+	It("Verify welcome page of Foo Spring Boot FrontEnd is working.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/", fooHost)
@@ -322,7 +322,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	framework.VzIt("Verify welcome page of Bar Spring Boot FrontEnd is working.", func() {
+	It("Verify welcome page of Bar Spring Boot FrontEnd is working.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/", barHost)
@@ -334,7 +334,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// GIVEN authorization test app is deployed
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the application endpoint must be accessible
-	framework.VzIt("Verify welcome page of NoIstio Spring Boot FrontEnd is working.", func() {
+	It("Verify welcome page of NoIstio Spring Boot FrontEnd is working.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", noIstioHost))
 			url := fmt.Sprintf("https://%s/", noIstioHost)
@@ -347,7 +347,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	framework.VzIt("Verify Foo Frontend can call Foo Backend.", func() {
+	It("Verify Foo Frontend can call Foo Backend.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.foo:8080/", fooHost)
@@ -360,7 +360,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	framework.VzIt("Verify Bar Frontend can call Bar Backend.", func() {
+	It("Verify Bar Frontend can call Bar Backend.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.bar:8080/", barHost)
@@ -373,7 +373,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	framework.VzIt("Verify Foo Frontend canNOT call Bar Backend.", func() {
+	It("Verify Foo Frontend canNOT call Bar Backend.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", fooHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.bar:8080/", fooHost)
@@ -386,7 +386,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	framework.VzIt("Verify Bar Frontend canNOT call Foo Backend.", func() {
+	It("Verify Bar Frontend canNOT call Foo Backend.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.foo:8080/", barHost)
@@ -399,7 +399,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// WHEN the component and appconfig with ingress trait are created
 	// THEN the frontend should be able to successfully call the backend and get a 200 on that invocation
 	// the http code is returned in the response body and captured in content
-	framework.VzIt("Verify Bar Frontend can call NoIstio Backend.", func() {
+	It("Verify Bar Frontend can call NoIstio Backend.", func() {
 		Eventually(func() (*pkg.HTTPResponse, error) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Ingress: %s", barHost))
 			url := fmt.Sprintf("https://%s/externalCall?inurl=http://springboot-backend-workload.noistio:8080/", barHost)
@@ -414,7 +414,7 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 	// the http code is returned in the response body and captured in content
 	// *** This call should fail for a 500 because Non-Istio can't call Istio when MTLS is STRICT
 	// If this should fail because the call succeeded, verify that peerauthentication exists in istio-system and is set to STRICT
-	framework.VzIt("Verify NoIstio Frontend canNOT call Bar Backend.", func() {
+	It("Verify NoIstio Frontend canNOT call Bar Backend.", func() {
 		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() bool {
@@ -448,29 +448,29 @@ var _ = framework.VzDescribe("Verify AuthPolicy Applications", func() {
 
 })
 
-var _ = framework.VzDescribe("Verify Auth Policy Prometheus Scrape Targets", func() {
+var _ = Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// Verify springboot-workload pod is running
 	// GIVEN springboot app is deployed
 	// WHEN the component and appconfig are created
 	// THEN the expected pod must be running in the test namespace
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(fooNamespace, expectedPodsFoo)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", fooNamespace))
 		})
 	})
 
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(barNamespace, expectedPodsBar)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", barNamespace))
 		})
 	})
 
-	framework.VzContext("Deployment.", func() {
-		framework.VzIt("and waiting for expected pods must be running", func() {
+	Context("Deployment.", func() {
+		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(noIstioNamespace, expectedPodsBar)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("Auth Policy Application failed to start in %s", noIstioNamespace))
@@ -481,7 +481,7 @@ var _ = framework.VzDescribe("Verify Auth Policy Prometheus Scrape Targets", fun
 	// GIVEN that springboot deployed to Istio namespace foo
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the https protocol
-	framework.VzIt("Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping.", func() {
+	It("Verify that Istio scrape target authpolicy-appconf_default_foo_springboot-frontend is using https for scraping.", func() {
 		Eventually(func() bool {
 			var httpsFound bool = false
 
@@ -519,7 +519,7 @@ var _ = framework.VzDescribe("Verify Auth Policy Prometheus Scrape Targets", fun
 	// GIVEN that springboot deployed to Istio namespace bar
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the https protocol
-	framework.VzIt("Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping.", func() {
+	It("Verify that Istio scrape target authpolicy-appconf_default_bar_springboot-frontend is using https for scraping.", func() {
 		Eventually(func() bool {
 			var httpsFound bool = false
 
@@ -557,7 +557,7 @@ var _ = framework.VzDescribe("Verify Auth Policy Prometheus Scrape Targets", fun
 	// GIVEN that springboot deployed to namespace noistio
 	// WHEN the Prometheus scrape targets are created
 	// THEN they should be created to use the http protocol
-	framework.VzIt("Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping.", func() {
+	It("Verify that Istio scrape target authpolicy-appconf_default_noistio_springboot-frontend is using http for scraping.", func() {
 		Eventually(func() bool {
 			var httpsNotFound bool = true
 


### PR DESCRIPTION
# Description

Introspect interface arguments and check that they are functions.  This begins to lay the groundwork for needing to do more extensive introspection of interfaces in ginkgo v2.

Undo framework changes from auth policy test to reduce the number of conflicts to address when we uptake ginkgo v2.

Fixes VZ-4021

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
