### PR TITLE
VZ-5019: Fix bug that breaks custom CA install

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -52,6 +52,8 @@ const (
 	crdDirectory  = "/cert-manager/"
 	crdInputFile  = "cert-manager.crds.yaml"
 	crdOutputFile = "output.crd.yaml"
+
+	clusterResourceNamespaceKey = "clusterResourceNamespace"
 )
 
 // Template for ClusterIssuer for Acme certificates
@@ -231,7 +233,8 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 		return []bom.KeyValue{}, err
 	}
 	if isCAValue {
-		kvs = append(kvs, bom.KeyValue{Key: "clusterResourceNamespace", Value: namespace})
+		ns := compContext.EffectiveCR().Spec.Components.CertManager.Certificate.CA.ClusterResourceNamespace
+		kvs = append(kvs, bom.KeyValue{Key: clusterResourceNamespaceKey, Value: ns})
 	}
 	return kvs, nil
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
@@ -5,6 +5,8 @@ package certmanager
 
 import (
 	"context"
+	"testing"
+
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -16,17 +18,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const (
-	profileDir = "../../../../manifests/profiles"
+	profileDir    = "../../../../manifests/profiles"
+	testNamespace = "testNamespace"
 )
 
 // default CA object
 var ca = vzapi.CA{
 	SecretName:               "testSecret",
-	ClusterResourceNamespace: namespace,
+	ClusterResourceNamespace: testNamespace,
 }
 
 // Default Acme object
@@ -147,6 +149,7 @@ func TestAppendCertManagerOverridesWithInstallArgs(t *testing.T) {
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, localvz, false), ComponentName, namespace, "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 1)
+	assert.Contains(t, kvs, bom.KeyValue{Key: clusterResourceNamespaceKey, Value: testNamespace})
 }
 
 // TestCertManagerPreInstall tests the PreInstall fn


### PR DESCRIPTION
# Description

I followed the public doc instructions for setting up a custom CA cert for my cluster. The Verrazzano install fails because cert-manager is configured to always look for the CA cert secret in the `cert-manager` namespace. It ignores the user-specified namespace in the Verrazzano CR.

This PR fixes it to set the `cert-manager` helm chart value to the user-specified namespace.

Fixes VZ-5019

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
