### PR TITLE
Add clusterdump wrappers to deploymetrics and authproxy tests

### DIFF
--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package authz_test
@@ -43,15 +43,9 @@ var _ = BeforeSuite(func() {
 	deployNoIstioApplication()
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentSpecReport().Failed()
-})
-
-var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
 	undeployFooApplication()
 	undeployBarApplication()
 	undeployNoIstioApplication()

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -27,10 +27,6 @@ var _ = BeforeSuite(func() {
 	deployMetricsApplication()
 })
 
-var failed = false
-var _ = AfterEach(func() {
-	failed = failed || CurrentSpecReport().Failed()
-})
 
 var _ = AfterSuite(func() {
 	if failed {

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package deploymetrics

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -27,11 +27,13 @@ var _ = BeforeSuite(func() {
 	deployMetricsApplication()
 })
 
-
 var _ = AfterSuite(func() {
-	if failed {
-		pkg.ExecuteClusterDumpWithEnvVarConfig()
-	}
+	undeployMetricsApplication()
+})
+
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
 	undeployMetricsApplication()
 })
 

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -27,10 +27,6 @@ var _ = BeforeSuite(func() {
 	deployMetricsApplication()
 })
 
-var _ = AfterSuite(func() {
-	undeployMetricsApplication()
-})
-
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails


### PR DESCRIPTION
Add clusterdump wrappers to deploymetrics and authproxy tests.  This will dumpcluster on aftersuite failure, where we are seeing namespace deletion hang.

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
