### PR TITLE
VZ-4372: Don't check that app metrics have been deleted

### DIFF
--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -13,7 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-const testNamespace string = "deploymetrics"
+const (
+	testNamespace     = "deploymetrics"
+	promConfigJobName = "deploymetrics-appconf_default_deploymetrics_deploymetrics-deployment"
+)
 
 var expectedPodsDeploymetricsApp = []string{"deploymetrics-workload"}
 var waitTimeout = 10 * time.Minute
@@ -75,12 +78,8 @@ func undeployMetricsApplication() {
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() bool {
-		return pkg.MetricsExist("http_server_requests_seconds_count", "app_oam_dev_name", "deploymetrics-appconf")
-	}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Prometheus scraped metrics for App Component should have been deleted.")
-
-	Eventually(func() bool {
-		return pkg.MetricsExist("tomcat_sessions_created_sessions_total", "app_oam_dev_component", "deploymetrics-deployment")
-	}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Prometheus scraped metrics for App Config should have been deleted.")
+		return pkg.IsAppInPromConfig(promConfigJobName)
+	}, waitTimeout, pollingInterval).Should(BeFalse(), "Expected App to be removed from Prometheus Config")
 
 	pkg.Log(pkg.Info, "Delete namespace")
 	Eventually(func() error {
@@ -112,6 +111,14 @@ var _ = Describe("Verify DeployMetrics Application", func() {
 		})
 	})
 
+	Context("Prometheus Config.", func() {
+		It("Verify that Prometheus Config Data contains deploymetrics-appconf_default_deploymetrics_deploymetrics-deployment", func() {
+			Eventually(func() bool {
+				return pkg.IsAppInPromConfig(promConfigJobName)
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find App in Prometheus Config")
+		})
+	})
+
 	Context("Verify Prometheus scraped metrics.", func() {
 		It("Retrieve Prometheus scraped metrics for App Component", func() {
 			Eventually(func() bool {
@@ -124,5 +131,4 @@ var _ = Describe("Verify DeployMetrics Application", func() {
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for App Config.")
 		})
 	})
-
 })

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -8,11 +8,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	vaoClient "github.com/verrazzano/verrazzano/application-operator/clients/app/clientset/versioned"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	promConfigmap = "vmi-system-prometheus-config"
+	dataKey       = "prometheus.yml"
 )
 
 // QueryMetricWithLabel queries a metric using a label from the Prometheus host, derived from the kubeconfig
@@ -162,6 +170,7 @@ func Jq(node interface{}, path ...string) interface{} {
 	return node
 }
 
+// DoesMetricsTemplateExist takes a metrics template name and checks if it exists
 func DoesMetricsTemplateExist(namespacedName types.NamespacedName) bool {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
@@ -192,4 +201,14 @@ func DoesMetricsTemplateExist(namespacedName types.NamespacedName) bool {
 		}
 	}
 	return false
+}
+
+// IsAppInPromConfig checks to see if the Prom config data contains the passed in App name
+func IsAppInPromConfig(configAppName string) bool {
+	promConfig, err := GetConfigMap(promConfigmap, constants.VerrazzanoSystemNamespace)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting Prometheus configmap, error: %v", err))
+		return false
+	}
+	return strings.Contains(promConfig.Data[dataKey], configAppName)
 }


### PR DESCRIPTION
This changes the deploymetrics test to not check that the metrics have been deleted from Prometheus after the app is uninstalled. Instead, the test checks the the app has been added to the Prometheus config. It then checks in the AfterSuite after the App components have been deleted that the app has been removed from the Prometheus config.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
