### PR TITLE
No JIRA.  Update rancher webhook to v0.1.2

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -53,6 +53,11 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		Key:   "hostname",
 		Value: rancherHostName,
 	})
+	// Always set useBundledChart=true
+	kvs = append(kvs, bom.KeyValue{
+		Key:   useBundledSystemChartKey,
+		Value: useBundledSystemChartValue,
+	})
 	kvs = appendRegistryOverrides(kvs)
 	return appendCAOverrides(kvs, ctx)
 }
@@ -72,12 +77,8 @@ func appendRegistryOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 		kvs = append(kvs, bom.KeyValue{
 			Key:   systemDefaultRegistryKey,
 			Value: rancherRegistry,
-		}, bom.KeyValue{
-			Key:   useBundledSystemChartKey,
-			Value: useBundledSystemChartValue,
 		})
 	}
-
 	return kvs
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -43,7 +43,7 @@ func TestAppendRegistryOverrides(t *testing.T) {
 	registry := "foobar"
 	imageRepo := "barfoo"
 	kvs, _ := AppendOverrides(ctx, "", "", "", []bom.KeyValue{})
-	assert.Equal(t, 6, len(kvs)) // should only have LetsEncrypt Overrides
+	assert.Equal(t, 7, len(kvs)) // should only have LetsEncrypt + useBundledSystemChart Overrides
 	_ = os.Setenv(constants.RegistryOverrideEnvVar, registry)
 	kvs, _ = AppendOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.Equal(t, 8, len(kvs))

--- a/platform-operator/helm_config/overrides/rancher-values.yaml
+++ b/platform-operator/helm_config/overrides/rancher-values.yaml
@@ -1,2 +1,5 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# Always use the Rancher-packaged system charts
+useBundledSystemChart: true

--- a/platform-operator/helm_config/overrides/rancher-values.yaml
+++ b/platform-operator/helm_config/overrides/rancher-values.yaml
@@ -1,5 +1,2 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-# Always use the Rancher-packaged system charts
-useBundledSystemChart: true

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -146,7 +146,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.2"
+              "tag": "v0.1.1"
             },
             {
               "image": "fleet-agent",
@@ -177,7 +177,7 @@
           "images": [
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.1"
+              "tag": "v0.1.2"
             }
           ]
         }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -146,7 +146,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.1"
+              "tag": "v0.1.2"
             },
             {
               "image": "fleet-agent",
@@ -167,17 +167,6 @@
             {
               "image": "local-path-provisioner",
               "tag": "v0.0.14"
-            }
-          ]
-        },
-        {
-          "registry": "docker.io",
-          "repository": "rancher",
-          "name": "additional-rancher-webhook",
-          "images": [
-            {
-              "image": "rancher-webhook",
-              "tag": "v0.1.2"
             }
           ]
         }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -169,6 +169,17 @@
               "tag": "v0.0.14"
             }
           ]
+        },
+        {
+          "registry": "docker.io",
+          "repository": "rancher",
+          "name": "additional-rancher-webhook",
+          "images": [
+            {
+              "image": "rancher-webhook",
+              "tag": "v0.1.1"
+            }
+          ]
         }
       ]
     },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -146,7 +146,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.1"
+              "tag": "v0.1.2"
             },
             {
               "image": "fleet-agent",


### PR DESCRIPTION
# Description

Update Rancher webhook version in the BOM to v0.1.2.
- also, set `useBundledSystemChart=true` for all installs to use bundled charts only.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
