### PR TITLE
VZ-3173 : fixing vz Uninstall log shows error

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -97,7 +97,7 @@ function finalize() {
   # Grab all leftover Helm repos and delete resources
   log "Deleting Helm repos"
   local helm_ls
-  helm_ls=$(helm repo ls)
+  helm_ls=$(helm repo ls >/dev/null 2>&1)
   if [ $? -eq 0 ]; then
     echo "$helm_ls" \
       | awk '/istio.io|stable|jetstack|rancher-stable|codecentric/ {print $1}' \


### PR DESCRIPTION
# Description

During Verrazzano Uninstallation Steps, there is an error message comes "Error: no repositories to show "
The "Error: no repositories to show" is likely to confuse customers even though we don't think anything was left behind.

This PR basically a fix for the same.

[2021-07-27 17:42:01 UTC] Finalizing Uninstall                                                         [ .... ]
[2021-07-27 17:42:01 UTC] 2021-07-27 17:42:01 UTC Removing Verrazzano ClusterRoles and ClusterRoleBindings
[2021-07-27 17:42:02 UTC] 2021-07-27 17:42:02 UTC Deleting Helm repos
[2021-07-27 17:42:02 UTC] WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/verrazzano/kubeconfig
[2021-07-27 17:42:02 UTC] WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/verrazzano/kubeconfig
[2021-07-27 17:42:02 UTC] Error: no repositories to show  

 

Fixes VZ-3173

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
