### PR TITLE
VZ-4945 Introduce Fluentd log parsing for Keycloak MySQL pod

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -427,6 +427,32 @@ data:
         </pattern>
       </parse>
     </filter>
+    
+    # filter to parse MySQL container log files
+    <filter kubernetes.**mysql**keycloak_mysql**>
+      @type parser
+      @id mysql
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # MySQL has two formats for log records
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z) \d+ \[(?<level>.*?)\] (\[.*?\] ){2}(?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\+\d{2}:\d{2} \[(?<level>.*?)\] \[.*?\]: (?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%d %H:%M:%S
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
 
   kubernetes-filter.conf: |
     # Query the API for extra metadata.

--- a/tests/e2e/logging/system/system_logging_test.go
+++ b/tests/e2e/logging/system/system_logging_test.go
@@ -135,6 +135,7 @@ var _ = t.Describe("Elasticsearch system component data", Label("f:observability
 		// THEN Verify there are valid log records
 		valid := true
 		valid = validateKeycloakLogs() && valid
+		valid = validateKeycloakMySQLLogs() && valid
 		if !valid {
 			// Don't fail for invalid logs until this is stable.
 			t.Logs.Info("Found problems with log records in Keycloak index")
@@ -224,6 +225,16 @@ func validateKeycloakLogs() bool {
 		keycloakIndex,
 		"kubernetes.labels.app.kubernetes.io/name",
 		"keycloak",
+		searchTimeWindow,
+		noExceptions)
+}
+
+func validateKeycloakMySQLLogs() bool {
+	return validateElasticsearchRecords(
+		basicElasticsearchRecordValidator,
+		keycloakIndex,
+		"app",
+		"mysql",
 		searchTimeWindow,
 		noExceptions)
 }


### PR DESCRIPTION
# Description

This introduces Fluentd logging patterns for the Keycloak MySQL pod. Also, it introduces an acceptance test to verify that the log records for MySQL are correct.

Fixes VZ-4945

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
