### PR TITLE
VZ-4392: increase timeout for helidon index test

### DIFF
--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	longWaitTimeout      = 10 * time.Minute
+	longWaitTimeout      = 20 * time.Minute
 	longPollingInterval  = 20 * time.Second
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	longWaitTimeout      = 10 * time.Minute
+	longWaitTimeout      = 20 * time.Minute
 	longPollingInterval  = 20 * time.Second
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	longWaitTimeout      = 10 * time.Minute
+	longWaitTimeout      = 20 * time.Minute
 	longPollingInterval  = 20 * time.Second
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	longPollingInterval  = 20 * time.Second
-	longWaitTimeout      = 10 * time.Minute
+	longWaitTimeout      = 20 * time.Minute
 	pollingInterval      = 5 * time.Second
 	waitTimeout          = 5 * time.Minute
 	consistentlyDuration = 1 * time.Minute


### PR DESCRIPTION
Tests have been failing because the ES index cannot be found for hello-helidon, helidon-config, and helidon-logging. It frequently takes the helidon index a long time to come up in ES even on successful runs. This change increases the Helidon tests wait timeout to 20m to try to stop this test from failing.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
