### PR TITLE
VZ-4410: Add cluster dumps to app tests that don't have it

### DIFF
--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonlogging

--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
@@ -32,7 +32,15 @@ var _ = BeforeSuite(func() {
 	loggingtrait.DeployApplication(namespace, componentsPath, applicationPath)
 })
 
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
 var _ = AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	loggingtrait.UndeployApplication(namespace, componentsPath, applicationPath, configMapName)
 })
 

--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
@@ -32,15 +32,9 @@ var _ = BeforeSuite(func() {
 	loggingtrait.DeployApplication(namespace, componentsPath, applicationPath)
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentSpecReport().Failed()
-})
-
-var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
 	loggingtrait.UndeployApplication(namespace, componentsPath, applicationPath, configMapName)
 })
 

--- a/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
+++ b/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 // +build metrics_template_test

--- a/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
+++ b/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
@@ -28,15 +28,9 @@ var _ = BeforeSuite(func() {
 	scrapegenerator.DeployApplication(namespace, yamlPath)
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentSpecReport().Failed()
-})
-
-var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
 	scrapegenerator.UndeployApplication(namespace, yamlPath)
 })
 

--- a/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
+++ b/tests/e2e/scrapegenerator/helidon/helidon_scrape_generator_test.go
@@ -28,7 +28,15 @@ var _ = BeforeSuite(func() {
 	scrapegenerator.DeployApplication(namespace, yamlPath)
 })
 
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
 var _ = AfterSuite(func() {
+	if failed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
 	scrapegenerator.UndeployApplication(namespace, yamlPath)
 })
 

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -73,6 +73,12 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		err := pkg.ExecuteClusterDumpWithEnvVarConfig()
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Error dumping cluster %v", err))
+		}
+	}
 	// undeploy the application here
 	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/security/network-policies/netpol-test.yaml")
@@ -81,13 +87,6 @@ var _ = AfterSuite(func() {
 	Eventually(func() error {
 		return pkg.DeleteNamespace(testNamespace)
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
-
-	if failed {
-		err := pkg.ExecuteClusterDumpWithEnvVarConfig()
-		if err != nil {
-			pkg.Log(pkg.Error, fmt.Sprintf("Error dumping cluster %v", err))
-		}
-	}
 })
 
 var _ = Describe("Test Network Policies", func() {

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -67,18 +67,9 @@ var _ = BeforeSuite(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentSpecReport().Failed()
-})
-
-var _ = AfterSuite(func() {
-	if failed {
-		err := pkg.ExecuteClusterDumpWithEnvVarConfig()
-		if err != nil {
-			pkg.Log(pkg.Error, fmt.Sprintf("Error dumping cluster %v", err))
-		}
-	}
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
 	// undeploy the application here
 	Eventually(func() error {
 		return pkg.DeleteResourceFromFile("testdata/security/network-policies/netpol-test.yaml")

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package netpol


### PR DESCRIPTION
This change adds cluster dumps after a failure to the app tests that don't have it. These are the helidon loggingtrait test, the helidon scrape generator test, and the network policy test. This will allow the team to debug any failures that stem from these tests. Currently, the app namespaces get blown away and so there is no way to debug them.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
