### PR TITLE
VZ-3458 Webhooks should not watch kube-system namespace

### DIFF
--- a/application-operator/config/webhook/manifests.yaml
+++ b/application-operator/config/webhook/manifests.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
@@ -16,6 +16,9 @@ webhooks:
       path: /appconfig-defaulter
   failurePolicy: Fail
   name: appconfig-defaulter.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
   rules:
   - apiGroups:
     - core.oam.dev
@@ -42,6 +45,9 @@ webhooks:
       path: /validate-oam-verrazzano-io-v1alpha1-ingresstrait
   failurePolicy: Fail
   name: vingresstrait.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
   rules:
   - apiGroups:
     - oam.verrazzano.io

--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants
@@ -110,3 +110,6 @@ const FluentdElasticsearchUserEnvVar = "ELASTICSEARCH_USER"
 // FluentdElasticsearchPwdEnvVar is the environment variable name used to identify the admin cluster's
 // Elasticsearch password for fluentd
 const FluentdElasticsearchPwdEnvVar = "ELASTICSEARCH_PASSWORD"
+
+// KubeSystem - The name of the kube-system namespace
+const KubeSystem = "kube-system"

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclusterapplicationconfiguration

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +38,15 @@ const finalizerName = "multiclusterapplicationconfiguration.verrazzano.io"
 // the embedded resource
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("multiclusterapplicationconfiguration", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		logger.Info("Multi-cluster application configuration resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
 	var mcAppConfig clustersv1alpha1.MultiClusterApplicationConfiguration
 	result := reconcile.Result{}
 	ctx := context.Background()

--- a/application-operator/controllers/clusters/multiclustercomponent/controller.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller.go
@@ -1,10 +1,11 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclustercomponent
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/go-logr/logr"
@@ -33,6 +34,15 @@ type Reconciler struct {
 // MultiClusterComponent to reflect the success or failure of the changes to the embedded resource
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("multiclustercomponent", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		logger.Info("Multi-cluster component resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
 	var mcComp clustersv1alpha1.MultiClusterComponent
 	result := reconcile.Result{}
 	ctx := context.Background()

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclustercomponent
@@ -6,6 +6,7 @@ package multiclustercomponent
 import (
 	"context"
 	"encoding/json"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"path/filepath"
 	"testing"
 
@@ -28,8 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const namespace = "unit-mccomp-namespace"
-const crName = "unit-mccomp"
+const (
+	namespace = "unit-mccomp-namespace"
+	crName    = "unit-mccomp"
+)
 
 // TestComponentReconcilerSetupWithManager test the creation of the MultiClusterComponentReconciler.
 // GIVEN a controller implementation
@@ -486,4 +489,22 @@ func newReconciler(c client.Client) Reconciler {
 		Log:    ctrl.Log.WithName("test"),
 		Scheme: clusters.NewScheme(),
 	}
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(constants.KubeSystem, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclusterconfigmap

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -6,6 +6,7 @@ package multiclusterconfigmap
 import (
 	"context"
 	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,15 @@ const finalizerName = "multiclusterconfigmap.verrazzano.io"
 // Currently it does NOT support Immutable ConfigMap resources
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("multiclusterconfigmap", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		logger.Info("Multi-cluster configmap resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
 	var mcConfigMap clustersv1alpha1.MultiClusterConfigMap
 	result := reconcile.Result{}
 	ctx := context.Background()

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"path/filepath"
 	"testing"
 
@@ -416,6 +417,24 @@ func doExpectGetMultiClusterConfigMap(cli *mocks.MockClient, mcConfigMapSample c
 			}
 			return nil
 		})
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(constants.KubeSystem, crName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }
 
 // assertConfigMapValid asserts that the metadata and content of the created/updated K8S ConfigMap

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclusterconfigmap

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclustersecret

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -6,6 +6,7 @@ package multiclustersecret
 import (
 	"context"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -406,6 +407,24 @@ func doExpectGetMultiClusterSecret(cli *mocks.MockClient, mcSecretSample cluster
 			}
 			return nil
 		})
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(constants.KubeSystem, crName)
+	reconciler := newSecretReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }
 
 // assertSecretValid asserts that the metadata and content of the created/updated K8S secret

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package multiclustersecret

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verrazzanoproject

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -55,6 +55,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // and create namespaces in the local cluster.
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("verrazzanoproject", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		logger.Info("Verrazzano project resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
 	var vp clustersv1alpha1.VerrazzanoProject
 	ctx := context.Background()
 	logger.Info("Fetching VerrazzanoProject")

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -625,3 +625,21 @@ func doExpectStatusUpdateSucceeded(cli *mocks.MockClient, mockStatusWriter *mock
 			return nil
 		})
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(constants.KubeSystem, "vpTest")
+	reconciler := newVerrazzanoProjectReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verrazzanoproject

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package cohworkload

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -119,8 +119,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanocoherenceworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanocoherenceworkloads/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	ctx := context.Background()
 	log := r.Log.WithValues("verrazzanocoherenceworkload", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		log.Info("Coherence workload resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
+	ctx := context.Background()
 	log.Info("Reconciling Verrazzano Coherence workload")
 
 	// fetch the workload and unwrap the Coherence resource

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package cohworkload

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -988,6 +988,24 @@ func TestCreateUpdateDestinationRuleNoLabel(t *testing.T) {
 	assert.NoError(err)
 }
 
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(constants.KubeSystem, "unit-test-verrazzano-coherence-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}
+
 // newScheme creates a new scheme that includes this package's object to use for testing
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -61,8 +61,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile reconciles a VerrazzanoHelidonWorkload resource. It fetches the embedded DeploymentSpec, mutates it to add
 // scopes and traits, and then writes out the apps/Deployment (or deletes it if the workload is being deleted).
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	ctx := context.Background()
 	log := r.Log.WithValues("verrazzanohelidonworkload", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		log.Info("Helidon workload resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
+	ctx := context.Background()
 	log.Info("Reconciling VerrazzanoHelidonWorkload")
 
 	// fetch the workload

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonworkload

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -906,6 +906,24 @@ func TestReconcileAlreadyExistsNoUpgrade(t *testing.T) {
 	assert.Equal(false, result.Requeue)
 }
 
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(constants.KubeSystem, "test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}
+
 // newScheme creates a new scheme that includes this package's object to use for testing
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonworkload

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -69,9 +69,18 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("trait", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		log.Info("Ingress trait resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
 	var err error
 	ctx := context.Background()
-	log := r.Log.WithValues("trait", req.NamespacedName)
 	log.Info("Reconcile ingress trait")
 
 	// Fetch the trait.

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresstrait

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -2529,6 +2529,24 @@ func newScheme() *runtime.Scheme {
 	return scheme
 }
 
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(constants.KubeSystem, "test-trait")
+	reconciler := newIngressTraitReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}
+
 // newIngressTraitReconciler creates a new reconciler for testing
 // c - The Kerberos client to inject into the reconciler
 func newIngressTraitReconciler(c client.Client) Reconciler {

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresstrait

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -6,6 +6,7 @@ package metricstrait
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"regexp"
 	"strconv"
 	"time"
@@ -195,6 +196,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=metricstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(1).Info("Reconcile metrics trait", "trait", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		r.Log.V(1).Info(fmt.Sprint("Metrics trait resource should not be reconciled in kube-system namespace, ignoring"))
+		return reconcile.Result{}, nil
+	}
+
 	ctx := context.Background()
 	var err error
 

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package metricstrait

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -201,7 +201,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
 	if req.Namespace == constants.KubeSystem {
-		r.Log.V(1).Info(fmt.Sprint("Metrics trait resource should not be reconciled in kube-system namespace, ignoring"))
+		r.Log.V(1).Info("Metrics trait resource should not be reconciled in kube-system namespace, ignoring")
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package metricstrait

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -2100,6 +2101,25 @@ func TestUseHTTPSForScrapeTargetTrueCondition(t *testing.T) {
 	// Expect https to be true for namespaces labeled for istio-injection
 	assert.True(https, "Expected https to be true for namespaces labeled for Istio injection")
 	mocker.Finish()
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: constants.KubeSystem, Name: "test-trait-name"}}
+	reconciler := newMetricsTraitReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }
 
 // newMetricsTraitReconciler creates a new reconciler for testing

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package wlsworkload

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -192,8 +192,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=verrazzanoweblogicworkloads/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	ctx := context.Background()
 	log := r.Log.WithValues("verrazzanoweblogicworkload", req.NamespacedName)
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == constants.KubeSystem {
+		log.Info("WebLogic workload resource should not be reconciled in kube-system namespace, ignoring")
+		return reconcile.Result{}, nil
+	}
+
+	ctx := context.Background()
 	log.Info("Reconciling Verrazzano WebLogic workload")
 
 	// fetch the workload and unwrap the WebLogic resource

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package wlsworkload

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -1021,6 +1021,24 @@ func TestIstioDisabled(t *testing.T) {
 	assert.Equal(specIstioEnabled, false)
 }
 
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(constants.KubeSystem, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}
+
 // newScheme creates a new scheme that includes this package's object to use for testing
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -336,6 +336,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-application-appconfig-defaulter.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -364,6 +367,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-application-ingresstrait-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -394,7 +400,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
           - {key: istio-injection, operator: In, values: [enabled]}
-          - {key: verrazzano.io/namespace, operator: NotIn, values: [verrazzano-system]}
+          - {key: verrazzano.io/namespace, operator: NotIn, values: [verrazzano-system, kube-system]}
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -421,6 +427,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-verrazzanoproject-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -448,6 +457,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclusterapplicationconfiguration-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -475,6 +487,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclustercomponent-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -502,6 +517,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclusterconfigmap-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -529,6 +547,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclustersecret-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -8,6 +8,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: install.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -26,6 +29,9 @@ webhooks:
     sideEffects: None
     failurePolicy: Fail
   - name: clusters.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}


### PR DESCRIPTION
# Description

Backporting changes from https://github.com/verrazzano/verrazzano/pull/2654 https://github.com/verrazzano/verrazzano/pull/2676 and https://github.com/verrazzano/verrazzano/pull/2689

Fixes VZ-3458

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
