### PR TITLE
Remove if Affinity in go template since it will always be valued

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
@@ -46,10 +46,8 @@ spec:
         enabled: true
         k8s:
           replicaCount: {{.EgressReplicaCount}}
-{{- if .EgressAffinity }}
           affinity:
 {{ multiLineIndent 12 .EgressAffinity }}
-{{- end}}
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
@@ -60,10 +58,8 @@ spec:
             externalIPs:
               {{.ExternalIps}}
           {{- end}}
-{{- if .IngressAffinity }}
           affinity:
 {{ multiLineIndent 12 .IngressAffinity }}
-{{- end}}
 `
 
 type ReplicaData struct {


### PR DESCRIPTION
# Description

Remove unnecessary Affinity if in istio operator Go Template

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
