### PR TITLE
VZ-4044 switch to use a separate job in internal agent for prerelease checks

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -394,28 +394,14 @@ pipeline {
                     }
                 }
                 stage('Release Candidate Validation Checks') {
-                    environment {
-                        JIRA_USERNAME = credentials('jira-username')
-                        JIRA_PASSWORD = credentials('jira-password')
-                    }
                     steps {
                         script {
-                            sh """
-                                set +e
-                                cd ${WORKSPACE}
-                                echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
-                                ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION > $WORKSPACE/prerelease_validation.out
-                                if [ \$? -eq 0 ]; then
-                                    echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
-                                    echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
-                                    oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
-                                    echo "${env.BUILD_NUMBER} : RELEASE CANDIDATE" > release_status.out
-                                else
-                                    echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
-                                    echo "${env.BUILD_NUMBER} : NOT RELEASABLE" > release_status.out
-                                fi
-                                set -e
-                            """
+                            def built = build job: "verrazzano-prerelease-check/${CLEAN_BRANCH_NAME}",
+                                parameters: [
+                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT)
+                                ], wait: true
+                            cd ${WORKSPACE}
+                            copyArtifacts(projectName: "verrazzano-prerelease-check/${CLEAN_BRANCH_NAME}", selector: specific("${built.number}"));
                             currentBuild.displayName = readFile file: "release_status.out"
                         }
                     }
@@ -425,7 +411,7 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: '**/prerelease_validation.out', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/prerelease_validation.out,**/release_status.out', allowEmptyArchive: true
         }
         failure {
             script {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -400,9 +400,10 @@ pipeline {
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT)
                                 ], wait: true
-                            cd ${WORKSPACE}
-                            copyArtifacts(projectName: "verrazzano-prerelease-check/${CLEAN_BRANCH_NAME}", selector: specific("${built.number}"));
-                            currentBuild.displayName = readFile file: "release_status.out"
+                            dir ("${WORKSPACE}") {
+                                copyArtifacts(projectName: "verrazzano-prerelease-check/${CLEAN_BRANCH_NAME}", selector: specific("${built.number}"));
+                                currentBuild.displayName = readFile file: "release_status.out"
+                            }
                         }
                     }
                 }

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -35,6 +35,11 @@ pipeline {
         DOCKER_REPO = 'ghcr.io'
         GITHUB_CREDENTIALS = credentials('github-markxnelns-private-access-token')
 
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_BUCKET="verrazzano-builds"
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
     }
 

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -11,6 +11,7 @@ def VERRAZZANO_DEV_VERSION
 pipeline {
     options {
         skipDefaultCheckout true
+        copyArtifactPermission('*');
         timestamps ()
     }
 

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -1,0 +1,124 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+def DOCKER_IMAGE_TAG
+def releaseBuild
+def RELEASE_JOB_NAME
+def RELEASE_BRANCH_COMMIT
+def IS_PATCH_RELEASE = false
+def VERRAZZANO_DEV_VERSION
+
+pipeline {
+    options {
+        skipDefaultCheckout true
+        timestamps ()
+    }
+
+    agent {
+       docker {
+            image "${RELEASE_RUNNER_IMAGE}"
+            args "${RELEASE_RUNNER_DOCKER_ARGS}"
+            registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
+            registryCredentialsId 'ocir-pull-and-push-account'
+            label "internal"
+        }
+    }
+
+    parameters {
+        string (description: 'The source commit for the release (required for full release)', name: 'COMMIT_TO_USE', defaultValue: 'NONE', trim: true )
+    }
+
+    environment {
+        OCR_CREDS = credentials('ocr-pull-and-push-account')
+        NETRC_FILE = credentials('netrc')
+        DOCKER_CREDS = credentials('github-packages-credentials-rw')
+        DOCKER_REPO = 'ghcr.io'
+        GITHUB_CREDENTIALS = credentials('github-markxnelns-private-access-token')
+
+        TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+    }
+
+    stages {
+        stage('Clean workspace and checkout') {
+            steps {
+                sh """
+                    echo "${NODE_LABELS}"
+                """
+                script {
+                    if (params.COMMIT_TO_USE == "NONE") {
+                        echo "Specific GIT commit was not specified, use current head"
+                        def scmInfo = checkout scm
+                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
+                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
+                    } else {
+                        echo "SCM checkout of ${params.COMMIT_TO_USE}"
+                        def scmInfo = checkout([
+                            $class: 'GitSCM',
+                            branches: [[name: params.COMMIT_TO_USE]],
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions: [],
+                            submoduleCfg: [],
+                            userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
+                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
+                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
+                        // If the commit we were handed is not what the SCM says we are using, fail
+                        if (!env.GIT_COMMIT.equals(params.COMMIT_TO_USE)) {
+                            echo "SCM didn't checkout the commit we expected. Expected: ${params.COMMIT_TO_USE}, Found: ${env.GIT_COMMIT}"
+                            sh "exit 1"
+                        }
+                    }
+                    // setup credential retrieval for possible release branch push
+                    sh """
+                        git config credential.https://github.com.username ${GITHUB_CREDENTIALS_USR}
+                        git config credential.helper '/bin/bash ${WORKSPACE}/release/scripts/credential_helper.sh'
+                    """
+                    echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
+                    RELEASE_BRANCH_COMMIT = env.GIT_COMMIT
+                }
+
+                script {
+                    def props = readProperties file: '.verrazzano-development-version'
+                    VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+                    SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
+                    // update the description with some meaningful info
+                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.COMMIT_TO_USE
+                }
+            }
+        }
+
+        stage('Release Candidate Validation Checks') {
+            environment {
+                IGNORE_FAILURES = "false"
+                JIRA_USERNAME = credentials('jira-username')
+                JIRA_PASSWORD = credentials('jira-password')
+            }
+            steps {
+                script {
+                    sh """
+                        set +e
+                        cd ${WORKSPACE}
+                        echo "Performing pre-release validation checks for target version ${VERRAZZANO_DEV_VERSION}"
+                        ./release/scripts/prerelease_validation.sh $VERRAZZANO_DEV_VERSION > $WORKSPACE/prerelease_validation.out
+                        if [ \$? -eq 0 ]; then
+                            echo "Passed pre-release checks for ${VERRAZZANO_DEV_VERSION}, promoting this to the latest releasable candidate"
+                            echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-$VERRAZZANO_DEV_VERSION-releasable-candidate-commit.txt --file $WORKSPACE/last-${VERRAZZANO_DEV_VERSION}-releasable-candidate-commit.txt
+                            echo "${env.BUILD_NUMBER} : RELEASE CANDIDATE" > release_status.out
+                        else
+                            echo "Failed pre-release checks for ${VERRAZZANO_DEV_VERSION}"
+                            echo "${env.BUILD_NUMBER} : NOT RELEASABLE" > release_status.out
+                        fi
+                        set -e
+                    """
+                    currentBuild.displayName = readFile file: "release_status.out"
+                }
+            }
+        }
+    }
+    post {}
+        always {
+            archiveArtifacts artifacts: '**/prerelease_validation.out,**/release_status.out', allowEmptyArchive: true
+        }
+    }
+}

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -116,7 +116,7 @@ pipeline {
             }
         }
     }
-    post {}
+    post {
         always {
             archiveArtifacts artifacts: '**/prerelease_validation.out,**/release_status.out', allowEmptyArchive: true
         }


### PR DESCRIPTION
# Description

VZ-4044 switch to use a separate job in internal agent for prerelease checks. Some checks required internal corpnet access, need  to run those checks on internal agent.

The periodic job also needed to get the artifacts from that job to properly set the RELEASABLE status

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
