### PR TITLE
VZ-4093: Fix bug in verify-scripts AT and simplify

### DIFF
--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -467,7 +467,7 @@ pipeline {
 def generateVerifyInfraStages(dumpRoot) {
     return [
         "verify-scripts": {
-            runGinkgo('scripts', '', ${KUBECONFIG}")
+            runGinkgo('scripts', '', "${KUBECONFIG}")
         },
         "verify-infra restapi": {
             runGinkgoRandomize('verify-infra/restapi', "${dumpRoot}/verify-infra-restapi")

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -467,7 +467,7 @@ pipeline {
 def generateVerifyInfraStages(dumpRoot) {
     return [
         "verify-scripts": {
-            runGinkgo('scripts', "${KUBECONFIG}")
+            runGinkgo('scripts', '', ${KUBECONFIG}")
         },
         "verify-infra restapi": {
             runGinkgoRandomize('verify-infra/restapi', "${dumpRoot}/verify-infra-restapi")
@@ -564,11 +564,14 @@ def runGinkgoRandomize(testSuitePath, dumpDir = '') {
     }
 }
 
-def runGinkgo(testSuitePath, dumpDir = '') {
+def runGinkgo(testSuitePath, dumpDir = '', kubeConfig = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             if [ ! -z "${dumpDir}" ]; then
                 export DUMP_DIRECTORY=${dumpDir}
+            fi
+            if [ ! -z "${kubeConfig}" ]; then
+                export KUBECONFIG="${kubeConfig}"
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -467,7 +467,7 @@ pipeline {
 def generateVerifyInfraStages(dumpRoot) {
     return [
         "verify-scripts": {
-            runGinkgo('scripts')
+            runGinkgo('scripts', "${KUBECONFIG}")
         },
         "verify-infra restapi": {
             runGinkgoRandomize('verify-infra/restapi', "${dumpRoot}/verify-infra-restapi")

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -282,7 +282,7 @@ pipeline {
                     parallel {
                         stage('verify-scripts') {
                             steps {
-                                runGinkgo('scripts', "${KUBECONFIG}")
+                                runGinkgoWithKubeConfig('scripts', "${KUBECONFIG}")
                             }
                         }
                         stage('verify-infra restapi') {
@@ -577,6 +577,16 @@ def runGinkgo(testSuitePath) {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v -keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+        """
+    }
+}
+
+def runGinkgoWithKubeConfig(testSuitePath, kubeConfig) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            export KUBECONFIG="${kubeConfig}"
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo  -p --randomize-all -v -keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -282,7 +282,7 @@ pipeline {
                     parallel {
                         stage('verify-scripts') {
                             steps {
-                                runGinkgo('scripts')
+                                runGinkgo('scripts', "${KUBECONFIG}")
                             }
                         }
                         stage('verify-infra restapi') {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -282,7 +282,7 @@ pipeline {
                     parallel {
                         stage('verify-scripts') {
                             steps {
-                                runGinkgoWithKubeConfig('scripts', "${KUBECONFIG}")
+                                runGinkgoRandomize('scripts', "${KUBECONFIG}")
                             }
                         }
                         stage('verify-infra restapi') {
@@ -554,9 +554,12 @@ pipeline {
     }
 }
 
-def runGinkgoRandomize(testSuitePath) {
+def runGinkgoRandomize(testSuitePath, kubeConfig = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
+            if [ ! -z "${kubeConfig}" ]; then
+                export KUBECONFIG="${kubeConfig}"
+            fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
@@ -577,16 +580,6 @@ def runGinkgo(testSuitePath) {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v -keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
-        """
-    }
-}
-
-def runGinkgoWithKubeConfig(testSuitePath, kubeConfig) {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        sh """
-            export KUBECONFIG="${kubeConfig}"
-            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo  -p --randomize-all -v -keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -420,7 +420,7 @@ pipeline {
                         }
                         stage('verify-scripts') {
                             steps {
-                                runGinkgo('scripts', "${ADMIN_KUBECONFIG}", "${params.TOTAL_CLUSTERS}")
+                                runGinkgoRandomize('scripts')
                             }
                         }
                         stage('verify-infra restapi') {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1102,18 +1102,6 @@ def runGinkgoRandomize(testSuitePath) {
     }
 }
 
-// Run a test suite using a given kube configuration against all clusters
-def runGinkgo(testSuitePath, kubeConfig, clusterCount) {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        sh """
-            export KUBECONFIG="${kubeConfig}"
-            export CLUSTER_COUNT="${clusterCount}"
-            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
-        """
-    }
-}
-
 // Configure the Admin and Managed cluster installer custom resources
 def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript, String... extraArgs) {
     script {

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -23,34 +21,17 @@ const (
 )
 
 var kubeConfigFromEnv = os.Getenv("KUBECONFIG")
-var totalClusters, present = os.LookupEnv("CLUSTER_COUNT")
 
 // This test checks that the Verrazzano install resource has the expected console URLs.
 var _ = Describe("Verify Verrazzano install scripts", func() {
 
 	Context("Verify Console URLs in the installed Verrazzano resource", func() {
-		clusterCount, _ := strconv.Atoi(totalClusters)
-		if present && clusterCount > 0 {
-			It("Verify the expected console URLs are there in the installed Verrazzano resource for the managed cluster(s)", func() {
-				// Validation for admin cluster
-				Eventually(func() bool {
-					return validateConsoleUrlsCluster(kubeConfigFromEnv)
-				}, waitTimeout, pollingInterval).Should(BeTrue())
-
-				// Validation for managed clusters
-				for i := 2; i <= clusterCount; i++ {
-					Eventually(func() bool {
-						return validateConsoleUrlsCluster(strings.Replace(kubeConfigFromEnv, "1", strconv.Itoa(i), 1))
-					}, waitTimeout, pollingInterval).Should(BeTrue())
-				}
-			})
-		} else {
-			It("Verify the expected console URLs are there in the installed Verrazzano resource", func() {
-				Eventually(func() bool {
-					return validateConsoleUrlsCluster(kubeConfigFromEnv)
-				}, waitTimeout, pollingInterval).Should(BeTrue())
-			})
-		}
+		It("Verify the expected console URLs are there in the installed Verrazzano resource", func() {
+			// Validation for passed in cluster
+			Eventually(func() bool {
+				return validateConsoleUrlsCluster(kubeConfigFromEnv)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+		})
 	})
 })
 


### PR DESCRIPTION
# Description

This pull request fixes the verify-scripts AT to run against a single kubeconfig instead of having logic for both multi-cluster and single cluster installs.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
