### PR TITLE
Remove special characters from returned password.  Make sure pw is sp…

### DIFF
--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -24,7 +24,24 @@ func GeneratePassword(length int) (string, error) {
 		return "", err
 	}
 	pw := b64.URLEncoding.EncodeToString(b)
+	pw, err = makeAlphaNumeric(pw)
+	if err != nil {
+		return "", err
+	}
+	if len(pw) < length {
+		return GeneratePassword(length)
+	}
 	return pw[:length], nil
+}
+
+// makeAlphaNumeric removes all special characters from a password string
+func makeAlphaNumeric(input string) (string, error) {
+	// Make a Regex to say we only want letters and numbers
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		return "", err
+	}
+	return reg.ReplaceAllString(input, ""), nil
 }
 
 //MaskFunction creates a function intended to mask passwords which are substrings in other strings

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -18,18 +18,16 @@ func GeneratePassword(length int) (string, error) {
 	if length < 1 {
 		return "", fmt.Errorf("cannot create password of length %d", length)
 	}
-	b := make([]byte, length)
+	// Enlarge buffer so plenty of room is left when special characters are stripped out
+	b := make([]byte, length*3)
 	_, err := rand.Read(b)
 	if err != nil {
 		return "", err
 	}
-	pw := b64.URLEncoding.EncodeToString(b)
+	pw := b64.StdEncoding.EncodeToString(b)
 	pw, err = makeAlphaNumeric(pw)
 	if err != nil {
 		return "", err
-	}
-	if len(pw) < length {
-		return GeneratePassword(length)
 	}
 	return pw[:length], nil
 }


### PR DESCRIPTION
…ecified length

# Description

This change removes special characters being returned in a password generated by generatePassword
This caused a problem with a kcadm set-password command where the password had an "-" in the first character
Now, all passwords will just be comprised of alphanumerics

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
