### PR TITLE
VZ-4408 Acceptance test for Prometheus annotation override

### DIFF
--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidonpodannotation
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// TestHelidonPodAnnotationOverride tests a helidon deployment workload for Prometheus metric scraping with a pod annotation preventing metrics scraping
+func TestHelidonDeploymentNamespaceAnnotation(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Helidon Deployment Workload with Namespace Template Annotation Test Suite")
+}

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -86,7 +86,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 				return podAnnotations[PrometheusPortAnnotation] == PrometheusPortDefault &&
 					podAnnotations[PrometheusPathAnnotation] == PrometheusPathDefault &&
 					podAnnotations[PrometheusScrapeAnnotation] == PrometheusScrapeOverride
-			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find Prometheus scraped metrics for Helidon application.")
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for Helidon application.")
 			Eventually(func() bool {
 				return pkg.MetricsExist("base_jvm_uptime_seconds", "app_verrazzano_io_workload", "hello-helidon-deployment-apps-v1-deployment")
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find Prometheus scraped metrics for Helidon application.")

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidonpodannotation
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/metricsbinding"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	longWaitTimeout      = 15 * time.Minute
+	longPollingInterval  = 20 * time.Second
+	namespace            = "hello-helidon-namespace"
+	applicationPodPrefix = "hello-helidon-deployment-"
+	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml"
+	templatePath         = "tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml"
+	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+
+	PrometheusPortAnnotation   = "prometheus.io/port"
+	PrometheusPathAnnotation   = "prometheus.io/path"
+	PrometheusScrapeAnnotation = "prometheus.io/scrape"
+
+	PrometheusPortDefault    = "8080"
+	PrometheusPathDefault    = "/metrics"
+	PrometheusScrapeOverride = "false"
+)
+
+var t = framework.NewTestFramework("helidonnamespaceannotation")
+
+var _ = t.BeforeSuite(func() {
+	start := time.Now()
+	metricsbinding.DeployApplicationAndTemplate(namespace, yamlPath, templatePath, map[string]string{"app.verrazzano.io/metrics": "standard-k8s-metrics-template"})
+	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var clusterDump = pkg.NewClusterDumpWrapper()
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
+	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+})
+
+var _ = t.AfterEach(func() {})
+
+var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
+	t.Context("app deployment", func() {
+		// GIVEN the app is deployed
+		// WHEN the running pods are checked
+		// THEN the Helidon pod should exist
+		t.It("Verify 'hello-helidon-deployment' pod is running", func() {
+			Eventually(func() bool {
+				return pkg.PodsRunning(namespace, []string{applicationPodPrefix})
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
+		})
+	})
+
+	// GIVEN the Helidon app is deployed and the pods are running
+	// WHEN the Prometheus metrics in the app namespace are scraped
+	// THEN the Helidon application metrics should exist using the default metrics template for deployments
+	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
+		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {
+			Eventually(func() bool {
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				if err != nil {
+					return false
+				}
+				clientset, err := pkg.GetKubernetesClientsetForCluster(kubeconfigPath)
+				if err != nil {
+					return false
+				}
+				pods, err := pkg.ListPodsInCluster("hello-helidon-namespace", clientset)
+				if err != nil {
+					return false
+				}
+				podItems := pods.Items
+				if len(podItems) != 1 {
+					return false
+				}
+				podAnnotations := podItems[0].GetAnnotations()
+				return podAnnotations[PrometheusPortAnnotation] == PrometheusPortDefault &&
+					podAnnotations[PrometheusPathAnnotation] == PrometheusPathDefault &&
+					podAnnotations[PrometheusScrapeAnnotation] == PrometheusScrapeOverride
+			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find Prometheus scraped metrics for Helidon application.")
+			Eventually(func() bool {
+				return pkg.MetricsExist("base_jvm_uptime_seconds", "app_verrazzano_io_workload", "hello-helidon-deployment-apps-v1-deployment")
+			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find Prometheus scraped metrics for Helidon application.")
+			Eventually(func() bool {
+				return pkg.MetricsExist("base_jvm_uptime_seconds", "job", promConfigJobName)
+			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected to find Prometheus scraped metrics for Helidon application.")
+			Eventually(func() bool {
+				return pkg.MetricsExist("base_jvm_uptime_seconds", "test_namespace", "hello-helidon-namespace-test")
+			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Expected not to find Prometheus scraped metrics for Helidon application.")
+		})
+	})
+})

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -21,7 +21,6 @@ const (
 	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml"
-	templatePath         = "tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml"
 	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
 
 	PrometheusPortAnnotation   = "prometheus.io/port"
@@ -37,7 +36,7 @@ var t = framework.NewTestFramework("helidonnamespaceannotation")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplicationAndTemplate(namespace, yamlPath, templatePath, map[string]string{"app.verrazzano.io/metrics": "standard-k8s-metrics-template"})
+	metricsbinding.DeployApplication(namespace, yamlPath)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-helidon-deployment
+  namespace: hello-helidon-namespace
+  annotations:
+    app.verrazzano.io/metrics: standard-k8s-metrics-template
+spec:
+  selector:
+    matchLabels:
+      app: hello-helidon-application
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hello-helidon-application
+      annotations:
+        prometheus.io/scrape: "false"
+    spec:
+      containers:
+      - name: hello-helidon-container
+        image: ghcr.io/verrazzano/example-helidon-greet-app-v1:1.0.0-1-20210728181814-eb1e622
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: web
+          containerPort: 8080
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-helidon-service
+  namespace: hello-helidon-namespace
+  labels:
+    app: hello-helidon-application
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+  selector:
+    app: hello-helidon-application


### PR DESCRIPTION
# Description

Acceptance tests for overriding the Prometheus metrics. Metrics should not be scraped when the scrape annotation is set to false.

Fixes VZ-4408

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
