### PR TITLE
VZ 5128: Uncomment code for isReady

### DIFF
--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -111,7 +111,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 		if ctx.EffectiveCR().Spec.Components.Elasticsearch != nil {
 			esInstallArgs := ctx.EffectiveCR().Spec.Components.Elasticsearch.ESInstallArgs
 			for _, args := range esInstallArgs {
-				/* This should be uncommented when VZ-5128 is fixed
 				if args.Name == "nodes.data.replicas" {
 					replicas, _ := strconv.Atoi(args.Value)
 					for i := 0; replicas > 0 && i < replicas; i++ {
@@ -120,7 +119,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					}
 					continue
 				}
-				*/
 				if args.Name == "nodes.ingest.replicas" {
 					replicas, _ := strconv.Atoi(args.Value)
 					if replicas > 0 {


### PR DESCRIPTION
Uncomments the isReady checks in the Verrazzano component now that VZ 5128 is resolved.
