### PR TITLE
VZ-3631: WLS has a bug at server startup where it can corrupt message…

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -469,16 +469,6 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				})
 			},
 		)
-		// GIVEN a WebLogic application with logging enabled
-		// WHEN the log records are retrieved from the Elasticsearch index
-		// THEN verify that no 'pattern not matched' log record of fluentd-stdout-sidecar is found
-		t.It("Verify recent 'pattern not matched' log records do not exist", func() {
-			Expect(pkg.NoLog(bobsIndexName,
-				[]pkg.Match{
-					{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-					{Key: "message", Value: "pattern not matched"}},
-				[]pkg.Match{})).To(BeTrue())
-		})
 		pkg.Concurrently(
 			// GIVEN a WebLogic application with logging enabled
 			// WHEN the log records are retrieved from the Elasticsearch index

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -410,17 +410,6 @@ var _ = t.Describe("ToDo List test", Label("f:app-lcm.oam",
 				})
 			},
 		)
-
-		// GIVEN a WebLogic application with logging enabled
-		// WHEN the log records are retrieved from the Elasticsearch index
-		// THEN verify that no 'pattern not matched' log record of fluentd-stdout-sidecar is found
-		t.It("Verify recent 'pattern not matched' log records do not exist", func() {
-			Expect(pkg.NoLog(indexName,
-				[]pkg.Match{
-					{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-					{Key: "message", Value: "pattern not matched"}},
-				[]pkg.Match{})).To(BeTrue())
-		})
 	})
 })
 


### PR DESCRIPTION
VZ-3631: WLS has a bug at server startup where it can corrupt messages, so there are cases where we can get pattern not matched failures which are due to that, removing the tests that expect that this will never happen.

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
