### PR TITLE
VZ-5236 Reject changes to persistence settings until supported

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -96,6 +96,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 	// generate the MySQl PV overrides
 	kvs, err = generateVolumeSourceOverrides(compContext, kvs)
 	if err != nil {
+		compContext.Log().Error(err)
 		return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 	}
 
@@ -178,9 +179,13 @@ func removeMySQLInitFile(ctx spi.ComponentContext) {
 	}
 }
 
-// generateVolumeSourceOverrides generates the appropriate persistence overrides given the effective CR
+// generateVolumeSourceOverrides generates the appropriate persistence overrides given the component context
 func generateVolumeSourceOverrides(compContext spi.ComponentContext, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
-	effectiveCR := compContext.EffectiveCR()
+	return doGenerateVolumeSourceOverrides(compContext.EffectiveCR(), kvs)
+}
+
+// doGenerateVolumeSourceOverrides generates the appropriate persistence overrides given the effective CR
+func doGenerateVolumeSourceOverrides(effectiveCR *vzapi.Verrazzano, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	var mySQLVolumeSource *v1.VolumeSource
 	if effectiveCR.Spec.Components.Keycloak != nil {
 		mySQLVolumeSource = effectiveCR.Spec.Components.Keycloak.MySQL.VolumeSource
@@ -205,7 +210,7 @@ func generateVolumeSourceOverrides(compContext spi.ComponentContext, kvs []bom.K
 		pvcs := mySQLVolumeSource.PersistentVolumeClaim
 		storageSpec, found := vzconfig.FindVolumeTemplate(pvcs.ClaimName, effectiveCR.Spec.VolumeClaimSpecTemplates)
 		if !found {
-			return kvs, compContext.Log().ErrorfNewErr("Failed, No VolumeClaimTemplate found for %s", pvcs.ClaimName)
+			return kvs, fmt.Errorf("Failed, No VolumeClaimTemplate found for %s", pvcs.ClaimName)
 		}
 		storageClass := storageSpec.StorageClassName
 		if storageClass != nil && len(*storageClass) > 0 {

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component_test.go
@@ -210,7 +210,7 @@ func Test_mysqlComponent_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "PVC to emptyDir in volumeSource",
+			name: "PVC to emptyDir in defaultVolumeSource",
 			old: &vzapi.Verrazzano{
 				Spec: vzapi.VerrazzanoSpec{
 					DefaultVolumeSource: &corev1.VolumeSource{
@@ -228,7 +228,7 @@ func Test_mysqlComponent_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "resize pvc in volumeSource",
+			name: "resize pvc in defaultVolumeSource",
 			old: &vzapi.Verrazzano{
 				Spec: vzapi.VerrazzanoSpec{
 					DefaultVolumeSource: &corev1.VolumeSource{
@@ -270,7 +270,7 @@ func Test_mysqlComponent_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "change storage class in volumeSource",
+			name: "change storage class in defaultVolumeSource",
 			old: &vzapi.Verrazzano{
 				Spec: vzapi.VerrazzanoSpec{
 					DefaultVolumeSource: &corev1.VolumeSource{

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component_test.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysql
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+)
+
+func Test_mysqlComponent_ValidateUpdate(t *testing.T) {
+	var pvc1Gi, _ = resource.ParseQuantity("1Gi")
+	var pvc2Gi, _ = resource.ParseQuantity("2Gi")
+	var storageClass1 = "class1"
+	var storageClass2 = "class2"
+	tests := []struct {
+		name    string
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
+		wantErr bool
+	}{
+		{
+			name:    "no change",
+			old:     &vzapi.Verrazzano{},
+			new:     &vzapi.Verrazzano{},
+			wantErr: false,
+		},
+		{
+			name: "emptyDir to PVC in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "PVC to emptyDir in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "resize pvc in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc1Gi,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc2Gi,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "change storage class in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &storageClass1,
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Keycloak: &vzapi.KeycloakComponent{
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+								},
+							},
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &storageClass2,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "emptyDir to PVC in defaultVolumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "PVC to emptyDir in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "resize pvc in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc1Gi,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc2Gi,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "change storage class in volumeSource",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &storageClass1,
+							},
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql"},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &storageClass2,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -456,7 +456,7 @@ func (f fakeComponent) Name() string {
 }
 
 func (f fakeComponent) GetJSONName() string {
-	return f.GetJSONName()
+	return f.name
 }
 
 func (f fakeComponent) GetDependencies() []string {


### PR DESCRIPTION
# Description

Reject any persistence changes that are not supported:
- If the volumeSource or defaultVolumeSource is changed from emptyDir to persistent storage, or vice-versa
- If the requested volume size is different than the current size
- If the storage class is changed

Fixes VZ-5236

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
