### PR TITLE
Add check for helidon pod running in network-policy AT

### DIFF
--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -52,13 +52,14 @@ type accessCheckConfig struct {
 }
 
 var (
-	expectedPods         = []string{"netpol-test"}
-	waitTimeout          = 15 * time.Minute
-	pollingInterval      = 30 * time.Second
-	shortWaitTimeout     = 30 * time.Second
-	shortPollingInterval = 10 * time.Second
-	generatedNamespace   = pkg.GenerateNamespace("hello-helidon")
-	yamlApplier          = k8sutil.YAMLApplier{}
+	expectedPods             = []string{"netpol-test"}
+	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
+	waitTimeout              = 15 * time.Minute
+	pollingInterval          = 30 * time.Second
+	shortWaitTimeout         = 30 * time.Second
+	shortPollingInterval     = 10 * time.Second
+	generatedNamespace       = pkg.GenerateNamespace("hello-helidon")
+	yamlApplier              = k8sutil.YAMLApplier{}
 )
 
 var t = framework.NewTestFramework("netpol")
@@ -106,6 +107,18 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 		t.It("and waiting for expected pod must be running", func() {
 			Eventually(func() bool {
 				return pkg.PodsRunning(testNamespace, expectedPods)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+		})
+	})
+
+	// Verify hello-helidon pod is running
+	// GIVEN hello-helidon is deployed
+	// WHEN the pod is created
+	// THEN the expected pod must be running in the hello-helidon namespace
+	t.Describe("Verify hello-helidon pod is running", func() {
+		t.It("and waiting for expected pod must be running", func() {
+			Eventually(func() bool {
+				return pkg.PodsRunning(namespace, expectedPodsHelloHelidon)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
Fix network-policy test to wait for hello-helidon pods to be running.  Previous change to the this test did not include this test which can cause an intermittent failure.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
