### PR TITLE
VZ-4275: Create skeleton controller for metrics workloads

### DIFF
--- a/application-operator/controllers/metricstemplate/metricstemplate_controller.go
+++ b/application-operator/controllers/metricstemplate/metricstemplate_controller.go
@@ -35,24 +35,25 @@ func (r *Reconciler) SetupWithManager(mgr k8scontroller.Manager) error {
 	if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "Deployment"); err != nil {
 		return err
 	}
-	if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "ReplicaSet"); err != nil {
-		return err
-	}
-	if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "StatefulSet"); err != nil {
-		return err
-	}
-	if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "DaemonSet"); err != nil {
-		return err
-	}
-	if err := r.setupWithManagerForGVK(mgr, "weblogic.oracle", "v7", "Domain"); err != nil {
-		return err
-	}
-	if err := r.setupWithManagerForGVK(mgr, "weblogic.oracle", "v8", "Domain"); err != nil {
-		return err
-	}
-	if err := r.setupWithManagerForGVK(mgr, "coherence.oracle.com", "v1", "Coherence"); err != nil {
-		return err
-	}
+	// Disabling for now as Domain and Coherence cause problems when those CRDs don't exist.
+	//if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "ReplicaSet"); err != nil {
+	//	return err
+	//}
+	//if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "StatefulSet"); err != nil {
+	//	return err
+	//}
+	//if err := r.setupWithManagerForGVK(mgr, "apps", "v1", "DaemonSet"); err != nil {
+	//	return err
+	//}
+	//if err := r.setupWithManagerForGVK(mgr, "weblogic.oracle", "v7", "Domain"); err != nil {
+	//	return err
+	//}
+	//if err := r.setupWithManagerForGVK(mgr, "weblogic.oracle", "v8", "Domain"); err != nil {
+	//	return err
+	//}
+	//if err := r.setupWithManagerForGVK(mgr, "coherence.oracle.com", "v1", "Coherence"); err != nil {
+	//	return err
+	//}
 	return nil
 }
 


### PR DESCRIPTION
# Description

Fixes issue caused by VZ-4275 change that prevents VAO from starting if WebLogic or Coherence CRDs are not installed.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
