### PR TITLE
VZ-2528: Elasticsearch number of replicas wrong after upgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -32,7 +32,6 @@ const containerName = "es-master"
 const portName = "http"
 const indexPattern = "verrazzano-*"
 
-
 var execCommand = exec.Command
 
 // ResolveVerrazzanoNamespace will return the default Verrazzano system namespace unless the namespace
@@ -150,7 +149,7 @@ func AppendOverrides(_ spi.ComponentContext, _ string, _ string, _ string, kvs [
 // fixupElasticSearchReplicaCount fixes the replica count set for single node Elasticsearch cluster
 func fixupElasticSearchReplicaCount(ctx spi.ComponentContext, namespace string) error {
 	// Only apply this fix to clusters with Elasticsearch enabled.
-	if *ctx.EffectiveCR().Spec.Components.Elasticsearch.Enabled {
+	if !*ctx.EffectiveCR().Spec.Components.Elasticsearch.Enabled {
 		ctx.Log().Info("Elasticsearch Post Upgrade: Replica count update unnecessary on managed cluster.")
 		return nil
 	}
@@ -176,7 +175,7 @@ func fixupElasticSearchReplicaCount(ctx spi.ComponentContext, namespace string) 
 		ctx.Log().Errorf("Elasticsearch Post Upgrade: Error getting the Elasticsearch pods: %s", err)
 		return err
 	}
-	if len(pods)==0 {
+	if len(pods) == 0 {
 		err := fmt.Errorf("no pods found")
 		ctx.Log().Errorf("Elasticsearch Post Upgrade: Failed to find Elasticsearch pods: %s", err)
 		return err
@@ -235,7 +234,7 @@ func getNamedContainerPortOfContainer(pod corev1.Pod, containerName string, port
 	return -1, fmt.Errorf("no port named %s found in container %s of pod %s", portName, containerName, pod.Name)
 }
 
-func getPodsWithReadyContainer(client clipkg.Client, containerName string, podSelectors... clipkg.ListOption) ([]corev1.Pod, error) {
+func getPodsWithReadyContainer(client clipkg.Client, containerName string, podSelectors ...clipkg.ListOption) ([]corev1.Pod, error) {
 	pods := []corev1.Pod{}
 	list := &corev1.PodList{}
 	err := client.List(context.TODO(), list, podSelectors...)
@@ -252,11 +251,11 @@ func getPodsWithReadyContainer(client clipkg.Client, containerName string, podSe
 	return pods, err
 }
 
-func waitForPodsWithReadyContainer(client clipkg.Client, retryDelay time.Duration, timeout time.Duration, containerName string, podSelectors... clipkg.ListOption) ([]corev1.Pod, error) {
+func waitForPodsWithReadyContainer(client clipkg.Client, retryDelay time.Duration, timeout time.Duration, containerName string, podSelectors ...clipkg.ListOption) ([]corev1.Pod, error) {
 	start := time.Now()
 	for {
 		pods, err := getPodsWithReadyContainer(client, containerName, podSelectors...)
-		if err == nil && len(pods)>0 {
+		if err == nil && len(pods) > 0 {
 			return pods, err
 		}
 		if time.Since(start) >= timeout {

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -171,7 +171,7 @@ func fixupElasticSearchReplicaCount(ctx spi.ComponentContext, namespace string) 
 	}
 
 	// Wait for an Elasticsearch (i.e., label app=system-es-master) pod with container (i.e. es-master) to be ready.
-	pods, err := waitForPodsWithReadyContainer(ctx.Client(), 1 * time.Second, 5*time.Minute, containerName, clipkg.MatchingLabels{"app": workloadName}, clipkg.InNamespace(namespace))
+	pods, err := waitForPodsWithReadyContainer(ctx.Client(), 15*time.Second, 5*time.Minute, containerName, clipkg.MatchingLabels{"app": workloadName}, clipkg.InNamespace(namespace))
 	if err != nil {
 		ctx.Log().Errorf("Elasticsearch Post Upgrade: Error getting the Elasticsearch pods: %s", err)
 		return err

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -210,7 +210,7 @@ func fixupElasticSearchReplicaCount(ctx spi.ComponentContext, namespace string) 
 		// Login to Elasticsearch and update index settings for single data node elasticsearch cluster
 		putCmd := execCommand("kubectl", "exec", pod.Name, "-n", namespace, "-c", containerName, "--", "sh", "-c",
 			fmt.Sprintf(`curl -v -XPUT -d '{"index":{"auto_expand_replicas":"0-1"}}' --header 'Content-Type: application/json' -s -k --fail http://localhost:%d/%s/_settings`, httpPort, indexPattern))
-		output, err = putCmd.Output()
+		_, err = putCmd.Output()
 		if err != nil {
 			ctx.Log().Errorf("Elasticsearch Post Upgrade: Error logging into Elasticsearch: %s", err)
 			return err

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -206,11 +206,11 @@ func fixupElasticSearchReplicaCount(ctx spi.ComponentContext, namespace string) 
 	}
 	ctx.Log().Info("Elasticsearch Post Upgrade: Output of the health of the Elasticsearch cluster %v", string(output))
 	// If the data node count is seen as 1 then the node is considered as single node cluster
-	if strings.Contains(string(output), "\"number_of_data_nodes\":1,") {
+	if strings.Contains(string(output), `"number_of_data_nodes":1,`) {
 		// Login to Elasticsearch and update index settings for single data node elasticsearch cluster
 		putCmd := execCommand("kubectl", "exec", pod.Name, "-n", namespace, "-c", containerName, "--", "sh", "-c",
-			fmt.Sprintf("curl -v -XPUT -d '{\"index\":{\"auto_expand_replicas\":\"0-1\"}}' --header 'Content-Type: application/json' -s -k --fail http://localhost:%d/%s/_settings", httpPort, indexPattern))
-		_, err = putCmd.Output()
+			fmt.Sprintf(`curl -v -XPUT -d '{"index":{"auto_expand_replicas":"0-1"}}' --header 'Content-Type: application/json' -s -k --fail http://localhost:%d/%s/_settings`, httpPort, indexPattern))
+		output, err = putCmd.Output()
 		if err != nil {
 			ctx.Log().Errorf("Elasticsearch Post Upgrade: Error logging into Elasticsearch: %s", err)
 			return err

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -27,3 +27,20 @@ func NewComponent() spi.Component {
 		},
 	}
 }
+
+// PostUpgrade Verrazzano-post-upgrade processing
+func (c verrazzanoComponent) PostUpgrade(ctx spi.ComponentContext) error {
+	ctx.Log().Debugf("Verrazzano component post-upgrade")
+	if err := c.HelmComponent.PostUpgrade(ctx); err != nil {
+		return err
+	}
+	return c.updateElasticsearchResources(ctx)
+}
+
+// updateElasticsearchResources updates elasticsearch resources
+func (c verrazzanoComponent) updateElasticsearchResources(ctx spi.ComponentContext) error {
+	if err := fixupElasticSearchReplicaCount(ctx, c.ChartNamespace); err != nil {
+		return err
+	}
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -181,51 +182,78 @@ func Test_appendOverrides(t *testing.T) {
 // GIVEN
 // WHEN
 // THEN
-//func Test_fixupElasticSearchReplicaCount(t *testing.T) {
-//	assert := assert.New(t)
-//	context, err := createFakeComponentContext()
-//	assert.NoError(err, "Failed to create fake component context.")
-//	err = fixupElasticSearchReplicaCount(context, "test-namespace-name")
-//	assert.NoError(err, "Failed to fixup Elasticsearch index template")
-//}
+func Test_fixupElasticSearchReplicaCount(t *testing.T) {
+	assert := assert.New(t)
+	//context, err := createFakeComponentContext(true)
+	_, err := createFakeComponentContext(true)
+	assert.NoError(err, "Failed to create fake component context.")
+	//	err = fixupElasticSearchReplicaCount(context, "test-namespace-name")
+	//	assert.Error(err, "Failed to fixup Elasticsearch index template")
+	//assert.NoError(err, "Failed to fixup Elasticsearch index template")
+}
 
 // Test_getNamedContainerPortOfContainer tests the getNamedContainerPortOfContainer function.
 // GIVEN
 // WHEN
 // THEN
-//func Test_getNamedContainerPortOfContainer(t *testing.T) {
-//	assert := assert.New(t)
-//	pod := corev1.Pod{}
-//	port, err := getNamedContainerPortOfContainer(pod, "test-container-name", "test-port-name")
-//	assert.NoError(err, "Failed to find fake container port")
-//	assert.Equal(42, port, "Expected to find valid named container port")
-//}
+func Test_getNamedContainerPortOfContainer(t *testing.T) {
+	assert := assert.New(t)
+	// Create a simple pod
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test-container-name",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 42,
+							Name:          "test-port-name",
+						},
+					},
+				},
+			},
+		},
+	}
+	port, err := getNamedContainerPortOfContainer(pod, "test-container-name", "test-port-name")
+	assert.NoError(err, "Failed to find fake container port")
+	assert.Equal(int32(42), port, "Expected to find valid named container port")
+	_, err = getNamedContainerPortOfContainer(pod, "wrong-container-name", "test-port-name")
+	assert.Error(err)
+	_, err = getNamedContainerPortOfContainer(pod, "test-container-name", "wrong-port-name")
+	assert.Error(err)
+}
 
 // Test_getPodsWithReadyContainer tests the getPodsWithReadyContainer function.
 // GIVEN
 // WHEN
 // THEN
-//func Test_getPodsWithReadyContainer(t *testing.T) {
-//	assert := assert.New(t)
-//	context, err := createFakeComponentContext()
-//	assert.NoError(err, "Failed to create fake component context.")
-//	pods, err := getPodsWithReadyContainer(context.Client(), "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
-//	assert.NoError(err, "Failed to find fake pod with ready container")
-//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
-//}
+func Test_getPodsWithReadyContainer(t *testing.T) {
+	assert := assert.New(t)
+	// context, err := createFakeComponentContext(true)
+	_, err := createFakeComponentContext(true)
+	assert.NoError(err, "Failed to create fake component context.")
+	//	pods, err := getPodsWithReadyContainer(context.Client(), "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+	//	assert.NoError(err, "Failed to find fake pod with ready container")
+	//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
+}
 
 // Test_waitForPodsWithReadyContainer tests the waitForPodsWithReadyContainer function.
 // GIVEN
 // WHEN
 // THEN
-//func Test_waitForPodsWithReadyContainer(t *testing.T) {
-//	assert := assert.New(t)
-//	context, err := createFakeComponentContext()
-//	assert.NoError(err, "Failed to create fake component context.")
-//	pods, err := waitForPodsWithReadyContainer(context.Client(), 1*time.Second, 5*time.Second, "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
-//	assert.NoError(err, "Failed to find fake pod with ready container")
-//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
-//}
+func Test_waitForPodsWithReadyContainer(t *testing.T) {
+	assert := assert.New(t)
+	//	context, err := createFakeComponentContext(true)
+	_, err := createFakeComponentContext(true)
+	assert.NoError(err, "Failed to create fake component context.")
+	//	pods, err := waitForPodsWithReadyContainer(context.Client(), 1*time.Second, 5*time.Second, "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+	//	assert.NoError(err, "Failed to find fake pod with ready container")
+	//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
+}
 
 // newFakeRuntimeScheme creates a new fake scheme
 func newFakeRuntimeScheme() *runtime.Scheme {
@@ -236,9 +264,21 @@ func newFakeRuntimeScheme() *runtime.Scheme {
 }
 
 // createFakeComponentContext creates a fake component context
-//func createFakeComponentContext() (spi.ComponentContext, error) {
-//	client := fake.NewFakeClientWithScheme(newFakeRuntimeScheme())
-//	logger, _ := zap.NewProduction()
-//	return spi.NewContext(logger.Sugar(), client, nil, false)
-//}
-
+func createFakeComponentContext(isElasticsearchEnabled bool) (spi.ComponentContext, error) {
+	client2 := fake.NewFakeClientWithScheme(newFakeRuntimeScheme())
+	//logger, _ := zap.NewProduction()
+	vz := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Version: "1.1.0",
+			Components: vzapi.ComponentSpec{
+				Elasticsearch: &vzapi.ElasticsearchComponent{
+					MonitoringComponent: vzapi.MonitoringComponent{Enabled: &isElasticsearchEnabled},
+				},
+			},
+		},
+		Status: vzapi.VerrazzanoStatus{
+			Version: "1.0.0",
+		},
+	}
+	return spi.NewFakeContext(client2, vz, false), nil
+}

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -5,8 +5,6 @@ package verrazzano
 
 import (
 	"context"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -19,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
 )
 
 // TestVzResolveNamespace tests the Verrazzano component name
@@ -40,9 +39,7 @@ func TestVzResolveNamespace(t *testing.T) {
 func TestFixupFluentdDaemonset(t *testing.T) {
 	const defNs = constants.VerrazzanoSystemNamespace
 	assert := assert.New(t)
-	scheme := runtime.NewScheme()
-	appsv1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
+	scheme := newFakeRuntimeScheme()
 	client := fake.NewFakeClientWithScheme(scheme)
 	logger, _ := zap.NewProduction()
 	log := logger.Sugar()
@@ -179,3 +176,69 @@ func Test_appendOverrides(t *testing.T) {
 		Value: "ghcr.io/oracle/oraclelinux:7.8",
 	})
 }
+
+// Test_fixupElasticSearchReplicaCount tests the fixupElasticSearchReplicaCount function.
+// GIVEN
+// WHEN
+// THEN
+//func Test_fixupElasticSearchReplicaCount(t *testing.T) {
+//	assert := assert.New(t)
+//	context, err := createFakeComponentContext()
+//	assert.NoError(err, "Failed to create fake component context.")
+//	err = fixupElasticSearchReplicaCount(context, "test-namespace-name")
+//	assert.NoError(err, "Failed to fixup Elasticsearch index template")
+//}
+
+// Test_getNamedContainerPortOfContainer tests the getNamedContainerPortOfContainer function.
+// GIVEN
+// WHEN
+// THEN
+//func Test_getNamedContainerPortOfContainer(t *testing.T) {
+//	assert := assert.New(t)
+//	pod := corev1.Pod{}
+//	port, err := getNamedContainerPortOfContainer(pod, "test-container-name", "test-port-name")
+//	assert.NoError(err, "Failed to find fake container port")
+//	assert.Equal(42, port, "Expected to find valid named container port")
+//}
+
+// Test_getPodsWithReadyContainer tests the getPodsWithReadyContainer function.
+// GIVEN
+// WHEN
+// THEN
+//func Test_getPodsWithReadyContainer(t *testing.T) {
+//	assert := assert.New(t)
+//	context, err := createFakeComponentContext()
+//	assert.NoError(err, "Failed to create fake component context.")
+//	pods, err := getPodsWithReadyContainer(context.Client(), "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+//	assert.NoError(err, "Failed to find fake pod with ready container")
+//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
+//}
+
+// Test_waitForPodsWithReadyContainer tests the waitForPodsWithReadyContainer function.
+// GIVEN
+// WHEN
+// THEN
+//func Test_waitForPodsWithReadyContainer(t *testing.T) {
+//	assert := assert.New(t)
+//	context, err := createFakeComponentContext()
+//	assert.NoError(err, "Failed to create fake component context.")
+//	pods, err := waitForPodsWithReadyContainer(context.Client(), 1*time.Second, 5*time.Second, "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+//	assert.NoError(err, "Failed to find fake pod with ready container")
+//	assert.Len(pods, 1, "Expected to find one pod with a ready container")
+//}
+
+// newFakeRuntimeScheme creates a new fake scheme
+func newFakeRuntimeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	appsv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	return scheme
+}
+
+// createFakeComponentContext creates a fake component context
+//func createFakeComponentContext() (spi.ComponentContext, error) {
+//	client := fake.NewFakeClientWithScheme(newFakeRuntimeScheme())
+//	logger, _ := zap.NewProduction()
+//	return spi.NewContext(logger.Sugar(), client, nil, false)
+//}
+

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -6,7 +6,7 @@ package verrazzano
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"github.com/stretchr/testify/assert"
@@ -203,8 +203,8 @@ func Test_fixupElasticSearchReplicaCount(t *testing.T) {
 	assert.NoError(err, "Failed to create fake component context.")
 	createElasticsearchPod(context.Client(), "http")
 	execCommand = fakeExecCommand
-	fakeExecScenarioNames = []string{"fixupElasticSearchReplicaCount/get", "fixupElasticSearchReplicaCount/put"}
-	fakeExecScenarioIndex = 0
+	fakeExecScenarioNames = []string{"fixupElasticSearchReplicaCount/get", "fixupElasticSearchReplicaCount/put"} //nolint,ineffassign
+	fakeExecScenarioIndex = 0                                                                                    //nolint,ineffassign
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "Failed to fixup Elasticsearch index template")
 
@@ -212,8 +212,8 @@ func Test_fixupElasticSearchReplicaCount(t *testing.T) {
 	//  WHEN fixupElasticSearchReplicaCount is called
 	//  THEN an error should be returned
 	//   AND no commands should be invoked
-	fakeExecScenarioNames = []string{}
-	fakeExecScenarioIndex = 0
+	fakeExecScenarioNames = []string{} //nolint,ineffassign
+	fakeExecScenarioIndex = 0          //nolint,ineffassign
 	context, err = createFakeComponentContext()
 	assert.NoError(err, "Failed to create fake component context.")
 	createElasticsearchPod(context.Client(), "tcp")
@@ -224,9 +224,10 @@ func Test_fixupElasticSearchReplicaCount(t *testing.T) {
 	//  WHEN fixupElasticSearchReplicaCount is called
 	//  THEN no error should be returned
 	//   AND no commands should be invoked
-	fakeExecScenarioNames = []string{}
-	fakeExecScenarioIndex = 0
+	fakeExecScenarioNames = []string{} //nolint,ineffassign
+	fakeExecScenarioIndex = 0          //nolint,ineffassign
 	context, err = createFakeComponentContext()
+	assert.NoError(err, "Unexpected error")
 	context.ActualCR().Status.Version = "1.1.0"
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "No error should be returned if the source version is 1.1.0 or later")
@@ -239,6 +240,7 @@ func Test_fixupElasticSearchReplicaCount(t *testing.T) {
 	fakeExecScenarioIndex = 0
 	falseValue := false
 	context, err = createFakeComponentContext()
+	assert.NoError(err, "Unexpected error")
 	context.EffectiveCR().Spec.Components.Elasticsearch.Enabled = &falseValue
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "No error should be returned if the elasticsearch is not enabled")
@@ -301,12 +303,13 @@ status:
 	//  THEN expect the pod to be returned
 	//   AND expect no error
 	readyPodParams := map[string]string{
-		"test_pod_name" : "test_ready_pod_name",
-		"test_label_value": "test_ready_label_value",
+		"test_pod_name":        "test_ready_pod_name",
+		"test_label_value":     "test_ready_label_value",
 		"test_container_ready": "true",
 	}
 	assert.NoError(createResourceFromTemplate(ctx.Client(), &corev1.Pod{}, podTemplate, readyPodParams), "Failed to create test pod.")
 	pods, err := getPodsWithReadyContainer(ctx.Client(), "test_container_name", client.InNamespace("test_namespace_name"), client.MatchingLabels{"test_label_name": "test_ready_label_value"})
+	assert.NoError(err, "Unexpected error")
 	assert.Len(pods, 1, "Expected to find one pod with a ready container")
 
 	// GIVEN a pod with an unready container
@@ -314,8 +317,8 @@ status:
 	//  THEN expect not pods to be returned
 	//   AND expect no error
 	unreadyPodParams := map[string]string{
-		"test_pod_name" : "test_unready_pod_name",
-		"test_label_value": "test_unready_label_value",
+		"test_pod_name":        "test_unready_pod_name",
+		"test_label_value":     "test_unready_label_value",
 		"test_container_ready": "false",
 	}
 	assert.NoError(createResourceFromTemplate(ctx.Client(), &corev1.Pod{}, podTemplate, unreadyPodParams), "Failed to create test pod.")
@@ -518,7 +521,7 @@ func TestFakeExecHandler(t *testing.T) {
 // template - The template text
 // params - a vararg of param maps
 func populateTemplate(templateStr string, data interface{}) (string, error) {
-	hasher := md5.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(templateStr))
 	name := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 	t, err := template.New(name).Option("missingkey=error").Parse(templateStr)

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -4,7 +4,11 @@
 package verrazzano
 
 import (
+	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -15,13 +19,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"os/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+	"strings"
 	"testing"
+	"text/template"
 	"time"
 )
 
@@ -185,28 +193,55 @@ func Test_appendOverrides(t *testing.T) {
 // Test_fixupElasticSearchReplicaCount tests the fixupElasticSearchReplicaCount function.
 func Test_fixupElasticSearchReplicaCount(t *testing.T) {
 	assert := assert.New(t)
+
+	// GIVEN an Elasticsearch pod with a http port
+	//  WHEN fixupElasticSearchReplicaCount is called
+	//  THEN a command should be executed to get the cluster health information
+	//   AND a command should be executed to update the cluster index settings
+	//   AND no error should be returned
 	context, err := createFakeComponentContext()
 	assert.NoError(err, "Failed to create fake component context.")
 	createElasticsearchPod(context.Client(), "http")
 	execCommand = fakeExecCommand
+	fakeExecScenarioNames = []string{"fixupElasticSearchReplicaCount/get", "fixupElasticSearchReplicaCount/put"}
+	fakeExecScenarioIndex = 0
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "Failed to fixup Elasticsearch index template")
-	// Error should be returned if there is no http port for the elasticsearch pod
-	context1, err := createFakeComponentContext()
+
+	// GIVEN an Elasticsearch pod with no http port
+	//  WHEN fixupElasticSearchReplicaCount is called
+	//  THEN an error should be returned
+	//   AND no commands should be invoked
+	fakeExecScenarioNames = []string{}
+	fakeExecScenarioIndex = 0
+	context, err = createFakeComponentContext()
 	assert.NoError(err, "Failed to create fake component context.")
-	createElasticsearchPod(context1.Client(), "tcp")
-	err = fixupElasticSearchReplicaCount(context1, "verrazzano-system")
+	createElasticsearchPod(context.Client(), "tcp")
+	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.Error(err, "Error should be returned if there is no http port for elasticsearch pods")
-	// Change source version to 1.1.0
-	context.ActualCR().Spec.Version = "1.1.0"
+
+	// GIVEN a Verrazzano resource with version 1.1.0 in the status
+	//  WHEN fixupElasticSearchReplicaCount is called
+	//  THEN no error should be returned
+	//   AND no commands should be invoked
+	fakeExecScenarioNames = []string{}
+	fakeExecScenarioIndex = 0
+	context, err = createFakeComponentContext()
+	context.ActualCR().Status.Version = "1.1.0"
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "No error should be returned if the source version is 1.1.0 or later")
-	// Disable Elasticsearch and no error should be returned
+
+	// GIVEN a Verrazzano resource with Elasticsearch disabled
+	//  WHEN fixupElasticSearchReplicaCount is called
+	//  THEN no error should be returned
+	//   AND no commands should be invoked
+	fakeExecScenarioNames = []string{}
+	fakeExecScenarioIndex = 0
 	falseValue := false
+	context, err = createFakeComponentContext()
 	context.EffectiveCR().Spec.Components.Elasticsearch.Enabled = &falseValue
 	err = fixupElasticSearchReplicaCount(context, "verrazzano-system")
 	assert.NoError(err, "No error should be returned if the elasticsearch is not enabled")
-
 }
 
 // Test_getNamedContainerPortOfContainer tests the getNamedContainerPortOfContainer function.
@@ -214,37 +249,103 @@ func Test_getNamedContainerPortOfContainer(t *testing.T) {
 	assert := assert.New(t)
 	// Create a simple pod
 	pod := newPod()
-	port, err := getNamedContainerPortOfContainer(*pod, "test-container-name", "test-port-name")
+
+	// GIVEN a pod with a ready container named test-ready-container-name
+	//  WHEN getNamedContainerPortOfContainer is invoked for test-ready-container-name
+	//  THEN return the port number for the container port named test-ready-port-name
+	port, err := getNamedContainerPortOfContainer(*pod, "test-ready-container-name", "test-ready-port-name")
 	assert.NoError(err, "Failed to find container port")
 	assert.Equal(int32(42), port, "Expected to find valid named container port")
+
+	// GIVEN a pod with a ready and unready container
+	//  WHEN getNamedContainerPortOfContainer is invoked for a invalid container name
+	//  THEN an error should be returned
 	_, err = getNamedContainerPortOfContainer(*pod, "wrong-container-name", "test-port-name")
 	assert.Error(err, "Error should be returned when the specified container name does not exist")
-	_, err = getNamedContainerPortOfContainer(*pod, "test-container-name", "wrong-port-name")
+
+	// GIVEN a pod with a ready container named test-ready-container-name
+	//  WHEN getNamedContainerPortOfContainer is invoked for the ready container but wrong port name
+	//  THEN an error should be returned
+	_, err = getNamedContainerPortOfContainer(*pod, "test-ready-container-name", "wrong-port-name")
 	assert.Error(err, "Error should be returned when the specified container port name does not exist")
 }
 
 // Test_getPodsWithReadyContainer tests the getPodsWithReadyContainer function.
 func Test_getPodsWithReadyContainer(t *testing.T) {
 	assert := assert.New(t)
-	context, err := createFakeComponentContext()
+	ctx, err := createFakeComponentContext()
 	assert.NoError(err, "Failed to create fake component context.")
-	pods, err := getPodsWithReadyContainer(context.Client(), "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
-	assert.NoError(err, "Failed to find pods with ready container")
+
+	podTemplate := `---
+apiVersion: v1
+kind: Pod
+metadata:
+ labels:
+   test_label_name: {{.test_label_value}}
+ name: {{.test_pod_name}}
+ namespace: test_namespace_name
+spec:
+ containers:
+   - name: test_container_name
+     ports:
+       - name: http
+         containerPort: 9200
+         protocol: TCP
+status:
+ containerStatuses:
+   - name: test_container_name
+     ready: {{.test_container_ready}}`
+
+	// GIVEN a pod with a ready container
+	//  WHEN getPodsWithReadyContainer is invoked
+	//  THEN expect the pod to be returned
+	//   AND expect no error
+	readyPodParams := map[string]string{
+		"test_pod_name" : "test_ready_pod_name",
+		"test_label_value": "test_ready_label_value",
+		"test_container_ready": "true",
+	}
+	assert.NoError(createResourceFromTemplate(ctx.Client(), &corev1.Pod{}, podTemplate, readyPodParams), "Failed to create test pod.")
+	pods, err := getPodsWithReadyContainer(ctx.Client(), "test_container_name", client.InNamespace("test_namespace_name"), client.MatchingLabels{"test_label_name": "test_ready_label_value"})
 	assert.Len(pods, 1, "Expected to find one pod with a ready container")
-	// No pod returned when the container is not yet ready
-	pods, err = getPodsWithReadyContainer(context.Client(), "test-not-ready-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
-	assert.NoError(err, "Failed to find pods")
-	assert.Len(pods, 0, "Expected none of the pods to be returned when the container is not ready")
+
+	// GIVEN a pod with an unready container
+	//  WHEN getPodsWithReadyContainer is invoked
+	//  THEN expect not pods to be returned
+	//   AND expect no error
+	unreadyPodParams := map[string]string{
+		"test_pod_name" : "test_unready_pod_name",
+		"test_label_value": "test_unready_label_value",
+		"test_container_ready": "false",
+	}
+	assert.NoError(createResourceFromTemplate(ctx.Client(), &corev1.Pod{}, podTemplate, unreadyPodParams), "Failed to create test pod.")
+	pods, err = getPodsWithReadyContainer(ctx.Client(), "test_container_name", client.InNamespace("test_namespace_name"), client.MatchingLabels{"test-label-name": "test_unready_label_value"})
+	assert.NoError(err, "Unexpected error")
+	assert.Len(pods, 0, "Expected not to find and pods with a ready container")
 }
 
 // Test_waitForPodsWithReadyContainer tests the waitForPodsWithReadyContainer function.
 func Test_waitForPodsWithReadyContainer(t *testing.T) {
 	assert := assert.New(t)
+
+	// GIVEN a pod with a ready container
+	//  WHEN waitForPodsWithReadyContainer is invoked for the container
+	//  THEN expect the ready pod to be returned
 	context, err := createFakeComponentContext()
+	createPod(context.Client())
 	assert.NoError(err, "Failed to create fake component context.")
-	pods, err := waitForPodsWithReadyContainer(context.Client(), 1*time.Second, 5*time.Second, "test-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
-	assert.NoError(err, "Failed to find fake pod with ready container")
+	pods, err := waitForPodsWithReadyContainer(context.Client(), 1*time.Nanosecond, 5*time.Nanosecond, "test-ready-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+	assert.NoError(err, "Unexpected error finding pods with ready container")
 	assert.Len(pods, 1, "Expected to find one pod with a ready container")
+
+	// GIVEN a pod with a ready container
+	//  WHEN waitForPodsWithReadyContainer is invoked for a container that will never be ready
+	//  THEN expect no pods to eventually be returned
+	context, err = createFakeComponentContext()
+	assert.NoError(err, "Failed to create fake component context.")
+	pods, err = waitForPodsWithReadyContainer(context.Client(), 1*time.Nanosecond, 2*time.Nanosecond, "test-unready-container-name", client.InNamespace("test-namespace-name"), client.MatchingLabels{"test-label-name": "test-label-value"})
+	assert.NoError(err, "Unexpected error finding pods with ready container")
+	assert.Len(pods, 0, "Expected to find no pods with a ready container")
 }
 
 // newFakeRuntimeScheme creates a new fake scheme
@@ -257,24 +358,29 @@ func newFakeRuntimeScheme() *runtime.Scheme {
 
 // createFakeComponentContext creates a fake component context
 func createFakeComponentContext() (spi.ComponentContext, error) {
-	trueValue := true
-	client2 := fake.NewFakeClientWithScheme(newFakeRuntimeScheme())
-	createPod(client2)
-	vz := &vzapi.Verrazzano{
-		Spec: vzapi.VerrazzanoSpec{
-			Version: "1.1.0",
-			Components: vzapi.ComponentSpec{
-				Elasticsearch: &vzapi.ElasticsearchComponent{
-					MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue},
-				},
-			},
-		},
-		Status: vzapi.VerrazzanoStatus{
-			Version: "1.0.0",
-		},
+	client := fake.NewFakeClientWithScheme(newFakeRuntimeScheme())
+
+	vzTemplate := `---
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: test-verrazzano
+  namespace: default
+spec:
+  version: 1.1.0
+  profile: dev
+  components:
+    elasticsearch:
+      enabled: true
+status:
+  version: 1.0.0
+`
+	vzObject := vzapi.Verrazzano{}
+	if err := createObjectFromTemplate(&vzObject, vzTemplate, nil); err != nil {
+		return nil, err
 	}
 
-	return spi.NewFakeContext(client2, vz, false), nil
+	return spi.NewFakeContext(client, &vzObject, false), nil
 }
 
 // createPod creates a k8s pod
@@ -295,11 +401,11 @@ func newPod() *corev1.Pod {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name: "test-container-name",
+					Name: "test-ready-container-name",
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 42,
-							Name:          "test-port-name",
+							Name:          "test-ready-port-name",
 						},
 					},
 				},
@@ -307,8 +413,8 @@ func newPod() *corev1.Pod {
 					Name: "test-not-ready-container-name",
 					Ports: []corev1.ContainerPort{
 						{
-							ContainerPort: 42,
-							Name:          "test-port-name",
+							ContainerPort: 777,
+							Name:          "test-not-ready-port-name",
 						},
 					},
 				},
@@ -317,7 +423,7 @@ func newPod() *corev1.Pod {
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name:  "test-container-name",
+					Name:  "test-ready-container-name",
 					Ready: true,
 				},
 				{
@@ -364,11 +470,106 @@ func createElasticsearchPod(cli client.Client, portName string) {
 	_ = cli.Create(context.TODO(), pod)
 }
 
+var fakeExecScenarioNames = []string{}
+var fakeExecScenarioIndex = 0
+
+// fakeExecCommand is used to fake command execution.
+// The TestFakeExecHandler test is executed as a test.
+// The test scenario is communicated using the TEST_FAKE_EXEC_SCENARIO environment variable.
+// The value of that variable is derrived from fakeExecScenarioNames at fakeExecScenarioIndex
+// The fakeExecScenarioIndex is incremented after every invocation.
 func fakeExecCommand(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs := []string{"-test.run=TestFakeExecHandler", "--", command}
 	cs = append(cs, args...)
 	firstArg := os.Args[0]
 	cmd := exec.Command(firstArg, cs...)
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	cmd.Env = []string{
+		fmt.Sprintf("TEST_FAKE_EXEC_SCENARIO=%s", fakeExecScenarioNames[fakeExecScenarioIndex]),
+	}
+	fakeExecScenarioIndex++
 	return cmd
+}
+
+// TestFakeExecHandler is a test intended to be use to handle fake command execution
+// See the fakeExecCommand function.
+// When this test is invoked normally no TEST_FAKE_EXEC_SCENARIO is present
+// so no assertions are made and therefore passes.
+func TestFakeExecHandler(t *testing.T) {
+	assert := assert.New(t)
+	scenario, found := os.LookupEnv("TEST_FAKE_EXEC_SCENARIO")
+	if found {
+		switch scenario {
+		case "fixupElasticSearchReplicaCount/get":
+			assert.Equal(`curl -v -XGET -s -k --fail http://localhost:42/_cluster/health`,
+				os.Args[13], "Expected curl command to be correct.")
+			fmt.Print(`"number_of_data_nodes":1,`)
+		case "fixupElasticSearchReplicaCount/put":
+			fmt.Println(scenario)
+			fmt.Println(strings.Join(os.Args, " "))
+			assert.Equal(`curl -v -XPUT -d '{"index":{"auto_expand_replicas":"0-1"}}' --header 'Content-Type: application/json' -s -k --fail http://localhost:42/verrazzano-*/_settings`,
+				os.Args[13], "Expected curl command to be correct.")
+		default:
+			assert.Fail("Unknown test scenario provided in environment variable TEST_FAKE_EXEC_SCENARIO: %s", scenario)
+		}
+	}
+}
+
+// populateTemplate reads a template from a file and replaces values in the template from param maps
+// template - The template text
+// params - a vararg of param maps
+func populateTemplate(templateStr string, data interface{}) (string, error) {
+	hasher := md5.New()
+	hasher.Write([]byte(templateStr))
+	name := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	t, err := template.New(name).Option("missingkey=error").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	err = t.ExecuteTemplate(&buf, name, data)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// updateUnstructuredFromYAMLTemplate updates an unstructured from a populated YAML template file.
+// uns - The unstructured to update
+// template - The template text
+// params - The param maps to merge into the template
+func updateUnstructuredFromYAMLTemplate(uns *unstructured.Unstructured, template string, data interface{}) error {
+	str, err := populateTemplate(template, data)
+	if err != nil {
+		return err
+	}
+	bytes, err := yaml.YAMLToJSON([]byte(str))
+	if err != nil {
+		return err
+	}
+	_, _, err = unstructured.UnstructuredJSONScheme.Decode(bytes, nil, uns)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createResourceFromTemplate builds a resource by merging the data with the template and then
+// stores the resource using the provided client.
+func createResourceFromTemplate(cli client.Client, obj runtime.Object, template string, data interface{}) error {
+	if err := createObjectFromTemplate(obj, template, data); err != nil {
+		return err
+	}
+	if err := cli.Create(context.TODO(), obj); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createObjectFromTemplate builds an object by merging the data with the template
+func createObjectFromTemplate(obj runtime.Object, template string, data interface{}) error {
+	uns := unstructured.Unstructured{}
+	if err := updateUnstructuredFromYAMLTemplate(&uns, template, data); err != nil {
+		return err
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(uns.Object, obj)
 }

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -334,7 +334,7 @@ data:
 
       template_file /fluentd/etc/elasticsearch-template-verrazzano.json
       template_name elasticsearch-template-verrazzano.json
-      template_overwrite false
+      template_overwrite true
 
       # time_as_integer needs to be set to false in order for Fluentd
       # to convert timestamps to Fluent::EventTime objects instead of
@@ -390,7 +390,9 @@ data:
       "settings" : {
         "index.refresh_interval" : "5s",
         "index.mapping.total_fields.limit" : "2000",
-        "number_of_shards": 5
+        "number_of_shards": 5,
+        "index.number_of_replicas" : 0,
+        "index.auto_expand_replicas" : "0-1"
       },
       "mappings" : {
         "dynamic_templates" : [ {

--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/verrazzano/verrazzano/pkg/httputil"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
@@ -54,23 +55,33 @@ func (e *Elastic) PodsRunning() bool {
 	return running
 }
 
-// Connect checks if the elasticsearch cluster can be connected
-func (e *Elastic) Connect() bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+// getResponseBody gets the response body for the specified path from elasticsearch cluster
+func (e *Elastic) getResponseBody(path string) ([]byte, error) {
+	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting kubeconfig: %v", err))
-		return false
+		return nil, err
 	}
 
-	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+	api, err := pkg.GetAPIEndpoint(kubeConfigPath)
 	if err != nil {
-		return false
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting API endpoint: %v", err))
+		return nil, err
 	}
+
 	esURL, err := api.GetElasticURL()
 	if err != nil {
-		return false
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Elasticsearch URL: %v", err))
+		return nil, err
 	}
-	body, err := e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath), kubeconfigPath)
+
+	esURL = esURL + path
+	return e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeConfigPath), kubeConfigPath)
+}
+
+// Connect checks if the elasticsearch cluster can be connected
+func (e *Elastic) Connect() bool {
+	body, err := e.getResponseBody("/")
 	if err != nil {
 		return false
 	}
@@ -122,32 +133,17 @@ func (e *Elastic) getVmiHTTPClient(kubeconfigPath string) (*retryablehttp.Client
 // ListIndices lists elasticsearch indices
 func (e *Elastic) ListIndices() []string {
 	idx := []string{}
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Error getting kubeconfig: %v", err))
-		return nil
-	}
-
-	for i := range e.getIndices(kubeconfigPath) {
+	for i := range e.getIndices() {
 		idx = append(idx, i)
 	}
 	return idx
 }
 
 // getIndices gets index metadata (aliases, mappings, and settings) of all elasticsearch indices in the given cluster
-func (e *Elastic) getIndices(kubeconfigPath string) map[string]interface{} {
-	api, err := pkg.GetAPIEndpoint(kubeconfigPath)
+func (e *Elastic) getIndices() map[string]interface{} {
+	body, err := e.getResponseBody("/_all")
 	if err != nil {
-		return nil
-	}
-	esURL, err := api.GetElasticURL()
-	if err != nil {
-		return nil
-	}
-	esURL = esURL + "/_all"
-	body, err := e.retryGet(esURL, pkg.Username, pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath), kubeconfigPath)
-	if err != nil {
-		pkg.Log(pkg.Info, fmt.Sprintf("Error ListIndices %v error: %v", esURL, err))
+		pkg.Log(pkg.Info, fmt.Sprintf("Error ListIndices error: %v", err))
 		return nil
 	}
 	var indices map[string]interface{}
@@ -159,6 +155,77 @@ func (e *Elastic) getIndices(kubeconfigPath string) map[string]interface{} {
 func (e *Elastic) CheckTLSSecret() bool {
 	secretName := fmt.Sprintf("%v-tls", e.binding)
 	return pkg.SecretsCreated("verrazzano-system", secretName)
+}
+
+// CheckHealth checks the health status of Elasticsearch cluster
+// Returns true if the health status is green otherwise false
+func (e *Elastic) CheckHealth() bool {
+	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
+		return false
+	}
+	if !supported {
+		pkg.Log(pkg.Info, "Skipping Elasticsearch cluster health check since version < 1.1.0")
+		return true
+	}
+	body, err := e.getResponseBody("/_cluster/health")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster health: %v", err))
+		return false
+	}
+	pkg.Log(pkg.Info, fmt.Sprintf("Response body %v", string(body)))
+	status, err := httputil.ExtractFieldFromResponseBodyOrReturnError(string(body), "status", "unable to find status in Elasticsearch health response")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error extracting health status from response body: %v", err))
+		return false
+	}
+	if status == "green" {
+		pkg.Log(pkg.Info, "Elasticsearch cluster health status is green")
+		return true
+	}
+	pkg.Log(pkg.Error, fmt.Sprintf("Elasticsearch cluster health status is %v instead of green", status))
+	return false
+}
+
+// CheckIndicesHealth checks the health status of indices in a cluster
+// Returns true if the health status of all the indices is green otherwise false
+func (e *Elastic) CheckIndicesHealth() bool {
+	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
+		return false
+	}
+	if !supported {
+		pkg.Log(pkg.Info, "Skipping Elasticsearch indices health check since version < 1.1.0")
+		return true
+	}
+	body, err := e.getResponseBody("/_cat/indices?format=json")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster indices: %v", err))
+		return false
+	}
+	pkg.Log(pkg.Info, fmt.Sprintf("Response body %v", string(body)))
+	var indices []map[string]interface{}
+	if err := json.Unmarshal(body, &indices); err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Error unmarshalling indices response body: %v", err))
+		return false
+	}
+
+	for _, index := range indices {
+		pkg.Log(pkg.Debug, fmt.Sprintf("Index details: %v", index))
+		val, found := index["health"]
+		if !found {
+			pkg.Log(pkg.Error, fmt.Sprintf("Not able to find the health of the index: %v", index))
+			return false
+		}
+		if val.(string) != "green" {
+			pkg.Log(pkg.Error, fmt.Sprintf("Current index health status %v is not green", val))
+			return false
+		}
+	}
+	pkg.Log(pkg.Info, "The health status of all the indices is green")
+	return true
 }
 
 ////Check the Elasticsearch certificate

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -190,6 +190,11 @@ var _ = Describe("VMI", func() {
 			)
 		})
 
+		It("Elasticsearch health should be green", func() {
+			Eventually(elasticHealth, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "cluster health status not green")
+			Eventually(elasticIndicesHealth, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "indices health status not green")
+		})
+
 		It("Elasticsearch systemd journal Index should be accessible", func() {
 			Eventually(func() bool {
 				return pkg.FindAnyLog("verrazzano-systemd-journal",
@@ -362,6 +367,14 @@ func elasticIndicesCreated() bool {
 
 func elasticConnected() bool {
 	return elastic.Connect()
+}
+
+func elasticHealth() bool {
+	return elastic.CheckHealth()
+}
+
+func elasticIndicesHealth() bool {
+	return elastic.CheckIndicesHealth()
 }
 
 func elasticTLSSecret() bool {


### PR DESCRIPTION
# Description

Fixes issues that caused Elasticsearch to report a Yellow status.  This occurs when Elasticsearch has a single data node but is also configured to have index replicas.  This change allows Elasticsearch to manage the replica count so avoid this issue in both the Dev and Prod profiles.

Fixes VZ-2528: Elasticsearch number of replicas wrong after upgrade

Note that I decided to leave the code in the Verrazzano post upgrade hook for two reasons.
1. It didn’t seem to add significant time to the upgrade.
2. Once parallel upgrade is worked out this code won’t need to get found and move from the global post upgrade hook.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
