### PR TITLE
VZ-4823: move component restart to the global post-upgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -5,6 +5,8 @@ package verrazzano
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"strconv"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -113,5 +115,5 @@ func fmtGeneration(gen int64) string {
 }
 
 func postUpgrade(log vzlog.VerrazzanoLogger, client clipkg.Client) error {
-	return nil
+	return istio.RestartComponents(log, config.GetInjectedSystemNamespaces(), client)
 }

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -495,6 +495,9 @@ func TestUpgradeCompleted(t *testing.T) {
 	})
 	defer registry.ResetGetComponentsFn()
 
+	// Add mocks necessary for the system component restart
+	mock.AddRestartMocks()
+
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
@@ -586,6 +589,9 @@ func TestUpgradeCompletedStatusReturnsError(t *testing.T) {
 
 	config.TestProfilesDir = "../../manifests/profiles"
 	defer func() { config.TestProfilesDir = "" }()
+
+	// Add mocks necessary for the system component restart
+	mock.AddRestartMocks()
 
 	// Expect a call to get the verrazzano resource.  Return resource with version
 	mock.EXPECT().
@@ -877,6 +883,9 @@ func TestUpgradeComponent(t *testing.T) {
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
+	// Add mocks necessary for the system component restart
+	mock.AddRestartMocks()
+
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -967,6 +976,9 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+
+	// Add mocks necessary for the system component restart
+	mock.AddRestartMocks()
 
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().

--- a/platform-operator/mocks/controller_mock.go
+++ b/platform-operator/mocks/controller_mock.go
@@ -9,6 +9,8 @@ package mocks
 
 import (
 	context "context"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -241,4 +243,51 @@ func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 interface{}, arg2 ...i
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStatusWriter)(nil).Update), varargs...)
+}
+
+func (mock *MockClient) AddRestartMocks() {
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, deployList *appsv1.DeploymentList) error {
+			deployList.Items = []appsv1.Deployment{{}}
+			return nil
+		})
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ssList *appsv1.StatefulSetList) error {
+			ssList.Items = []appsv1.StatefulSet{{}}
+			return nil
+		})
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, dsList *appsv1.DaemonSetList) error {
+			dsList.Items = []appsv1.DaemonSet{{}}
+			return nil
+		})
+
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, deploy *appsv1.Deployment) error {
+			deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			deploy.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
+			return nil
+		}).AnyTimes()
+
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ss *appsv1.StatefulSet) error {
+			ss.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			ss.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
+			return nil
+		}).AnyTimes()
+
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ds *appsv1.DaemonSet) error {
+			ds.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			ds.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = "some time"
+			return nil
+		}).AnyTimes()
 }

--- a/tests/e2e/pkg/upgrade.go
+++ b/tests/e2e/pkg/upgrade.go
@@ -10,28 +10,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 )
 
-func PodsHaveAnnotation(namespace string, annotation string) bool {
-	clientset, err := k8sutil.GetKubernetesClientset()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting clientset, error: %v", err))
-		return false
-	}
-	pods, err := ListPodsInCluster(namespace, clientset)
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error listing pods in cluster for namespace: %s, error: %v", namespace, err))
-		return false
-	}
-	for _, pod := range pods.Items {
-		_, hasAnnotation := pod.Annotations[annotation]
-		if !hasAnnotation &&
-			!strings.Contains(pod.Name, "vmi-system-kiali") &&
-			!strings.Contains(pod.Name, "vmi-system-es-data") {
-			return false
-		}
-	}
-	return true
-}
-
 // CheckPodsForEnvoySidecar checks if a pods which have Envoy sidecars, have the specified image
 func CheckPodsForEnvoySidecar(namespace string, imageName string) bool {
 	clientset, err := k8sutil.GetKubernetesClientset()

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -5,11 +5,11 @@ package verify
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/istio"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"time"
 
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/istio"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
@@ -49,33 +48,6 @@ var _ = t.Describe("Post upgrade", Label("f:platform-lcm.upgrade"), func() {
 			pkg.Log(pkg.Info, fmt.Sprintf("Skipping check '%v', Verrazzano is not at version 1.1.0", description))
 		}
 	}
-
-	// GIVEN the verrazzano-system namespace
-	// WHEN the annotations from the pods are retrieved
-	// THEN verify that the have the verrazzano.io/restartedAt annotations
-	MinimumVerrazzanoIt("pods in verrazzano-system restarted", func() {
-		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.VerrazzanoSystemNamespace, vzconst.VerrazzanoRestartAnnotation)
-		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in verrazzano-system")
-	})
-
-	// GIVEN the ingress-nginx namespace
-	// WHEN the annotations from the pods are retrieved
-	// THEN verify that the have the verrazzano.io/restartedAt annotations
-	MinimumVerrazzanoIt("pods in ingress-nginx restarted", func() {
-		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.IngressNginxNamespace, vzconst.VerrazzanoRestartAnnotation)
-		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in ingress-nginx")
-	})
-
-	// GIVEN the keycloak namespace
-	// WHEN the annotations from the pods are retrieved
-	// THEN verify that the have the verrazzano.io/restartedAt annotations
-	MinimumVerrazzanoIt("pods in keycloak restarted", func() {
-		Eventually(func() bool {
-			return pkg.PodsHaveAnnotation(constants.KeycloakNamespace, vzconst.VerrazzanoRestartAnnotation)
-		}, threeMinutes, pollingInterval).Should(BeTrue(), "Expected to find restart annotation in keycloak")
-	})
 
 	// GIVEN the verrazzano-system namespace
 	// WHEN the container images are retrieved


### PR DESCRIPTION
This change moves the component restart to the global post upgrade. Istio was moved to the first component in the registry which introduces a race condition between restarting the components and the components getting upgraded by helm. Moving the component restart solves this. This change also removes the test that checks for the restart annotation as this is already checked by the test that checks for the correct istio proxy image. A follow up change will be to only restart the components that have the incorrect istio proxy image.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
