### PR TITLE
JIRA:VZ-4313 Handle ingress cert and secret deletion in controller rather than webhook

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -56,7 +56,7 @@ const (
 	wlProxySSLHeaderVal       = "true"
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
-	finalizerName            = "ingresstrait.finalizers.verrazzano.io"
+	finalizerName             = "ingresstrait.finalizers.verrazzano.io"
 )
 
 // The port names used by WebLogic operator that do not have http prefix.
@@ -101,18 +101,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if isTraitBeingDeleted(trait) {
 			if err = r.cleanup(trait); err != nil {
 				return reconcile.Result{}, err
-			} else {
-				// resource cleanup has succeeded, remove the finalizer
-				if err = r.removeFinalizerIfRequired(ctx, trait); err != nil {
-					return reconcile.Result{}, err
-				}
 			}
-			return reconcile.Result{}, nil
-		} else {
-			// add finalizer
-			if err = r.addFinalizerIfRequired(ctx, trait); err != nil {
+			// resource cleanup has succeeded, remove the finalizer
+			if err = r.removeFinalizerIfRequired(ctx, trait); err != nil {
 				return reconcile.Result{}, err
 			}
+			return reconcile.Result{}, nil
+		}
+		// add finalizer
+		if err = r.addFinalizerIfRequired(ctx, trait); err != nil {
+			return reconcile.Result{}, err
 		}
 	} else {
 		return reconcile.Result{}, nil

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -207,7 +207,10 @@ func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
 
 // cleanupCert cleans up the generated certificate for the given app config
 func (r *Reconciler) cleanupCert(trait *vzapi.IngressTrait) (err error) {
-	gatewayCertName := fmt.Sprintf("%s-%s-cert", trait.Namespace, trait.Name)
+	gatewayCertName, err := buildCertificateNameFromAppName(trait)
+	if err != nil {
+		return err
+	}
 	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: constants.IstioSystemNamespace}
 	var cert *certapiv1alpha2.Certificate
 	cert, err = r.fetchCert(context.TODO(), r.Client, namespacedName)
@@ -222,7 +225,11 @@ func (r *Reconciler) cleanupCert(trait *vzapi.IngressTrait) (err error) {
 
 // cleanupSecret cleans up the generated secret for the given app config
 func (r *Reconciler) cleanupSecret(trait *vzapi.IngressTrait) (err error) {
-	gatewaySecretName := fmt.Sprintf("%s-%s-cert-secret", trait.Namespace, trait.Name)
+	gatewayCertName, err := buildCertificateNameFromAppName(trait)
+	if err != nil {
+		return err
+	}
+	gatewaySecretName := fmt.Sprintf("%s-secret", gatewayCertName)
 	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: constants.IstioSystemNamespace}
 	var secret *corev1.Secret
 	secret, err = r.fetchSecret(context.TODO(), r.Client, namespacedName)

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"reflect"
 	"strings"
 
@@ -55,6 +56,7 @@ const (
 	wlProxySSLHeaderVal       = "true"
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
+	finalizerName            = "ingresstrait.finalizers.verrazzano.io"
 )
 
 // The port names used by WebLogic operator that do not have http prefix.
@@ -94,8 +96,25 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// If the trait no longer exists or is being deleted then return success.
-	if trait == nil || isTraitBeingDeleted(trait) {
+	// If the trait no longer exists or is being deleted then cleanup the associated cert and secret resources
+	if trait != nil {
+		if isTraitBeingDeleted(trait) {
+			if err = r.cleanup(trait); err != nil {
+				return reconcile.Result{}, err
+			} else {
+				// resource cleanup has succeeded, remove the finalizer
+				if err = r.removeFinalizerIfRequired(ctx, trait); err != nil {
+					return reconcile.Result{}, err
+				}
+			}
+			return reconcile.Result{}, nil
+		} else {
+			// add finalizer
+			if err = r.addFinalizerIfRequired(ctx, trait); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	} else {
 		return reconcile.Result{}, nil
 	}
 
@@ -141,6 +160,111 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 		}
 	}
 	return &status
+}
+
+// addFinalizerIfRequired adds the finalizer to the trait if required
+// The finalizer is only added if the trait is not being deleted and the finalizer has not previously been added
+func (r *Reconciler) addFinalizerIfRequired(ctx context.Context, trait *vzapi.IngressTrait) error {
+	if trait.GetDeletionTimestamp().IsZero() && !vzstring.SliceContainsString(trait.Finalizers, finalizerName) {
+		traitName := vznav.GetNamespacedNameFromObjectMeta(trait.ObjectMeta).String()
+		r.Log.V(1).Info("Adding finalizer from trait", "trait", traitName)
+		trait.Finalizers = append(trait.Finalizers, finalizerName)
+		if err := r.Update(ctx, trait); err != nil {
+			r.Log.Error(err, "failed to add finalizer to trait", "trait", traitName)
+			return err
+		}
+	}
+	return nil
+}
+
+// removeFinalizerIfRequired removes the finalizer from the trait if required
+// The finalizer is only removed if the trait is being deleted and the finalizer had been added
+func (r *Reconciler) removeFinalizerIfRequired(ctx context.Context, trait *vzapi.IngressTrait) error {
+	if !trait.DeletionTimestamp.IsZero() && vzstring.SliceContainsString(trait.Finalizers, finalizerName) {
+		traitName := vznav.GetNamespacedNameFromObjectMeta(trait.ObjectMeta).String()
+		r.Log.Info("Removing finalizer from trait", "trait", traitName)
+		trait.Finalizers = vzstring.RemoveStringFromSlice(trait.Finalizers, finalizerName)
+		if err := r.Update(ctx, trait); err != nil {
+			r.Log.Error(err, "failed to remove finalizer to trait", "trait", traitName)
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupAppConfig cleans up the generated certificates and secrets associated with the given app config
+func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
+	err = r.cleanupCert(trait)
+	if err != nil {
+		return
+	}
+
+	err = r.cleanupSecret(trait)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// cleanupCert cleans up the generated certificate for the given app config
+func (r *Reconciler) cleanupCert(trait *vzapi.IngressTrait) (err error) {
+	gatewayCertName := fmt.Sprintf("%s-%s-cert", trait.Namespace, trait.Name)
+	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: constants.IstioSystemNamespace}
+	var cert *certapiv1alpha2.Certificate
+	cert, err = r.fetchCert(context.TODO(), r.Client, namespacedName)
+	if err != nil {
+		return err
+	}
+	if cert != nil {
+		err = r.Client.Delete(context.TODO(), cert, &client.DeleteOptions{})
+	}
+	return
+}
+
+// cleanupSecret cleans up the generated secret for the given app config
+func (r *Reconciler) cleanupSecret(trait *vzapi.IngressTrait) (err error) {
+	gatewaySecretName := fmt.Sprintf("%s-%s-cert-secret", trait.Namespace, trait.Name)
+	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: constants.IstioSystemNamespace}
+	var secret *corev1.Secret
+	secret, err = r.fetchSecret(context.TODO(), r.Client, namespacedName)
+	if err != nil {
+		return err
+	}
+	if secret != nil {
+		err = r.Client.Delete(context.TODO(), secret, &client.DeleteOptions{})
+	}
+	return
+}
+
+// fetchCert gets the cert for the given name; returns nil Certificate if not found
+func (r *Reconciler) fetchCert(ctx context.Context, c client.Reader, name types.NamespacedName) (*certapiv1alpha2.Certificate, error) {
+	var cert certapiv1alpha2.Certificate
+	err := c.Get(ctx, name, &cert)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("cert does not exist", "cert", name)
+			return nil, nil
+		}
+		r.Log.Info("failed to fetch cert", "cert", name)
+		return nil, err
+	}
+	return &cert, err
+}
+
+// fetchSecret gets the secret for the given name; returns nil Secret if not found
+func (r *Reconciler) fetchSecret(ctx context.Context, c client.Reader, name types.NamespacedName) (*corev1.Secret, error) {
+	var secret corev1.Secret
+	err := c.Get(ctx, name, &secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("secret does not exist", "secret", name)
+			return nil, nil
+		}
+		r.Log.Info("failed to fetch secret", "secret", name)
+		return nil, err
+	}
+	return &secret, err
 }
 
 // getGatewayName will generate a gateway name from the namespace and application name of the provided trait. Returns

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -427,11 +427,11 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 				APIVersion: "oam.verrazzano.io/v1alpha1",
 				Kind:       "IngressTrait"}
 			trait.ObjectMeta = metav1.ObjectMeta{
-				Namespace: name.Namespace,
-				Name:      name.Name,
+				Namespace:         name.Namespace,
+				Name:              name.Name,
 				DeletionTimestamp: &metav1.Time{Time: time.Now()},
-				Finalizers: []string{"ingresstrait.finalizers.verrazzano.io"},
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
 			trait.Spec.Rules = []vzapi.IngressRule{{
 				Hosts: []string{"test-host"},
 				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
@@ -444,8 +444,8 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 		})
 	// Expect a call to get the associated certificate
 	mock.EXPECT(). // get certificate
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
+			Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert"}, gomock.Not(gomock.Nil())).
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
 			cert.Namespace = name.Namespace
 			cert.Name = name.Name
 			return nil

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -444,7 +444,7 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 		})
 	// Expect a call to get the associated certificate
 	mock.EXPECT(). // get certificate
-			Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert"}, gomock.Not(gomock.Nil())).
+			Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
 			DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
 			cert.Namespace = name.Namespace
 			cert.Name = name.Name
@@ -455,12 +455,12 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, cert *certapiv1alpha2.Certificate, opt *client.DeleteOptions) error {
 			assert.Equal("istio-system", cert.Namespace)
-			assert.Equal("test-space-test-trait-name-cert", cert.Name)
+			assert.Equal("test-space-myapp-cert", cert.Name)
 			return nil
 		})
 	// Expect a call to get the secret
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert-secret"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *k8score.Secret) error {
 			sec.Namespace = name.Namespace
 			sec.Name = name.Name
@@ -471,7 +471,7 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, sec *k8score.Secret, opt *client.DeleteOptions) error {
 			assert.Equal("istio-system", sec.Namespace)
-			assert.Equal("test-space-test-trait-name-cert-secret", sec.Name)
+			assert.Equal("test-space-myapp-cert-secret", sec.Name)
 			return nil
 		})
 	// Expect a call to update the the ingress trait.

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -103,6 +103,16 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 				Name:       "test-workload-name"}
 			return nil
 		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
+			return nil
+		})
 	// Expect a call to get the containerized workload resource
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
@@ -272,6 +282,16 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 				Name:       "test-workload-name"}
 			return nil
 		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
+			return nil
+		})
 	// Expect a call to get the containerized workload resource
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
@@ -391,6 +411,89 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 	assert.Equal(time.Duration(0), result.RequeueAfter)
 }
 
+// TestDeleteCertAndSecretWhenTraitIsDeleted tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that is marked for deletion
+// WHEN the trait exists
+// THEN ensure that the cert and secret associated with the trait are also deleted
+func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers: []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to get the associated certificate
+	mock.EXPECT(). // get certificate
+		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
+			cert.Namespace = name.Namespace
+			cert.Name = name.Name
+			return nil
+		})
+	// Expect a call to delete the cert
+	mock.EXPECT().
+		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, cert *certapiv1alpha2.Certificate, opt *client.DeleteOptions) error {
+			assert.Equal("istio-system", cert.Namespace)
+			assert.Equal("test-space-test-trait-name-cert", cert.Name)
+			return nil
+		})
+	// Expect a call to get the secret
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-test-trait-name-cert-secret"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *k8score.Secret) error {
+			sec.Namespace = name.Namespace
+			sec.Name = name.Name
+			return nil
+		})
+	// Expect a call to delete the secret
+	mock.EXPECT().
+		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, sec *k8score.Secret, opt *client.DeleteOptions) error {
+			assert.Equal("istio-system", sec.Namespace)
+			assert.Equal("test-space-test-trait-name-cert-secret", sec.Name)
+			return nil
+		})
+	// Expect a call to update the the ingress trait.
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, obj *vzapi.IngressTrait) error {
+		assert.Equal("test-space", obj.Namespace)
+		assert.Equal("test-trait-name", obj.Name)
+		assert.Len(obj.Finalizers, 0)
+		return nil
+	})
+
+	// Create and make the request
+	request := newRequest("test-space", "test-trait-name")
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
 // TestSuccessfullyUpdateIngressWithCertSecret tests the Reconcile method for the following use case.
 // GIVEN a request to reconcile an ingress trait resource that specifies a certificate secret to use for security
 // WHEN the trait and ingress/gateway exist
@@ -419,6 +522,16 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 	// Expect a call to get the containerized workload resource
@@ -588,6 +701,16 @@ func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
 				Name:       "test-workload-name"}
 			return nil
 		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
+			return nil
+		})
 	// Expect a call to get the containerized workload resource
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
@@ -686,6 +809,16 @@ func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 	// Expect a call to get the containerized workload resource
@@ -791,6 +924,16 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 				APIVersion: "oam.verrazzano.io/v1alpha1",
 				Kind:       "VerrazzanoCoherenceWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 
@@ -981,6 +1124,16 @@ func TestFailureToGetWorkload(t *testing.T) {
 				Name:       "test-workload-name"}
 			return nil
 		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
+			return nil
+		})
 	// Expect a call to get the containerized workload resource and return an error
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
@@ -1026,6 +1179,16 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 	// Expect a call to get the containerized workload resource
@@ -1086,6 +1249,16 @@ func TestFailureToUpdateStatus(t *testing.T) {
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 	// Expect a call to get the containerized workload resource
@@ -1749,8 +1922,7 @@ func TestGetNotFoundResource(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-name"}, gomock.Any()).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "oam.verrazzano.io", Resource: "IngressTrait"}, "test-name")).
-		AnyTimes()
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "oam.verrazzano.io", Resource: "IngressTrait"}, "test-name"))
 	reconciler := newIngressTraitReconciler(mock)
 	request := newRequest("test-space", "test-name")
 	result, err := reconciler.Reconcile(request)
@@ -3076,6 +3248,16 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 				APIVersion: "oam.verrazzano.io/v1alpha1",
 				Kind:       "VerrazzanoCoherenceWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	// Expect a call to update the trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait) error {
+			assert.Equal("test-space", trait.Namespace)
+			assert.Equal("test-trait-name", trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal("ingresstrait.finalizers.verrazzano.io", trait.Finalizers[0])
 			return nil
 		})
 

--- a/application-operator/controllers/webhooks/appconfig_defaulter.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter.go
@@ -105,4 +105,3 @@ func (a *AppConfigWebhook) cleanupAppConfig(appConfig *oamv1.ApplicationConfigur
 	}
 	return ap.cleanupAuthorizationPoliciesForProjects(appConfig.Namespace, appConfig.Name)
 }
-

--- a/application-operator/controllers/webhooks/appconfig_defaulter.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter.go
@@ -6,17 +6,11 @@ package webhooks
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
-	certapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
-	"github.com/verrazzano/verrazzano/application-operator/constants"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 	v1beta12 "k8s.io/api/admission/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,16 +97,6 @@ func (a *AppConfigWebhook) Handle(ctx context.Context, req admission.Request) ad
 
 // cleanupAppConfig cleans up the generated certificates and secrets associated with the given app config
 func (a *AppConfigWebhook) cleanupAppConfig(appConfig *oamv1.ApplicationConfiguration) (err error) {
-	err = a.cleanupCert(appConfig)
-	if err != nil {
-		return
-	}
-
-	err = a.cleanupSecret(appConfig)
-	if err != nil {
-		return
-	}
-
 	// Fixup Istio Authorization policies within a project
 	ap := &AuthorizationPolicy{
 		Client:      a.Client,
@@ -122,62 +106,3 @@ func (a *AppConfigWebhook) cleanupAppConfig(appConfig *oamv1.ApplicationConfigur
 	return ap.cleanupAuthorizationPoliciesForProjects(appConfig.Namespace, appConfig.Name)
 }
 
-// cleanupCert cleans up the generated certificate for the given app config
-func (a *AppConfigWebhook) cleanupCert(appConfig *oamv1.ApplicationConfiguration) (err error) {
-	gatewayCertName := fmt.Sprintf("%s-%s-cert", appConfig.Namespace, appConfig.Name)
-	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: constants.IstioSystemNamespace}
-	var cert *certapiv1alpha2.Certificate
-	cert, err = fetchCert(context.TODO(), a.Client, namespacedName)
-	if err != nil {
-		return err
-	}
-	if cert != nil {
-		err = a.Client.Delete(context.TODO(), cert, &client.DeleteOptions{})
-	}
-	return
-}
-
-// cleanupSecret cleans up the generated secret for the given app config
-func (a *AppConfigWebhook) cleanupSecret(appConfig *oamv1.ApplicationConfiguration) (err error) {
-	gatewaySecretName := fmt.Sprintf("%s-%s-cert-secret", appConfig.Namespace, appConfig.Name)
-	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: constants.IstioSystemNamespace}
-	var secret *corev1.Secret
-	secret, err = fetchSecret(context.TODO(), a.Client, namespacedName)
-	if err != nil {
-		return err
-	}
-	if secret != nil {
-		err = a.Client.Delete(context.TODO(), secret, &client.DeleteOptions{})
-	}
-	return
-}
-
-// fetchCert gets the cert for the given name; returns nil Certificate if not found
-func fetchCert(ctx context.Context, c client.Reader, name types.NamespacedName) (*certapiv1alpha2.Certificate, error) {
-	var cert certapiv1alpha2.Certificate
-	err := c.Get(ctx, name, &cert)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			appConfDefLog.Info("cert does not exist", "cert", name)
-			return nil, nil
-		}
-		appConfDefLog.Info("failed to fetch cert", "cert", name)
-		return nil, err
-	}
-	return &cert, err
-}
-
-// fetchSecret gets the secret for the given name; returns nil Secret if not found
-func fetchSecret(ctx context.Context, c client.Reader, name types.NamespacedName) (*corev1.Secret, error) {
-	var secret corev1.Secret
-	err := c.Get(ctx, name, &secret)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			appConfDefLog.Info("secret does not exist", "secret", name)
-			return nil, nil
-		}
-		appConfDefLog.Info("failed to fetch secret", "secret", name)
-		return nil, err
-	}
-	return &secret, err
-}

--- a/application-operator/controllers/webhooks/appconfig_defaulter_test.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter_test.go
@@ -14,18 +14,12 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core"
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
-	certapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 )
@@ -146,60 +140,11 @@ func TestAppConfigDefaulterHandleDefaultError(t *testing.T) {
 }
 
 func testAppConfigWebhookHandleDelete(t *testing.T, certFound, secretFound, dryRun bool) {
-	const istioSystem = "istio-system"
-	const certName = "default-hello-app-cert"
-	const secretName = "default-hello-app-cert-secret"
 
 	mocker := gomock.NewController(t)
 	mockClient := mocks.NewMockClient(mocker)
 
 	if !dryRun {
-		// get cert
-		mockClient.EXPECT().
-			Get(gomock.Any(), types.NamespacedName{Namespace: istioSystem, Name: certName}, gomock.Not(gomock.Nil())).
-			DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
-				if certFound {
-					cert.Namespace = istioSystem
-					cert.Name = certName
-					return nil
-				}
-				return k8serrors.NewNotFound(k8sschema.GroupResource{}, certName)
-			})
-
-		// delete cert
-		if certFound {
-			mockClient.EXPECT().
-				Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, cert *certapiv1alpha2.Certificate, opt *client.DeleteOptions) error {
-					assert.Equal(t, istioSystem, cert.Namespace)
-					assert.Equal(t, certName, cert.Name)
-					return nil
-				})
-		}
-
-		// get secret
-		mockClient.EXPECT().
-			Get(gomock.Any(), types.NamespacedName{Namespace: istioSystem, Name: secretName}, gomock.Not(gomock.Nil())).
-			DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *corev1.Secret) error {
-				if secretFound {
-					sec.Namespace = istioSystem
-					sec.Name = secretName
-					return nil
-				}
-				return k8serrors.NewNotFound(k8sschema.GroupResource{}, secretName)
-			})
-
-		// delete secret
-		if secretFound {
-			mockClient.EXPECT().
-				Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, sec *corev1.Secret, opt *client.DeleteOptions) error {
-					assert.Equal(t, istioSystem, sec.Namespace)
-					assert.Equal(t, secretName, sec.Name)
-					return nil
-				})
-		}
-
 		// list projects
 		mockClient.EXPECT().
 			List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any())


### PR DESCRIPTION
# Description

The logic for deleting the cert and secret associated with an ingress during deletion was moved to the controller from the webhook.  This will facilitate retries of the deletion operations (reconciler retries).

Fixes VZ-4313

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
