### PR TITLE
fix letsencrypt production in 1.1

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common
@@ -115,17 +115,18 @@ func GetRootCA(c client.Reader) ([]byte, error) {
 }
 
 // GetAdditionalCA fetches the Rancher additional CA secret
-func GetAdditionalCA(c client.Reader) ([]byte, error) {
+// returns empty byte array of the secret tls-ca-additional is not found
+func GetAdditionalCA(c client.Reader) []byte {
 	secret := &corev1.Secret{}
 	nsName := types.NamespacedName{
 		Namespace: CattleSystem,
 		Name:      RancherAdditionalIngressCAName}
 
 	if err := c.Get(context.TODO(), nsName, secret); err != nil {
-		return nil, client.IgnoreNotFound(err)
+		return []byte{}
 	}
 
-	return secret.Data[RancherCAAdditionalPem], nil
+	return secret.Data[RancherCAAdditionalPem]
 }
 
 func CertPool(certs ...[]byte) *x509.CertPool {
@@ -143,14 +144,18 @@ func HTTPClient(c client.Reader, hostname string) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	additionalCA, err := GetAdditionalCA(c)
-	if err != nil {
-		return nil, err
-	}
-	if len(rootCA) < 1 && len(additionalCA) < 1 {
-		return nil, errors.New("neither root nor additional CA Secrets were found for Rancher")
-	}
+	additionalCA := GetAdditionalCA(c)
 
+	if len(rootCA) < 1 && len(additionalCA) < 1 {
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					ServerName: hostname,
+				},
+			},
+		}, nil
+	}
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{

--- a/platform-operator/controllers/verrazzano/component/common/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_test.go
@@ -1,22 +1,23 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-	"testing"
 )
 
 const (
@@ -181,14 +182,14 @@ func TestHttpClient(t *testing.T) {
 		isErr    bool
 	}{
 		{
-			"should get an HTTP Client when CA Secret exists",
+			"should get an HTTP Client when additional CA Secret exists",
 			fake.NewFakeClientWithScheme(getScheme(), &secret),
 			false,
 		},
 		{
-			"should fail to create an HTTP Client when CA Secret is not present",
+			"should get an HTTP Client when additional CA Secret is not present",
 			fake.NewFakeClientWithScheme(getScheme()),
-			true,
+			false,
 		},
 	}
 


### PR DESCRIPTION
# Description

When Verrazzano is using letsencryt production mode, root CA would be empty, and there should not be a secret tls-ca-additional, we can not throw an error in this case. Instead, we use the default RootCAs.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
