### PR TITLE
VZ-4113 backport part2 - Always create rancher namespace

### DIFF
--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -466,14 +466,14 @@ func createAndLabelNamespaces(ctx spi.ComponentContext) error {
 		}
 	}
 	if vzconfig.IsRancherEnabled(ctx.EffectiveCR()) {
-		// Create and/or label the Rancher system namespaces if necessary
-		if err := namespace.CreateRancherNamespace(ctx.Client()); err != nil {
-			return ctrlerrors.RetryableError{Source: componentName, Cause: err}
-		}
 		if err := namespace.CreateAndLabelNamespace(ctx.Client(), globalconst.RancherOperatorSystemNamespace,
 			true, false); err != nil {
 			return ctrlerrors.RetryableError{Source: componentName, Cause: err}
 		}
+	}
+	// cattle-system NS must be created since the rancher NetworkPolicy, which is always installed, requires it
+	if err := namespace.CreateRancherNamespace(ctx.Client()); err != nil {
+		return ctrlerrors.RetryableError{Source: componentName, Cause: err}
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

VZ-4113 backport part2 - Always create rancher namespace

Fixes VZ-4113

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
