### PR TITLE
VZ-4147.  VPO namespace controller for OCI logging management

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -99,3 +99,15 @@ const VerrazzanoUsernameData = "username"
 
 // VerrazzanoPasswordData - the field name in Verrazzano secret that contains the password
 const VerrazzanoPasswordData = "password"
+
+// MetricsWorkloadUIDLabel - the label for designating the workload UID in MetricsTemplate resources
+const MetricsWorkloadUIDLabel = "app.verrazzano.io/metrics-workload-uid"
+
+// MetricsTemplateUIDLabel - the label for designating the template UID in MetricsTemplate resources
+const MetricsTemplateUIDLabel = "app.verrazzano.io/metrics-template-uid"
+
+// MetricsPromConfigMapUIDLabel - the label for designating the Prometheus ConfigMap UID in MetricsTemplate resources
+const MetricsPromConfigMapUIDLabel = "app.verrazzano.io/metrics-prometheus-configmap-uid"
+
+// OCILoggingIDAnnotation Annotation name for a customized OCI log ID for all containers in a namespace
+const OCILoggingIDAnnotation = "verrazzano.io/oci-log-id"

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -100,14 +100,5 @@ const VerrazzanoUsernameData = "username"
 // VerrazzanoPasswordData - the field name in Verrazzano secret that contains the password
 const VerrazzanoPasswordData = "password"
 
-// MetricsWorkloadUIDLabel - the label for designating the workload UID in MetricsTemplate resources
-const MetricsWorkloadUIDLabel = "app.verrazzano.io/metrics-workload-uid"
-
-// MetricsTemplateUIDLabel - the label for designating the template UID in MetricsTemplate resources
-const MetricsTemplateUIDLabel = "app.verrazzano.io/metrics-template-uid"
-
-// MetricsPromConfigMapUIDLabel - the label for designating the Prometheus ConfigMap UID in MetricsTemplate resources
-const MetricsPromConfigMapUIDLabel = "app.verrazzano.io/metrics-prometheus-configmap-uid"
-
 // OCILoggingIDAnnotation Annotation name for a customized OCI log ID for all containers in a namespace
 const OCILoggingIDAnnotation = "verrazzano.io/oci-log-id"

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -85,7 +85,7 @@ func (nc *NamespaceController) removeFinalizer(ctx context.Context, ns *corev1.N
 	nc.log.V(1).Info("Removing finalizer %s", namespaceControllerFinalizer)
 	ns.Finalizers = vzstring.RemoveStringFromSlice(ns.Finalizers, namespaceControllerFinalizer)
 	err := nc.Update(ctx, ns)
-	if err != nil && !k8serrors.IsConflict(err) {
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package namespace
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const namespaceControllerFinalizer = "namespaces.verrazzano.io"
+
+// Reconciler reconciles a Verrazzano object
+type NamespaceController struct {
+	client.Client
+	scheme     *runtime.Scheme
+	controller controller.Controller
+	log        logr.Logger
+}
+
+// NewNamespaceController - Creates and configures the namespace controller
+func NewNamespaceController(mgr ctrl.Manager, logger logr.Logger) (*NamespaceController, error) {
+	nc := &NamespaceController{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		log:    logger,
+	}
+	return nc, nc.setupWithManager(mgr)
+}
+
+// SetupWithManager creates a new controller and adds it to the manager
+func (nc *NamespaceController) setupWithManager(mgr ctrl.Manager) error {
+	var err error
+	nc.controller, err = ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).Build(nc)
+	return err
+}
+
+// Reconcile - Watches for and manages namespace activity as it relates to Verrazzano platform services
+func (nc *NamespaceController) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+	log := nc.log.WithName("resource").WithName(req.Name)
+	log.Info("Reconciling namespace %s", req.Name)
+
+	// fetch the namespace
+	ns := corev1.Namespace{}
+	if err := nc.Client.Get(ctx, req.NamespacedName, &ns); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(1).Info("Namespace %s does not exist", req.Name)
+		} else {
+			log.Error(err, "Failed to fetch namespace %s", req.Name)
+		}
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !ns.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Finalizer is present, perform any required cleanup and remove the finalizer
+		if vzstring.SliceContainsString(ns.Finalizers, namespaceControllerFinalizer) {
+			if err := nc.reconcileNamespaceDelete(ctx, &ns); err != nil {
+				return vzctrl.NewRequeueWithDelay(10, 30, time.Second), err
+			}
+			return nc.removeFinalizer(ctx, &ns)
+		}
+	}
+
+	return nc.reconcileNamespace(ctx, &ns)
+}
+
+// removeFinalizer - Remove the finalizer and update the namespace resource if the post-delete processing is successful
+func (nc *NamespaceController) removeFinalizer(ctx context.Context, ns *corev1.Namespace) (reconcile.Result, error) {
+	nc.log.V(1).Info("Removing finalizer %s", namespaceControllerFinalizer)
+	ns.Finalizers = vzstring.RemoveStringFromSlice(ns.Finalizers, namespaceControllerFinalizer)
+	err := nc.Update(ctx, ns)
+	if err != nil && !k8serrors.IsConflict(err) {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+// reconcileNamespace - Reconcile any namespace changes
+func (nc *NamespaceController) reconcileNamespace(ctx context.Context, ns *corev1.Namespace) (reconcile.Result, error) {
+	if err := nc.reconcileOCILogging(ctx, ns); err != nil {
+		nc.log.Error(err, "Error occurred during OCI Logging reconciliation: %s")
+		return vzctrl.NewRequeueWithDelay(10, 30, time.Second), err
+	}
+	nc.log.V(1).Info("Reconciled namespace %s successfully", ns.Name)
+	return reconcile.Result{}, nil
+}
+
+// reconcileNamespaceDelete - Reconcile any post-delete changes required
+func (nc *NamespaceController) reconcileNamespaceDelete(ctx context.Context, ns *corev1.Namespace) error {
+	// Update the OCI Logging configuration to remove the namespace configuration
+	// If the annotation is not present, remove any existing logging configuration
+	return nc.removeOCILogging(ctx, ns)
+}
+
+// reconcileOCILogging - Configure OCI logging based on the annotation if present
+func (nc *NamespaceController) reconcileOCILogging(ctx context.Context, ns *corev1.Namespace) error {
+	// If the annotation is present, add the finalizer if necessary and update the logging configuration
+	if loggingOCID, ok := ns.Annotations[constants.OCILoggingIDAnnotation]; ok {
+		var added bool
+		if ns.Finalizers, added = vzstring.SliceAddString(ns.Finalizers, namespaceControllerFinalizer); added {
+			if err := nc.Update(ctx, ns); err != nil {
+				return err
+			}
+		}
+		nc.log.V(1).Info("Updating logging configuration for namespace %s, log ID: %s", ns.Name, loggingOCID)
+		updated, err := addNamespaceLoggingFunc(ctx, nc.Client, ns.Name, loggingOCID)
+		if err != nil {
+			return err
+		}
+		if updated {
+			nc.log.Info("Updated logging configuration for namespace %s", ns.Name)
+		}
+		return nil
+	}
+	// If the annotation is not present, remove any existing logging configuration
+	return nc.removeOCILogging(ctx, ns)
+}
+
+// removeOCILogging - Remove OCI logging if the namespace is deleted
+func (nc *NamespaceController) removeOCILogging(ctx context.Context, ns *corev1.Namespace) error {
+	removed, err := removeNamespaceLoggingFunc(ctx, nc.Client, ns.Name)
+	if err != nil {
+		return err
+	}
+	if removed {
+		nc.log.Info("Removed logging configuration for namespace %s", ns.Name)
+	}
+	return nil
+}
+
+// addNamespaceLoggingFuncSig - Type for add namespace logging  function, for unit testing
+type addNamespaceLoggingFuncSig func(_ context.Context, _ client.Client, _ string, _ string) (bool, error)
+
+// addNamespaceLoggingFunc - Variable to allow replacing add namespace logging func for unit tests
+var addNamespaceLoggingFunc addNamespaceLoggingFuncSig = AddNamespaceLogging
+
+// AddNamespaceLogging - placeholder for logging update
+func AddNamespaceLogging(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+	return true, nil
+}
+
+// removeNamespaceLoggingFuncSig - Type for remove namespace logging function, for unit testing
+type removeNamespaceLoggingFuncSig func(_ context.Context, _ client.Client, _ string) (bool, error)
+
+// removeNamespaceLoggingFunc - Variable to allow replacing remove namespace logging func for unit tests
+var removeNamespaceLoggingFunc removeNamespaceLoggingFuncSig = RemoveNamespaceLogging
+
+// RemoveNamespaceLogging - placeholder for logging update
+func RemoveNamespaceLogging(_ context.Context, _ client.Client, _ string) (bool, error) {
+	return true, nil
+}

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -4,7 +4,6 @@ package namespace
 
 import (
 	"context"
-	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
@@ -63,7 +62,7 @@ func (nc *NamespaceController) Reconcile(req reconcile.Request) (reconcile.Resul
 		if k8serrors.IsNotFound(err) {
 			nc.log.V(1).Info("Namespace does not exist", namespaceField, req.Name)
 		} else {
-			nc.log.Error(err, fmt.Sprintf("Failed to fetch namespace", namespaceField, req.Name))
+			nc.log.Error(err, "Failed to fetch namespace", namespaceField, req.Name)
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -234,8 +234,7 @@ func TestReconcileNamespaceDeletedErrorOnUpdate(t *testing.T) {
 
 	mocker.Finish()
 	asserts.Equal(expectedErr, err)
-	asserts.True(result.Requeue)
-	asserts.True(result.RequeueAfter > 0)
+	asserts.True(result.IsZero())
 }
 
 // Test_removeFinalizer tests the removeFinalizer method for the following use case
@@ -380,13 +379,11 @@ func Test_reconcileNamespaceErrorOnUpdate(t *testing.T) {
 			return expectedErr
 		})
 
-	result, err := nc.reconcileNamespace(context.TODO(), ns)
+	err = nc.reconcileNamespace(context.TODO(), ns)
 
 	mocker.Finish()
 	asserts.Error(err)
 	asserts.Equalf(expectedErr, err, "Did not get expected error: %v", err)
-	asserts.True(result.Requeue)
-	asserts.True(result.RequeueAfter > 0)
 }
 
 // Test_reconcileNamespace tests the reconcileNamespace method for the following use case
@@ -413,11 +410,10 @@ func Test_reconcileNamespace(t *testing.T) {
 		},
 	}
 
-	result, err := nc.reconcileNamespace(context.TODO(), ns)
+	err = nc.reconcileNamespace(context.TODO(), ns)
 
 	mocker.Finish()
 	asserts.NoError(err)
-	asserts.Equal(ctrl.Result{}, result)
 }
 
 // Test_reconcileNamespaceDelete tests the reconcileNamespaceDelete method for the following use case

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -1,0 +1,736 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"net/http"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"testing"
+	"time"
+)
+
+var testScheme = newScheme()
+
+// newScheme creates a new scheme that includes this package's object to use for testing
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	return scheme
+}
+
+// newTestController - test helper to boostrap a NamespaceController for test purposes
+func newTestController(c client.Client) (*NamespaceController, error) {
+	mgr := fakeManager{
+		Client: c,
+		scheme: testScheme,
+	}
+	return NewNamespaceController(mgr, log.NullLogger{})
+}
+
+// TestReconcileNamespaceUpdate tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the namespace has the expected annotation
+// THEN ensure that no error is returned and the result does not indicate a requeue
+func TestReconcileNamespaceUpdate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			ns.Name = "myns"
+			ns.Annotations = map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			}
+			ns.Finalizers = []string{"someFinalizer"}
+			return nil
+		})
+
+	// Expect a call to update the namespace that succeeds
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "myns"},
+	}
+	result, err := nc.Reconcile(req)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// TestReconcileNamespaceNotFound tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the namespace can not be found
+// THEN ensure that no error is returned and the result does not indicate a requeue
+func TestReconcileNamespaceNotFound(t *testing.T) {
+	runTestReconcileGetError(t, k8serrors.NewNotFound(schema.ParseGroupResource("Namespace"), "myns"), nil)
+}
+
+// TestReconcileNamespaceGetError tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the client Get() operation returns an error other than IsNotFound
+// THEN ensure that the unexpected error is returned and the result does not indicate a requeue (controllerruntime does this)
+func TestReconcileNamespaceGetError(t *testing.T) {
+	err := fmt.Errorf("some other error getting namespace")
+	runTestReconcileGetError(t, err, err)
+}
+
+// runTestReconcileGetError - Common test code for the namespace Get() error cases
+func runTestReconcileGetError(t *testing.T, returnErr error, expectedErr error) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return returnErr
+		})
+
+	// Expect no call to update the namespace
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "myns"},
+	}
+	result, err := nc.Reconcile(req)
+
+	mocker.Finish()
+	asserts.Equal(err, expectedErr)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// TestReconcileNamespaceDeleted tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the namespace DeletionTimestamp has been set (namespace is in the process of being deleted)
+// THEN ensure that the namespace finalizer is deleted and no error or requeue result are returned
+func TestReconcileNamespaceDeleted(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			ns.Name = "myns"
+			ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			ns.Annotations = map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			}
+			ns.Finalizers = []string{"someFinalizer", namespaceControllerFinalizer}
+			return nil
+		})
+
+	// Expect a call to update the namespace that succeeds
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			asserts.NotContainsf(ns.Finalizers, namespaceControllerFinalizer, "Finalizer not removed: ", ns.Finalizers)
+			return nil
+		})
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "myns"},
+	}
+	result, err := nc.Reconcile(req)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// TestReconcileNamespaceDeletedErrorOnUpdate tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the namespace DeletionTimestamp has been set (namespace deleted) and the remove OCI logging integration returns an error
+// THEN ensure than an error and a requeue are returned, and Update() is never called to remove the finalizer
+func TestReconcileNamespaceDeletedErrorOnUpdate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			ns.Name = "myns"
+			ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			ns.Annotations = map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			}
+			ns.Finalizers = []string{"someFinalizer", namespaceControllerFinalizer}
+			return nil
+		})
+
+	// Expect no call to update the namespace
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	// Force a failure
+	expectedErr := fmt.Errorf("error updating OCI Logging")
+	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
+		return false, expectedErr
+	}
+	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "myns"},
+	}
+	result, err := nc.Reconcile(req)
+
+	mocker.Finish()
+	asserts.Equal(expectedErr, err)
+	asserts.True(result.Requeue)
+	asserts.True(result.RequeueAfter > 0)
+}
+
+// Test_removeFinalizer tests the removeFinalizer method for the following use case
+// GIVEN a request to removeFinalizer for a Namespace resource
+// WHEN the namespace has the NamespaceController finalizer present
+// THEN the NamespaceController finalizer is removed from the Namespace resource and no requeue is indicated
+func Test_removeFinalizer(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace that succeeds
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myns",
+			Finalizers: []string{namespaceControllerFinalizer, "anotherFinalizer"},
+		},
+	}
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	result, err := nc.removeFinalizer(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.NotContainsf(ns.Finalizers, namespaceControllerFinalizer, "Finalizer not removed: ", ns.Finalizers)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// Test_removeFinalizerNotPresent tests the removeFinalizer method for the following use case
+// GIVEN a request to removeFinalizer for a Namespace resource
+// WHEN the namespace does not have the NamespaceController finalizer present
+// THEN the NamespaceController finalizer field unchanged and no requeue is indicated
+func Test_removeFinalizerNotPresent(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	// Expect a call to update the namespace that succeeds
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myns",
+			Finalizers: []string{"anotherFinalizer"},
+		},
+	}
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	result, err := nc.removeFinalizer(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equalf(ns.Finalizers, []string{"anotherFinalizer"}, "Finalizers modified unexpectedly: %v", ns.Finalizers)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// Test_removeFinalizerErrorOnUpdate tests the removeFinalizer method for the following use case
+// GIVEN a request to removeFinalizer for a Namespace resource
+// WHEN the client returns an error on Update()
+// THEN an error is returned
+func Test_removeFinalizerErrorOnUpdate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myns",
+			Finalizers: []string{namespaceControllerFinalizer, "anotherFinalizer"},
+		},
+	}
+
+	// Expect a call to update the namespace that fails
+	expectedErr := fmt.Errorf("error updating namespace")
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return expectedErr
+		})
+
+	result, err := nc.removeFinalizer(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.Error(err)
+	asserts.Equalf(expectedErr, err, "Did not get expected error: %v", err)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// Test_reconcileNamespaceErrorOnUpdate tests the reconcileNamespace method for the following use case
+// GIVEN a request to reconcileNamespace for a Namespace resource
+// WHEN the client returns an error on Update()
+// THEN an error and a requeue are returned
+func Test_reconcileNamespaceErrorOnUpdate(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer"},
+		},
+	}
+
+	expectedErr := fmt.Errorf("error updating namespace")
+
+	// Expect a call to update the namespace that fails
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return expectedErr
+		})
+
+	result, err := nc.reconcileNamespace(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.Error(err)
+	asserts.Equalf(expectedErr, err, "Did not get expected error: %v", err)
+	asserts.True(result.Requeue)
+	asserts.True(result.RequeueAfter > 0)
+}
+
+// Test_reconcileNamespace tests the reconcileNamespace method for the following use case
+// GIVEN a request to reconcileNamespace for a Namespace resource
+// WHEN the namespace is configured for OCI Logging
+// THEN no error or requeue are returned
+func Test_reconcileNamespace(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
+		},
+	}
+
+	result, err := nc.reconcileNamespace(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
+// Test_reconcileNamespaceDelete tests the reconcileNamespaceDelete method for the following use case
+// GIVEN a request to reconcileNamespaceDelete for a Namespace resource
+// WHEN the namespace is configured for OCI Logging
+// THEN no error is returned
+//
+// Largely a placeholder for now
+func Test_reconcileNamespaceDelete(t *testing.T) {
+	asserts := assert.New(t)
+
+	nc, err := newTestController(fake.NewFakeClientWithScheme(testScheme))
+	asserts.NoErrorf(err, "Error creating test controller")
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
+		},
+	}
+	err = nc.reconcileNamespaceDelete(context.TODO(), ns)
+	asserts.NoError(err)
+}
+
+// Test_reconcileOCILoggingRemoveOCILogging tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the namespace is configured for OCI Logging
+// THEN no error is returned
+func Test_reconcileOCILoggingRemoveOCILogging(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myns",
+			Finalizers: []string{"anotherFinalizer"},
+		},
+	}
+
+	removeCalled := false
+	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
+		removeCalled = true
+		return true, nil
+	}
+	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+
+	// Expect a no calls to update the namespace
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+
+	err = nc.reconcileOCILogging(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.True(removeCalled)
+}
+
+// Test_reconcileOCILoggingRemoveOCILoggingError tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the namespace is configured for OCI Logging
+// THEN no error is returned
+func Test_reconcileOCILoggingRemoveOCILoggingError(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "myns",
+			Finalizers: []string{"anotherFinalizer"},
+		},
+	}
+
+	expectedErr := fmt.Errorf("error removing OCI logging")
+	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
+		return false, expectedErr
+	}
+	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+
+	err = nc.reconcileOCILogging(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.Error(err)
+	asserts.Equal(expectedErr, err)
+}
+
+// Test_reconcileOCILoggingAddOCILoggingUpdated tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the namespace is configured for OCI Logging and processed for the first time
+// THEN the AddOCILogging function is called, the namespace finalizer is added, and no error is returned
+func Test_reconcileOCILoggingAddOCILoggingUpdated(t *testing.T) {
+	runAddOCILoggingTest(t, true)
+}
+
+// Test_reconcileOCILoggingAddOCILoggingUpdated tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the AddOCILogging returns false (no changes)
+// THEN the AddOCILogging function is called, the namespace finalizer is added, and no error is returned
+func Test_reconcileOCILoggingAddOCILoggingNoOp(t *testing.T) {
+	runAddOCILoggingTest(t, false)
+}
+
+// runAddOCILoggingTest - shared helper for the AddOCILogging tests
+func runAddOCILoggingTest(t *testing.T, addLoggingResult bool) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer"},
+		},
+	}
+
+	addCalled := false
+	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+		addCalled = true
+		return addLoggingResult, nil
+	}
+	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+
+	// Expect a call to update the namespace annotations that succeeds
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+			return nil
+		})
+
+	err = nc.reconcileOCILogging(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Contains(ns.Finalizers, namespaceControllerFinalizer)
+	asserts.Len(ns.Finalizers, 2)
+	asserts.Truef(addCalled, "Add OCI Logging fn not called")
+}
+
+// Test_reconcileOCILoggingFinalizerAlreadyAdded tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the NamespaceController finalizer is already present
+// THEN the AddOCILogging function is called, Update() is not called, the namespace finalizer set is unchanged, and no error is returned
+func Test_reconcileOCILoggingFinalizerAlreadyAdded(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
+		},
+	}
+
+	addCalled := false
+	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+		addCalled = true
+		return true, nil
+	}
+	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+
+	// Expect no calls to update the namespace
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+
+	err = nc.reconcileOCILogging(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Contains(ns.Finalizers, namespaceControllerFinalizer)
+	asserts.Len(ns.Finalizers, 2)
+	asserts.Truef(addCalled, "Add OCI Logging fn not called")
+}
+
+// Test_reconcileOCILoggingAddOCILoggingAddFailed tests the reconcileOCILogging method for the following use case
+// GIVEN a request to reconcileOCILogging for a Namespace resource
+// WHEN the OCI Logging annotation and NamespaceController finalizer are present and the AddOCILogging helper returns an error
+// THEN the AddOCILogging function is called, Update() is not called, the namespace finalizer set is unchanged, and an error is returned
+func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myns",
+			Annotations: map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			},
+			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
+		},
+	}
+
+	expectedErr := fmt.Errorf("error adding OCI Logging configuration")
+	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+		return false, expectedErr
+	}
+	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+
+	// Expect a call to update the namespace annotations that succeeds
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+
+	err = nc.reconcileOCILogging(context.TODO(), ns)
+
+	mocker.Finish()
+	asserts.Error(err)
+	asserts.Equal(expectedErr, err)
+	asserts.Contains(ns.Finalizers, namespaceControllerFinalizer)
+	asserts.Len(ns.Finalizers, 2)
+}
+
+// Fake manager for unit testing
+type fakeManager struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+func (f fakeManager) Add(_ manager.Runnable) error {
+	return nil
+}
+
+func (f fakeManager) Elected() <-chan struct{} {
+	return nil
+}
+
+func (f fakeManager) SetFields(_ interface{}) error {
+	return nil
+}
+
+func (f fakeManager) AddMetricsExtraHandler(_ string, _ http.Handler) error {
+	return nil
+}
+
+func (f fakeManager) AddHealthzCheck(_ string, _ healthz.Checker) error {
+	return nil
+}
+
+func (f fakeManager) AddReadyzCheck(_ string, _ healthz.Checker) error {
+	return nil
+}
+
+func (f fakeManager) Start(_ <-chan struct{}) error {
+	return nil
+}
+
+func (f fakeManager) GetConfig() *rest.Config {
+	return nil
+}
+
+func (f fakeManager) GetScheme() *runtime.Scheme {
+	return f.scheme
+}
+
+func (f fakeManager) GetClient() client.Client {
+	return f.Client
+}
+
+func (f fakeManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+
+func (f fakeManager) GetCache() cache.Cache {
+	return nil
+}
+
+func (f fakeManager) GetEventRecorderFor(_ string) record.EventRecorder {
+	return nil
+}
+
+func (f fakeManager) GetRESTMapper() meta.RESTMapper {
+	return nil
+}
+
+func (f fakeManager) GetAPIReader() client.Reader {
+	return nil
+}
+
+func (f fakeManager) GetWebhookServer() *webhook.Server {
+	return nil
+}
+
+func (f fakeManager) GetLogger() logr.Logger {
+	return log.NullLogger{}
+}
+
+var _ ctrl.Manager = fakeManager{}

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -5,11 +5,16 @@ package namespace
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
+
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -20,7 +25,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"testing"
-	"time"
 )
 
 var testScheme = newScheme()

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/loggingtrait"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/metricsbinding"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
+	"github.com/verrazzano/verrazzano/application-operator/controllers/namespace"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/webhooks"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/wlsworkload"
 	"github.com/verrazzano/verrazzano/application-operator/internal/certificates"
@@ -320,6 +321,11 @@ func main() {
 		Metrics: metricsReconciler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VerrazzanoHelidonWorkload")
+		os.Exit(1)
+	}
+	// Setup the namespace reconciler
+	if _, err := namespace.NewNamespaceController(mgr, ctrl.Log.WithName("controllers").WithName("VerrazzanoNamespaceController")); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VerrazzanoNamespaceController")
 		os.Exit(1)
 	}
 

--- a/pkg/controller/requeue.go
+++ b/pkg/controller/requeue.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/util/rand"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
+)
+
+// Create a new Result that will cause a reconcile requeue after a short delay
+func NewRequeueWithDelay(min int, max int, units time.Duration) ctrl.Result {
+	var seconds = rand.IntnRange(min, max)
+	delaySecs := time.Duration(seconds) * units
+	return ctrl.Result{Requeue: true, RequeueAfter: delaySecs}
+}

--- a/pkg/controller/requeue_test.go
+++ b/pkg/controller/requeue_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package controller
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// TestNewRequeueWithDelay tests the NewRequeueWithDelay func for the following use case
+// GIVEN a request to NewRequeueWithDelay
+// WHEN a min, max, time units are provided
+// THEN a requeue result is returned with a delay within the specified bounds
+func TestNewRequeueWithDelay(t *testing.T) {
+	asserts := assert.New(t)
+	requeueWithDelay := NewRequeueWithDelay(3, 5, time.Second)
+	t.Logf("Requeue result: %v", requeueWithDelay)
+	asserts.True(requeueWithDelay.Requeue)
+	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Second).Seconds())
+	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Second).Seconds())
+
+	requeueWithDelay = NewRequeueWithDelay(3, 5, time.Second)
+	t.Logf("Requeue result: %v", requeueWithDelay)
+	asserts.True(requeueWithDelay.Requeue)
+	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Second).Seconds())
+	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Second).Seconds())
+
+	requeueWithDelay = NewRequeueWithDelay(3, 5, time.Minute)
+	t.Logf("Requeue result: %v", requeueWithDelay)
+	asserts.True(requeueWithDelay.Requeue)
+	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Minute).Seconds())
+	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Minute).Seconds())
+}

--- a/pkg/string/slice.go
+++ b/pkg/string/slice.go
@@ -61,4 +61,3 @@ func SliceAddString(slice []string, s string) ([]string, bool) {
 	}
 	return slice, false
 }
-

--- a/pkg/string/slice.go
+++ b/pkg/string/slice.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Oracle and/or its affiliates.
+// Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package string
@@ -53,3 +53,12 @@ func SliceToSet(list []string) map[string]bool {
 	}
 	return outSet
 }
+
+// SliceAddString Adds a string to a slice if it is not already present
+func SliceAddString(slice []string, s string) ([]string, bool) {
+	if !SliceContainsString(slice, s) {
+		return append(slice, s), true
+	}
+	return slice, false
+}
+

--- a/pkg/string/slice_test.go
+++ b/pkg/string/slice_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, Oracle and/or its affiliates.
+// Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package string
@@ -151,3 +151,48 @@ func TestEmptyOrNilSliceToSet(t *testing.T) {
 	set = SliceToSet(nil)
 	assert.Len(set, 0, "Nil slice should result in empty set")
 }
+
+// TestAddString tests the SliceAddString func for the following use case
+// GIVEN a request to SliceAddString with an input slice of strings
+// WHEN string is added to the input slice
+// THEN a new slice is returned with the input string is appended to the end of it
+func TestAddString(t *testing.T) {
+	tests := []struct {
+		name          string
+		description   string
+		inputSlice    []string
+		stringToAdd   string
+		added         bool
+		expectedSlice []string
+	}{
+		{
+			name:          "AddToEmptySlice",
+			inputSlice:    []string{},
+			stringToAdd:   "astring",
+			added:         true,
+			expectedSlice: []string{"astring"},
+		},
+		{
+			name:          "AddToNonEmptySlice",
+			inputSlice:    []string{"foo", "bar"},
+			stringToAdd:   "astring",
+			added:         true,
+			expectedSlice: []string{"foo", "bar", "astring"},
+		},
+		{
+			name:          "StringAlreadyExistsInSlice",
+			inputSlice:    []string{"foo", "astring", "bar"},
+			stringToAdd:   "astring",
+			added:         false,
+			expectedSlice: []string{"foo", "astring", "bar"},
+		},
+	}
+	for _, test := range tests {
+		asserts := asserts.New(t)
+		t.Log(test.name)
+		result, added := SliceAddString(test.inputSlice, test.stringToAdd)
+		asserts.Equal(test.added, added)
+		asserts.Equal(test.expectedSlice, result)
+	}
+}
+

--- a/pkg/string/slice_test.go
+++ b/pkg/string/slice_test.go
@@ -195,4 +195,3 @@ func TestAddString(t *testing.T) {
 		asserts.Equal(test.expectedSlice, result)
 	}
 }
-

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"go.uber.org/zap"
@@ -63,14 +64,14 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 
 	if !vmc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Finalizer is present, so lets do the cluster deletion
-		if containsString(vmc.ObjectMeta.Finalizers, finalizerName) {
+		if vzstring.SliceContainsString(vmc.ObjectMeta.Finalizers, finalizerName) {
 			if err := r.reconcileManagedClusterDelete(ctx, vmc); err != nil {
 				return reconcile.Result{}, err
 			}
 
 			// Remove the finalizer and update the Verrazzano resource if the deletion has finished.
 			log.Infof("Removing finalizer %s", finalizerName)
-			vmc.ObjectMeta.Finalizers = removeString(vmc.ObjectMeta.Finalizers, finalizerName)
+			vmc.ObjectMeta.Finalizers = vzstring.RemoveStringFromSlice(vmc.ObjectMeta.Finalizers, finalizerName)
 			err := r.Update(ctx, vmc)
 			if err != nil && !errors.IsConflict(err) {
 				return reconcile.Result{}, err
@@ -80,7 +81,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 	}
 
 	// Add our finalizer if not already added
-	if !containsString(vmc.ObjectMeta.Finalizers, finalizerName) {
+	if !vzstring.SliceContainsString(vmc.ObjectMeta.Finalizers, finalizerName) {
 		log.Infof("Adding finalizer %s", finalizerName)
 		vmc.ObjectMeta.Finalizers = append(vmc.ObjectMeta.Finalizers, finalizerName)
 		if err := r.Update(ctx, vmc); err != nil {
@@ -304,25 +305,4 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatus(ctx context.Context, v
 	}
 	r.log.Debugf("Updating Status of VMC %s with condition type %s = %s: %v", vmc.Name, condition.Type, condition.Status, vmc.Status.Conditions)
 	return r.Status().Update(ctx, vmc)
-}
-
-// containsString checks for a string in a slice of strings
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-
-// removeString removes a string from a slice of strings
-func removeString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
 }

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -6,6 +6,8 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/vzinstance"
 	"os"
 	"strings"
@@ -29,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -804,27 +805,6 @@ func mergeMaps(to map[string]string, from map[string]string) (map[string]string,
 	return mergedMap, updated
 }
 
-// containsString checks for a string in a slice of strings
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-
-// removeString removes a string from a slice of strings
-func removeString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}
-
 // buildDomain Build the DNS Domain from the current install
 func buildDomain(c client.Client, vz *installv1alpha1.Verrazzano) (string, error) {
 	subdomain := vz.Spec.EnvironmentName
@@ -991,7 +971,7 @@ func (r *Reconciler) retryUpgrade(ctx context.Context, vz *installv1alpha1.Verra
 // Process the Verrazzano resource deletion
 func (r *Reconciler) procDelete(ctx context.Context, log *zap.SugaredLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	// Finalizer is present, so lets do the uninstall
-	if containsString(vz.ObjectMeta.Finalizers, finalizerName) {
+	if vzstring.SliceContainsString(vz.ObjectMeta.Finalizers, finalizerName) {
 		// Create the uninstall job if it doesn't exist
 		if err := r.createUninstallJob(log, vz); err != nil {
 			log.Errorf("Failed creating the uninstall job: %v", err)
@@ -1009,7 +989,7 @@ func (r *Reconciler) procDelete(ctx context.Context, log *zap.SugaredLogger, vz 
 				// All install related resources have been deleted, delete the finalizer so that the Verrazzano
 				// resource can get removed from etcd.
 				log.Debugf("Removing finalizer %s", finalizerName)
-				vz.ObjectMeta.Finalizers = removeString(vz.ObjectMeta.Finalizers, finalizerName)
+				vz.ObjectMeta.Finalizers = vzstring.RemoveStringFromSlice(vz.ObjectMeta.Finalizers, finalizerName)
 				err = r.Update(ctx, vz)
 				if err != nil {
 					return newRequeueWithDelay(), err
@@ -1062,9 +1042,7 @@ func (r *Reconciler) cleanupOld(ctx context.Context, log *zap.SugaredLogger, vz 
 
 // Create a new Result that will cause a reconcile requeue after a short delay
 func newRequeueWithDelay() ctrl.Result {
-	var seconds = rand.IntnRange(3, 5)
-	delaySecs := time.Duration(seconds) * time.Second
-	return ctrl.Result{Requeue: true, RequeueAfter: delaySecs}
+	return vzctrl.NewRequeueWithDelay(3, 5, time.Second)
 }
 
 // Return true if requeue is needed
@@ -1130,7 +1108,7 @@ func (r *Reconciler) initForVzResource(vz *installv1alpha1.Verrazzano, log *zap.
 	}
 
 	// Add our finalizer if not already added
-	if !containsString(vz.ObjectMeta.Finalizers, finalizerName) {
+	if !vzstring.SliceContainsString(vz.ObjectMeta.Finalizers, finalizerName) {
 		log.Debugf("Adding finalizer %s", finalizerName)
 		vz.ObjectMeta.Finalizers = append(vz.ObjectMeta.Finalizers, finalizerName)
 		if err := r.Update(context.TODO(), vz); err != nil {


### PR DESCRIPTION
# Description

Adds a namespace controller to the VPO to monitor namespace activity with respect to the new OCI logging feature
- Monitors namespace lifecycle (CRUD), looks for the OCI Logging annotation on the namespace
- If the annotation is detected during a namespace create/update, add a finalizer and call out to (currently placeholder) functions to update the fluentd configuration; it is expected that this will be idempotent
- if the annotation is not present during a namespace update, call the function to remove the OCI logging configuration for that namespace; it is expected that this will be idempotent
- During a namespace deletion, remove any OCI logging configuration for the namespace; it is expected that this will be idempotent
- add unit tests
- refactor common string and controller utils into a common package with unit tests

**NOTE:** This is currently using stubbed calls for the work being done in another PR to update the fluentd configmap.

Fixes VZ-4741.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
