### PR TITLE
VZ- 4774: add fluentd parsing for oam-kubernetes-runtime log files

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -248,7 +248,6 @@ data:
           format /^(?<logtime>\d{4}\/\d{2}\/\d{2} \d{2}\:\d{2}\:\d{2}) \[(?<level>.*?)\] ([\s\S]*?)$/
           time_key logtime
           time_format %Y/%m/%d %H:%M:%S
-          keep_time_key true
         </pattern>
         <pattern>
           format none
@@ -259,7 +258,6 @@ data:
     <filter kubernetes.**verrazzano-authproxy**verrazzano-authproxy**>
       @type record_transformer
       enable_ruby true
-      remove_keys remaining,logtime
       <record>
         @timestamp ${time.iso8601(3)}
       </record>
@@ -280,13 +278,11 @@ data:
           format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\t(?<level>.*?)\t([\s\S]*?)$/
           time_key logtime
           time_format %Y-%m-%dT%H:%M:%S.%NZ
-          keep_time_key true
         </pattern>
         <pattern>
           format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?([\s\S]*?)$/
           time_key logtime
           time_format %H:%M:%S.%N
-          keep_time_key true
         </pattern>
         <pattern>
           format none
@@ -297,7 +293,41 @@ data:
     <filter kubernetes.**coherence-operator**verrazzano-system_manager**>
       @type record_transformer
       enable_ruby true
-      remove_keys logtime
+      <record>
+        @timestamp ${time.iso8601(3)}
+      </record>
+    </filter>
+
+    # filter to parse oam-kubernetes-runtime container log files
+    <filter kubernetes.**oam-kubernetes-runtime**verrazzano-system_oam-kubernetes-runtime**>
+      @type parser
+      @id oam-kubernetes-runtime
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # oam-kubernetes-runtime has two formats for log records
+        # oam-kubernetes-runtime format and a klog format
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\t(?<level>.*?)\t([\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?([\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    <filter kubernetes.**oam-kubernetes-runtime**verrazzano-system_oam-kubernetes-runtime**>
+      @type record_transformer
+      enable_ruby true
       <record>
         @timestamp ${time.iso8601(3)}
       </record>


### PR DESCRIPTION
# Description

This pull request adds fluentd parsing/filter rules for oam-kubernetes runtime log files.  In addition, removes unneeded settings from previous fluentd PR.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
