### PR TITLE
VZ-4322 - Modify install test check for isConsoleURLExpected after backport of VZ-4322 fix to 1.1.1

### DIFF
--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -124,20 +124,20 @@ func isConsoleIngressHost(ingressHost string) bool {
 	return strings.HasPrefix(ingressHost, "verrazzano.")
 }
 
-// isConsoleURLExpected - Returns true in VZ < 1.2.0. For VZ >= 1.2.0, returns false only if explicitly disabled
+// isConsoleURLExpected - Returns true in VZ < 1.1.1. For VZ >= 1.1.1, returns false only if explicitly disabled
 // in the CR or when managed cluster profile is used
 func isConsoleURLExpected(kubeconfigPath string) (bool, error) {
-	isAtleastVz12, err := pkg.IsVerrazzanoMinVersion("1.2.0")
+	isAtleastVz111, err := pkg.IsVerrazzanoMinVersion("1.1.1")
 	if err != nil {
 		return false, err
 	}
-	// Pre 1.2.0, the console URL was always present irrespective of whether console is enabled
-	// This behavior changed in VZ 1.2.0
-	if !isAtleastVz12 {
+	// Pre 1.1.1, the console URL was always present irrespective of whether console is enabled
+	// This behavior changed in VZ 1.1.1
+	if !isAtleastVz111 {
 		return true, nil
 	}
 
-	// In 1.2.0 and later, the console URL will only be present in the VZ status instance info if the console is enabled
+	// In 1.1.1 and later, the console URL will only be present in the VZ status instance info if the console is enabled
 	vz, err := pkg.GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Description

Modify install test check for isConsoleURLExpected after backport of VZ-4322 fix to 1.1.1

Fixes VZ-4322

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
