### PR TITLE
Add a timeout for Verrazzano uninstall in upgrade pipeline

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -586,7 +586,7 @@ pipeline {
         }
         stage('Uninstall') {
             options {
-                timeout(time: 30, unit: "MINUTES")
+                timeout(time: 5, unit: "MINUTES")
             }
             steps {
                 script {
@@ -624,6 +624,9 @@ pipeline {
                 }
                 failure {
                     dumpK8sCluster('uninstall-failure-cluster-dump')
+                }
+                aborted {
+                    dumpK8sCluster('uninstall-aborted-cluster-dump')
                 }
             }
         }

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -586,7 +586,7 @@ pipeline {
         }
         stage('Uninstall') {
             options {
-                timeout(time: 5, unit: "MINUTES")
+                timeout(time: 30, unit: "MINUTES")
             }
             steps {
                 script {

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -585,11 +585,20 @@ pipeline {
             }
         }
         stage('Uninstall') {
+            options {
+                timeout(time: 30, unit: "MINUTES")
+            }
             steps {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    sh """
-                        kubectl delete verrazzano my-verrazzano
-                    """
+                script {
+                    try {
+                        sh """
+                            kubectl delete verrazzano my-verrazzano
+                        """
+                    } catch (err) {
+                        currentBuild.result = "FAILURE"
+                        echo "Caught: ${err}"
+                        err 'Verrazzano uninstall failed'
+                    }
                 }
             }
             post {


### PR DESCRIPTION
# Description

This change sets a timeout of 30 minutes for the stage in upgrade pipeline, which uninstalls Verrazzano.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
