### PR TITLE
VZ-4407 Allow Prometheus port, path, and scrape overrides

### DIFF
--- a/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
+++ b/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
@@ -63,11 +63,7 @@ func TestNoOwnerReferences(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := a.Handle(context.TODO(), req)
 
-	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 2)
-	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
-	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
+	verifyResponse(t, res, 2)
 }
 
 // TestOwnerReference tests the handling of a Pod resource
@@ -111,11 +107,7 @@ func TestOwnerReference(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := a.Handle(context.TODO(), req)
 
-	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 2)
-	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
-	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
+	verifyResponse(t, res, 2)
 }
 
 // TestMultipleOwnerReference tests the handling of a Pod resource
@@ -178,11 +170,7 @@ func TestMultipleOwnerReference(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := a.Handle(context.TODO(), req)
 
-	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 2)
-	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
-	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
+	verifyResponse(t, res, 2)
 }
 
 // TestMultipleOwnerReferenceAndWorkloadResources tests the handling of a Pod resource
@@ -293,9 +281,14 @@ func TestPodPrometheusAnnotations(t *testing.T) {
 	req.Object = runtime.RawExtension{Raw: marshaledPod}
 	res := a.Handle(context.TODO(), req)
 
+	verifyResponse(t, res, 1)
+}
+
+func verifyResponse(t *testing.T, res admission.Response, len int) {
 	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 1)
-	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
-	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
+	assert.Len(t, res.Patches, len)
+	for _, patch := range res.Patches {
+		assert.Equal(t, "add", patch.Operation)
+		assert.True(t, patch.Path == "/metadata/labels" || patch.Path == "/metadata/annotations")
+	}
 }

--- a/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
+++ b/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
@@ -64,7 +64,7 @@ func TestNoOwnerReferences(t *testing.T) {
 	res := a.Handle(context.TODO(), req)
 
 	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 1)
+	assert.Len(t, res.Patches, 2)
 	assert.Equal(t, "add", res.Patches[0].Operation)
 	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
@@ -112,7 +112,7 @@ func TestOwnerReference(t *testing.T) {
 	res := a.Handle(context.TODO(), req)
 
 	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 1)
+	assert.Len(t, res.Patches, 2)
 	assert.Equal(t, "add", res.Patches[0].Operation)
 	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
@@ -179,7 +179,7 @@ func TestMultipleOwnerReference(t *testing.T) {
 	res := a.Handle(context.TODO(), req)
 
 	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 1)
+	assert.Len(t, res.Patches, 2)
 	assert.Equal(t, "add", res.Patches[0].Operation)
 	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
@@ -295,36 +295,6 @@ func TestPodPrometheusAnnotations(t *testing.T) {
 
 	assert.True(t, res.Allowed)
 	assert.Len(t, res.Patches, 1)
-	assert.Equal(t, "add", res.Patches[0].Operation)
-	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
-	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)
-}
-
-// TestPodPrometheusNoAnnotations tests the default annotation of a Pod resource
-// GIVEN a call to the webhook Handle function
-// WHEN the pod does not have the Prometheus annotations
-// THEN the Handle function should populate annotations
-func TestPodPrometheusNoAnnotations(t *testing.T) {
-	a := newLabelerPodWebhook()
-
-	// Test data
-	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-	}
-	assert.NoError(t, a.Client.Create(context.TODO(), &pod))
-
-	req := admission.Request{}
-	req.Namespace = "default"
-	marshaledPod, err := json.Marshal(pod)
-	assert.NoError(t, err, "Unexpected error marshaling pod")
-	req.Object = runtime.RawExtension{Raw: marshaledPod}
-	res := a.Handle(context.TODO(), req)
-
-	assert.True(t, res.Allowed)
-	assert.Len(t, res.Patches, 2)
 	assert.Equal(t, "add", res.Patches[0].Operation)
 	assert.Equal(t, "/metadata/labels", res.Patches[0].Path)
 	assert.Contains(t, res.Patches[0].Value, constants.MetricsWorkloadLabel)

--- a/application-operator/internal/app/resources/templates/standard-k8s-metrics-template.yaml
+++ b/application-operator/internal/app/resources/templates/standard-k8s-metrics-template.yaml
@@ -27,7 +27,7 @@ spec:
           source_labels: null
           target_label: verrazzano_cluster
         - action: keep
-          regex: {{index .workload.metadata.labels "app.verrazzano.io/workload"}}, true
+          regex: {{index .workload.metadata.labels "app.verrazzano.io/workload"}};true
           source_labels:
             - __meta_kubernetes_pod_label_app_verrazzano_io_workload
             - __meta_kubernetes_pod_annotation_prometheus_io_scrape

--- a/application-operator/internal/app/resources/templates/standard-k8s-metrics-template.yaml
+++ b/application-operator/internal/app/resources/templates/standard-k8s-metrics-template.yaml
@@ -21,25 +21,28 @@ spec:
             names:
             - {{.workload.metadata.namespace}}
           role: pod
-      # Hardcoded Path
-      metrics_path: /metrics
       relabel_configs:
         - action: replace
           replacement: local
           source_labels: null
           target_label: verrazzano_cluster
         - action: keep
-          regex: {{index .workload.metadata.labels "app.verrazzano.io/workload"}};8080
+          regex: {{index .workload.metadata.labels "app.verrazzano.io/workload"}}, true
           source_labels:
             - __meta_kubernetes_pod_label_app_verrazzano_io_workload
-            - __meta_kubernetes_pod_container_port_number
+            - __meta_kubernetes_pod_annotation_prometheus_io_scrape
         - action: replace
           regex: ([^:]+)(?::\d+)?;(\d+)
-          # Hardcoded Port
-          replacement: $1:8080
+          replacement: $1:$2
           source_labels:
-            - __address__
+            - __address__ 
+            - __meta_kubernetes_pod_annotation_prometheus_io_port
           target_label: __address__
+        - action: replace
+          regex: (.*)
+          source_labels: 
+            - __meta_kubernetes_pod_annotation_prometheus_io_path
+          target_label: __metrics_path__
         - action: replace
           regex: (.*)
           replacement: $1


### PR DESCRIPTION
# Description

The default template and the pod labeler have been updated to allow for Prometheus config overrides. The port, path, and scrape enabling can be modified through annotations.

Fixes VZ-4407

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
