### PR TITLE
VZ-4953 - Reinstate Update to mysql 8.0.28 which is from mysql/mysql-server:8.0.28 and add extraInitContainer to MySQL to chown the data directory so that upgrade works

### DIFF
--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -346,7 +346,7 @@ spec:
                       key: password
                 - name: MYSQL_DATABASE
                   value: books
-              image: ghcr.io/verrazzano/mysql:8.0.26
+              image: ghcr.io/verrazzano/mysql:8.0.28
               imagePullPolicy: IfNotPresent
               name: mysql
               ports:

--- a/examples/multicluster/todo-list/todo-list-components.yaml
+++ b/examples/multicluster/todo-list/todo-list-components.yaml
@@ -181,7 +181,7 @@ spec:
                       key: password
                 - name: MYSQL_DATABASE
                   value: tododb
-              image: ghcr.io/verrazzano/mysql:8.0.26
+              image: ghcr.io/verrazzano/mysql:8.0.28
               imagePullPolicy: IfNotPresent
               name: mysql
               ports:

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -171,7 +171,7 @@ spec:
                       key: password
                 - name: MYSQL_DATABASE
                   value: tododb
-              image: ghcr.io/verrazzano/mysql:8.0.26
+              image: ghcr.io/verrazzano/mysql:8.0.28
               imagePullPolicy: IfNotPresent
               name: mysql
               ports:

--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # NOTE: The image you're looking for isn't here. The mysql and linux images now come from
@@ -9,3 +9,25 @@ imagePullPolicy: IfNotPresent
 ssl:
   enabled: false
 
+# Add an init container to chown the data directory to be owned by the mysql user
+# (uid=27 gid=27) so that when upgrading, mysql user can definitely access data dir
+# from previous volume. The Helm chart expects this to be a STRING, so using a multi-line string here
+# Note: if the Helm chart for MySQL changes, this should be reviewed for correctness
+extraInitContainers: |
+  - command:
+      - chown
+      - -R
+      - 27:27
+      - /var/lib/mysql
+    image: ghcr.io/oracle/oraclelinux:7-slim
+    imagePullPolicy: IfNotPresent
+    name: chown-data-dir
+    resources:
+      requests:
+        cpu: 10m
+        memory: 10Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+      - mountPath: /var/lib/mysql
+        name: data

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -368,7 +368,7 @@
           "images": [
             {
               "image": "mysql",
-              "tag": "8.0.26",
+              "tag": "8.0.28",
               "helmFullImageKey": "image",
               "helmTagKey": "imageTag"
             }


### PR DESCRIPTION
# Description

VZ-4953 - Reinstate Update to mysql 8.0.28 which is from mysql/mysql-server:8.0.28 and add extraInitContainer to MySQL to chown the data directory so that upgrade works

Fixes VZ-4953

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
