### PR TITLE
No JIRA: deploymetrics test fix

### DIFF
--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -88,6 +88,7 @@ func undeployMetricsApplication() {
 		return pkg.DeleteNamespace(testNamespace)
 	}, longWaitTimeout, longPollingInterval).ShouldNot(HaveOccurred())
 
+	pkg.Log(pkg.Info, "Waiting for namespace deletion")
 	Eventually(func() bool {
 		ns, err := pkg.GetNamespace(testNamespace)
 		if err == nil {
@@ -97,7 +98,7 @@ func undeployMetricsApplication() {
 			}
 		}
 		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+	}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
 }
 

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -90,13 +90,7 @@ func undeployMetricsApplication() {
 
 	pkg.Log(pkg.Info, "Waiting for namespace deletion")
 	Eventually(func() bool {
-		ns, err := pkg.GetNamespace(testNamespace)
-		if err == nil {
-			finalizeErr := pkg.RemoveNamespaceFinalizers(ns)
-			if finalizeErr != nil {
-				return false
-			}
-		}
+		_, err := pkg.GetNamespace(testNamespace)
 		return err != nil && errors.IsNotFound(err)
 	}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))


### PR DESCRIPTION
# Description

Fix namespace deletion in the deploymetrics test. Based on the console output and the cluster dump, here is the behavior I see. The console output shows:
```
[2022-02-04T12:35:51.380Z] [INFO] 4040-02-04 12:35:44.823262 Delete namespace
[2022-02-04T12:40:58.138Z] Execute cluster dump: KUBECONFIG=/home/opc/jenkins/workspace/new-kind-acceptance-tests_master/test_kubeconfig; 
```
The cluster dump is initiated 5 minutes after the namespace deletion. This leads me to believe that the call to delete the namespace returned quickly (because that call is wrapped in an Eventually that waits for 15 minutes). The test then fetches the namespace to see if it's gone, for up to 5 minutes.

The API server log shows:

```
E0204 12:40:52.480258       1 namespace_controller.go:162] deletion of namespace deploymetrics failed: context deadline exceeded
I0204 12:41:00.367683       1 namespace_controller.go:185] Namespace has been deleted deploymetrics
```

So the namespace was deleted a few seconds after the Eventually gave up. The 5 min wait for the namespace isn't long enough, so this PR extends the wait time. Also, removing the finalizers is a work-around that should not be needed, so I'm getting rid of it.




# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
