### PR TITLE
VZ-4821 Don't set Verrazzano CR to UpgradeComplete until it is completely done

### DIFF
--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -1766,7 +1766,7 @@ func expectClusterRoleBindingExists(mock *mocks.MockClient, verrazzanoToUse vzap
 			clusterRoleBinding.RoleRef = crb.RoleRef
 			clusterRoleBinding.Subjects = crb.Subjects
 			return nil
-		})
+		}).AnyTimes()
 }
 
 // expectGetServiceAccountExists expects a call to get the service account for the Verrazzano with the given
@@ -1779,7 +1779,7 @@ func expectGetServiceAccountExists(mock *mocks.MockClient, name string, labels m
 			newSA := rbac.NewServiceAccount(name.Namespace, name.Name, []string{}, labels)
 			serviceAccount.ObjectMeta = newSA.ObjectMeta
 			return nil
-		})
+		}).AnyTimes()
 }
 
 // expectGetVerrazzanoExists expects a call to get a Verrazzano with the given namespace and name, and returns
@@ -1793,12 +1793,12 @@ func expectGetVerrazzanoExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Ver
 			verrazzano.Spec.Components.DNS = verrazzanoToUse.Spec.Components.DNS
 			verrazzano.Status = verrazzanoToUse.Status
 			return nil
-		})
+		}).AnyTimes()
 }
 
 // expectDeleteServiceAccount expects a call to delete the service account used by install
 func expectDeleteServiceAccount(mock *mocks.MockClient, namespace string, name string) {
-	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 }
 
 // expectDeleteNamespace expects a call to delete the verrazzano-system ns

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -1798,7 +1798,7 @@ func expectGetVerrazzanoExists(mock *mocks.MockClient, verrazzanoToUse vzapi.Ver
 
 // expectDeleteServiceAccount expects a call to delete the service account used by install
 func expectDeleteServiceAccount(mock *mocks.MockClient, namespace string, name string) {
-	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
 
 // expectDeleteNamespace expects a call to delete the verrazzano-system ns

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -44,10 +44,12 @@ const (
 	vzStateEnd VerrazzanoUpgradeState = "vzStateEnd"
 )
 
-// ComponentUpgradeState identifies the state of a component during upgrade
+// VerrazzanoUpgradeState identifies the state of a Verrazzano upgrade operation
 type VerrazzanoUpgradeState string
 
 // upgradeTracker has the upgrade context for the Verrazzano upgrade
+// This tracker keeps an in-memory upgrade state for Verrazzano and the components that
+// are being upgrade.
 type upgradeTracker struct {
 	vzState VerrazzanoUpgradeState
 	gen     int64
@@ -57,15 +59,14 @@ type upgradeTracker struct {
 // upgradeTrackerMap has a map of upgradeTrackers, one entry per Verrazzano CR resource generation
 var upgradeTrackerMap = make(map[string]*upgradeTracker)
 
-// reconcileUpgrade will reconcile
+// reconcileUpgrade will upgrade a Verrazzano installation
 func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	log.Oncef("Upgrading Verrazzano to version %s", cr.Spec.Version)
-
-	tracker := getUpgradeTracker(cr)
 
 	// Upgrade version was validated in webhook, see ValidateVersion
 	targetVersion := cr.Spec.Version
 
+	tracker := getUpgradeTracker(cr)
 	for tracker.vzState != vzStateEnd {
 		switch tracker.vzState {
 		case vzStateStart:

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -113,9 +113,11 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 					return ctrl.Result{}, err
 				}
 				if installed && !comp.IsReady(compContext) {
-					log.Progressf("Component %s is not yet ready", compName)
+					log.Progressf("Waiting for component %s to be ready after being upgraded", compName)
 					return newRequeueWithDelay(), nil
 				}
+				log.Oncef("Component %s is ready after being upgraded", compName)
+
 			}
 			tracker.vzState = vzStateUpgradeDone
 

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -128,11 +128,11 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			}
 			// Upgrade completely done
 			deleteUpgradeTracker(cr)
-			return ctrl.Result{}, nil
 			tracker.vzState = vzStateEnd
 		}
 	}
-	return newRequeueWithDelay(), nil
+	// Upgrade done, no need to requeue
+	return ctrl.Result{}, nil
 }
 
 // resolvePendingUpgrdes will delete any helm secrets with a "pending-upgrade" status for the given component

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -103,10 +103,15 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			if err != nil {
 				return newRequeueWithDelay(), err
 			}
+			// Check installed enabled component and make sure it is ready
 			for _, comp := range registry.GetComponents() {
 				compName := comp.Name()
 				compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
-				if !comp.IsReady(compContext) {
+				installed, err := comp.IsInstalled(compContext)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				if installed && !comp.IsReady(compContext) {
 					log.Progressf("Component %s is not yet ready", compName)
 					return newRequeueWithDelay(), nil
 				}

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -130,8 +130,6 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			deleteUpgradeTracker(cr)
 			return ctrl.Result{}, nil
 			tracker.vzState = vzStateEnd
-
-		case vzStateEnd:
 		}
 	}
 	return newRequeueWithDelay(), nil

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -6,141 +6,118 @@ package verrazzano
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/controller"
+
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"time"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	kblabels "k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ComponentUpgradeState identifies the state of a component during upgrade
-type ComponentUpgradeState string
-
 const (
-	// StateInit is the state when a component is starting the upgrade flow
-	StateInit ComponentUpgradeState = "Init"
+	// vzStart is the state where Verrazzano is starting the upgrade flow
+	vzStart VerrazzanoUpgradeState = "vzStart"
 
-	// StatePreUpgrading is the state when a component has successfully called component preUpgrade
-	StatePreUpgrading ComponentUpgradeState = "PreUpgrading"
+	// vzUpgradeComponents is the state where the components are being upgraded
+	vzUpgradeComponents VerrazzanoUpgradeState = "vzUpgradeComponents"
 
-	// StateUpgrading is the state when a component has successfully called component Upgrade
-	StateUpgrading ComponentUpgradeState = "Upgrading"
+	// vzDoPostUpgrade is the state where Verrazzano is doing a post-upgrade
+	vzDoPostUpgrade VerrazzanoUpgradeState = "vzDoPostUpgrade"
+
+	// vzWaitPostUpgradeDone is the state when Verrazzano is waiting for postUpgrade to be done
+	vzWaitPostUpgradeDone VerrazzanoUpgradeState = "vzWaitPostUpgradeDone"
+
+	// vzUpgradeDone is the state when upgrade is done
+	vzUpgradeDone VerrazzanoUpgradeState = "vzUpgradeDone"
 )
+
+// ComponentUpgradeState identifies the state of a component during upgrade
+type VerrazzanoUpgradeState string
 
 // upgradeTracker has the upgrade context for the Verrazzano upgrade
 type upgradeTracker struct {
+	vzState VerrazzanoUpgradeState
 	gen     int64
 	compMap map[string]*componentUpgradeContext
-}
-
-// componentUpgradeContext has the upgrade context for a Verrazzano component upgrade
-type componentUpgradeContext struct {
-	state ComponentUpgradeState
 }
 
 // upgradeTrackerMap has a map of upgradeTrackers, one entry per Verrazzano CR resource generation
 var upgradeTrackerMap = make(map[string]*upgradeTracker)
 
-// reconcileUpgrade will upgrade the components as required
+// reconcileUpgrade will reconcile
 func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
-	// Get the upgradeTracker for this Verrazzano CR generation
-	upgradeTracker := getUpgradeTracker(cr)
-
 	log.Oncef("Upgrading Verrazzano to version %s", cr.Spec.Version)
+
+	tracker := getUpgradeTracker(cr)
 
 	// Upgrade version was validated in webhook, see ValidateVersion
 	targetVersion := cr.Spec.Version
 
-	// Only write the upgrade started message once
-	if !isLastCondition(cr.Status, installv1alpha1.CondUpgradeStarted) {
-		err := r.updateStatus(log, cr, fmt.Sprintf("Verrazzano upgrade to version %s in progress", cr.Spec.Version),
-			installv1alpha1.CondUpgradeStarted)
-		// Always requeue to get a fresh copy of status and avoid potential conflict
-		return ctrl.Result{Requeue: true, RequeueAfter: 1}, err
-	}
-
-	spiCtx, err := spi.NewContext(log, r, cr, r.DryRun)
-	if err != nil {
-		return newRequeueWithDelay(), err
-	}
-
-	// Loop through all of the Verrazzano components and upgrade each one sequentially
-	// - for now, upgrade is blocking
-	for _, comp := range registry.GetComponents() {
-		compName := comp.Name()
-		compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
-		compLog := compContext.Log()
-		upgradeContext := upgradeTracker.getComponentUpgradeContext(compName)
-
-		if upgradeContext.state == StateInit {
-			// Check if component is installed, if not continue
-			installed, err := comp.IsInstalled(compContext)
-			if err != nil {
-				return newRequeueWithDelay(), err
-			}
-			if !installed {
-				compLog.Oncef("Component %s is not installed; upgrade being skipped", compName)
-				continue
-			}
-			compLog.Oncef("Component %s pre-upgrade running", compName)
-			if err := comp.PreUpgrade(compContext); err != nil {
-				// for now, this will be fatal until upgrade is retry-able
-				return ctrl.Result{}, err
-			}
-			upgradeContext.state = StatePreUpgrading
+	switch tracker.vzState {
+	case vzStart:
+		// Only write the upgrade started message once
+		if !isLastCondition(cr.Status, installv1alpha1.CondUpgradeStarted) {
+			err := r.updateStatus(log, cr, fmt.Sprintf("Verrazzano upgrade to version %s in progress", cr.Spec.Version),
+				installv1alpha1.CondUpgradeStarted)
+			// Always requeue to get a fresh copy of status and avoid potential conflict
+			return ctrl.Result{Requeue: true, RequeueAfter: 1}, err
 		}
+		tracker.vzState = vzUpgradeComponents
 
-		if upgradeContext.state == StatePreUpgrading {
-			compLog.Oncef("Component %s upgrade running", compName)
-			if err := comp.Upgrade(compContext); err != nil {
-				compLog.Errorf("Error upgrading component %s: %v", compName, err)
-				// check to see whether this is due to a pending upgrade
-				r.resolvePendingUpgrades(compName, compLog)
-				// requeue for 30 to 60 seconds later
-				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
+	case vzUpgradeComponents:
+		// Upgrade the components
+		res, err := r.upgradeComponents(log, cr, getUpgradeTracker(cr))
+		if err != nil || res.Requeue {
+			return res, err
+		}
+		tracker.vzState = vzDoPostUpgrade
+
+	case vzDoPostUpgrade:
+		// Invoke the global post upgrade function after all components are upgraded.
+		err := postVerrazzanoUpgrade(log, r)
+		if err != nil {
+			log.Errorf("Error running Verrazzano system-level post-upgrade")
+			return newRequeueWithDelay(), err
+		}
+		tracker.vzState = vzWaitPostUpgradeDone
+
+	case vzWaitPostUpgradeDone:
+		spiCtx, err := spi.NewContext(log, r, cr, r.DryRun)
+		if err != nil {
+			return newRequeueWithDelay(), err
+		}
+		for _, comp := range registry.GetComponents() {
+			compName := comp.Name()
+			compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
+			if !comp.IsReady(compContext) {
+				log.Progressf("Post-upgrade is waiting for all components to be ready.  Component %s is not yet ready", compName)
+				return newRequeueWithDelay(), nil
 			}
-			upgradeContext.state = StateUpgrading
 		}
+		tracker.vzState = vzUpgradeDone
 
-		if !comp.IsReady(compContext) {
-			compLog.Progressf("Component %s has been upgraded. Waiting for the component to be ready", compName)
-			return newRequeueWithDelay(), nil
+	case vzUpgradeDone:
+		msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", cr.Spec.Version)
+		log.Once(msg)
+		cr.Status.Version = targetVersion
+		if err := r.updateStatus(log, cr, msg, installv1alpha1.CondUpgradeComplete); err != nil {
+			return newRequeueWithDelay(), err
 		}
-
-		compLog.Oncef("Component %s post-upgrade running", compName)
-		if err := comp.PostUpgrade(compContext); err != nil {
-			// for now, this will be fatal until upgrade is retry-able
-			return ctrl.Result{}, err
-		}
+		// Upgrade completely done
+		deleteUpgradeTracker(cr)
+		return ctrl.Result{}, nil
 	}
 
-	// Invoke the global post upgrade function after all components are upgraded.
-	log.Oncef("Checking if any pods with Istio sidecars need to be restarted")
-	err = postVerrazzanoUpgrade(log, r)
-	if err != nil {
-		log.Errorf("Error running Verrazzano system-level post-upgrade")
-		return ctrl.Result{Requeue: true, RequeueAfter: 1}, err
-	}
-
-	msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", cr.Spec.Version)
-	log.Once(msg)
-	cr.Status.Version = targetVersion
-	if err = r.updateStatus(log, cr, msg, installv1alpha1.CondUpgradeComplete); err != nil {
-		return newRequeueWithDelay(), err
-	}
-	// Upgrade completely done
-	deleteUpgradeTracker(cr)
 	return ctrl.Result{}, nil
 }
 
@@ -188,21 +165,23 @@ func isLastCondition(st installv1alpha1.VerrazzanoStatus, conditionType installv
 
 // postVerrazzanoUpgrade restarts pods with old Istio sidecar proxies
 func postVerrazzanoUpgrade(log vzlog.VerrazzanoLogger, client clipkg.Client) error {
+	log.Oncef("Checking if any pods with Istio sidecars need to be restarted")
 	return istio.RestartComponents(log, config.GetInjectedSystemNamespaces(), client)
 }
 
-// getNsnKey gets the key for the verrazzano resource
-func getNsnKey(cr *installv1alpha1.Verrazzano) string {
+// getNSNKey gets the key for the verrazzano resource
+func getNSNKey(cr *installv1alpha1.Verrazzano) string {
 	return fmt.Sprintf("%s-%s", cr.Namespace, cr.Name)
 }
 
 // getUpgradeTracker gets the upgrade tracker for Verrazzano
 func getUpgradeTracker(cr *installv1alpha1.Verrazzano) *upgradeTracker {
-	key := getNsnKey(cr)
+	key := getNSNKey(cr)
 	vuc, ok := upgradeTrackerMap[key]
 	// If the entry is missing or the generation is different create a new entry
 	if !ok || vuc.gen != cr.Generation {
 		vuc = &upgradeTracker{
+			vzState: vzStart,
 			gen:     cr.Generation,
 			compMap: make(map[string]*componentUpgradeContext),
 		}
@@ -213,21 +192,9 @@ func getUpgradeTracker(cr *installv1alpha1.Verrazzano) *upgradeTracker {
 
 // deleteUpgradeTracker deletes the upgrade tracker for the Verrazzano resource
 func deleteUpgradeTracker(cr *installv1alpha1.Verrazzano) {
-	key := getNsnKey(cr)
+	key := getNSNKey(cr)
 	_, ok := upgradeTrackerMap[key]
 	if ok {
 		delete(upgradeTrackerMap, key)
 	}
-}
-
-// getComponentUpgradeContext gets the upgrade context for the component
-func (vuc *upgradeTracker) getComponentUpgradeContext(compName string) *componentUpgradeContext {
-	cuc, ok := vuc.compMap[compName]
-	if !ok {
-		cuc = &componentUpgradeContext{
-			state: StateInit,
-		}
-		vuc.compMap[compName] = cuc
-	}
-	return cuc
 }

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verrazzano
+
+import (
+	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ComponentUpgradeState identifies the state of a component during upgrade
+type ComponentUpgradeState string
+
+const (
+	// start is the state when a component is starting the upgrade flow
+	start ComponentUpgradeState = "start"
+
+	// doPreUpgrade is the state when a component does pre-upgrade
+	doPreUpgrade ComponentUpgradeState = "doPreUpgrade"
+
+	// doUpgrade is the state where a component does upgrade
+	doUpgrade ComponentUpgradeState = "doUpgrade"
+
+	// waitReady is the state when a component is waiting for upgrade ready
+	waitReady ComponentUpgradeState = "waitReady"
+
+	// doPostUpgrade is the state when a component is doing post upgrade
+	doPostUpgrade ComponentUpgradeState = "doPostUpgrade"
+
+	// upgradeDone is the state when component upgrade is done
+	upgradeDone ComponentUpgradeState = "upgradeDone"
+)
+
+// componentUpgradeContext has the upgrade context for a Verrazzano component upgrade
+type componentUpgradeContext struct {
+	state ComponentUpgradeState
+}
+
+// upgradeComponents will upgrade the components as required
+func (r *Reconciler) upgradeComponents(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano, tracker *upgradeTracker) (ctrl.Result, error) {
+	spiCtx, err := spi.NewContext(log, r, cr, r.DryRun)
+	if err != nil {
+		return newRequeueWithDelay(), err
+	}
+
+	// Loop through all of the Verrazzano components and upgrade each one sequentially
+	// - for now, upgrade is blocking
+	for _, comp := range registry.GetComponents() {
+		compName := comp.Name()
+		compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
+		compLog := compContext.Log()
+		upgradeContext := tracker.getComponentUpgradeContext(compName)
+
+		switch upgradeContext.state {
+		case start:
+			// Check if component is installed, if not continue
+			installed, err := comp.IsInstalled(compContext)
+			if err != nil {
+				return newRequeueWithDelay(), err
+			}
+			if !installed {
+				compLog.Oncef("Component %s is not installed; upgrade being skipped", compName)
+				continue
+			}
+			upgradeContext.state = doPreUpgrade
+
+		case doPreUpgrade:
+			compLog.Oncef("Component %s pre-upgrade running", compName)
+			if err := comp.PreUpgrade(compContext); err != nil {
+				// for now, this will be fatal until upgrade is retry-able
+				return ctrl.Result{}, err
+			}
+			upgradeContext.state = doPreUpgrade
+
+		case doUpgrade:
+			compLog.Oncef("Component %s upgrade running", compName)
+			if err := comp.Upgrade(compContext); err != nil {
+				compLog.Errorf("Error upgrading component %s: %v", compName, err)
+				// check to see whether this is due to a pending upgrade
+				r.resolvePendingUpgrades(compName, compLog)
+				// requeue for 30 to 60 seconds later
+				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
+			}
+			upgradeContext.state = waitReady
+
+		case waitReady:
+			if !comp.IsReady(compContext) {
+				compLog.Progressf("Component %s has been upgraded. Waiting for the component to be ready", compName)
+				return newRequeueWithDelay(), nil
+			}
+			upgradeContext.state = doPostUpgrade
+
+		case doPostUpgrade:
+			compLog.Oncef("Component %s post-upgrade running", compName)
+			if err := comp.PostUpgrade(compContext); err != nil {
+				// for now, this will be fatal until upgrade is retry-able
+				return ctrl.Result{}, err
+			}
+			upgradeContext.state = upgradeDone
+
+		case upgradeDone:
+			compLog.Oncef("Component %s has successfully upgraded and is ready", compName)
+			continue
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// getComponentUpgradeContext gets the upgrade context for the component
+func (vuc *upgradeTracker) getComponentUpgradeContext(compName string) *componentUpgradeContext {
+	cuc, ok := vuc.compMap[compName]
+	if !ok {
+		cuc = &componentUpgradeContext{
+			state: start,
+		}
+		vuc.compMap[compName] = cuc
+	}
+	return cuc
+}

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -127,12 +127,12 @@ func (r *Reconciler) upgradeComponents(log vzlog.VerrazzanoLogger, cr *installv1
 
 // getComponentUpgradeContext gets the upgrade context for the component
 func (vuc *upgradeTracker) getComponentUpgradeContext(compName string) *componentUpgradeContext {
-	cuc, ok := vuc.compMap[compName]
+	context, ok := vuc.compMap[compName]
 	if !ok {
-		cuc = &componentUpgradeContext{
+		context = &componentUpgradeContext{
 			state: compStateInit,
 		}
-		vuc.compMap[compName] = cuc
+		vuc.compMap[compName] = context
 	}
-	return cuc
+	return context
 }

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -37,9 +37,6 @@ const (
 	// compStateUpgradeDone is the state when component upgrade is done
 	compStateUpgradeDone ComponentUpgradeState = "UpgradeDone"
 
-	// compStateUpgradeSkipped is the state when component upgrade is skipped
-	compStateUpgradeSkipped ComponentUpgradeState = "UpgradeSkipped"
-
 	// compStateEnd is the terminal state
 	compStateEnd ComponentUpgradeState = "End"
 )

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -83,7 +83,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 			installed, err := comp.IsInstalled(compContext)
 			if err != nil {
 				compLog.Errorf("Failed checking if component %s is installed: %v", compName, err)
-				return newRequeueWithDelay(), err
+				return ctrl.Result{}, err
 			}
 			if installed {
 				compLog.Oncef("Component %s is installed and will be upgraded", compName)
@@ -97,7 +97,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 			compLog.Oncef("Component %s pre-upgrade running", compName)
 			if err := comp.PreUpgrade(compContext); err != nil {
 				compLog.Errorf("Failed pre-upgrading component %s: %v", compName, err)
-				return newRequeueWithDelay(), err
+				return ctrl.Result{}, err
 			}
 			upgradeContext.state = compStateUpgrade
 
@@ -123,7 +123,6 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 		case compStatePostUpgrade:
 			compLog.Oncef("Component %s post-upgrade running", compName)
 			if err := comp.PostUpgrade(compContext); err != nil {
-				// for now, this will be fatal until upgrade is retry-able
 				return ctrl.Result{}, err
 			}
 			upgradeContext.state = compStateUpgradeDone

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -7,14 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
-	errors2 "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 

--- a/platform-operator/mocks/controller_mock.go
+++ b/platform-operator/mocks/controller_mock.go
@@ -9,9 +9,10 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
-	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	runtime "k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Do not set the Verrazzano CR status to UpgradeComplete until upgrade is completely done, including restarting all of the components needed for new Istio sidecar injection.

I broke up the code to have an overall upgrade for the Verrazzano CR, and a component upgrade.  This makes it easier to understand the overall flow (IMO).

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
