### PR TITLE
VZ-4316.  Backport netpol test update to release-1.0

### DIFF
--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	expectedPods    = []string{"netpol-test"}
-	waitTimeout     = 3 * time.Minute
+	waitTimeout     = 15 * time.Minute
 	pollingInterval = 30 * time.Second
 )
 


### PR DESCRIPTION
# Description

Backport change to bump timeout for netpol tests for rancher-webhook timing issue.

Fixes VZ-4316

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
