### PR TITLE
VZ-4616.  Add webhook validator for the Fluentd OCI config secret

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -5,9 +5,15 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"reflect"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v53/common"
 
 	"sigs.k8s.io/yaml"
 
@@ -35,20 +41,28 @@ const (
 	InstancePrincipalDelegationToken authenticationType = "instance_principle_delegation_token"
 	// UnknownAuthenticationType is used for none meaningful auth type
 	UnknownAuthenticationType authenticationType = "unknown_auth_type"
-	ociSecretFileName                            = "oci.yaml"
+
+	ociDNSSecretFileName            = "oci.yaml"
+	fluentdOCISecretConfigEntry     = "config"
+	fluentdOCISecretPrivateKeyEntry = "key"
+	fluentdExpectedKeyPath          = "/root/.oci/key"
+	expectedKeyHeader               = "RSA PRIVATE KEY"
+	fluentdOCIKeyFileEntry          = "key_file=/root/.oci/key"
 )
 
-// OCI Secret Auth
+// OCI DNS Secret Auth
 type authData struct {
-	Region      string             `yaml:"region"`
-	Tenancy     string             `yaml:"tenancy"`
-	User        string             `yaml:"user"`
-	Key         string             `yaml:"key"`
-	Fingerprint string             `yaml:"fingerprint"`
-	AuthType    authenticationType `yaml:"authtype"`
+	Region      string             `json:"region"`
+	Tenancy     string             `json:"tenancy"`
+	User        string             `json:"user"`
+	Key         string             `json:"key"`
+	Fingerprint string             `json:"fingerprint"`
+	AuthType    authenticationType `json:"authtype"`
 }
+
+// OCI DNS Secret Auth Wrapper
 type ociAuth struct {
-	auth authData `yaml:"auth"`
+	Auth authData `json:"auth"`
 }
 
 // GetCurrentBomVersion Get the version string from the bom and return it as a semver object
@@ -95,7 +109,7 @@ func ValidateProfile(requestedProfile ProfileType) error {
 		case Prod, Dev, ManagedCluster:
 			return nil
 		default:
-			return fmt.Errorf("Requested profile %s is invalid.  Valid options are dev, prod, or managed-cluster",
+			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, or managed-cluster",
 				requestedProfile)
 		}
 	}
@@ -181,30 +195,166 @@ func ValidateInProgress(old *Verrazzano, new *Verrazzano) error {
 	return fmt.Errorf("Updates to resource not allowed while install, uninstall or upgrade is in progress")
 }
 
-// ValidateOciDNSSecret makes sure that the OCI DNS secret required by install exists
-func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
-	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
-		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoInstallNamespace)
-			}
-			return err
-		}
+// validateOCISecrets - Validate that the OCI DNS and Fluentd OCI secrets required by install exists, if configured
+func validateOCISecrets(client client.Client, spec *VerrazzanoSpec) error {
+	if err := validateOCIDNSSecret(client, spec); err != nil {
+		return err
+	}
+	if err := validateFluentdOCIAuthSecret(client, spec); err != nil {
+		return err
+	}
+	return nil
+}
 
-		// validate auth_type
-		var authProp ociAuth
-		err = yaml.Unmarshal(secret.Data[ociSecretFileName], &authProp)
-		if err != nil {
-			zap.S().Errorf("yaml unmarshalling failed due to %v", err)
+func validateFluentdOCIAuthSecret(client client.Client, spec *VerrazzanoSpec) error {
+	if spec.Components.Fluentd == nil || spec.Components.Fluentd.OCI == nil {
+		return nil
+	}
+	apiSecretName := spec.Components.Fluentd.OCI.APISecret
+	if len(apiSecretName) > 0 {
+		secret := &corev1.Secret{}
+		if err := getInstallSecret(client, apiSecretName, secret); err != nil {
 			return err
 		}
-		if authProp.auth.AuthType != instancePrincipal && authProp.auth.AuthType != userPrincipal && authProp.auth.AuthType != "" {
-			return fmt.Errorf("The authtype \"%v\" in OCI secret must be either '%s' or '%s'", authProp.auth.AuthType, userPrincipal, instancePrincipal)
+		// validate config secret
+		if err := validateFluentdConfigData(secret); err != nil {
+			return err
+		}
+		// Validate key data exists and is a valid pem format
+		pemData, err := validateSecretKey(secret, fluentdOCISecretPrivateKeyEntry, nil)
+		if err != nil {
+			return err
+		}
+		if err := validatePrivateKey(pemData); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
+//validateFluentdConfigData - Validate the OCI config contents in the Fluentd secret
+func validateFluentdConfigData(secret *corev1.Secret) error {
+	secretName := secret.Name
+	configData, ok := secret.Data[fluentdOCISecretConfigEntry]
+	if !ok {
+		return fmt.Errorf("Did not find OCI configuration in secret %s", secretName)
+	}
+	// Write the OCI config in the secret to a temp file and use the OCI SDK
+	// ConfigurationProvider API to validate its contents
+	configTemp, err := os.CreateTemp(os.TempDir(), "validate-")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		os.Remove(configTemp.Name())
+	}()
+	const ociConfigErrorFormatString = "%s not specified in Fluentd OCI config secret %s"
+	if err := os.WriteFile(configTemp.Name(), configData, fs.ModeAppend); err != nil {
+		return err
+	}
+	provider, err := common.ConfigurationProviderFromFile(configTemp.Name(), "")
+	if err != nil {
+		return err
+	}
+	userOCID, err := provider.UserOCID()
+	if err != nil {
+		return err
+	}
+	if len(userOCID) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "User OCID", secretName)
+	}
+	tenancyOCID, err := provider.TenancyOCID()
+	if err != nil {
+		return err
+	}
+	if len(tenancyOCID) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Tenancy OCID", secretName)
+	}
+	fingerprint, err := provider.KeyFingerprint()
+	if err != nil {
+		return err
+	}
+	if len(fingerprint) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Fingerprint", secretName)
+	}
+	region, err := provider.Region()
+	if err != nil {
+		return err
+	}
+	if len(region) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Region", secretName)
+	}
+	if !strings.Contains(string(configData), fluentdOCIKeyFileEntry) {
+		return fmt.Errorf("Unexpected or missing value for the Fluentd OCI key file location, should be %s",
+			fluentdExpectedKeyPath)
+	}
+	return nil
+}
+
+func validateOCIDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
+	if spec.Components.DNS == nil || spec.Components.DNS.OCI == nil {
+		return nil
+	}
+	secret := &corev1.Secret{}
+	ociDNSConfigSecret := spec.Components.DNS.OCI.OCIConfigSecret
+	if err := getInstallSecret(client, ociDNSConfigSecret, secret); err != nil {
+		return err
+	}
+	// validate auth_type
+	var authProp ociAuth
+	if err := validateSecretContents(secret.Data[ociDNSSecretFileName], &authProp); err != nil {
+		return err
+	}
+	if err := validatePrivateKey([]byte(authProp.Auth.Key)); err != nil {
+		return err
+	}
+	if authProp.Auth.AuthType != instancePrincipal && authProp.Auth.AuthType != userPrincipal && authProp.Auth.AuthType != "" {
+		return fmt.Errorf("Authtype \"%v\" in OCI secret must be either '%s' or '%s'", authProp.Auth.AuthType, userPrincipal, instancePrincipal)
+	}
+	return nil
+}
+
+func getInstallSecret(client client.Client, secretName string, secret *corev1.Secret) error {
+	err := client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: constants.VerrazzanoInstallNamespace}, secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Errorf("Secret \"%s\" must be created in the %s namespace before installing Verrrazzano", secretName, constants.VerrazzanoInstallNamespace)
+		}
+		return err
+	}
+	return nil
+}
+
+func validatePrivateKey(pemData []byte) error {
+	block, _ := pem.Decode(pemData)
+	if block == nil || !strings.Contains(block.Type, expectedKeyHeader) {
+		return fmt.Errorf("Private key is either empty or not a valid key in PEM format")
+	}
+	return nil
+}
+
+func validateSecretKey(secret *corev1.Secret, dataKey string, target interface{}) ([]byte, error) {
+	var secretBytes []byte
+	var ok bool
+	if secretBytes, ok = secret.Data[dataKey]; !ok {
+		return nil, fmt.Errorf("Expected entry %s not found in secret %s", dataKey, secret.Name)
+	}
+	if target == nil {
+		return secretBytes, nil
+	}
+	if err := validateSecretContents(secretBytes, target); err != nil {
+		return secretBytes, nil
+	}
+	return secretBytes, nil
+}
+
+func validateSecretContents(bytes []byte, target interface{}) error {
+	if len(bytes) == 0 {
+		return fmt.Errorf("Secret data is empty")
+	}
+	if err := yaml.Unmarshal(bytes, &target); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -640,7 +640,7 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 
 	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "Secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano", err.Error())
+	assert.Equal(t, "Secret \"oci-bad-secret\" must be created in the \"verrazzano-install\" namespace before installing Verrrazzano", err.Error())
 }
 
 // TestValidateOciDnsSecretUserAuth tests validateOCISecrets
@@ -845,7 +845,7 @@ func TestValidateOciDnsSecretInvalidAPIKey(t *testing.T) {
 
 	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Private key is either empty or not a valid key in PEM format")
+	assert.Contains(t, err.Error(), "Private key in secret \"oci\" is either empty or not a valid key in PEM format")
 }
 
 // TestValidateOciDnsSecretInvalidAuthType tests validateOCISecrets
@@ -1009,7 +1009,7 @@ region=us-ashburn-1
 fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
 key_file=/root/.oci/key
 `
-	runTestFluentdOCIConfig(t, ociConfigBytes, "User OCID not specified in Fluentd OCI config secret fluentd-oci")
+	runTestFluentdOCIConfig(t, ociConfigBytes, "User OCID not specified in Fluentd OCI config secret \"fluentd-oci\"")
 }
 
 // TestValidateFluentdOCISecretNoTenancyOCID tests validateOCISecrets
@@ -1025,7 +1025,7 @@ region=us-ashburn-1
 fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
 key_file=/root/.oci/key
 `
-	runTestFluentdOCIConfig(t, ociConfigBytes, "Tenancy OCID not specified in Fluentd OCI config secret fluentd-oci")
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Tenancy OCID not specified in Fluentd OCI config secret \"fluentd-oci\"")
 }
 
 // TestValidateFluentdOCISecretNoRegion tests validateOCISecrets
@@ -1057,7 +1057,7 @@ region=us-ashburn-1
 fingerprint=
 key_file=/root/.oci/key
 `
-	runTestFluentdOCIConfig(t, ociConfigBytes, "Fingerprint not specified in Fluentd OCI config secret fluentd-oci")
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Fingerprint not specified in Fluentd OCI config secret \"fluentd-oci\"")
 }
 
 func runTestFluentdOCIConfig(t *testing.T, ociConfigBytes string, errorMsg ...string) {
@@ -1130,7 +1130,7 @@ func TestValidateFluentdOCISecretInvalidKeyFormat(t *testing.T) {
 // WHEN validateOCISecrets is called
 // THEN an error is returned from validateOCISecrets
 func TestValidateFluentdOCISecretNoKeyData(t *testing.T) {
-	runFluentdInvalidKeyTest(t, []byte{}, "Private key is either empty or not a valid key in PEM format")
+	runFluentdInvalidKeyTest(t, []byte{}, "Private key in secret \"fluentd-oci\" is either empty or not a valid key in PEM format")
 }
 
 func runFluentdInvalidKeyTest(t *testing.T, key []byte, msgSnippet string) {
@@ -1228,7 +1228,7 @@ key_file=/root/.oci/key
 
 	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("%s not found in secret", fluentdOCISecretPrivateKeyEntry))
+	assert.Contains(t, err.Error(), fmt.Sprintf("Expected entry \"%s\" not found in secret \"%s\"", fluentdOCISecretPrivateKeyEntry, ociSecretName))
 }
 
 // TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
@@ -1272,7 +1272,7 @@ func TestValidateFluentdOCISecretMissingConfigSection(t *testing.T) {
 
 	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Did not find OCI configuration in secret fluentd-oci")
+	assert.Contains(t, err.Error(), "Did not find OCI configuration in secret \"fluentd-oci\"")
 }
 
 // TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
@@ -1302,7 +1302,7 @@ func TestValidateFluentdOCISecretMissingSecret(t *testing.T) {
 
 	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("Secret \"%s\" must be created in the %s namespace", ociSecretName, constants.VerrazzanoInstallNamespace))
+	assert.Contains(t, err.Error(), fmt.Sprintf("Secret \"%s\" must be created in the \"%s\" namespace", ociSecretName, constants.VerrazzanoInstallNamespace))
 }
 
 // TestValidateFluentdOCISecretInvalidKeyPath tests validateOCISecrets
@@ -1318,7 +1318,7 @@ region=us-ashburn-1
 fingerprint=a-fingerprint
 key_file=invalid/path/to/key
 `
-	runTestFluentdOCIConfig(t, ociConfigBytes, "Unexpected or missing value for the Fluentd OCI key file location, should be /root/.oci/key")
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Unexpected or missing value for the Fluentd OCI key file location in secret \"fluentd-oci\", should be \"/root/.oci/key\"")
 }
 
 // Test_validateSecretContents Tests validateSecretContents
@@ -1326,7 +1326,7 @@ key_file=invalid/path/to/key
 // WHEN the YAML bytes are not valid
 // THEN an error is returned
 func Test_validateSecretContents(t *testing.T) {
-	err := validateSecretContents([]byte("foo"), &authData{})
+	err := validateSecretContents("mysecret", []byte("foo"), &authData{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error unmarshaling JSON")
 }
@@ -1336,9 +1336,9 @@ func Test_validateSecretContents(t *testing.T) {
 // WHEN the YAML bytes are empty
 // THEN an error is returned
 func Test_validateSecretContentsEmpty(t *testing.T) {
-	err := validateSecretContents([]byte{}, &authData{})
+	err := validateSecretContents("mysecret", []byte{}, &authData{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Secret data is empty")
+	assert.Contains(t, err.Error(), "Secret \"mysecret\" data is empty")
 }
 
 func newBool(v bool) *bool {

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -1,12 +1,19 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"path/filepath"
 	"testing"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -609,8 +616,8 @@ func TestValidateEnable(t *testing.T) {
 
 // TestValidateOciDnsSecretBadSecret tests that validate fails if a secret in the Verrazzano CR does not exist
 // GIVEN a Verrazzano spec containing a secret that does not exist
-// WHEN ValidateOciDNSSecret is called
-// THEN an error is returned from ValidateOciDNSSecret
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
 func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -631,16 +638,28 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "Secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano", err.Error())
 }
 
-// TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the Verrazzano CR exists
-// GIVEN a Verrazzano spec containing a secret that exists
-// WHEN ValidateOciDNSSecret is called
-// THEN success is returned from ValidateOciDNSSecret
-func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
+// TestValidateOciDnsSecretUserAuth tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS user-auth secret that exists
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateOciDnsSecretUserAuth(t *testing.T) {
+	runValidateOCIDNSAuthTest(t, userPrincipal)
+}
+
+// TestValidateOciDnsSecretInstancePrincipalAuth tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS instance-principal auth secret that exists
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateOciDnsSecretInstancePrincipalAuth(t *testing.T) {
+	runValidateOCIDNSAuthTest(t, instancePrincipal)
+}
+
+func runValidateOCIDNSAuthTest(t *testing.T, authType authenticationType) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
 			Components: ComponentSpec{
@@ -660,23 +679,152 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    authType,
+			Key:         string(key),
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "Error marshalling test data")
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oci",
 			Namespace: constants.VerrazzanoInstallNamespace,
 		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
 	}
 	err = client.Create(context.TODO(), secret)
 	assert.NoError(t, err)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
 	assert.NoError(t, err)
+}
+
+// TestValidateOciDnsSecretInvalidAPIKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a secret that exists but with an invalid private key
+// WHEN validateOCISecrets is called
+// THEN an error returned from validateOCISecrets
+func TestValidateOciDnsSecretInvalidAPIKey(t *testing.T) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    userPrincipal,
+			Key:         "foo",
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "Error marshalling test data")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Private key is either empty or not a valid key in PEM format")
+}
+
+// TestValidateOciDnsSecretInvalidAuthType tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a secret that exists but with an invalid OCI Auth type
+// WHEN validateOCISecrets is called
+// THEN an error returned from validateOCISecrets
+func TestValidateOciDnsSecretInvalidAuthType(t *testing.T) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    "InvalidAuthType",
+			Key:         string(key),
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "error marshalling test data")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("Authtype \"InvalidAuthType\" in OCI secret must be either '%s' or '%s'", userPrincipal, instancePrincipal))
 }
 
 // TestValidateOciDnsSecretNoOci tests that validate succeeds if the DNS component is not OCI
 // GIVEN a Verrazzano spec containing a wildcard DNS component
-// WHEN ValidateOciDNSSecret is called
-// THEN success is returned from ValidateOciDNSSecret
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
 func TestValidateOciDnsSecretNoOci(t *testing.T) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -697,8 +845,417 @@ func TestValidateOciDnsSecretNoOci(t *testing.T) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
 	assert.NoError(t, err)
+}
+
+// TestValidateFluentdOCISecretGoodSecretWithPassphrase tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a valid Fluentd OCI secret that exists with a passphrase
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateFluentdOCISecretGoodSecretWithPassphrase1(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+pass_phrase=apassphrase
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes)
+}
+
+// TestValidateFluentdOCISecretGoodSecretNoPassphrase tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a valid Fluentd OCI secret that exists without a passphrase
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateFluentdOCISecretGoodSecretNoPassphrase(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes)
+}
+
+// TestValidateFluentdOCISecretBadProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with a bad profile key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretBadProfileKey(t *testing.T) {
+	ociConfigBytes := `
+[blah]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "configuration file did not contain profile: DEFAULT")
+}
+
+// TestValidateFluentdOCISecretNoProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with no OCI profile key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoProfileKey(t *testing.T) {
+	ociConfigBytes := `
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "configuration file did not contain profile: DEFAULT")
+}
+
+// TestValidateFluentdOCISecretNoProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty user OCID
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoUserOCID(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "User OCID not specified in Fluentd OCI config secret fluentd-oci")
+}
+
+// TestValidateFluentdOCISecretNoTenancyOCID tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty tenancy OCID
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoTenancyOCID(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Tenancy OCID not specified in Fluentd OCI config secret fluentd-oci")
+}
+
+// TestValidateFluentdOCISecretNoRegion tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty region name
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoRegion(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "region can not be empty or have spaces")
+}
+
+// TestValidateFluentdOCISecretNoFingerprint tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty key fingerprint
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoFingerprint(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Fingerprint not specified in Fluentd OCI config secret fluentd-oci")
+}
+
+func runTestFluentdOCIConfig(t *testing.T, ociConfigBytes string, errorMsg ...string) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry:     []byte(ociConfigBytes),
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	if len(errorMsg) > 0 {
+		assert.Error(t, err)
+		if err != nil {
+			assert.Contains(t, err.Error(), errorMsg[0])
+		}
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
+// TestValidateFluentdOCISecretInvalidKeyType tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has an invalid key type
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyType(t *testing.T) {
+	key, err := generateTestPrivateKeyWithType("INVALID KEY TYPE")
+	assert.NoError(t, err)
+	runFluentdInvalidKeyTest(t, key, "not a valid key")
+}
+
+// TestValidateFluentdOCISecretInvalidKeyFormat tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret with a key not in PEM format
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyFormat(t *testing.T) {
+	runFluentdInvalidKeyTest(t, []byte("foo"), "not a valid key")
+}
+
+// TestValidateFluentdOCISecretNoKeyData tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret with a empty key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoKeyData(t *testing.T) {
+	runFluentdInvalidKeyTest(t, []byte{}, "Private key is either empty or not a valid key in PEM format")
+}
+
+func runFluentdInvalidKeyTest(t *testing.T, key []byte, msgSnippet string) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=/root/.oci/key
+`
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry:     []byte(ociConfigBytes),
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), msgSnippet)
+}
+
+// TestValidateFluentdOCISecretMissingKeySection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has a missing API key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingKeySection(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=/root/.oci/key
+`
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry: []byte(ociConfigBytes),
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("%s not found in secret", fluentdOCISecretPrivateKeyEntry))
+}
+
+// TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has a missing OCI Config key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingConfigSection(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Did not find OCI configuration in secret fluentd-oci")
+}
+
+// TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that does not exist
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingSecret(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("Secret \"%s\" must be created in the %s namespace", ociSecretName, constants.VerrazzanoInstallNamespace))
+}
+
+// TestValidateFluentdOCISecretInvalidKeyPath tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that an incorrect key path
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyPath(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=invalid/path/to/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Unexpected or missing value for the Fluentd OCI key file location, should be /root/.oci/key")
+}
+
+// Test_validateSecretContents Tests validateSecretContents
+// GIVEN a call to validateSecretContents
+// WHEN the YAML bytes are not valid
+// THEN an error is returned
+func Test_validateSecretContents(t *testing.T) {
+	err := validateSecretContents([]byte("foo"), &authData{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error unmarshaling JSON")
+}
+
+// Test_validateSecretContentsEmpty Tests validateSecretContents
+// GIVEN a call to validateSecretContents
+// WHEN the YAML bytes are empty
+// THEN an error is returned
+func Test_validateSecretContentsEmpty(t *testing.T) {
+	err := validateSecretContents([]byte{}, &authData{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Secret data is empty")
 }
 
 func newBool(v bool) *bool {
@@ -784,4 +1341,32 @@ func TestValidateProfileDevProfile(t *testing.T) {
 // THEN an error is returned
 func TestValidateProfileInvalidProfile(t *testing.T) {
 	assert.Error(t, ValidateProfile("wrong-profile"))
+}
+
+var testKey = []byte{}
+
+// Generate RSA for testing.
+func generateTestPrivateKey() ([]byte, error) {
+	var err error
+	if len(testKey) == 0 { // cache the test key, we only need one valid one and it can be expensive
+		testKey, err = generateTestPrivateKeyWithType("RSA PRIVATE KEY")
+	}
+	return testKey, err
+}
+
+// Generate RSA for testing with the specified type
+func generateTestPrivateKeyWithType(keyType string) ([]byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// Encode private key to PKCS#1 ASN.1 PEM.
+	keyPEM := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  keyType,
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		},
+	)
+	return keyPEM, nil
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
@@ -63,8 +63,7 @@ func (v *Verrazzano) ValidateCreate() error {
 		return err
 	}
 
-	// Validate that the OCI DNS secret required by install exists
-	if err := ValidateOciDNSSecret(client, &v.Spec); err != nil {
+	if err := validateOCISecrets(client, &v.Spec); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

Add validation in the VPO validating wehbook for the Fluentd OCI config secret if present in the Verrazzano CR.

Fixes VZ-4616.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
