### PR TITLE
VZ-5277 - Refactor tests to explicitly pass a kubeconfigPath to IsVerrazzanoMinVersion and GetClusterNameMetricsLabel

### DIFF
--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -89,8 +89,8 @@ func (t *TestFramework) It(text string, args ...interface{}) bool {
 	return ginkgo.It(text, args...)
 }
 
-func (t *TestFramework) ItMinimumVersion(text string, version string, args ...interface{}) bool {
-	supported, err := pkg.IsVerrazzanoMinVersion(version)
+func (t *TestFramework) ItMinimumVersion(text string, version string, kubeconfigPath string, args ...interface{}) bool {
+	supported, err := pkg.IsVerrazzanoMinVersion(version, kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 		return false
@@ -211,12 +211,12 @@ func (t *TestFramework) JustAfterEach(args ...interface{}) bool {
 	return ginkgo.JustAfterEach(args...)
 }
 
-//BeforeAll - wrapper function for Ginkgo BeforeAll
+// BeforeAll - wrapper function for Ginkgo BeforeAll
 func (t *TestFramework) BeforeAll(args ...interface{}) bool {
 	return ginkgo.BeforeAll(args...)
 }
 
-//AfterAll - wrapper function for Ginkgo AfterAll
+// AfterAll - wrapper function for Ginkgo AfterAll
 func (t *TestFramework) AfterAll(args ...interface{}) bool {
 	return ginkgo.AfterAll(args...)
 }

--- a/tests/e2e/logging/system/system_logging_test.go
+++ b/tests/e2e/logging/system/system_logging_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -381,8 +382,14 @@ func validateVMOLogs() bool {
 }
 
 func validateVOLogs() bool {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		return false
+	}
+
 	// VO not installed in 1.3.0+
-	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0"); !ok {
+	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); !ok {
 		return validateElasticsearchRecords(
 			allElasticsearchRecordValidator,
 			systemIndex,
@@ -666,7 +673,7 @@ func logLevelElasticsearchRecordValidator(hit pkg.ElasticsearchHit) bool {
 		pkg.Log(pkg.Info, "Log record has missing or empty level field")
 		return false
 	}
-	//level := val.(string)
+	// level := val.(string)
 	// Put this validation back in when the OAM logging is fixed.
 	// if strings.EqualFold(level, "debug") || strings.EqualFold(level, "dbg") || strings.EqualFold(level, "d") {
 	// 	pkg.Log(pkg.Info, fmt.Sprintf("Log record has invalid debug level: %s", level))
@@ -674,10 +681,10 @@ func logLevelElasticsearchRecordValidator(hit pkg.ElasticsearchHit) bool {
 	// }
 	// There is an Istio proxy error that causes this to fail.
 	// Put this validation back in when that is addressed.
-	//if strings.EqualFold(level, "error") || strings.EqualFold(level, "err") || strings.EqualFold(level, "e") {
+	// if strings.EqualFold(level, "error") || strings.EqualFold(level, "err") || strings.EqualFold(level, "e") {
 	//	pkg.Log(pkg.Info, fmt.Sprintf("Log record has invalid error level: %s", level))
 	//	valid = false
-	//}
+	// }
 
 	return true
 }

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -5,10 +5,11 @@ package syscomponents
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -101,7 +102,7 @@ var _ = t.BeforeSuite(func() {
 		}
 	}
 
-	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0")
+	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeConfig)
 	if err != nil {
 		Fail(err.Error())
 	}
@@ -221,7 +222,7 @@ func verifyEnvoyStats(metricName string) bool {
 func getClusterNameMetricLabel() string {
 	if clusterNameMetricsLabel == "" {
 		// ignore error getting the metric label - we'll just use the default value returned
-		lbl, err := pkg.GetClusterNameMetricLabel()
+		lbl, err := pkg.GetClusterNameMetricLabel(adminKubeConfig)
 		if err != nil {
 			pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
 		}

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -5,11 +5,12 @@ package mchelidon
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -185,7 +186,7 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 	// THEN expect Prometheus metrics for the app to exist in Prometheus on the admin cluster
 	t.Context("Metrics", func() {
 		t.It("Verify Prometheus metrics exist on admin cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				var m = map[string]string{clusterNameMetricsLabel: clusterName}
 				return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -5,11 +5,12 @@ package mchelidon
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -175,7 +176,7 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 	t.Context("for Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
 
 		t.It("Verify base_jvm_uptime_seconds metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
@@ -185,7 +186,7 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		})
 
 		t.It("Verify DNE base_jvm_uptime_seconds metrics does not exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testNamespace
@@ -195,7 +196,7 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		})
 
 		t.It("Verify vendor_requests_count_total metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["app"] = testApp
@@ -205,7 +206,7 @@ var _ = t.Describe("In Multi-cluster, verify hello-helidon", Label("f:multiclust
 		})
 
 		t.It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -5,11 +5,12 @@ package sock_shop
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -162,7 +163,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 	PContext("for Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
 
 		t.It("Verify base_jvm_uptime_seconds metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -172,7 +173,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 		})
 
 		t.It("Verify DNE base_jvm_uptime_seconds metrics does not exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -182,7 +183,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 		})
 
 		t.It("Verify vendor_requests_count_total metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["cluster"] = testCluster
@@ -192,7 +193,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 		})
 
 		t.It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -5,12 +5,13 @@ package todo_list
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -226,7 +227,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 	t.Context("for Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
 
 		t.It("Verify scrape_duration_seconds metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
@@ -236,7 +237,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 		})
 
 		t.It("Verify DNE scrape_duration_seconds metrics does not exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
@@ -246,7 +247,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 		})
 
 		t.It("Verify container_cpu_cfs_periods_total metrics exist for managed cluster", func() {
-			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel()
+			clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 			Eventually(func() bool {
 				m := make(map[string]string)
 				m["namespace"] = testNamespace

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -34,7 +34,8 @@ const verrazzanoSystemNamespace = "verrazzano-system"
 
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var vmiEsIngressURL = getVmiEsIngressURL()
-var externalEsURL = pkg.GetExternalElasticSearchURL(os.Getenv("ADMIN_KUBECONFIG"))
+var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
+var externalEsURL = pkg.GetExternalElasticSearchURL(adminKubeconfig)
 
 var t = framework.NewTestFramework("register_test")
 
@@ -86,7 +87,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 		})
 
 		t.It("no longer has a ClusterRoleBinding for a managed cluster", func() {
-			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -100,7 +101,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 		})
 
 		t.It("has a ClusterRoleBinding for a managed cluster", func() {
-			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -186,7 +187,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 		})
 
 		t.It("has the expected metrics from managed cluster", func() {
-			clusterNameMetricsLabel := getClusterNameMetricLabel()
+			clusterNameMetricsLabel := getClusterNameMetricLabel(adminKubeconfig)
 			pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric with label %s with value %s", clusterNameMetricsLabel, managedClusterName))
 			Eventually(func() bool {
 				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName)
@@ -194,7 +195,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 		})
 
 		t.It("Fluentd should point to the correct ES", func() {
-			supported, err := pkg.IsVerrazzanoMinVersion("1.3.0")
+			supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -383,12 +384,12 @@ func assertRegistrationSecret() {
 }
 
 func getVmiEsIngressURL() string {
-	return fmt.Sprintf("%s:443", pkg.GetSystemElasticSearchIngressURL(os.Getenv("ADMIN_KUBECONFIG")))
+	return fmt.Sprintf("%s:443", pkg.GetSystemElasticSearchIngressURL(adminKubeconfig))
 }
 
-func getClusterNameMetricLabel() string {
+func getClusterNameMetricLabel(kubeconfigPath string) string {
 	// ignore error getting the metric label - we'll just use the default value returned
-	lbl, err := pkg.GetClusterNameMetricLabel()
+	lbl, err := pkg.GetClusterNameMetricLabel(kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting cluster name metric label: %s", err.Error()))
 	}

--- a/tests/e2e/pkg/conditional_spec.go
+++ b/tests/e2e/pkg/conditional_spec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package pkg
 

--- a/tests/e2e/pkg/conditional_spec.go
+++ b/tests/e2e/pkg/conditional_spec.go
@@ -4,7 +4,9 @@ package pkg
 
 import (
 	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 )
 
 // ConditionalCheckFunc Test function for conditional specs
@@ -27,6 +29,11 @@ func ConditionalSpec(description string, skipMessage string, condition Condition
 // MinVersionSpec Executes the specified test spec/func when the Verrazzano version meets the minimum specified version
 func MinVersionSpec(description string, minVersion string, specFunc interface{}) {
 	ConditionalSpec(description, fmt.Sprintf("Min version not met: %s", minVersion), func() (bool, error) {
-		return IsVerrazzanoMinVersion(minVersion)
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			Log(Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+			return false, err
+		}
+		return IsVerrazzanoMinVersion(minVersion, kubeconfigPath)
 	}, specFunc)
 }

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -357,12 +357,7 @@ func GetVerrazzano() (*v1alpha1.Verrazzano, error) {
 }
 
 // GetVerrazzanoVersion returns the Verrazzano Version
-func GetVerrazzanoVersion() (string, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig: %v", err))
-		return "", err
-	}
+func GetVerrazzanoVersion(kubeconfigPath string) (string, error) {
 	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 	if err != nil {
 		return "", err
@@ -375,8 +370,8 @@ func GetVerrazzanoVersion() (string, error) {
 }
 
 // IsVerrazzanoMinVersion returns true if the Verrazzano version >= minVersion
-func IsVerrazzanoMinVersion(minVersion string) (bool, error) {
-	vzVersion, err := GetVerrazzanoVersion()
+func IsVerrazzanoMinVersion(minVersion string, kubeconfigPath string) (bool, error) {
+	vzVersion, err := GetVerrazzanoVersion(kubeconfigPath)
 	if err != nil {
 		return false, err
 	}
@@ -999,7 +994,7 @@ func CanIForAPIGroupForServiceAccountOrUser(saOrUserOCID string, namespace strin
 	return auth.Status.Allowed, auth.Status.Reason, nil
 }
 
-//GetTokenForServiceAccount returns the token associated with service account
+// GetTokenForServiceAccount returns the token associated with service account
 func GetTokenForServiceAccount(sa string, namespace string) ([]byte, error) {
 	serviceAccount, err := GetServiceAccount(namespace, sa)
 	if err != nil {

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -96,11 +96,11 @@ func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubecon
 
 // GetClusterNameMetricLabel returns the label name used for labeling metrics with the Verrazzano cluster
 // This is different in pre-1.1 VZ releases versus later releases
-func GetClusterNameMetricLabel() (string, error) {
-	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1.0")
+func GetClusterNameMetricLabel(kubeconfigPath string) (string, error) {
+	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error checking Verrazzano min version == 1.1: %t", err))
-		return "verrazzano_cluster", err //callers can choose to ignore the error
+		return "verrazzano_cluster", err // callers can choose to ignore the error
 	} else if !isVz11OrGreater {
 		Log(Info, "GetClusterNameMetricsLabel: version is less than 1.1.0")
 		// versions < 1.1 use the managed_cluster label not the verrazzano_cluster label

--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -165,8 +165,8 @@ func (e *Elastic) CheckTLSSecret() bool {
 
 // CheckHealth checks the health status of Elasticsearch cluster
 // Returns true if the health status is green otherwise false
-func (e *Elastic) CheckHealth() bool {
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+func (e *Elastic) CheckHealth(kubeconfigPath string) bool {
+	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 		return false
@@ -196,8 +196,8 @@ func (e *Elastic) CheckHealth() bool {
 
 // CheckIndicesHealth checks the health status of indices in a cluster
 // Returns true if the health status of all the indices is green otherwise false
-func (e *Elastic) CheckIndicesHealth() bool {
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+func (e *Elastic) CheckIndicesHealth(kubeconfigPath string) bool {
+	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 		return false
@@ -234,8 +234,8 @@ func (e *Elastic) CheckIndicesHealth() bool {
 	return true
 }
 
-////Check the Elasticsearch certificate
-//func (e *Elastic) CheckCertificate() bool {
+// //Check the Elasticsearch certificate
+// func (e *Elastic) CheckCertificate() bool {
 //	certList, _ := pkg.ListCertificates("verrazzano-system")
 //	for _, cert := range certList.Items {
 //		if cert.Name == fmt.Sprintf("%v-tls", e.binding) {
@@ -249,7 +249,7 @@ func (e *Elastic) CheckIndicesHealth() bool {
 //		}
 //	}
 //	return false
-//}
+// }
 
 // CheckIngress checks the Elasticsearch Ingress
 func (e *Elastic) CheckIngress() bool {

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -6,11 +6,12 @@ package install
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -134,7 +135,7 @@ func isConsoleIngressHost(ingressHost string) bool {
 // isConsoleURLExpected - Returns true in VZ < 1.1.1. For VZ >= 1.1.1, returns false only if explicitly disabled
 // in the CR or when managed cluster profile is used
 func isConsoleURLExpected(kubeconfigPath string) (bool, error) {
-	isAtleastVz111, err := pkg.IsVerrazzanoMinVersion("1.1.1")
+	isAtleastVz111, err := pkg.IsVerrazzanoMinVersion("1.1.1", kubeconfigPath)
 	if err != nil {
 		return false, err
 	}

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -439,7 +440,12 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 			},
 		}
 
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0"); !ok {
+		// Only add the following negative assertion if VZ version supports it.
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			Expect(err).To(BeNil(), fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		}
+		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); !ok {
 			assertions = append(assertions, func() {
 				pkg.Log(pkg.Info, "Negative test verrazzano-operator ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-operator"}}, "verrazzano-system", 8000, false)

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -48,8 +49,15 @@ const (
 var t = framework.NewTestFramework("verify")
 
 var vzcr *vzapi.Verrazzano
+var kubeconfigPath string
 
 var _ = t.BeforeSuite(func() {
+	var err error
+	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+
 	// Get the Verrazzano CR
 	Eventually(func() error {
 		var err error
@@ -68,7 +76,7 @@ var _ = t.Describe("Post upgrade", Label("f:platform-lcm.upgrade"), func() {
 	// GIVEN the verrazzano-system namespace
 	// WHEN the container images are retrieved
 	// THEN verify that each pod that uses istio has the correct istio proxy image
-	t.ItMinimumVersion("pods in verrazzano-system have correct istio proxy image", minimumVersion, func() {
+	t.ItMinimumVersion("pods in verrazzano-system have correct istio proxy image", minimumVersion, kubeconfigPath, func() {
 		Eventually(func() bool {
 			return pkg.CheckPodsForEnvoySidecar(constants.VerrazzanoSystemNamespace, envoyImage)
 		}, fiveMinutes, pollingInterval).Should(BeTrue(), "Expected to find istio proxy image in verrazzano-system")
@@ -77,7 +85,7 @@ var _ = t.Describe("Post upgrade", Label("f:platform-lcm.upgrade"), func() {
 	// GIVEN the ingress-nginx namespace
 	// WHEN the container images are retrieved
 	// THEN verify that each pod that uses istio has the correct istio proxy image
-	t.ItMinimumVersion("pods in ingress-nginx have correct istio proxy image", minimumVersion, func() {
+	t.ItMinimumVersion("pods in ingress-nginx have correct istio proxy image", minimumVersion, kubeconfigPath, func() {
 		Eventually(func() bool {
 			return pkg.CheckPodsForEnvoySidecar(constants.IngressNginxNamespace, envoyImage)
 		}, fiveMinutes, pollingInterval).Should(BeTrue(), "Expected to find istio proxy image in ingress-nginx")
@@ -86,7 +94,7 @@ var _ = t.Describe("Post upgrade", Label("f:platform-lcm.upgrade"), func() {
 	// GIVEN the keycloak namespace
 	// WHEN the container images are retrieved
 	// THEN verify that each pod that uses istio has the correct istio proxy image
-	t.ItMinimumVersion("pods in keycloak have correct istio proxy image", minimumVersion, func() {
+	t.ItMinimumVersion("pods in keycloak have correct istio proxy image", minimumVersion, kubeconfigPath, func() {
 		Eventually(func() bool {
 			return pkg.CheckPodsForEnvoySidecar(constants.KeycloakNamespace, envoyImage)
 		}, fiveMinutes, pollingInterval).Should(BeTrue(), "Expected to find istio proxy image in keycloak")

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -162,7 +162,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 			}
 			Eventually(elasticPodsRunning, waitTimeout, pollingInterval).Should(BeTrue(), "pods did not all show up")
 			Eventually(elasticTLSSecret, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "tls-secret did not show up")
-			//Eventually(elasticCertificate, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "certificate did not show up")
+			// Eventually(elasticCertificate, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "certificate did not show up")
 			Eventually(elasticIngress, elasticWaitTimeout, elasticPollingInterval).Should(BeTrue(), "ingress did not show up")
 			Expect(ingressURLs).To(HaveKey("vmi-system-es-ingest"), "Ingress vmi-system-es-ingest not found")
 			assertOidcIngressByName("vmi-system-es-ingest")
@@ -357,11 +357,21 @@ func elasticConnected() bool {
 }
 
 func elasticHealth() bool {
-	return elastic.CheckHealth()
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		return false
+	}
+	return elastic.CheckHealth(kubeconfigPath)
 }
 
 func elasticIndicesHealth() bool {
-	return elastic.CheckIndicesHealth()
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		return false
+	}
+	return elastic.CheckIndicesHealth(kubeconfigPath)
 }
 
 func elasticTLSSecret() bool {

--- a/tests/e2e/verify-install/kiali/kiali_test.go
+++ b/tests/e2e/verify-install/kiali/kiali_test.go
@@ -43,7 +43,11 @@ var _ = t.BeforeSuite(func() {
 
 // 'It' Wrapper to only run spec if Kiali is supported on the current Verrazzano installation
 func WhenKialiInstalledIt(description string, f interface{}) {
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0")
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -5,6 +5,8 @@ package kubernetes_test
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -12,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const waitTimeout = 15 * time.Minute
@@ -40,8 +41,8 @@ var expectedNonVMIPodsVerrazzanoSystem = []string{
 }
 
 // comment out while debugging so it does not break master
-//"vmi-system-prometheus",
-//"vmi-system-prometheus-gw"}
+// "vmi-system-prometheus",
+// "vmi-system-prometheus-gw"}
 
 var _ = t.AfterEach(func() {})
 
@@ -107,7 +108,7 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 			t.Entry("Check weblogic-operator deployment", "weblogic-operator", pkg.IsWebLogicOperatorEnabled(kubeconfigPath)),
 			t.Entry("Check coherence-operator deployment", "coherence-operator", pkg.IsCoherenceOperatorEnabled(kubeconfigPath)),
 		}
-		if isMinVersion1_3_0, _ := pkg.IsVerrazzanoMinVersion("1.3.0"); !isMinVersion1_3_0 {
+		if isMinVersion1_3_0, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); !isMinVersion1_3_0 {
 			componentsArgs = append(componentsArgs, t.Entry("includes verrazzano-operator", "verrazzano-operator", true))
 		}
 
@@ -183,7 +184,7 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 		t.DescribeTable("VMI components that don't exist in older versions are deployed,",
 			func(name string, expected bool) {
 				Eventually(func() (bool, error) {
-					ok, _ := pkg.IsVerrazzanoMinVersion("1.1.0")
+					ok, _ := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 					if !ok {
 						// skip test
 						fmt.Printf("Skipping Kiali check since version < 1.1.0")
@@ -226,7 +227,7 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 				},
 			}
 
-			if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0"); !ok {
+			if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); !ok {
 				assertions = append(assertions, func() {
 					Eventually(func() bool { return checkPodsRunning("verrazzano-system", []string{"verrazzano-operator"}) }, waitTimeout, pollingInterval).
 						Should(BeTrue())

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -4,11 +4,13 @@
 package verrazzano_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,11 +34,15 @@ var _ = t.AfterEach(func() {})
 
 var _ = t.BeforeSuite(func() {
 	var err error
-	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0")
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}
-	isMinVersion120, err = pkg.IsVerrazzanoMinVersion("1.2.0")
+	isMinVersion120, err = pkg.IsVerrazzanoMinVersion("1.2.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/verify-install/web/nginx_errors_test.go
+++ b/tests/e2e/verify-install/web/nginx_errors_test.go
@@ -27,8 +27,7 @@ const (
 
 var _ = t.Describe("nginx error pages", Label("f:mesh.ingress", "f:mesh.traffic-mgmt"), func() {
 	t.Context("test that an", func() {
-		var err error
-		kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		}

--- a/tests/e2e/verify-install/web/nginx_errors_test.go
+++ b/tests/e2e/verify-install/web/nginx_errors_test.go
@@ -25,18 +25,13 @@ const (
 	expected401    = "<html>\n<head><title>401 Unauthorized</title></head>\n<body>\n<center><h1>401 Unauthorized</h1></center>\n</body>\n</html>"
 )
 
-var kubeconfigPath string
-
-var _ = t.BeforeSuite(func() {
-	var err error
-	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-	}
-})
-
 var _ = t.Describe("nginx error pages", Label("f:mesh.ingress", "f:mesh.traffic-mgmt"), func() {
 	t.Context("test that an", func() {
+		var err error
+		kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		}
 		t.ItMinimumVersion("Incorrect path returns a 404", minimumVersion, kubeconfigPath, func() {
 			if !pkg.IsManagedClusterProfile() {
 				Eventually(func() (string, error) {

--- a/tests/e2e/verify-install/web/nginx_errors_test.go
+++ b/tests/e2e/verify-install/web/nginx_errors_test.go
@@ -25,9 +25,19 @@ const (
 	expected401    = "<html>\n<head><title>401 Unauthorized</title></head>\n<body>\n<center><h1>401 Unauthorized</h1></center>\n</body>\n</html>"
 )
 
+var kubeconfigPath string
+
+var _ = t.BeforeSuite(func() {
+	var err error
+	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+})
+
 var _ = t.Describe("nginx error pages", Label("f:mesh.ingress", "f:mesh.traffic-mgmt"), func() {
 	t.Context("test that an", func() {
-		t.ItMinimumVersion("Incorrect path returns a 404", minimumVersion, func() {
+		t.ItMinimumVersion("Incorrect path returns a 404", minimumVersion, kubeconfigPath, func() {
 			if !pkg.IsManagedClusterProfile() {
 				Eventually(func() (string, error) {
 					kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
@@ -62,7 +72,7 @@ var _ = t.Describe("nginx error pages", Label("f:mesh.ingress", "f:mesh.traffic-
 			}
 		})
 
-		t.ItMinimumVersion("Incorrect password returns a 401", minimumVersion, func() {
+		t.ItMinimumVersion("Incorrect password returns a 401", minimumVersion, kubeconfigPath, func() {
 			if !pkg.IsManagedClusterProfile() {
 				Eventually(func() (string, error) {
 					kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
@@ -92,7 +102,7 @@ var _ = t.Describe("nginx error pages", Label("f:mesh.ingress", "f:mesh.traffic-
 			}
 		})
 
-		t.ItMinimumVersion("Incorrect host returns a 404", minimumVersion, func() {
+		t.ItMinimumVersion("Incorrect host returns a 404", minimumVersion, kubeconfigPath, func() {
 			if !pkg.IsManagedClusterProfile() && os.Getenv("TEST_ENV") != "ocidns_oke" {
 				Eventually(func() (string, error) {
 					kubeConfigPath, err := k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -55,7 +55,11 @@ var _ = t.BeforeSuite(func() {
 	ingressRules := ingress.Spec.Rules
 	serverURL = fmt.Sprintf("https://%s/", ingressRules[0].Host)
 	var err error
-	isTestSupported, err = pkg.IsVerrazzanoMinVersion("1.1.0")
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	isTestSupported, err = pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}


### PR DESCRIPTION
# Description

Refactor tests to explicitly pass a kubeconfigPath to IsVerrazzanoMinVersion and GetClusterNameMetricsLabel

Fixes VZ-5277

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
