### PR TITLE
Revert "VZ-5014 Added build and runtime validation to check if BOM file is a valid JSON (#2578)

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -208,12 +208,6 @@ func ValidateInProgress(old *Verrazzano, new *Verrazzano) error {
 	return fmt.Errorf("Updates to resource not allowed while install, uninstall or upgrade is in progress")
 }
 
-// ValidateBom validates that the BOM file is readable and is a well formed JSON
-func ValidateBom() error {
-	_, err := bom.NewBom(config.GetDefaultBOMFilePath())
-	return err
-}
-
 // validateOCISecrets - Validate that the OCI DNS and Fluentd OCI secrets required by install exists, if configured
 func validateOCISecrets(client client.Client, spec *VerrazzanoSpec) error {
 	if err := validateOCIDNSSecret(client, spec); err != nil {

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -460,20 +460,6 @@ func TestGetCurrentBomVersionBadYAML(t *testing.T) {
 	assert.Nil(t, version)
 }
 
-// TestInvalidJsonBom Tests that the ValidateBom() method returns error when the BOM file is not a well-formed JSON
-// GIVEN a request for validating the BOM JSON file
-// WHEN an error occurs reading in the BOM file as json
-// THEN an error is returned
-func TestInvalidJsonBom(t *testing.T) {
-	config.SetDefaultBomFilePath(invalidTestBomFilePath)
-	defer func() {
-		config.SetDefaultBomFilePath("")
-	}()
-	err := ValidateBom()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected end of JSON input")
-}
-
 // TestValidateVersionInvalidVersionCheckingDisabled Tests  ValidateVersion() when version checking is disabled
 // GIVEN a request for the current VZ Bom version
 // WHEN the version provided is not valid version and checking is disabled

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -58,10 +58,6 @@ func (v *Verrazzano) ValidateCreate() error {
 		return err
 	}
 
-	if err := ValidateBom(); err != nil {
-		return err
-	}
-
 	if err := ValidateVersion(v.Spec.Version); err != nil {
 		return err
 	}
@@ -106,9 +102,6 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 		return fmt.Errorf("Profile change is not allowed oldResource %s to %s", oldResource.Spec.Profile, v.Spec.Profile)
 	}
 
-	if err := ValidateBom(); err != nil {
-		return err
-	}
 	// Check to see if the update is an upgrade request, and if it is valid and allowable
 	err := ValidateUpgradeRequest(&oldResource.Spec, &v.Spec)
 	if err != nil {

--- a/tools/scripts/generate_bom.sh
+++ b/tools/scripts/generate_bom.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tools/scripts/generate_bom.sh
+++ b/tools/scripts/generate_bom.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
@@ -41,16 +41,6 @@ if [ -z "$6" ]; then
   exit 1
 fi
 GENERATED_BOM_FILE=$6
-
-if [ -f "${BOM_FILE}" ]; then
-  cat ${BOM_FILE} | jq . > /dev/null
-  if [ $? != 0 ]; then
-    echo "[ERROR] BOM template file '${BOM_FILE}' is not a well formed JSON"
-    exit 1
-  fi
-else
-  echo "[ERROR] The BOM template '${BOM_FILE}' does not exist or is not a file"
-fi
 
 cp ${BOM_FILE} ${GENERATED_BOM_FILE}
 


### PR DESCRIPTION
This reverts commit c1493ff7bc3ee7311e23e2abf1249960a86a2bce.

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Reverts VZ-5014 as there is an existing unit test that is supposed to catch this error during build time

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
