### PR TITLE
VZ-4219: Private registry tests are leaking repositories in the tenancy

### DIFF
--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -553,6 +553,22 @@ pipeline {
     post {
         always {
             script {
+                if (SELECT_IMAGE_REGISTRY == "OCIR") {
+                    sh """
+                        echo "Current execution region: $ocirRegion"
+                        echo "OCIR Repository: ${OCIR_REGISTRY}"
+                        echo "Image repo subpath: ${imageRepoSubPath}"
+                        echo "Base image repo: ${baseImageRepo}"
+                        sh ${TEST_SCRIPTS_DIR}/delete_ocir_repositories.sh -p ${imageRepoSubPath}  -s $ocirRegion -c ${REPOSITORY_COMPARTMENT_OCID} -f -w
+                    """
+                } else if (SELECT_IMAGE_REGISTRY == "Harbor") {
+                    sh """
+                        sh ${TEST_SCRIPTS_DIR}/delete_harbor_repositories.sh -a ${HARBOR_STANDALONE_REGISTRY_REST_API_FULL_URL} -u ${HARBOR_STANDALONE_REGISTRY_CREDS_USR} -p ${HARBOR_STANDALONE_REGISTRY_CREDS_PSW} -m ${IMAGE_REPO_SUBPATH_PREFIX} -l ${TARBALL_DIR} -i ${IMAGE_REPO_SUBPATH_SUFFIX}
+                    """
+                }
+            }
+
+            script {
                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                     dumpVerrazzanoSystemPods()
                     dumpCattleSystemPods()
@@ -575,22 +591,6 @@ pipeline {
                   exit 1
                 fi
             """
-
-            script {
-                if (SELECT_IMAGE_REGISTRY == "OCIR") {
-                    sh """
-                        echo "Current execution region: $ocirRegion"
-                        echo "OCIR Repository: ${OCIR_REGISTRY}"
-                        echo "Image repo subpath: ${imageRepoSubPath}"
-                        echo "Base image repo: ${baseImageRepo}"
-                        sh ${TEST_SCRIPTS_DIR}/delete_ocir_repositories.sh -p ${imageRepoSubPath}  -s $ocirRegion -c ${REPOSITORY_COMPARTMENT_OCID} -f -w
-                    """
-                } else if (SELECT_IMAGE_REGISTRY == "Harbor") {
-                    sh """
-                        sh ${TEST_SCRIPTS_DIR}/delete_harbor_repositories.sh -a ${HARBOR_STANDALONE_REGISTRY_REST_API_FULL_URL} -u ${HARBOR_STANDALONE_REGISTRY_CREDS_USR} -p ${HARBOR_STANDALONE_REGISTRY_CREDS_PSW} -m ${IMAGE_REPO_SUBPATH_PREFIX} -l ${TARBALL_DIR} -i ${IMAGE_REPO_SUBPATH_SUFFIX}
-                    """
-                }
-            }
         }
         cleanup {
             deleteDir()


### PR DESCRIPTION
delete the images from the image registries as the very first thing in the "always" directive

Signed-off-by: Prasad Shirodkar <prasad.shirodkar@oracle.com>

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
