### PR TITLE
Fix isReady check to look for TLS secret

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -555,8 +555,8 @@ func getDNSDomain(c client.Client, vz *vzapi.Verrazzano) (string, error) {
 	return dnsDomain, nil
 }
 
-// getCertName returns certificate name
-func getCertName(vz *vzapi.Verrazzano) string {
+// getSecretName returns expected TLS secret name
+func getSecretName(vz *vzapi.Verrazzano) string {
 	return fmt.Sprintf("%s-secret", getEnvironmentName(vz.Spec.EnvironmentName))
 }
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"path/filepath"
 
-	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -136,25 +135,19 @@ func (c KeycloakComponent) IsEnabled(ctx spi.ComponentContext) bool {
 
 func (c KeycloakComponent) IsReady(ctx spi.ComponentContext) bool {
 	// TLS cert from Cert Manager should be in Ready state
-	certName := getCertName(ctx.EffectiveCR())
-	certificate := &certmanager.Certificate{}
-	namespacedName := types.NamespacedName{Name: certName, Namespace: ComponentNamespace}
-	if err := ctx.Client().Get(context.TODO(), namespacedName, certificate); err != nil {
+	secretName := getSecretName(ctx.EffectiveCR())
+	secret := &corev1.Secret{}
+	namespacedName := types.NamespacedName{Name: secretName, Namespace: ComponentNamespace}
+	if err := ctx.Client().Get(context.TODO(), namespacedName, secret); err != nil {
 		ctx.Log().Infof("Keycloak isReady: Failed to get Keycloak Certificate: %s", err)
 		return false
 	}
-	if certificate.Status.Conditions == nil {
-		ctx.Log().Infof("Keycloak IsReady: No Certificate Status conditions found")
-		return false
-	}
 
-	condition := certificate.Status.Conditions[0]
 	statefulsetName := []types.NamespacedName{
 		{
 			Namespace: ComponentNamespace,
 			Name:      ComponentName,
 		},
 	}
-	return condition.Type == "Ready" &&
-		status.StatefulsetReady(ctx.Log(), ctx.Client(), statefulsetName, 1)
+	return status.StatefulsetReady(ctx.Log(), ctx.Client(), statefulsetName, 1)
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package keycloak
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
@@ -71,17 +71,10 @@ func TestIsEnabled(t *testing.T) {
 }
 
 func TestIsReady(t *testing.T) {
-	readyCert := &certmanager.Certificate{
+	readySecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getCertName(testVZ),
+			Name:      getSecretName(testVZ),
 			Namespace: ComponentNamespace,
-		},
-		Status: certmanager.CertificateStatus{
-			Conditions: []certmanager.CertificateCondition{
-				{
-					Type: "Ready",
-				},
-			},
 		},
 	}
 	scheme := k8scheme.Scheme
@@ -100,37 +93,25 @@ func TestIsReady(t *testing.T) {
 			"should not be ready when certificate has no status",
 			fake.NewFakeClientWithScheme(scheme, &certmanager.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getCertName(testVZ),
+					Name:      getSecretName(testVZ),
 					Namespace: ComponentNamespace,
 				},
 			}),
 			false,
 		},
 		{
-			"should not be ready when certificate status is not ready",
-			fake.NewFakeClientWithScheme(scheme, &certmanager.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      getCertName(testVZ),
-					Namespace: ComponentNamespace,
-				},
-				Status: certmanager.CertificateStatus{
-					Conditions: []certmanager.CertificateCondition{
-						{
-							Type: "NotReady",
-						},
-					},
-				},
-			}),
+			"should not be ready when secret does not exists",
+			fake.NewFakeClientWithScheme(scheme),
 			false,
 		},
 		{
 			"should not be ready when certificate status is ready but statefulset is not ready",
-			fake.NewFakeClientWithScheme(scheme, readyCert),
+			fake.NewFakeClientWithScheme(scheme, readySecret),
 			false,
 		},
 		{
 			"should be ready when certificate status is ready and statefulset is ready",
-			fake.NewFakeClientWithScheme(scheme, readyCert, &appsv1.StatefulSet{
+			fake.NewFakeClientWithScheme(scheme, readySecret, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ComponentNamespace,
 					Name:      ComponentName,

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package keycloak


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fix the Keycloak isReady check for secret existence instead of certificate existence.  The check is better because, in the end, Keycloak needs the existence of the tls secret to offer its services publicly.  

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
