### PR TITLE
VZ-4316.  Bump network policies async assertion wait timeout to 15min

### DIFF
--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -50,7 +50,7 @@ type accessCheckConfig struct {
 
 var (
 	expectedPods         = []string{"netpol-test"}
-	waitTimeout          = 5 * time.Minute
+	waitTimeout          = 15 * time.Minute
 	pollingInterval      = 30 * time.Second
 	shortWaitTimeout     = 30 * time.Second
 	shortPollingInterval = 10 * time.Second


### PR DESCRIPTION
# Description

Bump network policies async assertion wait timeout to 15 min.

Fixes VZ-4316.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
