### PR TITLE
Update Keycloak and Elasticsearch images

### DIFF
--- a/examples/springboot-app/springboot-comp.yaml
+++ b/examples/springboot-app/springboot-comp.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: springboot-container
-        image: "ghcr.io/verrazzano/example-springboot:1.0.0-1-20211215184123-0a1b633"
+        image: "ghcr.io/verrazzano/example-springboot:1.0.0-1-20211220133936-937bbfb"
         ports:
           - containerPort: 8080
             name: springboot

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -213,7 +213,7 @@
             },
             {
               "image": "elasticsearch",
-              "tag": "7.10.2-20211213153837-168b4642",
+              "tag": "7.10.2-20211220140552-8bd728ed",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {
@@ -393,7 +393,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "15.0.2-20211213172016-b1b380919c",
+              "tag": "15.0.2-20211220135436-a2a614d2d0",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
# Description

This change updates the Keycloak (v.15.0.2) and Elasticsearch (v.7.10.2) images in verrazzano-bom.json. Also the image used by the Spring Boot application is updated in this change.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
