### PR TITLE
fix  letsencryt production 

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_test.go
@@ -5,18 +5,19 @@ package common
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-	"testing"
 )
 
 const (
@@ -181,14 +182,14 @@ func TestHttpClient(t *testing.T) {
 		isErr    bool
 	}{
 		{
-			"should get an HTTP Client when CA Secret exists",
+			"should get an HTTP Client when additional CA Secret exists",
 			fake.NewFakeClientWithScheme(getScheme(), &secret),
 			false,
 		},
 		{
-			"should fail to create an HTTP Client when CA Secret is not present",
+			"should get an HTTP Client when additional CA Secret is not present",
 			fake.NewFakeClientWithScheme(getScheme()),
-			true,
+			false,
 		},
 	}
 


### PR DESCRIPTION
# Description

When Verrazzano is using letsencryt production mode, root CA would be empty, and there should not be a secret tls-ca-additional, we can not throw an error in this case.  Instead, we use the default RootCAs.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
