### PR TITLE
Fix intermittent poko metrics binding AT failures

### DIFF
--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -59,12 +59,9 @@ func (r *Reconciler) Reconcile(req k8scontroller.Request) (k8scontroller.Result,
 	if clusters.ShouldRequeue(res) {
 		return res, nil
 	}
-	// Never return an error since it has already been logged and we don't want the
-	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
 	if err != nil {
-		return clusters.NewRequeueWithDelay(), nil
+		return clusters.NewRequeueWithDelay(), err
 	}
-
 	log.Oncef("Finished reconciling metrics binding %v", req.NamespacedName)
 
 	return k8scontroller.Result{}, nil

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -115,7 +115,7 @@ func (r *Reconciler) reconcileBindingCreateOrUpdate(ctx context.Context, metrics
 	}
 
 	// Requeue with a delay to account for situations where the scrape config
-	// has changed but without the Metricsinding changing.
+	// has changed but without the MetricsBinding changing.
 	var seconds = rand.IntnRange(45, 90)
 	var duration = time.Duration(seconds) * time.Second
 	return reconcile.Result{Requeue: true, RequeueAfter: duration}, nil

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -5,6 +5,10 @@ package metricsbinding
 
 import (
 	"context"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
@@ -20,14 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"testing"
-	"time"
 )
 
 // TestReconcilerSetupWithManager test the creation of the metrics trait reconciler.
@@ -368,7 +368,7 @@ func TestReconcileBindingCreateOrUpdate(t *testing.T) {
 	log := vzlog.DefaultLogger()
 	controllerResult, err := reconciler.reconcileBindingCreateOrUpdate(context.TODO(), localMetricsBinding, log)
 	assert.NoError(err, "Expected no error reconciling the Deployment")
-	assert.Equal(controllerResult, ctrl.Result{})
+	assert.True(controllerResult.Requeue)
 }
 
 // TestReconcileBindingDelete tests the reconciliation for a deletion
@@ -494,8 +494,7 @@ func TestCreateDeployment(t *testing.T) {
 
 	// Validate the results
 	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
-	assert.Equal(time.Duration(0), result.RequeueAfter)
+	assert.True(result.Requeue)
 }
 
 // newScheme creates a new scheme that includes this package's object to use for testing

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -227,10 +227,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if clusters.ShouldRequeue(res) {
 		return res, nil
 	}
-	// Never return an error since it has already been logged and we don't want the
-	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
 	if err != nil {
-		return clusters.NewRequeueWithDelay(), nil
+		return clusters.NewRequeueWithDelay(), err
 	}
 
 	log.Oncef("Finished reconciling metrics trait %v", req.NamespacedName)

--- a/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
+++ b/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package deploymentworkload
 
 import (

--- a/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_test.go
+++ b/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package helidonnamespaceannotation
 
 import (

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package helidonpodannotation
 
 import (

--- a/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package podworkload
 
 import (

--- a/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
+++ b/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package replicasetworkload
 
 import (

--- a/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_test.go
+++ b/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package helidonsharednamespace
 
 import (

--- a/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
+++ b/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package statefulsetworkload
 
 import (

--- a/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_test.go
+++ b/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-// +build unstable_test
-
 package helidonworkloadannotation
 
 import (

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -211,7 +211,7 @@ func IsAppInPromConfig(configAppName string) bool {
 	}
 	found := strings.Contains(promConfig.Data[dataKey], configAppName)
 	if !found {
-		Log(Info, fmt.Sprintf("scrap target %s not found in Prometheus configmap", configAppName))
+		Log(Error, fmt.Sprintf("scrap target %s not found in Prometheus configmap", configAppName))
 	}
 	return found
 }


### PR DESCRIPTION
# Description

This pull request changes the metrics binding controller to requeue with a staggered delay after successful reconciliation.  This accounts for situations where the scrape config has changed but without the MetricsBinding changing.

Also, changes return errors from the metrics binding controller and metrics trait controller since error messages were not being logged.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
