### PR TITLE
Fix upgrade-test regression with todo-list post-upgrde

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -554,7 +554,7 @@ pipeline {
                 }
                 stage('examples todo') {
                     steps {
-                        runGinkgo('examples/todo', "true", "true")
+                        runGinkgo('examples/todo', "false", "true")
                     }
                 }
                 stage('examples bobs-books') {


### PR DESCRIPTION
# Description

This pull request fixes a regression in the upgrade AT where the todo-list test was failing during post upgrade testing.
The fix was to deploy todo-list post upgrade.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
