### PR TITLE
VZ-4373: Timeout in examples tests too short

### DIFF
--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Verify Hello Helidon OAM App.", func() {
 	// THEN the expected pod must be running in the test namespace
 	Describe("Verify hello-helidon-deployment pod is running.", func() {
 		It("and waiting for expected pods must be running", func() {
-			Eventually(helloHelidonPodsRunning, waitTimeout, pollingInterval).Should(BeTrue())
+			Eventually(helloHelidonPodsRunning, longWaitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
# Description

Increases the timeout in the Helidon example test as the logs showed that waiting just a bit longer would have resulted in the test passing.

Fixes VZ-4373: Timeout in examples tests too short

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
