### PR TITLE
VZ-4345: Fix CRD comparison script to be smarter with version tags

### DIFF
--- a/release/scripts/compare_crds.sh
+++ b/release/scripts/compare_crds.sh
@@ -11,26 +11,45 @@ usage() {
   Shows all CRD differences between two git tags, commits, etc.
 
   Usage:
-    $(basename $0) <from> <to>
+    $(basename $0) <release version> <from> <to>
 
   Example:
-    $(basename $0) v1.0.0 HEAD
+    $(basename $0) 1.0.3
 
-  This script should be run from the git repository containing the bits to release. "from" and "to" can be tags, commits, etc.
-  "from" defaults to the most recent version tag and "to" defaults to HEAD.
+  This script should be run from the git repository containing the bits to release. "release version" is required.
+  "from" and "to" can be tags, commits, etc. "from" defaults to the most recent version tag for the previous release and "to" defaults to HEAD.
 EOM
     exit 0
 }
 
 [ "$1" == "-h" ] && { usage; }
 
-FROM=$1
-TO=${2:-HEAD}
+VERSION=$1
+FROM=$2
+TO=${3:-HEAD}
 
-# Default to the latest tag
+# Default to the latest tag from the prior release
 if [[ -z "$FROM" ]]; then
-   git fetch --tags
-   FROM=$(git tag --sort=taggerdate | tail -1)
+  MAJOR=$(echo ${VERSION} | cut -d. -f 1)
+  MINOR=$(echo ${VERSION} | cut -d. -f 2)
+  PATCH=$(echo ${VERSION} | cut -d. -f 3)
+
+  git fetch --tags
+
+  if [ "${MINOR}" == "0" ] && [ "${PATCH}" == "0" ]; then
+    # Major version release - find the latest tag matching the previous major release
+    PREV=v$(expr ${MAJOR} - "1").
+  else
+    if [ "${PATCH}" == "0" ]; then
+      # Minor version release - find the latest tag matching the previous minor release
+      PREV=v${MAJOR}.$(expr ${MINOR} - "1").
+    else
+      # Patch version release - find the latest tag matching the current major and minor version
+      PREV=v${MAJOR}.${MINOR}.
+    fi
+  fi
+
+  FROM=$(git tag --sort=taggerdate | grep ${PREV} | tail -1)
 fi
 
 echo "Showing all CRD differences between $FROM and $TO"

--- a/release/scripts/prerelease_validation.sh
+++ b/release/scripts/prerelease_validation.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR=$(dirname "$0")
 # Check for CRD changes
 
 echo "Checking for CRD changes... you should visually inspect for potential backward incompatibilities"
-$SCRIPT_DIR/compare_crds.sh
+$SCRIPT_DIR/compare_crds.sh $VERSION
 EXIT_CODE=$?
 echo ""
 


### PR DESCRIPTION
# Description

The CRD comparison script used in the release automation pipeline was defaulting to the last tagged release version. However, that does not work in many cases. For example, if the pipeline for release 1.0.4 is run after release 1.1 is created, the CRDs for 1.0.4 are compared with 1.1 instead of 1.0.3.

This PR makes the comparison script smarter about what release tag to compare against. Results from testing:
```
$ release/scripts/compare_crds.sh 1.0.4
Showing all CRD differences between v1.0.3 and HEAD

$ release/scripts/compare_crds.sh 1.2.0
Showing all CRD differences between v1.1.0 and HEAD

$ release/scripts/compare_crds.sh 2.0.0
Showing all CRD differences between v1.1.0 and HEAD
```

These changes will also need to be ported to the release-1.1 and master branches.

Fixes VZ-4345

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
