### PR TITLE
VZ-4375 Delete cluster terraform to remove reconciliation errors

### DIFF
--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -23,6 +23,8 @@ while true; do
       echo "Terraform apply tries exceeded.  Cluster creation has failed!"
       break
    fi
+   echo "Deleting Cluster Terraform and applying again"
+   $SCRIPT_DIR/delete-cluster.sh
    sleep 30
 done
 


### PR DESCRIPTION
# Description

The Terraform module for creating clusters does not hold the state for the cluster after it times out on creation. The test case that triggered this creation edit had a cluster that timed out after an hour. In order to avoid conflicts (The creation will fail because the names for the clusters will stick around, and the deletion will fail because of old VNICs that disallow subnets from being deleted), I have decided to delete after every iteration of Terraform apply. This will add about 10 minutes to each iteration if a timeout or failure occurs, but it will avoid conflict errors. I'm not in love with this solution, but I think it will help reliability.

Also, I didn't think extending the timeout was necessary, as I think an hour is enough time to gauge that an apply has gone awry.

Fixes VZ-4375

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
