### PR TITLE
Validate request body for console and api

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -79,6 +79,10 @@ data:
     end
 
     auth.info("Processing request for backend '"..ingressHost.."'")
+    if (backend == 'console' or backend == 'verrazzano') and (not auth.isBodyValidJson()) then
+        auth.bad_request("Invalid request")
+    end
+
     local authHeader = ngx.req.get_headers()["authorization"]
     local token = nil
     if authHeader then
@@ -1106,6 +1110,20 @@ data:
         ngx.req.set_header("Authorization", "Bearer "..token)
 
         return serverUrl
+    end
+
+    function me.isBodyValidJson()
+        ngx.req.read_body()
+        local data = ngx.req.get_body_data()
+        if data ~= nil then
+            local decoder = require("cjson.safe").decode
+            local decoded_data, err = decoder(data)
+            if err then
+                me.logJson(ngx.ERR, "Invalid request payload:" .. data)
+                return false
+            end
+        end
+        return true
     end
 
     return me

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -31,6 +31,7 @@ const (
 
 var serverURL string
 var isManagedClusterProfile bool
+var isTestSupported bool
 var _ = BeforeSuite(func() {
 	var ingress *networkingv1.Ingress
 	var clientset *kubernetes.Clientset
@@ -53,6 +54,11 @@ var _ = BeforeSuite(func() {
 	Expect(len(ingress.Spec.Rules)).To(Equal(1))
 	ingressRules := ingress.Spec.Rules
 	serverURL = fmt.Sprintf("https://%s/", ingressRules[0].Host)
+	var err error
+	isTestSupported, err = pkg.IsVerrazzanoMinVersion("1.1.0")
+	if err != nil {
+		Fail(err.Error())
+	}
 })
 
 var _ = Describe("Verrazzano Web UI", func() {
@@ -137,7 +143,7 @@ var _ = Describe("Verrazzano Web UI", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				ioutil.ReadAll(resp.Body)
 				resp.Body.Close()
-				// HTTP Access-Control-Allow-Origin header should never be returned.
+				// HTTP Access-Control-Allow-Origin header should never be returned.\
 				for headerName, headerValues := range resp.Header {
 					Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
 				}
@@ -177,5 +183,28 @@ var _ = Describe("Verrazzano Web UI", func() {
 				}
 			}
 		})
+
+		It("should not allow malformed requests", func() {
+			if !isManagedClusterProfile && isTestSupported {
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				Expect(err).ShouldNot(HaveOccurred())
+				httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+				Expect(err).ShouldNot(HaveOccurred())
+				body := []byte(`
+				0
+				POST /mal formed ZZZZ/9.7
+				Q: W`)
+				req, err := retryablehttp.NewRequest("POST", serverURL, body)
+				Expect(err).ShouldNot(HaveOccurred())
+				req.Header.Add("Content-Length", "36")
+				req.Header.Add("Transfer-Encoding", "chunked")
+				resp, err := httpClient.Do(req)
+				Expect(err).ShouldNot(HaveOccurred())
+				ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(400))
+			}
+		})
+
 	})
 })

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Verrazzano Web UI", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				ioutil.ReadAll(resp.Body)
 				resp.Body.Close()
-				// HTTP Access-Control-Allow-Origin header should never be returned.\
+				// HTTP Access-Control-Allow-Origin header should never be returned.
 				for headerName, headerValues := range resp.Header {
 					Expect(strings.ToLower(headerName)).ToNot(Equal("access-control-allow-origin"), fmt.Sprintf("Unexpected header %s:%v", headerName, headerValues))
 				}


### PR DESCRIPTION
# Description

This change to validate that the body of a request targeted to console or verrazzano api is a well formed json.

Fixes VZ-4063

This change was earlier merged as part of https://github.com/verrazzano/verrazzano/pull/2028 but was reverted due to a test failure caused due to version mismatch which is now fixed.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
