### PR TITLE
VZ-4263: add workload mutuating webhook code per spec

### DIFF
--- a/application-operator/controllers/webhooks/scrape_generator_webhook.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook.go
@@ -50,7 +50,7 @@ type ScrapeGeneratorWebhook struct {
 
 // Handle - handler for the mutating webhook
 func (a *ScrapeGeneratorWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
-	scrapeGeneratorLogger.Info(fmt.Sprintf("group: %s, version: %s, kind: %s, namespace: %s", req.Kind.Group, req.Kind.Version, req.Kind.Kind, req.Namespace))
+	scrapeGeneratorLogger.Info(fmt.Sprintf("group: %s, version: %s, kind: %s, namespace: %s, name: %s", req.Kind.Group, req.Kind.Version, req.Kind.Kind, req.Namespace, req.Name))
 
 	// Check the type of resource in the admission request
 	switch strings.ToLower(req.Kind.Kind) {

--- a/application-operator/controllers/webhooks/scrape_generator_webhook.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook.go
@@ -116,7 +116,7 @@ func (a *ScrapeGeneratorWebhook) handleWorkloadResource(ctx context.Context, req
 		// Look for a matching metrics template workload whose workload selector matches.
 		// First, check the namespace of the workload resource and then check the verrazzano-system namespace
 		// NOTE: use the first match for now
-		var metricsTemplate = &vzapp.MetricsTemplate{}
+		var metricsTemplate *vzapp.MetricsTemplate
 		found := true
 		metricsTemplate, err := a.findMatchingTemplate(ctx, unst, unst.GetNamespace())
 		if err != nil {

--- a/application-operator/controllers/webhooks/scrape_generator_webhook.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,9 +33,8 @@ var scrapeGeneratorLogger = ctrl.Log.WithName("webhooks.scrape-generator")
 // ScrapeGeneratorWebhook type for the mutating webhook
 type ScrapeGeneratorWebhook struct {
 	client.Client
-	Decoder       *admission.Decoder
-	KubeClient    kubernetes.Interface
-	DynamicClient dynamic.Interface
+	Decoder    *admission.Decoder
+	KubeClient kubernetes.Interface
 }
 
 // Handle - handler for the mutating webhook

--- a/application-operator/controllers/webhooks/scrape_generator_webhook.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook.go
@@ -31,7 +31,7 @@ const ScrapeGeneratorLoadPath = "/scrape-generator"
 // StatusReasonSuccess constant for successful response
 const StatusReasonSuccess = "success"
 
-const ( app.verrazzano.io/metrics
+const (
 	MetricsAnnotation            = "app.verrazzano.io/metrics"
 	MetricsWorkloadUIDLabel      = "app.verrazzano.io/metrics-workload-uid"
 	MetricsTemplateUIDLabel      = "app.verrazzano.io/metrics-template-uid"

--- a/application-operator/controllers/webhooks/scrape_generator_webhook.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook.go
@@ -68,6 +68,8 @@ func (a *ScrapeGeneratorWebhook) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
+// handleWorkloadResource decodes the admission request for a workload resource into an unstructured
+// and then processes workload resource
 func (a *ScrapeGeneratorWebhook) handleWorkloadResource(ctx context.Context, req admission.Request) admission.Response {
 	unst := &unstructured.Unstructured{}
 	err := a.Decoder.Decode(req, unst)

--- a/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
@@ -315,7 +315,12 @@ func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
 	res := v.Handle(context.TODO(), req)
 	assert.True(t, res.Allowed)
 	assert.NotNil(t, res.Patches)
-	assert.Len(t, res.Patches, 3)
+	assert.Len(t, res.Patches, 1)
+	assert.Equal(t, "add", res.Patches[0].Operation)
+	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
 }
 
 // TestHandleMetricsTemplateSystemNamespace tests the handling of a workload resource which references a metrics
@@ -363,7 +368,12 @@ func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
 	res := v.Handle(context.TODO(), req)
 	assert.True(t, res.Allowed)
 	assert.NotNil(t, res.Patches)
-	assert.Len(t, res.Patches, 3)
+	assert.Len(t, res.Patches, 1)
+	assert.Equal(t, "add", res.Patches[0].Operation)
+	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
 }
 
 // TestHandleMetricsTemplateConfigMapNotFound tests the handling of a workload resource which references a metrics
@@ -469,7 +479,7 @@ func TestHandleMatchWorkloadNamespace(t *testing.T) {
 	assert.NotNil(t, res.Patches)
 	assert.Len(t, res.Patches, 1)
 	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/annotations", res.Patches[0].Path)
+	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
@@ -533,7 +543,7 @@ func TestHandleMatchSystemNamespace(t *testing.T) {
 	assert.NotNil(t, res.Patches)
 	assert.Len(t, res.Patches, 1)
 	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/annotations", res.Patches[0].Path)
+	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
 	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")

--- a/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ func newScrapeGeneratorWebhook() ScrapeGeneratorWebhook {
 	scheme.AddKnownTypes(schema.GroupVersion{
 		Version: "v1",
 	}, &corev1.Pod{}, &appsv1.Deployment{}, &appsv1.ReplicaSet{}, &appsv1.StatefulSet{})
+	vzapp.AddToScheme(scheme)
 	decoder, _ := admission.NewDecoder(scheme)
 	cli := ctrlfake.NewFakeClientWithScheme(scheme)
 	v := ScrapeGeneratorWebhook{
@@ -144,6 +146,255 @@ func TestHandleStatefulSet(t *testing.T) {
 	assert.True(res.Allowed, "Expected validation to succeed.")
 }
 
+// TestHandleOwnerRefs tests the handling of a workload resource with owner references
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource has owner references
+// THEN the Handle function should succeed and the workload resource not mutated
+func TestHandleOwnerRefs(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", nil)
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "foo",
+				},
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.Nil(res.Patches, "expected no changes to workload resource")
+}
+
+// TestHandleNoNamespaceLabel tests the handling of a workload resource whose namespace is not labeled with
+// 	"verrazzano-managed": "true"
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource namespace is not labeled with "verrazzano-managed": "true"
+// THEN the Handle function should succeed and the workload resource not mutated
+func TestHandleNoNamespaceLabel(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", nil)
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.Nil(res.Patches, "expected no changes to workload resource")
+}
+
+// TestHandleNamespaceLabelFalse tests the handling of a workload resource whose namespace is labeled with
+// 	"verrazzano-managed": "false"
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource namespace is labeled with "verrazzano-managed": "false"
+// THEN the Handle function should succeed and the workload resource not mutated
+func TestHandleNamespaceLabelFalse(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", map[string]string{"verrazzano-managed": "false"})
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.Nil(res.Patches, "expected no changes to workload resource")
+}
+
+// TestHandleMetricsNone tests the handling of a workload resource with "app.verrazzano.io/metrics": "none"
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource has  "app.verrazzano.io/metrics": "none"
+// THEN the Handle function should succeed and the workload resource not mutated
+func TestHandleMetricsNone(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", map[string]string{"verrazzano-managed": "true"})
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"app.verrazzano.io/metrics": "none",
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.Nil(res.Patches, "expected no changes to workload resource")
+}
+
+// TestHandleInvalidMetricsTemplate tests the handling of a workload resource with references a metrics template
+//  that does not exist
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource has  "app.verrazzano.io/metrics": "badTemplate"
+// THEN the Handle function should generate an error
+func TestHandleInvalidMetricsTemplate(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", map[string]string{"verrazzano-managed": "true"})
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"app.verrazzano.io/metrics": "badTemplate",
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.False(res.Allowed)
+	assert.Equal("metricstemplates.app.verrazzano.io \"badTemplate\" not found", res.Result.Message)
+}
+
+// TestHandleMetricsTemplateWorkloadNamespace tests the handling of a workload resource which references a metrics
+//  template found in the namespace of the workload resource
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource has a valid metrics template reference
+// THEN the Handle function should succeed and the workload resource is patched
+func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", map[string]string{"verrazzano-managed": "true"})
+	v.createConfigMap(t, "test", "testPromConfigMap")
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			UID:       "11",
+			Annotations: map[string]string{
+				"app.verrazzano.io/metrics": "testTemplateSameNamespace",
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	testTemplate := vzapp.MetricsTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "testTemplateSameNamespace",
+			UID:       "22",
+		},
+		Spec: vzapp.MetricsTemplateSpec{
+			WorkloadSelector: vzapp.WorkloadSelector{},
+			PrometheusConfig: vzapp.PrometheusConfig{
+				TargetConfigMap: vzapp.TargetConfigMap{
+					Namespace: "test",
+					Name:      "testPromConfigMap",
+				},
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.NotNil(res.Patches)
+	assert.Len(res.Patches, 3)
+	assert.Equal("add", res.Patches[0].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-prometheus-configmap-uid", res.Patches[0].Path)
+	assert.Equal("33", res.Patches[0].Value)
+	assert.Equal("add", res.Patches[1].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-template-uid", res.Patches[1].Path)
+	assert.Equal("22", res.Patches[1].Value)
+	assert.Equal("add", res.Patches[2].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-workload-uid", res.Patches[2].Path)
+	assert.Equal("11", res.Patches[2].Value)
+}
+
+// TestHandleMetricsTemplateSystemNamespace tests the handling of a workload resource which references a metrics
+//  template found in the verrazzano-system namespace
+// GIVEN a call to the webhook Handle function
+// WHEN the workload resource has a valid metrics template reference
+// THEN the Handle function should succeed and the workload resource is patched
+func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
+	assert := assert.New(t)
+	v := newScrapeGeneratorWebhook()
+
+	// Test data
+	v.createNamespace(t, "test", map[string]string{"verrazzano-managed": "true"})
+	v.createNamespace(t, "verrazzano-system", nil)
+	v.createConfigMap(t, "test", "testPromConfigMap")
+	testDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			UID:       "11",
+			Annotations: map[string]string{
+				"app.verrazzano.io/metrics": "testTemplateSameNamespace",
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	testTemplate := vzapp.MetricsTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "verrazzano-system",
+			Name:      "testTemplateSameNamespace",
+			UID:       "22",
+		},
+		Spec: vzapp.MetricsTemplateSpec{
+			WorkloadSelector: vzapp.WorkloadSelector{},
+			PrometheusConfig: vzapp.PrometheusConfig{
+				TargetConfigMap: vzapp.TargetConfigMap{
+					Namespace: "test",
+					Name:      "testPromConfigMap",
+				},
+			},
+		},
+	}
+	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+
+	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
+	res := v.Handle(context.TODO(), req)
+	assert.True(res.Allowed)
+	assert.NotNil(res.Patches)
+	assert.Len(res.Patches, 3)
+	assert.Equal("add", res.Patches[0].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-prometheus-configmap-uid", res.Patches[0].Path)
+	assert.Equal("33", res.Patches[0].Value)
+	assert.Equal("add", res.Patches[1].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-template-uid", res.Patches[1].Path)
+	assert.Equal("22", res.Patches[1].Value)
+	assert.Equal("add", res.Patches[2].Operation)
+	assert.Equal("/metadata/annotations/app.verrazzano.io~1metrics-workload-uid", res.Patches[2].Path)
+	assert.Equal("11", res.Patches[2].Value)
+}
+
 func (v *ScrapeGeneratorWebhook) createNamespace(t *testing.T, name string, labels map[string]string) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -152,5 +403,17 @@ func (v *ScrapeGeneratorWebhook) createNamespace(t *testing.T, name string, labe
 		},
 	}
 	_, err := v.KubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	assert.NoError(t, err, "unexpected error creating namespace")
+}
+
+func (v *ScrapeGeneratorWebhook) createConfigMap(t *testing.T, namespace string, name string) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       "33",
+		},
+	}
+	_, err := v.KubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
 	assert.NoError(t, err, "unexpected error creating namespace")
 }

--- a/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -29,9 +30,10 @@ func newScrapeGeneratorWebhook() ScrapeGeneratorWebhook {
 	decoder, _ := admission.NewDecoder(scheme)
 	cli := ctrlfake.NewFakeClientWithScheme(scheme)
 	v := ScrapeGeneratorWebhook{
-		Client:     cli,
-		Decoder:    decoder,
-		KubeClient: fake.NewSimpleClientset(),
+		Client:        cli,
+		Decoder:       decoder,
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		KubeClient:    fake.NewSimpleClientset(),
 	}
 	return v
 }

--- a/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
@@ -59,7 +59,6 @@ func newScrapeGeneratorRequest(op admissionv1beta1.Operation, kind string, obj i
 // WHEN the Pod is properly formed
 // THEN the validation should succeed
 func TestHandlePod(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -70,11 +69,11 @@ func TestHandlePod(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testPod))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testPod))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Pod", testPod)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed, "Expected validation to succeed.")
+	assert.True(t, res.Allowed, "Expected validation to succeed.")
 }
 
 // TestHandleDeployment tests the handling of a Deployment resource
@@ -126,7 +125,6 @@ func TestHandleReplicaSet(t *testing.T) {
 // WHEN the StatefulSet is properly formed
 // THEN the validation should succeed
 func TestHandleStatefulSet(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -137,11 +135,11 @@ func TestHandleStatefulSet(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testStatefulSet))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testStatefulSet))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "StatefulSet", testStatefulSet)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed, "Expected validation to succeed.")
+	assert.True(t, res.Allowed, "Expected validation to succeed.")
 }
 
 // TestHandleOwnerRefs tests the handling of a workload resource with owner references
@@ -149,7 +147,6 @@ func TestHandleStatefulSet(t *testing.T) {
 // WHEN the workload resource has owner references
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleOwnerRefs(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -165,12 +162,12 @@ func TestHandleOwnerRefs(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Nil(res.Patches, "expected no changes to workload resource")
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.Patches, "expected no changes to workload resource")
 }
 
 // TestHandleNoNamespaceLabel tests the handling of a workload resource whose namespace is not labeled with
@@ -179,7 +176,6 @@ func TestHandleOwnerRefs(t *testing.T) {
 // WHEN the workload resource namespace is not labeled with "verrazzano-managed": "true"
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleNoNamespaceLabel(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -190,12 +186,12 @@ func TestHandleNoNamespaceLabel(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Nil(res.Patches, "expected no changes to workload resource")
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.Patches, "expected no changes to workload resource")
 }
 
 // TestHandleNamespaceLabelFalse tests the handling of a workload resource whose namespace is labeled with
@@ -204,7 +200,6 @@ func TestHandleNoNamespaceLabel(t *testing.T) {
 // WHEN the workload resource namespace is labeled with "verrazzano-managed": "false"
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleNamespaceLabelFalse(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -215,12 +210,12 @@ func TestHandleNamespaceLabelFalse(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Nil(res.Patches, "expected no changes to workload resource")
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.Patches, "expected no changes to workload resource")
 }
 
 // TestHandleMetricsNone tests the handling of a workload resource with "app.verrazzano.io/metrics": "none"
@@ -228,7 +223,6 @@ func TestHandleNamespaceLabelFalse(t *testing.T) {
 // WHEN the workload resource has  "app.verrazzano.io/metrics": "none"
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleMetricsNone(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -242,12 +236,12 @@ func TestHandleMetricsNone(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Nil(res.Patches, "expected no changes to workload resource")
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.Patches, "expected no changes to workload resource")
 }
 
 // TestHandleInvalidMetricsTemplate tests the handling of a workload resource with references a metrics template
@@ -256,7 +250,6 @@ func TestHandleMetricsNone(t *testing.T) {
 // WHEN the workload resource has  "app.verrazzano.io/metrics": "badTemplate"
 // THEN the Handle function should generate an error
 func TestHandleInvalidMetricsTemplate(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -270,12 +263,12 @@ func TestHandleInvalidMetricsTemplate(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.False(res.Allowed)
-	assert.Equal("metricstemplates.app.verrazzano.io \"badTemplate\" not found", res.Result.Message)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "metricstemplates.app.verrazzano.io \"badTemplate\" not found", res.Result.Message)
 }
 
 // TestHandleMetricsTemplateWorkloadNamespace tests the handling of a workload resource which references a metrics
@@ -284,7 +277,6 @@ func TestHandleInvalidMetricsTemplate(t *testing.T) {
 // WHEN the workload resource has a valid metrics template reference
 // THEN the Handle function should succeed and the workload resource is patched
 func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -300,7 +292,7 @@ func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -317,13 +309,13 @@ func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.NotNil(res.Patches)
-	assert.Len(res.Patches, 3)
+	assert.True(t, res.Allowed)
+	assert.NotNil(t, res.Patches)
+	assert.Len(t, res.Patches, 3)
 }
 
 // TestHandleMetricsTemplateSystemNamespace tests the handling of a workload resource which references a metrics
@@ -332,7 +324,6 @@ func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
 // WHEN the workload resource has a valid metrics template reference
 // THEN the Handle function should succeed and the workload resource is patched
 func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -349,7 +340,7 @@ func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "verrazzano-system",
@@ -366,13 +357,13 @@ func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.NotNil(res.Patches)
-	assert.Len(res.Patches, 3)
+	assert.True(t, res.Allowed)
+	assert.NotNil(t, res.Patches)
+	assert.Len(t, res.Patches, 3)
 }
 
 // TestHandleMetricsTemplateConfigMapNotFound tests the handling of a workload resource which references a metrics
@@ -381,7 +372,6 @@ func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
 // WHEN the workload resource has an invalid Prometheus config map reference
 // THEN the Handle function should fail and return an error
 func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -396,7 +386,7 @@ func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -413,12 +403,12 @@ func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.False(res.Allowed)
-	assert.Equal("configmaps \"testPromConfigMap\" not found", res.Result.Message)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "configmaps \"testPromConfigMap\" not found", res.Result.Message)
 }
 
 // TestHandleMatchWorkloadNamespace tests the handling of a workload resource with no metrics template specified
@@ -427,7 +417,6 @@ func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and the workload resource is patched
 func TestHandleMatchWorkloadNamespace(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -445,7 +434,7 @@ func TestHandleMatchWorkloadNamespace(t *testing.T) {
 			UID:       "11",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -472,18 +461,18 @@ func TestHandleMatchWorkloadNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.NotNil(res.Patches)
-	assert.Len(res.Patches, 1)
-	assert.Equal("add", res.Patches[0].Operation)
-	assert.Equal("/metadata/annotations", res.Patches[0].Path)
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
+	assert.True(t, res.Allowed)
+	assert.NotNil(t, res.Patches)
+	assert.Len(t, res.Patches, 1)
+	assert.Equal(t, "add", res.Patches[0].Operation)
+	assert.Equal(t, "/metadata/annotations", res.Patches[0].Path)
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
 }
 
 // TestHandleMatchSystemNamespace tests the handling of a workload resource with no metrics template specified
@@ -492,7 +481,6 @@ func TestHandleMatchWorkloadNamespace(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and the workload resource is patched
 func TestHandleMatchSystemNamespace(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -510,7 +498,7 @@ func TestHandleMatchSystemNamespace(t *testing.T) {
 			UID:       "11",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "verrazzano-system",
@@ -537,18 +525,18 @@ func TestHandleMatchSystemNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.NotNil(res.Patches)
-	assert.Len(res.Patches, 1)
-	assert.Equal("add", res.Patches[0].Operation)
-	assert.Equal("/metadata/annotations", res.Patches[0].Path)
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
-	assert.Contains(res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
+	assert.True(t, res.Allowed)
+	assert.NotNil(t, res.Patches)
+	assert.Len(t, res.Patches, 1)
+	assert.Equal(t, "add", res.Patches[0].Operation)
+	assert.Equal(t, "/metadata/annotations", res.Patches[0].Path)
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-prometheus-configmap-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-template-uid")
+	assert.Contains(t, res.Patches[0].Value, "app.verrazzano.io/metrics-workload-uid")
 }
 
 // TestHandleMatchNotFound tests the handling of a workload resource with no metrics template specified
@@ -557,7 +545,6 @@ func TestHandleMatchSystemNamespace(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleMatchNotFound(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -575,7 +562,7 @@ func TestHandleMatchNotFound(t *testing.T) {
 			UID:       "11",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "verrazzano-system",
@@ -602,12 +589,12 @@ func TestHandleMatchNotFound(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Empty(res.Patches)
+	assert.True(t, res.Allowed)
+	assert.Empty(t, res.Patches)
 }
 
 // TestHandleMatchTemplateNoWorkloadSelector tests the handling of a workload resource with no metrics template specified
@@ -616,7 +603,6 @@ func TestHandleMatchNotFound(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -634,7 +620,7 @@ func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
 			UID:       "11",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "verrazzano-system",
@@ -650,12 +636,12 @@ func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Empty(res.Patches)
+	assert.True(t, res.Allowed)
+	assert.Empty(t, res.Patches)
 }
 
 // TestHandleNoConfigMap tests the handling of a workload resource that doesn't have a Prometheus target
@@ -664,7 +650,6 @@ func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
 // WHEN the workload resource has a metrics template reference
 // THEN the Handle function should succeed and the workload resource not mutated
 func TestHandleNoConfigMap(t *testing.T) {
-	assert := assert.New(t)
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
@@ -684,7 +669,7 @@ func TestHandleNoConfigMap(t *testing.T) {
 			UID: "11",
 		},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testDeployment))
 	testTemplate := vzapp.MetricsTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -693,12 +678,12 @@ func TestHandleNoConfigMap(t *testing.T) {
 		},
 		Spec: vzapp.MetricsTemplateSpec{},
 	}
-	assert.NoError(v.Client.Create(context.TODO(), &testTemplate))
+	assert.NoError(t, v.Client.Create(context.TODO(), &testTemplate))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
 	res := v.Handle(context.TODO(), req)
-	assert.True(res.Allowed)
-	assert.Empty(res.Patches)
+	assert.True(t, res.Allowed)
+	assert.Empty(t, res.Patches)
 }
 
 func (v *ScrapeGeneratorWebhook) createNamespace(t *testing.T, name string, labels map[string]string) {

--- a/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
+++ b/application-operator/controllers/webhooks/scrape_generator_webhook_test.go
@@ -59,14 +59,13 @@ func TestHandlePod(t *testing.T) {
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
+	v.createNamespace(t, "test", nil)
 	testPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
 		},
 	}
-
-	// Test data
 	assert.NoError(v.Client.Create(context.TODO(), &testPod))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Pod", testPod)
@@ -83,14 +82,13 @@ func TestHandleDeployment(t *testing.T) {
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
+	v.createNamespace(t, "test", nil)
 	testDeployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
 		},
 	}
-
-	// Test data
 	assert.NoError(v.Client.Create(context.TODO(), &testDeployment))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "Deployment", testDeployment)
@@ -107,14 +105,13 @@ func TestHandleReplicaSet(t *testing.T) {
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
+	v.createNamespace(t, "test", nil)
 	testReplicaSet := appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
 		},
 	}
-
-	// Test data
 	assert.NoError(v.Client.Create(context.TODO(), &testReplicaSet))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "ReplicaSet", testReplicaSet)
@@ -131,17 +128,27 @@ func TestHandleStatefulSet(t *testing.T) {
 	v := newScrapeGeneratorWebhook()
 
 	// Test data
+	v.createNamespace(t, "test", nil)
 	testStatefulSet := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
 		},
 	}
-
-	// Test data
 	assert.NoError(v.Client.Create(context.TODO(), &testStatefulSet))
 
 	req := newScrapeGeneratorRequest(admissionv1beta1.Create, "StatefulSet", testStatefulSet)
 	res := v.Handle(context.TODO(), req)
 	assert.True(res.Allowed, "Expected validation to succeed.")
+}
+
+func (v *ScrapeGeneratorWebhook) createNamespace(t *testing.T, name string, labels map[string]string) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+	_, err := v.KubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	assert.NoError(t, err, "unexpected error creating namespace")
 }

--- a/application-operator/deploy/verrazzano.yaml_template
+++ b/application-operator/deploy/verrazzano.yaml_template
@@ -94,6 +94,14 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - app.verrazzano.io
+    resources:
+      - metricstemplates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - clusters.verrazzano.io
     resources:
       - multiclusterapplicationconfigurations/status

--- a/application-operator/internal/app/scripts/install-app-resources.sh
+++ b/application-operator/internal/app/scripts/install-app-resources.sh
@@ -22,7 +22,10 @@ webhooks:
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
-          values: ["kube-system", "verrazzano-system", "verrazzano-mc"]
+          values: ["kube-system", "verrazzano-mc"]
+        - key: verrazzano.io/namespace
+          operator: NotIn
+          values: ["verrazzano-system"]
     clientConfig:
       service:
         name: verrazzano-application-operator

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -226,9 +226,8 @@ func main() {
 				webhooks.ScrapeGeneratorLoadPath,
 				&webhook.Admission{
 					Handler: &webhooks.ScrapeGeneratorWebhook{
-						Client:        mgr.GetClient(),
-						KubeClient:    kubeClient,
-						DynamicClient: dynamicClient,
+						Client:     mgr.GetClient(),
+						KubeClient: kubeClient,
 					},
 				},
 			)

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -226,8 +226,9 @@ func main() {
 				webhooks.ScrapeGeneratorLoadPath,
 				&webhook.Admission{
 					Handler: &webhooks.ScrapeGeneratorWebhook{
-						Client:     mgr.GetClient(),
-						KubeClient: kubeClient,
+						Client:        mgr.GetClient(),
+						DynamicClient: dynamicClient,
+						KubeClient:    kubeClient,
 					},
 				},
 			)

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -227,8 +227,8 @@ func main() {
 				&webhook.Admission{
 					Handler: &webhooks.ScrapeGeneratorWebhook{
 						Client:        mgr.GetClient(),
-						DynamicClient: dynamicClient,
 						KubeClient:    kubeClient,
+						DynamicClient: dynamicClient,
 					},
 				},
 			)

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -153,6 +153,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - app.verrazzano.io
+    resources:
+      - metricstemplates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coherence.oracle.com
     resources:
       - coherence


### PR DESCRIPTION
# Description

This pull request adds the code as specified to process a workload resource.  The end result is that three labels are added to a workload resource if there is a matching metrics template for the workload resource.  The three labels added are:

	"app.verrazzano.io/metrics-workload-uid"
	"app.verrazzano.io/metrics-template-uid"
	"app.verrazzano.io/metrics-prometheus-configmap-uid"

This pull request also includes a change to the mutatingwebhookconfiguration and the verrazzano-application-operator clusterrole.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
