### PR TITLE
VZ-V4453: Integrate OCI Logging code

### DIFF
--- a/application-operator/controllers/namespace/fluentd_configmap.go
+++ b/application-operator/controllers/namespace/fluentd_configmap.go
@@ -110,7 +110,7 @@ func addNamespaceLoggingToConfigMap(configMap *corev1.ConfigMap, namespace strin
 	if fluentdConfig, ok := configMap.Data[fluentdConfigKey]; ok {
 		includeLine := fmt.Sprintf("@include %s", nsConfigKey)
 		if !strings.Contains(fluentdConfig, includeLine) {
-			replace := fmt.Sprintf("%s\n  %s", startNamespaceConfigsMarker, includeLine)
+			replace := fmt.Sprintf("%s\n%s", startNamespaceConfigsMarker, includeLine)
 			fluentdConfig = strings.Replace(fluentdConfig, startNamespaceConfigsMarker, replace, 1)
 			configMap.Data[fluentdConfigKey] = fluentdConfig
 		}
@@ -130,7 +130,7 @@ func removeNamespaceLoggingFromConfigMap(configMap *corev1.ConfigMap, namespace 
 	if fluentdConfig, ok := configMap.Data[fluentdConfigKey]; ok {
 		includeLine := fmt.Sprintf("@include %s", nsConfigKey)
 		if strings.Contains(fluentdConfig, includeLine) {
-			toRemove := fmt.Sprintf("%s\n  ", includeLine)
+			toRemove := fmt.Sprintf("%s\n", includeLine)
 			fluentdConfig = strings.Replace(fluentdConfig, toRemove, "", 1)
 			configMap.Data[fluentdConfigKey] = fluentdConfig
 		}

--- a/application-operator/controllers/namespace/fluentd_configmap_test.go
+++ b/application-operator/controllers/namespace/fluentd_configmap_test.go
@@ -23,23 +23,23 @@ const (
 )
 
 const fluentdConfig = `|
-  # Common config
-  @include general.conf
+# Common config
+@include general.conf
 
-  # Input sources
-  @include systemd-input.conf
-  @include kubernetes-input.conf
+# Input sources
+@include systemd-input.conf
+@include kubernetes-input.conf
 
-  # Parsing/Filtering
-  @include systemd-filter.conf
-  @include kubernetes-filter.conf
+# Parsing/Filtering
+@include systemd-filter.conf
+@include kubernetes-filter.conf
 
-  # Send to storage
-  @include output.conf
-  # Start namespace logging configs
-  # End namespace logging configs
-  @include oci-logging-system.conf
-  @include oci-logging-default-app.conf
+# Send to storage
+@include output.conf
+# Start namespace logging configs
+# End namespace logging configs
+@include oci-logging-system.conf
+@include oci-logging-default-app.conf
 `
 
 // TestAddAndRemoveNamespaceLogging tests adding and removing namespace logging config to the Fluentd config map.
@@ -65,7 +65,7 @@ func TestAddAndRemoveNamespaceLogging(t *testing.T) {
 	asserts.NoError(err)
 
 	nsConfigKey := fmt.Sprintf(nsConfigKeyTemplate, testNamespace)
-	includeSection := fmt.Sprintf("%s\n  @include oci-logging-ns-unit-test-ns.conf\n", startNamespaceConfigsMarker)
+	includeSection := fmt.Sprintf("%s\n@include oci-logging-ns-unit-test-ns.conf\n", startNamespaceConfigsMarker)
 	asserts.Contains(cm.Data[fluentdConfigKey], includeSection)
 	asserts.Contains(cm.Data, nsConfigKey)
 	asserts.Contains(cm.Data[nsConfigKey], testLogID)
@@ -169,7 +169,7 @@ func TestUpdateExistingLoggingConfig(t *testing.T) {
 	asserts.NoError(err)
 
 	nsConfigKey := fmt.Sprintf(nsConfigKeyTemplate, testNamespace)
-	includeSection := fmt.Sprintf("%s\n  @include oci-logging-ns-unit-test-ns.conf\n", startNamespaceConfigsMarker)
+	includeSection := fmt.Sprintf("%s\n@include oci-logging-ns-unit-test-ns.conf\n", startNamespaceConfigsMarker)
 	asserts.Contains(cm.Data[fluentdConfigKey], includeSection)
 	asserts.Contains(cm.Data, nsConfigKey)
 	asserts.Contains(cm.Data[nsConfigKey], updatedLogID)

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -4,20 +4,24 @@ package namespace
 
 import (
 	"context"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const namespaceControllerFinalizer = "namespaces.verrazzano.io"
+const namespaceControllerFinalizer = "verrazzano.io/namespace"
 
 const namespaceField = "namespace"
 
@@ -125,8 +129,9 @@ func (nc *NamespaceController) reconcileOCILogging(ctx context.Context, ns *core
 		}
 		if updated {
 			nc.log.Info("Updated logging configuration for namespace", namespaceField, ns.Name)
+			err = nc.restartFluentd(ctx)
 		}
-		return nil
+		return err
 	}
 	// If the annotation is not present, remove any existing logging configuration
 	return nc.removeOCILogging(ctx, ns)
@@ -140,7 +145,27 @@ func (nc *NamespaceController) removeOCILogging(ctx context.Context, ns *corev1.
 	}
 	if removed {
 		nc.log.Info("Removed logging configuration for namespace", namespaceField, ns.Name)
+		err = nc.restartFluentd(ctx)
 	}
+	return err
+}
+
+func (nc *NamespaceController) restartFluentd(ctx context.Context) error {
+	nc.log.Info("Restarting Fluentd")
+	daemonSet := &appsv1.DaemonSet{}
+	if err := nc.Client.Get(ctx, types.NamespacedName{Name: "fluentd", Namespace: constants.VerrazzanoSystemNamespace}, daemonSet); err != nil {
+		return err
+	}
+
+	if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
+		daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	daemonSet.Spec.Template.ObjectMeta.Annotations["verrazzano.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	if err := nc.Client.Update(ctx, daemonSet); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -148,20 +173,10 @@ func (nc *NamespaceController) removeOCILogging(ctx context.Context, ns *corev1.
 type addNamespaceLoggingFuncSig func(_ context.Context, _ client.Client, _ string, _ string) (bool, error)
 
 // addNamespaceLoggingFunc - Variable to allow replacing add namespace logging func for unit tests
-var addNamespaceLoggingFunc addNamespaceLoggingFuncSig = AddNamespaceLogging
-
-// AddNamespaceLogging - placeholder for logging update
-func AddNamespaceLogging(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
-	return true, nil
-}
+var addNamespaceLoggingFunc addNamespaceLoggingFuncSig = addNamespaceLogging
 
 // removeNamespaceLoggingFuncSig - Type for remove namespace logging function, for unit testing
 type removeNamespaceLoggingFuncSig func(_ context.Context, _ client.Client, _ string) (bool, error)
 
 // removeNamespaceLoggingFunc - Variable to allow replacing remove namespace logging func for unit tests
-var removeNamespaceLoggingFunc removeNamespaceLoggingFuncSig = RemoveNamespaceLogging
-
-// RemoveNamespaceLogging - placeholder for logging update
-func RemoveNamespaceLogging(_ context.Context, _ client.Client, _ string) (bool, error) {
-	return true, nil
-}
+var removeNamespaceLoggingFunc removeNamespaceLoggingFuncSig = removeNamespaceLogging

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -225,7 +225,7 @@ func TestReconcileNamespaceDeletedErrorOnUpdate(t *testing.T) {
 	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
 		return false, expectedErr
 	}
-	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "myns"},
@@ -466,7 +466,7 @@ func Test_reconcileOCILoggingRemoveOCILogging(t *testing.T) {
 		removeCalled = true
 		return true, nil
 	}
-	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
 
 	// Expect a no calls to update the namespace
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
@@ -503,7 +503,7 @@ func Test_reconcileOCILoggingRemoveOCILoggingError(t *testing.T) {
 	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
 		return false, expectedErr
 	}
-	defer func() { removeNamespaceLoggingFunc = RemoveNamespaceLogging }()
+	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
 
 	err = nc.reconcileOCILogging(context.TODO(), ns)
 
@@ -554,7 +554,7 @@ func runAddOCILoggingTest(t *testing.T, addLoggingResult bool) {
 		addCalled = true
 		return addLoggingResult, nil
 	}
-	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
 	// Expect a call to update the namespace annotations that succeeds
 	mock.EXPECT().
@@ -601,7 +601,7 @@ func Test_reconcileOCILoggingFinalizerAlreadyAdded(t *testing.T) {
 		addCalled = true
 		return true, nil
 	}
-	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
 	// Expect no calls to update the namespace
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
@@ -643,7 +643,7 @@ func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
 	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
 		return false, expectedErr
 	}
-	defer func() { addNamespaceLoggingFunc = AddNamespaceLogging }()
+	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
 	// Expect a call to update the namespace annotations that succeeds
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -62,13 +64,11 @@ func TestReconcileNamespaceUpdate(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
-	// Expect a call to update the namespace
+	// Expect a call to get the namespace
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			ns.Name = "myns"
 			ns.Annotations = map[string]string{
 				constants.OCILoggingIDAnnotation: "myocid",
@@ -83,6 +83,14 @@ func TestReconcileNamespaceUpdate(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, ns *corev1.Namespace, opts ...client.UpdateOption) error {
 			return nil
 		})
+
+	// Expect calls to restart Fluentd
+	mockFluentdRestart(mock, asserts)
+
+	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+		return true, nil
+	}
+	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -119,13 +127,11 @@ func runTestReconcileGetError(t *testing.T, returnErr error, expectedErr error) 
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
-	// Expect a call to update the namespace
+	// Expect a call to get the namespace
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			return returnErr
 		})
 
@@ -153,13 +159,11 @@ func TestReconcileNamespaceDeleted(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
-	// Expect a call to update the namespace
+	// Expect a call to get the namespace
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			ns.Name = "myns"
 			ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 			ns.Annotations = map[string]string{
@@ -169,6 +173,9 @@ func TestReconcileNamespaceDeleted(t *testing.T) {
 			return nil
 		})
 
+	// Expect calls to restart Fluentd
+	mockFluentdRestart(mock, asserts)
+
 	// Expect a call to update the namespace that succeeds
 	mock.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -176,6 +183,11 @@ func TestReconcileNamespaceDeleted(t *testing.T) {
 			asserts.NotContainsf(ns.Finalizers, namespaceControllerFinalizer, "Finalizer not removed: ", ns.Finalizers)
 			return nil
 		})
+
+	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
+		return true, nil
+	}
+	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -198,13 +210,11 @@ func TestReconcileNamespaceDeletedErrorOnUpdate(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
-	// Expect a call to update the namespace
+	// Expect a call to get the namespace
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace, opts ...client.UpdateOption) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
 			ns.Name = "myns"
 			ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 			ns.Annotations = map[string]string{
@@ -237,6 +247,42 @@ func TestReconcileNamespaceDeletedErrorOnUpdate(t *testing.T) {
 	asserts.True(result.IsZero())
 }
 
+// TestReconcileNamespaceDeletedNoFinalizer tests the Reconcile method for the following use case
+// GIVEN a request to Reconcile a Namespace resource
+// WHEN the namespace DeletionTimestamp has been set (namespace is in the process of being deleted)
+// AND our finalizer doesn't exist (for example, we removed it on a previous reconcile)
+// THEN we do not update the namespace or attempt to remove any logging config
+func TestReconcileNamespaceDeletedNoFinalizer(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	// Expect a call to get the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
+			ns.Name = "myns"
+			ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			ns.Annotations = map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			}
+			ns.Finalizers = []string{"someFinalizer"}
+			return nil
+		})
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "myns"},
+	}
+	result, err := nc.Reconcile(req)
+
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(ctrl.Result{}, result)
+}
+
 // Test_removeFinalizer tests the removeFinalizer method for the following use case
 // GIVEN a request to removeFinalizer for a Namespace resource
 // WHEN the namespace has the NamespaceController finalizer present
@@ -245,8 +291,6 @@ func Test_removeFinalizer(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	// Expect a call to update the namespace that succeeds
 	mock.EXPECT().
@@ -281,8 +325,6 @@ func Test_removeFinalizerNotPresent(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	// Expect a call to update the namespace that succeeds
 	mock.EXPECT().
@@ -317,8 +359,6 @@ func Test_removeFinalizerErrorOnUpdate(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -354,8 +394,6 @@ func Test_reconcileNamespaceErrorOnUpdate(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -394,8 +432,6 @@ func Test_reconcileNamespace(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -409,6 +445,11 @@ func Test_reconcileNamespace(t *testing.T) {
 			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
 		},
 	}
+
+	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
+		return false, nil
+	}
+	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
 	err = nc.reconcileNamespace(context.TODO(), ns)
 
@@ -436,20 +477,24 @@ func Test_reconcileNamespaceDelete(t *testing.T) {
 			Finalizers: []string{"anotherFinalizer", namespaceControllerFinalizer},
 		},
 	}
+
+	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
+		return false, nil
+	}
+	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
+
 	err = nc.reconcileNamespaceDelete(context.TODO(), ns)
 	asserts.NoError(err)
 }
 
 // Test_reconcileOCILoggingRemoveOCILogging tests the reconcileOCILogging method for the following use case
 // GIVEN a request to reconcileOCILogging for a Namespace resource
-// WHEN the namespace is configured for OCI Logging
+// WHEN the namespace is not configured for OCI Logging
 // THEN no error is returned
 func Test_reconcileOCILoggingRemoveOCILogging(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -464,12 +509,9 @@ func Test_reconcileOCILoggingRemoveOCILogging(t *testing.T) {
 	removeCalled := false
 	removeNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string) (bool, error) {
 		removeCalled = true
-		return true, nil
+		return false, nil
 	}
 	defer func() { removeNamespaceLoggingFunc = removeNamespaceLogging }()
-
-	// Expect a no calls to update the namespace
-	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
 
 	err = nc.reconcileOCILogging(context.TODO(), ns)
 
@@ -480,14 +522,12 @@ func Test_reconcileOCILoggingRemoveOCILogging(t *testing.T) {
 
 // Test_reconcileOCILoggingRemoveOCILoggingError tests the reconcileOCILogging method for the following use case
 // GIVEN a request to reconcileOCILogging for a Namespace resource
-// WHEN the namespace is configured for OCI Logging
-// THEN no error is returned
+// WHEN the namespace is not configured for OCI Logging and we fail removing the OCI Logging config from the configmap
+// THEN an error is returned
 func Test_reconcileOCILoggingRemoveOCILoggingError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -533,8 +573,6 @@ func runAddOCILoggingTest(t *testing.T, addLoggingResult bool) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -563,6 +601,12 @@ func runAddOCILoggingTest(t *testing.T, addLoggingResult bool) {
 			return nil
 		})
 
+	// if the result from adding logging returns true (meaning the Fluentd configmap was updated), then
+	// mock expections for restarting Fluentd
+	if addLoggingResult {
+		mockFluentdRestart(mock, asserts)
+	}
+
 	err = nc.reconcileOCILogging(context.TODO(), ns)
 
 	mocker.Finish()
@@ -580,8 +624,6 @@ func Test_reconcileOCILoggingFinalizerAlreadyAdded(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -599,7 +641,7 @@ func Test_reconcileOCILoggingFinalizerAlreadyAdded(t *testing.T) {
 	addCalled := false
 	addNamespaceLoggingFunc = func(_ context.Context, _ client.Client, _ string, _ string) (bool, error) {
 		addCalled = true
-		return true, nil
+		return false, nil
 	}
 	defer func() { addNamespaceLoggingFunc = addNamespaceLogging }()
 
@@ -623,8 +665,6 @@ func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
@@ -655,6 +695,22 @@ func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
 	asserts.Equal(expectedErr, err)
 	asserts.Contains(ns.Finalizers, namespaceControllerFinalizer)
 	asserts.Len(ns.Finalizers, 2)
+}
+
+// mockFluentdRestart - Mock expections for Fluentd daemonset restart
+func mockFluentdRestart(mock *mocks.MockClient, asserts *assert.Assertions) {
+	// Expect a call to get the Fleuntd Daemonset and another to update it with a restart time annotation
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ds *appsv1.DaemonSet) error {
+			return nil
+		})
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ds *appsv1.DaemonSet, opts ...client.UpdateOption) error {
+			asserts.Contains(ds.Spec.Template.ObjectMeta.Annotations, vzconst.VerrazzanoRestartAnnotation)
+			return nil
+		})
 }
 
 // Fake manager for unit testing

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -272,7 +272,7 @@ func (s *Syncer) updateDeployment(name string) {
 
 // reconfigure Fluentd by restarting Fluentd DaemonSet if ManagedClusterName has been changed
 func (s *Syncer) configureLogging() {
-	loggingName := types.NamespacedName{Name: "fluentd", Namespace: constants.VerrazzanoSystemNamespace}
+	loggingName := types.NamespacedName{Name: vzconstants.FluentdDaemonSetName, Namespace: constants.VerrazzanoSystemNamespace}
 	daemonSet := appsv1.DaemonSet{}
 	err := s.LocalClient.Get(context.TODO(), loggingName, &daemonSet)
 	if err != nil {

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mcagent

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -650,9 +651,9 @@ func TestSyncer_configureLogging(t *testing.T) {
 
 			// Managed Cluster - expect call to get the fluentd daemonset.
 			mcMock.EXPECT().
-				Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "fluentd"}, gomock.Not(gomock.Nil())).
+				Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconstants.FluentdDaemonSetName}, gomock.Not(gomock.Nil())).
 				DoAndReturn(func(ctx context.Context, name types.NamespacedName, ds *appsv1.DaemonSet) error {
-					ds.Name = "fluentd"
+					ds.Name = vzconstants.FluentdDaemonSetName
 					ds.Namespace = constants.VerrazzanoSystemNamespace
 					ds.Spec = getTestDaemonSetSpec(dsClusterName, dsEsURL, dsSecretName)
 					return nil
@@ -661,9 +662,9 @@ func TestSyncer_configureLogging(t *testing.T) {
 			// we always call controllerutil.CreateOrUpdate in mcagent_test, which will do another get for fluentd
 			// daemonset. However, update will only be called if we changed the daemonset
 			mcMock.EXPECT().
-				Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "fluentd"}, gomock.Not(gomock.Nil())).
+				Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconstants.FluentdDaemonSetName}, gomock.Not(gomock.Nil())).
 				DoAndReturn(func(ctx context.Context, name types.NamespacedName, ds *appsv1.DaemonSet) error {
-					ds.Name = "fluentd"
+					ds.Name = vzconstants.FluentdDaemonSetName
 					ds.Namespace = constants.VerrazzanoSystemNamespace
 					ds.Spec = getTestDaemonSetSpec(dsClusterName, dsEsURL, dsSecretName)
 					return nil

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mcagent

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,6 +8,9 @@ import "time"
 // RestartVersionAnnotation - the annotation used by user to tell Verrazzano applicaton to restart its components
 const RestartVersionAnnotation = "verrazzano.io/restart-version"
 
+// VerrazzanoRestartAnnotation is the annotation used to restart platform workloads
+const VerrazzanoRestartAnnotation = "verrazzano.io/restartedAt"
+
 // LifecycleActionAnnotation - the annotation perform lifecycle actions on a workload
 const LifecycleActionAnnotation = "verrazzano.io/lifecycle-action"
 
@@ -88,3 +91,6 @@ const VMCAgentPollingTimeInterval = 60 * time.Second
 
 // MaxTimesVMCAgentPollingTime - The constant used to set max polling time for vmc agent to determine VMC state
 const MaxTimesVMCAgentPollingTime = 3
+
+// FluentdDaemonSetName - The name of the Fluentd DaemonSet
+const FluentdDaemonSetName = "fluentd"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -122,9 +122,6 @@ const VerrazzanoVersion1_0_0 = "1.0.0"
 // Verrazzano version string for 1.1.0
 const VerrazzanoVersion1_1_0 = "1.1.0"
 
-// VerrazzanoRestartAnnotation is the annotation used to restart platform workloads
-const VerrazzanoRestartAnnotation = "verrazzano.io/restartedAt"
-
 // UpgradeRetryVersion is the restart version annotation field
 const UpgradeRetryVersion = "verrazzano.io/upgrade-retry-version"
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzString "github.com/verrazzano/verrazzano/pkg/string"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -251,7 +252,7 @@ func restartComponents(log *zap.SugaredLogger, err error, i istioComponent, clie
 			if deployment.Spec.Template.ObjectMeta.Annotations == nil {
 				deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			deployment.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
+			deployment.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
 			if err := client.Update(context.TODO(), deployment); err != nil {
 				return err
 			}
@@ -273,7 +274,7 @@ func restartComponents(log *zap.SugaredLogger, err error, i istioComponent, clie
 			if statefulSet.Spec.Template.ObjectMeta.Annotations == nil {
 				statefulSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			statefulSet.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
+			statefulSet.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
 			if err := client.Update(context.TODO(), statefulSet); err != nil {
 				return err
 			}
@@ -295,7 +296,7 @@ func restartComponents(log *zap.SugaredLogger, err error, i istioComponent, clie
 			if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
 				daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			daemonSet.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
+			daemonSet.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
 			if err := client.Update(context.TODO(), daemonSet); err != nil {
 				return err
 			}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -171,7 +172,7 @@ func getMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, deploy *appsv1.Deployment) error {
 			deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			deploy.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			deploy.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -179,7 +180,7 @@ func getMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ss *appsv1.StatefulSet) error {
 			ss.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ss.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ss.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -187,7 +188,7 @@ func getMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ds *appsv1.DaemonSet) error {
 			ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ds.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ds.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
@@ -6,8 +6,15 @@ package istio
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	spi2 "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -16,7 +23,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	"go.uber.org/zap"
-	"io/ioutil"
 	istiosec "istio.io/api/security/v1beta1"
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,11 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"os/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"testing"
-	"time"
 )
 
 // fakeIstioInstalledRunner is used to test if Istio is installed
@@ -324,7 +326,7 @@ func getIstioInstallMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, deploy *appsv1.Deployment) error {
 			deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			deploy.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			deploy.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -332,7 +334,7 @@ func getIstioInstallMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ss *appsv1.StatefulSet) error {
 			ss.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ss.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ss.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -340,7 +342,7 @@ func getIstioInstallMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ds *appsv1.DaemonSet) error {
 			ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ds.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ds.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -396,7 +398,7 @@ func createCertSecretMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, deploy *appsv1.Deployment) error {
 			deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			deploy.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			deploy.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -404,7 +406,7 @@ func createCertSecretMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ss *appsv1.StatefulSet) error {
 			ss.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ss.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ss.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 
@@ -412,7 +414,7 @@ func createCertSecretMock(t *testing.T) *mocks.MockClient {
 		Update(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ds *appsv1.DaemonSet) error {
 			ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-			ds.Spec.Template.ObjectMeta.Annotations[constants.VerrazzanoRestartAnnotation] = "some time"
+			ds.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
 			return nil
 		}).AnyTimes()
 

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -363,7 +363,7 @@ func getWildcardDNS(vz *vzapi.VerrazzanoSpec) (bool, string) {
 // template for the fluentd daemonset expects a Value.
 func fixupFluentdDaemonset(log *zap.SugaredLogger, client clipkg.Client, namespace string) error {
 	// Get the fluentd daemonset resource
-	fluentdNamespacedName := types.NamespacedName{Name: "fluentd", Namespace: namespace}
+	fluentdNamespacedName := types.NamespacedName{Name: globalconst.FluentdDaemonSetName, Namespace: namespace}
 	daemonSet := appsv1.DaemonSet{}
 	err := client.Get(context.TODO(), fluentdNamespacedName, &daemonSet)
 	if errors.IsNotFound(err) {

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -109,7 +109,7 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 	daemonSet := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: defNs,
-			Name:      "fluentd",
+			Name:      globalconst.FluentdDaemonSetName,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
@@ -191,7 +191,7 @@ func TestFixupFluentdDaemonset(t *testing.T) {
 	assert.NoError(err)
 
 	// env variables should be fixed up to use Value instead of ValueFrom
-	fluentdNamespacedName := types.NamespacedName{Name: "fluentd", Namespace: defNs}
+	fluentdNamespacedName := types.NamespacedName{Name: globalconst.FluentdDaemonSetName, Namespace: defNs}
 	updatedDaemonSet := appsv1.DaemonSet{}
 	err = client.Get(context.TODO(), fluentdNamespacedName, &updatedDaemonSet)
 	assert.NoError(err)

--- a/tests/e2e/pkg/fluentd.go
+++ b/tests/e2e/pkg/fluentd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/pkg/fluentd.go
+++ b/tests/e2e/pkg/fluentd.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const verrazzanoNamespace string = "verrazzano-system"
-const fluentdDaemonsetName string = "fluentd"
 const VmiESURL = "http://verrazzano-authproxy-elasticsearch:8775"
 const VmiESSecret = "verrazzano"
 
@@ -22,7 +22,7 @@ func getFluentdDaemonset() (*appv1.DaemonSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	ds, err := clientset.AppsV1().DaemonSets(verrazzanoNamespace).Get(context.TODO(), fluentdDaemonsetName, metav1.GetOptions{})
+	ds, err := clientset.AppsV1().DaemonSets(verrazzanoNamespace).Get(context.TODO(), globalconst.FluentdDaemonSetName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -5,12 +5,14 @@ package verify
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"time"
 )
 
 const (
@@ -49,7 +51,7 @@ var _ = t.Describe("verify platform pods post-upgrade", func() {
 	// THEN verify that the have the verrazzano.io/restartedAt annotations
 	MinimumVerrazzanoIt("Verify pods in verrazzano-system restarted post upgrade", func() {
 		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.VerrazzanoSystemNamespace, constants.VerrazzanoRestartAnnotation)
+			return pkg.PodsHaveAnnotation(constants.VerrazzanoSystemNamespace, vzconst.VerrazzanoRestartAnnotation)
 		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in verrazzano-system")
 	})
 
@@ -58,7 +60,7 @@ var _ = t.Describe("verify platform pods post-upgrade", func() {
 	// THEN verify that the have the verrazzano.io/restartedAt annotations
 	MinimumVerrazzanoIt("Verify pods in ingress-nginx restarted post upgrade", func() {
 		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.IngressNginxNamespace, constants.VerrazzanoRestartAnnotation)
+			return pkg.PodsHaveAnnotation(constants.IngressNginxNamespace, vzconst.VerrazzanoRestartAnnotation)
 		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in ingress-nginx")
 	})
 
@@ -67,7 +69,7 @@ var _ = t.Describe("verify platform pods post-upgrade", func() {
 	// THEN verify that the have the verrazzano.io/restartedAt annotations
 	MinimumVerrazzanoIt("Verify pods in keycloak restarted post upgrade", func() {
 		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.KeycloakNamespace, constants.VerrazzanoRestartAnnotation)
+			return pkg.PodsHaveAnnotation(constants.KeycloakNamespace, vzconst.VerrazzanoRestartAnnotation)
 		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in keycloak")
 	})
 


### PR DESCRIPTION
# Description

This PR integrates the new namespace controller with the code to update the Fluentd configmap and restart Fluentd. Also has bug fixes found during integration testing, updated controller unit tests, and a bunch of refactoring to share constants.

I have tested this manually and confirmed that it works as expected. I will have another PR to extend the automated e2e tests that includes testing this new functionality.

Fixes VZ-4453

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
