### PR TITLE
Introduce FlakeAttempts to improve test resiliency

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	t = framework.NewTestFramework("bobsbooks")
+	t                  = framework.NewTestFramework("bobsbooks")
 	generatedNamespace = pkg.GenerateNamespace("bobs-books")
 )
 
@@ -168,7 +168,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
 		metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 	})
-	t.Context("Ingress.", Label("f:mesh.ingress"), func() {
+	t.Context("Ingress.", Label("f:mesh.ingress"), FlakeAttempts(5), func() {
 		// Verify the application endpoint is working.
 		// GIVEN the Bobs Books app is deployed
 		// WHEN the roberts-books UI is accessed
@@ -216,7 +216,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 			}, longWaitTimeout, longPollingInterval).Should(And(pkg.HasStatus(200), pkg.BodyContains("Bob's Order Manager")))
 		})
 	})
-	t.Context("Metrics.", Label("f:observability.monitoring.prom"), func() {
+	t.Context("Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
 		// Verify application Prometheus scraped metrics
 		// GIVEN a deployed Bob's Books application
 		// WHEN the application configuration uses a default metrics trait

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -28,8 +28,8 @@ const (
 )
 
 var (
-	t                        = framework.NewTestFramework("helidon")
-	generatedNamespace       = pkg.GenerateNamespace("hello-helidon")
+	t                  = framework.NewTestFramework("helidon")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon")
 	//yamlApplier              = k8sutil.YAMLApplier{}
 	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
 )
@@ -118,7 +118,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 		})
 	})
 
-	t.Context("Logging.", Label("f:observability.logging.es"), func() {
+	t.Context("Logging.", Label("f:observability.logging.es"), FlakeAttempts(5), func() {
 
 		indexName := "verrazzano-namespace-" + namespace
 

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -96,7 +96,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// GIVEN OAM hello-helidon app is deployed
 	// WHEN the component and appconfig without metrics-trait(using default) are created
 	// THEN the application metrics must be accessible
-	t.Describe("for Metrics.", Label("f:observability.monitoring.prom"), func() {
+	t.Describe("for Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
 		t.It("Retrieve Prometheus scraped metrics", func() {
 			pkg.Concurrently(
 				func() {

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -24,7 +24,7 @@ var longWaitTimeout = 15 * time.Minute
 var longPollingInterval = 20 * time.Second
 
 var (
-	t = framework.NewTestFramework("springboot")
+	t                  = framework.NewTestFramework("springboot")
 	generatedNamespace = pkg.GenerateNamespace("springboot")
 )
 
@@ -105,7 +105,7 @@ var _ = t.Describe("Spring Boot test", Label("f:app-lcm.oam",
 		}, longWaitTimeout, longPollingInterval).Should(And(pkg.HasStatus(http.StatusOK), pkg.BodyNotEmpty()))
 	})
 
-	t.Context("for Logging.", Label("f:observability.logging.es"), func() {
+	t.Context("for Logging.", Label("f:observability.logging.es"), FlakeAttempts(5), func() {
 		indexName := "verrazzano-namespace-" + namespace
 		t.It("Verify Elasticsearch index exists", func() {
 			Eventually(func() bool {

--- a/tests/e2e/verify-infra/restapi/vmi_urls_test.go
+++ b/tests/e2e/verify-infra/restapi/vmi_urls_test.go
@@ -70,7 +70,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm",
 			}
 		})
 
-		t.It("Access VMI endpoints", Label("f:ui.api"), func() {
+		t.It("Access VMI endpoints", ginkgo.FlakeAttempts(5), Label("f:ui.api"), func() {
 			if !isManagedClusterProfile {
 				var api *pkg.APIEndpoint
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/verify-infra/restapi/vmi_urls_test.go
+++ b/tests/e2e/verify-infra/restapi/vmi_urls_test.go
@@ -70,7 +70,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm",
 			}
 		})
 
-		t.It("Access VMI endpoints", ginkgo.FlakeAttempts(5), Label("f:ui.api"), func() {
+		t.It("Access VMI endpoints", FlakeAttempts(5), Label("f:ui.api"), func() {
 			if !isManagedClusterProfile {
 				var api *pkg.APIEndpoint
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()


### PR DESCRIPTION
# Description

This PR introduces FlakeAttempts decorations on frequently failing tests, so that they will be retried before being considered a failure.  Testing shows that this change reduces the test failure rate from about 0.08% to around 0.02%, and none of the tests that were such decorated failed in that testing (around ten full/slow/triggered runs).

Contributes to VZ-4793

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
