### PR TITLE
VZ-4982 prevent Helm --upgrade being called twice

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -112,9 +111,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 // doReconcile the Verrazzano CR
 func (r *Reconciler) doReconcile(log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	ctx := context.TODO()
-
-	// Add cert-manager components to the scheme
-	cmapiv1.AddToScheme(r.Scheme)
 
 	// Initialize once for this Verrazzano resource when the operator starts
 	result, err := r.initForVzResource(vz, log)

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -139,7 +139,8 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 	if err = r.updateStatus(log, cr, msg, installv1alpha1.CondUpgradeComplete); err != nil {
 		return newRequeueWithDelay(), err
 	}
-
+	// Upgrade completely done
+	deleteUpgradeContext(cr)
 	return ctrl.Result{}, nil
 }
 
@@ -191,12 +192,21 @@ func getUpgradeContext(cr *installv1alpha1.Verrazzano) *vzUpgradeContext {
 	return vuc
 }
 
+// Delete the upgrade context for Verrazzano
+func deleteUpgradeContext(cr *installv1alpha1.Verrazzano) {
+	key := getNsnKey(cr)
+	_, ok := upgradeContextMap[key]
+	if ok {
+		delete(upgradeContextMap, key)
+	}
+}
+
 // Get the upgrade context for the component
 func (vuc *vzUpgradeContext) getUpgradeContext(compName string) *componentUpgradeContext {
 	cuc, ok := vuc.compMap[compName]
 	if !ok {
 		cuc = &componentUpgradeContext{
-			state: installv1alpha1.StateInit,
+			state: StateInit,
 		}
 		vuc.compMap[compName] = cuc
 	}

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -647,8 +647,8 @@ func TestUpgradeCompletedMultipleReconcile(t *testing.T) {
 	request := newRequest(namespace, name)
 	reconciler := newVerrazzanoReconciler(mock)
 	_, err := reconciler.Reconcile(request)
+	asserts.NoError(err)
 	result, err := reconciler.Reconcile(request)
-
 	// Validate the results
 	mocker.Finish()
 	asserts.NoError(err)

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -560,6 +560,103 @@ func TestUpgradeCompleted(t *testing.T) {
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
 }
 
+// TestUpgradeCompletedMultipleReconcile tests the reconcileUpgrade method for the following use case
+// GIVEN a request to reconcile an verrazzano resource after install is completed
+// WHEN spec.version doesn't match status.version and reconcile is called multiple times
+// THEN ensure a condition with type UpgradeCompleted is added
+func TestUpgradeCompletedMultipleReconcile(t *testing.T) {
+	initUnitTesing()
+	namespace := "verrazzano"
+	name := "test"
+	var verrazzanoToUse vzapi.Verrazzano
+
+	fname, _ := filepath.Abs(unitTestBomFile)
+	config.SetDefaultBomFilePath(fname)
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
+		}
+	})
+	defer registry.ResetGetComponentsFn()
+
+	// Add mocks necessary for the system component restart
+	mock.AddRestartMocks()
+	mock.AddRestartMocks()
+
+	// Expect a call to get the verrazzano resource.  Return resource with version
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, verrazzano *vzapi.Verrazzano) error {
+			verrazzano.TypeMeta = metav1.TypeMeta{
+				APIVersion: "install.verrazzano.io/v1alpha1",
+				Kind:       "Verrazzano"}
+			verrazzano.ObjectMeta = metav1.ObjectMeta{
+				Namespace:  name.Namespace,
+				Name:       name.Name,
+				Finalizers: []string{finalizerName}}
+			verrazzano.Spec = vzapi.VerrazzanoSpec{
+				Version: "0.2.0"}
+			verrazzano.Status = vzapi.VerrazzanoStatus{
+				State:      vzapi.VzStateReady,
+				Components: makeVerrazzanoComponentStatusMap(),
+				Conditions: []vzapi.Condition{
+					{
+						Type: vzapi.CondInstallComplete,
+					},
+					{
+						Type: vzapi.CondUpgradeStarted,
+					},
+				},
+			}
+			return nil
+		}).Times(2)
+
+	// Expect 2 calls to get the service account
+	expectGetServiceAccountExists(mock, name, nil)
+	expectGetServiceAccountExists(mock, name, nil)
+
+	// Expect 2 calls to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Expect calls to get the status writer and return a mock.
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+
+	// Expect a call to update the status of the Verrazzano resource
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
+			asserts.Len(verrazzano.Status.Conditions, 3, "Incorrect number of conditions")
+			asserts.Equal(vzapi.CondUpgradeComplete, verrazzano.Status.Conditions[2].Type, "Incorrect conditions")
+			return nil
+		}).Times(2)
+
+	config.TestProfilesDir = "../../manifests/profiles"
+	defer func() { config.TestProfilesDir = "" }()
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	_, err := reconciler.Reconcile(request)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(false, result.Requeue)
+	asserts.Equal(time.Duration(0), result.RequeueAfter)
+	asserts.Len(upgradeContextMap, 0, "Expect upgradeContextMap to be empty")
+}
+
 // TestUpgradeCompletedStatusReturnsError tests the reconcileUpgrade method for the following use case
 // GIVEN a request to reconcile an verrazzano resource after install is completed
 // WHEN the update of the VZ resource status fails and returns an error
@@ -696,6 +793,7 @@ func TestUpgradeHelmError(t *testing.T) {
 			verrazzano.ObjectMeta = metav1.ObjectMeta{
 				Namespace:  name.Namespace,
 				Name:       name.Name,
+				Generation: 1,
 				Finalizers: []string{finalizerName}}
 			verrazzano.Spec = vzapi.VerrazzanoSpec{
 				Version: "0.2.0"}

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -50,7 +50,7 @@ func init() {
 	_ = vzapp.AddToScheme(scheme)
 
 	// Add cert-manager components to the scheme
-	cmapiv1.AddToScheme(r.Scheme)
+	cmapiv1.AddToScheme(scheme)
 
 	// +kubebuilder:scaffold:scheme
 }

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core"
+	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
@@ -47,6 +48,9 @@ func init() {
 	_ = oam.AddToScheme(scheme)
 
 	_ = vzapp.AddToScheme(scheme)
+
+	// Add cert-manager components to the scheme
+	cmapiv1.AddToScheme(scheme)
 
 	// +kubebuilder:scaffold:scheme
 }

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -50,7 +50,7 @@ func init() {
 	_ = vzapp.AddToScheme(scheme)
 
 	// Add cert-manager components to the scheme
-	cmapiv1.AddToScheme(scheme)
+	cmapiv1.AddToScheme(r.Scheme)
 
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
Prevent upgrade from calling Helm twice to do an upgrade for reconciling a given generation of the Verrazzano CR

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
