### PR TITLE
JIRA:VZ-3961 remove unstable tag from verify-infra restapi tests

### DIFF
--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package restapi_test
 
 import (

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package restapi_test
 
 import (

--- a/tests/e2e/verify-infra/restapi/vmi_urls_test.go
+++ b/tests/e2e/verify-infra/restapi/vmi_urls_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package restapi_test
 
 import (


### PR DESCRIPTION
# Description

Removed the unstable tag from verify-infra restate suite since the new go-based rancher installation merge seems to have resolved the issue.

Fixes VZ-3961

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
