### PR TITLE
VZ-3458 Namespace controller should not be reconciled for kube-system namespace

### DIFF
--- a/application-operator/controllers/namespace/namespace_controller.go
+++ b/application-operator/controllers/namespace/namespace_controller.go
@@ -67,9 +67,9 @@ func (nc *NamespaceController) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == vzconst.KubeSystem {
+	if req.NamespacedName.Name == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
-		log.Infof("Namespace resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
+		log.Infof("Namespace resource %v should not be reconciled, ignoring", req.NamespacedName.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -732,7 +732,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 
 	// create a request and reconcile it
 	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: vzconst.KubeSystem},
+		NamespacedName: types.NamespacedName{Name: vzconst.KubeSystem},
 	}
 	result, err := nc.Reconcile(req)
 


### PR DESCRIPTION
# Description

This is a small change to the namespace controller to not reconcile namespaces with the name kube-system

Fixes VZ-3458

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
