### PR TITLE
enable all tests to run in LRE clusters

### DIFF
--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -1,12 +1,12 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-//properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1,
-//                    maxConcurrentTotal: 1, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project'],
-//               [$class: 'BuildDiscarderProperty',
-//                strategy: [$class: 'LogRotator', numToKeepStr: '10']],
-//                pipelineTriggers([cron('H/5 * * * *')]),
-//           ])
+properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1,
+                    maxConcurrentTotal: 1, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project'],
+               [$class: 'BuildDiscarderProperty',
+                strategy: [$class: 'LogRotator', numToKeepStr: '10']],
+                pipelineTriggers([cron('H/5 * * * *')]),
+           ])
 
 pipeline {
     options {

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -1,12 +1,12 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1,
-                    maxConcurrentTotal: 1, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project'],
-               [$class: 'BuildDiscarderProperty',
-                strategy: [$class: 'LogRotator', numToKeepStr: '10']],
-                pipelineTriggers([cron('H/5 * * * *')]),
-           ])
+//properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1,
+//                    maxConcurrentTotal: 1, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project'],
+//               [$class: 'BuildDiscarderProperty',
+//                strategy: [$class: 'LogRotator', numToKeepStr: '10']],
+//                pipelineTriggers([cron('H/5 * * * *')]),
+//           ])
 
 pipeline {
     options {
@@ -333,7 +333,26 @@ pipeline {
                         runGinkgo('metrics/deploymetrics')
                     }
                 }
-
+                stage('poko metricsbinding') {
+                    steps {
+                        runGinkgo('metricsbinding')
+                    }
+                }
+                stage('logging trait helodin workload') {
+                    steps {
+                        runGinkgo('loggingtrait/helidonworkload')
+                    }
+                }
+                stage('logging trait weblogic workload') {
+                    steps {
+                        runGinkgo('loggingtrait/weblogicworkload')
+                    }
+                }
+                stage('logging trait coherence workload') {
+                    steps {
+                        runGinkgo('loggingtrait/coherenceworkload')
+                    }
+                }
             }
             post {
                 always {

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -277,14 +277,14 @@ pipeline {
                 }
                 stage('istio authorization policy') {
                     steps {
-                        runGinkgo('istio/authz')
+                        runGinkgo('istio/authz', 'security/rbac', )
                     }
                 }
-                stage('security role based access') {
-                    steps {
-                        runGinkgo('security/rbac')
-                    }
-                }
+                //stage('security role based access') {
+                //    steps {
+                //        runGinkgo('security/rbac')
+                //    }
+                //}
                 stage('system logging') {
                     steps {
                         runGinkgo('logging/system')

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -277,14 +277,14 @@ pipeline {
                 }
                 stage('istio authorization policy') {
                     steps {
-                        runGinkgo('istio/authz','security/rbac')
+                        runGinkgo('istio/authz')
                     }
                 }
-                //stage('security role based access') {
-                //    steps {
-                //        runGinkgo('security/rbac')
-                //    }
-                //}
+                stage('security role based access') {
+                    steps {
+                        runGinkgo('security/rbac')
+                    }
+                }
                 stage('system logging') {
                     steps {
                         runGinkgo('logging/system')

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -277,7 +277,7 @@ pipeline {
                 }
                 stage('istio authorization policy') {
                     steps {
-                        runGinkgo('istio/authz', 'security/rbac', )
+                        runGinkgo('istio/authz','security/rbac')
                     }
                 }
                 //stage('security role based access') {

--- a/ci/scripts/lre_setup_ssh_tunnel.sh
+++ b/ci/scripts/lre_setup_ssh_tunnel.sh
@@ -35,6 +35,7 @@ fi
 SESSION_ID=$(oci bastion session create-port-forwarding \
    --bastion-id $BASTION_ID \
    --ssh-public-key-file ${ssh_public_key_path} \
+   --session-ttl 7200 \
    --target-private-ip ${CLUSTER_IP} \
    --target-port 6443 | jq '.data.id' | sed s/\"//g)
 

--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -80,7 +80,7 @@ func (t *TestFramework) It(text string, args ...interface{}) bool {
 		ginkgo.Fail("Unsupported body type - expected function")
 	}
 	f := func() {
-		metrics.Emit(t.Metrics.With(metrics.Status, metrics.Started)) // Starting point metric
+		metrics.Emit(t.Metrics) // Starting point metric
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	}
 
@@ -99,7 +99,7 @@ func (t *TestFramework) Describe(text string, args ...interface{}) bool {
 		ginkgo.Fail("Unsupported body type - expected function")
 	}
 	f := func() {
-		metrics.Emit(t.Metrics.With(metrics.Status, metrics.Started))
+		metrics.Emit(t.Metrics)
 		reflect.ValueOf(body).Call([]reflect.Value{})
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 	}
@@ -119,7 +119,7 @@ func (t *TestFramework) DescribeTable(text string, args ...interface{}) bool {
 	}
 	funcType := reflect.TypeOf(body)
 	f := reflect.MakeFunc(funcType, func(args []reflect.Value) (results []reflect.Value) {
-		metrics.Emit(t.Metrics.With(metrics.Status, metrics.Started))
+		metrics.Emit(t.Metrics)
 		rv := reflect.ValueOf(body).Call(args)
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 		return rv
@@ -135,7 +135,7 @@ func (t *TestFramework) BeforeSuite(body func()) bool {
 	}
 
 	f := func() {
-		metrics.Emit(t.Metrics.With(metrics.Status, metrics.Started))
+		metrics.Emit(t.Metrics)
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	}
 	return ginkgo.BeforeSuite(f)

--- a/tests/e2e/logging/helidon/helidon_logging_suite_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_suite_test.go
@@ -1,14 +1,21 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidon
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 func TestHelidonExample(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -48,7 +48,7 @@ var _ = t.BeforeSuite(func() {
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() bool {
-		return pkg.ContainerImagePullWait(testNamespace, expectedPodsHelloHelidon)
+		return pkg.ContainerImagePullWait(namespace, expectedPodsHelloHelidon)
 	}, imagePullWaitTimeout, imagePullPollingInterval).Should(BeTrue())
 	// Verify hello-helidon-workload pod is running
 	Eventually(helloHelidonPodsRunning, waitTimeout, pollingInterval).Should(BeTrue())

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -25,7 +25,10 @@ const (
 	imagePullPollingInterval = 30 * time.Second
 )
 
-var t = framework.NewTestFramework("helidon")
+var (
+	t                  = framework.NewTestFramework("helidon")
+	generatedNamespace = pkg.GenerateNamespace("helidon-logging")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -33,15 +36,15 @@ var _ = t.BeforeSuite(func() {
 		nsLabels := map[string]string{
 			"verrazzano-managed": "true",
 			"istio-injection":    "enabled"}
-		return pkg.CreateNamespace("helidon-logging", nsLabels)
+		return pkg.CreateNamespace(namespace, nsLabels)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
 
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("testdata/logging/helidon/helidon-logging-comp.yaml")
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/helidon/helidon-logging-comp.yaml", namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("testdata/logging/helidon/helidon-logging-app.yaml")
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/helidon/helidon-logging-app.yaml", namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() bool {
@@ -64,15 +67,15 @@ var _ = t.AfterSuite(func() {
 	// undeploy the application here
 	start := time.Now()
 	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("testdata/logging/helidon/helidon-logging-app.yaml")
+		return pkg.DeleteResourceFromFileInGeneratedNamespace("testdata/logging/helidon/helidon-logging-app.yaml", namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("testdata/logging/helidon/helidon-logging-comp.yaml")
+		return pkg.DeleteResourceFromFileInGeneratedNamespace("testdata/logging/helidon/helidon-logging-comp.yaml", namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	Eventually(func() error {
-		return pkg.DeleteNamespace("helidon-logging")
+		return pkg.DeleteNamespace(namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
 })
@@ -81,10 +84,6 @@ var (
 	expectedPodsHelloHelidon = []string{"hello-helidon-workload"}
 	waitTimeout              = 10 * time.Minute
 	pollingInterval          = 30 * time.Second
-)
-
-const (
-	testNamespace = "helidon-logging"
 )
 
 var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
@@ -98,7 +97,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	// THEN return the host name found in the gateway.
 	t.BeforeEach(func() {
 		Eventually(func() (string, error) {
-			host, err = k8sutil.GetHostnameFromGateway(testNamespace, "")
+			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 			return host, err
 		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
 	})
@@ -119,7 +118,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 	})
 
 	t.Context("for Logging.", Label("f:observability.logging.es"), func() {
-		indexName := fmt.Sprintf("verrazzano-namespace-%s", testNamespace)
+		indexName := fmt.Sprintf("verrazzano-namespace-%s", namespace)
 		// GIVEN an application with logging enabled
 		// WHEN the Elasticsearch index for hello-helidon namespace is retrieved
 		// THEN verify that it is found
@@ -158,9 +157,9 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 })
 
 func helloHelidonPodsRunning() bool {
-	result, err := pkg.PodsRunning(testNamespace, expectedPodsHelloHelidon)
+	result, err := pkg.PodsRunning(namespace, expectedPodsHelloHelidon)
 	if err != nil {
-		AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", testNamespace, err))
+		AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
 	}
 	return result
 }

--- a/tests/e2e/logging/system/system_logging_test.go
+++ b/tests/e2e/logging/system/system_logging_test.go
@@ -6,6 +6,7 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -229,19 +230,22 @@ var _ = t.Describe("Elasticsearch system component data", Label("f:observability
 		}
 	})
 
-	t.It("contains local-path-storage index with valid records", func() {
-		// GIVEN existing system logs
-		// WHEN the Elasticsearch index for the local-path-storage namespace is retrieved
-		// THEN verify that it is found
-		Eventually(func() bool {
-			return pkg.LogIndexFound(localPathStorageIndex)
-		}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find Elasticsearch index local-path-storage")
+	testEnv := os.Getenv("TEST_ENV")
+	if testEnv != "LRE" {
+		t.It("contains local-path-storage index with valid records", func() {
+			// GIVEN existing system logs
+			// WHEN the Elasticsearch index for the local-path-storage namespace is retrieved
+			// THEN verify that it is found
+			Eventually(func() bool {
+				return pkg.LogIndexFound(localPathStorageIndex)
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find Elasticsearch index local-path-storage")
 
-		if !validateLocalPathStorageLogs() {
-			// Don't fail for invalid logs until this is stable.
-			t.Logs.Info("Found problems with log records in local-path-storage index")
-		}
-	})
+			if !validateLocalPathStorageLogs() {
+				// Don't fail for invalid logs until this is stable.
+				t.Logs.Info("Found problems with log records in local-path-storage index")
+			}
+		})
+	}
 
 	t.It("contains rancher-operator-system index with valid records", func() {
 		// GIVEN existing system logs

--- a/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_suite_test.go
@@ -4,11 +4,18 @@
 package coherenceworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestCoherenceLoggingTrait tests an ingress trait setup for console access.
 func TestCoherenceLoggingTrait(t *testing.T) {

--- a/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_test.go
@@ -19,7 +19,6 @@ const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
 
-	namespace          = "sockshop-logging"
 	componentsPath     = "testdata/loggingtrait/coherenceworkload/coherence-logging-components.yaml"
 	applicationPath    = "testdata/loggingtrait/coherenceworkload/coherence-logging-application.yaml"
 	applicationPodName = "carts-coh-0"
@@ -28,7 +27,10 @@ const (
 
 var kubeConfig = os.Getenv("KUBECONFIG")
 
-var t = framework.NewTestFramework("coherenceworkload")
+var (
+	t                  = framework.NewTestFramework("coherenceworkload")
+	generatedNamespace = pkg.GenerateNamespace("sockshop-logging")
+)
 
 var _ = t.BeforeSuite(func() {
 	loggingtrait.DeployApplication(namespace, componentsPath, applicationPath, applicationPodName, t)

--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_suite_test.go
@@ -4,11 +4,18 @@
 package helidonworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonLoggingTrait tests an ingress trait setup for console access.
 func TestHelidonLoggingTrait(t *testing.T) {

--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_test.go
@@ -18,7 +18,6 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-logging"
 	componentsPath       = "testdata/loggingtrait/helidonworkload/helidon-logging-components.yaml"
 	applicationPath      = "testdata/loggingtrait/helidonworkload/helidon-logging-application.yaml"
 	applicationPodName   = "hello-helidon-deployment-"
@@ -27,7 +26,10 @@ const (
 
 var kubeConfig = os.Getenv("KUBECONFIG")
 
-var t = framework.NewTestFramework("helidonworkload")
+var (
+	t                  = framework.NewTestFramework("helidonworkload")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-logging")
+)
 
 var _ = t.BeforeSuite(func() {
 	loggingtrait.DeployApplication(namespace, componentsPath, applicationPath, applicationPodName, t)

--- a/tests/e2e/loggingtrait/loggingtrait_helper.go
+++ b/tests/e2e/loggingtrait/loggingtrait_helper.go
@@ -25,11 +25,6 @@ const (
 func DeployApplication(namespace, componentsPath, applicationPath, podName string, t *framework.TestFramework) {
 	pkg.Log(pkg.Info, "Deploy test application")
 	start := time.Now()
-	// Wait for namespace to finish deletion possibly from a prior run.
-	gomega.Eventually(func() bool {
-		_, err := pkg.GetNamespace(namespace)
-		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 
 	pkg.Log(pkg.Info, "Create namespace")
 	gomega.Eventually(func() (*v1.Namespace, error) {
@@ -41,12 +36,12 @@ func DeployApplication(namespace, componentsPath, applicationPath, podName strin
 
 	pkg.Log(pkg.Info, "Create component resources")
 	gomega.Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(componentsPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(componentsPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create application resources")
 	gomega.Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(applicationPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(applicationPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, fmt.Sprintf("Check pod %v is running", podName))
@@ -65,12 +60,12 @@ func UndeployApplication(namespace string, componentsPath string, applicationPat
 	pkg.Log(pkg.Info, "Delete application")
 	start := time.Now()
 	gomega.Eventually(func() error {
-		return pkg.DeleteResourceFromFile(applicationPath)
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(applicationPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Delete components")
 	gomega.Eventually(func() error {
-		return pkg.DeleteResourceFromFile(componentsPath)
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(componentsPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Verify ConfigMap is Deleted")

--- a/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_suite_test.go
@@ -4,11 +4,18 @@
 package weblogicworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestWebLogicLoggingTrait tests an ingress trait setup for console access.
 func TestWebLogicLoggingTrait(t *testing.T) {

--- a/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -24,7 +23,6 @@ const (
 	shortPollingInterval = 10 * time.Second
 	longWaitTimeout      = 15 * time.Minute
 	longPollingInterval  = 20 * time.Second
-	namespace            = "weblogic-logging-trait"
 	componentsPath       = "testdata/loggingtrait/weblogicworkload/weblogic-logging-components.yaml"
 	applicationPath      = "testdata/loggingtrait/weblogicworkload/weblogic-logging-application.yaml"
 	applicationPodName   = "tododomain-adminserver"
@@ -33,7 +31,10 @@ const (
 
 var kubeConfig = os.Getenv("KUBECONFIG")
 
-var t = framework.NewTestFramework("weblogicworkload")
+var (
+	t                  = framework.NewTestFramework("weblogicworkload")
+	generatedNamespace = pkg.GenerateNamespace("weblogic-logging-trait")
+)
 
 var _ = t.BeforeSuite(func() {
 	deployWebLogicApplication()
@@ -59,12 +60,6 @@ func deployWebLogicApplication() {
 	regServ := pkg.GetRequiredEnvVarOrFail("OCR_REPO")
 	regUser := pkg.GetRequiredEnvVarOrFail("OCR_CREDS_USR")
 	regPass := pkg.GetRequiredEnvVarOrFail("OCR_CREDS_PSW")
-
-	// Wait for namespace to finish deletion possibly from a prior run.
-	Eventually(func() bool {
-		_, err := pkg.GetNamespace(namespace)
-		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 
 	pkg.Log(pkg.Info, "Create namespace")
 	start := time.Now()
@@ -97,12 +92,12 @@ func deployWebLogicApplication() {
 
 	pkg.Log(pkg.Info, "Create component resources")
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(componentsPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(componentsPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create application resources")
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(applicationPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(applicationPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	pkg.Log(pkg.Info, "Check application pods are running")

--- a/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_suite_test.go
@@ -4,11 +4,18 @@
 package deploymentworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonDeploymentWorkload tests a helidon deployment workload for Prometheus metric scraping
 func TestHelidonDeploymentWorkload(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
+++ b/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
@@ -17,13 +17,15 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+	promConfigJobName    = "_hello-helidon-deployment_apps_v1_Deployment"
 )
 
-var t = framework.NewTestFramework("deploymentworkload")
+var (
+	t                  = framework.NewTestFramework("deploymentworkload")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -34,7 +36,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -47,7 +49,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {

--- a/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_suite_test.go
@@ -4,11 +4,18 @@
 package helidonnamespaceannotation
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonDeploymentWorkload tests a helidon deployment workload for Prometheus metric scraping with a Metrics Template override in the namespace annotation
 func TestHelidonDeploymentNamespaceAnnotation(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_test.go
+++ b/tests/e2e/metricsbinding/helidon-namespace-annotation/helidon_namespace_annotation_test.go
@@ -17,14 +17,16 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment.yaml"
 	templatePath         = "tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+	promConfigJobName    = "_hello-helidon-deployment_apps_v1_Deployment"
 )
 
-var t = framework.NewTestFramework("helidonnamespaceannotation")
+var (
+	t                  = framework.NewTestFramework("helidonnamespaceannotation")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -35,7 +37,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -48,7 +50,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_suite_test.go
@@ -4,11 +4,18 @@
 package helidonpodannotation
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonDeploymentPodAnnotation tests a helidon deployment workload for Prometheus metric scraping with a pod annotation preventing metrics scraping
 func TestHelidonDeploymentPodAnnotation(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -19,10 +19,9 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+	promConfigJobName    = "_hello-helidon-deployment_apps_v1_Deployment"
 
 	PrometheusPortAnnotation   = "prometheus.io/port"
 	PrometheusPathAnnotation   = "prometheus.io/path"
@@ -33,7 +32,10 @@ const (
 	PrometheusScrapeOverride = "false"
 )
 
-var t = framework.NewTestFramework("helidonpodannotation")
+var (
+	t                  = framework.NewTestFramework("helidonpodannotation")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -44,7 +46,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -57,7 +59,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {
@@ -72,7 +74,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 					pkg.Log(pkg.Error, fmt.Sprintf("Error creating clientset from kubeconfig, error: %v", err))
 					return false
 				}
-				pods, err := pkg.ListPodsInCluster("hello-helidon-namespace", clientset)
+				pods, err := pkg.ListPodsInCluster(namespace, clientset)
 				if err != nil {
 					pkg.Log(pkg.Error, fmt.Sprintf("Error listing pods in the namespace hello-helidon-namespace, error: %v", err))
 					return false

--- a/tests/e2e/metricsbinding/helidon-pod/helidon_pod_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod/helidon_pod_suite_test.go
@@ -4,11 +4,18 @@
 package podworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonPodWorkload tests a helidon pod workload for Prometheus metric scraping
 func TestHelidonPodWorkload(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
@@ -17,13 +17,15 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-pod"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-pod.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-pod_v1_Pod"
+	promConfigJobName    = "_hello-helidon-pod_v1_Pod"
 )
 
-var t = framework.NewTestFramework("podworkload")
+var (
+	t                  = framework.NewTestFramework("podworkload")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -34,7 +36,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -48,7 +50,7 @@ var _ = t.Describe("Verify application.", Label("f:app-lcm.poko"), func() {
 		func() {
 			t.It("Check Prometheus config map for scrape target", func() {
 				Eventually(func() bool {
-					return pkg.IsAppInPromConfig(promConfigJobName)
+					return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 				}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 			})
 			t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-pod' Pod", func() {

--- a/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_suite_test.go
@@ -4,11 +4,18 @@
 package replicasetworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonReplicaSetWorkload tests a helidon replicaset workload for Prometheus metric scraping
 func TestHelidonReplicaSetWorkload(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
+++ b/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
@@ -17,13 +17,15 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-replicaset-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-replicaset.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-replicaset_apps_v1_ReplicaSet"
+	promConfigJobName    = "_hello-helidon-replicaset_apps_v1_ReplicaSet"
 )
 
-var t = framework.NewTestFramework("replicasetworkload")
+var (
+	t                  = framework.NewTestFramework("replicasetworkload")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -34,7 +36,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -47,7 +49,7 @@ var _ = t.Describe("Verify application.", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-replicaset' Pod", func() {

--- a/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_suite_test.go
@@ -4,11 +4,18 @@
 package helidonsharednamespace
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonDeploymentWorkload tests a helidon deployment workload for Prometheus metric scraping with a Metrics Template override in the namespace
 func TestHelidonDeploymentWorkloadSharedNamespace(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_test.go
+++ b/tests/e2e/metricsbinding/helidon-shared-namespace/helidon_shared_namespace_test.go
@@ -17,14 +17,16 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment.yaml"
 	templatePath         = "tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+	promConfigJobName    = "_hello-helidon-deployment_apps_v1_Deployment"
 )
 
-var t = framework.NewTestFramework("helidonsharednamespace")
+var (
+	t                  = framework.NewTestFramework("helidonsharednamespace")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -35,7 +37,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -48,7 +50,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {
@@ -56,7 +58,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 				return pkg.MetricsExist("base_jvm_uptime_seconds", "app_verrazzano_io_workload", "hello-helidon-deployment-apps-v1-deployment")
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for Helidon application.")
 			Eventually(func() bool {
-				return pkg.MetricsExist("base_jvm_uptime_seconds", "test_namespace", "hello-helidon-namespace-test")
+				return pkg.MetricsExist("base_jvm_uptime_seconds", "test_namespace", namespace+"-test")
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for Helidon application.")
 		})
 	})

--- a/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_suite_test.go
@@ -4,11 +4,18 @@
 package statefulsetworkload
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonStatefulSetWorkload tests a helidon statefulset workload for Prometheus metric scraping
 func TestHelidonStatefulSetWorkload(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
+++ b/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
@@ -17,13 +17,15 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-statefulset-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-statefulset.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-statefulset_apps_v1_StatefulSet"
+	promConfigJobName    = "_hello-helidon-statefulset_apps_v1_StatefulSet"
 )
 
-var t = framework.NewTestFramework("statefulsetworkload")
+var (
+	t                  = framework.NewTestFramework("statefulsetworkload")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -34,7 +36,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -47,7 +49,7 @@ var _ = t.Describe("Verify application.", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-statefulset' Pod", func() {

--- a/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_suite_test.go
+++ b/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_suite_test.go
@@ -4,11 +4,18 @@
 package helidonworkloadannotation
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
 
 // TestHelidonDeploymentWorkload tests a helidon deployment workload for Prometheus metric scraping with a Metrics Template override in the workload annotation
 func TestHelidonDeploymentWorkloadAnnotation(t *testing.T) {

--- a/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_test.go
+++ b/tests/e2e/metricsbinding/helidon-workload-annotation/helidon_workload_annotation_test.go
@@ -17,14 +17,16 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	namespace            = "hello-helidon-namespace"
 	applicationPodPrefix = "hello-helidon-deployment-"
 	yamlPath             = "tests/e2e/metricsbinding/testdata/hello-helidon-deployment-annotated.yaml"
 	templatePath         = "tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml"
-	promConfigJobName    = "hello-helidon-namespace_hello-helidon-deployment_apps_v1_Deployment"
+	promConfigJobName    = "_hello-helidon-deployment_apps_v1_Deployment"
 )
 
-var t = framework.NewTestFramework("helidonworkloadannotation")
+var (
+	t                  = framework.NewTestFramework("helidonworkloadannotation")
+	generatedNamespace = pkg.GenerateNamespace("hello-helidon-namespace")
+)
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
@@ -35,7 +37,7 @@ var _ = t.BeforeSuite(func() {
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 var _ = clusterDump.AfterSuite(func() {  // Dump cluster if aftersuite fails
-	metricsbinding.UndeployApplication(namespace, yamlPath, promConfigJobName)
+	metricsbinding.UndeployApplication(namespace, yamlPath, namespace+promConfigJobName)
 })
 
 var _ = t.AfterEach(func() {})
@@ -48,7 +50,7 @@ var _ = t.Describe("Verify", Label("f:app-lcm.poko"), func() {
 	t.Context("Verify Prometheus scraped metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Check Prometheus config map for scrape target", func() {
 			Eventually(func() bool {
-				return pkg.IsAppInPromConfig(promConfigJobName)
+				return pkg.IsAppInPromConfig(namespace + promConfigJobName)
 			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected application to be found in Prometheus config")
 		})
 		t.It("Retrieve Prometheus scraped metrics for 'hello-helidon-deployment' Pod", func() {

--- a/tests/e2e/metricsbinding/metrics_binding_helper.go
+++ b/tests/e2e/metricsbinding/metrics_binding_helper.go
@@ -23,11 +23,6 @@ const (
 
 func DeployApplication(namespace, yamlPath, podPrefix string) {
 	pkg.Log(pkg.Info, "Deploy test application")
-	// Wait for namespace to finish deletion possibly from a prior run.
-	gomega.Eventually(func() bool {
-		_, err := pkg.GetNamespace(namespace)
-		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 
 	pkg.Log(pkg.Info, "Create namespace")
 	gomega.Eventually(func() (*v1.Namespace, error) {
@@ -39,7 +34,7 @@ func DeployApplication(namespace, yamlPath, podPrefix string) {
 
 	pkg.Log(pkg.Info, "Create helidon resources")
 	gomega.Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(yamlPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(yamlPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Check application pods are running")
@@ -55,7 +50,7 @@ func DeployApplication(namespace, yamlPath, podPrefix string) {
 func UndeployApplication(namespace string, yamlPath string, promConfigJobName string) {
 	pkg.Log(pkg.Info, "Delete application")
 	gomega.Eventually(func() error {
-		return pkg.DeleteResourceFromFile(yamlPath)
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(yamlPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Remove application from Prometheus Config")
@@ -76,11 +71,6 @@ func UndeployApplication(namespace string, yamlPath string, promConfigJobName st
 
 func DeployApplicationAndTemplate(namespace, appYamlPath, templateYamlPath, podPrefix string, nsAnnotations map[string]string) {
 	pkg.Log(pkg.Info, "Deploy test application")
-	// Wait for namespace to finish deletion possibly from a prior run.
-	gomega.Eventually(func() bool {
-		_, err := pkg.GetNamespace(namespace)
-		return err != nil && errors.IsNotFound(err)
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
 
 	pkg.Log(pkg.Info, "Create namespace")
 	gomega.Eventually(func() (*v1.Namespace, error) {
@@ -92,12 +82,12 @@ func DeployApplicationAndTemplate(namespace, appYamlPath, templateYamlPath, podP
 
 	pkg.Log(pkg.Info, "Create template resource")
 	gomega.Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(templateYamlPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(templateYamlPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Create helidon resources")
 	gomega.Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile(appYamlPath)
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(appYamlPath, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
 
 	pkg.Log(pkg.Info, "Check application pods are running")

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-annotated.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-annotated.yaml
@@ -5,7 +5,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-helidon-deployment
-  namespace: hello-helidon-namespace
   annotations:
     app.verrazzano.io/metrics: standard-k8s-metrics-template
 spec:
@@ -31,7 +30,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-deployment-pod-annotated.yaml
@@ -5,7 +5,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-helidon-deployment
-  namespace: hello-helidon-namespace
   annotations:
     app.verrazzano.io/metrics: standard-k8s-metrics-template
 spec:
@@ -33,7 +32,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-deployment.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-deployment.yaml
@@ -5,7 +5,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-helidon-deployment
-  namespace: hello-helidon-namespace
 spec:
   selector:
     matchLabels:
@@ -29,7 +28,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-metrics-template.yaml
@@ -5,7 +5,6 @@ apiVersion: app.verrazzano.io/v1alpha1
 kind: MetricsTemplate
 metadata:
   name: test-metrics-template
-  namespace: hello-helidon-namespace
 spec:
   workloadSelector:
     apiGroups: ["apps"]

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-pod.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-pod.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: hello-helidon-pod
-  namespace: hello-helidon-namespace
 spec:
   containers:
   - name: hello-helidon-container
@@ -20,7 +19,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-replicaset.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-replicaset.yaml
@@ -5,7 +5,6 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: hello-helidon-replicaset
-  namespace: hello-helidon-namespace
 spec:
   selector:
     matchLabels:
@@ -29,7 +28,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/e2e/metricsbinding/testdata/hello-helidon-statefulset.yaml
+++ b/tests/e2e/metricsbinding/testdata/hello-helidon-statefulset.yaml
@@ -5,7 +5,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: hello-helidon-statefulset
-  namespace: hello-helidon-namespace
 spec:
   selector:
     matchLabels:
@@ -30,7 +29,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-helidon-service
-  namespace: hello-helidon-namespace
   labels:
     app: hello-helidon-application
 spec:

--- a/tests/testdata/logging/helidon/helidon-logging-app.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-app.yaml
@@ -1,10 +1,9 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: hello-helidon-appconf
-  namespace: helidon-logging
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"

--- a/tests/testdata/logging/helidon/helidon-logging-comp.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-comp.yaml
@@ -4,14 +4,12 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: hello-helidon-component
-  namespace: helidon-logging
 spec:
   workload:
     apiVersion: core.oam.dev/v1alpha2
     kind: ContainerizedWorkload
     metadata:
       name: hello-helidon-workload
-      namespace: hello-helidon
       labels:
         app: hello-helidon
     spec:

--- a/tests/testdata/loggingtrait/coherenceworkload/coherence-logging-application.yaml
+++ b/tests/testdata/loggingtrait/coherenceworkload/coherence-logging-application.yaml
@@ -1,10 +1,9 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: sockshop-appconf
-  namespace: sockshop-logging
   annotations:
     version: v1.0.0
     description: "OAM Sock Shop Application"
@@ -34,7 +33,6 @@ spec:
             kind: LoggingTrait
             metadata:
               name: logging-trait
-              namespace: sockshop-logging
             spec:
               loggingImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.12.3-20210517195222-f345ec2
               loggingConfig: |

--- a/tests/testdata/loggingtrait/coherenceworkload/coherence-logging-components.yaml
+++ b/tests/testdata/loggingtrait/coherenceworkload/coherence-logging-components.yaml
@@ -1,11 +1,10 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: carts
-  namespace: sockshop-logging
 spec:
   workload:
     apiVersion: oam.verrazzano.io/v1alpha1

--- a/tests/testdata/loggingtrait/helidonworkload/helidon-logging-application.yaml
+++ b/tests/testdata/loggingtrait/helidonworkload/helidon-logging-application.yaml
@@ -1,11 +1,10 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: hello-helidon-appconf
-  namespace: hello-helidon-logging
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"
@@ -33,7 +32,6 @@ spec:
             kind: LoggingTrait
             metadata:
               name: logging-trait
-              namespace: hello-helidon-logging
             spec:
               loggingImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.12.3-20210517195222-f345ec2
               loggingConfig: |

--- a/tests/testdata/loggingtrait/helidonworkload/helidon-logging-components.yaml
+++ b/tests/testdata/loggingtrait/helidonworkload/helidon-logging-components.yaml
@@ -5,13 +5,11 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: hello-helidon-component
-  namespace: hello-helidon-logging
 spec:
   workload:
     apiVersion: oam.verrazzano.io/v1alpha1
     kind: VerrazzanoHelidonWorkload
     metadata:
-      name: hello-helidon-workload
       labels:
         app: hello-helidon
     spec:

--- a/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-application.yaml
+++ b/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-application.yaml
@@ -1,11 +1,10 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: todo-appconf
-  namespace: weblogic-logging-trait
   annotations:
     version: v1.0.0
     description: "ToDo List example application"
@@ -18,7 +17,6 @@ spec:
             kind: LoggingTrait
             metadata:
               name: logging-trait
-              namespace: weblogic-logging-trait
             spec:
               loggingImage: ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.12.3-20210517195222-f345ec2
               loggingConfig: |

--- a/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-components.yaml
+++ b/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-components.yaml
@@ -1,11 +1,10 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-domain
-  namespace: weblogic-logging-trait
 spec:
   workload:
     apiVersion: oam.verrazzano.io/v1alpha1
@@ -14,7 +13,6 @@ spec:
       template:
         metadata:
           name: todo-domain
-          namespace: weblogic-logging-trait
         spec:
           domainUID: tododomain
           domainHome: /u01/domains/tododomain
@@ -50,14 +48,12 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-jdbc-configmap
-  namespace: weblogic-logging-trait
 spec:
   workload:
     apiVersion: v1
     kind: ConfigMap
     metadata:
       name: tododomain-jdbc-config
-      namespace: weblogic-logging-trait
     data:
       wdt_jdbc.yaml: |
         resources:
@@ -91,14 +87,12 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-mysql-configmap
-  namespace: weblogic-logging-trait
 spec:
   workload:
     apiVersion: v1
     kind: ConfigMap
     metadata:
       name: mysql-initdb-config
-      namespace: weblogic-logging-trait
     data:
       initdb.sql: |
         create table `ToDos` (
@@ -112,14 +106,12 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-mysql-service
-  namespace: weblogic-logging-trait
 spec:
   workload:
     apiVersion: v1
     kind: Service
     metadata:
       name: mysql
-      namespace: weblogic-logging-trait
     spec:
       ports:
         - port: 3306
@@ -131,14 +123,12 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-mysql-deployment
-  namespace: weblogic-logging-trait
 spec:
   workload:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: mysql
-      namespace: weblogic-logging-trait
     spec:
       replicas: 1
       selector:


### PR DESCRIPTION
Reverting the revert of vz-4865 after merging from master and fixing errors. This PR fixes all the tests except upgrade and multicluster test to run in their own namespace