### PR TITLE
VZ-4953 part 2 - Add extraInitContainer to MySQL to chown the data directory to the mysql user/group so that upgrade works

### DIFF
--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -10,7 +10,8 @@ ssl:
   enabled: false
 
 # Add an init container to chown the data directory to be owned by the mysql user
-# (uid=27 gid=27) so that when upgrading, mysql user can definitely access data dir from previous volume
+# (uid=27 gid=27) so that when upgrading, mysql user can definitely access data dir
+# from previous volume. The Helm chart expects this to be a STRING, so using a multi-line string here
 # Note: if the Helm chart for MySQL changes, this should be reviewed for correctness
 extraInitContainers: |
   - command:

--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -12,7 +12,7 @@ ssl:
 # Add an init container to chown the data directory to be owned by the mysql user
 # (uid=27 gid=27) so that when upgrading, mysql user can definitely access data dir from previous volume
 # Note: if the Helm chart for MySQL changes, this should be reviewed for correctness
-extraInitContainers:
+extraInitContainers: |
   - command:
       - chown
       - -R
@@ -30,4 +30,3 @@ extraInitContainers:
     volumeMounts:
       - mountPath: /var/lib/mysql
         name: data
-

--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -9,3 +9,25 @@ imagePullPolicy: IfNotPresent
 ssl:
   enabled: false
 
+# Add an init container to chown the data directory to be owned by the mysql user
+# (uid=27 gid=27) so that when upgrading, mysql user can definitely access data dir from previous volume
+# Note: if the Helm chart for MySQL changes, this should be reviewed for correctness
+extraInitContainers:
+  - command:
+      - chown
+      - -R
+      - 27:27
+      - /var/lib/mysql
+    image: ghcr.io/oracle/oraclelinux:7-slim
+    imagePullPolicy: IfNotPresent
+    name: chown-data-dir
+    resources:
+      requests:
+        cpu: 10m
+        memory: 10Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+      - mountPath: /var/lib/mysql
+        name: data
+

--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # NOTE: The image you're looking for isn't here. The mysql and linux images now come from


### PR DESCRIPTION
# Description

Add extraInitContainer to MySQL to chown the data directory to the mysql user/group

Fixes VZ-4953

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
