### PR TITLE
VZ-5017 - Use busybox template values for chown-data-dir initContainer in mysql-values.yaml

### DIFF
--- a/platform-operator/helm_config/overrides/mysql-values.yaml
+++ b/platform-operator/helm_config/overrides/mysql-values.yaml
@@ -19,7 +19,7 @@ extraInitContainers: |
       - -R
       - 27:27
       - /var/lib/mysql
-    image: ghcr.io/oracle/oraclelinux:7-slim
+    image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"
     imagePullPolicy: IfNotPresent
     name: chown-data-dir
     resources:


### PR DESCRIPTION
# Description

VZ-5017 - Use busybox template values for chown-data-dir initContainer in mysql-values.yaml

Fixes VZ-5017

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
