### PR TITLE
VZ-4087 Update Port Name Field for Helidon Workload

### DIFF
--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -7,15 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-	"strconv"
-	"strings"
-
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/appconfig"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
@@ -258,19 +257,17 @@ func (r *Reconciler) createServiceFromDeployment(workload *vzapi.VerrazzanoHelid
 				for _, port := range container.Ports {
 					// All ports within a ServiceSpec must have unique names.
 					// When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort.
-					name := container.Name + "-" + strconv.FormatInt(int64(port.ContainerPort), 10)
+					name := strings.ToLower(string(corev1.ProtocolTCP)) + "-" + container.Name + "-" + strconv.FormatInt(int64(port.ContainerPort), 10)
 					protocol := corev1.ProtocolTCP
 					if len(port.Protocol) > 0 {
 						protocol = port.Protocol
 					}
-					appProtocol := strings.ToLower(string(corev1.ProtocolTCP))
 
 					servicePort := corev1.ServicePort{
 						Name:        name,
 						Port:        port.ContainerPort,
 						TargetPort:  intstr.FromInt(int(port.ContainerPort)),
 						Protocol:    protocol,
-						AppProtocol: &appProtocol,
 					}
 					r.Log.V(1).Info("Appending port to service", "servicePort", servicePort)
 					s.Spec.Ports = append(s.Spec.Ports, servicePort)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/appconfig"
@@ -262,11 +263,14 @@ func (r *Reconciler) createServiceFromDeployment(workload *vzapi.VerrazzanoHelid
 					if len(port.Protocol) > 0 {
 						protocol = port.Protocol
 					}
+					appProtocol := strings.ToLower(string(protocol))
+
 					servicePort := corev1.ServicePort{
 						Name:       name,
 						Port:       port.ContainerPort,
 						TargetPort: intstr.FromInt(int(port.ContainerPort)),
 						Protocol:   protocol,
+						AppProtocol: &appProtocol,
 					}
 					r.Log.V(1).Info("Appending port to service", "servicePort", servicePort)
 					s.Spec.Ports = append(s.Spec.Ports, servicePort)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -263,13 +263,13 @@ func (r *Reconciler) createServiceFromDeployment(workload *vzapi.VerrazzanoHelid
 					if len(port.Protocol) > 0 {
 						protocol = port.Protocol
 					}
-					appProtocol := strings.ToLower(string(protocol))
+					appProtocol := strings.ToLower(string(corev1.ProtocolTCP))
 
 					servicePort := corev1.ServicePort{
-						Name:       name,
-						Port:       port.ContainerPort,
-						TargetPort: intstr.FromInt(int(port.ContainerPort)),
-						Protocol:   protocol,
+						Name:        name,
+						Port:        port.ContainerPort,
+						TargetPort:  intstr.FromInt(int(port.ContainerPort)),
+						Protocol:    protocol,
 						AppProtocol: &appProtocol,
 					}
 					r.Log.V(1).Info("Appending port to service", "servicePort", servicePort)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -264,10 +264,10 @@ func (r *Reconciler) createServiceFromDeployment(workload *vzapi.VerrazzanoHelid
 					}
 
 					servicePort := corev1.ServicePort{
-						Name:        name,
-						Port:        port.ContainerPort,
-						TargetPort:  intstr.FromInt(int(port.ContainerPort)),
-						Protocol:    protocol,
+						Name:       name,
+						Port:       port.ContainerPort,
+						TargetPort: intstr.FromInt(int(port.ContainerPort)),
+						Protocol:   protocol,
 					}
 					r.Log.V(1).Info("Appending port to service", "servicePort", servicePort)
 					s.Spec.Ports = append(s.Spec.Ports, servicePort)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonworkload

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -394,11 +394,11 @@ func TestReconcileCreateHelidonWithMultipleContainers(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, service *corev1.Service, patch client.Patch, applyOpts ...client.PatchOption) error {
 			assert.Equal(serviceAPIVersion, service.APIVersion)
 			assert.Equal(serviceKind, service.Kind)
-			assert.Equal(service.Spec.Ports[0].Name, helidonTestContainer.Name+"-"+strconv.FormatInt(int64(helidonTestContainer.Ports[0].ContainerPort), 10))
+			assert.Equal(service.Spec.Ports[0].Name, "tcp-"+helidonTestContainer.Name+"-"+strconv.FormatInt(int64(helidonTestContainer.Ports[0].ContainerPort), 10))
 			assert.Equal(service.Spec.Ports[0].Port, helidonTestContainer.Ports[0].ContainerPort)
 			assert.Equal(service.Spec.Ports[0].TargetPort, intstr.FromInt(int(helidonTestContainer.Ports[0].ContainerPort)))
 			assert.Equal(service.Spec.Ports[0].Protocol, corev1.ProtocolTCP)
-			assert.Equal(service.Spec.Ports[1].Name, helidonTestContainer2.Name+"-"+strconv.FormatInt(int64(helidonTestContainer2.Ports[0].ContainerPort), 10))
+			assert.Equal(service.Spec.Ports[1].Name, "tcp-"+helidonTestContainer2.Name+"-"+strconv.FormatInt(int64(helidonTestContainer2.Ports[0].ContainerPort), 10))
 			assert.Equal(service.Spec.Ports[1].Port, helidonTestContainer2.Ports[0].ContainerPort)
 			assert.Equal(service.Spec.Ports[1].TargetPort, intstr.FromInt(int(helidonTestContainer2.Ports[0].ContainerPort)))
 			assert.Equal(service.Spec.Ports[1].Protocol, helidonTestContainer2.Ports[0].Protocol)


### PR DESCRIPTION
# Description

The formatting for the ports of Istio needs to be updated for helidon workloads based on this format: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

I made TCP the default for now. I don't think we allow for this to be customized, so that could possibly be a future addition.

Fixes VZ-4087

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
