### PR TITLE
VZ-4348 

### DIFF
--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -35,12 +35,7 @@ pipeline {
         DOCKER_CREDS = credentials('github-packages-credentials-rw')
         DOCKER_REPO = 'ghcr.io'
         GITHUB_CREDENTIALS = credentials('github-markxnelns-private-access-token')
-
-        OCI_CLI_AUTH="instance_principal"
-        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-        OCI_OS_BUCKET="verrazzano-builds"
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
-
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
     }
 
@@ -98,6 +93,15 @@ pipeline {
                 IGNORE_FAILURES = "false"
                 JIRA_USERNAME = credentials('jira-username')
                 JIRA_PASSWORD = credentials('jira-password')
+                OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+                OCI_OS_BUCKET="verrazzano-builds"
+                OCI_CLI_AUTH="api_key"
+                OCI_CLI_TENANCY = credentials('oci-tenancy')
+                OCI_CLI_USER = credentials('oci-dev-user-ocid')
+                OCI_CLI_FINGERPRINT = credentials('oci-dev-api-key-fingerprint')
+                OCI_CLI_KEY_FILE = credentials('oci-dev-api-key-file')
+                OCI_CLI_REGION = "us-phoenix-1"
+                OCI_REGION = "${env.OCI_CLI_REGION}"
             }
             steps {
                 script {

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -97,9 +97,9 @@ pipeline {
                 OCI_OS_BUCKET="verrazzano-builds"
                 OCI_CLI_AUTH="api_key"
                 OCI_CLI_TENANCY = credentials('oci-tenancy')
-                OCI_CLI_USER = credentials('oci-dev-user-ocid')
-                OCI_CLI_FINGERPRINT = credentials('oci-dev-api-key-fingerprint')
-                OCI_CLI_KEY_FILE = credentials('oci-dev-api-key-file')
+                OCI_CLI_USER = credentials('oci-user-ocid')
+                OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+                OCI_CLI_KEY_FILE = credentials('oci-api-key')
                 OCI_CLI_REGION = "us-phoenix-1"
                 OCI_REGION = "${env.OCI_CLI_REGION}"
             }


### PR DESCRIPTION
# Description

We can't use instance auth for pushing to object storage from internal runner, use oci user instead

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
