### PR TITLE
VZ-4619 vpo install logging changes.

### DIFF
--- a/application-operator/mocks/controller_manager_mock.go
+++ b/application-operator/mocks/controller_manager_mock.go
@@ -9,14 +9,15 @@
 package mocks
 
 import (
+	http "net/http"
+	reflect "reflect"
+
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	record "k8s.io/client-go/tools/record"
-	http "net/http"
-	reflect "reflect"
 	cache "sigs.k8s.io/controller-runtime/pkg/cache"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -204,7 +205,7 @@ func (mr *MockManagerMockRecorder) GetFieldIndexer() *gomock.Call {
 // GetLogger mocks base method
 func (m *MockManager) GetLogger() logr.Logger {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogger")
+	ret := m.ctrl.Call(m, "EnsureLogger")
 	ret0, _ := ret[0].(logr.Logger)
 	return ret0
 }
@@ -212,7 +213,7 @@ func (m *MockManager) GetLogger() logr.Logger {
 // GetLogger indicates an expected call of GetLogger
 func (mr *MockManagerMockRecorder) GetLogger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
 }
 
 // GetRESTMapper mocks base method

--- a/application-operator/mocks/controller_manager_mock.go
+++ b/application-operator/mocks/controller_manager_mock.go
@@ -9,15 +9,14 @@
 package mocks
 
 import (
-	http "net/http"
-	reflect "reflect"
-
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	record "k8s.io/client-go/tools/record"
+	http "net/http"
+	reflect "reflect"
 	cache "sigs.k8s.io/controller-runtime/pkg/cache"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	healthz "sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -205,7 +204,7 @@ func (mr *MockManagerMockRecorder) GetFieldIndexer() *gomock.Call {
 // GetLogger mocks base method
 func (m *MockManager) GetLogger() logr.Logger {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureLogger")
+	ret := m.ctrl.Call(m, "GetLogger")
 	ret0, _ := ret[0].(logr.Logger)
 	return ret0
 }
@@ -213,7 +212,7 @@ func (m *MockManager) GetLogger() logr.Logger {
 // GetLogger indicates an expected call of GetLogger
 func (mr *MockManagerMockRecorder) GetLogger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
 }
 
 // GetRESTMapper mocks base method

--- a/image-patch-operator/mocks/controller_manager_mock.go
+++ b/image-patch-operator/mocks/controller_manager_mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 

--- a/image-patch-operator/mocks/controller_manager_mock.go
+++ b/image-patch-operator/mocks/controller_manager_mock.go
@@ -205,7 +205,7 @@ func (mr *MockManagerMockRecorder) GetFieldIndexer() *gomock.Call {
 // GetLogger mocks base method
 func (m *MockManager) GetLogger() logr.Logger {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureLogger")
+	ret := m.ctrl.Call(m, "GetLogger")
 	ret0, _ := ret[0].(logr.Logger)
 	return ret0
 }
@@ -213,7 +213,7 @@ func (m *MockManager) GetLogger() logr.Logger {
 // GetLogger indicates an expected call of GetLogger
 func (mr *MockManagerMockRecorder) GetLogger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
 }
 
 // GetRESTMapper mocks base method

--- a/image-patch-operator/mocks/controller_manager_mock.go
+++ b/image-patch-operator/mocks/controller_manager_mock.go
@@ -205,7 +205,7 @@ func (mr *MockManagerMockRecorder) GetFieldIndexer() *gomock.Call {
 // GetLogger mocks base method
 func (m *MockManager) GetLogger() logr.Logger {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogger")
+	ret := m.ctrl.Call(m, "EnsureLogger")
 	ret0, _ := ret[0].(logr.Logger)
 	return ret0
 }
@@ -213,7 +213,7 @@ func (m *MockManager) GetLogger() logr.Logger {
 // GetLogger indicates an expected call of GetLogger
 func (mr *MockManagerMockRecorder) GetLogger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureLogger", reflect.TypeOf((*MockManager)(nil).GetLogger))
 }
 
 // GetRESTMapper mocks base method

--- a/image-patch-operator/mocks/controller_manager_mock.go
+++ b/image-patch-operator/mocks/controller_manager_mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -4,8 +4,9 @@ package spi
 
 import (
 	"fmt"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"strings"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 // RetryableError an error that can be used to indicate to a controller that a requeue is needed, with an optional custom result

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzos "github.com/verrazzano/verrazzano/pkg/os"
 
 	"go.uber.org/zap"
@@ -63,7 +64,7 @@ func SetDefaultChartStateFunction() {
 }
 
 // GetValues will run 'helm get values' command and return the output from the command.
-func GetValues(log *zap.SugaredLogger, releaseName string, namespace string) ([]byte, error) {
+func GetValues(log vzlog.VerrazzanoLogger, releaseName string, namespace string) ([]byte, error) {
 	// Helm get values command will get the current set values for the installed chart.
 	// The output will be used as input to the helm upgrade command.
 	args := []string{"get", "values", releaseName}
@@ -88,7 +89,7 @@ func GetValues(log *zap.SugaredLogger, releaseName string, namespace string) ([]
 
 // Upgrade will upgrade a Helm release with the specified charts.  The override files array
 // are in order with the first files in the array have lower precedence than latter files.
-func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides HelmOverrides) (stdout []byte, stderr []byte, err error) {
+func Upgrade(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides HelmOverrides) (stdout []byte, stderr []byte, err error) {
 	// Helm upgrade command will apply the new chart, but use all the existing
 	// overrides that we used during the install.
 	args := []string{"--install"}
@@ -129,7 +130,7 @@ func Upgrade(log *zap.SugaredLogger, releaseName string, namespace string, chart
 }
 
 // Uninstall will uninstall the release in the specified namespace  using helm uninstall
-func Uninstall(log *zap.SugaredLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error) {
+func Uninstall(log vzlog.VerrazzanoLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error) {
 	// Helm upgrade command will apply the new chart, but use all the existing
 	// overrides that we used during the install.
 	args := []string{}
@@ -143,7 +144,7 @@ func Uninstall(log *zap.SugaredLogger, releaseName string, namespace string, dry
 }
 
 // runHelm is a helper function to execute the helm CLI and return a result
-func runHelm(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, operation string, wait bool, args []string, dryRun bool) (stdout []byte, stderr []byte, err error) {
+func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, operation string, wait bool, args []string, dryRun bool) (stdout []byte, stderr []byte, err error) {
 	cmdArgs := []string{operation, releaseName}
 	if len(chartDir) > 0 {
 		cmdArgs = append(cmdArgs, chartDir)

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -169,7 +169,7 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 
 		// mask sensitive data before logging
 		cmdStr := maskSensitiveData(cmd.String())
-		log.Infof("Running Helm command, operation %s for release %s", operation, releaseName)
+		log.Infof("Running Helm command for release %s", releaseName)
 
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -184,8 +184,6 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %s of %s", operation, releaseName, i+1, maxRetry)
 	}
 
-	//  Log upgrade output
-	log.Infof("Successfully ran Helm command for operation %s on release %s", operation, releaseName)
 	return stdout, stderr, nil
 }
 

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -168,7 +168,7 @@ func runHelm(log *zap.SugaredLogger, releaseName string, namespace string, chart
 
 		// mask sensitive data before logging
 		cmdStr := maskSensitiveData(cmd.String())
-		log.Infof("Running Helm command: %s", cmdStr)
+		log.Infof("Running Helm command for operation %s: %s", cmdStr)
 
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {
@@ -176,14 +176,15 @@ func runHelm(log *zap.SugaredLogger, releaseName string, namespace string, chart
 			break
 		}
 		if i == 1 || i == maxRetry {
-			log.Errorf("Failed running Helm command for operation %s and release %s: stderr %s", operation, releaseName, string(stderr))
+			log.Errorf("Failed running Helm command for operation %s and release %s: stderr is %s",
+				operation, releaseName, string(stderr))
 			return stdout, stderr, err
 		}
 		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %s of %s", operation, releaseName, i+1, maxRetry)
 	}
 
 	//  Log upgrade output
-	log.Debugf("helm upgrade succeeded for %s", releaseName)
+	log.Infof("Successfully ran Helm command for operation %s on release %s", operation, releaseName)
 	return stdout, stderr, nil
 }
 

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -169,7 +169,7 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 
 		// mask sensitive data before logging
 		cmdStr := maskSensitiveData(cmd.String())
-		log.Infof("Running Helm command for operation %s: %s", cmdStr)
+		log.Infof("Running Helm command, operation %s for release %s", operation, releaseName)
 
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {
@@ -177,8 +177,8 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 			break
 		}
 		if i == 1 || i == maxRetry {
-			log.Errorf("Failed running Helm command for operation %s and release %s: stderr is %s",
-				operation, releaseName, string(stderr))
+			log.Errorf("Failed running Helm command for operation %s and release %s: command %s: stderr %s",
+				operation, releaseName, cmdStr, string(stderr))
 			return stdout, stderr, err
 		}
 		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %s of %s", operation, releaseName, i+1, maxRetry)

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -169,7 +169,7 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 
 		// mask sensitive data before logging
 		cmdStr := maskSensitiveData(cmd.String())
-		log.Infof("Running Helm command for release %s", releaseName)
+		log.Infof("Running Helm for release %s, command: %s", releaseName, cmdStr)
 
 		stdout, stderr, err = runner.Run(cmd)
 		if err == nil {
@@ -177,8 +177,8 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 			break
 		}
 		if i == 1 || i == maxRetry {
-			log.Errorf("Failed running Helm command for operation %s and release %s: command %s: stderr %s",
-				operation, releaseName, cmdStr, string(stderr))
+			log.Errorf("Failed running Helm command for release %s: stderr %s",
+				releaseName, string(stderr))
 			return stdout, stderr, err
 		}
 		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %s of %s", operation, releaseName, i+1, maxRetry)

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 )
 
 const ns = "my_namespace"
@@ -61,7 +61,7 @@ func TestGetValues(t *testing.T) {
 	SetCmdRunner(getValuesRunner{t: t})
 	defer SetDefaultRunner()
 
-	stdout, err := GetValues(zap.S(), release, ns)
+	stdout, err := GetValues(vzlog.DefaultLogger(), release, ns)
 	assert.NoError(err, "GetValues returned an error")
 	assert.NotZero(stdout, "GetValues stdout should not be empty")
 }
@@ -86,7 +86,7 @@ func TestUpgrade(t *testing.T) {
 	})
 	defer SetDefaultRunner()
 
-	stdout, stderr, err := Upgrade(zap.S(), release, ns, chartdir, false, false, overrides)
+	stdout, stderr, err := Upgrade(vzlog.DefaultLogger(), release, ns, chartdir, false, false, overrides)
 	assert.NoError(err, "Upgrade returned an error")
 	assert.Len(stderr, 0, "Upgrade stderr should be empty")
 	assert.NotZero(stdout, "Upgrade stdout should not be empty")
@@ -114,7 +114,7 @@ func TestUpgradeCustomFileOverrides(t *testing.T) {
 	})
 	defer SetDefaultRunner()
 
-	stdout, stderr, err := Upgrade(zap.S(), release, ns, chartdir, false, false, overrides)
+	stdout, stderr, err := Upgrade(vzlog.DefaultLogger(), release, ns, chartdir, false, false, overrides)
 	assert.NoError(err, "Upgrade returned an error")
 	assert.Len(stderr, 0, "Upgrade stderr should be empty")
 	assert.NotZero(stdout, "Upgrade stdout should not be empty")
@@ -130,7 +130,7 @@ func TestUpgradeFail(t *testing.T) {
 	SetCmdRunner(badRunner{t: t})
 	defer SetDefaultRunner()
 
-	stdout, stderr, err := Upgrade(zap.S(), release, ns, "", false, false, overrides)
+	stdout, stderr, err := Upgrade(vzlog.DefaultLogger(), release, ns, "", false, false, overrides)
 	assert.Error(err, "Upgrade should have returned an error")
 	assert.Len(stdout, 0, "Upgrade stdout should be empty")
 	assert.NotZero(stderr, "Upgrade stderr should not be empty")
@@ -150,7 +150,7 @@ func TestUninstall(t *testing.T) {
 		err:    nil,
 	})
 	defer SetDefaultRunner()
-	_, _, err := Uninstall(zap.S(), "weblogic-operator", "verrazzano-system", false)
+	_, _, err := Uninstall(vzlog.DefaultLogger(), "weblogic-operator", "verrazzano-system", false)
 	assert.NoError(t, err)
 }
 
@@ -168,7 +168,7 @@ func TestUninstallError(t *testing.T) {
 		err:    fmt.Errorf("Unexpected uninstall error"),
 	})
 	defer SetDefaultRunner()
-	_, _, err := Uninstall(zap.S(), "weblogic-operator", "verrazzano-system", false)
+	_, _, err := Uninstall(vzlog.DefaultLogger(), "weblogic-operator", "verrazzano-system", false)
 	assert.Error(t, err)
 }
 

--- a/pkg/log/vzlog/doc.go
+++ b/pkg/log/vzlog/doc.go
@@ -21,7 +21,19 @@ package vzlog
 // then we delete the logging context. So, if you changed the resource foo an hour later,
 // and the same code path is executed, then the message will be displayed once, for the new reconcile session.
 //
-// This logger is initialized with the zap.SugaredLogger and then used instead of the zap logger directly.
+// The main purpose of this package is to provide logging during Kubernetes resource reconcilation.  For that
+// use case, use the EnsureResourceLogger method as follows.  See the function descrition for more details.
+//
+//   	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+//		Name:           vz.Name,
+//		Namespace:      vz.Namespace,
+//		ID:             string(vz.UID),
+//		Generation:     vz.Generation,
+//		ControllerName: "verrazzano",
+//	})
+//
+// For other use cases, you can call the lower level functions to explicitly create a LogContext and VerrazzanoLogger
+// as described here. The logger is initialized with the zap.SugaredLogger and then used instead of the zap logger directly.
 // The same SugaredLogger calls can be made: Debug, Debugf, Info, Infof, Error, and Errorf.  The
 // two new calls are Progress and Progressf. The S() method will return the underlying SugaredLogger.
 // The following psuedo-code shows how this should be used:

--- a/pkg/log/vzlog/doc.go
+++ b/pkg/log/vzlog/doc.go
@@ -26,7 +26,7 @@ package vzlog
 // two new calls are Progress and Progressf. The S() method will return the underlying SugaredLogger.
 // The following psuedo-code shows how this should be used:
 //
-//   log := vzlog.GetContext(key).GetLogger("default", zaplog, zaplog)
+//   log := vzlog.EnsureContext(key).EnsureLogger("default", zaplog, zaplog)
 //
 // Display info and errors as usual
 //   p.Errorf(...)
@@ -36,11 +36,11 @@ package vzlog
 //   p.Progress("Reconciling namespace/resource")
 //
 // Display Keycloak progress
-//   cl := l.GetContext().GetLogger("Keycloak")
+//   cl := l.EnsureContext().EnsureLogger("Keycloak")
 //   cl.Progress("Waiting for Verrazzano secret")
 //   cl.Errorf(...)
 //
 // Display Istio progress
-//   cl := l.GetContext().GetLogger("Istio")
+//   cl := l.EnsureContext().EnsureLogger("Istio")
 //   cl.Progress("Waiting for Istio to start")
 //   cl.Errorf(...)

--- a/pkg/log/vzlog/doc.go
+++ b/pkg/log/vzlog/doc.go
@@ -15,12 +15,18 @@ package vzlog
 // is logged, that old message will never be displayed again.  This allows controllers to log
 // informative progress messages, without overwhelming the log files with superfluous information.
 //
+// The 'Once' and 'Progress' logging is done in the context of a reconcile session for a resource change.
+// This means if you change resource foo, and the controller reconciler is called 100 times, A call to log.Once will
+// log the message once.  When the resource foo is finally reconciled (return ctrl.Result{}, nil to controller runtime),
+// then we delete the logging context. So, if you changed the resource foo an hour later,
+// and the same code path is executed, then the message will be displayed once, for the new reconcile session.
+//
 // This logger is initialized with the zap.SugaredLogger and then used instead of the zap logger directly.
 // The same SugaredLogger calls can be made: Debug, Debugf, Info, Infof, Error, and Errorf.  The
 // two new calls are Progress and Progressf. The S() method will return the underlying SugaredLogger.
 // The following psuedo-code shows how this should be used:
 //
-//   log := vzlog.EnsureLogContext(key).EnsureLogger("default", zaplog, zaplog)
+//   log := vzlog.GetContext(key).GetLogger("default", zaplog, zaplog)
 //
 // Display info and errors as usual
 //   p.Errorf(...)
@@ -30,11 +36,11 @@ package vzlog
 //   p.Progress("Reconciling namespace/resource")
 //
 // Display Keycloak progress
-//   cl := l.GetContext().EnsureLogger("Keycloak")
+//   cl := l.GetContext().GetLogger("Keycloak")
 //   cl.Progress("Waiting for Verrazzano secret")
 //   cl.Errorf(...)
 //
 // Display Istio progress
-//   cl := l.GetContext().EnsureLogger("Istio")
+//   cl := l.GetContext().GetLogger("Istio")
 //   cl.Progress("Waiting for Istio to start")
 //   cl.Errorf(...)

--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -83,7 +83,7 @@ type VerrazzanoLogger interface {
 	ProgressLogger
 	SetZapLogger(zap *zap.SugaredLogger)
 	GetZapLogger() *zap.SugaredLogger
-	GetResourceZapLogger() *zap.SugaredLogger
+	GetRootZapLogger() *zap.SugaredLogger
 	GetContext() *LogContext
 }
 
@@ -96,8 +96,8 @@ type LogContext struct {
 	// Generation is the generation of the resource being logged
 	Generation int64
 
-	// resourceZapLogger is the zap SugaredLogger for the resource. Component lgogers are derived from this.
-	resourceZapLogger *zap.SugaredLogger
+	// RootZapLogger is the zap SugaredLogger for the resource. Component loggers are derived from this.
+	RootZapLogger *zap.SugaredLogger
 }
 
 // verrazzanoLogger implements the VerrazzanoLogger interface
@@ -172,7 +172,7 @@ func EnsureResourceLogger(config *ResourceConfig) (VerrazzanoLogger, error) {
 		context = EnsureContext(config.ID)
 	}
 	context.Generation = config.Generation
-	context.resourceZapLogger = zaplog
+	context.RootZapLogger = zaplog
 
 	// Finally, get the logger using this context.
 	logger := context.EnsureLogger("default", zaplog, zaplog)
@@ -222,6 +222,9 @@ func (c *LogContext) EnsureLogger(key string, sLogger SugaredLogger, zap *zap.Su
 	// with clauses
 	log.sLogger = sLogger
 	log.zapLogger = zap
+	if log.context.RootZapLogger == nil {
+		log.context.RootZapLogger = zap
+	}
 
 	return log
 }
@@ -311,9 +314,9 @@ func (v *verrazzanoLogger) GetZapLogger() *zap.SugaredLogger {
 	return v.zapLogger
 }
 
-// GetResourceZapLogger gets the resource zap logger at the context level
-func (v *verrazzanoLogger) GetResourceZapLogger() *zap.SugaredLogger {
-	return v.context.resourceZapLogger
+// GetRootZapLogger gets the root zap logger at the context level
+func (v *verrazzanoLogger) GetRootZapLogger() *zap.SugaredLogger {
+	return v.context.RootZapLogger
 }
 
 // EnsureContext gets the logger context

--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -309,7 +309,7 @@ func (v *verrazzanoLogger) SetZapLogger(zap *zap.SugaredLogger) {
 	v.sLogger = zap
 }
 
-// Clone zap logger gets a clone of the zap logger
+// GetZapLogger zap logger gets a clone of the zap logger
 func (v *verrazzanoLogger) GetZapLogger() *zap.SugaredLogger {
 	return v.zapLogger
 }

--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -83,6 +83,7 @@ type VerrazzanoLogger interface {
 	ProgressLogger
 	SetZapLogger(zap *zap.SugaredLogger)
 	GetZapLogger() *zap.SugaredLogger
+	GetResourceZapLogger() *zap.SugaredLogger
 	GetContext() *LogContext
 }
 
@@ -94,6 +95,9 @@ type LogContext struct {
 
 	// Generation is the generation of the resource being logged
 	Generation int64
+
+	// resourceZapLogger is the zap SugaredLogger for the resource. Component lgogers are derived from this.
+	resourceZapLogger *zap.SugaredLogger
 }
 
 // verrazzanoLogger implements the VerrazzanoLogger interface
@@ -168,6 +172,7 @@ func EnsureResourceLogger(config *ResourceConfig) (VerrazzanoLogger, error) {
 		context = EnsureContext(config.ID)
 	}
 	context.Generation = config.Generation
+	context.resourceZapLogger = zaplog
 
 	// Finally, get the logger using this context.
 	logger := context.EnsureLogger("default", zaplog, zaplog)
@@ -301,9 +306,14 @@ func (v *verrazzanoLogger) SetZapLogger(zap *zap.SugaredLogger) {
 	v.sLogger = zap
 }
 
-// GetZapLogger gets the zap logger
+// Clone zap logger gets a clone of the zap logger
 func (v *verrazzanoLogger) GetZapLogger() *zap.SugaredLogger {
 	return v.zapLogger
+}
+
+// GetResourceZapLogger gets the resource zap logger at the context level
+func (v *verrazzanoLogger) GetResourceZapLogger() *zap.SugaredLogger {
+	return v.context.resourceZapLogger
 }
 
 // EnsureContext gets the logger context

--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -131,12 +131,12 @@ type lastLog struct {
 	msgLogged string
 }
 
-// Ensure the default logger exists.  This is typically used for testing
+// DefaultLogger ensures the default logger exists.  This is typically used for testing
 func DefaultLogger() VerrazzanoLogger {
 	return EnsureContext("default").EnsureLogger("default", zap.S(), zap.S())
 }
 
-// Ensure a logger exists for a specific generation of a Kubernetes resource.
+// EnsureResourceLogger ensures that a logger exists for a specific generation of a Kubernetes resource.
 // When a resource is getting reconciled, the status may frequently get updated during
 // the reconciliation.  This is the case for the Verrazzano resource.  As a result,
 // the controller-runtime queue gets filled with updated instances of a resource that

--- a/pkg/log/vzlog/vzlog_test.go
+++ b/pkg/log/vzlog/vzlog_test.go
@@ -5,11 +5,12 @@ package vzlog
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log"
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
-	"time"
 
 	"go.uber.org/zap"
 )
@@ -30,8 +31,8 @@ func TestLog(t *testing.T) {
 	msg := "test1"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test"
-	rl := EnsureLogContext(rKey)
-	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(3)
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(3)
 
 	// 5 calls to log should result in only 2 log messages being written
 	// since the frequency is 3 secs
@@ -44,6 +45,78 @@ func TestLog(t *testing.T) {
 	DeleteLogContext(rKey)
 }
 
+// TestLogRepeat tests the ProgressLogger function ignore repeated logs
+// GIVEN a ProgressLogger with a frequency of 2 seconds
+// WHEN log is called 5 times with 1 message and no sleep
+// THEN ensure that 1 message is logged
+func TestLogRepeat(t *testing.T) {
+	msg := "test1"
+	logger := fakeLogger{expectedMsg: msg}
+	const rKey = "testns/test2"
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
+
+	// Calls to log should result in only 2 log messages being written
+	l.Progress(msg)
+	l.Progress(msg)
+	l.Progress(msg)
+	l.Progress(msg)
+	l.Progress(msg)
+	assert.Equal(t, 1, logger.count)
+	assert.Equal(t, logger.actualMsg, msg)
+	DeleteLogContext(rKey)
+}
+
+// TestHistory tests the ProgressLogger function ignore previous progrsss messages
+// GIVEN a ProgressLogger with a frequency of 2 seconds
+// WHEN log is called 5 times with 2 message using repeats, and no sleep
+// THEN ensure that 2 messages is logged
+func TestHistory(t *testing.T) {
+	msg := "test1"
+	msg2 := "test2"
+	logger := fakeLogger{expectedMsg: msg}
+	const rKey = "testns/test2"
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
+
+	// Calls to log should result in only 2 log messages being written
+	l.Progress(msg)
+	l.Progress(msg)
+	l.Progress(msg)
+	l.Progress(msg2)
+	l.Progress(msg2)
+	l.Progress(msg)
+	l.Progress(msg2)
+	l.Progress(msg)
+	assert.Equal(t, 2, logger.count)
+	assert.Equal(t, logger.actualMsg, msg2)
+	DeleteLogContext(rKey)
+}
+
+// TestHistoryOnce tests the ProgressLogger function ignore previous once messages
+// GIVEN a ProgressLogger with a frequency of 2 seconds
+// WHEN log is called 5 times with 2 message using repeats, and no sleep
+// THEN ensure that 2 messages is logged
+func TestHistoryOnce(t *testing.T) {
+	msg := "test1"
+	msg2 := "test2"
+	logger := fakeLogger{expectedMsg: msg}
+	const rKey = "testns/test2"
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S())
+
+	// Calls to log should result in only 2 log messages being written
+	l.Once(msg)
+	l.Once(msg)
+	l.Once(msg2)
+	l.Once(msg)
+	l.Once(msg2)
+	l.Once(msg)
+	assert.Equal(t, 2, logger.count)
+	assert.Equal(t, logger.actualMsg, msg2)
+	DeleteLogContext(rKey)
+}
+
 // TestLogNewMsg tests the ProgressLogger function periodic logging
 // GIVEN a ProgressLogger with a frequency of 2 seconds
 // WHEN log is called 5 times with 2 different message
@@ -53,8 +126,8 @@ func TestLogNewMsg(t *testing.T) {
 	msg2 := "test2"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test2"
-	rl := EnsureLogContext(rKey)
-	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(2)
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
 
 	// Calls to log should result in only 2 log messages being written
 	l.Progress(msg)
@@ -77,23 +150,23 @@ func TestLogFormat(t *testing.T) {
 	logger := fakeLogger{}
 	logger.expectedMsg = fmt.Sprintf(template, inStr)
 	const rKey = "testns/test3"
-	rl := EnsureLogContext(rKey)
-	l := rl.EnsureLogger("comp1", &logger, zap.S())
+	rl := GetContext(rKey)
+	l := rl.GetLogger("comp1", &logger, zap.S())
 	l.Progressf(template, inStr)
 	assert.Equal(t, 1, logger.count)
 	assert.Equal(t, logger.actualMsg, logger.expectedMsg)
 	DeleteLogContext(rKey)
 }
 
-// TestMultipleContexts tests the EnsureLogContext and DeleteLogContext
-// WHEN EnsureLogContext is called multiple times
+// TestMultipleContexts tests the GetContext and DeleteLogContext
+// WHEN GetContext is called multiple times
 // THEN ensure that the context map has an entry for each context and that
 //   the context map is empty when they the contexts are deleted
 func TestMultipleContexts(t *testing.T) {
 	const rKey1 = "k1"
 	const rKey2 = "k2"
-	c1 := EnsureLogContext(rKey1)
-	c2 := EnsureLogContext(rKey2)
+	c1 := GetContext(rKey1)
+	c2 := GetContext(rKey2)
 
 	assert.Equal(t, 2, len(LogContextMap))
 	c1Actual := LogContextMap[rKey1]
@@ -107,7 +180,7 @@ func TestMultipleContexts(t *testing.T) {
 
 // TestZap tests the zap SugaredLogger
 // GIVEN a zap SugaredLogger
-// WHEN EnsureLogContext is called with the SugaredLogger
+// WHEN GetContext is called with the SugaredLogger
 // THEN ensure that the ProgressMessage can be called
 func TestZap(t *testing.T) {
 	testOpts := kzap.Options{}
@@ -115,7 +188,7 @@ func TestZap(t *testing.T) {
 	testOpts.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	log.InitLogs(testOpts)
 	const rKey = "testns/test3"
-	l := EnsureLogContext(rKey).EnsureLogger("test", zap.S(), zap.S())
+	l := GetContext(rKey).GetLogger("test", zap.S(), zap.S())
 	l.Progress("testmsg")
 	DeleteLogContext(rKey)
 }

--- a/pkg/log/vzlog/vzlog_test.go
+++ b/pkg/log/vzlog/vzlog_test.go
@@ -31,8 +31,8 @@ func TestLog(t *testing.T) {
 	msg := "test1"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(3)
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(3)
 
 	// 5 calls to log should result in only 2 log messages being written
 	// since the frequency is 3 secs
@@ -53,8 +53,8 @@ func TestLogRepeat(t *testing.T) {
 	msg := "test1"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test2"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(2)
 
 	// Calls to log should result in only 2 log messages being written
 	l.Progress(msg)
@@ -76,8 +76,8 @@ func TestHistory(t *testing.T) {
 	msg2 := "test2"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test2"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(2)
 
 	// Calls to log should result in only 2 log messages being written
 	l.Progress(msg)
@@ -102,8 +102,8 @@ func TestHistoryOnce(t *testing.T) {
 	msg2 := "test2"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test2"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S())
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S())
 
 	// Calls to log should result in only 2 log messages being written
 	l.Once(msg)
@@ -126,8 +126,8 @@ func TestLogNewMsg(t *testing.T) {
 	msg2 := "test2"
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/test2"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S()).SetFrequency(2)
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(2)
 
 	// Calls to log should result in only 2 log messages being written
 	l.Progress(msg)
@@ -150,23 +150,23 @@ func TestLogFormat(t *testing.T) {
 	logger := fakeLogger{}
 	logger.expectedMsg = fmt.Sprintf(template, inStr)
 	const rKey = "testns/test3"
-	rl := GetContext(rKey)
-	l := rl.GetLogger("comp1", &logger, zap.S())
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S())
 	l.Progressf(template, inStr)
 	assert.Equal(t, 1, logger.count)
 	assert.Equal(t, logger.actualMsg, logger.expectedMsg)
 	DeleteLogContext(rKey)
 }
 
-// TestMultipleContexts tests the GetContext and DeleteLogContext
-// WHEN GetContext is called multiple times
+// TestMultipleContexts tests the EnsureContext and DeleteLogContext
+// WHEN EnsureContext is called multiple times
 // THEN ensure that the context map has an entry for each context and that
 //   the context map is empty when they the contexts are deleted
 func TestMultipleContexts(t *testing.T) {
 	const rKey1 = "k1"
 	const rKey2 = "k2"
-	c1 := GetContext(rKey1)
-	c2 := GetContext(rKey2)
+	c1 := EnsureContext(rKey1)
+	c2 := EnsureContext(rKey2)
 
 	assert.Equal(t, 2, len(LogContextMap))
 	c1Actual := LogContextMap[rKey1]
@@ -180,7 +180,7 @@ func TestMultipleContexts(t *testing.T) {
 
 // TestZap tests the zap SugaredLogger
 // GIVEN a zap SugaredLogger
-// WHEN GetContext is called with the SugaredLogger
+// WHEN EnsureContext is called with the SugaredLogger
 // THEN ensure that the ProgressMessage can be called
 func TestZap(t *testing.T) {
 	testOpts := kzap.Options{}
@@ -188,7 +188,7 @@ func TestZap(t *testing.T) {
 	testOpts.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	log.InitLogs(testOpts)
 	const rKey = "testns/test3"
-	l := GetContext(rKey).GetLogger("test", zap.S(), zap.S())
+	l := EnsureContext(rKey).EnsureLogger("test", zap.S(), zap.S())
 	l.Progress("testmsg")
 	DeleteLogContext(rKey)
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -154,10 +154,7 @@ func (c certManagerComponent) PreInstall(compContext spi.ComponentContext) error
 	err := c.applyManifest(compContext)
 	if err != nil {
 		compContext.Log().Errorf("Failed to apply the cert-manager manifest: %v", err)
-		return ctrlerrrors.RetryableError{
-			Source: c.Name(),
-			Cause:  fmt.Errorf("failed to apply the cert-manager manifest: %s", err),
-		}
+		return err
 	}
 	return nil
 }
@@ -175,7 +172,7 @@ func (c certManagerComponent) PostInstall(compContext spi.ComponentContext) erro
 	isCAValue, err := isCA(compContext)
 	if err != nil {
 		compContext.Log().Errorf("Failed to verify the config type: %s", err)
-		return ctrlerrrors.RetryableError{Source: c.Name()}
+		return err
 	}
 	if !isCAValue {
 		// Create resources needed for Acme certificates

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -212,7 +212,6 @@ func (h HelmComponent) Install(context spi.ComponentContext) error {
 	}
 
 	// Perform an install using the helm upgrade --install command
-	context.Log().Infof("Performing installation of %s", h.ReleaseName)
 	_, _, err = upgradeFunc(context.Log().GetZapLogger(), h.ReleaseName, resolvedNamespace, h.ChartDir, h.WaitForInstall, context.IsDryRun(), overrides)
 	return err
 }
@@ -311,8 +310,6 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Generate a list of component-specified override files if present
 	overrides.FileOverrides = append(overrides.FileOverrides, tmpFile.Name())
 
-	// Perform an upgrade using the helm upgrade --install command
-	context.Log().Infof("Performing upgrade of %s", h.ReleaseName)
 	_, _, err = upgradeFunc(context.Log().GetZapLogger(), h.ReleaseName, namespace, h.ChartDir, true, context.IsDryRun(), overrides)
 	return err
 }

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -9,8 +9,7 @@ import (
 	"os"
 	"strings"
 
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"go.uber.org/zap"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
@@ -107,7 +106,7 @@ type appendOverridesSig func(context spi.ComponentContext, releaseName string, n
 type resolveNamespaceSig func(ns string) string
 
 // upgradeFuncSig is a function needed for unit test override
-type upgradeFuncSig func(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error)
+type upgradeFuncSig func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error)
 
 // readyStatusFuncSig describes the function signature for doing deeper checks on a component's ready state
 type readyStatusFuncSig func(context spi.ComponentContext, releaseName string, namespace string) bool
@@ -195,7 +194,7 @@ func (h HelmComponent) Install(context spi.ComponentContext) error {
 		// NOTE: we'll likely have to put in some more logic akin to what we do for the scripts, see
 		//       reset_chart() in the common.sh script.  Recovering chart state can be a bit difficult, we
 		//       may need to draw on both the 'ls' and 'status' output for that.
-		helm.Uninstall(context.Log().GetZapLogger(), h.ReleaseName, resolvedNamespace, context.IsDryRun())
+		helm.Uninstall(context.Log(), h.ReleaseName, resolvedNamespace, context.IsDryRun())
 	}
 
 	var kvs []bom.KeyValue
@@ -212,7 +211,7 @@ func (h HelmComponent) Install(context spi.ComponentContext) error {
 	}
 
 	// Perform an install using the helm upgrade --install command
-	_, _, err = upgradeFunc(context.Log().GetZapLogger(), h.ReleaseName, resolvedNamespace, h.ChartDir, h.WaitForInstall, context.IsDryRun(), overrides)
+	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, resolvedNamespace, h.ChartDir, h.WaitForInstall, context.IsDryRun(), overrides)
 	return err
 }
 
@@ -282,7 +281,7 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 		return err
 	}
 
-	stdout, err := helm.GetValues(context.Log().GetZapLogger(), h.ReleaseName, namespace)
+	stdout, err := helm.GetValues(context.Log(), h.ReleaseName, namespace)
 	if err != nil {
 		return err
 	}
@@ -310,7 +309,7 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Generate a list of component-specified override files if present
 	overrides.FileOverrides = append(overrides.FileOverrides, tmpFile.Name())
 
-	_, _, err = upgradeFunc(context.Log().GetZapLogger(), h.ReleaseName, namespace, h.ChartDir, true, context.IsDryRun(), overrides)
+	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, namespace, h.ChartDir, true, context.IsDryRun(), overrides)
 	return err
 }
 

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -7,12 +7,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"go.uber.org/zap"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/helm"
@@ -104,7 +104,7 @@ func TestUpgradeIsInstalledUnexpectedError(t *testing.T) {
 
 	comp := HelmComponent{}
 
-	setUpgradeFunc(func(_ *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
+	setUpgradeFunc(func(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
 		return nil, nil, nil
 	})
 	defer setDefaultUpgradeFunc()
@@ -129,7 +129,7 @@ func TestUpgradeReleaseNotInstalled(t *testing.T) {
 
 	comp := HelmComponent{}
 
-	setUpgradeFunc(func(_ *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
+	setUpgradeFunc(func(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
 		return nil, nil, nil
 	})
 	helm.SetCmdRunner(helmFakeRunner{})
@@ -250,7 +250,7 @@ func TestInstallWithAllOverride(t *testing.T) {
 	helm.SetCmdRunner(helmFakeRunner{})
 	defer helm.SetDefaultRunner()
 
-	setUpgradeFunc(func(log *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
+	setUpgradeFunc(func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
 		assert.Contains(overrides.FileOverrides, "my-overrides.yaml", "Overrides file not found")
 		assert.Contains(overrides.SetOverrides, "setKey=setValue", "Incorrect --set overrides")
 		assert.Contains(overrides.SetStringOverrides, "setStringKey=setStringValue", "Incorrect --set overrides")
@@ -354,7 +354,7 @@ func TestInstallWithPreInstallFunc(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
 	helm.SetCmdRunner(helmFakeRunner{})
 	defer helm.SetDefaultRunner()
-	setUpgradeFunc(func(_ *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
+	setUpgradeFunc(func(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
 		if overrides.SetOverrides != expectedOverridesString {
 			return nil, nil, fmt.Errorf("Unexpected overrides string %s, expected %s", overrides, expectedOverridesString)
 		}
@@ -485,7 +485,7 @@ func TestReady(t *testing.T) {
 }
 
 // fakeUpgrade verifies that the correct parameter values are passed to upgrade
-func fakeUpgrade(_ *zap.SugaredLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
+func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides helm.HelmOverrides) (stdout []byte, stderr []byte, err error) {
 	if releaseName != "rancher" {
 		return []byte("error"), []byte(""), errors.New("Invalid release name")
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -5,16 +5,17 @@ package istio
 
 import (
 	"context"
+	"strings"
+
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 // StopDomainsUsingOldEnvoy stops all the WebLogic domains using Envoy 1.7.3

--- a/platform-operator/controllers/verrazzano/component/istio/envoy_filter.go
+++ b/platform-operator/controllers/verrazzano/component/istio/envoy_filter.go
@@ -5,7 +5,8 @@ package istio
 
 import (
 	"context"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/istio"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"go.uber.org/zap"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -88,7 +87,7 @@ func SetDefaultRestartComponentsFunction() {
 	restartComponentsFunction = restartComponents
 }
 
-type helmUninstallFuncSig func(log *zap.SugaredLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error)
+type helmUninstallFuncSig func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error)
 
 var helmUninstallFunction helmUninstallFuncSig = helm.Uninstall
 
@@ -320,7 +319,7 @@ func deleteIstioCoreDNS(context spi.ComponentContext) error {
 		return err
 	}
 	if found {
-		_, _, err = helmUninstallFunction(context.Log().GetZapLogger(), IstioCoreDNSReleaseName, constants.IstioSystemNamespace, context.IsDryRun())
+		_, _, err = helmUninstallFunction(context.Log(), IstioCoreDNSReleaseName, constants.IstioSystemNamespace, context.IsDryRun())
 		if err != nil {
 			context.Log().Errorf("Error returned when trying to uninstall istiocoredns: %v", err)
 		}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/istio"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -6,13 +6,13 @@ package istio
 import (
 	"context"
 	"fmt"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -132,7 +132,7 @@ func TestPostUpgrade(t *testing.T) {
 	assert.NoError(err, "PostUpgrade returned an error")
 }
 
-func fakeHelmUninstall(zap *zap.SugaredLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error) {
+func fakeHelmUninstall(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, dryRun bool) (stdout []byte, stderr []byte, err error) {
 	if releaseName != "istiocoredns" {
 		return []byte("error"), []byte(""), fmt.Errorf("expected release name istiocoredns does not match provided release name of %v", releaseName)
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -5,11 +5,12 @@ package istio
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/pkg/istio"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/verrazzano/verrazzano/pkg/istio"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
@@ -6,13 +6,14 @@ package istio
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/istio"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"io/ioutil"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/istio"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -58,7 +58,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 		return kvs, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 	}
 
-	if compContext.For(ComponentName).GetOperation() == vzconst.UpgradeOperation {
+	if compContext.Init(ComponentName).GetOperation() == vzconst.UpgradeOperation {
 		secret := &v1.Secret{}
 		nsName := types.NamespacedName{
 			Namespace: vzconst.KeycloakNamespace,
@@ -82,7 +82,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 
 	kvs = append(kvs, bom.KeyValue{Key: mySQLUsernameKey, Value: mySQLUsername})
 
-	if compContext.For(ComponentName).GetOperation() == vzconst.InstallOperation {
+	if compContext.Init(ComponentName).GetOperation() == vzconst.InstallOperation {
 		mySQLInitFile, err := createMySQLInitFile(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -4,9 +4,10 @@ package mysql
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"os"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +60,7 @@ func TestAppendMySQLOverrides(t *testing.T) {
 		config.SetDefaultBomFilePath("")
 	}()
 	vz := &vzapi.Verrazzano{}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 3+minExpectedHelmOverridesCount)
@@ -92,7 +93,7 @@ func TestAppendMySQLOverridesWithInstallArgs(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 4+minExpectedHelmOverridesCount)
@@ -120,7 +121,7 @@ func TestAppendMySQLOverridesDev(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 4+minExpectedHelmOverridesCount)
@@ -164,7 +165,7 @@ func TestAppendMySQLOverridesDevWithPersistence(t *testing.T) {
 			},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 5+minExpectedHelmOverridesCount)
@@ -190,7 +191,7 @@ func TestAppendMySQLOverridesProd(t *testing.T) {
 			Profile: vzapi.ProfileType("prod"),
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 3+minExpectedHelmOverridesCount)
@@ -229,7 +230,7 @@ func TestAppendMySQLOverridesProdWithOverrides(t *testing.T) {
 			}},
 		},
 	}
-	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).For(ComponentName).Operation(vzconst.InstallOperation)
+	ctx := spi.NewFakeContext(nil, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.InstallOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 5+minExpectedHelmOverridesCount)
@@ -262,7 +263,7 @@ func TestAppendMySQLOverridesUpgrade(t *testing.T) {
 			secret.Data[mySQLKey] = []byte("test-key")
 			return nil
 		})
-	ctx := spi.NewFakeContext(mock, vz, false, profilesDir).For(ComponentName).Operation(vzconst.UpgradeOperation)
+	ctx := spi.NewFakeContext(mock, vz, false, profilesDir).Init(ComponentName).Operation(vzconst.UpgradeOperation)
 	kvs, err := appendMySQLOverrides(ctx, "", "", "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 4+minExpectedHelmOverridesCount)

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -4,7 +4,7 @@
 package spi
 
 import (
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,8 +24,8 @@ type ComponentContext interface {
 	IsDryRun() bool
 	// Copy returns a copy of the current context
 	Copy() ComponentContext
-	// For returns a copy of the current context with an updated logging component field
-	For(comp string) ComponentContext
+	// Init returns a copy of the current context with an updated logging component field
+	Init(comp string) ComponentContext
 	// Operation specifies the logging operation field
 	Operation(op string) ComponentContext
 	// GetOperation returns the operation object in the context

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -7,7 +7,7 @@ package spi
 import (
 	"strings"
 
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
@@ -24,6 +24,7 @@ var _ ComponentContext = componentContext{}
 
 // NewContext creates a ComponentContext from a raw CR
 func NewContext(log vzlog.VerrazzanoLogger, c clipkg.Client, actualCR *vzapi.Verrazzano, dryRun bool) (ComponentContext, error) {
+
 	// Generate the effective CR based ond the declared profile and any overrides in the user-supplied one
 	effectiveCR, err := getEffectiveCR(actualCR)
 	if err != nil {
@@ -151,9 +152,11 @@ func (c componentContext) Copy() ComponentContext {
 	}
 }
 
-func (c componentContext) For(compName string) ComponentContext {
+// Clone the component context, initializing the zap logger from the resource
+// logger. This makes sure that we get the
+func (c componentContext) Init(compName string) ComponentContext {
 	// Get zap logger, add "with" field for this component name
-	zapLogger := c.log.GetZapLogger().With("component", compName)
+	zapLogger := c.log.GetResourceZapLogger().With("component", compName)
 	// Ensure that there is a logger for this component, inject the new zap logger
 	log := c.log.GetContext().EnsureLogger(compName, zapLogger, zapLogger)
 
@@ -172,12 +175,10 @@ func (c componentContext) For(compName string) ComponentContext {
 func (c componentContext) Operation(op string) ComponentContext {
 	// Get zap logger, add "with" field for this component operation
 	zapLogger := c.log.GetZapLogger().With("operation", op)
-	// Ensure that there is a logger for this component, inject the new zap logger
-	log := c.log.GetContext().EnsureLogger(c.component, zapLogger, zapLogger)
-
 	c.log.SetZapLogger(zapLogger)
+
 	return componentContext{
-		log:         log,
+		log:         c.log,
 		client:      c.client,
 		dryRun:      c.dryRun,
 		cr:          c.cr,

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -155,7 +155,7 @@ func (c componentContext) For(compName string) ComponentContext {
 	// Get zap logger, add "with" field for this component name
 	zapLogger := c.log.GetZapLogger().With("component", compName)
 	// Ensure that there is a logger for this component, inject the new zap logger
-	log := c.log.GetContext().GetLogger(compName, zapLogger, zapLogger)
+	log := c.log.GetContext().EnsureLogger(compName, zapLogger, zapLogger)
 
 	// c.log.
 	return componentContext{
@@ -173,7 +173,7 @@ func (c componentContext) Operation(op string) ComponentContext {
 	// Get zap logger, add "with" field for this component operation
 	zapLogger := c.log.GetZapLogger().With("operation", op)
 	// Ensure that there is a logger for this component, inject the new zap logger
-	log := c.log.GetContext().GetLogger(c.component, zapLogger, zapLogger)
+	log := c.log.GetContext().EnsureLogger(c.component, zapLogger, zapLogger)
 
 	c.log.SetZapLogger(zapLogger)
 	return componentContext{

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -156,7 +156,7 @@ func (c componentContext) Copy() ComponentContext {
 // logger. This makes sure that we get the
 func (c componentContext) Init(compName string) ComponentContext {
 	// Get zap logger, add "with" field for this component name
-	zapLogger := c.log.GetResourceZapLogger().With("component", compName)
+	zapLogger := c.log.GetRootZapLogger().With("component", compName)
 	// Ensure that there is a logger for this component, inject the new zap logger
 	log := c.log.GetContext().EnsureLogger(compName, zapLogger, zapLogger)
 

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -5,8 +5,9 @@ package spi
 // Default implementation of the ComponentContext interface
 
 import (
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"strings"
+
+	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
@@ -154,7 +155,7 @@ func (c componentContext) For(compName string) ComponentContext {
 	// Get zap logger, add "with" field for this component name
 	zapLogger := c.log.GetZapLogger().With("component", compName)
 	// Ensure that there is a logger for this component, inject the new zap logger
-	log := c.log.GetContext().EnsureLogger(compName, zapLogger, zapLogger)
+	log := c.log.GetContext().GetLogger(compName, zapLogger, zapLogger)
 
 	// c.log.
 	return componentContext{
@@ -172,7 +173,7 @@ func (c componentContext) Operation(op string) ComponentContext {
 	// Get zap logger, add "with" field for this component operation
 	zapLogger := c.log.GetZapLogger().With("operation", op)
 	// Ensure that there is a logger for this component, inject the new zap logger
-	log := c.log.GetContext().EnsureLogger(c.component, zapLogger, zapLogger)
+	log := c.log.GetContext().GetLogger(c.component, zapLogger, zapLogger)
 
 	c.log.SetZapLogger(zapLogger)
 	return componentContext{

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
@@ -3,20 +3,21 @@
 package spi
 
 import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"io/ioutil"
 	istioclinet "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 var testScheme = runtime.NewScheme()

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -6,7 +6,7 @@ spec:
   profile: "dev"
   environmentName: default
   defaultVolumeSource:
-    emptyDir: {}
+    emptyDir: { }
   components:
     applicationOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -6,7 +6,7 @@ spec:
   profile: "dev"
   environmentName: default
   defaultVolumeSource:
-    emptyDir: {}
+    emptyDir: { }
   components:
     applicationOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -6,7 +6,7 @@ spec:
   profile: "dev"
   environmentName: default
   defaultVolumeSource:
-    emptyDir: {}
+    emptyDir: { }
   components:
     applicationOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -6,7 +6,7 @@ spec:
   profile: "dev"
   environmentName: default
   defaultVolumeSource:
-    emptyDir: {}
+    emptyDir: { }
   components:
     applicationOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -28,10 +28,10 @@ spec:
       elasticsearchURL: https://myes.mycorp.com
       elasticsearchSecret: mysecret
       extraVolumeMounts:
-      - source: /u01/datarw
-        readOnly: false
-      - source: /u01/dataro
-        readOnly: true
+        - source: /u01/datarw
+          readOnly: false
+        - source: /u01/dataro
+          readOnly: true
     grafana:
       enabled: true
     ingress:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -43,7 +43,7 @@ spec:
           value: "3"
         - name: controller.service.externalIPs
           valueList:
-          - 11.22.33.44
+            - 11.22.33.44
       ports:
         - name: http
           nodePort: 30080
@@ -64,7 +64,7 @@ spec:
           value: "3"
         - name: gateways.istio-ingressgateway.externalIPs
           valueList:
-          - 11.22.33.44
+            - 11.22.33.44
     kiali:
       enabled: true
     keycloak:

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -96,7 +96,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 
 		zaplog.Errorf("Failed to fetch Verrazzano resource: %v", err)
-		return reconcile.Result{}, err
+		return newRequeueWithDelay(), nil
 	}
 
 	log.Progressf("Reconciling Verrazzano resource %v", req.NamespacedName)
@@ -1030,6 +1030,8 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 			if err != nil {
 				return newRequeueWithDelay(), err
 			}
+			// Uninstall is done, all cleanup is finished, and finalizer removed.
+			return ctrl.Result{}, nil
 		}
 	}
 	return newRequeueWithDelay(), nil

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -697,7 +697,7 @@ func (r *Reconciler) initializeComponentStatus(log vzlog.VerrazzanoLogger, cr *i
 	for _, comp := range registry.GetComponents() {
 		if comp.IsOperatorInstallSupported() {
 			// If the component is installed then mark it as ready
-			compContext := newContext.For(comp.Name()).Operation(vzconst.InitializeOperation)
+			compContext := newContext.Init(comp.Name()).Operation(vzconst.InitializeOperation)
 			state := installv1alpha1.Disabled
 			if !unitTesting {
 				installed, err := comp.IsInstalled(compContext)
@@ -1010,6 +1010,12 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 	// Remove the finalizer and update the Verrazzano resource if the uninstall has finished.
 	for _, condition := range vz.Status.Conditions {
 		if condition.Type == installv1alpha1.UninstallComplete || condition.Type == installv1alpha1.UninstallFailed {
+			if condition.Type == installv1alpha1.UninstallComplete {
+				log.Once("Successfully uninstalled Verrrazzano")
+			} else {
+				log.Once("Failed uninstalling Verraazzano")
+			}
+
 			err := r.cleanup(ctx, log, vz)
 			if err != nil {
 				return newRequeueWithDelay(), err

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -997,7 +997,6 @@ func (r *Reconciler) retryUpgrade(ctx context.Context, vz *installv1alpha1.Verra
 func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	// Finalizer is present, so lets do the uninstall
 	if vzstring.SliceContainsString(vz.ObjectMeta.Finalizers, finalizerName) {
-
 		log.Progress("Deleting Verrazzano installation")
 
 		// Create the uninstall job if it doesn't exist
@@ -1029,7 +1028,7 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 			}
 		}
 	}
-	return newRequeueWithDelay(), nil
+	return ctrl.Result{}, nil
 }
 
 // Cleanup the resources left over from install and uninstall

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Get the resource logger needed to log message using 'progress' and 'once' methods
-	log, err := vzlog.GetResourceLogger(&vzlog.ResourceConfig{
+	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
 		Name:           vz.Name,
 		Namespace:      vz.Namespace,
 		ID:             string(vz.UID),

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -1190,7 +1190,7 @@ func (r *Reconciler) updateVerrazzanoStatus(log vzlog.VerrazzanoLogger, vz *inst
 		return nil
 	}
 	if ctrlerrors.IsUpdateConflict(err) {
-		log.Info("Requeuing to get a fresh copy of the Verrazzano resource since the current one is outdated.")
+		log.Debugf("Requeuing to get a fresh copy of the Verrazzano resource since the current one is outdated.")
 	} else {
 		log.Errorf("Failed to update Verrazzano resource :v", err)
 	}

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -6,9 +6,10 @@ package verrazzano
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"testing"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -755,8 +756,8 @@ func TestUninstallStarted(t *testing.T) {
 	// Validate the results
 	mocker.Finish()
 	asserts.NoError(err)
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestUninstallFailed tests the Reconcile method for the following use case

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -34,12 +34,11 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 
 	// Loop through all of the Verrazzano components and upgrade each one sequentially for now; will parallelize later
 	for _, comp := range registry.GetComponents() {
-
 		compName := comp.Name()
 		compContext := spiCtx.For(compName).Operation(vzconst.InstallOperation)
 		compLog := compContext.Log()
 
-		compLog.Oncef("Processing install for %s", compName)
+		compLog.Oncef("Component %s is being reconciled", compName)
 
 		if !comp.IsOperatorInstallSupported() {
 			compLog.Debugf("Component based install not supported for %s", compName)

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -5,9 +5,9 @@ package verrazzano
 
 import (
 	"context"
+
 	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
-	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -81,14 +81,12 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 			}
 			compLog.Progressf("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
-				handleError(compLog, err)
 				requeue = true
 				continue
 			}
 			// If component is not installed,install it
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
-				handleError(compLog, err)
 				requeue = true
 				continue
 			}
@@ -104,7 +102,6 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 			if comp.IsReady(compContext) {
 				compLog.Progressf("Component %s post-install is running ", compName)
 				if err := comp.PostInstall(compContext); err != nil {
-					handleError(compLog, err)
 					requeue = true
 					continue
 				}
@@ -145,18 +142,4 @@ func isVersionOk(log vzlog.VerrazzanoLogger, compVersion string, vzVersion strin
 
 	// return false if VZ version is too low to install component, else true
 	return !vzSemver.IsLessThan(compSemver)
-}
-
-// handleError - detects if a an error is a RetryableError; if it is, logs it appropriately and
-func handleError(log vzlog.VerrazzanoLogger, err error) {
-	switch actualErr := err.(type) {
-	case ctrlerrors.RetryableError:
-		if actualErr.HasCause() {
-			log.Errorf("Retryable error occurred, %s", actualErr.Error())
-		} else {
-			log.Debugf("Retryable error returned: %s", actualErr.Error())
-		}
-	default:
-		log.Errorf("Unexpected error occurred during install/upgrade: %s", actualErr.Error())
-	}
 }

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -35,7 +35,7 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 	// Loop through all of the Verrazzano components and upgrade each one sequentially for now; will parallelize later
 	for _, comp := range registry.GetComponents() {
 		compName := comp.Name()
-		compContext := spiCtx.For(compName).Operation(vzconst.InstallOperation)
+		compContext := spiCtx.Init(compName).Operation(vzconst.InstallOperation)
 		compLog := compContext.Log()
 
 		compLog.Oncef("Component %s is being reconciled", compName)

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -28,7 +28,7 @@ import (
 //    immediately.
 func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.ComponentContext) (ctrl.Result, error) {
 	cr := spiCtx.ActualCR()
-	spiCtx.Log().Progress("Reconciling components")
+	spiCtx.Log().Progress("Reconciling components for Verrazzano installation")
 
 	var requeue bool
 

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -5,9 +5,11 @@ package verrazzano
 
 import (
 	"context"
+	"strings"
 
 	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -64,7 +66,7 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 			}
 			if !isVersionOk(compLog, comp.GetMinVerrazzanoVersion(), cr.Status.Version) {
 				// User needs to do upgrade before this component can be installed
-				compLog.Progressf("Component %s cannot be installed until Verrazzano is upgrade to at least version %s",
+				compLog.Progressf("Component %s cannot be installed until Verrazzano is upgraded to at least version %s",
 					comp.Name(), comp.GetMinVerrazzanoVersion())
 				continue
 			}
@@ -81,12 +83,14 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 			}
 			compLog.Progressf("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
+				handleError(compLog, err)
 				requeue = true
 				continue
 			}
 			// If component is not installed,install it
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
+				handleError(compLog, err)
 				requeue = true
 				continue
 			}
@@ -102,6 +106,7 @@ func (r *Reconciler) reconcileComponents(_ context.Context, spiCtx spi.Component
 			if comp.IsReady(compContext) {
 				compLog.Progressf("Component %s post-install is running ", compName)
 				if err := comp.PostInstall(compContext); err != nil {
+					handleError(compLog, err)
 					requeue = true
 					continue
 				}
@@ -142,4 +147,22 @@ func isVersionOk(log vzlog.VerrazzanoLogger, compVersion string, vzVersion strin
 
 	// return false if VZ version is too low to install component, else true
 	return !vzSemver.IsLessThan(compSemver)
+}
+
+// handleError - detects if a an error is a RetryableError; if it is, logs it appropriately and
+func handleError(log vzlog.VerrazzanoLogger, err error) {
+	switch actualErr := err.(type) {
+	case ctrlerrors.RetryableError:
+		if actualErr.HasCause() {
+			cause := actualErr.Cause
+			if ctrlerrors.IsUpdateConflict(cause) ||
+				strings.Contains(cause.Error(), "failed calling webhook") {
+				log.Debugf("Failed during install: %v", cause)
+				return
+			}
+			log.Errorf("Failed during install: %v", actualErr.Error())
+		}
+	default:
+		log.Errorf("Unexpected error occurred during install/upgrade: %s", actualErr.Error())
+	}
 }

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -40,7 +40,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 	// - for now, upgrade is blocking
 	for _, comp := range registry.GetComponents() {
 		compName := comp.Name()
-		compContext := spiCtx.For(compName).Operation(vzconst.UpgradeOperation)
+		compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
 		compLog := compContext.Log()
 
 		installed, err := comp.IsInstalled(compContext)

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -18,7 +18,7 @@ import (
 
 // Reconcile upgrade will upgrade the components as required
 func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
-	log.Debugf("enter reconcileUpgrade")
+	log.Oncef("Upgrading Verrazzano to version %s", cr.Spec.Version)
 
 	// Upgrade version was validated in webhook, see ValidateVersion
 	targetVersion := cr.Spec.Version
@@ -31,7 +31,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 		return ctrl.Result{Requeue: true, RequeueAfter: 1}, err
 	}
 
-	newContext, err := spi.NewContext(log, r, cr, r.DryRun)
+	spiCtx, err := spi.NewContext(log, r, cr, r.DryRun)
 	if err != nil {
 		return newRequeueWithDelay(), err
 	}
@@ -40,31 +40,32 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 	// - for now, upgrade is blocking
 	for _, comp := range registry.GetComponents() {
 		compName := comp.Name()
-		log.Infof("Upgrading %s", compName)
-		upgradeContext := newContext.For(compName).Operation(vzconst.UpgradeOperation)
-		installed, err := comp.IsInstalled(upgradeContext)
+		compContext := spiCtx.For(compName).Operation(vzconst.UpgradeOperation)
+		compLog := compContext.Log()
+
+		installed, err := comp.IsInstalled(compContext)
 		if err != nil {
 			return newRequeueWithDelay(), err
 		}
 		if !installed {
-			log.Infof("Skip upgrade for %s, not installed", compName)
+			compLog.Oncef("Component %s is not installed; upgrade being skipped", compName)
 			continue
 		}
-		log.Infof("Running pre-upgrade for %s", compName)
-		if err := comp.PreUpgrade(upgradeContext); err != nil {
+		compLog.Oncef("Component %s pre-upgrade running", compName)
+		if err := comp.PreUpgrade(compContext); err != nil {
 			// for now, this will be fatal until upgrade is retry-able
 			return ctrl.Result{}, err
 		}
-		log.Infof("Running upgrade for %s", compName)
-		if err := comp.Upgrade(upgradeContext); err != nil {
-			log.Errorf("Error upgrading component %s: %v", compName, err)
+		compLog.Oncef("Component %s upgrade running", compName)
+		if err := comp.Upgrade(compContext); err != nil {
+			compLog.Errorf("Error upgrading component %s: %v", compName, err)
 			msg := fmt.Sprintf("Error upgrading component %s - %s\".  Error is %s", compName,
 				fmtGeneration(cr.Generation), err.Error())
 			err := r.updateStatus(log, cr, msg, installv1alpha1.UpgradeFailed)
 			return ctrl.Result{}, err
 		}
-		log.Infof("Running post-upgrade for %s", compName)
-		if err := comp.PostUpgrade(upgradeContext); err != nil {
+		compLog.Oncef("Component %s post-upgrade running", compName)
+		if err := comp.PostUpgrade(compContext); err != nil {
 			// for now, this will be fatal until upgrade is retry-able
 			return ctrl.Result{}, err
 		}
@@ -77,7 +78,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 		return ctrl.Result{Requeue: true, RequeueAfter: 1}, err
 	}
 
-	msg := fmt.Sprintf("Verrazzano upgraded to version %s successfully", cr.Spec.Version)
+	msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", cr.Spec.Version)
 	log.Info(msg)
 	cr.Status.Version = targetVersion
 	if err = r.updateStatus(log, cr, msg, installv1alpha1.UpgradeComplete); err != nil {

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -18,14 +18,14 @@ func DeploymentsReady(log vzlog.VerrazzanoLogger, client clipkg.Client, deployme
 		deployment := appsv1.Deployment{}
 		if err := client.Get(context.TODO(), namespacedName, &deployment); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s waiting for deployment %v to exist", prefix, namespacedName)
+				log.Progressf("%s is waiting for deployment %v to exist", prefix, namespacedName)
 				return false
 			}
 			log.Errorf("Failed getting deployment %v: %v", namespacedName, err)
 			return false
 		}
 		if deployment.Status.AvailableReplicas < expectedReplicas {
-			log.Progressf("%s waiting for deployment %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
+			log.Progressf("%s is waiting for deployment %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
 			return false
 		}
 	}

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -25,7 +25,8 @@ func DeploymentsReady(log vzlog.VerrazzanoLogger, client clipkg.Client, deployme
 			return false
 		}
 		if deployment.Status.AvailableReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for deployment %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
+			log.Progressf("%s is waiting for deployment %s replicas to be %v. Current replicas is %v", prefix, namespacedName,
+				expectedReplicas, deployment.Status.AvailableReplicas)
 			return false
 		}
 	}

--- a/platform-operator/internal/k8s/status/ingresses_present.go
+++ b/platform-operator/internal/k8s/status/ingresses_present.go
@@ -19,7 +19,7 @@ func IngressesPresent(log vzlog.VerrazzanoLogger, client clipkg.Client, ingressN
 		ing := v1.Ingress{}
 		if err := client.Get(context.TODO(), ingName, &ing); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s waiting for ingress %v to exist", prefix, ingressNames)
+				log.Progressf("%s is waiting for ingress %v to exist", prefix, ingressNames)
 				// Ingress not found
 				return false
 			}

--- a/platform-operator/internal/k8s/status/statefulset_ready.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready.go
@@ -27,7 +27,8 @@ func StatefulsetReady(log vzlog.VerrazzanoLogger, client client.Client, stateful
 			return false
 		}
 		if statefulset.Status.ReadyReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for statefulset %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
+			log.Progressf("%s is waiting for statefulset %s replicas to be %v. Current replicas is %v", prefix, namespacedName,
+				expectedReplicas, statefulset.Status.ReadyReplicas)
 			return false
 		}
 	}

--- a/platform-operator/internal/k8s/status/statefulset_ready.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready.go
@@ -19,7 +19,7 @@ func StatefulsetReady(log vzlog.VerrazzanoLogger, client client.Client, stateful
 		statefulset := appsv1.StatefulSet{}
 		if err := client.Get(context.TODO(), namespacedName, &statefulset); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s waiting for statefulset %v to exist", prefix, namespacedName)
+				log.Progressf("%s is waiting for statefulset %v to exist", prefix, namespacedName)
 				// StatefulSet not found
 				return false
 			}
@@ -27,7 +27,7 @@ func StatefulsetReady(log vzlog.VerrazzanoLogger, client client.Client, stateful
 			return false
 		}
 		if statefulset.Status.ReadyReplicas < expectedReplicas {
-			log.Progressf("%s waiting for statefulset %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
+			log.Progressf("%s is waiting for statefulset %s to have %v replica(s)", prefix, namespacedName, expectedReplicas)
 			return false
 		}
 	}


### PR DESCRIPTION
- Create controller resource specific logging init function
- Fix some issues with logging related to queued up Verrazzano CRs that are delivered after reconciliation is done.  
- Fix the log initialization at the component level, change componet.For to Init to make it clear that it is an initialization function that must be called for when getting a component level component context.  
- Fine tuning logging messages to comply with some of the bugs entered.
- Add more comments
- Add more tests

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
