### PR TITLE
VZ-4137: Automated tests for the OCI Logging integration

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -2568,8 +2568,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-<<<<<<< HEAD
-License file based on go.mod with md5 sum: 15b92f1e405d0ac256c133e7b5b39c23
-=======
-License file based on go.mod with md5 sum: 937cb84ded50cef3a8ab13a528d7bb2b
->>>>>>> 5a85ec766... VZ-4137: Add automated tests for OCI Logging integration
+License file based on go.mod with md5 sum: 127e0b16fe18d22794f1ff447eca11bb

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -2568,4 +2568,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
+<<<<<<< HEAD
 License file based on go.mod with md5 sum: 15b92f1e405d0ac256c133e7b5b39c23
+=======
+License file based on go.mod with md5 sum: 937cb84ded50cef3a8ab13a528d7bb2b
+>>>>>>> 5a85ec766... VZ-4137: Add automated tests for OCI Logging integration

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -2568,4 +2568,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 127e0b16fe18d22794f1ff447eca11bb
+License file based on go.mod with md5 sum: 24207bb69f062fea25d02dab6a3846a8

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jetstack/cert-manager v1.2.0
 	github.com/onsi/ginkgo/v2 v2.0.0-rc2
 	github.com/onsi/gomega v1.17.0
+	github.com/oracle/oci-go-sdk/v53 v53.1.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module github.com/verrazzano/verrazzano

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/oracle/oci-go-sdk/v53 v53.1.0 h1:v/vGMO8SuIi840ld6U1iaTYZkAx38C670PM+FXj8FeU=
+github.com/oracle/oci-go-sdk/v53 v53.1.0/go.mod h1:ODabZxMRxdDLEMxlwoEo1yHkWg5G4SYToDmJSAZ/hOM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
@@ -517,6 +519,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b h1:br+bPNZsJWKicw/5rALEo67QHs5weyD5tf8WST+4sJ0=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -537,6 +541,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -12,11 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
-
-const testNamespace string = "springboot"
 
 var expectedPodsSpringBootApp = []string{"springboot-workload"}
 var waitTimeout = 10 * time.Minute
@@ -28,7 +24,7 @@ var longPollingInterval = 20 * time.Second
 
 var _ = BeforeSuite(func() {
 	if !skipDeploy {
-		deploySpringBootApplication()
+		pkg.DeploySpringBootApplication()
 	}
 })
 
@@ -42,54 +38,9 @@ var _ = AfterSuite(func() {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
 	if !skipUndeploy {
-		undeploySpringBootApplication()
+		pkg.UndeploySpringBootApplication()
 	}
 })
-
-func deploySpringBootApplication() {
-	pkg.Log(pkg.Info, "Deploy Spring Boot Application")
-
-	pkg.Log(pkg.Info, "Create namespace")
-	Eventually(func() (*v1.Namespace, error) {
-		nsLabels := map[string]string{
-			"verrazzano-managed": "true",
-			"istio-injection":    "enabled"}
-		return pkg.CreateNamespace(testNamespace, nsLabels)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
-
-	pkg.Log(pkg.Info, "Create component resource")
-	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("examples/springboot-app/springboot-comp.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	pkg.Log(pkg.Info, "Create application resource")
-	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("examples/springboot-app/springboot-app.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred(), "Failed to create Spring Boot application resource")
-}
-
-func undeploySpringBootApplication() {
-	pkg.Log(pkg.Info, "Undeploy Spring Boot Application")
-	pkg.Log(pkg.Info, "Delete application")
-	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("examples/springboot-app/springboot-app.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	pkg.Log(pkg.Info, "Delete components")
-	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("examples/springboot-app/springboot-comp.yaml")
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	pkg.Log(pkg.Info, "Delete namespace")
-	Eventually(func() error {
-		return pkg.DeleteNamespace(testNamespace)
-	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
-
-	Eventually(func() bool {
-		_, err := pkg.GetNamespace(testNamespace)
-		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-}
 
 var _ = Describe("Verify Spring Boot Application", func() {
 	// Verify springboot-workload pod is running
@@ -99,7 +50,7 @@ var _ = Describe("Verify Spring Boot Application", func() {
 	Context("Deployment.", func() {
 		It("and waiting for expected pods must be running", func() {
 			Eventually(func() bool {
-				return pkg.PodsRunning(testNamespace, expectedPodsSpringBootApp)
+				return pkg.PodsRunning(pkg.SpringbootNamespace, expectedPodsSpringBootApp)
 			}, longWaitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -112,7 +63,7 @@ var _ = Describe("Verify Spring Boot Application", func() {
 	// THEN return the host name found in the gateway.
 	It("Get host from gateway.", func() {
 		Eventually(func() (string, error) {
-			host, err = k8sutil.GetHostnameFromGateway(testNamespace, "")
+			host, err = k8sutil.GetHostnameFromGateway(pkg.SpringbootNamespace, "")
 			return host, err
 		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
 	})

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package springboot

--- a/tests/e2e/oci/logging/ocilogging_suite_test.go
+++ b/tests/e2e/oci/logging/ocilogging_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestOCILogging(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "OCI Logging Suite")
+}

--- a/tests/e2e/oci/logging/ocilogging_suite_test.go
+++ b/tests/e2e/oci/logging/ocilogging_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package logging

--- a/tests/e2e/oci/logging/ocilogging_suite_test.go
+++ b/tests/e2e/oci/logging/ocilogging_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package logging

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -43,9 +43,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// if failed {
-	// 	pkg.ExecuteClusterDumpWithEnvVarConfig()
-	// }
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	pkg.UndeploySpringBootApplication()
 })
 

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package logging

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/oracle/oci-go-sdk/v53/common"
+	"github.com/oracle/oci-go-sdk/v53/loggingsearch"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	compartmentIDEnvVar = "COMPARTMENT_ID"
+	logGroupIDEnvVar    = "LOG_GROUP_ID"
+
+	waitTimeout     = 15 * time.Minute
+	pollingInterval = 30 * time.Second
+)
+
+var compartmentID string
+var logGroupID string
+
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = BeforeSuite(func() {
+	compartmentID = os.Getenv(compartmentIDEnvVar)
+	logGroupID = os.Getenv(logGroupIDEnvVar)
+	Expect(compartmentID).ToNot(BeEmpty(), fmt.Sprintf("%s env var must be set", compartmentIDEnvVar))
+	Expect(logGroupID).ToNot(BeEmpty(), fmt.Sprintf("%s env var must be set", logGroupIDEnvVar))
+})
+
+var _ = AfterSuite(func() {
+	// if failed {
+	// 	pkg.ExecuteClusterDumpWithEnvVarConfig()
+	// }
+	pkg.UndeploySpringBootApplication()
+})
+
+var _ = Describe("OCI Logging", func() {
+	var systemLogID, defaultAppLogID string
+
+	BeforeEach(func() {
+		var err error
+		systemLogID, defaultAppLogID, err = getLogIdentifiersFromVZCustomResource()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(systemLogID).ToNot(BeEmpty())
+		Expect(defaultAppLogID).ToNot(BeEmpty())
+	})
+
+	Context("initially", func() {
+		// GIVEN a Verrazzano installation
+		// WHEN I search for log records in the kube-system namespace
+		// THEN I expect to find at least one record
+		It("the system log object has recent log records in the kube-system namespace", func() {
+			Eventually(func() (int, error) {
+				logs, err := getLogRecordsFromOCI(compartmentID, logGroupID, systemLogID, "kube-system")
+				if err != nil {
+					return 0, err
+				}
+				return *logs.Summary.ResultCount, nil
+			}, waitTimeout, pollingInterval).Should(Not(BeZero()), "Expected to find kube-system logs but found none")
+		})
+
+		// GIVEN a Verrazzano installation
+		// WHEN I search for log records in the verrazzano-system namespace
+		// THEN I expect to find at least one record
+		It("the system log object has recent log records in the verrazzano-system namespace", func() {
+			Eventually(func() (int, error) {
+				logs, err := getLogRecordsFromOCI(compartmentID, logGroupID, systemLogID, constants.VerrazzanoSystemNamespace)
+				if err != nil {
+					return 0, err
+				}
+				return *logs.Summary.ResultCount, nil
+			}, waitTimeout, pollingInterval).Should(Not(BeZero()), "Expected to find verrazzano-system logs but found none")
+		})
+
+		// GIVEN a Verrazzano installation with no applications installed
+		// WHEN I search for log records in the default app Log object
+		// THEN I expect to find no records
+		It("the app log object has no log records", func() {
+			logs, err := getLogRecordsFromOCI(compartmentID, logGroupID, defaultAppLogID, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(*logs.Summary.ResultCount).To(BeZero(), "Expected no app logs but found at least one")
+		})
+	})
+
+	Context("after deploying an example application", func() {
+		// GIVEN a Verrazzano installation with an application deployed
+		// WHEN I search for log records in the default app Log object using the application namespace
+		// THEN I expect to find at least one record
+		It("the app log object has recent log records", func() {
+			pkg.DeploySpringBootApplication()
+
+			Eventually(func() (int, error) {
+				logs, err := getLogRecordsFromOCI(compartmentID, logGroupID, defaultAppLogID, pkg.SpringbootNamespace)
+				if err != nil {
+					return 0, err
+				}
+				return *logs.Summary.ResultCount, nil
+			}, waitTimeout, pollingInterval).Should(Not(BeZero()))
+		})
+	})
+})
+
+// getLogIdentifiersFromVZCustomResource returns the system and default app OCI Log identifiers from the
+// Verrazzano custom resource.
+func getLogIdentifiersFromVZCustomResource() (string, string, error) {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		return "", "", err
+	}
+	vz, err := pkg.GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		return "", "", err
+	}
+	if vz.Spec.Components.Fluentd.OCI == nil {
+		return "", "", fmt.Errorf("expected to find Fluentd OCI logging settings but found nil")
+	}
+
+	return vz.Spec.Components.Fluentd.OCI.SystemLogID, vz.Spec.Components.Fluentd.OCI.DefaultAppLogID, nil
+}
+
+// getLogRecordsFromOCI searches an OCI Log object for log records in the last 5 minutes. If the optional
+// namespace is specified, only log records in the namespace are matched, otherwise search for all log records
+// in the Log object identified by the compartment id, log group id, and log id.
+func getLogRecordsFromOCI(compartmentID, logGroupID, logID, namespace string) (*loggingsearch.SearchLogsResponse, error) {
+	pkg.Log(pkg.Info, "Checking for recent log records")
+
+	config := common.DefaultConfigProvider()
+	client, err := loggingsearch.NewLogSearchClientWithConfigurationProvider(config)
+	if err != nil {
+		return nil, err
+	}
+
+	var query string
+	if namespace == "" {
+		// no namespace specified, so fetch all records in the Log object
+		query = `search "%s/%s/%s" | sort by datetime desc`
+		query = fmt.Sprintf(query, compartmentID, logGroupID, logID)
+	} else {
+		query = `search "%s/%s/%s" | where "data"."kubernetes.namespace_name"='%s' | sort by datetime desc`
+		query = fmt.Sprintf(query, compartmentID, logGroupID, logID, namespace)
+	}
+
+	now := time.Now()
+	past := now.Add(-time.Minute * 5)
+	search := loggingsearch.SearchLogsDetails{
+		TimeStart:   &common.SDKTime{Time: past},
+		TimeEnd:     &common.SDKTime{Time: now},
+		SearchQuery: &query,
+	}
+
+	pkg.Log(pkg.Debug, fmt.Sprintf("Running log search query: %s", query))
+	logs, err := client.SearchLogs(context.Background(), loggingsearch.SearchLogsRequest{SearchLogsDetails: search})
+	if err != nil {
+		return nil, err
+	}
+
+	pkg.Log(pkg.Debug, fmt.Sprintf("Found %d log records", *logs.Summary.ResultCount))
+	if *logs.Summary.ResultCount > 0 {
+		pkg.Log(pkg.Debug, fmt.Sprintf("Last record: %s", logs.Results[0].String()))
+	}
+
+	return &logs, nil
+}

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package logging

--- a/tests/e2e/pkg/springboot.go
+++ b/tests/e2e/pkg/springboot.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/pkg/springboot.go
+++ b/tests/e2e/pkg/springboot.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const SpringbootNamespace = "springboot"
+
+const (
+	springbootPollingInterval = 10 * time.Second
+	springbootWaitTimeout     = 5 * time.Minute
+
+	springbootComponentYaml = "examples/springboot-app/springboot-comp.yaml"
+	springbootAppYaml       = "examples/springboot-app/springboot-app.yaml"
+)
+
+// DeploySpringBootApplication deploys the Springboot example application.
+func DeploySpringBootApplication() {
+	Log(Info, "Deploy Spring Boot Application")
+	Log(Info, "Create namespace")
+	gomega.Eventually(func() (*v1.Namespace, error) {
+		nsLabels := map[string]string{
+			"verrazzano-managed": "true",
+			"istio-injection":    "enabled"}
+		return CreateNamespace(SpringbootNamespace, nsLabels)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.BeNil())
+
+	Log(Info, "Create component resource")
+	gomega.Eventually(func() error {
+		return CreateOrUpdateResourceFromFile(springbootComponentYaml)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	Log(Info, "Create application resource")
+	gomega.Eventually(func() error {
+		return CreateOrUpdateResourceFromFile(springbootAppYaml)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+// UndeploySpringBootApplication undeploys the Springboot example application.
+func UndeploySpringBootApplication() {
+	Log(Info, "Undeploy Spring Boot Application")
+	Log(Info, "Delete application")
+	gomega.Eventually(func() error {
+		return DeleteResourceFromFile(springbootAppYaml)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	Log(Info, "Delete components")
+	gomega.Eventually(func() error {
+		return DeleteResourceFromFile(springbootComponentYaml)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	Log(Info, "Delete namespace")
+	gomega.Eventually(func() error {
+		return DeleteNamespace(SpringbootNamespace)
+	}, springbootWaitTimeout, springbootPollingInterval).ShouldNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func() bool {
+		_, err := GetNamespace(SpringbootNamespace)
+		return err != nil && errors.IsNotFound(err)
+	}, springbootWaitTimeout, springbootPollingInterval).Should(gomega.BeTrue())
+}


### PR DESCRIPTION
# Description

This PR adds automated e2e tests for the OCI Logging integration. The tests validate that log records appear in both the system and default application Log objects in OCI. The PR includes some refactoring to share the code for deploying and undeploying the Springboot example application.

Note that I added a dependency to `go.mod` for the OCI Golang SDK. The SDK is used to search for log records in OCI. Because this dependency is used only by tests, no additional licenses needed to be added to `THIRD_PARTY_LICENSES.txt` (at least that's my understanding).

Also note that the OCI Log Group and Log objects must exist prior to running this test. The next task is to integrate this test suite into a CI/CD pipeline that will test OCI service integrations. That pipeline will create the cluster, create the Log Group and Log objects, run the tests, and then clean up the OCI Logging and cluster resources.

Implements VZ-4137

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
