### PR TITLE
Add a periodic namespace scanner

### DIFF
--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -4,6 +4,9 @@ package namespace
 
 import (
 	"context"
+	"fmt"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,13 +42,13 @@ func NewNamespaceController(mgr ctrl.Manager, logger logr.Logger) (*NamespaceCon
 	nc := &NamespaceController{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
-		log:    logger,
+		log:    logger.WithValues("function", "controller"),
 	}
-	return nc, nc.setupWithManager(mgr)
-}
 
-// SetupWithManager creates a new controller and adds it to the manager
-func (nc *NamespaceController) setupWithManager(mgr ctrl.Manager) error {
+	// Launch a periodic task to scan all namespaces; this is required for cases where the configmap
+	// may have been reset (e.g., post-upgrade)
+	go scannerFunc(nc, logger.WithValues("function", "scanner"), 30, time.Second)
+
 	var err error
 	nc.controller, err = ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
@@ -53,7 +56,8 @@ func (nc *NamespaceController) setupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&corev1.Namespace{}).
 		Build(nc)
-	return err
+
+	return nc, err
 }
 
 // Reconcile - Watches for and manages namespace activity as it relates to Verrazzano platform services
@@ -83,7 +87,7 @@ func (nc *NamespaceController) Reconcile(req reconcile.Request) (reconcile.Resul
 		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{}, nc.reconcileNamespace(ctx, &ns)
+	return ctrl.Result{}, nc.reconcileNamespace(ctx, nc.log, &ns)
 }
 
 // removeFinalizer - Remove the finalizer and update the namespace resource if the post-delete processing is successful
@@ -98,12 +102,12 @@ func (nc *NamespaceController) removeFinalizer(ctx context.Context, ns *corev1.N
 }
 
 // reconcileNamespace - Reconcile any namespace changes
-func (nc *NamespaceController) reconcileNamespace(ctx context.Context, ns *corev1.Namespace) error {
-	if err := nc.reconcileOCILogging(ctx, ns); err != nil {
-		nc.log.Error(err, "Error occurred during OCI Logging reconciliation")
+func (nc *NamespaceController) reconcileNamespace(ctx context.Context, log logr.Logger, ns *corev1.Namespace) error {
+	if err := nc.reconcileOCILogging(ctx, log, ns); err != nil {
+		log.Error(err, "Error occurred during OCI Logging reconciliation")
 		return err
 	}
-	nc.log.V(1).Info("Reconciled namespace %s successfully", namespaceField, ns.Name)
+	log.V(1).Info("Reconciled namespace successfully", namespaceField, ns.Name)
 	return nil
 }
 
@@ -111,11 +115,11 @@ func (nc *NamespaceController) reconcileNamespace(ctx context.Context, ns *corev
 func (nc *NamespaceController) reconcileNamespaceDelete(ctx context.Context, ns *corev1.Namespace) error {
 	// Update the OCI Logging configuration to remove the namespace configuration
 	// If the annotation is not present, remove any existing logging configuration
-	return nc.removeOCILogging(ctx, ns)
+	return nc.removeOCILogging(ctx, nc.log, ns)
 }
 
 // reconcileOCILogging - Configure OCI logging based on the annotation if present
-func (nc *NamespaceController) reconcileOCILogging(ctx context.Context, ns *corev1.Namespace) error {
+func (nc *NamespaceController) reconcileOCILogging(ctx context.Context, log logr.Logger, ns *corev1.Namespace) error {
 	// If the annotation is present, add the finalizer if necessary and update the logging configuration
 	if loggingOCID, ok := ns.Annotations[constants.OCILoggingIDAnnotation]; ok {
 		var added bool
@@ -124,29 +128,29 @@ func (nc *NamespaceController) reconcileOCILogging(ctx context.Context, ns *core
 				return err
 			}
 		}
-		nc.log.V(1).Info("Updating logging configuration for namespace", namespaceField, ns.Name, "log-id", loggingOCID)
+		log.V(1).Info("Updating logging configuration for namespace", namespaceField, ns.Name, "log-id", loggingOCID)
 		updated, err := addNamespaceLoggingFunc(ctx, nc.Client, ns.Name, loggingOCID)
 		if err != nil {
 			return err
 		}
 		if updated {
-			nc.log.Info("Updated logging configuration for namespace", namespaceField, ns.Name)
+			log.Info("Updated logging configuration for namespace", namespaceField, ns.Name)
 			err = nc.restartFluentd(ctx)
 		}
 		return err
 	}
 	// If the annotation is not present, remove any existing logging configuration
-	return nc.removeOCILogging(ctx, ns)
+	return nc.removeOCILogging(ctx, log, ns)
 }
 
 // removeOCILogging - Remove OCI logging if the namespace is deleted
-func (nc *NamespaceController) removeOCILogging(ctx context.Context, ns *corev1.Namespace) error {
+func (nc *NamespaceController) removeOCILogging(ctx context.Context, log logr.Logger, ns *corev1.Namespace) error {
 	removed, err := removeNamespaceLoggingFunc(ctx, nc.Client, ns.Name)
 	if err != nil {
 		return err
 	}
 	if removed {
-		nc.log.Info("Removed logging configuration for namespace", namespaceField, ns.Name)
+		log.Info("Removed logging configuration for namespace", namespaceField, ns.Name)
 		err = nc.restartFluentd(ctx)
 	}
 	return err
@@ -172,6 +176,52 @@ func (nc *NamespaceController) restartFluentd(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (nc *NamespaceController) scanNamespaces(ctx context.Context, log logr.Logger) (bool, error) {
+	log.V(1).Info("Examining all namespaces")
+	namespaceList := corev1.NamespaceList{}
+	if err := nc.List(ctx, &namespaceList); err != nil {
+		return false, err
+	}
+	for i := range namespaceList.Items {
+		if err := nc.reconcileNamespace(ctx, log, &namespaceList.Items[i]); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// scannerFuncSig - Func type for namespace scanner, for unit testing
+type scannerFuncSig func(nc *NamespaceController, log logr.Logger, period int, units time.Duration)
+
+// scannerFunc - Var to allow overriding the scanner function, for unit testing
+var scannerFunc scannerFuncSig = namespaceScanner
+
+// scanOnce - indicates to the namespaceScanner routine that we should only execute once, for unit testing
+var scanOnce = false
+
+// namespaceScanner - Goroutine that reconciles all namespaces periodically
+// - this will enable us to re-sync any changes (e.g., OCI Logging) that may need to be rebuilt post-upgrade, etc
+func namespaceScanner(nc *NamespaceController, log logr.Logger, period int, units time.Duration) {
+	periodDelay := time.Duration(period) * units
+	delay := periodDelay
+	for {
+		log.V(1).Info(fmt.Sprintf("Delay %v seconds", delay.Seconds()))
+		time.Sleep(delay)
+		if completed, err := nc.scanNamespaces(context.Background(), log); !completed {
+			// the scan didn't complete either due to an error or a failure to acquire the lock
+			if err != nil {
+				log.Error(err, "Error on periodic namespace scan")
+			}
+			delay = vzctrl.CalculateDelay(1, period, units)
+			continue
+		}
+		delay = periodDelay
+		if scanOnce {
+			break
+		}
+	}
 }
 
 // addNamespaceLoggingFuncSig - Type for add namespace logging  function, for unit testing

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -5,14 +5,13 @@ package namespace
 import (
 	"context"
 	"fmt"
-	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
-
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -210,7 +209,7 @@ func namespaceScanner(nc *NamespaceController, log logr.Logger, period int, unit
 		log.V(1).Info(fmt.Sprintf("Delay %v seconds", delay.Seconds()))
 		time.Sleep(delay)
 		if completed, err := nc.scanNamespaces(context.Background(), log); !completed {
-			// the scan didn't complete either due to an error or a failure to acquire the lock
+			// the scan didn't complete due to an error
 			if err != nil {
 				log.Error(err, "Error on periodic namespace scan")
 			}

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -684,7 +684,7 @@ func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
 // Test_scanNamespaces tests the scanNamespaces method for the following use case
 // GIVEN a request to scanNamespaces
 // WHEN a valid list of Namespaces are returned
-// THEN true and no error are returned, and the controller lock is UNLOCKED
+// THEN true and no error are returned
 func Test_scanNamespaces(t *testing.T) {
 	asserts := assert.New(t)
 
@@ -729,7 +729,7 @@ func Test_scanNamespaces(t *testing.T) {
 // Test_scanNamespacesFailure tests the scanNamespaces method for the following use case
 // GIVEN a request to scanNamespaces
 // WHEN an error occurs
-// THEN false and an error are returned, and the controller lock is UNLOCKED
+// THEN false and an error are returned
 func Test_scanNamespacesFailure(t *testing.T) {
 	asserts := assert.New(t)
 
@@ -768,7 +768,7 @@ func Test_scanNamespacesFailure(t *testing.T) {
 // Test_namespaceScanner tests the namespaceScanner method for the following use case (mainly code coverage and simple validation)
 // GIVEN a request to namespaceScanner
 // WHEN no errors are encountered
-// THEN the happy path executes without an issue and the controller lock is UNLOCKED
+// THEN the happy path executes without an issue
 func Test_namespaceScanner(t *testing.T) {
 	asserts := assert.New(t)
 

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -333,8 +333,8 @@ func main() {
 		os.Exit(1)
 	}
 	// Setup the namespace reconciler
-	if _, err := namespace.NewNamespaceController(mgr, ctrl.Log.WithName("controllers").WithName("VerrazzanoNamespaceController")); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "VerrazzanoNamespaceController")
+	if _, err := namespace.NewNamespaceController(mgr, ctrl.Log.WithName("controllers").WithName("NamespaceController")); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NamespaceController")
 		os.Exit(1)
 	}
 

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -134,15 +134,13 @@ pipeline {
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${TEST_ENV}"
         K8S_VERSION_LABEL = "${params.OKE_CLUSTER_VERSION}"
+
+        SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
+        SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
+        SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
     }
 
     stages {
-        environment {
-            SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
-            SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
-            SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
-        }
-
         stage('Initialize') {
             steps {
                 script {

--- a/pkg/controller/requeue.go
+++ b/pkg/controller/requeue.go
@@ -10,7 +10,12 @@ import (
 
 // Create a new Result that will cause a reconcile requeue after a short delay
 func NewRequeueWithDelay(min int, max int, units time.Duration) ctrl.Result {
+	return ctrl.Result{Requeue: true, RequeueAfter: CalculateDelay(min, max, units)}
+}
+
+//CalculateDelay - calculate a pseudo-random delay between min and max in the specified units
+func CalculateDelay(min int, max int, units time.Duration) time.Duration {
 	var seconds = rand.IntnRange(min, max)
 	delaySecs := time.Duration(seconds) * units
-	return ctrl.Result{Requeue: true, RequeueAfter: delaySecs}
+	return delaySecs
 }


### PR DESCRIPTION
# Description

Add a periodic namespace scanner to periodically scan all namespaces and update the fluentd configmap
- handles cases like upgrade, where the configmap may get reset

Fixes VZ-4147

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
