### PR TITLE
Remove domains and coherences as resources from bindings generator webhook

### DIFF
--- a/application-operator/deploy/verrazzano.yaml_template
+++ b/application-operator/deploy/verrazzano.yaml_template
@@ -540,7 +540,7 @@ webhooks:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["deployments","coherences","domains","pods","replicasets","statefulsets"]
+        resources: ["deployments","pods","replicasets","statefulsets"]
         scope: "Namespaced"
     sideEffects: None
     failurePolicy: Fail

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -632,7 +632,7 @@ webhooks:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["deployments","coherences","domains","pods","replicasets","statefulsets"]
+        resources: ["deployments","pods","replicasets","statefulsets"]
         scope: "Namespaced"
     sideEffects: None
     failurePolicy: Fail


### PR DESCRIPTION
This pull request removes domains and coherences as accepted resources from the bindings generator webhook.
Initially, these are not supported.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
