### PR TITLE
Change image pull keyname to match cert-manager chart

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -31,7 +31,7 @@ func NewComponent() spi.Component {
 			ChartNamespace:          ComponentName,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
+			ImagePullSecretKeyname:  "global.imagePullSecrets[0].name",
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "cert-manager-values.yaml"),
 			AppendOverridesFunc:     AppendOverrides,
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_0_0,

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -7,7 +7,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"path/filepath"
 )
@@ -32,7 +31,7 @@ func NewComponent() spi.Component {
 			ChartNamespace:          ComponentName,
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
+			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "cert-manager-values.yaml"),
 			AppendOverridesFunc:     AppendOverrides,
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_0_0,


### PR DESCRIPTION
# Description

Override key name of image to match the cert-manager chart.

Fixes VZ-3936

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
