### PR TITLE
VZ-4340 Delete Ingress Certificate and its Secret only when no other IngressTraits references them

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresstrait

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -210,6 +210,13 @@ func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
 		return err
 	}
 
+	// Check if the TLS certificate associated to this ingress trait is also used by other ingress traits,
+	// if so do not delete the TLS certifacte and its associated secret. If no other ingress traits
+	// references the certificate, then proceed with the deletion of the Certificate and Secret objects
+	if !r.checkIfCertSafeToDelete(trait, certName) {
+		return
+	}
+
 	err = r.cleanupCert(trait, certName)
 	if err != nil {
 		return
@@ -221,6 +228,32 @@ func (r *Reconciler) cleanup(trait *vzapi.IngressTrait) (err error) {
 	}
 
 	return
+}
+
+// checkIfCertSafeToDelete checks if the TLS certificate referenced by this ingress trait is also referenced by other
+// ingress traits in the same namespace and Application. If there are other ingress traits referencing the same
+// TLS certificate, then it is not safe to delete it.
+func (r *Reconciler) checkIfCertSafeToDelete(trait *vzapi.IngressTrait, certName string) bool {
+	// Get all IngressTraits associated with this ApplicationConfiguration in the same namespace
+	ingressTraitList := vzapi.IngressTraitList{}
+	r.Client.List(context.TODO(), &ingressTraitList,
+		client.InNamespace(trait.GetNamespace()),
+		client.MatchingLabels(map[string]string{oam.LabelAppName: trait.Labels[oam.LabelAppName]}))
+	// Iterate the IngressTraits and see if any of them refer the same certificate as this IngressTrait
+	for _, ingress := range ingressTraitList.Items {
+		// if it is the current IngressTrait, ignore it and look for other IngressTraits
+		if ingress.Name == trait.Name {
+			continue
+		}
+		for _, resource := range ingress.Status.Resources {
+			if resource.Kind == certificateKind && resource.Name == certName {
+				// It is not safe to delete the Certificate object as it is associated to at least
+				// one another IngressTrait in the same ApplicationConfiguration
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // cleanupCert deletes up the generated certificate for the given app config

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -411,6 +411,198 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 	assert.Equal(time.Duration(0), result.RequeueAfter)
 }
 
+// TestDeleteCertUsedByMultipleTraitsIsNotDeleted tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that is marked for deletion
+// WHEN the trait exists and the Application has other ingress traits that refer to the same TLS Certificate
+// THEN ensure that the cert and secret associated with the trait are not deleted
+func TestDeleteCertUsedByMultipleTraitsIsNotDeleted(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         name.Namespace,
+				Name:              name.Name,
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       "test-workload-name"}
+			return nil
+		})
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ingressList *vzapi.IngressTraitList, listOptions ...client.ListOption) error {
+			// IngressTrait that needs to be deleted.
+			trait1 := vzapi.IngressTrait{}
+			trait1.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait1.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         "test-space",
+				Name:              "test-trait-name",
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
+			trait1.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait1.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait1.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       "test-workload-name"}
+			trait1.Status.Resources = []oamrt.TypedReference{
+				{
+					Name: "test-space-myapp-cert",
+					Kind: certificateKind,
+				},
+			}
+			// Create IngressTrait 'AnotherIngressTraitWithSameCert' by doing a deep copy
+			// of trait1 and just changing the name
+			trait2 := trait1.DeepCopy()
+			trait2.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         "test-space",
+				Name:              "AnotherIngressTraitWithSameCert",
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
+
+			// Fill ingressList with 2 IngressTraits referencing the same cert and cert secret
+			ingressList.Items = []vzapi.IngressTrait{trait1, *trait2}
+			return nil
+		})
+	// Ensure that no call to DeleteCertificate and DeleteSecret is made
+	// Expect a call to update the the ingress trait.
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, obj *vzapi.IngressTrait) error {
+		assert.Equal("test-space", obj.Namespace)
+		assert.Equal("test-trait-name", obj.Name)
+		assert.Len(obj.Finalizers, 0)
+		return nil
+	})
+
+	// Create and make the request
+	request := newRequest("test-space", "test-trait-name")
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestDeleteCertAndSecretIsDeletedWithCertReuseCheck tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that is marked for deletion
+// WHEN the trait exists and no other IngressTraits that refer the same TLS Certificate,
+// THEN ensure that the cert and secret associated with the trait are also deleted
+func TestDeleteCertAndSecretIsDeletedWithCertReuseCheck(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         name.Namespace,
+				Name:              name.Name,
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       "test-workload-name"}
+			return nil
+		})
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ingressList *vzapi.IngressTraitList, listOptions ...client.ListOption) error {
+			// IngressTrait that needs to be deleted.
+			trait1 := vzapi.IngressTrait{}
+			trait1.TypeMeta = metav1.TypeMeta{
+				APIVersion: "oam.verrazzano.io/v1alpha1",
+				Kind:       "IngressTrait"}
+			trait1.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         "test-space",
+				Name:              "test-trait-name",
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"ingresstrait.finalizers.verrazzano.io"},
+				Labels:            map[string]string{oam.LabelAppName: "myapp"}}
+			trait1.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait1.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait1.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       "test-workload-name"}
+			trait1.Status.Resources = []oamrt.TypedReference{
+				{
+					Name: "test-space-myapp-cert",
+					Kind: certificateKind,
+				},
+			}
+			ingressList.Items = []vzapi.IngressTrait{trait1}
+			return nil
+		})
+	// Expect a call to delete the cert
+	mock.EXPECT().
+		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, cert *certapiv1alpha2.Certificate, opt *client.DeleteOptions) error {
+			assert.Equal("istio-system", cert.Namespace)
+			assert.Equal("test-space-myapp-cert", cert.Name)
+			return nil
+		})
+	// Expect a call to delete the secret
+	mock.EXPECT().
+		Delete(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, sec *k8score.Secret, opt *client.DeleteOptions) error {
+			assert.Equal("istio-system", sec.Namespace)
+			assert.Equal("test-space-myapp-cert-secret", sec.Name)
+			return nil
+		})
+	// Expect a call to update the the ingress trait.
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, obj *vzapi.IngressTrait) error {
+		assert.Equal("test-space", obj.Namespace)
+		assert.Equal("test-trait-name", obj.Name)
+		assert.Len(obj.Finalizers, 0)
+		return nil
+	})
+
+	// Create and make the request
+	request := newRequest("test-space", "test-trait-name")
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
 // TestDeleteCertAndSecretWhenTraitIsDeleted tests the Reconcile method for the following use case.
 // GIVEN a request to reconcile an ingress trait resource that is marked for deletion
 // WHEN the trait exists
@@ -440,6 +632,11 @@ func TestDeleteCertAndSecretWhenTraitIsDeleted(t *testing.T) {
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
 				Name:       "test-workload-name"}
+			return nil
+		})
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ingressList *vzapi.IngressTraitList, listOptions ...client.ListOption) error {
 			return nil
 		})
 	// Expect a call to delete the cert

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresstrait


### PR DESCRIPTION
Signed-off-by: anajosep <anand.francis.joseph.augustin@oracle.com>

# Description

During an IngressTrait deletion, delete its associated Certificate and Secret only when no other IngressTrait(s) within the ApplicationConfiguration references them.

Fixes VZ-4340

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
