### PR TITLE
VZ-4334: Set log_es_400_reason to capture more information

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -339,6 +339,7 @@ data:
       @type elasticsearch
       @id out_elasticsearch
       @log_level info
+      log_es_400_reason true
       logstash_format true
       logstash_prefix verrazzano-logstash
       target_index_key target_index


### PR DESCRIPTION
# Description

We have had multiple AT failures related to Elasticsearch, where Fluentd reports a "400" error attempting to send logs to Elasticsearch. This PR enables a flag that causes Fluentd to log the reason for that error. Hopefully this will provide more informations so we can troubleshoot the error.

I first tried to reproduce this locally but could not.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
