### PR TITLE
Add failure handler to sock-shop

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_suite_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_suite_test.go
@@ -19,6 +19,6 @@ func init() {
 }
 
 func TestSockShopApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
+	gomega.RegisterFailHandler(FailHandler)
 	ginkgo.RunSpecs(t, "Sock Shop Suite")
 }

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -8,7 +8,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/ginkgo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
@@ -33,9 +32,6 @@ const (
 	sockshopAppName      = "sockshop-appconfig"
 	sockshopNamespace    = "sockshop"
 )
-
-// Needed to get around linter
-var gingoFail = ginkgo.Fail
 
 var sockShop SockShop
 var username, password string
@@ -357,5 +353,5 @@ func getVariant() string {
 // FailHandler to handle failures
 func FailHandler(message string, callerSkip ...int) {
 	pkg.ExecuteClusterDumpWithEnvVarConfig()
-	gingoFail(message, callerSkip...)
+	Fail(message, callerSkip...)
 }

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -259,6 +259,9 @@ var _ = AfterSuite(func() {
 		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
 		pkg.Log(pkg.Info, "Delete application")
+
+		Expect(false).Should(BeTrue())
+
 		Eventually(func() error {
 			return pkg.DeleteResourceFromFile("examples/sock-shop/" + variant + "/sock-shop-app.yaml")
 		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -34,6 +34,9 @@ const (
 	sockshopNamespace    = "sockshop"
 )
 
+// Needed to get around linter
+var gingoFail = ginkgo.Fail
+
 var sockShop SockShop
 var username, password string
 
@@ -354,5 +357,5 @@ func getVariant() string {
 // FailHandler to handle failures
 func FailHandler(message string, callerSkip ...int) {
 	pkg.ExecuteClusterDumpWithEnvVarConfig()
-	ginkgo.Fail(message, callerSkip...)
+	gingoFail(message, callerSkip...)
 }

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -8,6 +8,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/onsi/ginkgo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
@@ -254,10 +255,6 @@ var _ = AfterEach(func() {
 
 // undeploys the application, components, and namespace
 var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
-	failed = false
 	if !skipUndeploy {
 		variant := getVariant()
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
@@ -299,9 +296,6 @@ var _ = AfterSuite(func() {
 			}
 			return false
 		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-	}
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
 	}
 })
 
@@ -352,4 +346,10 @@ func getVariant() string {
 	}
 
 	return variant
+}
+
+// FailHandler to handle failures
+func FailHandler(message string, callerSkip ...int) {
+	pkg.ExecuteClusterDumpWithEnvVarConfig()
+	ginkgo.Fail(message, callerSkip...)
 }

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -259,8 +259,6 @@ var _ = AfterSuite(func() {
 		pkg.Log(pkg.Info, "Undeploy Sock Shop application")
 		pkg.Log(pkg.Info, "Delete application")
 
-		Expect(false).Should(BeTrue())
-
 		Eventually(func() error {
 			return pkg.DeleteResourceFromFile("examples/sock-shop/" + variant + "/sock-shop-app.yaml")
 		}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())


### PR DESCRIPTION
Add a failure handler so that AfterSuite failures are logged.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
