### PR TITLE
Fix the issue with getting the Kubernetes version in new test framework

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -285,7 +285,7 @@ pipeline {
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
                     // Derive Kubernetes version, which is one of the labels emitted by the test metrics
-                    env.K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION').trim()}"
+                    env.K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}').trim()}"
                 }
                 sh """
                     echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : params.OKE_CLUSTER_VERSION}"
+        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : get_k8s_version(params.OKE_CLUSTER_VERSION)}"
 
         // sample app deployed before upgrade and UI console tests
         SAMPLE_APP_NAME="hello-helidon-appconf"
@@ -1542,4 +1542,17 @@ def runConsoleTests() {
         export CONSOLE_APP_COMP="${SAMPLE_APP_COMPONENT}"
         KUBECONFIG=${ADMIN_KUBECONFIG} RUN_APP_TESTS=true ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh
    """
+}
+
+// Return the Kubernetes version in the format <major version>.<minor version>
+def get_k8s_version(k8sVersion) {
+	if (k8sVersion.startsWith("v")) {
+		count = k8sVersion.count(".")
+		if (count == 2) {
+		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
+		  return result
+		}
+		return k8sVersion.substring(1)
+	}
+	return k8sVersion
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -284,12 +284,9 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
-                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    // Derive Kubernetes version, which is used to set the value for a label in the metrics emitted by the tests
                     env.K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}').trim()}"
                 }
-                sh """
-                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
-                """
             }
         }
 
@@ -1103,7 +1100,6 @@ def runGinkgoRandomize(testSuitePath) {
                     clusterName="managed${count-1}"
                 }
                 sh """
-                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e
@@ -1548,4 +1544,3 @@ def runConsoleTests() {
         KUBECONFIG=${ADMIN_KUBECONFIG} RUN_APP_TESTS=true ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh
    """
 }
-

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : get_k8s_version(params.OKE_CLUSTER_VERSION)}"
+        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION').trim()}"
 
         // sample app deployed before upgrade and UI console tests
         SAMPLE_APP_NAME="hello-helidon-appconf"
@@ -202,6 +202,7 @@ pipeline {
             steps {
                 sh """
                     echo "${NODE_LABELS}"
+                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
 
                 script {
@@ -1544,15 +1545,3 @@ def runConsoleTests() {
    """
 }
 
-// Return the Kubernetes version in the format <major version>.<minor version>
-def get_k8s_version(k8sVersion) {
-	if (k8sVersion.startsWith("v")) {
-		count = k8sVersion.count(".")
-		if (count == 2) {
-		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
-		  return result
-		}
-		return k8sVersion.substring(1)
-	}
-	return k8sVersion
-}

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -184,7 +184,6 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION').trim()}"
 
         // sample app deployed before upgrade and UI console tests
         SAMPLE_APP_NAME="hello-helidon-appconf"
@@ -202,7 +201,6 @@ pipeline {
             steps {
                 sh """
                     echo "${NODE_LABELS}"
-                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
 
                 script {
@@ -286,7 +284,12 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
+                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    env.K8S_VERSION_LABEL = "${params.TEST_ENV == 'kind' ? params.KIND_CLUSTER_VERSION : sh(returnStdout: true, script: '${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION').trim()}"
                 }
+                sh """
+                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
+                """
             }
         }
 
@@ -1100,6 +1103,7 @@ def runGinkgoRandomize(testSuitePath) {
                     clusterName="managed${count-1}"
                 }
                 sh """
+                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -108,6 +108,7 @@ pipeline {
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
+        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -108,7 +108,6 @@ pipeline {
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
-        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {
@@ -173,6 +172,7 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
+                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
             }
         }

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -172,6 +172,7 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
+                    // Derive Kubernetes version, which is used to set the value for a label in the metrics emitted by the tests
                     env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
             }

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -203,12 +203,9 @@ pipeline {
                     // derive the prefix for the OKE cluster
                     OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
 
-                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    // Derive Kubernetes version, which is used to set the value for a label in the metrics emitted by the tests
                     env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
-                sh """
-                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
-                """
             }
         }
 

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -146,7 +146,6 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.OKE_CLUSTER_VERSION}"
     }
 
     stages {
@@ -203,7 +202,13 @@ pipeline {
 
                     // derive the prefix for the OKE cluster
                     OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
+
+                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
+                sh """
+                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
+                """
             }
         }
 

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = "${params.OKE_CLUSTER_VERSION}"
+        K8S_VERSION_LABEL = get_k8s_version(params.OKE_CLUSTER_VERSION)
     }
 
     stages {
@@ -976,4 +976,17 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
+}
+
+// Return the Kubernetes version in the format <major version>.<minor version>
+def get_k8s_version(k8sVersion) {
+	if (k8sVersion.startsWith("v")) {
+		count = k8sVersion.count(".")
+		if (count == 2) {
+		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
+		  return result
+		}
+		return k8sVersion.substring(1)
+	}
+	return k8sVersion
 }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
         TF_VAR_tenancy_id = credentials('oci-tenancy')
         TF_VAR_user_id = credentials('oci-user-ocid')
 
+
         TF_VAR_kubernetes_version = "${params.OKE_CLUSTER_VERSION}"
         TF_VAR_nodepool_config = "${params.OKE_NODE_POOL}"
         TF_VAR_api_fingerprint = credentials('oci-api-key-fingerprint')
@@ -226,12 +227,9 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
-                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    // Derive Kubernetes version, which is used to set the value for a label in the metrics emitted by the tests
                     env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
-                sh """
-                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
-                """
             }
         }
 
@@ -696,7 +694,6 @@ def getTestClusterType(testEnv) {
 def runGinkgo(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
-            echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
             cd ${WORKSPACE}/tests/e2e
             ginkgo -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
@@ -706,7 +703,6 @@ def runGinkgo(testSuitePath) {
 def runGinkgoFailFast(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
-            echo "K8S_VERSION_LABEL: ${K8S_VERSION_LABEL}"
             cd ${WORKSPACE}/tests/e2e
             ginkgo -v --fail-fast --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -109,7 +109,6 @@ pipeline {
         TF_VAR_tenancy_id = credentials('oci-tenancy')
         TF_VAR_user_id = credentials('oci-user-ocid')
 
-
         TF_VAR_kubernetes_version = "${params.OKE_CLUSTER_VERSION}"
         TF_VAR_nodepool_config = "${params.OKE_NODE_POOL}"
         TF_VAR_api_fingerprint = credentials('oci-api-key-fingerprint')
@@ -118,7 +117,6 @@ pipeline {
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
         TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
-
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -176,7 +174,6 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {
@@ -217,7 +214,6 @@ pipeline {
                 println("agentlabel: ${agentLabel}")
                 sh """
                     echo "${NODE_LABELS}"
-                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
 
                 script {
@@ -230,7 +226,12 @@ pipeline {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
                     }
+                    // Derive Kubernetes version, which is one of the labels emitted by the test metrics
+                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
+                sh """
+                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
+                """
             }
         }
 
@@ -695,6 +696,7 @@ def getTestClusterType(testEnv) {
 def runGinkgo(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
+            echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
             cd ${WORKSPACE}/tests/e2e
             ginkgo -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
@@ -704,6 +706,7 @@ def runGinkgo(testSuitePath) {
 def runGinkgoFailFast(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
+            echo "K8S_VERSION_LABEL: ${K8S_VERSION_LABEL}"
             cd ${WORKSPACE}/tests/e2e
             ginkgo -v --fail-fast --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "${params.TEST_ENV}"
-        K8S_VERSION_LABEL = get_k8s_version(params.OKE_CLUSTER_VERSION)
+        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {
@@ -217,6 +217,7 @@ pipeline {
                 println("agentlabel: ${agentLabel}")
                 sh """
                     echo "${NODE_LABELS}"
+                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
 
                 script {
@@ -976,17 +977,4 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
-}
-
-// Return the Kubernetes version in the format <major version>.<minor version>
-def get_k8s_version(k8sVersion) {
-	if (k8sVersion.startsWith("v")) {
-		count = k8sVersion.count(".")
-		if (count == 2) {
-		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
-		  return result
-		}
-		return k8sVersion.substring(1)
-	}
-	return k8sVersion
 }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -118,6 +118,8 @@ pipeline {
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
+
+        K8S_VERSION_LABEL = "${params.KUBERNETES_CLUSTER_VERSION}"
     }
 
     stages {

--- a/ci/scripts/derive_kubernetes_version.sh
+++ b/ci/scripts/derive_kubernetes_version.sh
@@ -6,7 +6,7 @@
 set -o pipefail
 
 if [ -z $1 ]; then
-    echo "Kubernetes Version is required to be supplied"
+    echo "Kubernetes Version is required"
     exit 1
 fi
 KUBERNETES_VERSION=$1

--- a/ci/scripts/derive_kubernetes_version.sh
+++ b/ci/scripts/derive_kubernetes_version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+set -o pipefail
+
+if [ -z $1 ]; then
+    echo "Kubernetes Version is required to be supplied"
+    exit 1
+fi
+KUBERNETES_VERSION=$1
+
+# If the Kubernetes version starts with v, remove it
+if [[ $KUBERNETES_VERSION == v* ]] ; then
+  KUBERNETES_VERSION="${KUBERNETES_VERSION:1}"
+fi
+
+# If the Kubernetes version contains the patch version, remove it
+COUNT_DOT=$(echo "$KUBERNETES_VERSION" | tr -cd "." | wc -c)
+
+if [ "$COUNT_DOT" -gt "1" ]; then
+  KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | cut -f1,2 -d'.')
+fi
+
+# Kubernetes version in the form <major version>.<minor version>
+echo "$KUBERNETES_VERSION"

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -117,7 +117,6 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "magicdns_oke"
-        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {
@@ -213,7 +212,11 @@ pipeline {
 
                     // derive the prefix for the OKE cluster
                     OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
+                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
                 }
+                sh """
+                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
+                """
             }
         }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -124,7 +124,6 @@ pipeline {
             steps {
                 sh """
                     echo "${NODE_LABELS}"
-                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
                 script {
                    EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -211,11 +211,10 @@ pipeline {
 
                     // derive the prefix for the OKE cluster
                     OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_oke_cluster_name.sh").trim()
-                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
+
+                    // Derive Kubernetes version, which is used to set the value for a label in the metrics emitted by the tests
+                    env.K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh ${params.OKE_CLUSTER_VERSION}").trim()
                 }
-                sh """
-                    echo "K8S_VERSION_LABEL: ${env.K8S_VERSION_LABEL}"
-                """
             }
         }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "magicdns_oke"
-        K8S_VERSION_LABEL = "${params.OKE_CLUSTER_VERSION}"
+        K8S_VERSION_LABEL = get_k8s_version(params.OKE_CLUSTER_VERSION)
     }
 
     stages {
@@ -752,4 +752,17 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
+}
+
+// Return the Kubernetes version in the format <major version>.<minor version>
+def get_k8s_version(k8sVersion) {
+	if (k8sVersion.startsWith("v")) {
+		count = k8sVersion.count(".")
+		if (count == 2) {
+		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
+		  return result
+		}
+		return k8sVersion.substring(1)
+	}
+	return k8sVersion
 }

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
         TEST_ENV_LABEL = "magicdns_oke"
-        K8S_VERSION_LABEL = get_k8s_version(params.OKE_CLUSTER_VERSION)
+        K8S_VERSION_LABEL = sh(returnStdout: true, script: "${WORKSPACE}/ci/scripts/derive_kubernetes_version.sh params.OKE_CLUSTER_VERSION").trim()
     }
 
     stages {
@@ -125,6 +125,7 @@ pipeline {
             steps {
                 sh """
                     echo "${NODE_LABELS}"
+                    echo "K8S_VERSION_LABEL ${K8S_VERSION_LABEL}"
                 """
                 script {
                    EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
@@ -752,17 +753,4 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
-}
-
-// Return the Kubernetes version in the format <major version>.<minor version>
-def get_k8s_version(k8sVersion) {
-	if (k8sVersion.startsWith("v")) {
-		count = k8sVersion.count(".")
-		if (count == 2) {
-		  result = k8sVersion.substring(1, k8sVersion.lastIndexOf("."));
-		  return result
-		}
-		return k8sVersion.substring(1)
-	}
-	return k8sVersion
 }

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -101,9 +101,12 @@ func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 
 	kubernetesVersion := os.Getenv("K8S_VERSION_LABEL")
 	if kubernetesVersion != "" {
+		logger.Info("Kubernetes Version ", kubernetesVersion)
 		log = log.With(KubernetesVersion, kubernetesVersion)
+	} else {
+		logger.Warn("Not setting the label for Kubernetes version")
 	}
-	logger.Info("Kubernetes Version ", kubernetesVersion)
+
 	branchName := os.Getenv("BRANCH_NAME")
 	if branchName != "" {
 		log = log.With(BranchName, branchName)

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -29,6 +29,7 @@ const (
 	CommitHash        = "commit_hash"
 	KubernetesVersion = "kubernetes_version"
 	TestEnv           = "test_env"
+	Label             = "label"
 
 	MetricsIndex     = "metrics"
 	TestLogIndex     = "testlogs"
@@ -96,42 +97,10 @@ func NewLogger(pkg string, ind string) (*zap.SugaredLogger, error) {
 	return configureLoggerWithJenkinsEnv(sugaredLogger), nil
 }
 
-func getKubernetesVersion() (string, error) {
-	kubeVersion := "1.20"
-	/*
-		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
-		if err != nil {
-			logger.Errorf("error getting kubeconfig path:  %v", err)
-			return kubeVersion, err
-		}
-		kubeConfig, err := k8sutil.GetKubeConfigGivenPath(kubeConfigPath)
-
-		if err != nil {
-			logger.Errorf("error getting kubeconfig:  %v", err)
-			return kubeVersion, err
-		}
-
-		discover, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
-		if err != nil {
-			logger.Errorf("error getting discovery client:  %v", err)
-			return kubeVersion, err
-		}
-
-		version, err := discover.ServerVersion()
-		if err != nil {
-			logger.Errorf("error getting ServerVersion info:  %v", err)
-			return kubeVersion, err
-		}
-		kubeVersion = version.Major + "." + version.Minor
-	*/
-	return kubeVersion, nil
-}
-
 func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 
-	kubernetesVersion, err := getKubernetesVersion()
-
-	if err == nil {
+	kubernetesVersion := os.Getenv("K8S_VERSION_LABEL")
+	if kubernetesVersion != "" {
 		log = log.With(KubernetesVersion, kubernetesVersion)
 	}
 
@@ -193,9 +162,11 @@ func Emit(log *zap.SugaredLogger) {
 		log = log.With(Status, spec.State)
 	}
 	t := spec.FullText()
+	l := spec.Labels()
 
 	log.With(attempts, spec.NumAttempts).
 		With(test, t).
+		With(Label, l).
 		Info()
 }
 

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/discovery"
 )
 
 const (
@@ -99,33 +97,33 @@ func NewLogger(pkg string, ind string) (*zap.SugaredLogger, error) {
 }
 
 func getKubernetesVersion() (string, error) {
+	kubeVersion := "1.20"
+	/*
+		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			logger.Errorf("error getting kubeconfig path:  %v", err)
+			return kubeVersion, err
+		}
+		kubeConfig, err := k8sutil.GetKubeConfigGivenPath(kubeConfigPath)
 
-	var kubeVersion string
-	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		logger.Errorf("error getting kubeconfig path:  %v", err)
-		return kubeVersion, err
-	}
-	kubeConfig, err := k8sutil.GetKubeConfigGivenPath(kubeConfigPath)
+		if err != nil {
+			logger.Errorf("error getting kubeconfig:  %v", err)
+			return kubeVersion, err
+		}
 
-	if err != nil {
-		logger.Errorf("error getting kubeconfig:  %v", err)
-		return kubeVersion, err
-	}
+		discover, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+		if err != nil {
+			logger.Errorf("error getting discovery client:  %v", err)
+			return kubeVersion, err
+		}
 
-	discover, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
-	if err != nil {
-		logger.Errorf("error getting discovery client:  %v", err)
-		return kubeVersion, err
-	}
-
-	version, err := discover.ServerVersion()
-	if err != nil {
-		logger.Errorf("error getting ServerVersion info:  %v", err)
-		return kubeVersion, err
-	}
-	kubeVersion = version.Major + "." + version.Minor
-
+		version, err := discover.ServerVersion()
+		if err != nil {
+			logger.Errorf("error getting ServerVersion info:  %v", err)
+			return kubeVersion, err
+		}
+		kubeVersion = version.Major + "." + version.Minor
+	*/
 	return kubeVersion, nil
 }
 

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -101,10 +101,7 @@ func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 
 	kubernetesVersion := os.Getenv("K8S_VERSION_LABEL")
 	if kubernetesVersion != "" {
-		logger.Info("Kubernetes Version ", kubernetesVersion)
 		log = log.With(KubernetesVersion, kubernetesVersion)
-	} else {
-		logger.Warn("Not setting the label for Kubernetes version")
 	}
 
 	branchName := os.Getenv("BRANCH_NAME")

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -103,7 +103,7 @@ func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 	if kubernetesVersion != "" {
 		log = log.With(KubernetesVersion, kubernetesVersion)
 	}
-
+	logger.Info("Kubernetes Version ", kubernetesVersion)
 	branchName := os.Getenv("BRANCH_NAME")
 	if branchName != "" {
 		log = log.With(BranchName, branchName)


### PR DESCRIPTION
# Description

This PR makes use of the existing system property set by most of the Jenkins scripts for the Kubernetes version. A script is added to obtain a consistent Kubernetes version. 
This change also has the change to include the labels added for the feature set while emitting the metrics from the tests.

Contributes to VZ-4601

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
