### PR TITLE
VZ-3458 Add namespace selector to vpo webhook config

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
@@ -34,6 +34,9 @@ webhooks:
       - v1beta1
       - v1
   - name: clusters.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}


### PR DESCRIPTION
Signed-off-by: stshapir <steven.shapiro@oracle.com>

# Description

This change should have been made with the previous PR's to exclude namespace kube-system from being watched.

Fixes VZ-3458

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
