### PR TITLE
VZ-4390.  Re-enable copyright fixes, and disable fix-copyright tool for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -740,6 +740,7 @@ def qualityCheck() {
 
         echo "copyright scan"
         time make copyright-check
+        ./ci/scripts/check_if_clean_after_generate.sh
 
         echo "Third party license check"
     """

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 // This is temporary, to experiment with the Git settings in the Jenkins pipelines
@@ -138,6 +138,7 @@ pipeline {
                     git diff origin/master --name-only
                     git log --since=01-01-2021 --name-only --oneline --pretty="format:" | sort -u
                     time make copyright-check
+                    ./ci/scripts/check_if_clean_after_generate.sh
                 """
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,10 @@ copyright-test: ## run the tests for the copyright checker
 .PHONY: copyright-check-year
 copyright-check-year: copyright-test ## check copyright notices have correct current year
 	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
+	go run tools/fix-copyright/copyright.go $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
 
 .PHONY: copyright-check
-copyright-check: copyright-test  ## check copyright notices are correct
+copyright-check: copyright-test copyright-check-year  ## check copyright notices are correct
 	go run tools/copyright/copyright.go --verbose .
 
 .PHONY: copyright-check-local

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ copyright-test: ## run the tests for the copyright checker
 .PHONY: copyright-check-year
 copyright-check-year: copyright-test ## check copyright notices have correct current year
 	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
-	go run tools/fix-copyright/copyright.go $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
+	#go run tools/fix-copyright/copyright.go $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
 
 .PHONY: copyright-check
 copyright-check: copyright-test copyright-check-year  ## check copyright notices are correct

--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,10 @@ copyright-test: ## run the tests for the copyright checker
 .PHONY: copyright-check-year
 copyright-check-year: copyright-test ## check copyright notices have correct current year
 	go run tools/copyright/copyright.go --enforce-current $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
-	#go run tools/fix-copyright/copyright.go $(shell git log --since=01-01-${CURRENT_YEAR} --name-only --oneline --pretty="format:" | sort -u)
 
 .PHONY: copyright-check
 copyright-check: copyright-test copyright-check-year  ## check copyright notices are correct
-	go run tools/copyright/copyright.go --verbose .
+	go run tools/copyright/copyright.go .
 
 .PHONY: copyright-check-local
 copyright-check-local: copyright-test  ## check copyright notices are correct in local working copy

--- a/application-operator/hack/add-crd-header.sh
+++ b/application-operator/hack/add-crd-header.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Add YAML boilerplate to generated CRDs - kubebuilder currently does not seem to have a way to
@@ -13,5 +13,14 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 GENERATED_CRDS_DIR=${SCRIPT_DIR}/../../platform-operator/helm_config/charts/verrazzano-application-operator/crds
 INTERNAL_CRDS_DIR=${SCRIPT_DIR}/../internal/app/crds
 
-go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go $GENERATED_CRDS_DIR
-go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go $INTERNAL_CRDS_DIR
+# The following two steps are required to handle the cases of running "make manifests" when there
+# are and are not api changes.  This is necessary because fix-copyright currently cannot handle both
+# cases correctly with the same set of options.
+
+# First put in the headers from the Git history
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader $GENERATED_CRDS_DIR
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader $INTERNAL_CRDS_DIR
+
+# Then fix the updated year for files that were modified this year
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go  $GENERATED_CRDS_DIR
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go  $INTERNAL_CRDS_DIR

--- a/application-operator/hack/add-yml-header.sh
+++ b/application-operator/hack/add-yml-header.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Add YAML boilerplate to generated CRDs - kubebuilder currently does not seem to have a way to
@@ -11,4 +11,4 @@ set -o pipefail
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 YML_FILENAME=${SCRIPT_DIR}/../${1}
-go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -extension .yaml ${YML_FILENAME} 
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader -extension .yaml ${YML_FILENAME}

--- a/ci/scripts/check_if_clean_after_generate.sh
+++ b/ci/scripts/check_if_clean_after_generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
@@ -12,8 +12,9 @@
 if [[ -n $(git status --porcelain) ]]; then
   git status
   git diff
-  echo "***************************************************************************************************************"
-  echo "* ERROR: Looks like you need to run 'make generate' and/or 'make manifests' and include the changes in your PR *"
-  echo "***************************************************************************************************************"
+  echo "****************************************************************************************************************"
+  echo "* ERROR: The result of a 'make generate', 'make manifests' or 'make copyright-check' resulted in files being   *"
+  echo "*        modified. These changes need to be included in your PR.                                               *"
+  echo "****************************************************************************************************************"
   exit 1
 fi

--- a/image-patch-operator/hack/add-crd-header.sh
+++ b/image-patch-operator/hack/add-crd-header.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Add YAML boilerplate to generated CRDs - kubebuilder currently does not seem to have a way to
@@ -12,4 +12,12 @@ set -o pipefail
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 GENERATED_CRDS_DIR=${SCRIPT_DIR}/../../image-patch-operator/helm_config/charts/image-patch-operator/crds
 
+# The following two steps are required to handle the cases of running "make manifests" when there
+# are and are not api changes.  This is necessary because fix-copyright currently cannot handle both
+# cases correctly with the same set of options.
+
+# First put in the headers from the Git history
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader $GENERATED_CRDS_DIR
+
+# Then fix the updated year for files that were modified this year
 go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go $GENERATED_CRDS_DIR

--- a/image-patch-operator/hack/add-yml-header.sh
+++ b/image-patch-operator/hack/add-yml-header.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Add YAML boilerplate to generated CRDs - kubebuilder currently does not seem to have a way to
@@ -11,4 +11,4 @@ set -o pipefail
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 YML_FILENAME=${SCRIPT_DIR}/../${1}
-go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -extension .yaml ${YML_FILENAME} 
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader -extension .yaml ${YML_FILENAME}

--- a/platform-operator/hack/add-crd-header.sh
+++ b/platform-operator/hack/add-crd-header.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Add YAML boilerplate to generated CRDs - kubebuilder currently does not seem to have a way to
@@ -12,4 +12,12 @@ set -o pipefail
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 GENERATED_CRDS_DIR=$SCRIPT_DIR/../helm_config/charts/verrazzano-platform-operator/crds
 
+# The following two steps are required to handle the cases of running "make manifests" when there
+# are and are not api changes.  This is necessary because fix-copyright currently cannot handle both
+# cases correctly with the same set of options.
+
+# First put in the headers from the Git history
+go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go -useExistingUpdateYearFromHeader $GENERATED_CRDS_DIR
+
+# Then fix the updated year for files that were modified this year
 go run ${SCRIPT_DIR}/../../tools/fix-copyright/copyright.go $GENERATED_CRDS_DIR

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: v1

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -82,6 +82,7 @@ var (
 		".jar",
 		".zip",
 		".gz",
+		".test",
 	}
 
 	// copyrightRegex is the regular expression for recognizing correctly formatted copyright statements

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package main
 


### PR DESCRIPTION
# Description

Re-enables the copyright check fixes for VZ-4390, and disables the fix-copyright tool for now.
- Also, add `.test` files to the ignored file extensions.

Fixes VZ-4390.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
