### PR TITLE
VZ-4349-Update helm to list specific namespaces at cleanup

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -15,7 +15,7 @@ set -o pipefail
 
 function delete_external_dns() {
   log "Deleting external-dns"
-  helm ls -A \
+  helm ls -n cert-manager \
     | awk '/external-dns/ {print $1}' \
     | xargsr helm uninstall -n cert-manager \
     || err_return $? "Could not delete external-dns from helm" || return $? # return on pipefail
@@ -29,7 +29,7 @@ function delete_external_dns() {
 function delete_nginx() {
   # uninstall ingress-nginx
   log "Deleting ingress-nginx"
-  helm ls -A \
+  helm ls -n ingress-nginx \
     | awk '/ingress-controller/ {print $1}' \
     | xargsr helm uninstall -n ingress-nginx \
     || err_return $? "Could not delete ingress-controller from helm" || return $? # return on pipefail
@@ -51,7 +51,7 @@ function delete_nginx() {
 function delete_cert_manager() {
   # uninstall cert manager deployment
   log "Deleting cert-manager"
-  helm ls -A \
+  helm ls -n cert-manager \
     | awk '/cert-manager/ {print $1}' \
     | xargsr helm uninstall -n cert-manager \
     || err_return $? "Could not delete cert-manager from helm" || return $? # return on pipefail


### PR DESCRIPTION
# Description

Today during cleanup , helm looks for ingress across all namespaces, and finds a match to delete the specific release

helm ls -A \
  | awk '/ingress-controller/ {print $1}' \
  | xargsr helm uninstall -n ingress-nginx \
this is incorrect, because there might be other ingress controllers with the same release name in other namespaces. As a result deletion will fail for other namespaces 

example 

[opc@aamitrawls-admin ~]$ helm ls -A     | grep ingress-controller[opc@aamitrawls-admin ~]$ helm ls -A     | grep ingress-controlleringress-controller              default                 1        2021-12-16 19:28:39.152258543 +0000 UTC deployed nginx-ingress-controller-1.0.0ingress-controller              ingress-nginx           1        2021-12-16 21:43:43.404289654 +0000 UTC deployed ingress-nginx-3.30.0                                                                     0.46.0
 

Options

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
