### PR TITLE
VZ-5311  Bug, progress logging skipping old messages

### DIFF
--- a/pkg/log/vzlog/vzlog_test.go
+++ b/pkg/log/vzlog/vzlog_test.go
@@ -45,6 +45,30 @@ func TestLog(t *testing.T) {
 	DeleteLogContext(rKey)
 }
 
+// TestLog2 tests the ProgressLogger function periodic logging
+// GIVEN a ProgressLogger with a frequency of 3 seconds
+// WHEN log is called 5 times in 5 seconds to log the 2 messages
+// THEN ensure that 2 messages are logged twice each
+func TestLog2(t *testing.T) {
+	msg := "test1"
+	msg2 := "test2"
+	logger := fakeLogger{expectedMsg: msg2}
+	const rKey = "testns/test"
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(3)
+
+	// 5 calls to log should result in only 2 log messages being written
+	// since the frequency is 3 secs
+	for i := 0; i < 5; i++ {
+		l.Progress(msg)
+		l.Progress(msg2)
+		time.Sleep(time.Duration(1) * time.Second)
+	}
+	assert.Equal(t, 4, logger.count)
+	assert.Equal(t, logger.expectedMsg, logger.actualMsg)
+	DeleteLogContext(rKey)
+}
+
 // TestLogRepeat tests the ProgressLogger function ignore repeated logs
 // GIVEN a ProgressLogger with a frequency of 2 seconds
 // WHEN log is called 5 times with 1 message and no sleep


### PR DESCRIPTION
Logging a Progress message is ignored if it has been logged previously and a new progress message has been logged.
This is a logic bug in the Verrazzano logger.   The vzlog.go doLog method is putting an old progress message in the trash if a new progress message is logged.  

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
