### PR TITLE
No JIRA.  Update BOM validator to ignore Rancher additional images

### DIFF
--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -167,6 +167,7 @@ func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][tagLen]string,
 	for _, component := range vBom.Components {
 		for _, subcomponent := range component.Subcomponents {
 			if ignoreSubComponent(subcomponent.Name) {
+				fmt.Printf("Subcomponent %s of component %s on ignore list, skipping images %v\n", subcomponent.Name, component.Name, subcomponent.Images)
 				continue
 			}
 			for _, image := range subcomponent.Images {

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -40,6 +40,10 @@ type imageError struct {
 	clusterImageTags [tagLen]string
 }
 
+var ignoreSubComponents = []string{
+	"additional-rancher",
+}
+
 func main() {
 	var vBom verrazzanoBom                                // BOM from platform operator in struct form
 	var imagesInstalled = make(map[string][tagLen]string) // Map that contains the images installed into the cluster with associated set of tags
@@ -162,6 +166,9 @@ func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][tagLen]string,
 	var errorsFound bool = false
 	for _, component := range vBom.Components {
 		for _, subcomponent := range component.Subcomponents {
+			if ignoreSubComponent(subcomponent.Name) {
+				continue
+			}
 			for _, image := range subcomponent.Images {
 				if tags, ok := clusterImageMap[image.Image]; ok {
 					var tagFound bool = false
@@ -183,6 +190,16 @@ func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][tagLen]string,
 		}
 	}
 	return !errorsFound
+}
+
+//ignoreSubComponent - checks to see if a particular subcomponent is to be ignored
+func ignoreSubComponent(name string) bool {
+	for _, subComp := range ignoreSubComponents {
+		if subComp == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Report out the findings


### PR DESCRIPTION
# Description

Updates the BOM validator to ignore Rancher images that get installed in the background.  

At present we need to reference these images for private registry installs, however, Rancher does not strictly install what we declare.  Rancher requires a "min version" for these components, so in some cases (like upgrade) it may meet that requirement, but not match what's in our BOM.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
