### PR TITLE
VZ-4358 Sockshop ensure application deleted

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -262,7 +262,7 @@ var _ = AfterSuite(func() {
 		pkg.Log(pkg.Info, "Delete application")
 		Eventually(func() error {
 			return pkg.DeleteResourceFromFile("examples/sock-shop/" + variant + "/sock-shop-app.yaml")
-		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 
 		pkg.Log(pkg.Info, "Delete components")
 		Eventually(func() error {
@@ -272,14 +272,14 @@ var _ = AfterSuite(func() {
 		pkg.Log(pkg.Info, "Wait for sockshop application to be deleted")
 		Eventually(func() bool {
 			_, err := pkg.GetAppConfig(sockshopNamespace, sockshopAppName)
+			if err != nil && errors.IsNotFound(err) {
+				return true
+			}
 			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
 				pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop appconfig: %v\n", err.Error()))
 			}
 			return false
-		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 
 		pkg.Log(pkg.Info, "Delete namespace")
 		Eventually(func() error {
@@ -289,14 +289,14 @@ var _ = AfterSuite(func() {
 		pkg.Log(pkg.Info, "Wait for sockshop namespace to be deleted")
 		Eventually(func() bool {
 			_, err := pkg.GetNamespace(sockshopNamespace)
+			if err != nil && errors.IsNotFound(err) {
+				return true
+			}
 			if err != nil {
-				if errors.IsNotFound(err) {
-					return true
-				}
 				pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop namespace: %v\n", err.Error()))
 			}
 			return false
-		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 	}
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -256,13 +256,14 @@ var _ = AfterSuite(func() {
 	if failed {
 		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
+	failed = false
 	if !skipUndeploy {
 		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
 		pkg.Log(pkg.Info, "Delete application")
 		Eventually(func() error {
 			return pkg.DeleteResourceFromFile("examples/sock-shop/" + variant + "/sock-shop-app.yaml")
-		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 		pkg.Log(pkg.Info, "Delete components")
 		Eventually(func() error {

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -272,13 +272,12 @@ var _ = AfterSuite(func() {
 		pkg.Log(pkg.Info, "Wait for sockshop application to be deleted")
 		Eventually(func() bool {
 			_, err := pkg.GetAppConfig(sockshopNamespace, sockshopAppName)
-			if err == nil {
-				return false
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return true
+				}
+				pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop appconfig: %v\n", err.Error()))
 			}
-			if errors.IsNotFound(err) {
-				return true
-			}
-			pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop appconfig: %v\n", err.Error()))
 			return false
 		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
@@ -289,14 +288,13 @@ var _ = AfterSuite(func() {
 
 		pkg.Log(pkg.Info, "Wait for sockshop namespace to be deleted")
 		Eventually(func() bool {
-			_, err := pkg.DoesNamespaceExist(sockshopNamespace)
-			if err == nil {
-				return false
+			_, err := pkg.GetNamespace(sockshopNamespace)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return true
+				}
+				pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop namespace: %v\n", err.Error()))
 			}
-			if errors.IsNotFound(err) {
-				return true
-			}
-			pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop namespace: %v\n", err.Error()))
 			return false
 		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 	}

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -28,13 +28,12 @@ const (
 	shortPollingInterval = 10 * time.Second
 	waitTimeout          = 10 * time.Minute
 	pollingInterval      = 30 * time.Second
-	sockshopAppName		 = "sockshop-appconfig"
+	sockshopAppName      = "sockshop-appconfig"
 	sockshopNamespace    = "sockshop"
-	)
+)
 
 var sockShop SockShop
 var username, password string
-
 
 // creates the sockshop namespace and applies the components and application yaml
 var _ = BeforeSuite(func() {
@@ -254,6 +253,9 @@ var _ = AfterEach(func() {
 
 // undeploys the application, components, and namespace
 var _ = AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	if !skipUndeploy {
 		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
@@ -269,7 +271,7 @@ var _ = AfterSuite(func() {
 
 		pkg.Log(pkg.Info, "Wait for sockshop application to be deleted")
 		Eventually(func() bool {
-			_, err := pkg.GetAppConfig(sockshopNamespace, sockshopAppName )
+			_, err := pkg.GetAppConfig(sockshopNamespace, sockshopAppName)
 			if err == nil {
 				return false
 			}

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -254,10 +254,6 @@ var _ = AfterEach(func() {
 
 // undeploys the application, components, and namespace
 var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
-
 	if !skipUndeploy {
 		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
@@ -301,6 +297,9 @@ var _ = AfterSuite(func() {
 			pkg.Log(pkg.Info, fmt.Sprintf("Error getting sockshop namespace: %v\n", err.Error()))
 			return false
 		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+	}
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
 })
 

--- a/tests/e2e/pkg/oam.go
+++ b/tests/e2e/pkg/oam.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GetAppConfig returns the specified appconfig in a given namespace
+func GetAppConfig(namespace string, name string) (*unstructured.Unstructured, error) {
+	client, err := GetDynamicClient()
+	if err != nil {
+		return nil, err
+	}
+	a, err := client.Resource(getOamAppConfigScheme()).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// getOamAppConfigScheme returns the appconfig scheme needed to get unstructured data
+func getOamAppConfigScheme() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "core.oam.dev",
+		Version:  "v1alpha2",
+		Resource: "ApplicationConfiguration",
+	}
+}


### PR DESCRIPTION
Ensure that the sockshop appconfig and namespace is deleted in the AfterSuite.  Dump cluster if it fails.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
