### PR TITLE
VZ-4616.  Remove private key header check from OCI auth secret validation

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -48,7 +48,6 @@ const (
 	fluentdOCISecretPrivateKeyEntry = "key"
 	fluentdExpectedKeyPath          = "/root/.oci/key"
 	fluentdOCIKeyFileEntry          = "key_file=/root/.oci/key"
-	expectedKeyHeader               = "RSA PRIVATE KEY"
 	validateTempFilePattern         = "validate-"
 )
 
@@ -344,7 +343,7 @@ func getInstallSecret(client client.Client, secretName string, secret *corev1.Se
 
 func validatePrivateKey(secretName string, pemData []byte) error {
 	block, _ := pem.Decode(pemData)
-	if block == nil || !strings.Contains(block.Type, expectedKeyHeader) {
+	if block == nil {
 		return fmt.Errorf("Private key in secret \"%s\" is either empty or not a valid key in PEM format", secretName)
 	}
 	return nil

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -1120,16 +1120,6 @@ func runTestFluentdOCIConfig(t *testing.T, ociConfigBytes string, errorMsg ...st
 	}
 }
 
-// TestValidateFluentdOCISecretInvalidKeyType tests validateOCISecrets
-// GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret that has an invalid key type
-// WHEN validateOCISecrets is called
-// THEN an error is returned from validateOCISecrets
-func TestValidateFluentdOCISecretInvalidKeyType(t *testing.T) {
-	key, err := generateTestPrivateKeyWithType("INVALID KEY TYPE")
-	assert.NoError(t, err)
-	runFluentdInvalidKeyTest(t, key, "not a valid key")
-}
-
 // TestValidateFluentdOCISecretInvalidKeyFormat tests validateOCISecrets
 // GIVEN a Verrazzano spec containing a fluentd configuration with a Fluentd OCI secret with a key not in PEM format
 // WHEN validateOCISecrets is called


### PR DESCRIPTION
# Description

Remove the RSA header check from the private key validation in the VPO.

Fixes VZ-4616.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
