### PR TITLE
add CN in ingress certs

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -431,19 +431,25 @@ func getEnvironmentName(envName string) string {
 	return envName
 }
 
-// updateKeycloakIngress updates the Ingress when using externalDNS
+// updateKeycloakIngress updates the Ingress
 func updateKeycloakIngress(ctx spi.ComponentContext) error {
 	ingress := networkv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{Name: "keycloak", Namespace: "keycloak"},
 	}
 	_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &ingress, func() error {
-		dnsSubDomain, err := vzconfig.BuildDNSDomain(ctx.Client(), ctx.EffectiveCR())
-		if err != nil {
-			return err
+		dnsSuffix, _ := vzconfig.GetDNSSuffix(ctx.Client(), ctx.EffectiveCR())
+		ingress.Annotations["cert-manager.io/common-name"] = fmt.Sprintf("%s.%s.%s",
+			ComponentName, ctx.EffectiveCR().Spec.EnvironmentName, dnsSuffix)
+		// update target annotation on Keycloak Ingress for external DNS
+		if vzconfig.IsExternalDNSEnabled(ctx.EffectiveCR()) {
+			dnsSubDomain, err := vzconfig.BuildDNSDomain(ctx.Client(), ctx.EffectiveCR())
+			if err != nil {
+				return err
+			}
+			ingressTarget := fmt.Sprintf("verrazzano-ingress.%s", dnsSubDomain)
+			ctx.Log().Debugf("updateKeycloakIngress: Updating Keycloak Ingress with ingressTarget = %s", ingressTarget)
+			ingress.Annotations["external-dns.alpha.kubernetes.io/target"] = ingressTarget
 		}
-		ingressTarget := fmt.Sprintf("verrazzano-ingress.%s", dnsSubDomain)
-		ctx.Log().Debugf("updateKeycloakIngress: Updating Keycloak Ingress with ingressTarget = %s", ingressTarget)
-		ingress.Annotations["external-dns.alpha.kubernetes.io/target"] = ingressTarget
 		return nil
 	})
 	ctx.Log().Debugf("updateKeycloakIngress: Keycloak ingress operation result: %v", err)

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -19,7 +19,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -143,12 +142,10 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// If OCI DNS, update annotation on Keycloak Ingress
-	if vzconfig.IsExternalDNSEnabled(ctx.EffectiveCR()) {
-		err := updateKeycloakIngress(ctx)
-		if err != nil {
-			return err
-		}
+	// Update annotations on Keycloak Ingress
+	err = updateKeycloakIngress(ctx)
+	if err != nil {
+		return err
 	}
 
 	return c.HelmComponent.PostInstall(ctx)

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -112,6 +112,7 @@ func createOrUpdateKialiIngress(ctx spi.ComponentContext, namespace string) erro
 		ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTP"
 		ingress.Annotations["nginx.ingress.kubernetes.io/service-upstream"] = "true"
 		ingress.Annotations["nginx.ingress.kubernetes.io/upstream-vhost"] = "${service_name}.${namespace}.svc.cluster.local"
+		ingress.Annotations["cert-manager.io/common-name"] = kialiHostName
 		if vzconfig.IsExternalDNSEnabled(ctx.EffectiveCR()) {
 			ingress.Annotations["external-dns.alpha.kubernetes.io/target"] = ingressTarget
 			ingress.Annotations["external-dns.alpha.kubernetes.io/ttl"] = "60"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher
@@ -86,4 +86,5 @@ func addAcmeIngressAnnotations(name, dnsSuffix string, ingress *networking.Ingre
 func addCAIngressAnnotations(name, dnsSuffix string, ingress *networking.Ingress) {
 	ingress.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = fmt.Sprintf("%s.%s auth", name, dnsSuffix)
 	ingress.Annotations["cert-manager.io/cluster-issuer"] = "verrazzano-cluster-issuer"
+	ingress.Annotations["cert-manager.io/common-name"] = fmt.Sprintf("%s.%s.%s", common.RancherName, name, dnsSuffix)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
@@ -1,10 +1,12 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -14,7 +16,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const (
@@ -61,6 +62,7 @@ func TestAddCAIngressAnnotations(t *testing.T) {
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/auth-realm": fmt.Sprintf("%s.%s auth", name, dnsSuffix),
 				"cert-manager.io/cluster-issuer":         "verrazzano-cluster-issuer",
+				"cert-manager.io/common-name":            fmt.Sprintf("%s.%s.%s", common.RancherName, name, dnsSuffix),
 			},
 		},
 	}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
@@ -33,6 +33,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/upstream-vhost: "${service_name}.${namespace}.svc.cluster.local"
+    cert-manager.io/common-name: verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
   name: verrazzano-ingress
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
# Description

As a part of https://jira.oraclecorp.com/jira/browse/VZ-4588, add CN to keycloak, rancher, kiali, vmi, and verrazzano ingress subject.

Fixes VZ-4588

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
