### PR TITLE
No JIRA.  Move SOCKS app test to stage 2 in dynamic config test pipeline

### DIFF
--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -567,9 +567,6 @@ def generate_nonwls_tests(dumpRoot) {
         "examples logging helidon": {
             runGinkgo('logging/helidon', "${dumpRoot}/examples-logging-helidon")
         },
-        "examples socks": {
-            runGinkgo('examples/socks', "${dumpRoot}/examples-socks")
-        },
         "examples spring": {
             runGinkgo('examples/springboot', "${dumpRoot}/examples-spring")
         },
@@ -590,6 +587,10 @@ def generate_wls_tests(dumpRoot) {
             } else {
                 echo "Slow tests disabled, skipping Bob's Books tests"
             }
+        },
+        "examples socks": {
+            // socks uses COH
+            runGinkgo('examples/socks', "${dumpRoot}/examples-socks")
         },
         "examples todo": {
             runGinkgo('examples/todo', "${dumpRoot}/examples-todo")


### PR DESCRIPTION
# Description

No JIRA.  Move SOCKS app test to stage 2 in dynamic config test pipeline.  The example app requires COH, which is disabled in the initial test pass.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
