### PR TITLE
wildcard tls.hosts for VMI ingresses 

### DIFF
--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -223,5 +223,5 @@ func (r *VerrazzanoManagedClusterReconciler) getKeycloakURL() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch ingress %s/%s, %v", "keycloak", "keycloak", err)
 	}
-	return fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0]), nil
+	return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host), nil
 }

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1436,8 +1436,8 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 			ingress.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name}
-			ingress.Spec.TLS = []networkingv1.IngressTLS{{
-				Hosts: []string{"keycloak"},
+			ingress.Spec.Rules = []k8net.IngressRule{{
+				Host: "keycloak",
 			}}
 			return nil
 		})

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -97,7 +97,7 @@ func createOrUpdateKialiIngress(ctx spi.ComponentContext, namespace string) erro
 		}
 		ingress.Spec.TLS = []v1.IngressTLS{
 			{
-				Hosts:      []string{kialiHostName},
+				Hosts:      []string{"*." + dnsSubDomain},
 				SecretName: constants.VerrazzanoSystemTLSSecretName,
 			},
 		}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -195,8 +195,8 @@
               "helmFullImageKey": "verrazzanoOperator.nodeExporterImage"
             },
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "1.2.0-20220131204315-c976ec4",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "1.2.0-20220207204504-ef137f5",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/tests/e2e/pkg/api.go
+++ b/tests/e2e/pkg/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg
@@ -181,5 +181,5 @@ func (api *APIEndpoint) GetElasticURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0]), nil
+	return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host), nil
 }

--- a/tests/e2e/verify-infra/restapi/keycloak_url_test.go
+++ b/tests/e2e/verify-infra/restapi/keycloak_url_test.go
@@ -41,7 +41,7 @@ var _ = t.Describe("keycloak", Label("f:infra-lcm",
 					if err != nil {
 						return err
 					}
-					keycloakURL = fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
+					keycloakURL = fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host)
 					pkg.Log(pkg.Info, fmt.Sprintf("Found ingress URL: %s", keycloakURL))
 					return nil
 				}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -47,7 +47,7 @@ var _ = t.Describe("rancher", Label("f:infra-lcm",
 					if err != nil {
 						return err
 					}
-					rancherURL = fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
+					rancherURL = fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host)
 					t.Logs.Info(fmt.Sprintf("Found ingress URL: %s", rancherURL))
 					return nil
 				}, waitTimeout, pollingInterval).Should(BeNil())

--- a/tests/e2e/verify-infra/restapi/vmi_urls_test.go
+++ b/tests/e2e/verify-infra/restapi/vmi_urls_test.go
@@ -132,7 +132,7 @@ func verifySystemVMIComponent(api *pkg.APIEndpoint, sysVmiHTTPClient *retryableh
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting ingress from API: %v", err))
 		return false
 	}
-	vmiComponentURL := fmt.Sprintf("https://%s", ingress.Spec.TLS[0].Hosts[0])
+	vmiComponentURL := fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host)
 	if !strings.HasPrefix(vmiComponentURL, expectedURLPrefix) {
 		pkg.Log(pkg.Error, fmt.Sprintf("URL '%s' does not have expected prefix: %s", vmiComponentURL, expectedURLPrefix))
 		return false


### PR DESCRIPTION
# Description

kiali and VMI uses wildcard tls host in ingress.  It is required for upgrading cert-manager 1.6.1.

Fixes OLCNE-3501.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
