### PR TITLE
VZ-4616.  Re-introduce validator, and fix instance-principal case

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -5,9 +5,16 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	vzos "github.com/verrazzano/verrazzano/pkg/os"
+	"io/fs"
+	"os"
 	"reflect"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v53/common"
 
 	"sigs.k8s.io/yaml"
 
@@ -35,20 +42,36 @@ const (
 	InstancePrincipalDelegationToken authenticationType = "instance_principle_delegation_token"
 	// UnknownAuthenticationType is used for none meaningful auth type
 	UnknownAuthenticationType authenticationType = "unknown_auth_type"
-	ociSecretFileName                            = "oci.yaml"
+
+	ociDNSSecretFileName            = "oci.yaml"
+	fluentdOCISecretConfigEntry     = "config"
+	fluentdOCISecretPrivateKeyEntry = "key"
+	fluentdExpectedKeyPath          = "/root/.oci/key"
+	fluentdOCIKeyFileEntry          = "key_file=/root/.oci/key"
+	expectedKeyHeader               = "RSA PRIVATE KEY"
+	validateTempFilePattern         = "validate-"
 )
 
-// OCI Secret Auth
+// OCI DNS Secret Auth
 type authData struct {
-	Region      string             `yaml:"region"`
-	Tenancy     string             `yaml:"tenancy"`
-	User        string             `yaml:"user"`
-	Key         string             `yaml:"key"`
-	Fingerprint string             `yaml:"fingerprint"`
-	AuthType    authenticationType `yaml:"authtype"`
+	Region      string             `json:"region"`
+	Tenancy     string             `json:"tenancy"`
+	User        string             `json:"user"`
+	Key         string             `json:"key"`
+	Fingerprint string             `json:"fingerprint"`
+	AuthType    authenticationType `json:"authtype"`
 }
+
+// OCI DNS Secret Auth Wrapper
 type ociAuth struct {
-	auth authData `yaml:"auth"`
+	Auth authData `json:"auth"`
+}
+
+func cleanTempFiles(log *zap.SugaredLogger) error {
+	if err := vzos.RemoveTempFiles(log, validateTempFilePattern); err != nil {
+		return fmt.Errorf("Error cleaning temp files: %s", err.Error())
+	}
+	return nil
 }
 
 // GetCurrentBomVersion Get the version string from the bom and return it as a semver object
@@ -95,7 +118,7 @@ func ValidateProfile(requestedProfile ProfileType) error {
 		case Prod, Dev, ManagedCluster:
 			return nil
 		default:
-			return fmt.Errorf("Requested profile %s is invalid.  Valid options are dev, prod, or managed-cluster",
+			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, or managed-cluster",
 				requestedProfile)
 		}
 	}
@@ -181,30 +204,172 @@ func ValidateInProgress(old *Verrazzano, new *Verrazzano) error {
 	return fmt.Errorf("Updates to resource not allowed while install, uninstall or upgrade is in progress")
 }
 
-// ValidateOciDNSSecret makes sure that the OCI DNS secret required by install exists
-func ValidateOciDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
-	if spec.Components.DNS != nil && spec.Components.DNS.OCI != nil {
-		secret := &corev1.Secret{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: spec.Components.DNS.OCI.OCIConfigSecret, Namespace: constants.VerrazzanoInstallNamespace}, secret)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("The secret \"%s\" must be created in the %s namespace before installing Verrrazzano for OCI DNS", spec.Components.DNS.OCI.OCIConfigSecret, constants.VerrazzanoInstallNamespace)
-			}
-			return err
-		}
+// validateOCISecrets - Validate that the OCI DNS and Fluentd OCI secrets required by install exists, if configured
+func validateOCISecrets(client client.Client, spec *VerrazzanoSpec) error {
+	if err := validateOCIDNSSecret(client, spec); err != nil {
+		return err
+	}
+	if err := validateFluentdOCIAuthSecret(client, spec); err != nil {
+		return err
+	}
+	return nil
+}
 
-		// validate auth_type
-		var authProp ociAuth
-		err = yaml.Unmarshal(secret.Data[ociSecretFileName], &authProp)
-		if err != nil {
-			zap.S().Errorf("yaml unmarshalling failed due to %v", err)
+func validateFluentdOCIAuthSecret(client client.Client, spec *VerrazzanoSpec) error {
+	if spec.Components.Fluentd == nil || spec.Components.Fluentd.OCI == nil {
+		return nil
+	}
+	apiSecretName := spec.Components.Fluentd.OCI.APISecret
+	if len(apiSecretName) > 0 {
+		secret := &corev1.Secret{}
+		if err := getInstallSecret(client, apiSecretName, secret); err != nil {
 			return err
 		}
-		if authProp.auth.AuthType != instancePrincipal && authProp.auth.AuthType != userPrincipal && authProp.auth.AuthType != "" {
-			return fmt.Errorf("The authtype \"%v\" in OCI secret must be either '%s' or '%s'", authProp.auth.AuthType, userPrincipal, instancePrincipal)
+		// validate config secret
+		if err := validateFluentdConfigData(secret); err != nil {
+			return err
+		}
+		// Validate key data exists and is a valid pem format
+		pemData, err := validateSecretKey(secret, fluentdOCISecretPrivateKeyEntry, nil)
+		if err != nil {
+			return err
+		}
+		if err := validatePrivateKey(secret.Name, pemData); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
+//validateFluentdConfigData - Validate the OCI config contents in the Fluentd secret
+func validateFluentdConfigData(secret *corev1.Secret) error {
+	secretName := secret.Name
+	configData, ok := secret.Data[fluentdOCISecretConfigEntry]
+	if !ok {
+		return fmt.Errorf("Did not find OCI configuration in secret \"%s\"", secretName)
+	}
+	// Write the OCI config in the secret to a temp file and use the OCI SDK
+	// ConfigurationProvider API to validate its contents
+	configTemp, err := os.CreateTemp(os.TempDir(), validateTempFilePattern)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		os.Remove(configTemp.Name())
+	}()
+	const ociConfigErrorFormatString = "%s not specified in Fluentd OCI config secret \"%s\""
+	if err := os.WriteFile(configTemp.Name(), configData, fs.ModeAppend); err != nil {
+		return err
+	}
+	provider, err := common.ConfigurationProviderFromFile(configTemp.Name(), "")
+	if err != nil {
+		return err
+	}
+	userOCID, err := provider.UserOCID()
+	if err != nil {
+		return err
+	}
+	if len(userOCID) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "User OCID", secretName)
+	}
+	tenancyOCID, err := provider.TenancyOCID()
+	if err != nil {
+		return err
+	}
+	if len(tenancyOCID) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Tenancy OCID", secretName)
+	}
+	fingerprint, err := provider.KeyFingerprint()
+	if err != nil {
+		return err
+	}
+	if len(fingerprint) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Fingerprint", secretName)
+	}
+	region, err := provider.Region()
+	if err != nil {
+		return err
+	}
+	if len(region) == 0 {
+		return fmt.Errorf(ociConfigErrorFormatString, "Region", secretName)
+	}
+	if !strings.Contains(string(configData), fluentdOCIKeyFileEntry) {
+		return fmt.Errorf("Unexpected or missing value for the Fluentd OCI key file location in secret \"%s\", should be \"%s\"",
+			secretName, fluentdExpectedKeyPath)
+	}
+	return nil
+}
+
+func validateOCIDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
+	if spec.Components.DNS == nil || spec.Components.DNS.OCI == nil {
+		return nil
+	}
+	secret := &corev1.Secret{}
+	ociDNSConfigSecret := spec.Components.DNS.OCI.OCIConfigSecret
+	if err := getInstallSecret(client, ociDNSConfigSecret, secret); err != nil {
+		return err
+	}
+	// Verify that the oci secret has one value
+	if len(secret.Data) != 1 {
+		return fmt.Errorf("Secret \"%s\" for OCI DNS should have one data key, found %v", ociDNSConfigSecret, len(secret.Data))
+	}
+	for key := range secret.Data {
+		// validate auth_type
+		var authProp ociAuth
+		if err := validateSecretContents(secret.Name, secret.Data[key], &authProp); err != nil {
+			return err
+		}
+		if err := validatePrivateKey(secret.Name, []byte(authProp.Auth.Key)); err != nil {
+			return err
+		}
+		if authProp.Auth.AuthType != instancePrincipal && authProp.Auth.AuthType != userPrincipal && authProp.Auth.AuthType != "" {
+			return fmt.Errorf("Authtype \"%v\" in OCI secret must be either '%s' or '%s'", authProp.Auth.AuthType, userPrincipal, instancePrincipal)
+		}
+	}
+	return nil
+}
+
+func getInstallSecret(client client.Client, secretName string, secret *corev1.Secret) error {
+	err := client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: constants.VerrazzanoInstallNamespace}, secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Errorf("Secret \"%s\" must be created in the \"%s\" namespace before installing Verrrazzano", secretName, constants.VerrazzanoInstallNamespace)
+		}
+		return err
+	}
+	return nil
+}
+
+func validatePrivateKey(secretName string, pemData []byte) error {
+	block, _ := pem.Decode(pemData)
+	if block == nil || !strings.Contains(block.Type, expectedKeyHeader) {
+		return fmt.Errorf("Private key in secret \"%s\" is either empty or not a valid key in PEM format", secretName)
+	}
+	return nil
+}
+
+func validateSecretKey(secret *corev1.Secret, dataKey string, target interface{}) ([]byte, error) {
+	var secretBytes []byte
+	var ok bool
+	if secretBytes, ok = secret.Data[dataKey]; !ok {
+		return nil, fmt.Errorf("Expected entry \"%s\" not found in secret \"%s\"", dataKey, secret.Name)
+	}
+	if target == nil {
+		return secretBytes, nil
+	}
+	if err := validateSecretContents(secret.Name, secretBytes, target); err != nil {
+		return secretBytes, nil
+	}
+	return secretBytes, nil
+}
+
+func validateSecretContents(secretName string, bytes []byte, target interface{}) error {
+	if len(bytes) == 0 {
+		return fmt.Errorf("Secret \"%s\" data is empty", secretName)
+	}
+	if err := yaml.Unmarshal(bytes, &target); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -319,11 +319,13 @@ func validateOCIDNSSecret(client client.Client, spec *VerrazzanoSpec) error {
 		if err := validateSecretContents(secret.Name, secret.Data[key], &authProp); err != nil {
 			return err
 		}
-		if err := validatePrivateKey(secret.Name, []byte(authProp.Auth.Key)); err != nil {
-			return err
-		}
 		if authProp.Auth.AuthType != instancePrincipal && authProp.Auth.AuthType != userPrincipal && authProp.Auth.AuthType != "" {
 			return fmt.Errorf("Authtype \"%v\" in OCI secret must be either '%s' or '%s'", authProp.Auth.AuthType, userPrincipal, instancePrincipal)
+		}
+		if authProp.Auth.AuthType == userPrincipal {
+			if err := validatePrivateKey(secret.Name, []byte(authProp.Auth.Key)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -696,7 +696,7 @@ func runValidateOCIDNSAuthTest(t *testing.T, authType authenticationType) {
 				Key:         string(key),
 			},
 		}
-	case instancePrincipal:
+	default:
 		ociConfig = ociAuth{
 			Auth: authData{
 				AuthType: authType,

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -5,8 +5,17 @@ package v1alpha1
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"go.uber.org/zap"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -609,8 +618,8 @@ func TestValidateEnable(t *testing.T) {
 
 // TestValidateOciDnsSecretBadSecret tests that validate fails if a secret in the Verrazzano CR does not exist
 // GIVEN a Verrazzano spec containing a secret that does not exist
-// WHEN ValidateOciDNSSecret is called
-// THEN an error is returned from ValidateOciDNSSecret
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
 func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -631,16 +640,83 @@ func TestValidateOciDnsSecretBadSecret(t *testing.T) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
 	assert.Error(t, err)
-	assert.Equal(t, "The secret \"oci-bad-secret\" must be created in the verrazzano-install namespace before installing Verrrazzano for OCI DNS", err.Error())
+	assert.Equal(t, "Secret \"oci-bad-secret\" must be created in the \"verrazzano-install\" namespace before installing Verrrazzano", err.Error())
 }
 
-// TestValidateOciDnsSecretGoodSecret tests that validate succeeds if a secret in the Verrazzano CR exists
-// GIVEN a Verrazzano spec containing a secret that exists
-// WHEN ValidateOciDNSSecret is called
-// THEN success is returned from ValidateOciDNSSecret
-func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
+// TestValidateOciDnsSecretUserAuth tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS user-auth secret that exists
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateOciDnsSecretUserAuth(t *testing.T) {
+	runValidateOCIDNSAuthTest(t, userPrincipal)
+}
+
+// TestValidateOciDnsSecretInstancePrincipalAuth tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS instance-principal auth secret that exists
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateOciDnsSecretInstancePrincipalAuth(t *testing.T) {
+	runValidateOCIDNSAuthTest(t, instancePrincipal)
+}
+
+func runValidateOCIDNSAuthTest(t *testing.T, authType authenticationType) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    authType,
+			Key:         string(key),
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "Error marshalling test data")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.NoError(t, err)
+}
+
+// TestValidateOciDnsSecretNoDataKeys tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS instance-principal auth secret that exists but has no data keys
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateOciDnsSecretNoDataKeys(t *testing.T) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
 			Components: ComponentSpec{
@@ -669,14 +745,171 @@ func TestValidateOciDnsSecretGoodSecret(t *testing.T) {
 	err = client.Create(context.TODO(), secret)
 	assert.NoError(t, err)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Secret \"oci\" for OCI DNS should have one data key, found 0")
+	}
+}
+
+// TestValidateOciDnsSecretTooManyDataKeys tests validateOCISecrets
+// GIVEN a Verrazzano spec containing an OCI DNS instance-principal auth secret that exists but has more than one data key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateOciDnsSecretTooManyDataKeys(t *testing.T) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
 	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName:        []byte("value1"),
+			ociDNSSecretFileName + "-2": []byte("value2"),
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Secret \"oci\" for OCI DNS should have one data key, found 2")
+	}
+
+}
+
+// TestValidateOciDnsSecretInvalidAPIKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a secret that exists but with an invalid private key
+// WHEN validateOCISecrets is called
+// THEN an error returned from validateOCISecrets
+func TestValidateOciDnsSecretInvalidAPIKey(t *testing.T) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    userPrincipal,
+			Key:         "foo",
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "Error marshalling test data")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Private key in secret \"oci\" is either empty or not a valid key in PEM format")
+}
+
+// TestValidateOciDnsSecretInvalidAuthType tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a secret that exists but with an invalid OCI Auth type
+// WHEN validateOCISecrets is called
+// THEN an error returned from validateOCISecrets
+func TestValidateOciDnsSecretInvalidAuthType(t *testing.T) {
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret: "oci",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	ociConfig := ociAuth{
+		Auth: authData{
+			Region:      "us-ashburn-1",
+			Tenancy:     "my-tenancy",
+			User:        "my-user",
+			Fingerprint: "a-fingerprint",
+			AuthType:    "InvalidAuthType",
+			Key:         string(key),
+		},
+	}
+	secretData, err := yaml.Marshal(&ociConfig)
+	assert.NoError(t, err, "error marshalling test data")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci",
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			ociDNSSecretFileName: secretData,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("Authtype \"InvalidAuthType\" in OCI secret must be either '%s' or '%s'", userPrincipal, instancePrincipal))
 }
 
 // TestValidateOciDnsSecretNoOci tests that validate succeeds if the DNS component is not OCI
 // GIVEN a Verrazzano spec containing a wildcard DNS component
-// WHEN ValidateOciDNSSecret is called
-// THEN success is returned from ValidateOciDNSSecret
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
 func TestValidateOciDnsSecretNoOci(t *testing.T) {
 	vz := Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -697,8 +930,417 @@ func TestValidateOciDnsSecretNoOci(t *testing.T) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
-	err = ValidateOciDNSSecret(client, &vz.Spec)
+	err = validateOCISecrets(client, &vz.Spec)
 	assert.NoError(t, err)
+}
+
+// TestValidateFluentdOCISecretGoodSecretWithPassphrase tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a valid Fluentd OCI secret that exists with a passphrase
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateFluentdOCISecretGoodSecretWithPassphrase1(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+pass_phrase=apassphrase
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes)
+}
+
+// TestValidateFluentdOCISecretGoodSecretNoPassphrase tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a valid Fluentd OCI secret that exists without a passphrase
+// WHEN validateOCISecrets is called
+// THEN success is returned from validateOCISecrets
+func TestValidateFluentdOCISecretGoodSecretNoPassphrase(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes)
+}
+
+// TestValidateFluentdOCISecretBadProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with a bad profile key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretBadProfileKey(t *testing.T) {
+	ociConfigBytes := `
+[blah]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "configuration file did not contain profile: DEFAULT")
+}
+
+// TestValidateFluentdOCISecretNoProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with no OCI profile key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoProfileKey(t *testing.T) {
+	ociConfigBytes := `
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "configuration file did not contain profile: DEFAULT")
+}
+
+// TestValidateFluentdOCISecretNoProfileKey tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty user OCID
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoUserOCID(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "User OCID not specified in Fluentd OCI config secret \"fluentd-oci\"")
+}
+
+// TestValidateFluentdOCISecretNoTenancyOCID tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty tenancy OCID
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoTenancyOCID(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=
+region=us-ashburn-1
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Tenancy OCID not specified in Fluentd OCI config secret \"fluentd-oci\"")
+}
+
+// TestValidateFluentdOCISecretNoRegion tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty region name
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoRegion(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=
+fingerprint=a0:bb:dd:c2:dd:e0:f1:fa:cd:d1:8a:11:bb:c0:f1:55
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "region can not be empty or have spaces")
+}
+
+// TestValidateFluentdOCISecretNoFingerprint tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with an OCI secret with an empty key fingerprint
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoFingerprint(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=ocid1.user.oc1..sfafasfasfsdafas
+tenancy=ocid1.tenancy.oc1..sfdasfsafas
+region=us-ashburn-1
+fingerprint=
+key_file=/root/.oci/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Fingerprint not specified in Fluentd OCI config secret \"fluentd-oci\"")
+}
+
+func runTestFluentdOCIConfig(t *testing.T, ociConfigBytes string, errorMsg ...string) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry:     []byte(ociConfigBytes),
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	if len(errorMsg) > 0 {
+		assert.Error(t, err)
+		if err != nil {
+			assert.Contains(t, err.Error(), errorMsg[0])
+		}
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
+// TestValidateFluentdOCISecretInvalidKeyType tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has an invalid key type
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyType(t *testing.T) {
+	key, err := generateTestPrivateKeyWithType("INVALID KEY TYPE")
+	assert.NoError(t, err)
+	runFluentdInvalidKeyTest(t, key, "not a valid key")
+}
+
+// TestValidateFluentdOCISecretInvalidKeyFormat tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret with a key not in PEM format
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyFormat(t *testing.T) {
+	runFluentdInvalidKeyTest(t, []byte("foo"), "not a valid key")
+}
+
+// TestValidateFluentdOCISecretNoKeyData tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret with a empty key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretNoKeyData(t *testing.T) {
+	runFluentdInvalidKeyTest(t, []byte{}, "Private key in secret \"fluentd-oci\" is either empty or not a valid key in PEM format")
+}
+
+func runFluentdInvalidKeyTest(t *testing.T, key []byte, msgSnippet string) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=/root/.oci/key
+`
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry:     []byte(ociConfigBytes),
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), msgSnippet)
+}
+
+// TestValidateFluentdOCISecretMissingKeySection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has a missing API key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingKeySection(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=/root/.oci/key
+`
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretConfigEntry: []byte(ociConfigBytes),
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("Expected entry \"%s\" not found in secret \"%s\"", fluentdOCISecretPrivateKeyEntry, ociSecretName))
+}
+
+// TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has a missing OCI Config key
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingConfigSection(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	key, err := generateTestPrivateKey()
+	assert.NoError(t, err)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ociSecretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			fluentdOCISecretPrivateKeyEntry: key,
+		},
+	}
+	err = client.Create(context.TODO(), secret)
+	assert.NoError(t, err)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Did not find OCI configuration in secret \"fluentd-oci\"")
+}
+
+// TestValidateFluentdOCISecretMissingConfigSection tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that does not exist
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretMissingSecret(t *testing.T) {
+	const ociSecretName = "fluentd-oci"
+	vz := Verrazzano{
+		Spec: VerrazzanoSpec{
+			Components: ComponentSpec{
+				Fluentd: &FluentdComponent{
+					OCI: &OciLoggingConfiguration{
+						APISecret: ociSecretName,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = clientgoscheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	err = validateOCISecrets(client, &vz.Spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("Secret \"%s\" must be created in the \"%s\" namespace", ociSecretName, constants.VerrazzanoInstallNamespace))
+}
+
+// TestValidateFluentdOCISecretInvalidKeyPath tests validateOCISecrets
+// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that an incorrect key path
+// WHEN validateOCISecrets is called
+// THEN an error is returned from validateOCISecrets
+func TestValidateFluentdOCISecretInvalidKeyPath(t *testing.T) {
+	ociConfigBytes := `
+[DEFAULT]
+user=my-user
+tenancy=my-tenancy
+region=us-ashburn-1
+fingerprint=a-fingerprint
+key_file=invalid/path/to/key
+`
+	runTestFluentdOCIConfig(t, ociConfigBytes, "Unexpected or missing value for the Fluentd OCI key file location in secret \"fluentd-oci\", should be \"/root/.oci/key\"")
+}
+
+// Test_validateSecretContents Tests validateSecretContents
+// GIVEN a call to validateSecretContents
+// WHEN the YAML bytes are not valid
+// THEN an error is returned
+func Test_validateSecretContents(t *testing.T) {
+	err := validateSecretContents("mysecret", []byte("foo"), &authData{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error unmarshaling JSON")
+}
+
+// Test_validateSecretContentsEmpty Tests validateSecretContents
+// GIVEN a call to validateSecretContents
+// WHEN the YAML bytes are empty
+// THEN an error is returned
+func Test_validateSecretContentsEmpty(t *testing.T) {
+	err := validateSecretContents("mysecret", []byte{}, &authData{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Secret \"mysecret\" data is empty")
 }
 
 func newBool(v bool) *bool {
@@ -784,4 +1426,55 @@ func TestValidateProfileDevProfile(t *testing.T) {
 // THEN an error is returned
 func TestValidateProfileInvalidProfile(t *testing.T) {
 	assert.Error(t, ValidateProfile("wrong-profile"))
+}
+
+// TestValidateProfileInvalidProfile Tests cleanTempFiles()
+// GIVEN a call to cleanTempFiles
+// WHEN there are leftover validation temp files in the TMP dir
+// THEN the temp files are cleaned up properly
+func Test_cleanTempFiles(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpFiles := []*os.File{}
+	for i := 1; i < 5; i++ {
+		temp, err := os.CreateTemp(os.TempDir(), validateTempFilePattern)
+		assert.NoErrorf(err, "Unable to create temp file %s for testing: %s", temp.Name(), err)
+		assert.FileExists(temp.Name())
+		tmpFiles = append(tmpFiles, temp)
+	}
+
+	err := cleanTempFiles(zap.S())
+	if assert.NoError(err) {
+		for _, tmpFile := range tmpFiles {
+			assert.NoFileExists(tmpFile.Name(), "Error, temp file %s not deleted", tmpFile.Name())
+		}
+	}
+}
+
+var testKey = []byte{}
+
+// Generate RSA for testing.
+func generateTestPrivateKey() ([]byte, error) {
+	var err error
+	if len(testKey) == 0 { // cache the test key, we only need one valid one and it can be expensive
+		testKey, err = generateTestPrivateKeyWithType("RSA PRIVATE KEY")
+	}
+	return testKey, err
+}
+
+// Generate RSA for testing with the specified type
+func generateTestPrivateKeyWithType(keyType string) ([]byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// Encode private key to PKCS#1 ASN.1 PEM.
+	keyPEM := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  keyType,
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		},
+	)
+	return keyPEM, nil
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -681,18 +681,29 @@ func runValidateOCIDNSAuthTest(t *testing.T, authType authenticationType) {
 	assert.NoError(t, err)
 	client := fake.NewFakeClientWithScheme(scheme)
 
-	key, err := generateTestPrivateKey()
-	assert.NoError(t, err)
-	ociConfig := ociAuth{
-		Auth: authData{
-			Region:      "us-ashburn-1",
-			Tenancy:     "my-tenancy",
-			User:        "my-user",
-			Fingerprint: "a-fingerprint",
-			AuthType:    authType,
-			Key:         string(key),
-		},
+	var ociConfig ociAuth
+	switch authType {
+	case userPrincipal:
+		key, err := generateTestPrivateKey()
+		assert.NoError(t, err)
+		ociConfig = ociAuth{
+			Auth: authData{
+				Region:      "us-ashburn-1",
+				Tenancy:     "my-tenancy",
+				User:        "my-user",
+				Fingerprint: "a-fingerprint",
+				AuthType:    authType,
+				Key:         string(key),
+			},
+		}
+	case instancePrincipal:
+		ociConfig = ociAuth{
+			Auth: authData{
+				AuthType: authType,
+			},
+		}
 	}
+
 	secretData, err := yaml.Marshal(&ociConfig)
 	assert.NoError(t, err, "Error marshalling test data")
 

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -6,7 +6,6 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	v1 "k8s.io/api/core/v1"
@@ -22,7 +21,11 @@ import (
 var getControllerRuntimeClient = getClient
 
 // SetupWebhookWithManager is used to let the controller manager know about the webhook
-func (v *Verrazzano) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (v *Verrazzano) SetupWebhookWithManager(mgr ctrl.Manager, log *zap.SugaredLogger) error {
+	// clean up any temp files that may have been left over after a container restart
+	if err := cleanTempFiles(log); err != nil {
+		return err
+	}
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(v).
 		Complete()
@@ -63,8 +66,7 @@ func (v *Verrazzano) ValidateCreate() error {
 		return err
 	}
 
-	// Validate that the OCI DNS secret required by install exists
-	if err := ValidateOciDNSSecret(client, &v.Spec); err != nil {
+	if err := validateOCISecrets(client, &v.Spec); err != nil {
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"time"
 
+	ctrlerrrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -36,6 +39,17 @@ func preInstall(compContext spi.ComponentContext) error {
 	if compContext.IsDryRun() {
 		compContext.Log().Debug("cert-manager PreInstall dry run")
 		return nil
+	}
+
+	compContext.Log().Debug("Creating namespace %s namespace if necessary", externalDNSNamespace)
+	ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: externalDNSNamespace}}
+	if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &ns, func() error {
+		return nil
+	}); err != nil {
+		return ctrlerrrors.RetryableError{
+			Source: compContext.GetComponent(),
+			Cause:  fmt.Errorf("Failed to create or update the cert-manager namespace: %v", err),
+		}
 	}
 
 	// Get OCI DNS secret from the verrazzano-install namespace

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -161,7 +161,7 @@ func main() {
 	// Setup the validation webhook
 	if config.WebhooksEnabled {
 		log.Debug("Setting up Verrazzano webhook with manager")
-		if err = (&installv1alpha1.Verrazzano{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&installv1alpha1.Verrazzano{}).SetupWebhookWithManager(mgr, log); err != nil {
 			log.Errorf("Failed to setup webhook with manager: %v", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
# Description

Re-re-introduce the fluentd OCI auth secret validation again, and fix the case for `instance_principal` auth validation.

Fixes VZ-4616

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
