### PR TITLE
Explicitly delete sock shop  appconfig and components before deleting namespace

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+// +build unstable_test
+
 package socks
 
 import (

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -32,21 +32,13 @@ const (
 var sockShop SockShop
 var username, password string
 
-// variant is used to pass in which version of the sock shop we want to run the test
-// suite against (helidon, micronaut, or spring)
-var variant string
-
 // creates the sockshop namespace and applies the components and application yaml
 var _ = BeforeSuite(func() {
 	username = "username" + strconv.FormatInt(time.Now().Unix(), 10)
 	password = b64.StdEncoding.EncodeToString([]byte(time.Now().String()))
 	sockShop = NewSockShop(username, password, pkg.Ingress())
 
-	// read the variant from the environment - if not specified, default to "helidon"
-	variant := os.Getenv("SOCKS_SHOP_VARIANT")
-	if variant != "helidon" && variant != "micronaut" && variant != "spring" {
-		variant = "helidon"
-	}
+	variant := getVariant()
 	GinkgoWriter.Write([]byte(fmt.Sprintf("*** Socks shop test is running against variant: %s\n", variant)))
 
 	if !skipDeploy {
@@ -263,6 +255,7 @@ var _ = AfterSuite(func() {
 	}
 
 	if !skipUndeploy {
+		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
 		pkg.Log(pkg.Info, "Delete application")
 		Eventually(func() error {
@@ -317,4 +310,15 @@ func appComponentMetricsExists() bool {
 // appConfigMetricsExists checks whether config metrics are available
 func appConfigMetricsExists() bool {
 	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "orders")
+}
+
+// getVariant returns the variant of the sock shop application being tested
+func getVariant() string {
+	// read the variant from the environment - if not specified, default to "helidon"
+	variant := os.Getenv("SOCKS_SHOP_VARIANT")
+	if variant != "helidon" && variant != "micronaut" && variant != "spring" {
+		variant = "helidon"
+	}
+
+	return variant
 }


### PR DESCRIPTION
# Description

This pull request changes the AfterSuite function of the sock shop test to delete the appconfig and components before deleting the namespace.  When we only delete the namespace the test intermittently fails due to finalizers not being called for Coherence resources by the Coherence operator.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
