### PR TITLE
pmackin/VZ-4313 IngressTrait finalizer cleanup

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -204,12 +204,18 @@ func (r *Reconciler) removeFinalizerIfRequired(ctx context.Context, trait *vzapi
 
 // cleanupAppConfig cleans up the generated certificates and secrets associated with the given app config
 func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
-	err = r.cleanupCert(trait)
+	certName, err := buildCertificateNameFromAppName(trait)
+	if err != nil {
+		r.Log.Error(err, "Error building certificate name", "trait", trait.Name)
+		return err
+	}
+
+	err = r.cleanupCert(trait, certName)
 	if err != nil {
 		return
 	}
 
-	err = r.cleanupSecret(trait)
+	err = r.cleanupSecret(trait, certName)
 	if err != nil {
 		return
 	}
@@ -217,71 +223,49 @@ func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
 	return
 }
 
-// cleanupCert cleans up the generated certificate for the given app config
-func (r *Reconciler) cleanupCert(trait *vzapi.IngressTrait) (err error) {
-	gatewayCertName, err := buildCertificateNameFromAppName(trait)
-	if err != nil {
-		return err
+// cleanupCert deletes up the generated certificate for the given app config
+func (r *Reconciler) cleanupCert(trait *vzapi.IngressTrait, certName string) (err error) {
+	nsn := types.NamespacedName{Name: certName, Namespace: constants.IstioSystemNamespace}
+	cert := &certapiv1alpha2.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsn.Namespace,
+			Name:      nsn.Name,
+		},
 	}
-	namespacedName := types.NamespacedName{Name: gatewayCertName, Namespace: constants.IstioSystemNamespace}
-	var cert *certapiv1alpha2.Certificate
-	cert, err = r.fetchCert(context.TODO(), r.Client, namespacedName)
-	if err != nil {
-		return err
-	}
-	if cert != nil {
-		err = r.Client.Delete(context.TODO(), cert, &client.DeleteOptions{})
-	}
-	return
-}
-
-// cleanupSecret cleans up the generated secret for the given app config
-func (r *Reconciler) cleanupSecret(trait *vzapi.IngressTrait) (err error) {
-	gatewayCertName, err := buildCertificateNameFromAppName(trait)
-	if err != nil {
-		return err
-	}
-	gatewaySecretName := fmt.Sprintf("%s-secret", gatewayCertName)
-	namespacedName := types.NamespacedName{Name: gatewaySecretName, Namespace: constants.IstioSystemNamespace}
-	var secret *corev1.Secret
-	secret, err = r.fetchSecret(context.TODO(), r.Client, namespacedName)
-	if err != nil {
-		return err
-	}
-	if secret != nil {
-		err = r.Client.Delete(context.TODO(), secret, &client.DeleteOptions{})
-	}
-	return
-}
-
-// fetchCert gets the cert for the given name; returns nil Certificate if not found
-func (r *Reconciler) fetchCert(ctx context.Context, c client.Reader, name types.NamespacedName) (*certapiv1alpha2.Certificate, error) {
-	var cert certapiv1alpha2.Certificate
-	err := c.Get(ctx, name, &cert)
+	// Delete the cert, ignore not found
+	err = r.Delete(context.TODO(), cert, &client.DeleteOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			r.Log.Info("cert does not exist", "cert", name)
-			return nil, nil
+			return nil
 		}
-		r.Log.Info("failed to fetch cert", "cert", name)
-		return nil, err
+		r.Log.Error(err, "Error deleting the cert", "cert", nsn)
+		return err
 	}
-	return &cert, err
+	r.Log.Info("Ingress trait certificate deleted", "cert", nsn)
+	return nil
 }
 
-// fetchSecret gets the secret for the given name; returns nil Secret if not found
-func (r *Reconciler) fetchSecret(ctx context.Context, c client.Reader, name types.NamespacedName) (*corev1.Secret, error) {
-	var secret corev1.Secret
-	err := c.Get(ctx, name, &secret)
+// cleanupSecret deletes up the generated secret for the given app config
+func (r *Reconciler) cleanupSecret(trait *vzapi.IngressTrait, certName string) (err error) {
+	secretName := fmt.Sprintf("%s-secret", certName)
+	nsn := types.NamespacedName{Name: secretName, Namespace: constants.IstioSystemNamespace}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsn.Namespace,
+			Name:      nsn.Name,
+		},
+	}
+	// Delete the secret, ignore not found
+	err = r.Delete(context.TODO(), secret, &client.DeleteOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			r.Log.Info("secret does not exist", "secret", name)
-			return nil, nil
+			return nil
 		}
-		r.Log.Info("failed to fetch secret", "secret", name)
-		return nil, err
+		r.Log.Error(err, "Error deleting the secret", "secret", nsn)
+		return err
 	}
-	return &secret, err
+	r.Log.Info("Ingress trait secret deleted", "cert", nsn)
+	return nil
 }
 
 // getGatewayName will generate a gateway name from the namespace and application name of the provided trait. Returns

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -442,28 +442,12 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 				Name:       "test-workload-name"}
 			return nil
 		})
-	// Expect a call to get the associated certificate
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, cert *certapiv1alpha2.Certificate) error {
-			cert.Namespace = name.Namespace
-			cert.Name = name.Name
-			return nil
-		})
 	// Expect a call to delete the cert
 	mock.EXPECT().
 		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, cert *certapiv1alpha2.Certificate, opt *client.DeleteOptions) error {
 			assert.Equal("istio-system", cert.Namespace)
 			assert.Equal("test-space-myapp-cert", cert.Name)
-			return nil
-		})
-	// Expect a call to get the secret
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert-secret"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, sec *k8score.Secret) error {
-			sec.Namespace = name.Namespace
-			sec.Name = name.Name
 			return nil
 		})
 	// Expect a call to delete the secret


### PR DESCRIPTION
Change the IngressTrait cleanup to delete the cert and secret, ignoring the notExist error.  This eliminates a potential race condition where a get and then is called, and another thread could then delete the cert/secret.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
