### PR TITLE
VZ-4319.  Fix external-dns private registry install for release-1.1 branch.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -24,6 +24,7 @@ const (
 	externalDNSNamespace      = "cert-manager"
 	externalDNSDeploymentName = "external-dns"
 	ociSecretFileName         = "oci.yaml"
+	imagePullSecretHelmKey    = "global.imagePullSecrets[0]"
 )
 
 func preInstall(compContext spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
@@ -6,7 +6,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"path/filepath"
 )
@@ -26,7 +25,7 @@ func NewComponent() spi.Component {
 			ChartNamespace:          "cert-manager",
 			IgnoreNamespaceOverride: true,
 			SupportsOperatorInstall: true,
-			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
+			ImagePullSecretKeyname:  imagePullSecretHelmKey,
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "external-dns-values.yaml"),
 			AppendOverridesFunc:     AppendOverrides,
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_0_0,


### PR DESCRIPTION
# Description

Fix the Helm key used for image pull secret overrides when installing external-dns, 1.1 branch port.

Fixes VZ-4319

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
