### PR TITLE
VZ-4142.  Helper script for creating a secret for the fluentd OCI plugin

### DIFF
--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -3,49 +3,11 @@
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
+# Creates a Kubernetes secret based on an OCI CLI configuration for consumption by External-DNS and/or Cert-Manager
+#
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-if [ -z "${KUBECONFIG:-}" ] ; then
-  echo "Environment variable KUBECONFIG must be set an point to a valid kube config file"
-  exit 1
-fi
-
-TMP_DIR=$(mktemp -d)
-trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
-
-# read a config item from a specified section of an oci config file
-function read_config() {
-  if [[ $# -lt 2 || ! -f $1 ]]; then
-    echo "usage: iniget <file> [--list|<SECTION> [key]]"
-    return 1
-  fi
-  local ocifile=$1
-
-  if [ "$2" == "--list" ]; then
-    for SECTION in $(cat $ocifile | grep "\[" | sed -e "s#\[##g" | sed -e "s#\]##g"); do
-      echo $SECTION
-    done
-    return 0
-  fi
-
-  local SECTION=$2
-  local key
-  [ $# -eq 3 ] && key=$3
-
- local lines=$(awk '/\[/{prefix=$0; next} $1{print prefix $0}' $ocifile)
-  for line in $lines; do
-    if [[ "$line" = \[$SECTION\]* ]]; then
-      local keyval=$(echo $line | sed -e "s/^\[$SECTION\]//")
-      if [[ -z "$key" ]]; then
-        echo $keyval
-      else
-        if [[ "$keyval" = $key=* ]]; then
-          echo $(echo $keyval | sed -e "s/^$key=//")
-        fi
-      fi
-    fi
-  done
-}
+. ${SCRIPT_DIR}/oci_secret_common.sh
 
 function usage {
     echo

--- a/platform-operator/scripts/install/create_oci_fluentd_secret.sh
+++ b/platform-operator/scripts/install/create_oci_fluentd_secret.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+#
+# Creates a Kubernetes secret based on an OCI CLI configuration for consumption by the fluentd OCI plugin
+#
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+
+. ${SCRIPT_DIR}/oci_secret_common.sh
+
+function usage {
+    echo
+    echo "usage: $0 [-o oci_config_file] [-s config_file_section]"
+    echo "  -o oci_config_file         The full path to the OCI configuration file (default ~/.oci/config)"
+    echo "  -s config_file_section     The properties section within the OCI configuration file.  Default is DEFAULT"
+    echo "  -k secret_name             The secret name containing the OCI configuration.  Default is oci"
+    echo "  -c context_name            The kubectl context to use"
+    echo "  -h                         Help"
+    echo
+    exit 1
+}
+
+OUTPUT_FILE=$TMP_DIR/oci.yaml
+
+OCI_CONFIG_FILE=~/.oci/config
+SECTION=DEFAULT
+OCI_FLUENTD_SECRET_NAME=oci-fluentd
+K8SCONTEXT=""
+VERRAZZANO_INSTALL_NS=verrazzano-install
+
+while getopts c:o:s:k:h flag
+do
+    case "${flag}" in
+        o) OCI_CONFIG_FILE=${OPTARG};;
+        s) SECTION=${OPTARG};;
+        k) OCI_FLUENTD_SECRET_NAME=${OPTARG};;
+        c) K8SCONTEXT="--context=${OPTARG}";;
+        h) usage;;
+        *) usage;;
+    esac
+done
+
+SECTION_PROPS=$(read_config $OCI_CONFIG_FILE $SECTION *)
+eval $SECTION_PROPS
+
+CONFIG_TMP=$TMP_DIR/oci_config_tmp
+cat <<EOT > $CONFIG_TMP
+[DEFAULT]
+user=${user}
+tenancy=${tenancy}
+region=${region}
+fingerprint=${fingerprint}
+key_file=/root/.oci/key
+EOT
+
+if [[ ! -z "$pass_phrase" ]]; then
+echo "pass_phrase=${pass_phrase}" >> CONFIG_TMP
+fi
+
+# create the secret in verrazzano-install namespace
+kubectl ${K8SCONTEXT} get secret $OCI_FLUENTD_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  # secret exists
+  echo "Secret $OCI_FLUENTD_SECRET_NAME already exists in ${VERRAZZANO_INSTALL_NS} namespace."
+  exit 1
+fi
+
+# Create the secret
+kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_FLUENTD_SECRET_NAME --from-file=config=${CONFIG_TMP} \
+  --from-file=key=${key_file}

--- a/platform-operator/scripts/install/create_oci_fluentd_secret.sh
+++ b/platform-operator/scripts/install/create_oci_fluentd_secret.sh
@@ -15,7 +15,7 @@ function usage {
     echo "usage: $0 [-o oci_config_file] [-s config_file_section]"
     echo "  -o oci_config_file         The full path to the OCI configuration file (default ~/.oci/config)"
     echo "  -s config_file_section     The properties section within the OCI configuration file.  Default is DEFAULT"
-    echo "  -k secret_name             The secret name containing the OCI configuration.  Default is oci"
+    echo "  -k secret_name             The secret name containing the OCI configuration.  Default is \"oci-fluentd\""
     echo "  -c context_name            The kubectl context to use"
     echo "  -h                         Help"
     echo

--- a/platform-operator/scripts/install/oci_secret_common.sh
+++ b/platform-operator/scripts/install/oci_secret_common.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+if [ -z "${KUBECONFIG:-}" ] ; then
+  echo "Environment variable KUBECONFIG must be set an point to a valid kube config file"
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
+
+# read a config item from a specified section of an oci config file
+function read_config() {
+  if [[ $# -lt 2 || ! -f $1 ]]; then
+    echo "usage: iniget <file> [--list|<SECTION> [key]]"
+    return 1
+  fi
+  local ocifile=$1
+
+  if [ "$2" == "--list" ]; then
+    for SECTION in $(cat $ocifile | grep "\[" | sed -e "s#\[##g" | sed -e "s#\]##g"); do
+      echo $SECTION
+    done
+    return 0
+  fi
+
+  local SECTION=$2
+  local key
+  [ $# -eq 3 ] && key=$3
+
+ local lines=$(awk '/\[/{prefix=$0; next} $1{print prefix $0}' $ocifile)
+  for line in $lines; do
+    if [[ "$line" = \[$SECTION\]* ]]; then
+      local keyval=$(echo $line | sed -e "s/^\[$SECTION\]//")
+      if [[ -z "$key" ]]; then
+        echo $keyval
+      else
+        if [[ "$keyval" = $key=* ]]; then
+          echo $(echo $keyval | sed -e "s/^$key=//")
+        fi
+      fi
+    fi
+  done
+}
+


### PR DESCRIPTION

# Description

Create a helper script to create an OCI config secret for the fluentd OCI plugin.
- Also creates a common base script for both this and the helper that creates an OCI secret for `external-dns`/`Cert-Manager`

Fixes VZ-4142.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
