### PR TITLE
VZ-4712: Add optional helm --debug flag

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var Debug bool
+
 // cmdRunner needed for unit tests
 var runner vzos.CmdRunner = vzos.DefaultRunner{}
 
@@ -148,6 +150,9 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 	cmdArgs := []string{operation, releaseName}
 	if len(chartDir) > 0 {
 		cmdArgs = append(cmdArgs, chartDir)
+	}
+	if Debug {
+		cmdArgs = append(cmdArgs, "--debug")
 	}
 	if dryRun {
 		cmdArgs = append(cmdArgs, "--dry-run")

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// Debug is set from a platform-operator arg and sets the helm --debug flag
 var Debug bool
 
 // cmdRunner needed for unit tests

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -70,6 +71,7 @@ func main() {
 	flag.StringVar(&config.VerrazzanoRootDir, "vz-root-dir", config.VerrazzanoRootDir,
 		"Specify the root directory of Verrazzano (used for development)")
 	flag.StringVar(&bomOverride, "bom-path", "", "BOM file location")
+	flag.BoolVar(&helm.Debug, "helm-debug", helm.Debug, "Add the --debug flag to helm commands")
 
 	// Add the zap logger flag set to the CLI.
 	opts := kzap.Options{}


### PR DESCRIPTION
This change adds a helm-debug platform-operator flag. When set to true, this adds a --debug helm flag that will be added to helm commands. This can be enabled in conjunction with debug logging to get more detailed logs on failures in helm commands. It is especially useful for debugging when helm commands time out.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
