### PR TITLE
VZ-5026 Add common check for IsReady for AppVersions

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -19,13 +19,13 @@ type ChartInfo struct {
 	AppVersion  string
 }
 
-// Package-level var and functions to allow overriding getReleaseState for unit test purposes
-type chartInfoFnType func(chartDir string) (ChartInfo, error)
+// ChartInfoFnType - Package-level var and functions to allow overriding getReleaseState for unit test purposes
+type ChartInfoFnType func(chartDir string) (ChartInfo, error)
 
-var chartInfoFn chartInfoFnType = getChartInfo
+var chartInfoFn ChartInfoFnType = getChartInfo
 
 // SetChartInfoFunction Override the chart info function for unit testing
-func SetChartInfoFunction(f chartInfoFnType) {
+func SetChartInfoFunction(f ChartInfoFnType) {
 	chartInfoFn = f
 }
 

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -6,6 +6,7 @@ package helm
 import (
 	"io/ioutil"
 	"path/filepath"
+
 	"sigs.k8s.io/yaml"
 )
 
@@ -18,8 +19,28 @@ type ChartInfo struct {
 	AppVersion  string
 }
 
-// GetChartInfo loads the Chart.yaml from the specified chart dir into a ChartInfo struct
+// Package-level var and functions to allow overriding getReleaseState for unit test purposes
+type chartInfoFnType func(chartDir string) (ChartInfo, error)
+
+var chartInfoFn chartInfoFnType = getChartInfo
+
+// SetChartInfoFunction Override the chart info function for unit testing
+func SetChartInfoFunction(f chartInfoFnType) {
+	chartInfoFn = f
+}
+
+// SetDefaultChartInfoFunction Reset the chart info function
+func SetDefaultChartInfoFunction() {
+	chartInfoFn = getChartInfo
+}
+
+// GetChartInfo - public entry point
 func GetChartInfo(chartDir string) (ChartInfo, error) {
+	return chartInfoFn(chartDir)
+}
+
+// getChartInfo loads the Chart.yaml from the specified chart dir into a ChartInfo struct
+func getChartInfo(chartDir string) (ChartInfo, error) {
 	chartBytes, err := ioutil.ReadFile(filepath.Join(chartDir + "/Chart.yaml"))
 	if err != nil {
 		return ChartInfo{}, err

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -12,17 +12,15 @@ import (
 	"strings"
 	"testing"
 
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/helm"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -434,55 +432,111 @@ func TestIsInstalled(t *testing.T) {
 //  WHEN I call IsReady
 //  THEN true is returned based on chart status and the status check function if defined for the component
 func TestReady(t *testing.T) {
-	assert := assert.New(t)
-
 	defer helm.SetDefaultChartStatusFunction()
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
-	})
-
 	defer helm.SetDefaultChartInfoFunction()
-	helm.SetChartInfoFunction(func(chartDir string) (helm.ChartInfo, error) {
-		return helm.ChartInfo{
-			AppVersion: "1.0",
-		}, nil
-	})
-
 	defer helm.SetDefaultReleaseAppVersionFunction()
-	helm.SetReleaseAppVersionFunction(func(releaseName string, namespace string) (string, error) {
-		return "1.0", nil
-	})
 
-	comp := HelmComponent{}
+	tests := []struct {
+		name                string
+		chartStatusFn       helm.ChartStatusFnType
+		chartInfoFn         helm.ChartInfoFnType
+		releaseAppVersionFn helm.ReleaseAppVersionFnType
+		expectSuccess       bool
+	}{
+		{
+			name: "IsReady when all conditions are met",
+			chartStatusFn: func(releaseName string, namespace string) (string, error) {
+				return helm.ChartStatusDeployed, nil
+			},
+			chartInfoFn: func(chartDir string) (helm.ChartInfo, error) {
+				return helm.ChartInfo{
+					AppVersion: "1.0",
+				}, nil
+			},
+			releaseAppVersionFn: func(releaseName string, namespace string) (string, error) {
+				return "1.0", nil
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "IsReady fail because chart not found",
+			chartStatusFn: func(releaseName string, namespace string) (string, error) {
+				return helm.ChartNotFound, nil
+			},
+			chartInfoFn: func(chartDir string) (helm.ChartInfo, error) {
+				return helm.ChartInfo{
+					AppVersion: "1.0",
+				}, nil
+			},
+			releaseAppVersionFn: func(releaseName string, namespace string) (string, error) {
+				return "1.0", nil
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "IsReady fail because chart status is failure",
+			chartStatusFn: func(releaseName string, namespace string) (string, error) {
+				return helm.ChartStatusFailed, nil
+			},
+			chartInfoFn: func(chartDir string) (helm.ChartInfo, error) {
+				return helm.ChartInfo{
+					AppVersion: "1.0",
+				}, nil
+			},
+			releaseAppVersionFn: func(releaseName string, namespace string) (string, error) {
+				return "1.0", nil
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "IsReady fail because error from getting chart status",
+			chartStatusFn: func(releaseName string, namespace string) (string, error) {
+				return "", fmt.Errorf("Unexpected error")
+			},
+			chartInfoFn: func(chartDir string) (helm.ChartInfo, error) {
+				return helm.ChartInfo{
+					AppVersion: "1.0",
+				}, nil
+			},
+			releaseAppVersionFn: func(releaseName string, namespace string) (string, error) {
+				return "1.0", nil
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "IsReady fail because app version not matched between release and chart",
+			chartStatusFn: func(releaseName string, namespace string) (string, error) {
+				return helm.ChartStatusDeployed, nil
+			},
+			chartInfoFn: func(chartDir string) (helm.ChartInfo, error) {
+				return helm.ChartInfo{
+					AppVersion: "1.1",
+				}, nil
+			},
+			releaseAppVersionFn: func(releaseName string, namespace string) (string, error) {
+				return "1.0", nil
+			},
+			expectSuccess: false,
+		},
+	}
+
+	assert := assert.New(t)
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
-	compContext := spi.NewFakeContext(client, &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false)
+	ctx := spi.NewFakeContext(client, &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false)
 
-	assert.True(comp.IsReady(compContext))
-
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartNotFound, nil
-	})
-	assert.False(comp.IsReady(compContext))
-
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusFailed, nil
-	})
-	assert.False(comp.IsReady(compContext))
-
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return "", fmt.Errorf("Unexpected error")
-	})
-	assert.False(comp.IsReady(compContext))
-
-	// IsReady should fail when app versions do not match
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
-	})
-	helm.SetReleaseAppVersionFunction(func(releaseName string, namespace string) (string, error) {
-		return "1.1", nil
-	})
-	assert.False(comp.IsReady(compContext))
-
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := HelmComponent{}
+			helm.SetChartStatusFunction(tt.chartStatusFn)
+			helm.SetChartInfoFunction(tt.chartInfoFn)
+			helm.SetReleaseAppVersionFunction(tt.releaseAppVersionFn)
+			if tt.expectSuccess {
+				assert.True(comp.IsReady(ctx))
+			} else {
+				assert.False(comp.IsReady(ctx))
+			}
+		})
+	}
 }
 
 // fakeUpgrade verifies that the correct parameter values are passed to upgrade

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -204,10 +204,24 @@ func TestComponentMultipleDependenciesMet(t *testing.T) {
 		newReadyDeployment(certManagerDeploymentName, certManagerNamespace),
 		newReadyDeployment(cainjectorDeploymentName, certManagerNamespace),
 		newReadyDeployment(webhookDeploymentName, certManagerNamespace))
+
 	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
+
+	helm.SetChartInfoFunction(func(chartDir string) (helm.ChartInfo, error) {
+		return helm.ChartInfo{
+			AppVersion: "1.0",
+		}, nil
+	})
+	defer helm.SetDefaultChartInfoFunction()
+
+	helm.SetReleaseAppVersionFunction(func(releaseName string, namespace string) (string, error) {
+		return "1.0", nil
+	})
+	defer helm.SetDefaultReleaseAppVersionFunction()
+
 	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.True(t, ready)
 }


### PR DESCRIPTION
# Description

Add an additional check to the common IsReady function.  Compare the chart app-version being installed/upgraded with the app-version of the chart currently installed.  If they do not match, then IsReady will fail.  This check was added because the function was only checking if the chart is deployed, but not which version of the chart.

Fixes VZ-5026

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
