### PR TITLE
VZ-4388 increase wko timeout

### DIFF
--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/install/3-install-verrazzano.sh
+++ b/platform-operator/scripts/install/3-install-verrazzano.sh
@@ -251,6 +251,7 @@ function install_weblogic_operator {
   helm upgrade --install --wait ${chart_name} \
     ${CHARTS_DIR}/weblogic-operator \
     --namespace "${VERRAZZANO_NS}" \
+    --timeout 10m \
     -f $VZ_OVERRIDES_DIR/weblogic-values.yaml \
     --set serviceAccount=weblogic-operator-sa \
     --set domainNamespaceSelectionStrategy=LabelSelector \


### PR DESCRIPTION
This change adds the --timeout 10m flag to the helm upgrade command for Weblogic Kubernetes Operator. There was an upgrade pipeline run that failed because the WKO helm command timed out. It has a default timeout of 5m and it took 4m58s to pull the image.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
