### PR TITLE
VZ-4134 Fix registration of a managed cluster when using LetsEncrypt staging certs

### DIFF
--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -101,16 +101,13 @@ func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, lo
 	}
 	rc.certificateAuthorityData = caCert
 
-	log.Infof("Checking for Rancher additional CA in secret %s", rancherTLSAdditional)
+	log.Debugf("Checking for Rancher additional CA in secret %s", rancherTLSAdditional)
 	additionalCA, err := getAdditionalCA(rdr)
 	if err != nil {
 		log.Errorf("Unable to check Rancher for additional CA: %v", err)
 		return "", err
 	}
 	rc.additionalCA = additionalCA
-	if len(additionalCA) > 0 {
-		log.Infof("Additional CA content found - %s", string(additionalCA))
-	}
 
 	log.Debug("Getting admin token from Rancher")
 	adminToken, err := getAdminTokenFromRancher(rdr, rc, log)
@@ -302,7 +299,7 @@ func getAdminSecret(rdr client.Reader) (string, error) {
 	return string(secret.Data["password"]), nil
 }
 
-// getAdditionalCA fetches the Rancher admin secret
+// getAdditionalCA fetches the Rancher additional CA secret
 func getAdditionalCA(rdr client.Reader) ([]byte, error) {
 	secret := &corev1.Secret{}
 	nsName := types.NamespacedName{

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1502,7 +1502,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockStatus *mocks.
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetManifestSecretName(name)}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoMultiClusterNamespace, Resource: "Secret"}, GetManifestSecretName(name)))
 
-	// Expect all of the calls needed to register the cluster with Rancher
+	// Expect all the calls needed to register the cluster with Rancher
 	expectRegisterClusterWithRancher(t, mock, mockRequestSender, name, clusterAlreadyRegistered)
 
 	mock.EXPECT().Status().Return(mockStatus)
@@ -1658,6 +1658,11 @@ func expectRegisterClusterWithRancherK8sCalls(t *testing.T, k8sMock *mocks.MockC
 			}
 			return nil
 		})
+
+	// Expect a call to get the Rancher additional CA secret
+	k8sMock.EXPECT().
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherTLSAdditional}), gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: rancherNamespace, Resource: "Secret"}, rancherTLSAdditional))
 }
 
 // expectRegisterClusterWithRancherHTTPCalls asserts all of the expected calls on the HTTP client mock


### PR DESCRIPTION
# Description

Fix registration of a managed cluster when using LetsEncrypt staging certs.  If additional CA certs are present on the system, use them for the platform-operator to connect to Rancher in order to register a managed cluster.

Fixes VZ-4134

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
