### PR TITLE
VZ-4170: backport bom change for ingress-nginx v0.46.0 cve fixes

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -27,13 +27,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20211122142855-e5c824157",
+              "tag": "0.46.0-20211209212613-c6a2d0dd3",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "0.46.0-20211122142855-e5c824157",
+              "tag": "0.46.0-20211209212613-c6a2d0dd3",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -228,7 +228,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20211122142855-e5c824157",
+              "tag": "0.46.0-20211209212613-c6a2d0dd3",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             },
             {
@@ -244,7 +244,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "0.46.0-20211122142855-e5c824157",
+              "tag": "0.46.0-20211209212613-c6a2d0dd3",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             }


### PR DESCRIPTION
# Description

Backport BOM change to pick up latest BFS ingress-nginx v0.46.0 image, fixes some CVEs.

Fixes VZ-4170

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
