### PR TITLE
VZ-4749: Wrap call to get Kiali ingress in Eventually

### DIFF
--- a/tests/e2e/verify-install/kiali/kiali_test.go
+++ b/tests/e2e/verify-install/kiali/kiali_test.go
@@ -6,6 +6,8 @@ package kiali
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/go-retryablehttp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +17,6 @@ import (
 	networking "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"time"
 )
 
 const (
@@ -85,10 +86,11 @@ var _ = t.Describe("Kiali", Label("f:platform-lcm.install"), func() {
 			)
 
 			BeforeEach(func() {
-				ingress, kialiErr = client.NetworkingV1().
-					Ingresses(systemNamespace).
-					Get(context.TODO(), kiali, v1.GetOptions{})
-				Expect(kialiErr).ToNot(HaveOccurred())
+				Eventually(func() (*networking.Ingress, error) {
+					var err error
+					ingress, err = client.NetworkingV1().Ingresses(systemNamespace).Get(context.TODO(), kiali, v1.GetOptions{})
+					return ingress, err
+				}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 				rules := ingress.Spec.Rules
 				Expect(len(rules)).To(Equal(1))
 				Expect(rules[0].Host).To(ContainSubstring("kiali.vmi.system"))


### PR DESCRIPTION
# Description

The Kiali test in the upgrade pipeline fails intermittently. We looked at several of the recent failures and the test always fails attempting to get the ingress. Wrapping the get of the ingress in Eventually seems to solve the problem.

Fixes VZ-4749

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
