### PR TITLE
Basic Emit Metrics

### DIFF
--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -92,7 +92,7 @@ func AfterEachM(log *zap.SugaredLogger, body interface{}) bool {
 		ginkgo.Fail("Unsupported body type - expected function")
 	}
 	return ginkgo.AfterEach(func() {
-		metrics.Emit(log) // Starting point metric
+		metrics.Emit(log.With(metrics.Started)) // Starting point metric
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	})
 }

--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -48,7 +48,7 @@ func ItM(log *zap.SugaredLogger, text string, body interface{}) bool {
 		ginkgo.Fail("Unsupported body type - expected function")
 	}
 	return ginkgo.It(text, func() {
-		metrics.Emit(log) // Starting point metric
+		metrics.Emit(log.With(metrics.Status, metrics.Started)) // Starting point metric
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	})
 }
@@ -92,7 +92,7 @@ func AfterEachM(log *zap.SugaredLogger, body interface{}) bool {
 		ginkgo.Fail("Unsupported body type - expected function")
 	}
 	return ginkgo.AfterEach(func() {
-		metrics.Emit(log.With(metrics.Started)) // Starting point metric
+		metrics.Emit(log) // Starting point metric
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	})
 }

--- a/pkg/test/framework/ginkgo_wrapper_test.go
+++ b/pkg/test/framework/ginkgo_wrapper_test.go
@@ -4,7 +4,6 @@
 package framework
 
 import (
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"reflect"
 	"testing"
 
@@ -12,11 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var m, _ = metrics.NewForPackage("framework")
-
 // TestVzAfterEach
 func TestVzAfterEach(t *testing.T) {
-	result := VzAfterEach(m, func() {})
+	result := VzAfterEach(func() {})
 	assert.True(t, result)
 }
 
@@ -58,7 +55,7 @@ func TestVzDescribe(t *testing.T) {
 
 // TestVzIt
 func TestVzIt(t *testing.T) {
-	result := VzIt(m, "Test It", func() {})
+	result := VzIt("Test It", func() {})
 	assert.True(t, result)
 }
 

--- a/pkg/test/framework/ginkgo_wrapper_test.go
+++ b/pkg/test/framework/ginkgo_wrapper_test.go
@@ -4,6 +4,7 @@
 package framework
 
 import (
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"reflect"
 	"testing"
 
@@ -11,9 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var m, _ = metrics.NewForPackage("framework")
+
 // TestVzAfterEach
 func TestVzAfterEach(t *testing.T) {
-	result := VzAfterEach(func() {})
+	result := VzAfterEach(m, func() {})
 	assert.True(t, result)
 }
 
@@ -44,7 +47,7 @@ func TestVzContext(t *testing.T) {
 // TestVzCurrentGinkgoTestDescription
 func TestVzCurrentGinkgoTestDescription(t *testing.T) {
 	result := VzCurrentGinkgoTestDescription()
-	assert.True(t, reflect.DeepEqual(result, ginkgo.GinkgoTestDescription{}))
+	assert.True(t, reflect.DeepEqual(result, ginkgo.CurrentSpecReport()))
 }
 
 // TestVzDescribe
@@ -55,7 +58,7 @@ func TestVzDescribe(t *testing.T) {
 
 // TestVzIt
 func TestVzIt(t *testing.T) {
-	result := VzIt("Test It", func() {})
+	result := VzIt(m, "Test It", func() {})
 	assert.True(t, result)
 }
 

--- a/pkg/test/framework/ginkgo_wrapper_util_test.go
+++ b/pkg/test/framework/ginkgo_wrapper_util_test.go
@@ -62,7 +62,7 @@ func Test_createMetricsConfigFromEnv(t *testing.T) {
 	cfg, err := createMetricsConfigFromEnv("testname")
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
-	assert.Equal(t, "*testmetrics.PrometheusMetricsReceiverConfig", reflect.TypeOf(cfg).String())
+	assert.Equal(t, "*metrics.PrometheusMetricsReceiverConfig", reflect.TypeOf(cfg).String())
 	promCfg := cfg.(*testmetrics.PrometheusMetricsReceiverConfig)
 	assert.Equal(t, testURL, promCfg.PushGatewayURL)
 	assert.Equal(t, testUser, promCfg.PushGatewayUser)

--- a/pkg/test/framework/ginkgo_wrapper_util_test.go
+++ b/pkg/test/framework/ginkgo_wrapper_util_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	testmetrics "github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 )
 
 // TestIsBodyFunc - test function for introspecting an interface value
@@ -63,7 +63,7 @@ func Test_createMetricsConfigFromEnv(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, "*metrics.PrometheusMetricsReceiverConfig", reflect.TypeOf(cfg).String())
-	promCfg := cfg.(*testmetrics.PrometheusMetricsReceiverConfig)
+	promCfg := cfg.(*metrics.PrometheusMetricsReceiverConfig)
 	assert.Equal(t, testURL, promCfg.PushGatewayURL)
 	assert.Equal(t, testUser, promCfg.PushGatewayUser)
 	assert.Equal(t, testPass, promCfg.PushGatewayPassword)

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+const (
+	status   = "status"
+	attempts = "attempts"
+	test     = "test"
+)
+
+const (
+	pending = "pending"
+	passed  = "passed"
+	failed  = "failed"
+)
+
+func NewForPackage(pkg string) (*zap.SugaredLogger, error) {
+	cfg := zap.Config{
+		Encoding: "json",
+		Level:    zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey: zapcore.OmitKey,
+
+			LevelKey: zapcore.OmitKey,
+
+			TimeKey:    "timestamp",
+			EncodeTime: zapcore.EpochNanosTimeEncoder,
+
+			CallerKey:    "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+	cfg.OutputPaths = []string{"stdout"}
+	log, err := cfg.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return log.Sugar().With("id", uuid.NewUUID()).With("package", pkg), nil
+}
+
+func Emit(log *zap.SugaredLogger) {
+	spec := ginkgo.CurrentSpecReport()
+	s := getStatus(spec.State)
+	t := spec.LeafNodeText
+
+	log.With(status, s).
+		With(attempts, spec.NumAttempts).
+		With(test, t).
+		Info()
+}
+
+func getStatus(state types.SpecState) string {
+	if state == types.SpecStateInvalid {
+		return pending
+	}
+	return state.String()
+}

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	Started  = "started"
-	Status   = "Status"
+	Status   = "status"
 	attempts = "attempts"
 	test     = "test"
 	pending  = "pending"
@@ -53,7 +53,7 @@ type (
 		Data      string `json:"msg"`
 		Timestamp int64  `json:"timestamp"`
 		Test      string `json:"test,omitempty"`
-		Status    string `json:"Status,omitempty"`
+		Status    string `json:"status,omitempty"`
 	}
 )
 

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -26,7 +26,6 @@ const (
 	Status   = "status"
 	attempts = "attempts"
 	test     = "test"
-	pending  = "pending"
 
 	metricsIndex     = "metrics"
 	testLogIndex     = "testlogs"

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	status   = "status"
+	Started  = "started"
+	Status   = "Status"
 	attempts = "attempts"
 	test     = "test"
 	pending  = "pending"
@@ -52,7 +53,7 @@ type (
 		Data      string `json:"msg"`
 		Timestamp int64  `json:"timestamp"`
 		Test      string `json:"test,omitempty"`
-		Status    string `json:"status,omitempty"`
+		Status    string `json:"Status,omitempty"`
 	}
 )
 
@@ -204,18 +205,12 @@ func TeeToSearchWriter() {
 
 func Emit(log *zap.SugaredLogger) {
 	spec := ginkgo.CurrentSpecReport()
-	s := getStatus(spec.State)
+	if spec.State != types.SpecStateInvalid {
+		log = log.With(Status, spec.State.String())
+	}
 	t := spec.LeafNodeText
 
-	log.With(status, s).
-		With(attempts, spec.NumAttempts).
+	log.With(attempts, spec.NumAttempts).
 		With(test, t).
 		Info()
-}
-
-func getStatus(state types.SpecState) string {
-	if state == types.SpecStateInvalid {
-		return pending
-	}
-	return state.String()
 }

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -4,26 +4,60 @@
 package metrics
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"io"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"strings"
+	"time"
 )
 
 const (
 	status   = "status"
 	attempts = "attempts"
 	test     = "test"
+	pending  = "pending"
+
+	metricsIndex     = "metrics"
+	testLogIndex     = "testlogs"
+	searchWriterKey  = "searchWriter"
+	timeFormatString = "2006.01.02"
+	searchURL        = "SEARCH_HTTP_ENDPOINT"
+	searchPW         = "SEARCH_PASSWORD"
+	searchUser       = "SEARCH_USERNAME"
 )
 
-const (
-	pending = "pending"
-	passed  = "passed"
-	failed  = "failed"
+type (
+	//SearchWriter writes to a search endpoint, as an io.Writer and zapcore.WriteSyncer
+	SearchWriter struct {
+		hc    *http.Client
+		url   string
+		index string
+		auth  string
+	}
+
+	GinkgoLogFormatter struct {
+		s SearchWriter
+	}
+	GinkgoLogMessage struct {
+		Data      string `json:"msg"`
+		Timestamp int64  `json:"timestamp"`
+		Test      string `json:"test,omitempty"`
+		Status    string `json:"status,omitempty"`
+	}
 )
 
-func NewForPackage(pkg string) (*zap.SugaredLogger, error) {
+//NewMetricsLogger generates a new metrics logger, and tees ginkgo output to the search db
+func NewMetricsLogger(pkg string) (*zap.SugaredLogger, error) {
 	cfg := zap.Config{
 		Encoding: "json",
 		Level:    zap.NewAtomicLevelAt(zapcore.InfoLevel),
@@ -33,19 +67,139 @@ func NewForPackage(pkg string) (*zap.SugaredLogger, error) {
 			LevelKey: zapcore.OmitKey,
 
 			TimeKey:    "timestamp",
-			EncodeTime: zapcore.EpochNanosTimeEncoder,
+			EncodeTime: zapcore.EpochMillisTimeEncoder,
 
 			CallerKey:    "caller",
 			EncodeCaller: zapcore.ShortCallerEncoder,
 		},
 	}
-	cfg.OutputPaths = []string{"stdout"}
+
+	outputPaths, err := configureOutputs()
+	if err != nil {
+		return nil, err
+	}
+	cfg.OutputPaths = outputPaths
 	log, err := cfg.Build()
 	if err != nil {
 		return nil, err
 	}
 
-	return log.Sugar().With("id", uuid.NewUUID()).With("package", pkg), nil
+	TeeToSearchWriter()
+	return log.Sugar().With("suite_uuid", uuid.NewUUID()).With("package", pkg), nil
+}
+
+func (g GinkgoLogFormatter) Write(data []byte) (int, error) {
+	//spec := ginkgo.CurrentSpecReport()
+	msg := GinkgoLogMessage{
+		Data:      string(data),
+		Timestamp: timestamp(),
+		//Test:      spec.LeafNodeText,
+		//Status:    spec.State.String(),
+	}
+
+	msgData, err := json.Marshal(msg)
+	if err != nil {
+		return 0, err
+	}
+	return g.s.Write(msgData)
+}
+
+func timestamp() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}
+
+//SearchWriterFromEnv creates a SearchWriter using environment variables
+func SearchWriterFromEnv(index string) (SearchWriter, error) {
+	uri := os.Getenv(searchURL)
+	if uri == "" {
+		return SearchWriter{}, fmt.Errorf("%s is empty", searchURL)
+	}
+	auth := ""
+	user := os.Getenv(searchUser)
+	pw := os.Getenv(searchPW)
+	if user != "" && pw != "" {
+		auth = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", user, pw)))
+	}
+
+	return SearchWriter{
+		hc:    &http.Client{},
+		url:   uri,
+		index: index,
+		auth:  auth,
+	}, nil
+}
+
+//Close implement as needed
+func (s SearchWriter) Close() error {
+	return nil
+}
+
+//Sync implement as needed
+func (s SearchWriter) Sync() error {
+	return nil
+}
+
+//Write out the record to the search data store
+func (s SearchWriter) Write(data []byte) (int, error) {
+	index := s.timeStampIndex()
+
+	if strings.Contains(index, "metrics") {
+		v := string(data)
+		fmt.Println(v)
+	}
+
+	uri := fmt.Sprintf("%s/%s/_doc", s.url, index)
+	reader := bytes.NewReader(data)
+	if err := postRecord(s.hc, s.auth, uri, reader); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+//postRecord sends the reader record to the search data store via HTTP Post
+// Basic Authorization is used, if encoded auth is provided for basicAuth
+func postRecord(hc *http.Client, basicAuth, uri string, reader io.Reader) error {
+	req, err := http.NewRequest("POST", uri, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if basicAuth != "" { // Basic Auth is used if provided
+		req.Header.Set("Authorization", basicAuth)
+	}
+	_, err = hc.Do(req)
+	return err
+}
+
+//timeStampIndex formats the current index in %s-YYYY.mm.dd format
+func (s SearchWriter) timeStampIndex() string {
+	return fmt.Sprintf("%s-%s", s.index, time.Now().Format(timeFormatString))
+}
+
+//configureOutputs configures the search output path if it is available
+func configureOutputs() ([]string, error) {
+	searchWriter, err := SearchWriterFromEnv(metricsIndex)
+	if err != nil {
+		return []string{"stdout"}, nil
+	}
+
+	if err := zap.RegisterSink(searchWriterKey, func(u *neturl.URL) (zap.Sink, error) {
+		return searchWriter, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return []string{searchWriterKey + ":search"}, nil
+}
+
+func TeeToSearchWriter() {
+	searchWriter, err := SearchWriterFromEnv(testLogIndex)
+	if err == nil {
+		logFormatter := GinkgoLogFormatter{s: searchWriter}
+		ginkgo.GinkgoWriter.TeeTo(logFormatter)
+	}
 }
 
 func Emit(log *zap.SugaredLogger) {

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package metrics
 
 import (

--- a/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package metrics_test
 
 import (
@@ -8,5 +11,5 @@ import (
 
 func TestWriter(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Writer Suite")
+	RunSpecs(t, "Metrics Suite")
 }

--- a/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
@@ -1,0 +1,12 @@
+package metrics_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestWriter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Writer Suite")
+}

--- a/pkg/test/framework/metrics/ginkgo_metrics_test.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics_test.go
@@ -1,0 +1,24 @@
+package metrics_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+)
+
+var _ = Describe("Logger", func() {
+	m, _ := metrics.NewForPackage("metrics_test")
+
+	_ = framework.VzAfterEach(m, func() {})
+
+	framework.VzIt(m, "Should do a thing", func() {
+		fmt.Println("Ran a test!")
+
+	})
+
+	framework.VzIt(m, "Should do another thing", func() {
+		fmt.Println("Second test!")
+
+	})
+})

--- a/pkg/test/framework/metrics/ginkgo_metrics_test.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics_test.go
@@ -11,16 +11,18 @@ import (
 )
 
 var _ = Describe("Logger", func() {
-	m, _ := metrics.NewForPackage("metrics_test")
+	// Setup the Suite
+	m, _ := metrics.NewMetricsLogger("metrics")
+	_ = framework.AfterEachM(m, func() {})
 
-	_ = framework.VzAfterEach(m, func() {})
-
-	framework.VzIt(m, "Should do a thing", func() {
+	framework.ItM(m, "Should do a thing", func() {
 		fmt.Println("Ran a test!")
+		// Emits a metric with key(foo), value(bar)
+		metrics.Emit(m.With("foo", "bar"))
 
 	})
 
-	framework.VzIt(m, "Should do another thing", func() {
+	framework.ItM(m, "Should do another thing", func() {
 		fmt.Println("Second test!")
 
 	})

--- a/pkg/test/framework/metrics/ginkgo_metrics_test.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package metrics_test
 
 import (

--- a/pkg/test/framework/metrics/metrics.go
+++ b/pkg/test/framework/metrics/metrics.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package testmetrics
+package metrics
 
 import (
 	"fmt"

--- a/pkg/test/framework/metrics/prometheus.go
+++ b/pkg/test/framework/metrics/prometheus.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package testmetrics
+package metrics
 
 import (
 	"fmt"

--- a/pkg/test/framework/metrics/prometheus_test.go
+++ b/pkg/test/framework/metrics/prometheus_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package testmetrics
+package metrics
 
 import (
 	"testing"

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -45,7 +45,7 @@ var _ = BeforeSuite(func() {
 })
 
 var failed = false
-var _ = framework.VzAfterEach(func() {
+var _ = AfterEach(func() {
 	failed = failed || framework.VzCurrentGinkgoTestDescription().Failed()
 })
 


### PR DESCRIPTION
Metric would look like:
```
{
   "timestamp":1639520348298250000,
   "caller":"metrics/ginkgo_logger.go:56",
   "suite_id":"ba2b8cff-40fa-490a-97ed-ce43c2a88038",
   "package":"metrics_test",
   "status":"passed",
   "attempts":1,
   "test":"Should do another thing"
}
```

Client has full control to emit additional metrics by operating on the SugaredLogger.