### PR TITLE
the config to disable concurrent was lost on the periodics, adding it…

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -19,6 +19,7 @@ def verrazzanoImagesBuildNumber = 0 // will be set to actual build number when t
 pipeline {
     options {
         skipDefaultCheckout true
+        disableConcurrentBuilds()
         timestamps ()
     }
 


### PR DESCRIPTION
… into the Jenkinsfile

# Description

The configuration for the periodics lost the disableconcurrent setting somehow.
I'm adding it to the Jenkinsfile so we don't get more than one run going on any particular branch at the same time.

We may revisit the 2 hour interval as well once these stabilize, successful runs take over 3 hours. Failing runs take about an hour and a half though, so using the shorter interval as long as disable concurrent is being honored should give us faster turnaround on new runs when things fail, and still ensure we don't have parallel runs when they are passing.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
