### PR TITLE
Change name of authproxy overrides file to be more intuitive

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	keycloakInClusterURL = "keycloak-http.keycloak.svc.cluster.local"
-	tmpFilePrefix        = "verrazzano-overrides-"
+	tmpFilePrefix        = "authproxy-overrides-"
 	tmpSuffix            = "yaml"
 	tmpFileCreatePattern = tmpFilePrefix + "*." + tmpSuffix
 	tmpFileCleanPattern  = tmpFilePrefix + ".*\\." + tmpSuffix


### PR DESCRIPTION
# Description

The helm override file for the authproxy helm chart was named "verrazzano-overrides".  Instead it is now named "authproxy-overrides".

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
