### PR TITLE
VZ-4365: Rancher post-install step failed to reset admin password

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -269,7 +269,7 @@ func TestPostInstall(t *testing.T) {
 	caSecret := createCASecret()
 	rootCASecret := createRootCASecret()
 	adminSecret := createAdminSecret()
-	rancherPodList := createRancherPodList()
+	rancherPodList := createRancherPodListWithAllRunning()
 	ingress := v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: common.CattleSystem,

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -90,7 +90,7 @@ func createCASecret() v1.Secret {
 	}
 }
 
-func createRancherPodList() v1.PodList {
+func createRancherPodListWithAllRunning() v1.PodList {
 	return v1.PodList{
 		Items: []v1.Pod{
 			{
@@ -99,6 +99,62 @@ func createRancherPodList() v1.PodList {
 					Namespace: common.CattleSystem,
 					Labels: map[string]string{
 						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "True"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createRancherPodListWithNoneRunning() v1.PodList {
+	return v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func createRancherPodListWithLastRunning() v1.PodList {
+	return v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod1",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "False"},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancherpod2",
+					Namespace: common.CattleSystem,
+					Labels: map[string]string{
+						"app": common.RancherName,
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "Ready", Status: "True"},
 					},
 				},
 			},


### PR DESCRIPTION
Un-revert original change
> Fixes issue where install was attempting to update the admin password by execing into a rancher pod but was picking a non-running pod. This change selects the first rancher pod found running to perform the operations.
https://github.com/verrazzano/verrazzano/pull/2678