### PR TITLE
VZ-3458 Webhooks should not watch kube-system namespace

### DIFF
--- a/application-operator/config/webhook/manifests.yaml
+++ b/application-operator/config/webhook/manifests.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---
@@ -22,6 +22,9 @@ webhooks:
     - v1beta1
     - v1
   name: appconfig-defaulter.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
   rules:
   - apiGroups:
     - core.oam.dev
@@ -54,6 +57,9 @@ webhooks:
     - v1beta1
     - v1
   name: vingresstrait.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
   rules:
   - apiGroups:
     - oam.verrazzano.io

--- a/application-operator/controllers/appconfig/appconfig_controller.go
+++ b/application-operator/controllers/appconfig/appconfig_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/ingresstrait"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
@@ -37,8 +38,8 @@ type Reconciler struct {
 }
 
 const (
-	finalizerName = "appconfig.finalizers.verrazzano.io"
-	kubeSystem    = "kube-system"
+	finalizerName  = "appconfig.finalizers.verrazzano.io"
+	controllerName = "appconfig"
 )
 
 // SetupWithManager registers our controller with the manager
@@ -56,7 +57,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(vzlog.FieldResourceNamespace, req.Namespace, vzlog.FieldResourceName, req.Name, vzlog.FieldController, controllerName)
+		log.Infof("Application configuration resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -67,7 +70,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("applicationconfiguration", req.NamespacedName, &appConfig)
 	if err != nil {
-		log.Errorf("Failed to create controller logger for application configuration", err)
+		log.Errorf("Failed to create controller logger for application configuration resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling application configuration resource %v, generation %v", req.NamespacedName, appConfig.Generation)

--- a/application-operator/controllers/appconfig/appconfig_controller_test.go
+++ b/application-operator/controllers/appconfig/appconfig_controller_test.go
@@ -63,7 +63,7 @@ func newReconciler(c client.Client) Reconciler {
 func newRequest(namespace string, name string) ctrl.Request {
 	return ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: testNamespace,
+			Namespace: namespace,
 			Name:      name,
 		},
 	}
@@ -890,4 +890,22 @@ func TestDeleteCertAndSecretWhenAppConfigIsDeleted(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(false, result.Requeue)
 	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(kubeSystem, testAppConfigName)
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }

--- a/application-operator/controllers/appconfig/appconfig_controller_test.go
+++ b/application-operator/controllers/appconfig/appconfig_controller_test.go
@@ -900,7 +900,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	cli := mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, testAppConfigName)
+	request := newRequest(vzconst.KubeSystem, testAppConfigName)
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -6,6 +6,7 @@ package multiclusterapplicationconfiguration
 import (
 	"context"
 	"encoding/json"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
 
@@ -494,7 +495,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -484,3 +484,21 @@ func newReconciler(c client.Client) Reconciler {
 		Scheme: clusters.NewScheme(),
 	}
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -485,3 +485,21 @@ func newReconciler(c client.Client) Reconciler {
 		Scheme: clusters.NewScheme(),
 	}
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -6,6 +6,7 @@ package multiclustercomponent
 import (
 	"context"
 	"encoding/json"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
 
@@ -495,7 +496,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Reconciler reconciles a MultiClusterConfigMap object
@@ -25,13 +26,24 @@ type Reconciler struct {
 	AgentChannel chan clusters.StatusUpdateMessage
 }
 
-const finalizerName = "multiclusterconfigmap.verrazzano.io"
+const (
+	finalizerName = "multiclusterconfigmap.verrazzano.io"
+	kubeSystem    = "kube-system"
+)
 
 // Reconcile reconciles a MultiClusterConfigMap resource. It fetches the embedded ConfigMap,
 // mutates it based on the MultiClusterConfigMap, and updates the status of the
 // MultiClusterConfigMap to reflect the success or failure of the changes to the embedded resource
 // Currently it does NOT support Immutable ConfigMap resources
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		return reconcile.Result{}, nil
+	}
+
 	ctx := context.Background()
 	var mcConfigMap clustersv1alpha1.MultiClusterConfigMap
 	err := r.fetchMultiClusterConfigMap(ctx, req.NamespacedName, &mcConfigMap)

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -44,7 +44,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// If this is the case then return success
 	if req.Namespace == constants.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
-		log.Infof("Multi-cluster application configuration resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
+		log.Infof("Multi-cluster ConfigMap resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -27,8 +29,8 @@ type Reconciler struct {
 }
 
 const (
-	finalizerName = "multiclusterconfigmap.verrazzano.io"
-	kubeSystem    = "kube-system"
+	finalizerName  = "multiclusterconfigmap.verrazzano.io"
+	controllerName = "multiclusterconfigmap"
 )
 
 // Reconcile reconciles a MultiClusterConfigMap resource. It fetches the embedded ConfigMap,
@@ -40,7 +42,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Multi-cluster application configuration resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -52,7 +56,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("mcconfigmap", req.NamespacedName, &mcConfigMap)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for multi-cluster config map", err)
+		zap.S().Error("Failed to create controller logger for multi-cluster config map resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling multi-cluster config map resource %v, generation %v", req.NamespacedName, mcConfigMap.Generation)

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
 
@@ -478,7 +479,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -468,3 +468,21 @@ func newReconciler(c client.Client) Reconciler {
 		Scheme: clusters.NewScheme(),
 	}
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Reconciler reconciles a MultiClusterSecret object
@@ -25,12 +26,23 @@ type Reconciler struct {
 	AgentChannel chan clusters.StatusUpdateMessage
 }
 
-const finalizerName = "multiclustersecret.verrazzano.io"
+const (
+	finalizerName = "multiclustersecret.verrazzano.io"
+	kubeSystem    = "kube-system"
+)
 
 // Reconcile reconciles a MultiClusterSecret resource. It fetches the embedded Secret, mutates it
 // based on the MultiClusterSecret, and updates the status of the MultiClusterSecret to reflect the
 // success or failure of the changes to the embedded Secret
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		return reconcile.Result{}, nil
+	}
+
 	ctx := context.Background()
 	var mcSecret clustersv1alpha1.MultiClusterSecret
 	err := r.fetchMultiClusterSecret(ctx, req.NamespacedName, &mcSecret)

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -27,8 +29,8 @@ type Reconciler struct {
 }
 
 const (
-	finalizerName = "multiclustersecret.verrazzano.io"
-	kubeSystem    = "kube-system"
+	finalizerName  = "multiclustersecret.verrazzano.io"
+	controllerName = "multiclustersecret"
 )
 
 // Reconcile reconciles a MultiClusterSecret resource. It fetches the embedded Secret, mutates it
@@ -39,7 +41,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Multi-cluster secret resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -51,7 +55,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("mcsecret", req.NamespacedName, &mcSecret)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for multi-cluster secret", err)
+		zap.S().Errorf("Failed to create controller logger for multi-cluster secret resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling multi-cluster secret resource %v, generation %v", req.NamespacedName, mcSecret.Generation)

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -436,3 +436,21 @@ func newSecretReconciler(c client.Client) Reconciler {
 		Scheme: clusters.NewScheme(),
 	}
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newSecretReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -6,6 +6,7 @@ package multiclustersecret
 import (
 	"context"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -446,7 +447,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newSecretReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -9,6 +9,7 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	vzConstants "github.com/verrazzano/verrazzano/pkg/constants"
 	log2 "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
@@ -35,7 +36,7 @@ const (
 	projectMonitorGroupTemplate = "verrazzano-project-%s-monitors"
 	finalizerName               = "project.verrazzano.io"
 	managedClusterRole          = "verrazzano-managed-cluster"
-	kubeSystem                  = "kube-system"
+	controllerName              = "verrazzanoproject"
 )
 
 // Reconciler reconciles a VerrazzanoProject object
@@ -61,7 +62,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == vzConstants.KubeSystem {
+		log := zap.S().With(log2.FieldResourceNamespace, req.Namespace, log2.FieldResourceName, req.Name, log2.FieldController, controllerName)
+		log.Infof("Verrazzano project resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -75,7 +78,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("mcconfigmap", req.NamespacedName, &vp)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for Verrazzano project", err)
+		zap.S().Errorf("Failed to create controller logger for Verrazzano project resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling Verrazzano project resource %v, generation %v", req.NamespacedName, vp.Generation)

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -760,3 +760,21 @@ func doExpectStatusUpdateSucceeded(cli *mocks.MockClient, mockStatusWriter *mock
 			return nil
 		})
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newVerrazzanoProjectReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller_test.go
@@ -6,6 +6,7 @@ package verrazzanoproject
 import (
 	"context"
 	"fmt"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"testing"
 	"time"
 
@@ -770,7 +771,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := clusterstest.NewRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := clusterstest.NewRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newVerrazzanoProjectReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/logging"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/metricstrait"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	log2 "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -88,7 +89,7 @@ const (
 	loggingMountPath          = "/fluentd/etc/custom.conf"
 	loggingKey                = "custom.conf"
 	fluentdVolumeName         = "fluentd-config-volume"
-	kubeSystem                = "kube-system"
+	controllerName            = "coherenceworkload"
 )
 
 var specLabelsFields = []string{specField, "labels"}
@@ -133,7 +134,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(log2.FieldResourceNamespace, req.Namespace, log2.FieldResourceName, req.Name, log2.FieldController, controllerName)
+		log.Infof("Coherence workload resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -144,7 +147,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("verrazzanocoherenceworkload", req.NamespacedName, workload)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for Coherence workload", err)
+		zap.S().Errorf("Failed to create controller logger for Coherence workload resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling Coherence workload resource %v, generation %v", req.NamespacedName, workload.Generation)

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -1539,3 +1539,21 @@ func TestReconcileRestart(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(false, result.Requeue)
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -1549,7 +1549,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := newRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/containerizedworkload/containerizedworkload_controller.go
+++ b/application-operator/controllers/containerizedworkload/containerizedworkload_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
@@ -29,7 +30,7 @@ type Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-const kubeSystem = "kube-system"
+const controllerName = "containerizedworkload"
 
 // SetupWithManager registers our controller with the manager
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -45,7 +46,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Containerized workload resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -56,7 +59,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("containerizedworkload", req.NamespacedName, &workload)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for containerized workload", err)
+		zap.S().Errorf("Failed to create controller logger for containerized workload resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling containerized workload resource %v, generation %v", req.NamespacedName, workload.Generation)

--- a/application-operator/controllers/containerizedworkload/containerizedworkload_controller_test.go
+++ b/application-operator/controllers/containerizedworkload/containerizedworkload_controller_test.go
@@ -54,7 +54,7 @@ func newReconciler(c client.Client) Reconciler {
 func newRequest(namespace string, name string) ctrl.Request {
 	return ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: testNamespace,
+			Namespace: namespace,
 			Name:      name,
 		},
 	}
@@ -125,6 +125,24 @@ func TestReconcileRestart(t *testing.T) {
 	mocker.Finish()
 	assert.NoError(err)
 	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	cli := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(vzconst.KubeSystem, "test-verrazzano-containerized-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.True(result.IsZero())
 }
 
 // updateObjectFromYAMLTemplate updates an object from a populated YAML template file.

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/appconfig"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -37,8 +38,8 @@ import (
 )
 
 const (
-	labelKey   = "verrazzanohelidonworkloads.oam.verrazzano.io"
-	kubeSystem = "kube-system"
+	labelKey       = "verrazzanohelidonworkloads.oam.verrazzano.io"
+	controllerName = "helidonworkload"
 )
 
 var (
@@ -72,7 +73,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Helidon workload resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -84,7 +87,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("verrazzanohelidonworkload", req.NamespacedName, &workload)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for Helidon workload", err)
+		zap.S().Errorf("Failed to create controller logger for Helidon workload resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling Helidon workload resource %v, generation %v", req.NamespacedName, workload.Generation)

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -927,7 +927,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := newRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -37,8 +37,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const namespace = "unit-test-namespace"
-const testRestartVersion = "new-restart"
+const (
+	namespace          = "unit-test-namespace"
+	testRestartVersion = "new-restart"
+)
 
 // TestReconcilerSetupWithManager test the creation of the VerrazzanoHelidonWorkload reconciler.
 // GIVEN a controller implementation
@@ -914,4 +916,23 @@ func TestReconcileRestart(t *testing.T) {
 	mocker.Finish()
 	assert.NoError(err)
 	assert.Equal(false, result.Requeue)
+}
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
 }

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"reflect"
 	"strings"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/reconcileresults"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
 	istionet "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -58,6 +58,7 @@ const (
 	wlProxySSLHeaderVal       = "true"
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
+	kubeSystem                = "kube-system"
 )
 
 // The port names used by WebLogic operator that do not have http prefix.
@@ -89,6 +90,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=ingresstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		return reconcile.Result{}, nil
+	}
+
 	var err error
 	var trait *vzapi.IngressTrait
 	ctx := context.Background()

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"reflect"
 	"strings"
 
@@ -58,7 +60,7 @@ const (
 	wlProxySSLHeaderVal       = "true"
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
-	kubeSystem                = "kube-system"
+	controllerName            = "ingresstrait"
 )
 
 // The port names used by WebLogic operator that do not have http prefix.
@@ -94,7 +96,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Ingress trait resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -110,7 +114,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	log, err := clusters.GetResourceLogger("ingresstrait", req.NamespacedName, trait)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for ingress trait", err)
+		zap.S().Errorf("Failed to create controller logger for ingress trait resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling ingress trait resource %v, generation %v", req.NamespacedName, trait.Generation)

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -3184,3 +3184,21 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 	assert.Equal(true, result.Requeue)
 	assert.Equal(time.Duration(0), result.RequeueAfter)
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newIngressTraitReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -26,6 +26,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	istionet "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -3194,7 +3195,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := newRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newIngressTraitReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/loggingtrait/loggingtrait_controller.go
+++ b/application-operator/controllers/loggingtrait/loggingtrait_controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"os"
 	"strings"
@@ -35,7 +37,7 @@ const (
 	loggingMountPath          = "/fluentd/etc/custom.conf"
 	loggingKey                = "custom.conf"
 	defaultMode         int32 = 400
-	kubeSystem                = "kube-system"
+	controllerName            = "loggingtrait"
 )
 
 // LoggingTraitReconciler reconciles a LoggingTrait object
@@ -60,7 +62,9 @@ func (r *LoggingTraitReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Logging trait resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -72,7 +76,7 @@ func (r *LoggingTraitReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 	log, err := clusters.GetResourceLogger("loggingtrait", req.NamespacedName, trait)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for logging trait", err)
+		zap.S().Errorf("Failed to create controller logger for logging trait resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling logging trait resource %v, generation %v", req.NamespacedName, trait.Generation)

--- a/application-operator/controllers/loggingtrait/loggingtrait_controller_test.go
+++ b/application-operator/controllers/loggingtrait/loggingtrait_controller_test.go
@@ -308,3 +308,21 @@ func newDeployment(deploymentName string, namespaceName string, workloadName str
 		},
 	}
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: kubeSystem, Name: "test-trait-name"}}
+	reconciler := newLoggingTraitReconciler(mock, t)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/loggingtrait/loggingtrait_controller_test.go
+++ b/application-operator/controllers/loggingtrait/loggingtrait_controller_test.go
@@ -6,6 +6,7 @@ package loggingtrait
 import (
 	"context"
 	"encoding/json"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"testing"
 	"time"
@@ -317,7 +318,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: kubeSystem, Name: "test-trait-name"}}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: vzconst.KubeSystem, Name: "test-trait-name"}}
 	reconciler := newLoggingTraitReconciler(mock, t)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -12,7 +12,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vztemplate "github.com/verrazzano/verrazzano/application-operator/controllers/template"
-	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
 	k8scorev1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +35,8 @@ type Reconciler struct {
 	Scraper string
 }
 
+const kubeSystem = "kube-system"
+
 // SetupWithManager creates controller for the MetricsBinding
 func (r *Reconciler) SetupWithManager(mgr k8scontroller.Manager) error {
 	return k8scontroller.NewControllerManagedBy(mgr).For(&vzapi.MetricsBinding{}).Complete(r)
@@ -43,6 +45,14 @@ func (r *Reconciler) SetupWithManager(mgr k8scontroller.Manager) error {
 // Reconcile reconciles a workload to keep the Prometheus ConfigMap scrape job configuration up to date.
 // No kubebuilder annotations are used as the application RBAC for the application operator is now manually managed.
 func (r *Reconciler) Reconcile(req k8scontroller.Request) (k8scontroller.Result, error) {
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		return reconcile.Result{}, nil
+	}
+
 	ctx := context.Background()
 	metricsBinding := vzapi.MetricsBinding{}
 	if err := r.Client.Get(context.TODO(), req.NamespacedName, &metricsBinding); err != nil {

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -6,6 +6,8 @@ package metricsbinding
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"time"
 
 	"github.com/Jeffail/gabs/v2"
@@ -35,7 +37,7 @@ type Reconciler struct {
 	Scraper string
 }
 
-const kubeSystem = "kube-system"
+const controllerName = "metricsbinding"
 
 // SetupWithManager creates controller for the MetricsBinding
 func (r *Reconciler) SetupWithManager(mgr k8scontroller.Manager) error {
@@ -49,7 +51,9 @@ func (r *Reconciler) Reconcile(req k8scontroller.Request) (k8scontroller.Result,
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == constants.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Metrics binding resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -60,7 +64,7 @@ func (r *Reconciler) Reconcile(req k8scontroller.Request) (k8scontroller.Result,
 	}
 	log, err := clusters.GetResourceLogger("metricsbinding", req.NamespacedName, &metricsBinding)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for metrics binding", err)
+		zap.S().Errorf("Failed to create controller logger for metrics binding resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling metrics binding resource %v, generation %v", req.NamespacedName, metricsBinding.Generation)
@@ -144,7 +148,7 @@ func (r *Reconciler) updateMetricsBinding(metricsBinding *vzapi.MetricsBinding, 
 
 	// Return error if UID is not found
 	if len(workloadObject.GetUID()) == 0 {
-		err = fmt.Errorf("Could not get UID from workload resource: %s, %s", workloadObject.GetKind(), workloadObject.GetName())
+		err = fmt.Errorf("could not get UID from workload resource: %s, %s", workloadObject.GetKind(), workloadObject.GetName())
 		log.Errorf("Failed to find UID for workload %s: %v", workloadObject.GetName(), err)
 		return err
 	}

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -522,3 +522,23 @@ func newReconciler(c client.Client) Reconciler {
 	}
 	return reconciler
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	namespacedName := types.NamespacedName{Namespace: kubeSystem, Name: testMetricsBindingName}
+	request := ctrl.Request{NamespacedName: namespacedName}
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -5,6 +5,7 @@ package metricsbinding
 
 import (
 	"context"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"os"
 	"strings"
 	"testing"
@@ -532,7 +533,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	namespacedName := types.NamespacedName{Namespace: kubeSystem, Name: testMetricsBindingName}
+	namespacedName := types.NamespacedName{Namespace: vzconst.KubeSystem, Name: testMetricsBindingName}
 	request := ctrl.Request{NamespacedName: namespacedName}
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -40,6 +40,7 @@ const (
 	deploymentKind  = "Deployment"
 	statefulSetKind = "StatefulSet"
 	podKind         = "Pod"
+	kubeSystem      = "kube-system"
 
 	// In code defaults for metrics trait configuration
 	defaultWLSAdminScrapePort = 7001
@@ -208,6 +209,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=metricstraits,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oam.verrazzano.io,resources=metricstraits/status,verbs=get;update;patch
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	// We do not want any resource to get reconciled if it is in namespace kube-system
+	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
+	// If this is the case then return success
+	if req.Namespace == kubeSystem {
+		return reconcile.Result{}, nil
+	}
+
 	ctx := context.Background()
 	// Fetch the trait.
 	var err error

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -2250,3 +2250,22 @@ func updateObjectFromYAMLTemplate(obj interface{}, template string, params ...ma
 	}
 	return nil
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: kubeSystem, Name: "test-trait-name"}}
+	reconciler := newMetricsTraitReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -2260,7 +2261,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: kubeSystem, Name: "test-trait-name"}}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: vzconst.KubeSystem, Name: "test-trait-name"}}
 	reconciler := newMetricsTraitReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -69,7 +69,7 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// If this is the case then return success
 	if req.NamespacedName.Name == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
-		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName.Name)
+		log.Infof("Namespace resource %v should not be reconciled, ignoring", req.NamespacedName.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -67,7 +67,7 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == vzconst.KubeSystem {
+	if req.NamespacedName.Namespace == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
 		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -67,9 +67,9 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.NamespacedName.Namespace == vzconst.KubeSystem {
+	if req.NamespacedName.Name == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
-		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
+		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -1,10 +1,12 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package namespace
 
 import (
 	"context"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"time"
 
@@ -26,10 +28,10 @@ import (
 const (
 	namespaceControllerFinalizer = "verrazzano.io/namespace"
 	namespaceField               = "namespace"
-	kubeSystem                   = "kube-system"
+	controllerName               = "namespace"
 )
 
-// Reconciler reconciles a Verrazzano object
+// NamespaceController Reconciler reconciles a Verrazzano object
 type NamespaceController struct {
 	client.Client
 	scheme     *runtime.Scheme
@@ -65,7 +67,9 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == kubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
+		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
+		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -77,7 +81,7 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	}
 	log, err := clusters.GetResourceLogger("namespace", req.NamespacedName, &ns)
 	if err != nil {
-		zap.S().Errorf("Failed to create controller logger for namespace", err)
+		zap.S().Errorf("Failed to create controller logger for namespace resource: %v", err)
 		return clusters.NewRequeueWithDelay(), nil
 	}
 	log.Oncef("Reconciling namespace resource %v, generation %v", req.NamespacedName, ns.Generation)

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -732,7 +732,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 
 	// create a request and reconcile it
 	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: vzconst.KubeSystem},
+		NamespacedName: types.NamespacedName{Name: vzconst.KubeSystem},
 	}
 	result, err := nc.Reconcile(req)
 

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -732,7 +732,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 
 	// create a request and reconcile it
 	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: kubeSystem},
+		NamespacedName: types.NamespacedName{Namespace: vzconst.KubeSystem},
 	}
 	result, err := nc.Reconcile(req)
 

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -719,6 +719,29 @@ func mockFluentdRestart(mock *mocks.MockClient, asserts *assert.Assertions) {
 		})
 }
 
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	asserts := assert.New(t)
+
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	nc, err := newTestController(mock)
+	asserts.NoError(err)
+
+	// create a request and reconcile it
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: kubeSystem},
+	}
+	result, err := nc.Reconcile(req)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.Nil(err)
+	asserts.True(result.IsZero())
+}
+
 // Fake manager for unit testing
 type fakeManager struct {
 	client.Client

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -2151,3 +2151,22 @@ func TestReconcileStartDomain(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(false, result.Requeue)
 }
+
+// TestReconcileKubeSystem tests to make sure we do not reconcile
+// Any resource that belong to the kube-system namespace
+func TestReconcileKubeSystem(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+
+	// create a request and reconcile it
+	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.Nil(err)
+	assert.True(result.IsZero())
+}

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -2161,7 +2161,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 	var cli = mocks.NewMockClient(mocker)
 
 	// create a request and reconcile it
-	request := newRequest(kubeSystem, "unit-test-verrazzano-helidon-workload")
+	request := newRequest(vzconst.KubeSystem, "unit-test-verrazzano-helidon-workload")
 	reconciler := newReconciler(cli)
 	result, err := reconciler.Reconcile(request)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,3 +94,6 @@ const MaxTimesVMCAgentPollingTime = 3
 
 // FluentdDaemonSetName - The name of the Fluentd DaemonSet
 const FluentdDaemonSetName = "fluentd"
+
+// KubeSystem - The name of the kube-system namespace
+const KubeSystem = "kube-system"

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -360,6 +360,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-application-appconfig-defaulter.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -393,6 +396,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-application-ingresstrait-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -428,7 +434,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
           - {key: istio-injection, operator: In, values: [enabled]}
-          - {key: verrazzano.io/namespace, operator: NotIn, values: [verrazzano-system]}
+          - {key: verrazzano.io/namespace, operator: NotIn, values: [verrazzano-system, kube-system]}
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -460,6 +466,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-verrazzanoproject-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -492,6 +501,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclusterapplicationconfiguration-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -524,6 +536,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclustercomponent-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -556,6 +571,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclusterconfigmap-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -588,6 +606,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: verrazzano-clusters-multiclustersecret-validator.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}
@@ -621,6 +642,8 @@ metadata:
 webhooks:
   - name: metrics-binding-generator-workload.verrazzano.io
     namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
       matchLabels:
         verrazzano-managed: "true"
     objectSelector:
@@ -647,6 +670,8 @@ webhooks:
       - v1
   - name: metrics-binding-labeler-pod.verrazzano.io
     namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
       matchLabels:
         verrazzano-managed: "true"
     objectSelector:

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
@@ -34,6 +34,9 @@ webhooks:
       - v1beta1
       - v1
   - name: clusters.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -8,6 +8,9 @@ metadata:
     app: {{ .Values.name }}
 webhooks:
   - name: install.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
     clientConfig:
       service:
         name: {{ .Values.name }}


### PR DESCRIPTION
# Description

Backporting changes from https://github.com/verrazzano/verrazzano/pull/2654 https://github.com/verrazzano/verrazzano/pull/2676 and https://github.com/verrazzano/verrazzano/pull/2689

Fixes VZ-3458

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
