### PR TITLE
No JIRA: Fix Console ingress test

### DIFF
--- a/tests/testdata/ingress/console/components.yaml
+++ b/tests/testdata/ingress/console/components.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2

--- a/tests/testdata/ingress/console/components.yaml
+++ b/tests/testdata/ingress/console/components.yaml
@@ -71,7 +71,7 @@ spec:
                   JNDIName: jdbc/ToDoDB
                 JDBCDriverParams:
                   # for MySQL, the last element in the URL is the database name, and must match the name inside the DB server
-                  URL: "jdbc:mysql://mysql.todo-list.svc.cluster.local:3306/tododb"
+                  URL: "jdbc:mysql://mysql:3306/tododb"
                   PasswordEncrypted: '@@SECRET:tododomain-jdbc-tododb:password@@'
                   DriverName: com.mysql.cj.jdbc.Driver
                   Properties:
@@ -159,7 +159,7 @@ spec:
                       key: password
                 - name: MYSQL_DATABASE
                   value: tododb
-              image: ghcr.io/verrazzano/mysql:8.0.26
+              image: ghcr.io/verrazzano/mysql:8.0.28
               imagePullPolicy: IfNotPresent
               name: mysql
               ports:


### PR DESCRIPTION
# Description

The Console ingress test has the wrong namespace in the MySQL URL. It happens to work because the todo example app test runs at the same time, but the test fails if the todo MySQL pod goes away before this test runs.

The fix removes the qualified domain since it's not needed.

Also, the test uses an older MySQL image so I replaced it with the latest.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
