### PR TITLE
VZ-4467 Change log levels in the auth lua to remove verbosity

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -899,7 +899,7 @@ data:
         local ck = require "resty.cookie"
         local cookie, err = ck:new()
         if not cookie then
-            me.logJson(ngx.ERR, "Error setting cookie "..ckName, err)
+            me.logJson(ngx.DEBUG, "Error setting cookie "..ckName, err)
             return
         end
         local expires = ngx.cookie_time(ngx.time() + expiresInSec)
@@ -961,7 +961,7 @@ data:
         local certsUri = me.getOidcCertsUri()
         local res, err = httpc:request_uri(certsUri)
         if err then
-            me.logJson(ngx.WARN, "Could not retrieve certs", err)
+            me.logJson(ngx.DEBUG, "Could not retrieve certs", err)
             return nil
         end
         local data = cjson.decode(res.body)
@@ -1135,7 +1135,7 @@ data:
             local decoder = require("cjson.safe").decode
             local decoded_data, err = decoder(data)
             if err then
-                me.logJson(ngx.ERR, "Invalid request payload:" .. data)
+                me.logJson(ngx.DEBUG, "Invalid request payload:" .. data)
                 return false
             end
         end

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -787,8 +787,6 @@ data:
         if not publicKey then
             me.unauthorized("No public key found")
         end
-        me.debug("TOKEN: iss is "..jwt_obj.payload.iss)
-        me.debug("TOKEN: oidcIssuerUri is"..oidcIssuerUri)
         local verified = jwt:verify_jwt_obj(publicKey, jwt_obj, default_claim_spec, claim_spec)
         if not verified or (tostring(jwt_obj.valid) == "false" or tostring(jwt_obj.verified) == "false") then
             me.unauthorized("Failed to validate token", jwt_obj.reason)

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -966,7 +966,7 @@ data:
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.error("No keys found")
+            me.debug("No keys found")
             return nil
         end
         for i, key in pairs(data.keys) do

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -40,7 +40,7 @@ data:
     -- CORS handling
     local h, _ = ngx.req.get_headers()["origin"]
     if h ~= nil and h ~= "" then
-        auth.info("Origin header: "..h)
+        auth.debug("Origin header: "..h)
         if h == "*" then
             -- not a legit origin, could be intended to trick us into oversharing
             auth.bad_request("Invalid Origin header: '*'")
@@ -80,7 +80,7 @@ data:
         end
     end
 
-    auth.info("Processing request for backend '"..ingressHost.."'")
+    auth.debug("Processing request for backend '"..ingressHost.."'")
     if (backend == 'console' or backend == 'verrazzano') and (not auth.isBodyValidJson()) then
         auth.bad_request("Invalid request")
     end
@@ -94,10 +94,10 @@ data:
             token = auth.handleBasicAuth(authHeader)
         end
         if not token then
-            auth.info("No recognized credentials in authorization header")
+            auth.error("No recognized credentials in authorization header")
         end
     else
-        auth.info("No authorization header found")
+        auth.debug("No authorization header found")
         if auth.requestUriMatches(ngx.var.request_uri, callbackPath) then
             -- we initiated authentication via pkce, and OP is delivering the code
             -- will redirect to target url, where token will be found in cookie
@@ -148,10 +148,10 @@ data:
         end
         -- set the oidc_user
         ngx.var.oidc_user = auth.usernameFromIdToken(token)
-        auth.info("Authorized: oidc_user is "..ngx.var.oidc_user)
+        auth.debug("Authorized: oidc_user is "..ngx.var.oidc_user)
     end
 
-    auth.info("Setting backend_server_url to '"..backendUrl.."'")
+    auth.debug("Setting backend_server_url to '"..backendUrl.."'")
     ngx.var.backend_server_url = backendUrl
   auth.lua: |
     local me = {}
@@ -192,8 +192,6 @@ data:
             me.internal_server_error("Error getting cookie key")
         end
         local salt = string.sub(key, 49, 56)
-        -- me.info("Got encryption key from secret: '"..key.."', length: "..#key)
-        -- me.info("Salt is: '"..salt.."', length: "..#salt)
         local encryptor, err = aes:new(key, salt, aes.cipher(256, "cbc"), aes.hash.sha256, 3)
         if err or not encryptor then
             me.internal_server_error("Unable to get encryptor, error is: '"..err.."'")
@@ -209,7 +207,7 @@ data:
 
         local keycloakURL = me.read_file("/api-config/keycloak-url")
         if keycloakURL and keycloakURL ~= "" then
-            me.info("keycloak-url specified in multi-cluster secret, will not use in-cluster oidc provider host.")
+            me.debug("keycloak-url specified in multi-cluster secret, will not use in-cluster oidc provider host.")
             oidcProviderUri = keycloakURL..'/auth/realms/'..oidcRealm
             oidcProviderInClusterUri = nil
         end
@@ -239,6 +237,14 @@ data:
             me.log(ngx.INFO, msg, 'object', obj)
         else
             me.log(ngx.INFO, msg)
+        end
+    end
+    
+    function me.error(msg, obj)
+        if obj then
+            me.log(ngx.ERR, msg, 'object', obj)
+        else
+            me.log(ngx.ERR, msg)
         end
     end
     
@@ -507,7 +513,7 @@ data:
         if found then
             local token = string.sub(authHeader, index+2)
             if token then
-                me.info("Found bearer token in authorization header")
+                me.debug("Found bearer token in authorization header")
                 me.oidcValidateBearerToken(token)
                 return token
             else
@@ -524,18 +530,18 @@ data:
     function me.handleBasicAuth(authHeader)
         local found, index = authHeader:find('Basic')
         if not found then
-            me.info("No basic auth credentials found")
+            me.debug("No basic auth credentials found")
             return nil
         end
         local basicCred = string.sub(authHeader, index+2)
         if not basicCred then
             me.unauthorized("Invalid BasicAuth authorization header")
         end
-        me.info("Found basic auth credentials in authorization header")
+        me.debug("Found basic auth credentials in authorization header")
         local now = ngx.time()
         local basicAuth = basicCache[basicCred]
         if basicAuth and (now < basicAuth.expiry) then
-            me.info("Returning cached token")
+            me.debug("Returning cached token")
             return basicAuth.id_token
         end
         local decode, err = ngx.decode_base64(basicCred)
@@ -596,7 +602,7 @@ data:
     end
 
     function me.oidcAuthenticate()
-        me.info("Authenticating user")
+        me.debug("Authenticating user")
         local sha256 = (require 'resty.sha256'):new()
         -- code verifier must be between 43 and 128 characters
         local codeVerifier = me.randomBase64(56)
@@ -631,7 +637,7 @@ data:
     end
 
     function me.oidcHandleCallback()
-        me.info("Handle authentication callback")
+        me.debug("Handle authentication callback")
         local queryParams = me.queryParams(ngx.var.request_uri)
         local state = queryParams.state
         local code = queryParams.code
@@ -665,7 +671,7 @@ data:
     end
 
     function me.oidcTokenRequest(formArgs)
-        me.info("Requesting token from OP")
+        me.debug("Requesting token from OP")
         local tokenUri = me.getOidcTokenUri()
         local http = require "resty.http"
         local httpc = http.new()
@@ -684,7 +690,7 @@ data:
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then
-            me.info("Error requesting token")
+            me.error("Error requesting token")
             me.unauthorized(tokenRes.error_description)
         end
         return tokenRes
@@ -765,7 +771,7 @@ data:
     end
 
     function me.oidcValidateTokenWithClaims(token, claim_spec)
-        me.info("Validating JWT token")
+        me.debug("Validating JWT token")
         local default_claim_spec = {
             iat = validators.is_not_before(),
             exp = validators.is_not_expired(),
@@ -780,8 +786,8 @@ data:
         if not publicKey then
             me.unauthorized("No public key found")
         end
-        -- me.info("TOKEN: iss is "..jwt_obj.payload.iss)
-        -- me.info("TOKEN: oidcIssuerUri is"..oidcIssuerUri)
+        me.debug("TOKEN: iss is "..jwt_obj.payload.iss)
+        me.debug("TOKEN: oidcIssuerUri is"..oidcIssuerUri)
         local verified = jwt:verify_jwt_obj(publicKey, jwt_obj, default_claim_spec, claim_spec)
         if not verified or (tostring(jwt_obj.valid) == "false" or tostring(jwt_obj.verified) == "false") then
             me.unauthorized("Failed to validate token", jwt_obj.reason)
@@ -789,7 +795,7 @@ data:
     end
 
     function me.isAuthorized(idToken)
-        me.info("Checking for required role '"..requiredRole.."'")
+        me.debug("Checking for required role '"..requiredRole.."'")
         local id_token = jwt:load_jwt(idToken)
         if id_token and id_token.payload and id_token.payload.realm_access and id_token.payload.realm_access.roles then
             for _, role in ipairs(id_token.payload.realm_access.roles) do
@@ -802,7 +808,7 @@ data:
     end
 
     function me.usernameFromIdToken(idToken)
-        -- me.info("usernameFromIdToken: fetching preferred_username")
+        me.debug("usernameFromIdToken: fetching preferred_username")
         local id_token = jwt:load_jwt(idToken)
         if id_token and id_token.payload and id_token.payload.preferred_username then
             return id_token.payload.preferred_username
@@ -813,35 +819,35 @@ data:
     -- returns id token, token is refreshed first, if necessary.
     -- nil token returned if no session or the refresh token has expired
     function me.getTokenFromSession()
-        -- me.info("Check for existing session")
+        me.debug("Check for existing session")
         local ck = me.readCookie("vz_authn")
         if ck then
-            me.info("Existing session found")
+            me.debug("Existing session found")
             local rft = ck.rt
             local now = ngx.time()
             local expiry = tonumber(ck.expiry)
             local refresh_expiry = tonumber(ck.refresh_expiry)
             if now < expiry then
-                -- me.info("Returning ID token")
+                me.debug("Returning ID token")
                 return ck.it
             else
                 if now < refresh_expiry then
-                    me.info("Token is expired, refreshing")
+                    me.debug("Token is expired, refreshing")
                     local tokenRes = me.oidcRefreshToken(rft, me.callbackUri)
                     if tokenRes then
                         me.oidcValidateIDTokenPKCE(tokenRes.id_token)
                         me.tokenToCookie(tokenRes)
-                        -- me.info("Token refreshed",  tokenRes)
+                        me.debug("Token refreshed",  tokenRes)
                         return tokenRes.id_token
                     else
-                        me.info("No valid response from token refresh")
+                        me.debug("No valid response from token refresh")
                     end
                 else
-                    me.info("Refresh token expired, cannot refresh")
+                    me.debug("Refresh token expired, cannot refresh")
                 end
             end
         else
-            me.info("No existing session found")
+            me.debug("No existing session found")
         end
         -- no valid token found, delete cookie
         me.deleteCookies("vz_authn", "vz_userinfo")
@@ -926,17 +932,17 @@ data:
         local cookie, err = require("resty.cookie"):new()
         local ck = cookie:get(ckName)
         if not ck then
-            me.info("Cookie not found")
+            me.debug("Cookie not found")
             return nil
         end
         local decoded = base64.decode_base64url(ck)
         if not decoded then
-            me.info("Cookie not decoded")
+            me.debug("Cookie not decoded")
             return nil
         end
         local json = me.aes256:decrypt(decoded)
         if not json then
-            me.info("Cookie not decrypted")
+            me.debug("Cookie not decrypted")
             return nil
         end
         return cjson.decode(json)
@@ -959,7 +965,7 @@ data:
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.info("No keys found")
+            me.debug("No keys found")
             return nil
         end
         for i, key in pairs(data.keys) do
@@ -1221,6 +1227,7 @@ data:
 
         # Posts from Fluentd can require more than the default 1m max body size
         client_max_body_size {{ .MaxRequestSize }};
+        client_body_buffer_size {{ .MaxRequestSize }};
         proxy_buffer_size {{ .ProxyBufferSize }};
 
         #keepalive_timeout  0;

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -94,7 +94,7 @@ data:
             token = auth.handleBasicAuth(authHeader)
         end
         if not token then
-            auth.error("No recognized credentials in authorization header")
+            auth.debug("No recognized credentials in authorization header")
         end
     else
         auth.debug("No authorization header found")
@@ -284,7 +284,7 @@ data:
     end
 
     function me.internal_server_error(msg, err)
-        me.logJson(ngx.ERR, msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
         ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
         ngx.say("500 Internal Server Error")
         ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
@@ -292,28 +292,28 @@ data:
 
     function me.unauthorized(msg, err)
         me.deleteCookies("vz_authn", "vz_userinfo", "vz_state")
-        me.logJson(ngx.ERR, msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
         ngx.status = ngx.HTTP_UNAUTHORIZED
         ngx.say("401 Unauthorized")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     function me.forbidden(msg, err)
-        me.logJson(ngx.ERR, msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
         ngx.status = ngx.HTTP_FORBIDDEN
         ngx.say("403 Forbidden")
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
     function me.not_found(msg, err)
-        me.logJson(ngx.ERR, msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
         ngx.status = ngx.HTTP_NOT_FOUND
         ngx.say("404 Not Found")
         ngx.exit(ngx.HTTP_NOT_FOUND)
     end
 
     function me.bad_request(msg, err)
-        me.logJson(ngx.ERR, msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
         ngx.status = ngx.HTTP_BAD_REQUEST
         ngx.say("400 Bad Request")
         ngx.exit(ngx.HTTP_BAD_REQUEST)
@@ -684,14 +684,16 @@ data:
             }
         })
         if err then
+            me.error("Error requesting token from Keycloak")
             me.unauthorized("Error requesting token", err)
         end
         if not res then
+            me.error("Error requesting token from Keycloak: response is nil")
             me.unauthorized("Error requesting token: response was nil")
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then
-            me.error("Error requesting token")
+            me.error("Error requesting token from Keycloak")
             me.unauthorized(tokenRes.error_description)
         end
         return tokenRes
@@ -931,17 +933,17 @@ data:
         local cookie, err = require("resty.cookie"):new()
         local ck = cookie:get(ckName)
         if not ck then
-            me.error("Cookie not found")
+            me.debug("Cookie not found")
             return nil
         end
         local decoded = base64.decode_base64url(ck)
         if not decoded then
-            me.error("Cookie not decoded")
+            me.debug("Cookie not decoded")
             return nil
         end
         local json = me.aes256:decrypt(decoded)
         if not json then
-            me.error("Cookie not decrypted")
+            me.debug("Cookie not decrypted")
             return nil
         end
         return cjson.decode(json)

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -97,7 +97,7 @@ data:
             auth.error("No recognized credentials in authorization header")
         end
     else
-        auth.error("No authorization header found")
+        auth.debug("No authorization header found")
         if auth.requestUriMatches(ngx.var.request_uri, callbackPath) then
             -- we initiated authentication via pkce, and OP is delivering the code
             -- will redirect to target url, where token will be found in cookie

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -132,6 +132,9 @@ data:
     if not auth.isAuthorized(token) then
         auth.forbidden("Not authorized")
     end
+  
+    local usernameFromToken = auth.usernameFromIdToken(token)
+    me.audit("User "..usernameFromToken.." authenticated and authorized")
 
     if backend == 'verrazzano' then
         local args = ngx.req.get_uri_args()
@@ -147,7 +150,7 @@ data:
             ngx.req.clear_header("Authorization")
         end
         -- set the oidc_user
-        ngx.var.oidc_user = auth.usernameFromIdToken(token)
+        ngx.var.oidc_user = usernameFromToken
         auth.debug("Authorized: oidc_user is "..ngx.var.oidc_user)
     end
 
@@ -688,16 +691,16 @@ data:
             }
         })
         if err then
-            me.error("Error requesting token from Keycloak")
+            me.error("Failed requesting token from Keycloak: "..err)
             me.unauthorized("Error requesting token", err)
         end
         if not res then
-            me.error("Error requesting token from Keycloak: response is nil")
+            me.info("Failed requesting token from Keycloak: response is nil")
             me.unauthorized("Error requesting token: response was nil")
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then
-            me.error("Error requesting token from Keycloak")
+            me.info("Failed requesting token from Keycloak: "..tokenRes.error_description)
             me.unauthorized(tokenRes.error_description)
         end
         return tokenRes
@@ -905,7 +908,7 @@ data:
         local ck = require "resty.cookie"
         local cookie, err = ck:new()
         if not cookie then
-            me.audit("Error setting cookie "..ckName, err)
+            me.debug("Error setting cookie "..ckName..": "..err)
             return
         end
         local expires = ngx.cookie_time(ngx.time() + expiresInSec)
@@ -967,12 +970,12 @@ data:
         local certsUri = me.getOidcCertsUri()
         local res, err = httpc:request_uri(certsUri)
         if err then
-            me.audit("Could not retrieve certs", err)
+            me.error("Could not retrieve certs"..err)
             return nil
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.debug("No keys found")
+            me.error("No keys found")
             return nil
         end
         for i, key in pairs(data.keys) do
@@ -997,7 +1000,7 @@ data:
     local vzApiVersion = os.getenv("VZ_API_VERSION")
 
     function me.getServiceAccountToken()
-      me.audit("Read service account token")
+      me.debug("Read service account token")
       local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token")
       if not (serviceAccountToken) then
         me.unauthorized("No service account token present in pod.")
@@ -1047,7 +1050,7 @@ data:
         end
 
         local serviceAccountToken = me.getServiceAccountToken()
-        me.audit("Set service account bearer token as Authorization header")
+        me.debug("Set service account bearer token as Authorization header")
         ngx.req.set_header("Authorization", "Bearer " .. serviceAccountToken)
 
         if not token then
@@ -1063,17 +1066,17 @@ data:
 
         if jwt_obj.payload and jwt_obj.payload.sub then
             -- Uid is ignored prior to kubernetes v1.22
-            me.audit(("Adding sub as Impersonate-Uid: " .. jwt_obj.payload.sub))
+            me.debug(("Adding sub as Impersonate-Uid: " .. jwt_obj.payload.sub))
             ngx.req.set_header("Impersonate-Uid", jwt_obj.payload.sub)
             -- this group is needed for discovery, but not automatically set for impersonated users prior to v1.20.
             -- the group is ignored if duplicated >= v1.20, so no harm done if we always send it.
             -- adding it here so that it's present IFF we actually have a subject.
             local sys_auth = "system:authenticated"
-            me.audit(("Including group: " .. sys_auth))
+            me.debug(("Including group: " .. sys_auth))
             table.insert(groups, sys_auth)
         end
         if jwt_obj.payload and jwt_obj.payload.preferred_username then
-            me.audit(("Adding preferred_username as Impersonate-User: " .. jwt_obj.payload.preferred_username))
+            me.debug(("Adding preferred_username as Impersonate-User: " .. jwt_obj.payload.preferred_username))
             ngx.req.set_header("Impersonate-User", jwt_obj.payload.preferred_username)
         end
         if jwt_obj.payload and jwt_obj.payload.groups then
@@ -1082,7 +1085,7 @@ data:
             end
         end
         if #groups > 0 then
-            me.audit(("Adding groups as Impersonate-Group: " .. table.concat(groups, ", ")))
+            me.debug(("Adding groups as Impersonate-Group: " .. table.concat(groups, ", ")))
             ngx.req.set_header("Impersonate-Group", groups)
         end
     end
@@ -1090,7 +1093,7 @@ data:
     function me.handleExternalAPICall(token)
         local args = ngx.req.get_uri_args()
 
-        me.audit("Read vmc resource for " .. args.cluster)
+        me.debug("Read vmc resource for " .. args.cluster)
         local vmc = me.getVMC(token, args.cluster)
         if not(vmc) or not(vmc.status) or not(vmc.status.apiUrl) then
             me.unauthorized("Unable to fetch vmc api url for vmc " .. args.cluster)
@@ -1103,13 +1106,13 @@ data:
         -- The value of cacrt field is decoded to get the ca certificate and is appended to file being pointed to by the proxy_ssl_trusted_certificate variable.
 
         if not(vmc.spec) or not(vmc.spec.caSecret) then
-            me.audit("ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            me.debug("ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
 
         local secret = me.getSecret(token, vmc.spec.caSecret)
         if not(secret) or not(secret.data) or not(secret.data["cacrt"]) or secret.data["cacrt"] == "" then
-            me.audit("Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            me.debug("Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
 
@@ -1141,7 +1144,7 @@ data:
             local decoder = require("cjson.safe").decode
             local decoded_data, err = decoder(data)
             if err then
-                me.audit("Invalid request payload:" .. data)
+                me.debug("Invalid request payload: " .. data)
                 return false
             end
         end

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -241,6 +241,14 @@ data:
             me.log(ngx.INFO, msg)
         end
     end
+    
+    function me.debug(msg, obj)
+        if obj then
+            me.log(ngx.DEBUG, msg, 'object', obj)
+        else
+            me.log(ngx.DEBUG, msg)
+        end
+    end
 
     function me.queryParams(req_uri)
          local i = req_uri:find("?")
@@ -418,7 +426,7 @@ data:
         local able_to_redirect = true
         local hostname = nil
         if ingressHost and #ingressHost > 0 then
-            me.info("ingressHost is '"..ingressHost.."'")
+            me.debug("ingressHost is '"..ingressHost.."'")
             -- Strip the port off, if present
             local first, last = nil
             first, last, hostname = ingressHost:find("^([^:]+)")
@@ -428,10 +436,10 @@ data:
                     -- Strip the auth proxy prefix from the extracted backend name if present
                     if string.sub(backend_name, 1, #authproxy_prefix) == authproxy_prefix then
                         backend_name = string.sub(backend_name, #authproxy_prefix+1, -1)
-                        me.info("Validating host (local): backend_name is '"..backend_name.."', hostname is '"..hostname.."'")
+                        me.debug("Validating host (local): backend_name is '"..backend_name.."', hostname is '"..hostname.."'")
                         backend_name = me.validateIngressHost(backend_name, hostname, true)
                     else
-                        me.info("Validating host (ingress): backend_name is '"..backend_name.."', hostname is '"..hostname.."'")
+                        me.debug("Validating host (ingress): backend_name is '"..backend_name.."', hostname is '"..hostname.."'")
                         backend_name = me.validateIngressHost(backend_name, hostname, false)
                     end
                 end
@@ -452,9 +460,9 @@ data:
             end
         end
         if able_to_redirect == true then
-            me.info("returning backend_name '"..backend_name.."', able_to_redirect is true")
+            me.debug("returning backend_name '"..backend_name.."', able_to_redirect is true")
         else
-            me.info("returning backend_name '"..backend_name.."', able_to_redirect is false")
+            me.debug("returning backend_name '"..backend_name.."', able_to_redirect is false")
         end
         return backend_name, able_to_redirect
     end
@@ -514,7 +522,6 @@ data:
     -- should only be called if some vz process is trying to access vmi using basic auth
     -- tokens are cached locally
     function me.handleBasicAuth(authHeader)
-        -- me.info("Checking for basic auth credentials")
         local found, index = authHeader:find('Basic')
         if not found then
             me.info("No basic auth credentials found")

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -509,7 +509,6 @@ data:
     -- console originally sent access token by itself, as bearer token (originally obtained via pkce client)
     -- with combined proxy, console no longer handles tokens, but tests may be sending ID tokens.
     function me.handleBearerToken(authHeader)
-        me.debug("Checking for basic auth credentials")
         local found, index = authHeader:find('Bearer')
         if found then
             local token = string.sub(authHeader, index+2)
@@ -529,6 +528,7 @@ data:
     -- should only be called if some vz process is trying to access vmi using basic auth
     -- tokens are cached locally
     function me.handleBasicAuth(authHeader)
+        me.debug("Checking for basic auth credentials")
         local found, index = authHeader:find('Basic')
         if not found then
             me.debug("No basic auth credentials found")
@@ -933,17 +933,17 @@ data:
         local cookie, err = require("resty.cookie"):new()
         local ck = cookie:get(ckName)
         if not ck then
-            me.debug("Cookie not found")
+            me.error("Cookie not found")
             return nil
         end
         local decoded = base64.decode_base64url(ck)
         if not decoded then
-            me.debug("Cookie not decoded")
+            me.error("Cookie not decoded")
             return nil
         end
         local json = me.aes256:decrypt(decoded)
         if not json then
-            me.debug("Cookie not decrypted")
+            me.error("Cookie not decrypted")
             return nil
         end
         return cjson.decode(json)
@@ -966,7 +966,7 @@ data:
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.debug("No keys found")
+            me.error("No keys found")
             return nil
         end
         for i, key in pairs(data.keys) do

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -282,9 +282,13 @@ data:
             return req_uri:sub(begin, endin-1)
         end
     end
+    
+    function me.audit(msg, err)
+        me.logJson(ngx.DEBUG, msg, err)
+    end
 
     function me.internal_server_error(msg, err)
-        me.logJson(ngx.DEBUG, msg, err)
+        me.audit(msg, err)
         ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
         ngx.say("500 Internal Server Error")
         ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
@@ -292,28 +296,28 @@ data:
 
     function me.unauthorized(msg, err)
         me.deleteCookies("vz_authn", "vz_userinfo", "vz_state")
-        me.logJson(ngx.DEBUG, msg, err)
+        me.audit(msg, err)
         ngx.status = ngx.HTTP_UNAUTHORIZED
         ngx.say("401 Unauthorized")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     function me.forbidden(msg, err)
-        me.logJson(ngx.DEBUG, msg, err)
+        me.audit(msg, err)
         ngx.status = ngx.HTTP_FORBIDDEN
         ngx.say("403 Forbidden")
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
     function me.not_found(msg, err)
-        me.logJson(ngx.DEBUG, msg, err)
+        me.audit(msg, err)
         ngx.status = ngx.HTTP_NOT_FOUND
         ngx.say("404 Not Found")
         ngx.exit(ngx.HTTP_NOT_FOUND)
     end
 
     function me.bad_request(msg, err)
-        me.logJson(ngx.DEBUG, msg, err)
+        me.audit(msg, err)
         ngx.status = ngx.HTTP_BAD_REQUEST
         ngx.say("400 Bad Request")
         ngx.exit(ngx.HTTP_BAD_REQUEST)
@@ -899,7 +903,7 @@ data:
         local ck = require "resty.cookie"
         local cookie, err = ck:new()
         if not cookie then
-            me.logJson(ngx.DEBUG, "Error setting cookie "..ckName, err)
+            me.audit("Error setting cookie "..ckName, err)
             return
         end
         local expires = ngx.cookie_time(ngx.time() + expiresInSec)
@@ -961,7 +965,7 @@ data:
         local certsUri = me.getOidcCertsUri()
         local res, err = httpc:request_uri(certsUri)
         if err then
-            me.logJson(ngx.DEBUG, "Could not retrieve certs", err)
+            me.audit("Could not retrieve certs", err)
             return nil
         end
         local data = cjson.decode(res.body)
@@ -991,7 +995,7 @@ data:
     local vzApiVersion = os.getenv("VZ_API_VERSION")
 
     function me.getServiceAccountToken()
-      me.logJson(ngx.INFO, "Read service account token")
+      me.audit("Read service account token")
       local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token")
       if not (serviceAccountToken) then
         me.unauthorized("No service account token present in pod.")
@@ -1041,7 +1045,7 @@ data:
         end
 
         local serviceAccountToken = me.getServiceAccountToken()
-        me.logJson(ngx.INFO, "Set service account bearer token as Authorization header")
+        me.audit("Set service account bearer token as Authorization header")
         ngx.req.set_header("Authorization", "Bearer " .. serviceAccountToken)
 
         if not token then
@@ -1057,17 +1061,17 @@ data:
 
         if jwt_obj.payload and jwt_obj.payload.sub then
             -- Uid is ignored prior to kubernetes v1.22
-            me.logJson(ngx.INFO, ("Adding sub as Impersonate-Uid: " .. jwt_obj.payload.sub))
+            me.audit(("Adding sub as Impersonate-Uid: " .. jwt_obj.payload.sub))
             ngx.req.set_header("Impersonate-Uid", jwt_obj.payload.sub)
             -- this group is needed for discovery, but not automatically set for impersonated users prior to v1.20.
             -- the group is ignored if duplicated >= v1.20, so no harm done if we always send it.
             -- adding it here so that it's present IFF we actually have a subject.
             local sys_auth = "system:authenticated"
-            me.logJson(ngx.INFO, ("Including group: " .. sys_auth))
+            me.audit(("Including group: " .. sys_auth))
             table.insert(groups, sys_auth)
         end
         if jwt_obj.payload and jwt_obj.payload.preferred_username then
-            me.logJson(ngx.INFO, ("Adding preferred_username as Impersonate-User: " .. jwt_obj.payload.preferred_username))
+            me.audit(("Adding preferred_username as Impersonate-User: " .. jwt_obj.payload.preferred_username))
             ngx.req.set_header("Impersonate-User", jwt_obj.payload.preferred_username)
         end
         if jwt_obj.payload and jwt_obj.payload.groups then
@@ -1076,7 +1080,7 @@ data:
             end
         end
         if #groups > 0 then
-            me.logJson(ngx.INFO, ("Adding groups as Impersonate-Group: " .. table.concat(groups, ", ")))
+            me.audit(("Adding groups as Impersonate-Group: " .. table.concat(groups, ", ")))
             ngx.req.set_header("Impersonate-Group", groups)
         end
     end
@@ -1084,7 +1088,7 @@ data:
     function me.handleExternalAPICall(token)
         local args = ngx.req.get_uri_args()
 
-        me.logJson(ngx.INFO, "Read vmc resource for " .. args.cluster)
+        me.audit("Read vmc resource for " .. args.cluster)
         local vmc = me.getVMC(token, args.cluster)
         if not(vmc) or not(vmc.status) or not(vmc.status.apiUrl) then
             me.unauthorized("Unable to fetch vmc api url for vmc " .. args.cluster)
@@ -1097,13 +1101,13 @@ data:
         -- The value of cacrt field is decoded to get the ca certificate and is appended to file being pointed to by the proxy_ssl_trusted_certificate variable.
 
         if not(vmc.spec) or not(vmc.spec.caSecret) then
-            me.logJson(ngx.INFO, "ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            me.audit("ca secret name not present on vmc resource, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
 
         local secret = me.getSecret(token, vmc.spec.caSecret)
         if not(secret) or not(secret.data) or not(secret.data["cacrt"]) or secret.data["cacrt"] == "" then
-            me.logJson(ngx.INFO, "Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
+            me.audit("Unable to fetch ca secret for vmc, assuming well known CA certificate exists for managed cluster " .. args.cluster)
             do return end
         end
 
@@ -1135,7 +1139,7 @@ data:
             local decoder = require("cjson.safe").decode
             local decoded_data, err = decoder(data)
             if err then
-                me.logJson(ngx.DEBUG, "Invalid request payload:" .. data)
+                me.audit("Invalid request payload:" .. data)
                 return false
             end
         end

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -975,7 +975,7 @@ data:
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.error("No keys found")
+            me.error("No keys found: key object is nil")
             return nil
         end
         for i, key in pairs(data.keys) do

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -97,7 +97,7 @@ data:
             auth.error("No recognized credentials in authorization header")
         end
     else
-        auth.debug("No authorization header found")
+        auth.error("No authorization header found")
         if auth.requestUriMatches(ngx.var.request_uri, callbackPath) then
             -- we initiated authentication via pkce, and OP is delivering the code
             -- will redirect to target url, where token will be found in cookie

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
@@ -509,6 +509,7 @@ data:
     -- console originally sent access token by itself, as bearer token (originally obtained via pkce client)
     -- with combined proxy, console no longer handles tokens, but tests may be sending ID tokens.
     function me.handleBearerToken(authHeader)
+        me.debug("Checking for basic auth credentials")
         local found, index = authHeader:find('Bearer')
         if found then
             local token = string.sub(authHeader, index+2)

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -1227,7 +1227,6 @@ data:
 
         # Posts from Fluentd can require more than the default 1m max body size
         client_max_body_size {{ .MaxRequestSize }};
-        client_body_buffer_size {{ .MaxRequestSize }};
         proxy_buffer_size {{ .ProxyBufferSize }};
 
         #keepalive_timeout  0;

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -532,7 +532,7 @@ data:
     -- should only be called if some vz process is trying to access vmi using basic auth
     -- tokens are cached locally
     function me.handleBasicAuth(authHeader)
-        me.debug("Checking for basic auth credentials")
+        -- me.debug("Checking for basic auth credentials")
         local found, index = authHeader:find('Basic')
         if not found then
             me.debug("No basic auth credentials found")
@@ -793,6 +793,8 @@ data:
         if not publicKey then
             me.unauthorized("No public key found")
         end
+        -- me.debug("TOKEN: iss is "..jwt_obj.payload.iss)
+        -- me.debug("TOKEN: oidcIssuerUri is"..oidcIssuerUri)
         local verified = jwt:verify_jwt_obj(publicKey, jwt_obj, default_claim_spec, claim_spec)
         if not verified or (tostring(jwt_obj.valid) == "false" or tostring(jwt_obj.verified) == "false") then
             me.unauthorized("Failed to validate token", jwt_obj.reason)
@@ -813,7 +815,7 @@ data:
     end
 
     function me.usernameFromIdToken(idToken)
-        me.debug("usernameFromIdToken: fetching preferred_username")
+        -- me.debug("usernameFromIdToken: fetching preferred_username")
         local id_token = jwt:load_jwt(idToken)
         if id_token and id_token.payload and id_token.payload.preferred_username then
             return id_token.payload.preferred_username
@@ -824,7 +826,7 @@ data:
     -- returns id token, token is refreshed first, if necessary.
     -- nil token returned if no session or the refresh token has expired
     function me.getTokenFromSession()
-        me.debug("Check for existing session")
+        -- me.debug("Check for existing session")
         local ck = me.readCookie("vz_authn")
         if ck then
             me.debug("Existing session found")
@@ -833,7 +835,7 @@ data:
             local expiry = tonumber(ck.expiry)
             local refresh_expiry = tonumber(ck.refresh_expiry)
             if now < expiry then
-                me.debug("Returning ID token")
+                -- me.debug("Returning ID token")
                 return ck.it
             else
                 if now < refresh_expiry then
@@ -842,7 +844,7 @@ data:
                     if tokenRes then
                         me.oidcValidateIDTokenPKCE(tokenRes.id_token)
                         me.tokenToCookie(tokenRes)
-                        me.debug("Token refreshed",  tokenRes)
+                        -- me.debug("Token refreshed",  tokenRes)
                         return tokenRes.id_token
                     else
                         me.debug("No valid response from token refresh")

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -971,7 +971,7 @@ data:
         local certsUri = me.getOidcCertsUri()
         local res, err = httpc:request_uri(certsUri)
         if err then
-            me.error("Could not retrieve certs"..err)
+            me.error("Could not retrieve certs: "..err)
             return nil
         end
         local data = cjson.decode(res.body)

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -134,7 +134,7 @@ data:
     end
   
     local usernameFromToken = auth.usernameFromIdToken(token)
-    me.audit("User "..usernameFromToken.." authenticated and authorized")
+    auth.audit("User "..usernameFromToken.." authenticated and authorized")
 
     if backend == 'verrazzano' then
         local args = ngx.req.get_uri_args()
@@ -976,7 +976,7 @@ data:
         end
         local data = cjson.decode(res.body)
         if not (data.keys) then
-            me.error("No keys found: key object is nil")
+            me.error("Failed to find keys: key object is nil")
             return nil
         end
         for i, key in pairs(data.keys) do

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -286,6 +286,7 @@ data:
         end
     end
     
+    -- For now, auditing reports a log message at the debug level
     function me.audit(msg, err)
         me.logJson(ngx.DEBUG, msg, err)
     end


### PR DESCRIPTION
# Description

Currently, the auth.lua logger is emitting messages too quickly with little useful information. In response, I have downgraded all of the info messages to debugging. This is a first pass at fixing this issue. Future iterations will need to expand upon the error logging.

Fixes VZ-4467

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
