### PR TITLE
Fix bad var init - so it will work in parallel and randomized runs

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -160,7 +160,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the bobs-books namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.It("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
 		start := time.Now()
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -160,7 +160,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the bobs-books namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach(func() {
 		start := time.Now()
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -72,7 +72,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the hello-helidon namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -72,7 +72,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the hello-helidon namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.It("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	t = framework.NewTestFramework("helidonconfig")
+	t                  = framework.NewTestFramework("helidonconfig")
 	generatedNamespace = pkg.GenerateNamespace("helidon-config")
 )
 
@@ -103,7 +103,7 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the helidon-config namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.It("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -103,7 +103,7 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the helidon-config namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -99,7 +99,7 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 
 	var hostname = ""
 	var err error
-	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			hostname, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return hostname, err

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -99,7 +99,7 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 
 	var hostname = ""
 	var err error
-	t.It("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
 		Eventually(func() (string, error) {
 			hostname, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return hostname, err

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -80,7 +80,7 @@ var _ = t.Describe("Spring Boot test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the springboot namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.It("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -80,7 +80,7 @@ var _ = t.Describe("Spring Boot test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the springboot namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.BeforeEach("Get host from gateway.", Label("f:mesh.ingress"), func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -190,7 +190,7 @@ var _ = t.Describe("ToDo List test", Label("f:app-lcm.oam",
 		// GIVEN the Istio gateway for the todo-list namespace
 		// WHEN GetHostnameFromGateway is called
 		// THEN return the host name found in the gateway.
-		t.BeforeEach("Get host from gateway.", func() {
+		t.BeforeEach(func() {
 			Eventually(func() (string, error) {
 				host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 				return host, err

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -190,7 +190,7 @@ var _ = t.Describe("ToDo List test", Label("f:app-lcm.oam",
 		// GIVEN the Istio gateway for the todo-list namespace
 		// WHEN GetHostnameFromGateway is called
 		// THEN return the host name found in the gateway.
-		t.It("Get host from gateway.", func() {
+		t.BeforeEach("Get host from gateway.", func() {
 			Eventually(func() (string, error) {
 				host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 				return host, err

--- a/tests/e2e/ingress/console/console_ingress_test.go
+++ b/tests/e2e/ingress/console/console_ingress_test.go
@@ -145,7 +145,7 @@ var _ = t.Describe("console-ingress app test", Label("f:app-lcm.oam",
 		// GIVEN the Istio gateway for the test namespace
 		// WHEN GetHostnameFromGateway is called
 		// THEN return the host name found in the gateway.
-		t.BeforeEach("Get host from gateway.", func() {
+		t.BeforeEach(func() {
 			Eventually(func() (string, error) {
 				host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 				return host, err

--- a/tests/e2e/ingress/console/console_ingress_test.go
+++ b/tests/e2e/ingress/console/console_ingress_test.go
@@ -145,7 +145,7 @@ var _ = t.Describe("console-ingress app test", Label("f:app-lcm.oam",
 		// GIVEN the Istio gateway for the test namespace
 		// WHEN GetHostnameFromGateway is called
 		// THEN return the host name found in the gateway.
-		t.It("Get host from gateway.", func() {
+		t.BeforeEach("Get host from gateway.", func() {
 			Eventually(func() (string, error) {
 				host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 				return host, err

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -291,24 +291,21 @@ var _ = t.Describe("AuthPolicy test,", Label("f:security.authpol",
 	})
 
 	var fooHost = ""
+	var barHost = ""
+	var noIstioHost = ""
+
 	var err error
-	t.It("Get foo host from gateway.", func() {
+	t.BeforeEach("Get hosts from gateways.", func() {
 		Eventually(func() (string, error) {
 			fooHost, err = k8sutil.GetHostnameFromGateway(fooNamespace, "")
 			return fooHost, err
 		}, waitTimeout, shortPollingInterval).Should(Not(BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", fooNamespace))
-	})
 
-	var barHost = ""
-	t.It("Get bar host from gateway.", func() {
 		Eventually(func() (string, error) {
 			barHost, err = k8sutil.GetHostnameFromGateway(barNamespace, "")
 			return barHost, err
 		}, waitTimeout, shortPollingInterval).Should(Not(BeEmpty()), fmt.Sprintf("Failed to get host from gateway in %s", barNamespace))
-	})
 
-	var noIstioHost = ""
-	t.It("Get noistio host from gateway.", func() {
 		Eventually(func() (string, error) {
 			noIstioHost, err = k8sutil.GetHostnameFromGateway(noIstioNamespace, "")
 			return noIstioHost, err

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -295,7 +295,7 @@ var _ = t.Describe("AuthPolicy test,", Label("f:security.authpol",
 	var noIstioHost = ""
 
 	var err error
-	t.BeforeEach("Get hosts from gateways.", func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			fooHost, err = k8sutil.GetHostnameFromGateway(fooNamespace, "")
 			return fooHost, err

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -97,7 +97,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the helidon-logging namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.BeforeEach("Get host from gateway.", func() {
+	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(testNamespace, "")
 			return host, err

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -97,7 +97,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// GIVEN the Istio gateway for the helidon-logging namespace
 	// WHEN GetHostnameFromGateway is called
 	// THEN return the host name found in the gateway.
-	t.It("Get host from gateway.", func() {
+	t.BeforeEach("Get host from gateway.", func() {
 		Eventually(func() (string, error) {
 			host, err = k8sutil.GetHostnameFromGateway(testNamespace, "")
 			return host, err


### PR DESCRIPTION
Signed-off-by: Mark Nelson <mark.x.nelson@oracle.com>

# Description

This test fixes the incorrect initialization of variables in some tests, so that those tests will work when run in parallelized and randomized fashion.

Fixes VZ-4991

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
