### PR TITLE
VZ-4150 Update to k8s.io/api/admissionregistration/v1 for Kubernetes 1.22 support

### DIFF
--- a/platform-operator/internal/k8s/certificate/certificate.go
+++ b/platform-operator/internal/k8s/certificate/certificate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certificate
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	adminv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	adminv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -159,8 +159,8 @@ func writeFile(filepath string, pem *bytes.Buffer) error {
 
 // UpdateValidatingnWebhookConfiguration sets the CABundle
 func UpdateValidatingnWebhookConfiguration(kubeClient kubernetes.Interface, caCert *bytes.Buffer) error {
-	var validatingWebhook *adminv1beta1.ValidatingWebhookConfiguration
-	validatingWebhook, err := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), OperatorName, metav1.GetOptions{})
+	var validatingWebhook *adminv1.ValidatingWebhookConfiguration
+	validatingWebhook, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), OperatorName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func UpdateValidatingnWebhookConfiguration(kubeClient kubernetes.Interface, caCe
 	}
 	validatingWebhook.Webhooks[0].ClientConfig.CABundle = caCert.Bytes()
 	validatingWebhook.Webhooks[1].ClientConfig.CABundle = caCert.Bytes()
-	_, err = kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(), validatingWebhook, metav1.UpdateOptions{})
+	_, err = kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.TODO(), validatingWebhook, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/platform-operator/internal/k8s/certificate/certificate_test.go
+++ b/platform-operator/internal/k8s/certificate/certificate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certificate
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	adminv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	adminv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -77,45 +77,45 @@ func TestUpdateValidatingnWebhookConfiguration(t *testing.T) {
 	var caCert bytes.Buffer
 	caCert.WriteString("Fake CABundle")
 	pathInstall := "/validate-install-verrazzano-io-v1alpha1-verrazzano"
-	serviceInstall := adminv1beta1.ServiceReference{
+	serviceInstall := adminv1.ServiceReference{
 		Name:      OperatorName,
 		Namespace: OperatorNamespace,
 		Path:      &pathInstall,
 	}
 	pathClusters := "/validate-clusters-verrazzano-io-v1alpha1-verrazzanomanagedcluster"
-	serviceClusters := adminv1beta1.ServiceReference{
+	serviceClusters := adminv1.ServiceReference{
 		Name:      OperatorName,
 		Namespace: OperatorNamespace,
 		Path:      &pathClusters,
 	}
-	webhook := adminv1beta1.ValidatingWebhookConfiguration{
+	webhook := adminv1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: OperatorName,
 		},
-		Webhooks: []adminv1beta1.ValidatingWebhook{
+		Webhooks: []adminv1.ValidatingWebhook{
 			{
 				Name: "install.verrazzano.io",
-				ClientConfig: adminv1beta1.WebhookClientConfig{
+				ClientConfig: adminv1.WebhookClientConfig{
 					Service: &serviceInstall,
 				},
 			},
 			{
 				Name: "clusters.verrazzano.io",
-				ClientConfig: adminv1beta1.WebhookClientConfig{
+				ClientConfig: adminv1.WebhookClientConfig{
 					Service: &serviceClusters,
 				},
 			},
 		},
 	}
 
-	_, err := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), &webhook, metav1.CreateOptions{})
+	_, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), &webhook, metav1.CreateOptions{})
 	assert.Nil(err, "error should not be returned creating validation webhook configuration")
 
 	err = UpdateValidatingnWebhookConfiguration(kubeClient, &caCert)
 	assert.Nil(err, "error should not be returned updating validation webhook configuration")
 
-	updatedWebhook, _ := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), "verrazzano-platform-operator", metav1.GetOptions{})
+	updatedWebhook, _ := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), "verrazzano-platform-operator", metav1.GetOptions{})
 	assert.Equal(caCert.Bytes(), updatedWebhook.Webhooks[0].ClientConfig.CABundle, "Expected CA bundle name did not match")
 }
 
@@ -132,27 +132,27 @@ func TestUpdateValidatingnWebhookConfigurationFail(t *testing.T) {
 	var caCert bytes.Buffer
 	caCert.WriteString("Fake CABundle")
 	path := "/validate-install-verrazzano-io-v1alpha1-verrazzano"
-	service := adminv1beta1.ServiceReference{
+	service := adminv1.ServiceReference{
 		Name:      OperatorName,
 		Namespace: OperatorNamespace,
 		Path:      &path,
 	}
-	webhook := adminv1beta1.ValidatingWebhookConfiguration{
+	webhook := adminv1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "InvalidName",
 		},
-		Webhooks: []adminv1beta1.ValidatingWebhook{
+		Webhooks: []adminv1.ValidatingWebhook{
 			{
 				Name: "install.verrazzano.io",
-				ClientConfig: adminv1beta1.WebhookClientConfig{
+				ClientConfig: adminv1.WebhookClientConfig{
 					Service: &service,
 				},
 			},
 		},
 	}
 
-	_, err := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), &webhook, metav1.CreateOptions{})
+	_, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), &webhook, metav1.CreateOptions{})
 	assert.Nil(err, "error should not be returned creating validation webhook configuration")
 
 	err = UpdateValidatingnWebhookConfiguration(kubeClient, &caCert)


### PR DESCRIPTION
# Description

Update to k8s.io/api/admissionregistration/v1 for Kubernetes 1.22 support

Fixes VZ-4150

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
