### PR TITLE
VZ-5140 Added assets make target as dependency to docker-build target

### DIFF
--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -61,6 +61,7 @@ ENV_NAME=verrazzano-platform-operator
 GO ?= GO111MODULE=on GOPRIVATE=github.com/verrazzano go
 GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}
 GO_BINDATA_VERSION ?= $(shell go list -m -f '{{.Version}}' 'github.com/go-bindata/go-bindata/v3' )
+ASSETS_TIMESTAMP=1646174971
 
 CRD_PATH=helm_config/charts/verrazzano-platform-operator/crds
 
@@ -134,7 +135,7 @@ endif
 
 .PHONY: assets
 assets: go-bindata
-	$(GO_BINDATA) -pkg verrazzano -o generated_assets.go ./manifests/dashboards/...
+	$(GO_BINDATA) -modtime ${ASSETS_TIMESTAMP} -pkg verrazzano -o generated_assets.go ./manifests/dashboards/...
 	echo '// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.' | cat - generated_assets.go > tmp && mv tmp generated_assets.go
 	echo '// Copyright (C) 2022, Oracle and/or its affiliates.' | cat - generated_assets.go > tmp && mv tmp generated_assets.go
 	mv ./generated_assets.go ./controllers/verrazzano/component/verrazzano/

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -147,7 +147,7 @@ docker-clean:
 	rm -rf ${DIST_DIR}
 
 .PHONY: docker-build
-docker-build: generate-bom go-build-linux
+docker-build: generate-bom go-build-linux assets
 	@echo Building verrazzano-platform-operator image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	@echo using verrazzano-application-operator image ${VERRAZZANO_APPLICATION_OPERATOR_IMAGE}
 	# the TPL file needs to be copied into this dir so it is in the docker build context

--- a/platform-operator/controllers/verrazzano/component/verrazzano/generated_assets.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/generated_assets.go
@@ -515,7 +515,7 @@ func manifestsDashboardsWeblogicWeblogic_dashboardJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "manifests/dashboards/weblogic/weblogic_dashboard.json", size: 100819, mode: os.FileMode(420), modTime: time.Unix(1646240198, 0)}
+	info := bindataFileInfo{name: "manifests/dashboards/weblogic/weblogic_dashboard.json", size: 100819, mode: os.FileMode(420), modTime: time.Unix(1646174971, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
# Description

Problem

When updates are made to the system-dashboards, the "assets" target must be explicitly run to regenerate the gobin data.  
Adding "assets" as a dependency to the "docker-build" target would help in resolving this issue. Another benefit of adding this dependency is that if someone makes a change to the dashboards without running "assets" target and pushes their branch, the build will fail because running the target will create changed files.  The build pipeline checks that running our targets do not create uncommitted file changes. go-bindata always updates the timestamp, in order to avoid it being updated each time, hardcoded timestamp is being set in the assets target.

Fixes VZ-5140

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
