### PR TITLE
MySQL second pass cleanup

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -122,3 +122,12 @@ const ObservedUpgradeRetryVersion = "verrazzano.io/observed-upgrade-retry-versio
 
 // NGINXControllerServiceName
 const NGINXControllerServiceName = "ingress-controller-ingress-nginx-controller"
+
+// InstallOperation is the install string
+const InstallOperation = "install"
+
+// UpgradeOperation is the install string
+const UpgradeOperation = "upgrade"
+
+// InitializeOperation is the initialize string
+const InitializeOperation = "initialize"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -6,6 +6,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -14,6 +15,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+
 	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -12,12 +12,10 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	helmutil "github.com/verrazzano/verrazzano/platform-operator/internal/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
@@ -36,8 +34,6 @@ const (
 	mySQLRootKey        = "mysql-root-password"
 	mySQLInitFilePrefix = "init-mysql-"
 )
-
-var pvc100Gi, _ = resource.ParseQuantity("100Gi")
 
 // isReady checks to see if the MySQL component is in ready state
 func isReady(context spi.ComponentContext, name string, namespace string) bool {
@@ -60,17 +56,17 @@ func isEnabled(context spi.ComponentContext) bool {
 func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	cr := compContext.EffectiveCR()
 
-	secret := &v1.Secret{}
-	nsName := types.NamespacedName{
-		Namespace: vzconst.KeycloakNamespace,
-		Name:      secretName}
-	// Get the mysql secret
-	err := compContext.Client().Get(context.TODO(), nsName, secret)
-	if err != nil && !k8serror.IsNotFound(err) {
-		return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
-	}
-	// see if the mysql exists
-	if !k8serror.IsNotFound(err) {
+	if compContext.For(ComponentName).GetOperation() == "upgrade" {
+		secret := &v1.Secret{}
+		nsName := types.NamespacedName{
+			Namespace: vzconst.KeycloakNamespace,
+			Name:      secretName}
+		// Get the mysql secret
+		err := compContext.Client().Get(context.TODO(), nsName, secret)
+		if err != nil {
+			compContext.Log().Errorf("Error getting mysql secret: %v", err)
+			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
+		}
 		// Force mysql to use the initial password and root password during the upgrade, by specifying as helm overrides
 		kvs = append(kvs, bom.KeyValue{
 			Key:   helmRootPwd,
@@ -84,12 +80,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 
 	kvs = append(kvs, bom.KeyValue{Key: mySQLUsernameKey, Value: mySQLUsername})
 
-	// See if MySQL is deployed and create the MySQL init file if not
-	deployed, err := helmutil.IsReleaseDeployed(ComponentName, vzconst.KeycloakNamespace)
-	if err != nil {
-		return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
-	}
-	if !deployed {
+	if compContext.For(ComponentName).GetOperation() == "install" {
 		mySQLInitFile, err := createMySQLInitFile(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
@@ -98,7 +89,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 	}
 
 	// generate the MySQl PV overrides
-	kvs, err = generateVolumeSourceOverrides(compContext, kvs)
+	kvs, err := generateVolumeSourceOverrides(compContext, kvs)
 	if err != nil {
 		return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 	}
@@ -209,7 +200,7 @@ func generateVolumeSourceOverrides(compContext spi.ComponentContext, kvs []bom.K
 	} else if mySQLVolumeSource.PersistentVolumeClaim != nil {
 		// Configured for persistence, adapt the PVC Spec template to the appropriate Helm args
 		pvcs := mySQLVolumeSource.PersistentVolumeClaim
-		storageSpec, found := findVolumeTemplate(pvcs.ClaimName, effectiveCR.Spec.VolumeClaimSpecTemplates)
+		storageSpec, found := vzconfig.FindVolumeTemplate(pvcs.ClaimName, effectiveCR.Spec.VolumeClaimSpecTemplates)
 		if !found {
 			err := fmt.Errorf("No VolumeClaimTemplate found for %s", pvcs.ClaimName)
 			return kvs, err
@@ -246,16 +237,6 @@ func generateVolumeSourceOverrides(compContext spi.ComponentContext, kvs []bom.K
 		})
 	}
 	return kvs, nil
-}
-
-// findVolumeTemplate Find a named VolumeClaimTemplate in the list
-func findVolumeTemplate(templateName string, templates []vzapi.VolumeClaimSpecTemplate) (*v1.PersistentVolumeClaimSpec, bool) {
-	for i, template := range templates {
-		if templateName == template.Name {
-			return &templates[i].Spec, true
-		}
-	}
-	return nil, false
 }
 
 // getInstallArgs get the install args for MySQL

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -56,7 +56,7 @@ func isEnabled(context spi.ComponentContext) bool {
 func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	cr := compContext.EffectiveCR()
 
-	if compContext.For(ComponentName).GetOperation() == "upgrade" {
+	if compContext.For(ComponentName).GetOperation() == vzconst.UpgradeOperation {
 		secret := &v1.Secret{}
 		nsName := types.NamespacedName{
 			Namespace: vzconst.KeycloakNamespace,
@@ -80,7 +80,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 
 	kvs = append(kvs, bom.KeyValue{Key: mySQLUsernameKey, Value: mySQLUsername})
 
-	if compContext.For(ComponentName).GetOperation() == "install" {
+	if compContext.For(ComponentName).GetOperation() == vzconst.InstallOperation {
 		mySQLInitFile, err := createMySQLInitFile(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -6,7 +6,6 @@ package mysql
 import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -36,8 +35,9 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "mysql-values.yaml"),
 			AppendOverridesFunc:     appendMySQLOverrides,
-			Dependencies:            []string{istio.ComponentName},
-			ReadyStatusFunc:         isReady,
+			//Dependencies:            []string{istio.ComponentName},
+			Dependencies:    []string{},
+			ReadyStatusFunc: isReady,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -4,13 +4,14 @@
 package mysql
 
 import (
+	"path/filepath"
+
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"path/filepath"
 )
 
 // ComponentName is the name of the component

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -6,6 +6,7 @@ package mysql
 import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -35,9 +36,8 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "mysql-values.yaml"),
 			AppendOverridesFunc:     appendMySQLOverrides,
-			//Dependencies:            []string{istio.ComponentName},
-			Dependencies:    []string{},
-			ReadyStatusFunc: isReady,
+			Dependencies:            []string{istio.ComponentName},
+			ReadyStatusFunc:         isReady,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -264,10 +264,10 @@ func TestIsMySQLNotReady(t *testing.T) {
 	assert.False(t, isReady(spi.NewFakeContext(fakeClient, nil, false), "", vzconst.KeycloakNamespace))
 }
 
-// TestSQLFileCreatedAndDRemoved tests the creation and deletion of the mysql db init file
+// TestSQLFileCreatedAndRemoved tests the creation and deletion of the mysql db init file
 // WHEN the appendMySQLOverrides and then postInstall functions are called
 // THEN ensure that the mysql db init file is created successfully and then deleted successfully
-func TestSQLFileCreatedAndDRemoved(t *testing.T) {
+func TestSQLFileCreatedAndRemoved(t *testing.T) {
 	fakeContext := spi.NewFakeContext(nil, nil, false)
 	tmpFile, err := createMySQLInitFile(fakeContext)
 	assert.NoError(t, err)

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -32,7 +32,7 @@ var pvc100Gi, _ = resource.ParseQuantity("100Gi")
 // THEN the correct overrides are returned
 func TestAppendMySQLOverrides(t *testing.T) {
 	vz := &vzapi.Verrazzano{}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 2)
@@ -58,7 +58,7 @@ func TestAppendMySQLOverridesWithInstallArgs(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 3)
@@ -78,7 +78,7 @@ func TestAppendMySQLOverridesDev(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 3)
@@ -114,7 +114,7 @@ func TestAppendMySQLOverridesDevWithPersistence(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 4)
@@ -132,7 +132,7 @@ func TestAppendMySQLOverridesProd(t *testing.T) {
 			Profile: vzapi.ProfileType("prod"),
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 2)
@@ -163,7 +163,7 @@ func TestAppendMySQLOverridesProdWithOverrides(t *testing.T) {
 			}},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation("install")
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 4)
@@ -188,7 +188,7 @@ func TestAppendMySQLOverridesUpgrade(t *testing.T) {
 			secret.Data[mySQLKey] = []byte("test-key")
 			return nil
 		})
-	ctx := spi.NewFakeContext(mock, vz, false, profilesDir).For(ComponentName).Operation("upgrade")
+	ctx := spi.NewFakeContext(mock, vz, false, profilesDir).For(ComponentName).Operation(vzconst.UpgradeOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 3)

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -4,22 +4,24 @@ package mysql
 
 import (
 	"context"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const profilesDir = "../../../../manifests/profiles"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -4,7 +4,6 @@ package mysql
 
 import (
 	"context"
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -19,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"os"
-	"os/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
@@ -27,32 +25,6 @@ import (
 const profilesDir = "../../../../manifests/profiles"
 
 var pvc100Gi, _ = resource.ParseQuantity("100Gi")
-
-// genericHelmTestRunner is used to run generic OS commands with expected results
-type genericHelmTestRunner struct {
-	stdOut []byte
-	stdErr []byte
-	err    error
-}
-
-// notDeployedRunner returns the expected helm status output when mysql is not deployed
-var notDeployedRunner = genericHelmTestRunner{
-	stdOut: []byte{},
-	stdErr: []byte("Error: release: not found"),
-	err:    fmt.Errorf("release was not found in output"),
-}
-
-// deployedRunner returns the expected helm status output when mysql is deployed
-var deployedRunner = genericHelmTestRunner{
-	stdOut: []byte("{\"info\":{\"status\":\"deployed\"}}"),
-	stdErr: []byte{},
-	err:    nil,
-}
-
-// Run genericHelmTestRunner executor
-func (r genericHelmTestRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
-	return r.stdOut, r.stdErr, r.err
-}
 
 // TestAppendMySQLOverrides tests the appendMySQLOverrides function
 // GIVEN a call to appendMySQLOverrides

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -828,7 +828,7 @@ func (r *Reconciler) initializeComponentStatus(log *zap.SugaredLogger, cr *insta
 	for _, comp := range registry.GetComponents() {
 		if comp.IsOperatorInstallSupported() {
 			// If the component is installed then mark it as ready
-			compContext := newContext.For(comp.Name()).Operation("initialize")
+			compContext := newContext.For(comp.Name()).Operation(vzconst.InitializeOperation)
 			state := installv1alpha1.Disabled
 			if !unitTesting {
 				installed, err := comp.IsInstalled(compContext)

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -13,22 +13,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzinstance"
-
-	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
-
 	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/installjob"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/uninstalljob"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzinstance"
 
 	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
@@ -38,11 +31,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/yaml"
 )
 

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -5,6 +5,7 @@ package verrazzano
 
 import (
 	"context"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/semver"
@@ -36,7 +37,7 @@ func (r *Reconciler) reconcileComponents(_ context.Context, log *zap.SugaredLogg
 	// Loop through all of the Verrazzano components and upgrade each one sequentially for now; will parallelize later
 	for _, comp := range registry.GetComponents() {
 		compName := comp.Name()
-		compContext := newContext.For(compName).Operation("install")
+		compContext := newContext.For(compName).Operation(vzconst.InstallOperation)
 		log.Debugf("processing install for %s", compName)
 
 		if !comp.IsOperatorInstallSupported() {

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -5,16 +5,16 @@ package verrazzano
 
 import (
 	"context"
-	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"go.uber.org/zap"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // reconcileComponents reconciles each component using the following rules:

--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -8,11 +8,12 @@ package installjob
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"strconv"
 
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/platform-operator/controllers/verrazzano/installjob/install_config.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config.go
@@ -408,7 +408,7 @@ func getKeycloak(keycloak *installv1alpha1.KeycloakComponent, templates []instal
 	} else if mysqlVolumeSource.PersistentVolumeClaim != nil {
 		// Configured for persistence, adapt the PVC Spec template to the appropriate Helm args
 		pvcs := mysqlVolumeSource.PersistentVolumeClaim
-		storageSpec, found := findVolumeTemplate(pvcs.ClaimName, templates)
+		storageSpec, found := vzconfig.FindVolumeTemplate(pvcs.ClaimName, templates)
 		if !found {
 			err := fmt.Errorf("No VolumeClaimTemplate found for %s", pvcs.ClaimName)
 			return Keycloak{}, err
@@ -551,7 +551,7 @@ func getVerrazzanoInstallArgs(vzSpec *installv1alpha1.VerrazzanoSpec) ([]Install
 			}...)
 		} else if vzSpec.DefaultVolumeSource.PersistentVolumeClaim != nil {
 			pvcs := vzSpec.DefaultVolumeSource.PersistentVolumeClaim
-			storageSpec, found := findVolumeTemplate(pvcs.ClaimName, vzSpec.VolumeClaimSpecTemplates)
+			storageSpec, found := vzconfig.FindVolumeTemplate(pvcs.ClaimName, vzSpec.VolumeClaimSpecTemplates)
 			if !found {
 				err := fmt.Errorf("No VolumeClaimTemplate found for %s", pvcs.ClaimName)
 				return []InstallArg{}, err
@@ -697,16 +697,6 @@ func getVMIInstallArgs(vzSpec *installv1alpha1.VerrazzanoSpec) []InstallArg {
 	}
 
 	return vmiArgs
-}
-
-// findVolumeTemplate Find a named VolumeClaimTemplate in the list
-func findVolumeTemplate(templateName string, templates []installv1alpha1.VolumeClaimSpecTemplate) (*corev1.PersistentVolumeClaimSpec, bool) {
-	for i, template := range templates {
-		if templateName == template.Name {
-			return &templates[i].Spec, true
-		}
-	}
-	return nil, false
 }
 
 func getFluentd(comp *installv1alpha1.FluentdComponent) Fluentd {

--- a/platform-operator/controllers/verrazzano/installjob/install_config_test.go
+++ b/platform-operator/controllers/verrazzano/installjob/install_config_test.go
@@ -472,59 +472,6 @@ func TestNodePortInstall(t *testing.T) {
 	assert.Equalf(t, "verrazzano-ca-certificate-secret", config.Certificates.CA.SecretName, "Expected CA secret name did not match")
 }
 
-// TestFindVolumeTemplate Test the findVolumeTemplate utility function
-// GIVEN a call to findVolumeTemplate
-// WHEN valid or invalid arguments are given
-// THEN true and the found template are is returned if found, nil/false otherwise
-func TestFindVolumeTemplate(t *testing.T) {
-
-	specTemplateList := []installv1alpha1.VolumeClaimSpecTemplate{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName: "defVolume",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "template1"},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName: "temp1Volume",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "template2"},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName: "temp2Volume",
-			},
-		},
-	}
-	// Test boundary conditions
-	invalidName, found := findVolumeTemplate("blah", specTemplateList)
-	assert.Nil(t, invalidName)
-	assert.False(t, found)
-	emptyName, found2 := findVolumeTemplate("", specTemplateList)
-	assert.Nil(t, emptyName)
-	assert.False(t, found2)
-	nilList, found3 := findVolumeTemplate("default", nil)
-	assert.Nil(t, nilList)
-	assert.False(t, found3)
-	emptyList, found4 := findVolumeTemplate("default", []installv1alpha1.VolumeClaimSpecTemplate{})
-	assert.Nil(t, emptyList)
-	assert.False(t, found4)
-
-	// Test normal behavior
-	defTemplate, found := findVolumeTemplate("default", specTemplateList)
-	assert.True(t, found)
-	assert.Equal(t, "defVolume", defTemplate.VolumeName)
-	temp1, found := findVolumeTemplate("template1", specTemplateList)
-	assert.True(t, found)
-	assert.Equal(t, "temp1Volume", temp1.VolumeName)
-	temp2, found := findVolumeTemplate("template2", specTemplateList)
-	assert.True(t, found)
-	assert.Equal(t, "temp2Volume", temp2.VolumeName)
-
-}
-
 // TestGetVerrazzanoInstallArgsNilDefaultVolumeSource Test the getVerrazzanoInstallArgs  function
 // GIVEN a call to getVerrazzanoInstallArgs
 // WHEN No default volume source is specified (nil)

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -5,6 +5,7 @@ package verrazzano
 
 import (
 	"fmt"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"strconv"
 	"strings"
 
@@ -50,7 +51,7 @@ func (r *Reconciler) reconcileUpgrade(log *zap.SugaredLogger, cr *installv1alpha
 	for _, comp := range registry.GetComponents() {
 		compName := comp.Name()
 		log.Infof("Upgrading %s", compName)
-		upgradeContext := newContext.For(compName).Operation("upgrade")
+		upgradeContext := newContext.For(compName).Operation(vzconst.UpgradeOperation)
 		installed, err := comp.IsInstalled(upgradeContext)
 		if err != nil {
 			return newRequeueWithDelay(), err

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -5,13 +5,14 @@ package verrazzano
 
 import (
 	"fmt"
-	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"strconv"
 	"strings"
 
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
 	"go.uber.org/zap"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/internal/vzconfig/enabled_test.go
+++ b/platform-operator/internal/vzconfig/enabled_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestIsExternalDNSEnabledDefault tests the IsExternalDNSEnabled function
@@ -77,26 +76,6 @@ func TestIsExternalDNSEnabledExternalDNS(t *testing.T) {
 		},
 	}
 	assert.False(t, IsExternalDNSEnabled(vz))
-}
-
-// TestFindVolumeTemplate tests the FindVolumeTemplate function
-// GIVEN a call to FindVolumeTemplate
-//  WHEN the template list does and does not have the requested template by name
-//  THEN nil/false is returned if not found, true/template are returned otherwise
-func TestFindVolumeTemplate(t *testing.T) {
-	template, found := FindVolumeTemplate("vmi",
-		[]vzapi.VolumeClaimSpecTemplate{
-			{ObjectMeta: metav1.ObjectMeta{Name: "vmi"}},
-		})
-	assert.True(t, found)
-	assert.NotNil(t, template)
-
-	template, found = FindVolumeTemplate("boo",
-		[]vzapi.VolumeClaimSpecTemplate{
-			{ObjectMeta: metav1.ObjectMeta{Name: "vmi"}},
-		})
-	assert.False(t, found)
-	assert.Nil(t, template)
 }
 
 var trueValue = true

--- a/platform-operator/internal/vzconfig/ingress_test.go
+++ b/platform-operator/internal/vzconfig/ingress_test.go
@@ -4,13 +4,14 @@ package vzconfig
 
 import (
 	"fmt"
-	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/platform-operator/internal/vzconfig/ingress_test.go
+++ b/platform-operator/internal/vzconfig/ingress_test.go
@@ -401,3 +401,56 @@ func TestBuildDNSDomainCustomEnv(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "myenv.mydomain.com", domain)
 }
+
+// TestFindVolumeTemplate Test the FindVolumeTemplate utility function
+// GIVEN a call to FindVolumeTemplate
+// WHEN valid or invalid arguments are given
+// THEN true and the found template are is returned if found, nil/false otherwise
+func TestFindVolumeTemplate(t *testing.T) {
+
+	specTemplateList := []vzapi.VolumeClaimSpecTemplate{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName: "defVolume",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "template1"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName: "temp1Volume",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "template2"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName: "temp2Volume",
+			},
+		},
+	}
+	// Test boundary conditions
+	invalidName, found := FindVolumeTemplate("blah", specTemplateList)
+	assert.Nil(t, invalidName)
+	assert.False(t, found)
+	emptyName, found2 := FindVolumeTemplate("", specTemplateList)
+	assert.Nil(t, emptyName)
+	assert.False(t, found2)
+	nilList, found3 := FindVolumeTemplate("default", nil)
+	assert.Nil(t, nilList)
+	assert.False(t, found3)
+	emptyList, found4 := FindVolumeTemplate("default", []vzapi.VolumeClaimSpecTemplate{})
+	assert.Nil(t, emptyList)
+	assert.False(t, found4)
+
+	// Test normal behavior
+	defTemplate, found := FindVolumeTemplate("default", specTemplateList)
+	assert.True(t, found)
+	assert.Equal(t, "defVolume", defTemplate.VolumeName)
+	temp1, found := FindVolumeTemplate("template1", specTemplateList)
+	assert.True(t, found)
+	assert.Equal(t, "temp1Volume", temp1.VolumeName)
+	temp2, found := FindVolumeTemplate("template2", specTemplateList)
+	assert.True(t, found)
+	assert.Equal(t, "temp2Volume", temp2.VolumeName)
+
+}


### PR DESCRIPTION
This is a second pass on https://github.com/verrazzano/verrazzano/commit/34bf6e23945a2cd00aa275c3de462206f073aac3
and resolves comments from https://github.com/verrazzano/verrazzano/pull/2045
Contents:
- Leverages the operation field in the component context
- Moves findVolumeTemplate to common code and removes all duplicate non-exported functions
- Cleans up misplaced constant
- Cleans up typo

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
