### PR TITLE
VZ-5016: Fail test immediately when the container enters ImagePullBackOff or CrashLoopBackoff state

### DIFF
--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -128,18 +128,21 @@ func VerifyMCResourcesV100(kubeconfigPath string, isAdminCluster bool, placedInT
 
 // VerifyHelloHelidonInCluster verifies that the hello helidon app resources are either present or absent
 // depending on whether the app is placed in this cluster
-func VerifyHelloHelidonInCluster(kubeConfigPath string, isAdminCluster bool, placedInThisCluster bool, projectName string, namespace string) bool {
+func VerifyHelloHelidonInCluster(kubeConfigPath string, isAdminCluster bool, placedInThisCluster bool, projectName string, namespace string) (bool, error) {
 	projectExists := projectExists(kubeConfigPath, projectName)
 	workloadExists := componentWorkloadExists(kubeConfigPath, namespace)
-	podsRunning := helloHelidonPodsRunning(kubeConfigPath, namespace)
+	podsRunning, err := helloHelidonPodsRunning(kubeConfigPath, namespace)
+	if err != nil {
+		return false, err
+	}
 
 	if placedInThisCluster {
-		return projectExists && workloadExists && podsRunning
+		return projectExists && workloadExists && podsRunning, nil
 	} else {
 		if isAdminCluster {
-			return projectExists && !workloadExists && !podsRunning
+			return projectExists && !workloadExists && !podsRunning, nil
 		} else {
-			return !workloadExists && !podsRunning && !projectExists
+			return !workloadExists && !podsRunning && !projectExists, nil
 		}
 	}
 }
@@ -166,7 +169,7 @@ func VerifyHelloHelidonDeletedInManagedCluster(kubeconfigPath string, namespace 
 // VerifyAppDeleted - verifies that the workload and pods are deleted on the the specified cluster
 func VerifyAppDeleted(kubeconfigPath string, namespace string) bool {
 	workloadExists := componentWorkloadExists(kubeconfigPath, namespace)
-	podsRunning := helloHelidonPodsRunning(kubeconfigPath, namespace)
+	podsRunning, _ := helloHelidonPodsRunning(kubeconfigPath, namespace)
 	return !workloadExists && !podsRunning
 }
 
@@ -253,11 +256,11 @@ func resourceExists(gvr schema.GroupVersionResource, ns string, name string, kub
 	return u != nil
 }
 
-func helloHelidonPodsRunning(kubeconfigPath string, namespace string) bool {
-	// TODO: Go through each of the test cases calling this and decide whether to fail the test or test suite
+func helloHelidonPodsRunning(kubeconfigPath string, namespace string) (bool, error) {
 	result, err := pkg.PodsRunningInCluster(namespace, expectedPodsHelloHelidon, kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
+		return false, err
 	}
-	return result
+	return result, nil
 }

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -88,7 +88,11 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
 		t.It("Does not have application placed", func() {
 			Consistently(func() bool {
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -107,7 +111,11 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 		// THEN expect that the app is deployed to the managed cluster
 		t.It("Has application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -134,7 +142,11 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 			})
 			t.It("Does not have application placed", func() {
 				Eventually(func() bool {
-					return examples.VerifyHelloHelidonInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					result, err := examples.VerifyHelloHelidonInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					if err != nil {
+						AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+					}
+					return result
 				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		}
@@ -196,14 +208,22 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 		t.It("App should be removed from managed cluster", func() {
 			Eventually(func() bool {
 				// app should not be placed in the managed cluster
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		t.It("App should be placed in admin cluster", func() {
 			Eventually(func() bool {
 				// app should be placed in the admin cluster
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, true, testProjectName, testProjectName)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, true, testProjectName, testProjectName)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -224,7 +244,11 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 		// THEN expect that the app is not deployed to the admin cluster
 		t.It("Admin cluster does not have application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
@@ -233,7 +257,11 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 		// THEN expect that the app is now deployed to the cluster
 		t.It("Managed cluster again has application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})

--- a/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
+++ b/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_delete_ns_test.go
@@ -72,7 +72,11 @@ var _ = t.Describe("In Multi-cluster, verify delete ns of hello-helidon-ns", Lab
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
 		t.It("Does not have application placed", func() {
 			Consistently(func() bool {
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -91,7 +95,11 @@ var _ = t.Describe("In Multi-cluster, verify delete ns of hello-helidon-ns", Lab
 		// THEN expect that the app is deployed to the managed cluster
 		t.It("Has application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -77,7 +77,11 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
 		t.It("Does not have application placed", func() {
 			Consistently(func() bool {
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -96,7 +100,11 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		// THEN expect that the app is deployed to the managed cluster
 		t.It("Has application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -123,7 +131,11 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 			})
 			t.It("Does not have application placed", func() {
 				Eventually(func() bool {
-					return examples.VerifyHelloHelidonInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					result, err := examples.VerifyHelloHelidonInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					if err != nil {
+						AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+					}
+					return result
 				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		}
@@ -218,14 +230,22 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		t.It("App should be removed from managed cluster", func() {
 			Eventually(func() bool {
 				// app should not be placed in the managed cluster
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		It("App should be placed in admin cluster", func() {
 			Eventually(func() bool {
 				// app should be placed in the admin cluster
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, true, testProjectName, testProjectName)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, true, testProjectName, testProjectName)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -246,7 +266,11 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		// THEN expect that the app is not deployed to the admin cluster
 		t.It("Admin cluster does not have application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
@@ -255,7 +279,11 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		// THEN expect that the app is now deployed to the cluster
 		t.It("Managed cluster again has application placed", func() {
 			Eventually(func() bool {
-				return examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := examples.VerifyHelloHelidonInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -76,7 +76,11 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
 		t.It("Does not have application placed", func() {
 			Consistently(func() bool {
-				return VerifySockShopInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := VerifySockShopInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -95,7 +99,11 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 		// THEN expect that the app is deployed to the managed cluster
 		t.It("Has application placed", func() {
 			Eventually(func() bool {
-				return VerifySockShopInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := VerifySockShopInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -122,7 +130,11 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 			})
 			t.It("Does not have application placed", func() {
 				Eventually(func() bool {
-					return VerifySockShopInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					result, err := VerifySockShopInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					if err != nil {
+						AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+					}
+					return result
 				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		}

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -99,7 +99,11 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 		// THEN expect that the app is not deployed to the admin cluster consistently for some length of time
 		t.It("Does not have application placed", func() {
 			Consistently(func() bool {
-				return VerifyTodoListInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				result, err := VerifyTodoListInCluster(adminKubeconfig, true, false, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, consistentlyDuration, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -118,7 +122,11 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 		// THEN expect that the app is deployed to the managed cluster
 		t.It("Has application placed", func() {
 			Eventually(func() bool {
-				return VerifyTodoListInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				result, err := VerifyTodoListInCluster(managedKubeconfig, false, true, testProjectName, testNamespace)
+				if err != nil {
+					AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+				}
+				return result
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 	})
@@ -145,7 +153,11 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 			})
 			It("Does not have application placed", func() {
 				Eventually(func() bool {
-					return VerifyTodoListInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					result, err := VerifyTodoListInCluster(kubeconfig, false, false, testProjectName, testNamespace)
+					if err != nil {
+						AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+					}
+					return result
 				}, waitTimeout, pollingInterval).Should(BeTrue())
 			})
 		}

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_utils.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_utils.go
@@ -131,17 +131,20 @@ func resourceExists(gvr schema.GroupVersionResource, ns string, name string, kub
 
 // VerifyTodoListInCluster verifies that the todo-list app resources are either present or absent
 // depending on whether the app is placed in this cluster
-func VerifyTodoListInCluster(kubeconfigPath string, isAdminCluster bool, placedInThisCluster bool, projectName string, namespace string) bool {
+func VerifyTodoListInCluster(kubeconfigPath string, isAdminCluster bool, placedInThisCluster bool, projectName string, namespace string) (bool, error) {
 	projectExists := projectExists(kubeconfigPath, projectName)
-	podsRunning := todoListPodsRunning(kubeconfigPath, namespace)
+	podsRunning, err := todoListPodsRunning(kubeconfigPath, namespace)
+	if err != nil {
+		return false, err
+	}
 
 	if placedInThisCluster {
-		return projectExists && podsRunning
+		return projectExists && podsRunning, nil
 	} else {
 		if isAdminCluster {
-			return projectExists && !podsRunning
+			return projectExists && !podsRunning, nil
 		} else {
-			return !podsRunning && !projectExists
+			return !podsRunning && !projectExists, nil
 		}
 	}
 }
@@ -157,22 +160,22 @@ func projectExists(kubeconfigPath string, projectName string) bool {
 }
 
 // todoListPodsRunning Check if expected pods are running on a given cluster
-func todoListPodsRunning(kubeconfigPath string, namespace string) bool {
+func todoListPodsRunning(kubeconfigPath string, namespace string) (bool, error) {
 	result, err := pkg.PodsRunningInCluster(namespace, expectedPodsTodoList, kubeconfigPath)
-	// TODO: Go through each of the test cases calling this and decide whether to fail the test or test suite
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
+		return false, err
 	}
-	return result
+	return result, nil
 }
 
 // todoListPodDeleted Check if expected pods are running on a given cluster
 func todoListPodDeleted(kubeconfigPath string, namespace string, pod string) bool {
 	deletedPod := []string{pod}
 	result, err := pkg.PodsRunningInCluster(namespace, deletedPod, kubeconfigPath)
-	// TODO: Go through each of the test cases calling this and decide whether to fail the test or test suite
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("There is an error in checking whether the pods are running in the namespace: %v, error: %v", namespace, err))
+		return false
 	}
 	return !result
 }

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_utils.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_utils.go
@@ -172,11 +172,7 @@ func todoListPodsRunning(kubeconfigPath string, namespace string) (bool, error) 
 // todoListPodDeleted Check if expected pods are running on a given cluster
 func todoListPodDeleted(kubeconfigPath string, namespace string, pod string) bool {
 	deletedPod := []string{pod}
-	result, err := pkg.PodsRunningInCluster(namespace, deletedPod, kubeconfigPath)
-	if err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("There is an error in checking whether the pods are running in the namespace: %v, error: %v", namespace, err))
-		return false
-	}
+	result, _ := pkg.PodsRunningInCluster(namespace, deletedPod, kubeconfigPath)
 	return !result
 }
 


### PR DESCRIPTION
# Description

This PR fixes few test cases which were left out in the initial change for VZ-5016. Here is the description provided for the previous PR, which is applicable here as well.

The utility function isPodRunning used by the tests to find out whether the pods with a given prefix and the namespace are up and running, is enhanced to return an error in the event of ImagePullBackOff and CrashLoopBackoff. The tests (except few) are updated to handle the error and abort the test run, rather than waiting for the duration specified by the timeout.

Contributes to VZ-5016

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
