### PR TITLE
VZ-4627 update the buffer size to eliminate large ES request warning

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -1239,7 +1239,7 @@ data:
         # Posts from Fluentd can require more than the default 1m max body size
         client_max_body_size {{ .MaxRequestSize }};
         proxy_buffer_size {{ .ProxyBufferSize }};
-        client_body_buffer_size 256k
+        client_body_buffer_size 256k;
 
         #keepalive_timeout  0;
         keepalive_timeout  65;

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-authproxy-configmap.yaml
@@ -1239,6 +1239,7 @@ data:
         # Posts from Fluentd can require more than the default 1m max body size
         client_max_body_size {{ .MaxRequestSize }};
         proxy_buffer_size {{ .ProxyBufferSize }};
+        client_body_buffer_size 256k
 
         #keepalive_timeout  0;
         keepalive_timeout  65;


### PR DESCRIPTION
# Description

After discussion with the team, it seems important to eliminate load on ES by reducing the amount of log messages in the AuthProxy. This includes updating the buffer size to 256Kb. We will keep an eye on this with load testing that will hopefully tell us how this change affects performance.

Fixes VZ-4627

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
