### PR TITLE
VZ-3988: Build elasticsearch from source and clear of vulnerabilities.

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -212,8 +212,8 @@
               "helmFullImageKey": "monitoringOperator.prometheusImage"
             },
             {
-              "image": "elasticsearch-jenkins",
-              "tag": "20211110213241-e9690db0455",
+              "image": "elasticsearch",
+              "tag": "7.10.2-20211111000022-a865f813d61",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch-jenkins",
-              "tag": "20211109211809-4fc6e65f699",
+              "tag": "20211110002011-4b91f2bf930",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch",
-              "tag": "7.10.2-20211111000022-a865f813d61",
+              "tag": "7.10.2-20211118212642-8549e32c",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch-jenkins",
-              "tag": "20211104163200-eb2beea",
+              "tag": "20211108233144-46a2a58ae22",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch-jenkins",
-              "tag": "20211110002011-4b91f2bf930",
+              "tag": "20211110213241-e9690db0455",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch",
-              "tag": "7.6.1-20211019200525-4786a7f",
+              "tag": "ghcr.io/verrazzano/elasticsearch-jenkins:20211104152034-eb2beea",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch-jenkins",
-              "tag": "20211108233144-46a2a58ae22",
+              "tag": "20211109211809-4fc6e65f699",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch",
-              "tag": "ghcr.io/verrazzano/elasticsearch-jenkins:20211104152034-eb2beea",
+              "tag": "ghcr.io/verrazzano/elasticsearch-jenkins:20211104163200-eb2beea",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -212,8 +212,8 @@
               "helmFullImageKey": "monitoringOperator.prometheusImage"
             },
             {
-              "image": "elasticsearch",
-              "tag": "ghcr.io/verrazzano/elasticsearch-jenkins:20211104163200-eb2beea",
+              "image": "elasticsearch-jenkins",
+              "tag": "20211104163200-eb2beea",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {


### PR DESCRIPTION
# Description

Uptakes the new Elastic search 7.10.2 image built from source.

Fixes VZ-3988: Build elasticsearch from source and clear of vulnerabilities.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
