### PR TITLE
Update Sock Shop test Eventually and Expect Combination

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Sock Shop Application", func() {
 	sockShop.SetHostHeader(hostname)
 
 	It("SockShop can be accessed and user can be registered", func() {
-		Eventually(func() bool {
+		Eventually(func() (bool, error) {
 			return sockShop.RegisterUser(fmt.Sprintf(registerTemp, username, password), hostname)
 		}, waitTimeout, pollingInterval).Should(BeTrue(), "Failed to register SockShop User")
 	})

--- a/tests/e2e/examples/socks/sockshop.go
+++ b/tests/e2e/examples/socks/sockshop.go
@@ -99,12 +99,14 @@ func (s *SockShop) Delete(url string) (*pkg.HTTPResponse, error) {
 }
 
 // RegisterUser interacts with sock shop to create a user
-func (s *SockShop) RegisterUser(body string, hostname string) bool {
+func (s *SockShop) RegisterUser(body string, hostname string) (bool, error) {
 	url := fmt.Sprintf("https://%v/register", hostname)
 	resp, err := pkg.PostWithHostHeader(url, "application/json", s.hostHeader, strings.NewReader(body))
-	Expect(err).ShouldNot(HaveOccurred())
+	if err != nil {
+		return false, err
+	}
 	pkg.Log(Info, fmt.Sprintf("Finished register %s status: %v", resp.Body, resp.StatusCode))
-	return (resp.StatusCode == http.StatusOK) && (strings.Contains(string(resp.Body), "username"))
+	return (resp.StatusCode == http.StatusOK) && (strings.Contains(string(resp.Body), "username")), nil
 }
 
 // GetCatalogItems retrieves the catalog items


### PR DESCRIPTION
# Description

Sock shop test, "SockShop can be accessed and user can be registered," contains an Expect inside an Eventually which causes unnecessary testing failures. This PR updates the return of this test to include the errors rather than using the Expect.

Fixes VZ-4370

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
