### PR TITLE
VZ-3458 Adding logging for silent kube-system return

### DIFF
--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
@@ -56,7 +56,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
 	if req.Namespace == kubeSystem {
-		log.Oncef("Application configuration resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		log.Oncef("Multi-cluster application configuration resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -490,11 +490,16 @@ func newReconciler(c client.Client) Reconciler {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the ApplicationConfiguration
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "core.oam.dev", Resource: "ApplicationConfiguration"}, crName))
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(kubeSystem, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclustercomponent/controller.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller.go
@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
 	if req.Namespace == kubeSystem {
-		log.Oncef("Application configuration resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		log.Oncef("Multi-cluster component resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -491,11 +491,17 @@ func newReconciler(c client.Client) Reconciler {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MultiClusterComponent
+	// and return a not found error
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: clustersv1alpha1.SchemeGroupVersion.Group, Resource: clustersv1alpha1.MultiClusterComponentResource}, crName))
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(kubeSystem, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -36,14 +36,6 @@ const (
 // MultiClusterConfigMap to reflect the success or failure of the changes to the embedded resource
 // Currently it does NOT support Immutable ConfigMap resources
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	ctx := context.Background()
 	var mcConfigMap clustersv1alpha1.MultiClusterConfigMap
 	err := r.fetchMultiClusterConfigMap(ctx, req.NamespacedName, &mcConfigMap)
@@ -55,6 +47,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for multi-cluster config map", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Config map resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling multi-cluster config map resource %v, generation %v", req.NamespacedName, mcConfigMap.Generation)
 
 	res, err := r.doReconcile(ctx, mcConfigMap, log)

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
 	if req.Namespace == kubeSystem {
-		log.Oncef("Config map resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		log.Oncef("Multi-cluster config map resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -474,11 +474,16 @@ func newReconciler(c client.Client) Reconciler {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch existing K8S ConfigMap, and return not found error, to test create case
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "ConfigMap"}, crName))
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(kubeSystem, crName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -51,7 +51,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
 	if req.Namespace == kubeSystem {
-		log.Oncef("Secret resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		log.Oncef("Multi-cluster secret resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -442,11 +442,16 @@ func newSecretReconciler(c client.Client) Reconciler {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch existing corev1.Secret and return not found error, to test create case
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: crName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: "", Resource: "Secret"}, crName))
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(kubeSystem, crName)
 	reconciler := newSecretReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -129,14 +129,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanocoherenceworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanocoherenceworkloads/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	ctx := context.Background()
 	workload, err := r.fetchWorkload(ctx, req.NamespacedName, zap.S())
 	if err != nil {
@@ -147,6 +139,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for Coherence workload", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Coherence workload resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling Coherence workload resource %v, generation %v", req.NamespacedName, workload.Generation)
 	res, err := r.doReconcile(ctx, workload, log)
 	if clusters.ShouldRequeue(res) {

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -1543,13 +1543,21 @@ func TestReconcileRestart(t *testing.T) {
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
+	componentName := "unit-test-component"
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the VerrazzanoCoherenceWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: componentName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoCoherenceWorkload) error {
+			return nil
+		})
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := newRequest(kubeSystem, componentName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/containerizedworkload/containerizedworkload_controller.go
+++ b/application-operator/controllers/containerizedworkload/containerizedworkload_controller.go
@@ -41,14 +41,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile checks restart version annotations on an ContainerizedWorkload and
 // restarts as needed.
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	ctx := context.Background()
 	var workload oamv1.ContainerizedWorkload
 	if err := r.Client.Get(ctx, req.NamespacedName, &workload); err != nil {
@@ -59,6 +51,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for containerized workload", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Containerized workload resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling containerized workload resource %v, generation %v", req.NamespacedName, workload.Generation)
 
 	res, err := r.doReconcile(ctx, workload, log)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -923,8 +923,15 @@ func TestReconcileRestart(t *testing.T) {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the VerrazzanoHelidonWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: kubeSystem, Name: "unit-test-verrazzano-helidon-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoHelidonWorkload) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
 
 	// create a request and reconcile it
 	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -91,14 +91,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	var err error
 	var trait *vzapi.IngressTrait
 	ctx := context.Background()
@@ -114,6 +106,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for ingress trait", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Ingress trait resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling ingress trait resource %v, generation %v", req.NamespacedName, trait.Generation)
 
 	res, err := r.doReconcile(ctx, trait, log)

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -528,13 +528,18 @@ func newReconciler(c client.Client) Reconciler {
 func TestReconcileKubeSystem(t *testing.T) {
 	assert := asserts.New(t)
 
-	var mocker = gomock.NewController(t)
-	var cli = mocks.NewMockClient(mocker)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	// expect a call to fetch the MetricsBinding
+	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: kubeSystem, Name: testMetricsBindingName}), gomock.Not(gomock.Nil())).DoAndReturn(
+		func(ctx context.Context, key client.ObjectKey, binding *vzapi.MetricsBinding) error {
+			return nil
+		})
 
 	// create a request and reconcile it
-	namespacedName := types.NamespacedName{Namespace: kubeSystem, Name: testMetricsBindingName}
-	request := ctrl.Request{NamespacedName: namespacedName}
-	reconciler := newReconciler(cli)
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: kubeSystem, Name: testMetricsBindingName}}
+	reconciler := newReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
 	// Validate the results

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -216,14 +216,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=metricstraits,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=metricstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	ctx := context.Background()
 	// Fetch the trait.
 	var err error
@@ -237,6 +229,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for metrics trait", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Metrics trait resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling metrics trait resource %v, generation %v", req.NamespacedName, trait.Generation)
 
 	res, err := r.doReconcile(ctx, trait, log)

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -730,6 +730,18 @@ func TestReconcileKubeSystem(t *testing.T) {
 	nc, err := newTestController(mock)
 	asserts.NoError(err)
 
+	// Expect a call to get the namespace
+	mock.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ns *corev1.Namespace) error {
+			ns.Name = "myns"
+			ns.Annotations = map[string]string{
+				constants.OCILoggingIDAnnotation: "myocid",
+			}
+			ns.Finalizers = []string{"someFinalizer"}
+			return nil
+		})
+
 	// create a request and reconcile it
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: kubeSystem},

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -224,14 +224,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-
-	// We do not want any resource to get reconciled if it is in namespace kube-system
-	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
-	// If this is the case then return success
-	if req.Namespace == kubeSystem {
-		return reconcile.Result{}, nil
-	}
-
 	ctx := context.Background()
 	// fetch the workload and unwrap the WebLogic resource
 	workload, err := r.fetchWorkload(ctx, req.NamespacedName, zap.S())
@@ -243,6 +235,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		zap.S().Errorf("Failed to create controller logger for weblogic workload", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		log.Oncef("Weblogic workload resource %v should not be reconciled in kube-system namespace, returning", req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	log.Oncef("Reconciling weblogic workload resource %v, generation %v", req.NamespacedName, workload.Generation)
 
 	res, err := r.doReconcile(ctx, workload, log)


### PR DESCRIPTION
# Description

Adding logging for kube-system reconciler changes

Fixes VZ-3458

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
