### PR TITLE
Fix the code location reported by framework

### DIFF
--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -84,7 +84,8 @@ func (t *TestFramework) It(text string, args ...interface{}) bool {
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	}
 
-	args[len(args)-1] = f
+	args[len(args)-1] = ginkgo.Offset(1)
+	args = append(args, f)
 	return ginkgo.It(text, args...)
 }
 
@@ -102,7 +103,8 @@ func (t *TestFramework) Describe(text string, args ...interface{}) bool {
 		reflect.ValueOf(body).Call([]reflect.Value{})
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 	}
-	args[len(args)-1] = f
+	args[len(args)-1] = ginkgo.Offset(1)
+	args = append(args, f)
 	return ginkgo.Describe(text, args...)
 }
 
@@ -154,6 +156,10 @@ func (t *TestFramework) AfterSuite(body func()) bool {
 
 // Entry - wrapper function for Ginkgo Entry
 func (t *TestFramework) Entry(description interface{}, args ...interface{}) ginkgo.TableEntry {
+	// insert an Offset into the args, but not as the last item, so that the right code location is reported
+	f := args[len(args)-1]
+	args[len(args)-1] = ginkgo.Offset(6) // need to go 6 up the stack to get the caller
+	args = append(args, f)
 	return ginkgo.Entry(description, args...)
 }
 

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -171,6 +171,8 @@ func Emit(log *zap.SugaredLogger) {
 }
 
 func DurationMillis() int64 {
+	// this value is in nanoseconds, so we need to divide by one million
+	// to convert to milliseconds
 	spec := ginkgo.CurrentSpecReport()
-	return int64(spec.RunTime) / 1000
+	return int64(spec.RunTime) / 1_000_000
 }


### PR DESCRIPTION
# Description

This PR fixes the code location reported by some of the test wrappers, so that they will show the actual test source line where the wrapper is called, not the location of the wrapper code.

Fixes VZ-4794

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
