### PR TITLE
Component retryable errors for install/upgrade

### DIFF
--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -110,6 +110,7 @@ type KeyValue struct {
 	Key       string
 	Value     string
 	SetString bool
+	IsFile    bool
 }
 
 // Create a new bom from a JSON file

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package spi
+
+import (
+	"fmt"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"strings"
+)
+
+// RetryableError an error that can be used to indicate to a controller that a requeue is needed, with an optional custom result
+type RetryableError struct {
+	// The source of the error
+	Source string
+	// The operation type
+	Operation string
+	// The root cause error
+	Cause error
+	// An optional Result type to return to the controllerruntime
+	Result controllerruntime.Result
+}
+
+// HasCause indicates whether or not the error has a root cause
+func (r RetryableError) HasCause() bool {
+	return r.Cause != nil
+}
+
+var _ error = RetryableError{}
+
+// Error implements the basic Go error contract
+func (r RetryableError) Error() string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Retryable error for operation %s on source %s", r.Operation, r.Source))
+	if r.Cause != nil {
+		builder.WriteString(fmt.Sprintf(", cause %s", r.Cause))
+	}
+	if !r.Result.IsZero() {
+		builder.WriteString(fmt.Sprintf(", result: {requeue: %v, requeueAfter: %s}", r.Result.Requeue, r.Result.RequeueAfter))
+	}
+	return builder.String()
+}

--- a/pkg/controller/errors/errors_test.go
+++ b/pkg/controller/errors/errors_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package spi
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"testing"
+	"time"
+)
+
+// TestRetryableError Tests RetryableError
+// GIVEN a RetryableError
+// THEN the error is properly created and the Error() message returns the proper values
+func TestRetryableError(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		err         RetryableError
+	}{
+		{
+			name:        "EmptyError",
+			description: "Retryable error with nothing provided",
+			err:         RetryableError{},
+		},
+		{
+			name:        "SourceOnly",
+			description: "Retryable error with only a source",
+			err: RetryableError{
+				Source: "mySource",
+			},
+		},
+		{
+			name:        "SourceAndOp",
+			description: "Retryable error with a source and an operation",
+			err: RetryableError{
+				Source:    "mySource",
+				Operation: "myOp",
+			},
+		},
+		{
+			name:        "SourceAndOpAndCause",
+			description: "Retryable error with a source, an op, and a cause",
+			err: RetryableError{
+				Source:    "mySource",
+				Operation: "myOp",
+				Cause:     fmt.Errorf("Custom error"),
+			},
+		},
+		{
+			name:        "SourceAndOpAndCauseAndResult",
+			description: "Retryable error with a source, an op, a cause, and a Result",
+			err: RetryableError{
+				Source:    "mySource",
+				Operation: "myOp",
+				Cause:     fmt.Errorf("Custom error"),
+				Result: controllerruntime.Result{
+					Requeue:      true,
+					RequeueAfter: time.Second * 30,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		assert := assert.New(t)
+
+		t.Log(test.description)
+
+		err := test.err
+		t.Logf("Error message: %s", err)
+
+		if len(err.Operation) > 0 {
+			assert.Contains(err.Error(), err.Source, "Source not found in message")
+		}
+		if len(err.Operation) > 0 {
+			assert.Contains(err.Error(), err.Operation, "Operation not found in message")
+		}
+		if err.Cause != nil {
+			assert.True(err.HasCause(), "HasCause should return true")
+			assert.Contains(err.Error(), err.Cause.Error())
+		} else {
+			assert.False(err.HasCause(), "HasCause should return false")
+		}
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -7,9 +7,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	ctrlerrrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -19,12 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
-	"text/template"
 )
 
 const (
@@ -100,16 +103,21 @@ func (c certManagerComponent) PreInstall(compContext spi.ComponentContext) error
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &ns, func() error {
 		return nil
 	}); err != nil {
-		compContext.Log().Errorf("Failed to create or update the cert-manager namespace: %s", err)
-		return err
+		return ctrlerrrors.RetryableError{
+			Source: c.Name(),
+			Cause:  fmt.Errorf("Failed to create or update the cert-manager namespace: %s", err),
+		}
 	}
 
 	// Apply the cert-manager manifest, patching if needed
 	compContext.Log().Info("Applying cert-manager crds")
-	err := c.ApplyManifest(compContext)
+	err := c.applyManifest(compContext)
 	if err != nil {
 		compContext.Log().Errorf("Failed to apply the cert-manager manifest: %s", err)
-		return err
+		return ctrlerrrors.RetryableError{
+			Source: c.Name(),
+			Cause:  fmt.Errorf("Failed to apply the cert-manager manifest: %s", err),
+		}
 	}
 	return nil
 }
@@ -127,28 +135,32 @@ func (c certManagerComponent) PostInstall(compContext spi.ComponentContext) erro
 	isCAValue, err := isCA(compContext)
 	if err != nil {
 		compContext.Log().Errorf("Failed to verify the config type: %s", err)
-		return err
+		return ctrlerrrors.RetryableError{Source: c.Name()}
 	}
 	if !isCAValue {
 		// Create resources needed for Acme certificates
 		err := createAcmeResources(compContext)
 		if err != nil {
-			compContext.Log().Errorf("Failed creating Acme resources: %s", err)
-			return err
+			return ctrlerrrors.RetryableError{
+				Source: c.Name(),
+				Cause:  fmt.Errorf("Failed creating Acme resources: %s", err),
+			}
 		}
 	} else {
 		// Create resources needed for CA certificates
 		err := createCAResources(compContext)
 		if err != nil {
-			compContext.Log().Errorf("Failed creating CA resources: %s", err)
-			return err
+			return ctrlerrrors.RetryableError{
+				Source: c.Name(),
+				Cause:  fmt.Errorf("Failed creating CA resources: %s", err),
+			}
 		}
 	}
 	return nil
 }
 
-// ApplyManifest uses the patch file to patch the cert manager manifest and apply it to the cluster
-func (c certManagerComponent) ApplyManifest(compContext spi.ComponentContext) error {
+// applyManifest uses the patch file to patch the cert manager manifest and apply it to the cluster
+func (c certManagerComponent) applyManifest(compContext spi.ComponentContext) error {
 	// find the script location
 	script := filepath.Join(config.GetInstallDir(), "apply-cert-manager-manifest.sh")
 
@@ -157,15 +169,19 @@ func (c certManagerComponent) ApplyManifest(compContext spi.ComponentContext) er
 		compContext.Log().Info("Patch cert-manager crds to use OCI DNS")
 		err := os.Setenv("DNS_TYPE", "oci")
 		if err != nil {
-			compContext.Log().Errorf("Could not set DNS_TYPE environment variable: %s", err)
-			return err
+			return ctrlerrrors.RetryableError{
+				Source: c.Name(),
+				Cause:  fmt.Errorf("Could not set DNS_TYPE environment variable: %s", err),
+			}
 		}
 	}
 
 	// Call and execute script for the given DNS type
 	if _, stderr, err := bashFunc(script); err != nil {
-		compContext.Log().Errorf("Failed to apply the cert-manager manifest %s: %s", err, stderr)
-		return err
+		return ctrlerrrors.RetryableError{
+			Source: c.Name(),
+			Cause:  fmt.Errorf("Failed to apply the cert-manager manifest %s: %s", err, stderr),
+		}
 	}
 	return nil
 }
@@ -185,7 +201,7 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 	isCAValue, err := isCA(compContext)
 	if err != nil {
 		compContext.Log().Errorf("Failed to verify the config type: %s", err)
-		return []bom.KeyValue{}, err
+		return []bom.KeyValue{}, ctrlerrrors.RetryableError{Source: ComponentName}
 	}
 	if isCAValue {
 		kvs = append(kvs, bom.KeyValue{Key: "clusterResourceNamespace", Value: namespace})
@@ -245,8 +261,7 @@ func createAcmeResources(compContext spi.ComponentContext) error {
 	// Verify that the secret exists
 	secret := v1.Secret{}
 	if err := compContext.Client().Get(context.TODO(), client.ObjectKey{Name: ociDNSConfigSecret, Namespace: namespace}, &secret); err != nil {
-		compContext.Log().Errorf("Failed to retireve the OCI DNS config secret: %s", err)
-		return err
+		return fmt.Errorf("Failed to retireve the OCI DNS config secret: %s", err)
 	}
 
 	// Verify the acme environment and set the server
@@ -267,22 +282,19 @@ func createAcmeResources(compContext spi.ComponentContext) error {
 	// Parse the template string and create the template object
 	template, err := template.New("clusterIssuer").Parse(clusterIssuerTemplate)
 	if err != nil {
-		compContext.Log().Errorf("Failed to parse the ClusterIssuer yaml template: %s", err)
-		return err
+		return fmt.Errorf("Failed to parse the ClusterIssuer yaml template: %s", err)
 	}
 
 	// Execute the template object with the given data
 	err = template.Execute(&buff, &clusterIssuerData)
 	if err != nil {
-		compContext.Log().Errorf("Failed to execute the ClusterIssuer template: %s", err)
-		return err
+		return fmt.Errorf("Failed to execute the ClusterIssuer template: %s", err)
 	}
 
 	// Create an unstructured object from the template output
 	ciObject := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	if err := yaml.Unmarshal(buff.Bytes(), ciObject); err != nil {
-		compContext.Log().Errorf("Unable to unmarshal yaml: %s", err)
-		return err
+		return fmt.Errorf("Unable to unmarshal yaml: %s", err)
 	}
 
 	// Update or create the unstructured object
@@ -290,8 +302,7 @@ func createAcmeResources(compContext spi.ComponentContext) error {
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), ciObject, func() error {
 		return nil
 	}); err != nil {
-		compContext.Log().Errorf("Failed to create or update the ClusterIssuer: %s", err)
-		return err
+		return fmt.Errorf("Failed to create or update the ClusterIssuer: %s", err)
 	}
 	return nil
 }
@@ -315,8 +326,7 @@ func createCAResources(compContext spi.ComponentContext) error {
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &issuer, func() error {
 		return nil
 	}); err != nil {
-		compContext.Log().Errorf("Failed to create or update the Issuer: %s", err)
-		return err
+		return fmt.Errorf("Failed to create or update the Issuer: %s", err)
 	}
 
 	// Create the certificate resource for CA cert
@@ -339,8 +349,7 @@ func createCAResources(compContext spi.ComponentContext) error {
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &certObject, func() error {
 		return nil
 	}); err != nil {
-		compContext.Log().Errorf("Failed to create or update the Certificate: %s", err)
-		return err
+		return fmt.Errorf("Failed to create or update the Certificate: %s", err)
 	}
 
 	// Create the cluster issuer resource for CA cert
@@ -360,8 +369,7 @@ func createCAResources(compContext spi.ComponentContext) error {
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &clusterIssuer, func() error {
 		return nil
 	}); err != nil {
-		compContext.Log().Errorf("Failed to create or update the ClusterIssuer: %s", err)
-		return err
+		return fmt.Errorf("Failed to create or update the ClusterIssuer: %s", err)
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -18,6 +18,8 @@ const (
 	baseProfile = "base"
 )
 
+var _ ComponentContext = componentContext{}
+
 // NewContext creates a ComponentContext from a raw CR
 func NewContext(log *zap.SugaredLogger, c clipkg.Client, actualCR *vzapi.Verrazzano, dryRun bool) (ComponentContext, error) {
 	// Generate the effective CR based ond the declared profile and any overrides in the user-supplied one

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
@@ -33,6 +33,10 @@ func init() {
 	// +kubebuilder:scaffold:testScheme
 }
 
+// TestContextProfilesMerge Tests the profiles context merge
+// GIVEN a Verrazzano instance with a profile
+// WHEN I call NewContext
+// THEN the correct correct context is created with the proper merge of the profile and user overrides
 func TestContextProfilesMerge(t *testing.T) {
 	config.TestProfilesDir = "../../../../manifests/profiles"
 	defer func() { config.TestProfilesDir = "" }()


### PR DESCRIPTION
# Description

Creates a custom error type to be returned from `spi.Component` to indicate to the controller that it should requeue, and is a non-fatal event. 

Also, adds support to `bom.KeyValue` and `HelmComponent` to allow a component to specify a custom helm file override.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
