### PR TITLE
VZ-4044

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -392,6 +392,28 @@ pipeline {
                         }
                     }
                 }
+                stage('Release Candidate Validation Checks') {
+                    environment {
+                        JIRA_USERNAME = credentials('jira-username')
+                        JIRA_PASSWORD = credentials('jira-password')
+                    }
+                    steps {
+                        script {
+                            sh """
+                                cd ${WORKSPACE}
+                                echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
+                                ./release/scripts/prerelease_validation.sh ${VERRAZZANO_DEV_VERSION}
+                                if [ $? -eq 0 ]; then
+                                    echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
+                                    echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                                    oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                                else
+                                    echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
+                                fi
+                            """
+                        }
+                    }
+                }
             }
         }
     }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -416,7 +416,7 @@ pipeline {
                                 fi
                                 set -e
                             """
-                            currentBuild.displayName = readFile file: release_status.out
+                            currentBuild.displayName = readFile file: "release_status.out"
                         }
                     }
                 }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -401,9 +401,10 @@ pipeline {
                     steps {
                         script {
                             sh """
+                                set +e
                                 cd ${WORKSPACE}
                                 echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
-                                ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION
+                                ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION > $WORKSPACE/prerelease_validation.out
                                 if [ \$? -eq 0 ]; then
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
@@ -411,6 +412,7 @@ pipeline {
                                 else
                                     echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
                                 fi
+                                set -e
                             """
                         }
                     }
@@ -419,6 +421,9 @@ pipeline {
         }
     }
     post {
+        always {
+            archiveArtifacts artifacts: '**/prerelease_validation.out', allowEmptyArchive: true
+        }
         failure {
             script {
                 if (isAlertingEnabled()) {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -402,7 +402,7 @@ pipeline {
                             sh """
                                 cd ${WORKSPACE}
                                 echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
-                                ./release/scripts/prerelease_validation.sh ${VERRAZZANO_DEV_VERSION}
+                                ./release/scripts/prerelease_validation.sh "${VERRAZZANO_DEV_VERSION}"
                                 if [ $? -eq 0 ]; then
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -409,14 +409,14 @@ pipeline {
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
                                     oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
-                                    echo "${env.BUILD_NUMBER} : RELEASE CANDIDATE" > $WORKSPACE/release_status.out
+                                    echo "${env.BUILD_NUMBER} : RELEASE CANDIDATE" > release_status.out
                                 else
                                     echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
-                                    echo "${env.BUILD_NUMBER} : NOT RELEASABLE" > $WORKSPACE/release_status.out
+                                    echo "${env.BUILD_NUMBER} : NOT RELEASABLE" > release_status.out
                                 fi
                                 set -e
                             """
-                            currentBuild.displayName = readFile file: $WORKSPACE/release_status.out
+                            currentBuild.displayName = readFile file: release_status.out
                         }
                     }
                 }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -403,11 +403,11 @@ pipeline {
                             sh """
                                 cd ${WORKSPACE}
                                 echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
-                                ./release/scripts/prerelease_validation.sh ${VERRAZZANO_DEV_VERSION}
+                                ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION
                                 if [ $? -eq 0 ]; then
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
-                                    oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                                    oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
                                 else
                                     echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
                                 fi

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -459,7 +459,7 @@ def getCronSchedule() {
     if (env.BRANCH_NAME.equals("master")) {
         return "H */2 * * *"
     } else if (env.BRANCH_NAME.startsWith("release-1")) {
-        return "@Daily"
+        return "@daily"
     }
     return ""
 }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -2,6 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def GIT_COMMIT_TO_USE
+def VERRAZZANO_DEV_VERSION
 
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 def TESTS_FAILED = false
@@ -402,7 +403,7 @@ pipeline {
                             sh """
                                 cd ${WORKSPACE}
                                 echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
-                                ./release/scripts/prerelease_validation.sh "${VERRAZZANO_DEV_VERSION}"
+                                ./release/scripts/prerelease_validation.sh ${VERRAZZANO_DEV_VERSION}
                                 if [ $? -eq 0 ]; then
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -404,7 +404,7 @@ pipeline {
                                 cd ${WORKSPACE}
                                 echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
                                 ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION
-                                if [ $? -eq 0 ]; then
+                                if [ \$? -eq 0 ]; then
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
                                     oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -409,11 +409,14 @@ pipeline {
                                     echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
                                     echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
                                     oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                                    echo "${env.BUILD_NUMBER} : RELEASE CANDIDATE" > $WORKSPACE/release_status.out
                                 else
                                     echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
+                                    echo "${env.BUILD_NUMBER} : NOT RELEASABLE" > $WORKSPACE/release_status.out
                                 fi
                                 set -e
                             """
+                            currentBuild.displayName = readFile file: $WORKSPACE/release_status.out
                         }
                     }
                 }


### PR DESCRIPTION
# Description

VZ-4044, this adds prerelease validation checking into the periodic pipelines. Ultimately the intention is that the periodic pipeline will be pre-vetting the release candidates automatically for us. This is a step towards that end.

The checking needs to be reviewed by a human, and is pretty likely to fail, so failing pre-release checking is not something that we will fail the periodic test run for, but it will use the status from the prerelease checks to mark the display info for the run to indicate whether it is a release candidate or not.

This also applies the daily cron fix, which is already in the release-1.0 line

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
