### PR TITLE
VZ-4322 bug fix - component registry should maintain a list, not a map, since order of items in GetComponents is significant

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -22,11 +22,11 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
 )
 
-type GetCompoentsFnType func() map[string]spi.Component
+type GetCompoentsFnType func() []spi.Component
 
 var getComponentsFn = getComponents
 
-var componentsRegistry map[string]spi.Component
+var componentsRegistry []spi.Component
 
 // OverrideGetComponentsFn Allows overriding the set of registry components for testing purposes
 func OverrideGetComponentsFn(fnType GetCompoentsFnType) {
@@ -41,36 +41,37 @@ func ResetGetComponentsFn() {
 // GetComponents returns the list of components that are installable and upgradeable.
 // The components will be processed in the order items in the array
 // The components will be processed in the order items in the array
-func GetComponents() map[string]spi.Component {
+func GetComponents() []spi.Component {
 	return getComponentsFn()
 }
 
 // getComponents is the internal impl function for GetComponents, to allow overriding it for testing purposes
-func getComponents() map[string]spi.Component {
+func getComponents() []spi.Component {
 	if len(componentsRegistry) == 0 {
-		componentsRegistry = map[string]spi.Component{
-			nginx.ComponentName:       nginx.NewComponent(),
-			certmanager.ComponentName: certmanager.NewComponent(),
-			externaldns.ComponentName: externaldns.NewComponent(),
-			rancher.ComponentName:     rancher.NewComponent(),
-			verrazzano.ComponentName:  verrazzano.NewComponent(),
-			coherence.ComponentName:   coherence.NewComponent(),
-			weblogic.ComponentName:    weblogic.NewComponent(),
-			oam.ComponentName:         oam.NewComponent(),
-			appoper.ComponentName:     appoper.NewComponent(),
-			mysql.ComponentName:       mysql.NewComponent(),
-			keycloak.ComponentName:    keycloak.NewComponent(),
-			kiali.ComponentName:       kiali.NewComponent(),
-			istio.ComponentName:       istio.NewComponent(),
+		componentsRegistry = []spi.Component{
+			nginx.NewComponent(),
+			certmanager.NewComponent(),
+			externaldns.NewComponent(),
+			rancher.NewComponent(),
+			verrazzano.NewComponent(),
+			coherence.NewComponent(),
+			weblogic.NewComponent(),
+			oam.NewComponent(),
+			appoper.NewComponent(),
+			mysql.NewComponent(),
+			keycloak.NewComponent(),
+			kiali.NewComponent(),
+			istio.NewComponent(),
 		}
 	}
 	return componentsRegistry
 }
 
 func FindComponent(releaseName string) (bool, spi.Component) {
-	foundComp := GetComponents()[releaseName]
-	if foundComp != nil {
-		return true, foundComp
+	for _, comp := range GetComponents() {
+		if comp.Name() == releaseName {
+			return true, comp
+		}
 	}
 	return false, &helm.HelmComponent{}
 }

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -48,19 +48,19 @@ func TestGetComponents(t *testing.T) {
 	comps := GetComponents()
 
 	assert.Len(comps, 13, "Wrong number of components")
-	assert.Equal(comps[nginx.ComponentName].Name(), nginx.ComponentName)
-	assert.Equal(comps[certmanager.ComponentName].Name(), certmanager.ComponentName)
-	assert.Equal(comps[externaldns.ComponentName].Name(), externaldns.ComponentName)
-	assert.Equal(comps[rancher.ComponentName].Name(), rancher.ComponentName)
-	assert.Equal(comps[verrazzano.ComponentName].Name(), verrazzano.ComponentName)
-	assert.Equal(comps[coherence.ComponentName].Name(), coherence.ComponentName)
-	assert.Equal(comps[weblogic.ComponentName].Name(), weblogic.ComponentName)
-	assert.Equal(comps[oam.ComponentName].Name(), oam.ComponentName)
-	assert.Equal(comps[appoper.ComponentName].Name(), appoper.ComponentName)
-	assert.Equal(comps[mysql.ComponentName].Name(), mysql.ComponentName)
-	assert.Equal(comps[keycloak.ComponentName].Name(), keycloak.ComponentName)
-	assert.Equal(comps[kiali.ComponentName].Name(), kiali.ComponentName)
-	assert.Equal(comps[istio.ComponentName].Name(), istio.ComponentName)
+	assert.Equal(comps[0].Name(), nginx.ComponentName)
+	assert.Equal(comps[1].Name(), certmanager.ComponentName)
+	assert.Equal(comps[2].Name(), externaldns.ComponentName)
+	assert.Equal(comps[3].Name(), rancher.ComponentName)
+	assert.Equal(comps[4].Name(), verrazzano.ComponentName)
+	assert.Equal(comps[5].Name(), coherence.ComponentName)
+	assert.Equal(comps[6].Name(), weblogic.ComponentName)
+	assert.Equal(comps[7].Name(), oam.ComponentName)
+	assert.Equal(comps[8].Name(), appoper.ComponentName)
+	assert.Equal(comps[9].Name(), mysql.ComponentName)
+	assert.Equal(comps[10].Name(), keycloak.ComponentName)
+	assert.Equal(comps[11].Name(), kiali.ComponentName)
+	assert.Equal(comps[12].Name(), istio.ComponentName)
 }
 
 // TestFindComponent tests FindComponent
@@ -253,19 +253,19 @@ func TestComponentDependenciesCycles(t *testing.T) {
 	indirectCycle2 := fakeComponent{name: "indirectCycle2", dependencies: []string{"fake4"}}
 	nocycles := fakeComponent{name: "nocycles", dependencies: []string{"fake6", "fake5"}}
 	noDependencies := fakeComponent{name: "fake1"}
-	OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			noDependencies.Name(): noDependencies,
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			noDependencies,
 			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-			"fake2": fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
+			fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
 			// fake3 -> fake2 -> indirectCycle1 -> fake3
-			"fake3":               fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
-			"fake4":               fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
-			"fake5":               fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
-			"fake6":               fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
-			nocycles.Name():       nocycles,
-			indirectCycle1.Name(): indirectCycle1,
-			indirectCycle2.Name(): indirectCycle2,
+			fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
+			fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
+			fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
+			nocycles,
+			indirectCycle1,
+			indirectCycle2,
 		}
 	})
 	defer ResetGetComponentsFn()
@@ -291,19 +291,19 @@ func Test_checkDependencies(t *testing.T) {
 	indirectCycle2 := fakeComponent{name: "indirectCycle2", dependencies: []string{"fake4"}}
 	nocycles := fakeComponent{name: "nocycles", dependencies: []string{"fake6", "fake5"}}
 	noDependencies := fakeComponent{name: "fake1"}
-	OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			noDependencies.Name(): noDependencies,
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			noDependencies,
 			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-			"fake2": fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
+			fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
 			// fake3 -> fake2 -> indirectCycle1 -> fake3
-			"fake3":               fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
-			"fake4":               fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
-			"fake5":               fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
-			"fake6":               fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
-			nocycles.Name():       nocycles,
-			indirectCycle1.Name(): indirectCycle1,
-			indirectCycle2.Name(): indirectCycle2,
+			fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
+			fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
+			fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
+			nocycles,
+			indirectCycle1,
+			indirectCycle2,
 		}
 	})
 	defer ResetGetComponentsFn()
@@ -340,12 +340,12 @@ func Test_checkDependencies(t *testing.T) {
 func TestComponentDependenciesChainNoCycle(t *testing.T) {
 	chainNoCycle := fakeComponent{name: "chainNoCycle", dependencies: []string{"fake2"}}
 	repeatDepdendency := fakeComponent{name: "repeatDependency", dependencies: []string{"fake1", "fake2", "fake1"}}
-	OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fake1":                  fakeComponent{name: "fake1"},
-			"fake2":                  fakeComponent{name: "fake2", dependencies: []string{"fake1"}},
-			chainNoCycle.Name():      chainNoCycle,
-			repeatDepdendency.Name(): repeatDepdendency,
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{name: "fake1"},
+			fakeComponent{name: "fake2", dependencies: []string{"fake1"}},
+			chainNoCycle,
+			repeatDepdendency,
 		}
 	})
 	defer ResetGetComponentsFn()

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -114,9 +114,9 @@ func TestSuccessfulInstall(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
 	defer config.SetDefaultBomFilePath("")
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fakeCompName": fakeComponent{},
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
 		}
 	})
 	defer registry.ResetGetComponentsFn()

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -680,9 +680,9 @@ func TestUpgradeCompleted(t *testing.T) {
 	defer config.Set(config.Get())
 	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fakeCompName": fakeComponent{},
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
 		}
 	})
 	defer registry.ResetGetComponentsFn()
@@ -769,9 +769,9 @@ func TestUpgradeCompletedStatusReturnsError(t *testing.T) {
 	defer config.Set(config.Get())
 	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fakeCompName": fakeComponent{},
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
 		}
 	})
 	defer registry.ResetGetComponentsFn()
@@ -859,9 +859,9 @@ func TestUpgradeHelmError(t *testing.T) {
 	config.TestProfilesDir = "../../manifests/profiles"
 	defer func() { config.TestProfilesDir = "" }()
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fakeCompName": fakeComponent{
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{
 				upgradeFunc: func(ctx spi.ComponentContext) error {
 					return fmt.Errorf("Error running upgrade")
 				},
@@ -969,9 +969,9 @@ func TestUpgradeIsCompInstalledFailure(t *testing.T) {
 		Components: makeVerrazzanoComponentStatusMap(),
 	}
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"fakeCompName": fakeComponent{
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{
 				isInstalledFunc: func(ctx spi.ComponentContext) (bool, error) {
 					return false, fmt.Errorf("Error running isInstalled")
 				},
@@ -1049,9 +1049,9 @@ func TestUpgradeComponent(t *testing.T) {
 
 	mockComp := mocks.NewMockComponent(mocker)
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"mockCompName": mockComp,
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			mockComp,
 		}
 	})
 	defer registry.ResetGetComponentsFn()
@@ -1132,10 +1132,10 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 	mockEnabledComp := mocks.NewMockComponent(mocker)
 	mockDisabledComp := mocks.NewMockComponent(mocker)
 
-	registry.OverrideGetComponentsFn(func() map[string]spi.Component {
-		return map[string]spi.Component{
-			"mockEnabledCompName":  mockEnabledComp,
-			"mockDisabledCompName": mockDisabledComp,
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			mockEnabledComp,
+			mockDisabledComp,
 		}
 	})
 	defer registry.ResetGetComponentsFn()


### PR DESCRIPTION
# Description

VZ-4322 bug fix - component registry should maintain a list, not a map, since order of items in GetComponents is significant

Fixes VZ-4322

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
