### PR TITLE
Fix multi-cluster todo-list mysql deployment yaml

### DIFF
--- a/examples/multicluster/todo-list/todo-list-components.yaml
+++ b/examples/multicluster/todo-list/todo-list-components.yaml
@@ -175,14 +175,17 @@ spec:
               image: ghcr.io/verrazzano/mysql:8.0.26
               imagePullPolicy: IfNotPresent
               name: mysql
-              protocol: TCP
-          volumeMounts:
-            - mountPath: /docker-entrypoint-initdb.d
+              ports:
+                - containerPort: 3306
+                  name: mysql
+                  protocol: TCP
+              volumeMounts:
+                - mountPath: /docker-entrypoint-initdb.d
+                  name: mysql-initdb
+          imagePullSecrets:
+            - name: ocr
+          volumes:
+            - configMap:
+                defaultMode: 420
+                name: mysql-initdb-config
               name: mysql-initdb
-      imagePullSecrets:
-        - name: ocr
-      volumes:
-        - configMap:
-            defaultMode: 420
-            name: mysql-initdb-config
-          name: mysql-initdb


### PR DESCRIPTION
# Description

This pull request changes the multicluster todo-list yaml for deploying mysql.  Changed the container port info to match the non-multicluster flavor and fixed some indentation.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
