### PR TITLE
Update base profile storage definition to rely on chart defaults

### DIFF
--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -7,7 +7,6 @@ spec:
   environmentName: default
   defaultVolumeSource:
     emptyDir: {}
-  volumeClaimSpecTemplates: []
   components:
     certManager:
       certificate:
@@ -42,9 +41,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          emptyDir: {}
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   profile: "managed-cluster"
   environmentName: default
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -40,10 +30,6 @@ spec:
       enabled: false
     keycloak:
       enabled: false
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: false
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   profile: "prod"
   environmentName: default
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -40,10 +30,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -7,7 +7,6 @@ spec:
   environmentName: default
   defaultVolumeSource:
     emptyDir: {}
-  volumeClaimSpecTemplates: []
   components:
     certManager:
       certificate:
@@ -42,9 +41,6 @@ spec:
       enabled: false
     keycloak:
       enabled: false
-      mysql:
-        volumeSource:
-          emptyDir: {}
     kibana:
       enabled: false
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -7,7 +7,6 @@ spec:
   environmentName: default
   defaultVolumeSource:
     emptyDir: {}
-  volumeClaimSpecTemplates: []
   components:
     certManager:
       certificate:
@@ -43,9 +42,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          emptyDir: {}
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -49,9 +49,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          emptyDir: {}
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -7,7 +7,6 @@ spec:
   environmentName: default
   defaultVolumeSource:
     emptyDir: {}
-  volumeClaimSpecTemplates: []
   components:
     certManager:
       certificate:
@@ -45,9 +44,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          emptyDir: {}
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   profile: "managed-cluster"
   environmentName: default
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -40,10 +30,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -53,10 +53,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   profile: "prod"
   environmentName: prodenv
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -47,10 +37,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   profile: "prod"
   environmentName: prodenv
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -72,10 +62,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/manifests/profiles/base.yaml
+++ b/platform-operator/manifests/profiles/base.yaml
@@ -2,16 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 spec:
   environmentName: default
-  defaultVolumeSource:
-    persistentVolumeClaim:
-      claimName: default-storage
-  volumeClaimSpecTemplates:
-    - metadata:
-        name: default-storage
-      spec:
-        resources:
-          requests:
-            storage: 50Gi
   components:
     certManager:
       certificate:
@@ -37,10 +27,6 @@ spec:
       enabled: true
     keycloak:
       enabled: true
-      mysql:
-        volumeSource:
-          persistentVolumeClaim:
-            claimName: default-storage
     kibana:
       enabled: true
     prometheus:

--- a/platform-operator/manifests/profiles/dev.yaml
+++ b/platform-operator/manifests/profiles/dev.yaml
@@ -14,8 +14,3 @@ spec:
           value: "0"
         - name: nodes.data.replicas
           value: "0"
-    keycloak:
-      mysql:
-        volumeSource:
-          emptyDir: {}
-  volumeClaimSpecTemplates: []


### PR DESCRIPTION
# Description

Initially the in-operator profile definitions in `platform-operator/manifests/profiles` defined the storage values in the profile yamls themselves; i.e., the defaults for `prod` profile were defined in `base.yaml` and overridden where necessary.  However, how we do the yaml merges to produce the effective CR might make it difficult to do overrides as we currently document it.

For example, the defaults for MySQL are 8G, and for the VMI stack is 50G.  If I define those in the profile yamls, I would have to add a `defaultVolumeSource` of 50G an override for MySQL of 8G to match the current chart defaults in the profiles.  

```
spec:
  defaultVolumeSource:
      claimName: default
  volumeClaimSpecTemplates:
    - metadata:
        name: default-storage
      spec:
        resources:
          requests:
            storage: 50Gi
    - metadata:
        name: default-mysql
      spec:
        resources:
          requests:
            storage: 8Gi
  components:
     keycloak:
         mysql:
             volumeSource:
                claimName: default-mysql
```

If a user later defines a CR that only defines a `defaultVolumeSource` of 100G, and expects that to be the value for MySQL as well, it will fail unexpectedly as the inherited profile value of 8G will still be in effect transparently to the user, and effectively look like this:

```
spec:
  defaultVolumeSource:
      claimName: storageoverride
  volumeClaimSpecTemplates:
    - metadata:
        name: storageoverride
      spec:
        resources:
          requests:
            storage: 100Gi
    - metadata:
        name: default-storage
      spec:
        resources:
          requests:
            storage: 50Gi
    - metadata:
        name: default-mysql
      spec:
        resources:
          requests:
            storage: 8Gi
  components:
     keycloak:
         mysql:
             volumeSource:
                claimName: default-mysql
```

The solution here for now to preserve expected volume override behavior is to remove storage definitions from the profile yamls to allow values to drop through to the chart defaults.  The `dev` profile does define an `emptyDir` override for `defaultVolumeSource`, but that is easily overridden by the user and will not impact expected storage override behavior; i.e., if the user defines `defaultVolumeSource` to be something else, then it will replace the profile value and behave as expected.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
