### PR TITLE
VZ-4140: Support user-supplied API creds for OCI Logging integration

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -604,10 +604,12 @@ spec:
             - mountPath: /fluentd/secret
               name: secret-volume
               readOnly: true
+  {{- if .Values.fluentd.oci }}
   {{- if .Values.fluentd.oci.apiSecret }}
             - mountPath: /root/.oci
               name: oci-secret-volume
               readOnly: true
+  {{- end }}
   {{- end }}
             - mountPath: /fluentd/etc
               name: {{ .Values.logging.name }}-config
@@ -645,10 +647,12 @@ spec:
   {{- else }}
             secretName: verrazzano
   {{- end }}
+  {{- if .Values.fluentd.oci }}
   {{- if .Values.fluentd.oci.apiSecret }}
         - name: oci-secret-volume
           secret:
             secretName: {{ .Values.fluentd.oci.apiSecret }}
+  {{- end }}
   {{- end }}
         - configMap:
             name: {{ .Values.logging.name }}-config

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -604,6 +604,11 @@ spec:
             - mountPath: /fluentd/secret
               name: secret-volume
               readOnly: true
+  {{- if .Values.fluentd.oci.apiSecret }}
+            - mountPath: /root/.oci
+              name: oci-secret-volume
+              readOnly: true
+  {{- end }}
             - mountPath: /fluentd/etc
               name: {{ .Values.logging.name }}-config
               readOnly: true
@@ -639,6 +644,11 @@ spec:
             secretName: {{ .Values.logging.elasticsearchSecret }}
   {{- else }}
             secretName: verrazzano
+  {{- end }}
+  {{- if .Values.fluentd.oci.apiSecret }}
+        - name: oci-secret-volume
+          secret:
+            secretName: {{ .Values.fluentd.oci.apiSecret }}
   {{- end }}
         - configMap:
             name: {{ .Values.logging.name }}-config


### PR DESCRIPTION
# Description

This PR allows a user to configure OCI Logging using a secret containing OCI API configuration. There are two parts to this:

1. Update the helm template to mount the secret data into the Fluentd pods on install
2. Install pre-configuration function update that copies the user-supplied secret from the `verrazzano-install` namespace to the `verrazzano-system` namespace. I also did some refactoring to move the secret copying into a function to reduce duplication.

Implements VZ-4140

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
