### PR TITLE
Fix chart override keys for fluentd extra volume mounts

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -566,8 +566,8 @@ spec:
             - mountPath: /run/log/journal
               name: run-log-journal
               readOnly: true
-{{- if .Values.logging.extraVolumeMounts }}
-{{- range $i, $e := .Values.logging.extraVolumeMounts }}
+{{- if .Values.fluentd.extraVolumeMounts }}
+{{- range $i, $e := .Values.fluentd.extraVolumeMounts }}
             - mountPath: {{ $e.destination }}
               name: extra-volume-{{ $i }}
               readOnly: {{ $e.readOnly }}
@@ -605,8 +605,8 @@ spec:
             path: /run/log/journal
             type: ""
           name: run-log-journal
-{{- if .Values.logging.extraVolumeMounts }}
-{{- range $i, $e := .Values.logging.extraVolumeMounts }}
+{{- if .Values.fluentd.extraVolumeMounts }}
+{{- range $i, $e := .Values.fluentd.extraVolumeMounts }}
         - hostPath:
             path: {{ $e.source }}
             type: ""


### PR DESCRIPTION
# Description

The helm chart override keys in `verrazzano-logging.yaml` do match what the code is setting in the platform operator. As a result the `extraVolumeMounts` settings in the Verrazzano CR were being ignored. This fixes the key names.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
