### PR TITLE
JIRA: VZ-5020 clear helm upgrades blocked due to any status other than 'deployed'

### DIFF
--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -138,7 +138,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 	return ctrl.Result{}, nil
 }
 
-// resolvePendingUpgrdes will delete any helm secrets with a "pending-upgrade" status for the given component
+// resolvePendingUpgrdes will delete any helm secrets with a status other than "deployed" for the given component
 func (r *Reconciler) resolvePendingUpgrades(compName string, compLog vzlog.VerrazzanoLogger) {
 	nameReq, _ := kblabels.NewRequirement("name", selection.Equals, []string{compName})
 	statusReq, _ := kblabels.NewRequirement("status", selection.NotEquals, []string{"deployed"})

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -6,6 +6,7 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/selection"
 
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
@@ -139,7 +140,10 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 
 // resolvePendingUpgrdes will delete any helm secrets with a "pending-upgrade" status for the given component
 func (r *Reconciler) resolvePendingUpgrades(compName string, compLog vzlog.VerrazzanoLogger) {
-	labelSelector := kblabels.Set{"name": compName, "status": "pending-upgrade"}.AsSelector()
+	nameReq, _ := kblabels.NewRequirement("name", selection.Equals, []string{compName})
+	statusReq, _ := kblabels.NewRequirement("status", selection.NotEquals, []string{"deployed"})
+	labelSelector := kblabels.NewSelector()
+	labelSelector = labelSelector.Add(*nameReq, *statusReq)
 	helmSecrets := v1.SecretList{}
 	err := r.Client.List(context.TODO(), &helmSecrets, &clipkg.ListOptions{LabelSelector: labelSelector})
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -1170,8 +1170,8 @@ func TestUpgradeComponent(t *testing.T) {
 
 // TestUpgradeComponentWithBlockingStatus tests the reconcileUpgrade method for the following use case
 // GIVEN a request to reconcile an upgrade
-// WHEN the component fails to upgrade since a pending upgrade exists
-// THEN the pending status secret is deleted so the upgrade can proceed
+// WHEN the component fails to upgrade since a status other than "deployed" exists
+// THEN the offending secret is deleted so the upgrade can proceed
 func TestUpgradeComponentWithBlockingStatus(t *testing.T) {
 	initUnitTesing()
 	namespace := "verrazzano"
@@ -1226,7 +1226,7 @@ func TestUpgradeComponentWithBlockingStatus(t *testing.T) {
 	mockComp.EXPECT().Upgrade(gomock.Any()).Return(fmt.Errorf("Upgrade in progress")).AnyTimes()
 	mockComp.EXPECT().Name().Return("testcomp").Times(1).AnyTimes()
 
-	// expect a call to list any pending upgrade secrets for the component
+	// expect a call to list any secrets with a status other than "deployed" for the component
 	statuses := []string{"unknown", "uninstalled", "superseded", "failed", "uninstalling", "pending-install", "pending-upgrade", "pending-rollback"}
 	n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(statuses))))
 	status := statuses[int(n.Int64())]


### PR DESCRIPTION
# Description

Code currently exists to remove helm component release secrets that present a 'pending-upgrade' status in order to un-block the given upgrade.  This PR expands the statuses that qualify for this workaround to all statuses other than 'deployed'

Fixes VZ-5020

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
