### PR TITLE
VZ-4767 multi-cluster logging

### DIFF
--- a/pkg/controller/requeue.go
+++ b/pkg/controller/requeue.go
@@ -3,9 +3,10 @@
 package controller
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/util/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"time"
 )
 
 // Create a new Result that will cause a reconcile requeue after a short delay
@@ -13,4 +14,9 @@ func NewRequeueWithDelay(min int, max int, units time.Duration) ctrl.Result {
 	var seconds = rand.IntnRange(min, max)
 	delaySecs := time.Duration(seconds) * units
 	return ctrl.Result{Requeue: true, RequeueAfter: delaySecs}
+}
+
+// Return true if requeue is needed
+func ShouldRequeue(r ctrl.Result) bool {
+	return r.Requeue || r.RequeueAfter > 0
 }

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package clusters
@@ -55,7 +55,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	if rancherYAML, err := registerManagedClusterWithRancher(r.Client, vmc.Name, r.log); err != nil {
 		msg := fmt.Sprintf("Registration of managed cluster failed: %v", err)
 		r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, msg)
-		r.log.Warn("Unable to register managed cluster with Rancher, manifest secret will not contain Rancher YAML")
+		r.log.Info("Unable to register managed cluster with Rancher, manifest secret will not contain Rancher YAML")
 	} else {
 		msg := "Registration of managed cluster completed successfully"
 		r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationCompleted, msg)

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -53,9 +53,9 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	// Rancher YAML is applied on the managed cluster
 	// NOTE: If this errors we log it and do not fail the reconcile
 	if rancherYAML, err := registerManagedClusterWithRancher(r.Client, vmc.Name, r.log); err != nil {
-		msg := fmt.Sprintf("Registration of managed cluster failed: %v", err)
+		msg := fmt.Sprintf("Failed to register managed cluster: %v", err)
 		r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, msg)
-		r.log.Info("Unable to register managed cluster with Rancher, manifest secret will not contain Rancher YAML")
+		r.log.Info("Failed to register managed cluster with Rancher, manifest secret will not contain Rancher YAML")
 	} else {
 		msg := "Registration of managed cluster completed successfully"
 		r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationCompleted, msg)

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -75,7 +75,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.C
 	// Get the Prometheus configuration.  The ConfigMap may not exist if this delete is being called during an uninstall of Verrazzano.
 	promConfigMap, err := r.getPrometheusConfig(ctx, vmc)
 	if err != nil {
-		r.log.Infof("unable to add Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
+		r.log.Infof("Failed adding Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterPrometheusConfiguratio
 	// Get the Prometheus configuration.  The ConfigMap may not exist if this delete is being called during an uninstall of Verrazzano.
 	promConfigMap, err := r.getPrometheusConfig(ctx, vmc)
 	if err != nil {
-		r.log.Infof("unable to delete Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
+		r.log.Infof("Failed deleting Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
 		return nil
 	}
 

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package clusters
@@ -75,7 +75,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.C
 	// Get the Prometheus configuration.  The ConfigMap may not exist if this delete is being called during an uninstall of Verrazzano.
 	promConfigMap, err := r.getPrometheusConfig(ctx, vmc)
 	if err != nil {
-		r.log.Warn(fmt.Sprintf("unable to add Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err))
+		r.log.Infof("unable to add Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterPrometheusConfiguratio
 	// Get the Prometheus configuration.  The ConfigMap may not exist if this delete is being called during an uninstall of Verrazzano.
 	promConfigMap, err := r.getPrometheusConfig(ctx, vmc)
 	if err != nil {
-		r.log.Warn(fmt.Sprintf("unable to delete Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err))
+		r.log.Infof("unable to delete Prometheus configuration for managed cluster %s: %v", vmc.ClusterName, err)
 		return nil
 	}
 

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -138,7 +138,7 @@ func (r *VerrazzanoManagedClusterReconciler) getVzESURLSecret() (string, string,
 	vzList := vzapi.VerrazzanoList{}
 	err := r.List(context.TODO(), &vzList, &client.ListOptions{})
 	if err != nil {
-		r.log.Error(err, "Can not list Verrazzano CR")
+		r.log.Errorf("Failed to list Verrazzano CR: %v", err)
 		return url, secret, err
 	}
 	// what to do when there is more than one Verrazzano CR

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package clusters

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -54,7 +54,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
-		zap.S().Errorf("Failed to fetch Verrazzano resource: %v", err)
+		zap.S().Errorf("Failed to fetch VerrazzanoManagedCluster resource: %v", err)
 		return newRequeueWithDelay(), nil
 	}
 
@@ -67,7 +67,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 		ControllerName: "multicluster",
 	})
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for Verrazzano controller", err)
+		zap.S().Errorf("Failed to create controller logger for VerrazzanoManagedCluster controller", err)
 	}
 
 	r.log = log
@@ -76,13 +76,21 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 	if vzctrl.ShouldRequeue(res) {
 		return res, nil
 	}
+
 	// Never return an error since it has already been logged and we don't want the
 	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
 	if err != nil {
 		return newRequeueWithDelay(), nil
 	}
-	// The Verrazzano resource has been reconciled.
-	log.Oncef("Successfully reconciled Verrazzano resource %v", req.NamespacedName)
+
+	// Never return an error since it has already been logged and we don't want the
+	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
+	if err != nil {
+		return newRequeueWithDelay(), nil
+	}
+
+	// The resource has been reconciled.
+	log.Oncef("Successfully reconciled VerrazzanoManagedCluster resource %v", req.NamespacedName)
 
 	return ctrl.Result{}, nil
 }
@@ -184,7 +192,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncServiceAccount(vmc *clustersv1a
 	// Does the VerrazzanoManagedCluster object contain the service account name?
 	saName := generateManagedResourceName(vmc.Name)
 	if vmc.Spec.ServiceAccount != saName {
-		r.log.Infof("Updating ServiceAccount from %q to %q", vmc.Spec.ServiceAccount, saName)
+		r.log.Oncef("Updating ServiceAccount from %q to %q", vmc.Spec.ServiceAccount, saName)
 		vmc.Spec.ServiceAccount = saName
 		err = r.Update(context.TODO(), vmc)
 		if err != nil {

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -6,6 +6,10 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"time"
+
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
@@ -31,7 +35,7 @@ const finalizerName = "managedcluster.verrazzano.io"
 type VerrazzanoManagedClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
-	log    *zap.SugaredLogger
+	log    vzlog.VerrazzanoLogger
 }
 
 // bindingParams used to mutate the RoleBinding
@@ -41,26 +45,51 @@ type bindingParams struct {
 	serviceAccountName string
 }
 
-// Reconcile reconciles a VerrazzanoManagedCluster object
 func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	ctx := context.TODO()
-	log := zap.S().With("resource", fmt.Sprintf("%s:%s", req.Namespace, req.Name))
-	r.log = log
-	log.Info("Reconciler called")
-	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{}
-
-	err := r.Get(ctx, req.NamespacedName, vmc)
-	if err != nil {
+	// Get the  resource
+	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	if err := r.Get(context.TODO(), req.NamespacedName, cr); err != nil {
 		// If the resource is not found, that means all of the finalizers have been removed,
 		// and the Verrazzano resource has been deleted, so there is nothing left to do.
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
-
-		// Error getting the VerrazzanoManagedCluster resource
-		log.Errorf("Failed to fetch resource: %v", err)
-		return reconcile.Result{}, err
+		zap.S().Errorf("Failed to fetch Verrazzano resource: %v", err)
+		return newRequeueWithDelay(), nil
 	}
+
+	// Get the resource logger needed to log message using 'progress' and 'once' methods
+	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+		Name:           cr.Name,
+		Namespace:      cr.Namespace,
+		ID:             string(cr.UID),
+		Generation:     cr.Generation,
+		ControllerName: "multicluster",
+	})
+	if err != nil {
+		zap.S().Errorf("Failed to create controller logger for Verrazzano controller", err)
+	}
+
+	r.log = log
+	log.Oncef("Reconciling Verrazzano resource %v", req.NamespacedName)
+	res, err := r.doReconcile(log, cr)
+	if vzctrl.ShouldRequeue(res) {
+		return res, nil
+	}
+	// Never return an error since it has already been logged and we don't want the
+	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
+	if err != nil {
+		return newRequeueWithDelay(), nil
+	}
+	// The Verrazzano resource has been reconciled.
+	log.Oncef("Successfully reconciled Verrazzano resource %v", req.NamespacedName)
+
+	return ctrl.Result{}, nil
+}
+
+// Reconcile reconciles a VerrazzanoManagedCluster object
+func (r *VerrazzanoManagedClusterReconciler) doReconcile(log vzlog.VerrazzanoLogger, vmc *clustersv1alpha1.VerrazzanoManagedCluster) (ctrl.Result, error) {
+	ctx := context.TODO()
 
 	if !vmc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Finalizer is present, so lets do the cluster deletion
@@ -91,7 +120,7 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(req ctrl.Request) (ctrl.R
 
 	// Sync the service account
 	log.Debugf("Syncing the ServiceAccount for VMC %s", vmc.Name)
-	err = r.syncServiceAccount(vmc)
+	err := r.syncServiceAccount(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the ServiceAccount", err, log)
 		return ctrl.Result{}, err
@@ -250,7 +279,7 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatusReady(ctx context.Conte
 	return r.updateStatus(ctx, vmc, clustersv1alpha1.Condition{Status: corev1.ConditionTrue, Type: clustersv1alpha1.ConditionReady, Message: msg, LastTransitionTime: &now})
 }
 
-func (r *VerrazzanoManagedClusterReconciler) handleError(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, msg string, err error, log *zap.SugaredLogger) {
+func (r *VerrazzanoManagedClusterReconciler) handleError(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, msg string, err error, log vzlog.VerrazzanoLogger) {
 	fullMsg := fmt.Sprintf("%s: %v", msg, err)
 	log.Errorf(fullMsg)
 	statusErr := r.updateStatusNotReady(ctx, vmc, fullMsg)
@@ -305,4 +334,9 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatus(ctx context.Context, v
 	}
 	r.log.Debugf("Updating Status of VMC %s with condition type %s = %s: %v", vmc.Name, condition.Type, condition.Status, vmc.Status.Conditions)
 	return r.Status().Update(ctx, vmc)
+}
+
+// Create a new Result that will cause a reconcile requeue after a short delay
+func newRequeueWithDelay() ctrl.Result {
+	return vzctrl.NewRequeueWithDelay(2, 3, time.Second)
 }

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -559,10 +559,9 @@ func TestCreateVMCSyncSvcAccountFailed(t *testing.T) {
 
 	// Validate the results - there should have been an error returned for failing to sync svc account
 	mocker.Finish()
-	asserts.NotNil(err)
-	asserts.Contains(err.Error(), "failing syncServiceAccount")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Nil(err)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestCreateVMCSyncRoleBindingFailed tests the Reconcile method for the following use case
@@ -596,10 +595,9 @@ func TestCreateVMCSyncRoleBindingFailed(t *testing.T) {
 
 	// Validate the results - there should have been an error returned
 	mocker.Finish()
-	asserts.NotNil(err)
-	asserts.Contains(err.Error(), "failing syncRoleBinding")
-	asserts.Equal(false, result.Requeue)
-	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Nil(err)
+	asserts.Equal(true, result.Requeue)
+	asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 }
 
 // TestDeleteVMC tests the Reconcile method for the following use case
@@ -767,7 +765,7 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 		Update(gomock.Any(), gomock.AssignableToTypeOf(&clustersapi.VerrazzanoManagedCluster{})).
 		DoAndReturn(func(ctx context.Context, vmc *clustersapi.VerrazzanoManagedCluster) error {
 			asserts.Equal(clustersapi.RegistrationFailed, vmc.Status.RancherRegistration.Status)
-			asserts.Equal("Registration of managed cluster failed: unable to get rancher ingress host name", vmc.Status.RancherRegistration.Message)
+			asserts.Equal("Failed to register managed cluster: Failed, Rancher ingress cattle-system/rancher is missing host names", vmc.Status.RancherRegistration.Message)
 			return nil
 		})
 

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	k8net "k8s.io/api/networking/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -792,7 +792,7 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 	// fail but the result of syncManifestSecret should be success
 	vmc := clustersapi.VerrazzanoManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: constants.VerrazzanoMultiClusterNamespace}}
 	reconciler := newVMCReconciler(mock)
-	reconciler.log = zap.S()
+	reconciler.log = vzlog.DefaultLogger()
 
 	err := reconciler.syncManifestSecret(context.TODO(), &vmc)
 
@@ -819,7 +819,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 			return nil
 		})
 
-	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -847,7 +847,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 			return errors.NewResourceExpired("something bad happened")
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -888,7 +888,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -931,7 +931,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -986,7 +986,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1054,7 +1054,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, zap.S())
+	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1108,7 +1108,7 @@ func TestRegisterClusterWithRancherRetryRequest(t *testing.T) {
 			return resp, nil
 		}).Times(retrySteps)
 
-	_, err := registerManagedClusterWithRancher(mock, clusterName, zap.S())
+	_, err := registerManagedClusterWithRancher(mock, clusterName, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package clusters


### PR DESCRIPTION
Cleanup logging for Multicluster

1. Use VerrazzanoLogger
2. Don't return error to controller-runtime
3. Cleanup log message

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
