### PR TITLE
VZ-5171 re-entry into the install flow

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -162,6 +162,8 @@ type ComponentStatusDetails struct {
 	State CompStateType `json:"state,omitempty"`
 	// The version of Verrazzano that is installed
 	Version string `json:"version,omitempty"`
+	// The generation of the last VZ resource the Component was reconciled against
+	LastReconciledGeneration int64 `json:"lastReconciledGeneration,omitempty"`
 }
 
 // ConditionType identifies the condition of the install/uninstall/upgrade which can be checked with kubectl wait

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -189,21 +189,9 @@ func (h HelmComponent) Install(context spi.ComponentContext) error {
 	// Resolve the namespace
 	resolvedNamespace := h.resolveNamespace(context.EffectiveCR().Namespace)
 
-	failed, err := helm.IsReleaseFailed(h.ReleaseName, resolvedNamespace)
-	if err != nil {
-		return err
-	}
-	if failed {
-		// Chart install failed, reset the chart to start over
-		// NOTE: we'll likely have to put in some more logic akin to what we do for the scripts, see
-		//       reset_chart() in the common.sh script.  Recovering chart state can be a bit difficult, we
-		//       may need to draw on both the 'ls' and 'status' output for that.
-		helm.Uninstall(context.Log(), h.ReleaseName, resolvedNamespace, context.IsDryRun())
-	}
-
 	var kvs []bom.KeyValue
 	// check for global image pull secret
-	kvs, err = secret.AddGlobalImagePullSecretHelmOverride(context.Log(), context.Client(), resolvedNamespace, kvs, h.ImagePullSecretKeyname)
+	kvs, err := secret.AddGlobalImagePullSecretHelmOverride(context.Log(), context.Client(), resolvedNamespace, kvs, h.ImagePullSecretKeyname)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -611,6 +611,7 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 	}
 	if conditionType == installv1alpha1.CondInstallComplete {
 		cr.Status.VerrazzanoInstance = vzinstance.GetInstanceInfo(compContext)
+		componentStatus.LastReconciledGeneration = cr.Generation
 	}
 	componentStatus.Conditions = appendConditionIfNecessary(log, componentStatus, condition)
 
@@ -721,13 +722,17 @@ func (r *Reconciler) initializeComponentStatus(log vzlog.VerrazzanoLogger, cr *i
 
 	statusUpdated := false
 	for _, comp := range registry.GetComponents() {
-		if _, ok := cr.Status.Components[comp.Name()]; ok {
+		if status, ok := cr.Status.Components[comp.Name()]; ok {
+			if status.LastReconciledGeneration == 0 {
+				status.LastReconciledGeneration = cr.Generation
+			}
 			// Skip components that have already been processed
 			continue
 		}
 		if comp.IsOperatorInstallSupported() {
 			// If the component is installed then mark it as ready
 			compContext := newContext.Init(comp.Name()).Operation(vzconst.InitializeOperation)
+			lastReconciled := int64(0)
 			state := installv1alpha1.CompStateDisabled
 			if !unitTesting {
 				installed, err := comp.IsInstalled(compContext)
@@ -737,11 +742,13 @@ func (r *Reconciler) initializeComponentStatus(log vzlog.VerrazzanoLogger, cr *i
 				}
 				if installed {
 					state = installv1alpha1.CompStateReady
+					lastReconciled = compContext.ActualCR().Generation
 				}
 			}
 			cr.Status.Components[comp.Name()] = &installv1alpha1.ComponentStatusDetails{
-				Name:  comp.Name(),
-				State: state,
+				Name:                     comp.Name(),
+				State:                    state,
+				LastReconciledGeneration: lastReconciled,
 			}
 			statusUpdated = true
 		}

--- a/platform-operator/controllers/verrazzano/install_test.go
+++ b/platform-operator/controllers/verrazzano/install_test.go
@@ -1,0 +1,369 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verrazzano
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	"github.com/verrazzano/verrazzano/pkg/helm"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestUpdate tests the reconcile func with updated generation
+// GIVEN a request to reconcile an verrazzano resource after install is completed
+// WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
+// THEN ensure a condition with type InstallStarted
+func TestUpdate(t *testing.T) {
+	initUnitTesing()
+	namespace := "verrazzano"
+	name := "test"
+	lastReconciledGeneration := int64(2)
+	var verrazzanoToUse vzapi.Verrazzano
+	labels := map[string]string{}
+
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+	var vz *vzapi.Verrazzano
+	fakeComp := fakeComponent{}
+	fakeComp.ReleaseName = "my-component"
+	fakeComp.SupportsOperatorInstall = true
+	fakeCompUpdated := false
+	fakeComp.installFunc = func(ctx spi.ComponentContext) error {
+		fakeCompUpdated = true
+		return nil
+	}
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComp,
+		}
+	})
+	defer registry.ResetGetComponentsFn()
+	compStatusMap := makeVerrazzanoComponentStatusMap()
+	for _, status := range compStatusMap {
+		status.LastReconciledGeneration = lastReconciledGeneration
+	}
+	// Expect a call to get the verrazzano resource.  Return resource with version
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, verrazzano *vzapi.Verrazzano) error {
+			vz = verrazzano
+			verrazzano.TypeMeta = metav1.TypeMeta{
+				APIVersion: "install.verrazzano.io/v1alpha1",
+				Kind:       "Verrazzano"}
+			verrazzano.ObjectMeta = metav1.ObjectMeta{
+				Namespace:  name.Namespace,
+				Name:       name.Name,
+				Generation: lastReconciledGeneration + 1,
+				Finalizers: []string{finalizerName}}
+			verrazzano.Spec = vzapi.VerrazzanoSpec{
+				Version: "1.2.0"}
+			verrazzano.Status = vzapi.VerrazzanoStatus{
+				State:   vzapi.VzStateReady,
+				Version: "1.2.0",
+				Conditions: []vzapi.Condition{
+					{
+						Type: vzapi.CondInstallComplete,
+					},
+				},
+			}
+			verrazzano.Status.Components = compStatusMap
+			return nil
+		})
+
+	// The mocks are added to accomodate the expected calls to List instance when component is Ready
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList) error {
+			ingressList.Items = []networkingv1.Ingress{}
+			return nil
+		}).AnyTimes()
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
+			asserts.NotZero(len(verrazzano.Status.Components), "Status.Components len should not be zero")
+			return nil
+		}).AnyTimes()
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	config.TestProfilesDir = "../../manifests/profiles"
+	defer func() { config.TestProfilesDir = "" }()
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(vzapi.VzStateInstalling, vz.Status.State)
+	asserts.True(fakeCompUpdated)
+	asserts.True(result.Requeue)
+}
+
+// TestNoUpdateSameGeneration tests the reconcile func with same generation
+// GIVEN a request to reconcile an verrazzano resource after install is completed
+// WHEN all components have the same LastReconciledGeneration as verrazzano CR
+// THEN ensure a condition with type InstallStarted is not added
+func TestNoUpdateSameGeneration(t *testing.T) {
+	initUnitTesing()
+	namespace := "verrazzano"
+	name := "test"
+	lastReconciledGeneration := int64(2)
+	var verrazzanoToUse vzapi.Verrazzano
+	labels := map[string]string{}
+
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+	var vz *vzapi.Verrazzano
+	compStatusMap := makeVerrazzanoComponentStatusMap()
+	for _, status := range compStatusMap {
+		status.LastReconciledGeneration = lastReconciledGeneration
+	}
+
+	// Expect a call to get the verrazzano resource.  Return resource with version
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, verrazzano *vzapi.Verrazzano) error {
+			vz = verrazzano
+			verrazzano.TypeMeta = metav1.TypeMeta{
+				APIVersion: "install.verrazzano.io/v1alpha1",
+				Kind:       "Verrazzano"}
+			verrazzano.ObjectMeta = metav1.ObjectMeta{
+				Namespace:  name.Namespace,
+				Name:       name.Name,
+				Generation: lastReconciledGeneration,
+				Finalizers: []string{finalizerName}}
+			verrazzano.Spec = vzapi.VerrazzanoSpec{
+				Version: "1.2.0"}
+			verrazzano.Status = vzapi.VerrazzanoStatus{
+				State:   vzapi.VzStateReady,
+				Version: "1.2.0",
+				Conditions: []vzapi.Condition{
+					{
+						Type: vzapi.CondInstallComplete,
+					},
+				},
+			}
+			verrazzano.Status.Components = compStatusMap
+			return nil
+		})
+
+	// The mocks are added to accomodate the expected calls to List instance when component is Ready
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList) error {
+			ingressList.Items = []networkingv1.Ingress{}
+			return nil
+		}).AnyTimes()
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
+			asserts.NotZero(len(verrazzano.Status.Components), "Status.Components len should not be zero")
+			return nil
+		}).AnyTimes()
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	config.TestProfilesDir = "../../manifests/profiles"
+	defer func() { config.TestProfilesDir = "" }()
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
+	asserts.Equal(false, result.Requeue)
+	asserts.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestUpdateWithUpgrade tests the reconcile func with updated generation
+// GIVEN a request to reconcile an verrazzano resource after install is completed
+// WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
+// THEN ensure a condition with type UpgradeStarted
+func TestUpdateWithUpgrade(t *testing.T) {
+	initUnitTesing()
+	namespace := "verrazzano"
+	name := "test"
+	lastReconciledGeneration := int64(2)
+	var verrazzanoToUse vzapi.Verrazzano
+	labels := map[string]string{}
+
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+	var vz *vzapi.Verrazzano
+	compStatusMap := makeVerrazzanoComponentStatusMap()
+	for _, status := range compStatusMap {
+		status.LastReconciledGeneration = lastReconciledGeneration
+	}
+	// Expect a call to get the verrazzano resource.  Return resource with version
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: name}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, verrazzano *vzapi.Verrazzano) error {
+			vz = verrazzano
+			verrazzano.TypeMeta = metav1.TypeMeta{
+				APIVersion: "install.verrazzano.io/v1alpha1",
+				Kind:       "Verrazzano"}
+			verrazzano.ObjectMeta = metav1.ObjectMeta{
+				Namespace:  name.Namespace,
+				Name:       name.Name,
+				Generation: lastReconciledGeneration + 1,
+				Finalizers: []string{finalizerName}}
+			verrazzano.Spec = vzapi.VerrazzanoSpec{
+				Version: "1.2.0"}
+			verrazzano.Status = vzapi.VerrazzanoStatus{
+				State:   vzapi.VzStateReady,
+				Version: "1.1.0",
+				Conditions: []vzapi.Condition{
+					{
+						Type: vzapi.CondInstallComplete,
+					},
+				},
+			}
+			verrazzano.Status.Components = compStatusMap
+			return nil
+		})
+
+	// The mocks are added to accomodate the expected calls to List instance when component is Ready
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList) error {
+			ingressList.Items = []networkingv1.Ingress{}
+			return nil
+		}).AnyTimes()
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
+			asserts.NotZero(len(verrazzano.Status.Components), "Status.Components len should not be zero")
+			return nil
+		}).AnyTimes()
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	// Expect a call to get the service account
+	expectGetServiceAccountExists(mock, name, labels)
+
+	// Expect a call to get the ClusterRoleBinding
+	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	// Sample bom file for version validation functions
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	// Stubout the call to check the chart status
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	config.TestProfilesDir = "../../manifests/profiles"
+	defer func() { config.TestProfilesDir = "" }()
+
+	// Create and make the request
+	request := newRequest(namespace, name)
+	reconciler := newVerrazzanoReconciler(mock)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(vzapi.VzStateUpgrading, vz.Status.State)
+	asserts.True(result.Requeue)
+}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -5984,6 +5984,11 @@ spec:
                         - type
                         type: object
                       type: array
+                    lastReconciledGeneration:
+                      description: The generation of the last VZ resource the Component
+                        was reconciled against
+                      format: int64
+                      type: integer
                     name:
                       description: Name of the component
                       type: string


### PR DESCRIPTION
# Description
* allow re-entry of install flow by resetting the component state to disabled to restart the install flow 
* add LastReconciledGeneration to component state
	* at the end of install or upgrade, component.LastReconciledGeneration is set to VerrazzanoCR.Generation
	* update(re-install) is triggered when component.LastReconciledGeneration < VerrazzanoCR.Generation
* test with following CR, it moved an 'InstallComplete' verrazzano to 'InstallStarted' to update/scale the authProxy to 2 replicas:  
```
apiVersion: install.verrazzano.io/v1alpha1
kind: Verrazzano
metadata:
  name: my-verrazzano
spec:
  profile: dev
  components:
    authProxy:
      kubernetes:
        replicas: 2
```
Fixes VZ-5171

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
