### PR TITLE
fail fast on 'pattern not matched' errors

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -380,20 +380,6 @@ var _ = Describe("Verify Bobs Books example application.", func() {
 			},
 			// GIVEN a WebLogic application with logging enabled
 			// WHEN the log records are retrieved from the Elasticsearch index
-			// THEN verify that no 'pattern not matched' log record of fluentd-stdout-sidecar is found
-			func() {
-				It("Verify recent 'pattern not matched' log records do not exist", func() {
-					Eventually(func() bool {
-						return pkg.FindLog(bobsIndexName,
-							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "message", Value: "pattern not matched"}},
-							[]pkg.Match{})
-					}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find No pattern not matched log records")
-				})
-			},
-			// GIVEN a WebLogic application with logging enabled
-			// WHEN the log records are retrieved from the Elasticsearch index
 			// THEN verify that a recent log record of bobbys-front-end-managed-server log file is found
 			func() {
 				It("Verify recent bobbys-front-end-managed-server1 log record exists", func() {
@@ -446,6 +432,16 @@ var _ = Describe("Verify Bobs Books example application.", func() {
 				})
 			},
 		)
+		// GIVEN a WebLogic application with logging enabled
+		// WHEN the log records are retrieved from the Elasticsearch index
+		// THEN verify that no 'pattern not matched' log record of fluentd-stdout-sidecar is found
+		It("Verify recent 'pattern not matched' log records do not exist", func() {
+			Expect(pkg.NoLog(bobsIndexName,
+				[]pkg.Match{
+					{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+					{Key: "message", Value: "pattern not matched"}},
+				[]pkg.Match{})).To(BeTrue())
+		})
 		pkg.Concurrently(
 			// GIVEN a WebLogic application with logging enabled
 			// WHEN the log records are retrieved from the Elasticsearch index


### PR DESCRIPTION
# Description

improve test to fail fast when the 'pattern not matched' log is found; using Eventually unnecessarily add 20min timeout to the failure. 

Fixes VZ-3631

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
