### PR TITLE
VZ-5077: Uptake latest Rancher images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4",
+              "tag": "20220225194305-6fcf453aa",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4"
+              "tag": "20220225194305-6fcf453aa"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20220225194305-6fcf453aa",
+              "tag": "v2.5.9-20220228142012-806336795",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20220225194305-6fcf453aa"
+              "tag": "v2.5.9-20220228142012-806336795"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -150,7 +150,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.2"
+              "tag": "v0.1.3"
             },
             {
               "image": "fleet-agent",


### PR DESCRIPTION
# Description

Uptake the latest Rancher images that include upgraded dependencies. Rebuilding the Rancher images upgraded the patch version of rancher-webhook so that also needed to be updated in the BOM.

Fixes VZ-5077

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
