### PR TITLE
VZ-4365: Rancher post-install step failed to reset admin password

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -269,7 +269,7 @@ func TestPostInstall(t *testing.T) {
 	caSecret := createCASecret()
 	rootCASecret := createRootCASecret()
 	adminSecret := createAdminSecret()
-	rancherPodList := createRancherPodList()
+	rancherPodList := createRancherPodListWithAllRunning()
 	ingress := v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: common.CattleSystem,

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
@@ -57,16 +57,16 @@ func resetAdminPassword(c client.Client) (string, error) {
 	if err := c.List(context.TODO(), podList, namespaceMatcher, labelMatcher); err != nil {
 		return "", err
 	}
-	if len(podList.Items) < 1 {
-		return "", errors.New("Failed to reset Rancher admin secret, no Rancher pods found")
+	pod := selectFirstRunningPod(podList.Items)
+	if pod == nil {
+		return "", errors.New("Failed to reset Rancher admin secret, no running Rancher pods found")
 	}
-	pod := podList.Items[0]
-	// Ensure the default rancer admin user is present
-	_, stderr, err := k8sutil.ExecPod(cli, cfg, &pod, common.RancherName, []string{ensureAdminCommand})
+	// Ensure the default Rancher admin user is present
+	_, stderr, err := k8sutil.ExecPod(cli, cfg, pod, common.RancherName, []string{ensureAdminCommand})
 	if err != nil {
 		return "", fmt.Errorf("Failed execing into Rancher pod %s: %v", stderr, err)
 	}
-	stdout, stderr, err := k8sutil.ExecPod(cli, cfg, &pod, common.RancherName, []string{resetPasswordCommand})
+	stdout, stderr, err := k8sutil.ExecPod(cli, cfg, pod, common.RancherName, []string{resetPasswordCommand})
 	if err != nil {
 		return "", err
 	}
@@ -76,6 +76,27 @@ func resetAdminPassword(c client.Client) (string, error) {
 		return "", fmt.Errorf("Failed to reset Rancher admin password: %s", stderr)
 	}
 	return password, nil
+}
+
+// selectFirstRunningPod selects the first running pod from the slice and return a pointer, nil if none found
+func selectFirstRunningPod(pods []v1.Pod) *v1.Pod {
+	for _, pod := range pods {
+		if isPodRunning(pod) {
+			return &pod
+		}
+	}
+	return nil
+}
+
+// isPodRunning determines if the pod is running by checking for a Ready condition with Status equal True
+func isPodRunning(pod v1.Pod) bool {
+	conditions := pod.Status.Conditions
+	for j := range conditions {
+		if conditions[j].Type == "Ready" && conditions[j].Status == "True" {
+			return true
+		}
+	}
+	return false
 }
 
 // hack to parse the stdout of Rancher reset password

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -90,7 +90,7 @@ func createCASecret() v1.Secret {
 	}
 }
 
-func createRancherPodList() v1.PodList {
+func createRancherPodListWithAllRunning() v1.PodList {
 	return v1.PodList{
 		Items: []v1.Pod{
 			{
@@ -99,6 +99,62 @@ func createRancherPodList() v1.PodList {
 					Namespace: common.CattleSystem,
 					Labels: map[string]string{
 						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "True"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createRancherPodListWithNoneRunning() v1.PodList {
+	return v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func createRancherPodListWithLastRunning() v1.PodList {
+	return v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod1",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "False"},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod2",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "True"},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes issue where install was attempting to update the admin password by execing into a rancher pod but was picking a non-running pod.  This change selects the first rancher pod found running to perform the operations.