### PR TITLE
Changed to metrics binding webhook configs

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -623,6 +623,10 @@ webhooks:
     namespaceSelector:
       matchLabels:
         verrazzano-managed: "true"
+    objectSelector:
+      matchExpressions:
+        - key: app.oam.dev/component
+          operator: DoesNotExist
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -632,7 +636,7 @@ webhooks:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["deployments","coherences","domains","pods","replicasets","statefulsets"]
+        resources: ["deployments","pods","replicasets","statefulsets"]
         scope: "Namespaced"
     sideEffects: None
     failurePolicy: Fail
@@ -645,6 +649,10 @@ webhooks:
     namespaceSelector:
       matchLabels:
         verrazzano-managed: "true"
+    objectSelector:
+      matchExpressions:
+        - key: app.oam.dev/component
+          operator: DoesNotExist
     clientConfig:
       service:
         name: {{ .Values.name }}


### PR DESCRIPTION
# Description

This pull request includes a couple of changes to the poko metrics binding webhooks.

1. Removes coherence and domain resources from the metrics binding generator webhook.
2. Adds an objectsSelector to both metrics binding webhooks so that resources with the 
app.oam.dev/component label are not processed by the webhooks.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
