### PR TITLE
VZ-5146.  Multi-node KIND config for updates testing

### DIFF
--- a/tests/e2e/config/scripts/kind-config-calico.yaml
+++ b/tests/e2e/config/scripts/kind-config-calico.yaml
@@ -12,6 +12,18 @@ nodes:
           extraArgs:
             "service-account-issuer": "kubernetes.default.svc"
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker1"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker2"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker3"
 networking:
   disableDefaultCNI: true # disable kindnet
   podSubnet: 192.168.0.0/16 # set to Calico's default subnet

--- a/tests/e2e/config/scripts/kind-config.yaml
+++ b/tests/e2e/config/scripts/kind-config.yaml
@@ -12,3 +12,15 @@ nodes:
           extraArgs:
             "service-account-issuer": "kubernetes.default.svc"
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker1"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker2"
+  - role: worker
+    image: kindest/node:KIND_IMAGE
+    labels:
+      nodeName: "worker3"


### PR DESCRIPTION
# Description

Allow multi-node KIND config for updates testing (e.g., nodeAffinity).

Fixes VZ-5146.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
