### PR TITLE
VZ-3985 upgrade test

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -544,7 +544,7 @@ pipeline {
                 }
                 stage('verify-upgrade post-upgrade') {
                     steps {
-                        runGinkgoRandomize('verify-upgrade/postupgrade')
+                        runGinkgoRandomize('upgrade/post-upgrade/verify')
                     }
                 }
                 stage('examples socks') {

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -303,11 +303,11 @@ func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 	// Every pod with istio enabled must containe the Envoy sidecar
 	for _, pod := range pods.Items {
 		// skip if istio sidecar disabled
-		v, ok := pod.Labels["sidecar.istio.io/inject"]
+		v := pod.Labels["sidecar.istio.io/inject"]
 		if v == "false" {
 			continue
 		}
-		_, ok = pod.Labels["istio.io/rev"]
+		_, ok := pod.Labels["istio.io/rev"]
 		if ok {
 			containers := pod.Spec.Containers
 			found := false

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -296,6 +296,10 @@ func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 		Log(Error, fmt.Sprintf("Error listing pods in cluster for namespace: %s, error: %v", namespace, err))
 		return false
 	}
+	if len(pods.Items) == 0 {
+		Log(Info, fmt.Sprintf("No pods in namespace: %s", namespace))
+		return false
+	}
 	// Every pod with istio enabled must containe the Envoy sidecar
 	for _, pod := range pods.Items {
 		// skip if istio sidecar disabled

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -284,7 +284,8 @@ func PodsHaveAnnotation(namespace string, annotation string) bool {
 	return true
 }
 
-func CheckPodsForIstioImage(namespace string) bool {
+// CheckPodsForEnvoySidecar checks if a pods which have Envoy sidecars, have the specified image
+func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 	clientset, err := k8sutil.GetKubernetesClientset()
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error getting clientset, error: %v", err))
@@ -312,7 +313,6 @@ func CheckPodsForIstioImage(namespace string) bool {
 				return false
 			}
 		}
-
 	}
 	return true
 }

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -297,7 +297,7 @@ func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 		return false
 	}
 	if len(pods.Items) == 0 {
-		Log(Info, fmt.Sprintf("No pods in namespace: %s", namespace))
+		Log(Info, fmt.Sprintf("No pods in namespace: %s, error: %v", namespace, err))
 		return false
 	}
 	// Every pod with istio enabled must containe the Envoy sidecar
@@ -308,21 +308,19 @@ func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 			continue
 		}
 		_, ok = pod.Labels["istio.io/rev"]
-		if !ok {
-			Log(Error, fmt.Sprintf("Pod %s is missing label istio.io/rev %s", pod.Name))
-			return false
-		}
-		containers := pod.Spec.Containers
-		found := false
-		for _, container := range containers {
-			if strings.Contains(container.Image, "proxyv2:1.10") {
-				found = true
-				break
+		if ok {
+			containers := pod.Spec.Containers
+			found := false
+			for _, container := range containers {
+				if strings.Contains(container.Image, "proxyv2:1.10") {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			Log(Error, fmt.Sprintf("No istio proxy image found in pod %s", pod.Name))
-			return false
+			if !found {
+				Log(Error, fmt.Sprintf("No istio proxy image found in pod %s", pod.Name))
+				return false
+			}
 		}
 	}
 	return true

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package postupgrade
+package verify
 
 import (
 	"fmt"

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package postupgrade
+package verify
 
 import (
 	"fmt"


### PR DESCRIPTION
Add an e2e test to ensure that the application pods contain the Envoy 1.104 sidecar post-upgrade.  This proves that the applications were restarted and contain the new version of Envoy.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
