### PR TITLE
No JIRA: Fix bug in PR ticket commits pipeline, escape " in PR title

### DIFF
--- a/ci/ticket-commits/JenkinsfilePullRequests
+++ b/ci/ticket-commits/JenkinsfilePullRequests
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 pipeline {
@@ -47,8 +47,11 @@ pipeline {
                 script {
                     // Do not add a comment to the JIRA if an existing pull request is being updated
                     if (currentBuild.changeSets.size() == 0) {
+                        // Escape double quotes in the PR title
+                        env.PR_TITLE = sh(script:'echo "${CHANGE_TITLE}" | sed \'s/"/\\"/g\'', returnStdout: true).trim()
                         sh """
-                            verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.CHANGE_TITLE}" --pr-target "${env.CHANGE_TARGET}" --token unused --jira-env=prod
+                            echo "PR title: ${env.PR_TITLE}"
+                            verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.PR_TITLE}" --pr-target "${env.CHANGE_TARGET}" --token unused --jira-env=prod
                         """
                     } else {
                         echo "Existing pull request updated, skipping update of JIRA ticket"


### PR DESCRIPTION
# Description

The PR ticket commits job fails if the PR title contains unbalanced double quotes. I fixed the Jenkinsfile to escape double quotes in the PR title before passing the string to the helper.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
