### PR TITLE
mysql soft dependency

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -43,7 +43,7 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride: true,
 			//  Check on Image Pull Pull Key
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "keycloak-values.yaml"),
-			Dependencies:            []string{istio.ComponentName, mysql.ComponentName},
+			Dependencies:            []string{istio.ComponentName},
 			SupportsOperatorInstall: true,
 			AppendOverridesFunc:     AppendKeycloakOverrides,
 			IngressNames: []types.NamespacedName{


### PR DESCRIPTION
MySQL is a soft dependency on KeyCloak, we shouldn't need to block until MySQL is fully ready.