### PR TITLE
No JIRA: Add retries around terraform plan

### DIFF
--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -8,9 +8,23 @@
 . ./init.sh
 
 $SCRIPT_DIR/terraform init -no-color -reconfigure
-$SCRIPT_DIR/terraform plan -var-file=$TF_VAR_nodepool_config.tfvars -var-file=$TF_VAR_region.tfvars -no-color
 
 set -o pipefail
+
+# retry 3 times, 30 seconds apart
+tries=0
+MAX_TRIES=3
+while true; do
+   tries=$((tries+1))
+   echo "terraform plan iteration ${tries}"
+   $SCRIPT_DIR/terraform plan -var-file=$TF_VAR_nodepool_config.tfvars -var-file=$TF_VAR_region.tfvars -no-color && break
+   if [ "$tries" -ge "$MAX_TRIES" ];
+   then
+      echo "Terraform plan tries exceeded.  Cluster creation has failed!"
+      exit 1
+   fi
+   sleep 30
+done
 
 # retry 3 times, 30 seconds apart
 tries=0


### PR DESCRIPTION
# Description

There have been test pipeline failures due to network connectivity issues when performing `terraform plan`. This PR updates the script to add retries when `terraform plan` fails.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
