### PR TITLE
VZ-4705 Default values for new AuthProxy component using profile overrides

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/affinityOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/affinityOverrideValues.yaml
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 imageName: ghcr.io/verrazzano/nginx-ingress-controller
 imageVersion: 0.46.0-20210510134749-abc2d2088
+replicas: 1
 
 proxy:
   OidcProviderHost: keycloak.default.11.22.33.44.nip.io

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/dnsWildcardDomainOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/dnsWildcardDomainOverrideValues.yaml
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 imageName: ghcr.io/verrazzano/nginx-ingress-controller
 imageVersion: 0.46.0-20210510134749-abc2d2088
+replicas: 1
 
 proxy:
   OidcProviderHost: keycloak.default.11.22.33.44.sslip.io

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/dnsWildcardDomainOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/dnsWildcardDomainOverrideValues.yaml
@@ -14,3 +14,17 @@ config:
 dns:
   wildcard:
     domain: sslip.io
+
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - verrazzano-authproxy
+        topologyKey: kubernetes.io/hostname
+      weight: 100
+

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/enabledOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/enabledOverrideValues.yaml
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 imageName: ghcr.io/verrazzano/nginx-ingress-controller
 imageVersion: 0.46.0-20210510134749-abc2d2088
+replicas: 1
 
 proxy:
   OidcProviderHost: keycloak.default.11.22.33.44.nip.io

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/enabledOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/enabledOverrideValues.yaml
@@ -14,3 +14,16 @@ config:
 dns:
   wildcard:
     domain: nip.io
+
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - verrazzano-authproxy
+        topologyKey: kubernetes.io/hostname
+      weight: 100

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/noOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/noOverrideValues.yaml
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 imageName: ghcr.io/verrazzano/nginx-ingress-controller
 imageVersion: 0.46.0-20210510134749-abc2d2088
+replicas: 1
 
 proxy:
   OidcProviderHost: keycloak.default.11.22.33.44.nip.io

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/noOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/noOverrideValues.yaml
@@ -14,3 +14,16 @@ config:
 dns:
   wildcard:
     domain: nip.io
+
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - verrazzano-authproxy
+        topologyKey: kubernetes.io/hostname
+      weight: 100

--- a/platform-operator/controllers/verrazzano/component/authproxy/testdata/replicasOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/authproxy/testdata/replicasOverrideValues.yaml
@@ -15,3 +15,16 @@ config:
 dns:
   wildcard:
     domain: nip.io
+
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - verrazzano-authproxy
+        topologyKey: kubernetes.io/hostname
+      weight: 100

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -13,6 +13,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -10,6 +10,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -12,6 +12,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -11,6 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -10,6 +10,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -8,6 +8,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -8,6 +8,10 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
+      kubernetes:
+        replicas: 2
     certManager:
       enabled: true
       certificate:
@@ -78,8 +82,5 @@ spec:
       enabled: true
     verrazzano:
       enabled: true
-      installArgs:
-        - name: api.replicas
-          value: "2"
     weblogicOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -12,6 +12,18 @@ spec:
       enabled: true
       kubernetes:
         replicas: 2
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -13,6 +13,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -10,6 +10,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -12,6 +12,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -13,6 +13,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -10,6 +10,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -12,6 +12,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -20,6 +20,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -18,6 +18,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -21,6 +21,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
@@ -20,6 +20,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
@@ -17,6 +17,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
@@ -19,6 +19,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -13,6 +13,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -10,6 +10,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -12,6 +12,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -11,6 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -10,6 +10,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -8,6 +8,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -18,6 +18,10 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
+      kubernetes:
+        replicas: 2
     certManager:
       enabled: true
       certificate:
@@ -101,8 +105,5 @@ spec:
       enabled: true
     verrazzano:
       enabled: true
-      installArgs:
-        - name: api.replicas
-          value: "2"
     weblogicOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -22,6 +22,18 @@ spec:
       enabled: true
       kubernetes:
         replicas: 2
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -12,6 +12,18 @@ spec:
       enabled: true
       kubernetes:
         replicas: 2
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -8,6 +8,10 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
+      kubernetes:
+        replicas: 2
     certManager:
       enabled: true
       certificate:
@@ -83,8 +87,5 @@ spec:
       enabled: true
     verrazzano:
       enabled: true
-      installArgs:
-        - name: api.replicas
-          value: "2"
     weblogicOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -8,6 +8,10 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
+      kubernetes:
+        replicas: 2
     certManager:
       enabled: true
       certificate:
@@ -109,8 +113,5 @@ spec:
       enabled: true
     verrazzano:
       enabled: true
-      installArgs:
-        - name: api.replicas
-          value: "2"
     weblogicOperator:
       enabled: true

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -12,6 +12,18 @@ spec:
       enabled: true
       kubernetes:
         replicas: 2
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -769,8 +769,8 @@ func Test_appendVerrazzanoOverrides(t *testing.T) {
 			//t.Logf("Num kvs: %d", actualNumKvs)
 			expectedNumKvs := test.numKeyValues
 			if expectedNumKvs == 0 {
-				// default is 4, 2 file override + 2 custom image overrides
-				expectedNumKvs = 4
+				// default is 3, 2 file override + 1 custom image overrides
+				expectedNumKvs = 3
 			}
 			assert.Equal(expectedNumKvs, actualNumKvs)
 			// Check Temp file

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -27,18 +27,7 @@ proxy:
   MaxRequestSize: 65m
   ProxyBufferSize: 8k
 
-affinity: |
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app
-                operator: In
-                values:
-                  - {{ .Values.name }}
-          topologyKey: kubernetes.io/hostname
+affinity:
 
 config:
   envName:

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -7,7 +7,7 @@ namespace: verrazzano-system
 global:
   imagePullSecrets: []
 
-replicas: 1
+replicas:
 # NOTE: The AuthProxy deployment runs the nginx-ingress-controller image.  The nginx-ingress-controller image
 # is obtained from the bill of materials file (verrazzano-bom.json).
 pullPolicy: IfNotPresent

--- a/platform-operator/manifests/profiles/base.yaml
+++ b/platform-operator/manifests/profiles/base.yaml
@@ -5,6 +5,8 @@ spec:
   components:
     applicationOperator:
       enabled: true
+    authProxy:
+      enabled: true
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/manifests/profiles/base.yaml
+++ b/platform-operator/manifests/profiles/base.yaml
@@ -8,6 +8,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/platform-operator/manifests/profiles/base.yaml
+++ b/platform-operator/manifests/profiles/base.yaml
@@ -7,6 +7,19 @@ spec:
       enabled: true
     authProxy:
       enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
     certManager:
       enabled: true
       certificate:

--- a/platform-operator/manifests/profiles/prod.yaml
+++ b/platform-operator/manifests/profiles/prod.yaml
@@ -3,10 +3,9 @@
 
 spec:
   components:
-    verrazzano:
-      installArgs:
-        - name: api.replicas
-          value: "2"
+    authproxy:
+      kubernetes:
+        replicas: 2
     istio:
       ingress:
         kubernetes:


### PR DESCRIPTION
# Description

- Specify the default and override values for AuthProxy Kubernetes settings via the Verrazzano profile files, instead of through values.yaml

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
