### PR TITLE
VZ-5027: followup to not explicity specify label selector for isReady checks

### DIFF
--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -90,7 +89,6 @@ func isApplicationOperatorReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": ComponentName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -83,12 +83,10 @@ func AppendApplicationOperatorOverrides(compContext spi.ComponentContext, _ stri
 
 // isApplicationOperatorReady checks if the application operator deployment is ready
 func isApplicationOperatorReady(ctx spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -38,12 +38,10 @@ func resetWriteFileFunc() {
 
 // isAuthProxyReady checks if the AuthProxy deployment is ready
 func isAuthProxyReady(ctx spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 )
@@ -45,7 +44,6 @@ func isAuthProxyReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": ComponentName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -238,24 +238,18 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 
 // isCertManagerReady checks the state of the expected cert-manager deployments and returns true if they are in a ready state
 func isCertManagerReady(context spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      certManagerDeploymentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      certManagerDeploymentName,
+			Namespace: ComponentNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      cainjectorDeploymentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      cainjectorDeploymentName,
+			Namespace: ComponentNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      webhookDeploymentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      webhookDeploymentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"text/template"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -246,21 +244,18 @@ func isCertManagerReady(context spi.ComponentContext) bool {
 				Name:      certManagerDeploymentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": certManagerDeploymentName}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      cainjectorDeploymentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": "cainjector"}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      webhookDeploymentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": "webhook"}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence.go
@@ -13,12 +13,10 @@ import (
 
 // IsCoherenceOperatorReady checks if the COH operator deployment is ready
 func isCoherenceOperatorReady(ctx spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -20,7 +19,6 @@ func isCoherenceOperatorReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"control-plane": "coherence"}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -15,7 +15,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -89,7 +88,6 @@ func isExternalDNSReady(compContext spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app.kubernetes.io/instance": "external-dns"}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", compContext.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -82,12 +82,10 @@ func preInstall(compContext spi.ComponentContext) error {
 }
 
 func isExternalDNSReady(compContext spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", compContext.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -36,11 +36,11 @@ const ComponentJSONName = "istio"
 // IstiodDeployment is the name of the istiod deployment
 const IstiodDeployment = "istiod"
 
-// IstioInressgatewayDeployment is the name of the istio ingressgateway deployment
-const IstioInressgatewayDeployment = "istio-ingressgateway"
+// IstioIngressgatewayDeployment is the name of the istio ingressgateway deployment
+const IstioIngressgatewayDeployment = "istio-ingressgateway"
 
-// IstioEressgatewayDeployment is the name of the istio egressgateway deployment
-const IstioEressgatewayDeployment = "istio-egressgateway"
+// IstioEgressgatewayDeployment is the name of the istio egressgateway deployment
+const IstioEgressgatewayDeployment = "istio-egressgateway"
 
 const istioGlobalHubKey = "global.hub"
 
@@ -192,11 +192,11 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 			Namespace: IstioNamespace,
 		},
 		{
-			Name:      IstioInressgatewayDeployment,
+			Name:      IstioIngressgatewayDeployment,
 			Namespace: IstioNamespace,
 		},
 		{
-			Name:      IstioEressgatewayDeployment,
+			Name:      IstioEgressgatewayDeployment,
 			Namespace: IstioNamespace,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -186,24 +186,18 @@ func (i istioComponent) Upgrade(context spi.ComponentContext) error {
 }
 
 func (i istioComponent) IsReady(context spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      IstiodDeployment,
-				Namespace: IstioNamespace,
-			},
+			Name:      IstiodDeployment,
+			Namespace: IstioNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      IstioInressgatewayDeployment,
-				Namespace: IstioNamespace,
-			},
+			Name:      IstioInressgatewayDeployment,
+			Namespace: IstioNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      IstioEressgatewayDeployment,
-				Namespace: IstioNamespace,
-			},
+			Name:      IstioEressgatewayDeployment,
+			Namespace: IstioNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -23,7 +23,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -193,21 +192,18 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 				Name:      IstiodDeployment,
 				Namespace: IstioNamespace,
 			},
-			LabelSelector: labels.Set{"app": IstiodDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      IstioInressgatewayDeployment,
 				Namespace: IstioNamespace,
 			},
-			LabelSelector: labels.Set{"app": IstioInressgatewayDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      IstioEressgatewayDeployment,
 				Namespace: IstioNamespace,
 			},
-			LabelSelector: labels.Set{"app": IstioEressgatewayDeployment}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -367,8 +367,8 @@ func TestIsReady(t *testing.T) {
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: IstioNamespace,
-				Name:      IstioInressgatewayDeployment,
-				Labels:    map[string]string{"app": IstioInressgatewayDeployment},
+				Name:      IstioIngressgatewayDeployment,
+				Labels:    map[string]string{"app": IstioIngressgatewayDeployment},
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 1,
@@ -379,8 +379,8 @@ func TestIsReady(t *testing.T) {
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: IstioNamespace,
-				Name:      IstioEressgatewayDeployment,
-				Labels:    map[string]string{"app": IstioEressgatewayDeployment},
+				Name:      IstioEgressgatewayDeployment,
+				Labels:    map[string]string{"app": IstioEgressgatewayDeployment},
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 1,

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -1254,7 +1253,6 @@ func isKeycloakReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app.kubernetes.io/name": ComponentName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1247,12 +1247,10 @@ func isKeycloakReady(ctx spi.ComponentContext) bool {
 		return false
 	}
 
-	statefulset := []status.PodReadyCheck{
+	statefulset := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -32,12 +32,10 @@ const (
 
 // isKialiReady checks if the Kiali deployment is ready
 func isKialiReady(ctx spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      kialiSystemName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      kialiSystemName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -18,7 +18,6 @@ import (
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
@@ -39,7 +38,6 @@ func isKialiReady(ctx spi.ComponentContext) bool {
 				Name:      kialiSystemName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": kialiSystemName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -39,12 +39,10 @@ const (
 
 // isMySQLReady checks to see if the MySQL component is in ready state
 func isMySQLReady(context spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -22,7 +22,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
@@ -46,7 +45,6 @@ func isMySQLReady(context spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": ComponentName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -31,18 +31,14 @@ const (
 )
 
 func isNginxReady(context spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ControllerName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ControllerName,
+			Namespace: ComponentNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      backendName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      backendName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -17,7 +17,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,14 +37,12 @@ func isNginxReady(context spi.ComponentContext) bool {
 				Name:      ControllerName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app.kubernetes.io/component": "controller"}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      backendName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app.kubernetes.io/component": "default-backend"}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -13,12 +13,10 @@ import (
 
 // isOAMReady checks if the OAM operator deployment is ready
 func isOAMReady(context spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -20,7 +19,6 @@ func isOAMReady(context spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app.kubernetes.io/name": "oam-kubernetes-runtime"}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -11,7 +11,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -80,42 +79,36 @@ func isRancherReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": ComponentName}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      rancherWebhookDeployment,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": rancherWebhookDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      rancherOperatorDeployment,
 				Namespace: OperatorNamespace,
 			},
-			LabelSelector: labels.Set{"app": rancherOperatorDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      fleetAgentDeployment,
 				Namespace: fleetSystemNamespace,
 			},
-			LabelSelector: labels.Set{"app": fleetAgentDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      fleetControllerDeployment,
 				Namespace: fleetSystemNamespace,
 			},
-			LabelSelector: labels.Set{"app": fleetControllerDeployment}.AsSelector(),
 		},
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      gitjobDeployment,
 				Namespace: fleetSystemNamespace,
 			},
-			LabelSelector: labels.Set{"app": gitjobDeployment}.AsSelector(),
 		},
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -73,42 +73,30 @@ func getRancherHostname(c client.Client, vz *vzapi.Verrazzano) (string, error) {
 func isRancherReady(ctx spi.ComponentContext) bool {
 	log := ctx.Log()
 	c := ctx.Client()
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      rancherWebhookDeployment,
-				Namespace: ComponentNamespace,
-			},
+			Name:      rancherWebhookDeployment,
+			Namespace: ComponentNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      rancherOperatorDeployment,
-				Namespace: OperatorNamespace,
-			},
+			Name:      rancherOperatorDeployment,
+			Namespace: OperatorNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      fleetAgentDeployment,
-				Namespace: fleetSystemNamespace,
-			},
+			Name:      fleetAgentDeployment,
+			Namespace: fleetSystemNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      fleetControllerDeployment,
-				Namespace: fleetSystemNamespace,
-			},
+			Name:      fleetControllerDeployment,
+			Namespace: fleetSystemNamespace,
 		},
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      gitjobDeployment,
-				Namespace: fleetSystemNamespace,
-			},
+			Name:      gitjobDeployment,
+			Namespace: fleetSystemNamespace,
 		},
 	}
 

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -28,7 +28,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,7 +94,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      verrazzanoConsoleDeployment,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"app": verrazzanoConsoleDeployment}.AsSelector(),
 			})
 	}
 	if vzconfig.IsVMOEnabled(ctx.EffectiveCR()) {
@@ -105,7 +103,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      vmoDeployment,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"k8s-app": vmoDeployment}.AsSelector(),
 			})
 	}
 	if vzconfig.IsGrafanaEnabled(ctx.EffectiveCR()) {
@@ -115,7 +112,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      grafanaDeployment,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"app": "system-grafana"}.AsSelector(),
 			})
 	}
 	if vzconfig.IsKibanaEnabled(ctx.EffectiveCR()) {
@@ -125,7 +121,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      kibanaDeployment,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"app": "system-kibana"}.AsSelector(),
 			})
 	}
 	if vzconfig.IsPrometheusEnabled(ctx.EffectiveCR()) {
@@ -135,7 +130,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      prometheusDeployment,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"app": "system-prometheus"}.AsSelector(),
 			})
 	}
 	if vzconfig.IsElasticsearchEnabled(ctx.EffectiveCR()) {
@@ -151,7 +145,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 									Name:      fmt.Sprintf("%s-%d", esDataDeployment, i),
 									Namespace: ComponentNamespace,
 								},
-								LabelSelector: labels.Set{"app": "system-es-data", "index": fmt.Sprintf("%d", i)}.AsSelector(),
 							})
 					}
 					continue
@@ -165,7 +158,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 									Name:      esIngestDeployment,
 									Namespace: ComponentNamespace,
 								},
-								LabelSelector: labels.Set{"app": "system-es-ingest"}.AsSelector(),
 							})
 					}
 				}
@@ -192,7 +184,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 									Name:      esMasterStatefulset,
 									Namespace: ComponentNamespace,
 								},
-								LabelSelector: labels.Set{"app": "system-es-master"}.AsSelector(),
 							})
 						if !status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulsets, 1, prefix) {
 							return false
@@ -213,7 +204,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      nodeExporterDaemonset,
 					Namespace: globalconst.VerrazzanoMonitoringNamespace,
 				},
-				LabelSelector: labels.Set{"app": nodeExporterDaemonset}.AsSelector(),
 			})
 	}
 	if vzconfig.IsFluentdEnabled(ctx.EffectiveCR()) && getProfile(ctx.EffectiveCR()) != vzapi.ManagedCluster {
@@ -223,7 +213,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					Name:      fluentDaemonset,
 					Namespace: ComponentNamespace,
 				},
-				LabelSelector: labels.Set{"app": fluentDaemonset}.AsSelector(),
 			})
 	}
 	if !status.DaemonSetsAreReady(ctx.Log(), ctx.Client(), daemonsets, 1, prefix) {

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -86,50 +86,40 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
 
 	// First, check deployments
-	var deployments []status.PodReadyCheck
+	var deployments []types.NamespacedName
 	if vzconfig.IsConsoleEnabled(ctx.EffectiveCR()) {
 		deployments = append(deployments,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      verrazzanoConsoleDeployment,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      verrazzanoConsoleDeployment,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if vzconfig.IsVMOEnabled(ctx.EffectiveCR()) {
 		deployments = append(deployments,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      vmoDeployment,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      vmoDeployment,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if vzconfig.IsGrafanaEnabled(ctx.EffectiveCR()) {
 		deployments = append(deployments,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      grafanaDeployment,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      grafanaDeployment,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if vzconfig.IsKibanaEnabled(ctx.EffectiveCR()) {
 		deployments = append(deployments,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      kibanaDeployment,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      kibanaDeployment,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if vzconfig.IsPrometheusEnabled(ctx.EffectiveCR()) {
 		deployments = append(deployments,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      prometheusDeployment,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      prometheusDeployment,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if vzconfig.IsElasticsearchEnabled(ctx.EffectiveCR()) {
@@ -140,11 +130,9 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					replicas, _ := strconv.Atoi(args.Value)
 					for i := 0; replicas > 0 && i < replicas; i++ {
 						deployments = append(deployments,
-							status.PodReadyCheck{
-								NamespacedName: types.NamespacedName{
-									Name:      fmt.Sprintf("%s-%d", esDataDeployment, i),
-									Namespace: ComponentNamespace,
-								},
+							types.NamespacedName{
+								Name:      fmt.Sprintf("%s-%d", esDataDeployment, i),
+								Namespace: ComponentNamespace,
 							})
 					}
 					continue
@@ -153,11 +141,9 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 					replicas, _ := strconv.Atoi(args.Value)
 					if replicas > 0 {
 						deployments = append(deployments,
-							status.PodReadyCheck{
-								NamespacedName: types.NamespacedName{
-									Name:      esIngestDeployment,
-									Namespace: ComponentNamespace,
-								},
+							types.NamespacedName{
+								Name:      esIngestDeployment,
+								Namespace: ComponentNamespace,
 							})
 					}
 				}
@@ -175,15 +161,13 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 			esInstallArgs := ctx.EffectiveCR().Spec.Components.Elasticsearch.ESInstallArgs
 			for _, args := range esInstallArgs {
 				if args.Name == "nodes.master.replicas" {
-					var statefulsets []status.PodReadyCheck
+					var statefulsets []types.NamespacedName
 					replicas, _ := strconv.Atoi(args.Value)
 					if replicas > 0 {
 						statefulsets = append(statefulsets,
-							status.PodReadyCheck{
-								NamespacedName: types.NamespacedName{
-									Name:      esMasterStatefulset,
-									Namespace: ComponentNamespace,
-								},
+							types.NamespacedName{
+								Name:      esMasterStatefulset,
+								Namespace: ComponentNamespace,
 							})
 						if !status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulsets, 1, prefix) {
 							return false
@@ -196,23 +180,19 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 	}
 
 	// Finally, check daemonsets
-	var daemonsets []status.PodReadyCheck
+	var daemonsets []types.NamespacedName
 	if vzconfig.IsPrometheusEnabled(ctx.EffectiveCR()) {
 		daemonsets = append(daemonsets,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      nodeExporterDaemonset,
-					Namespace: globalconst.VerrazzanoMonitoringNamespace,
-				},
+			types.NamespacedName{
+				Name:      nodeExporterDaemonset,
+				Namespace: globalconst.VerrazzanoMonitoringNamespace,
 			})
 	}
 	if vzconfig.IsFluentdEnabled(ctx.EffectiveCR()) && getProfile(ctx.EffectiveCR()) != vzapi.ManagedCluster {
 		daemonsets = append(daemonsets,
-			status.PodReadyCheck{
-				NamespacedName: types.NamespacedName{
-					Name:      fluentDaemonset,
-					Namespace: ComponentNamespace,
-				},
+			types.NamespacedName{
+				Name:      fluentDaemonset,
+				Namespace: ComponentNamespace,
 			})
 	}
 	if !status.DaemonSetsAreReady(ctx.Log(), ctx.Client(), daemonsets, 1, prefix) {

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
@@ -72,12 +72,10 @@ func WeblogicOperatorPreInstall(ctx spi.ComponentContext, _ string, namespace st
 }
 
 func isWeblogicOperatorReady(ctx spi.ComponentContext) bool {
-	deployments := []status.PodReadyCheck{
+	deployments := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      ComponentName,
-				Namespace: ComponentNamespace,
-			},
+			Name:      ComponentName,
+			Namespace: ComponentNamespace,
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -79,7 +78,6 @@ func isWeblogicOperatorReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			},
-			LabelSelector: labels.Set{"app": ComponentName}.AsSelector(),
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())

--- a/platform-operator/internal/k8s/status/daemonset_ready.go
+++ b/platform-operator/internal/k8s/status/daemonset_ready.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/internal/k8s/status/daemonset_ready.go
+++ b/platform-operator/internal/k8s/status/daemonset_ready.go
@@ -18,49 +18,49 @@ import (
 )
 
 // DaemonSetsAreReady Check that the named daemonsets have the minimum number of specified nodes ready and available
-func DaemonSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, checks []PodReadyCheck, expectedNodes int32, prefix string) bool {
-	for _, check := range checks {
+func DaemonSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, namespacedNames []types.NamespacedName, expectedNodes int32, prefix string) bool {
+	for _, namespacedName := range namespacedNames {
 		daemonset := appsv1.DaemonSet{}
-		if err := client.Get(context.TODO(), check.NamespacedName, &daemonset); err != nil {
+		if err := client.Get(context.TODO(), namespacedName, &daemonset); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s is waiting for daemonsets %v to exist", prefix, check.NamespacedName)
+				log.Progressf("%s is waiting for daemonsets %v to exist", prefix, namespacedName)
 				// StatefulSet not found
 				return false
 			}
-			log.Errorf("Failed getting daemonset %v: %v", check.NamespacedName, err)
+			log.Errorf("Failed getting daemonset %v: %v", namespacedName, err)
 			return false
 		}
 		if daemonset.Status.UpdatedNumberScheduled < expectedNodes {
-			log.Progressf("%s is waiting for daemonset %s nodes to be %v. Current updated nodes is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for daemonset %s nodes to be %v. Current updated nodes is %v", prefix, namespacedName,
 				expectedNodes, daemonset.Status.NumberAvailable)
 			return false
 		}
 
 		if daemonset.Status.NumberAvailable < expectedNodes {
-			log.Progressf("%s is waiting for daemonset %s nodes to be %v. Current available nodes is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for daemonset %s nodes to be %v. Current available nodes is %v", prefix, namespacedName,
 				expectedNodes, daemonset.Status.NumberAvailable)
 			return false
 		}
-		if !podsReadyDaemonSet(log, client, check, daemonset.Spec.Selector, expectedNodes, prefix) {
+		if !podsReadyDaemonSet(log, client, namespacedName, daemonset.Spec.Selector, expectedNodes, prefix) {
 			return false
 		}
-		log.Oncef("%s has enough nodes for daemonsets %v", prefix, check.NamespacedName)
+		log.Oncef("%s has enough nodes for daemonsets %v", prefix, namespacedName)
 	}
 	return true
 }
 
 // podsReadyDaemonSet checks for an expected number of pods to be using the latest controllerRevision resource and are
 // running and ready
-func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector, expectedNodes int32, prefix string) bool {
+func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedNodes int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := getPodsList(log, client, check, selector)
+	pods := getPodsList(log, client, namespacedName, selector)
 	if pods == nil {
 		return false
 	}
 
 	// If no pods found log a progress message and return
 	if len(pods.Items) == 0 {
-		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, check.NamespacedName.Namespace)
+		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, namespacedName.Namespace)
 		return true
 	}
 
@@ -82,10 +82,10 @@ func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client clipkg.Client, check 
 
 		// Get the controllerRevision resource for the pod given the controller-revision-hash label
 		var cr appsv1.ControllerRevision
-		crName := fmt.Sprintf("%s-%s", check.NamespacedName.Name, pod.Labels[controllerRevisionHashLabel])
-		err := client.Get(context.TODO(), types.NamespacedName{Namespace: check.NamespacedName.Namespace, Name: crName}, &cr)
+		crName := fmt.Sprintf("%s-%s", namespacedName.Name, pod.Labels[controllerRevisionHashLabel])
+		err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespacedName.Namespace, Name: crName}, &cr)
 		if err != nil {
-			log.Errorf("Failed to get controllerRevision %s: %v", check.NamespacedName, err)
+			log.Errorf("Failed to get controllerRevision %s: %v", namespacedName, err)
 			return false
 		}
 
@@ -104,7 +104,7 @@ func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client clipkg.Client, check 
 	}
 
 	if podsReady < expectedNodes {
-		log.Progressf("%s is waiting for daemonset %s pods to be %v. Current available pods are %v", prefix, check.NamespacedName,
+		log.Progressf("%s is waiting for daemonset %s pods to be %v. Current available pods are %v", prefix, namespacedName,
 			expectedNodes, podsReady)
 		return false
 	}

--- a/platform-operator/internal/k8s/status/daemonset_ready_test.go
+++ b/platform-operator/internal/k8s/status/daemonset_ready_test.go
@@ -6,12 +6,10 @@ package status
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
@@ -21,10 +19,18 @@ import (
 
 func TestDaemonSetsReady(t *testing.T) {
 
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	enoughReplicas := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: selector,
 		},
 		Status: appsv1.DaemonSetStatus{
 			NumberAvailable:        1,
@@ -36,6 +42,9 @@ func TestDaemonSetsReady(t *testing.T) {
 			Name:      "foo",
 			Namespace: "bar",
 		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: selector,
+		},
 		Status: appsv1.DaemonSetStatus{
 			NumberAvailable:        2,
 			UpdatedNumberScheduled: 2,
@@ -46,6 +55,9 @@ func TestDaemonSetsReady(t *testing.T) {
 			Name:      "foo",
 			Namespace: "bar",
 		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: selector,
+		},
 		Status: appsv1.DaemonSetStatus{
 			NumberAvailable:        0,
 			UpdatedNumberScheduled: 1,
@@ -55,6 +67,9 @@ func TestDaemonSetsReady(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: selector,
 		},
 		Status: appsv1.DaemonSetStatus{
 			NumberAvailable:        1,
@@ -144,7 +159,6 @@ func TestDaemonSetsReady(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 

--- a/platform-operator/internal/k8s/status/daemonset_ready_test.go
+++ b/platform-operator/internal/k8s/status/daemonset_ready_test.go
@@ -153,96 +153,94 @@ func TestDaemonSetsReady(t *testing.T) {
 		Revision: 1,
 	}
 
-	podCheckValid := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 
 	var tests = []struct {
 		name     string
 		c        client.Client
-		n        []PodReadyCheck
+		n        []types.NamespacedName
 		ready    bool
 		expected int32
 	}{
 		{
 			"should be ready when daemonset has enough replicas and pod is ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			true,
 			1,
 		},
 		{
 			"should be ready when daemonset has enough replicas and one pod of two pods is ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicasMultiple, notReadyContainerPod, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			true,
 			1,
 		},
 		{
 			"should be not ready when expected pods ready not reached",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicasMultiple, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			2,
 		},
 		{
 			"should be not ready when daemonset has enough replicas but pod init container pods is not ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, notReadyInitContainerPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when daemonset has enough replicas but pod container pods is not ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, notReadyContainerPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when daemonset not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when controller-revision-hash label not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, noPodHashLabel),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when controllerrevision resource not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, readyPod),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when daemonset doesn't have enough ready replicas",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, notEnoughReadyReplicas),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when daemonset doesn't have enough updated replicas",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, notEnoughUpdatedReplicas),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be ready when no PodReadyCheck provided",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme),
-			[]PodReadyCheck{},
+			[]types.NamespacedName{},
 			true,
 			1,
 		},

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 	"strconv"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +39,7 @@ func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, check
 				expectedReplicas, deployment.Status.AvailableReplicas)
 			return false
 		}
-		if !podsReadyDeployment(log, client, check, expectedReplicas, prefix) {
+		if !podsReadyDeployment(log, client, check, deployment.Spec.Selector, expectedReplicas, prefix) {
 			return false
 		}
 		log.Oncef("%s has enough replicas for deployment %v", prefix, check.NamespacedName)
@@ -47,16 +49,16 @@ func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, check
 
 // podsReadyDeployment checks for an expected number of pods to be using the latest replicaset revision and are
 // running and ready
-func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, expectedReplicas int32, prefix string) bool {
+func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := getPodsList(log, client, check)
+	pods := getPodsList(log, client, check, selector)
 	if pods == nil {
 		return false
 	}
 
 	// If no pods found log a progress message and return
 	if len(pods.Items) == 0 {
-		log.Progressf("Found no pods with matching labels selector %v for namespace %s", check.LabelSelector, check.NamespacedName.Namespace)
+		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, check.NamespacedName.Namespace)
 		return true
 	}
 

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -17,47 +17,47 @@ import (
 )
 
 // DeploymentsAreReady check that the named deployments have the minimum number of specified replicas ready and available
-func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, checks []PodReadyCheck, expectedReplicas int32, prefix string) bool {
-	for _, check := range checks {
+func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedNames []types.NamespacedName, expectedReplicas int32, prefix string) bool {
+	for _, namespacedName := range namespacedNames {
 		deployment := appsv1.Deployment{}
-		if err := client.Get(context.TODO(), check.NamespacedName, &deployment); err != nil {
+		if err := client.Get(context.TODO(), namespacedName, &deployment); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s is waiting for deployment %v to exist", prefix, check.NamespacedName)
+				log.Progressf("%s is waiting for deployment %v to exist", prefix, namespacedName)
 				return false
 			}
-			log.Errorf("%s failed getting deployment %v: %v", prefix, check.NamespacedName, err)
+			log.Errorf("%s failed getting deployment %v: %v", prefix, namespacedName, err)
 			return false
 		}
 		if deployment.Status.UpdatedReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for deployment %s replicas to be %v. Current updated replicas is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for deployment %s replicas to be %v. Current updated replicas is %v", prefix, namespacedName,
 				expectedReplicas, deployment.Status.UpdatedReplicas)
 			return false
 		}
 		if deployment.Status.AvailableReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for deployment %s replicas to be %v. Current available replicas is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for deployment %s replicas to be %v. Current available replicas is %v", prefix, namespacedName,
 				expectedReplicas, deployment.Status.AvailableReplicas)
 			return false
 		}
-		if !podsReadyDeployment(log, client, check, deployment.Spec.Selector, expectedReplicas, prefix) {
+		if !podsReadyDeployment(log, client, namespacedName, deployment.Spec.Selector, expectedReplicas, prefix) {
 			return false
 		}
-		log.Oncef("%s has enough replicas for deployment %v", prefix, check.NamespacedName)
+		log.Oncef("%s has enough replicas for deployment %v", prefix, namespacedName)
 	}
 	return true
 }
 
 // podsReadyDeployment checks for an expected number of pods to be using the latest replicaset revision and are
 // running and ready
-func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
+func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := getPodsList(log, client, check, selector)
+	pods := getPodsList(log, client, namespacedName, selector)
 	if pods == nil {
 		return false
 	}
 
 	// If no pods found log a progress message and return
 	if len(pods.Items) == 0 {
-		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, check.NamespacedName.Namespace)
+		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, namespacedName.Namespace)
 		return true
 	}
 
@@ -79,10 +79,10 @@ func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, check
 
 		// Get the replica set for the pod given the pod-template-hash label
 		var rs appsv1.ReplicaSet
-		rsName := fmt.Sprintf("%s-%s", check.NamespacedName.Name, pod.Labels[podTemplateHashLabel])
-		err := client.Get(context.TODO(), types.NamespacedName{Namespace: check.NamespacedName.Namespace, Name: rsName}, &rs)
+		rsName := fmt.Sprintf("%s-%s", namespacedName.Name, pod.Labels[podTemplateHashLabel])
+		err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespacedName.Namespace, Name: rsName}, &rs)
 		if err != nil {
-			log.Errorf("Failed to get replicaset %s: %v", check.NamespacedName, err)
+			log.Errorf("Failed to get replicaset %s: %v", namespacedName, err)
 			return false
 		}
 
@@ -108,7 +108,7 @@ func podsReadyDeployment(log vzlog.VerrazzanoLogger, client clipkg.Client, check
 	}
 
 	if podsReady < expectedReplicas {
-		log.Progressf("%s is waiting for deployment %s pods to be %v. Current available pods are %v", prefix, check.NamespacedName,
+		log.Progressf("%s is waiting for deployment %s pods to be %v. Current available pods are %v", prefix, namespacedName,
 			expectedReplicas, podsReady)
 		return false
 	}

--- a/platform-operator/internal/k8s/status/deployment_ready_test.go
+++ b/platform-operator/internal/k8s/status/deployment_ready_test.go
@@ -10,7 +10,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -27,7 +26,6 @@ func TestDeploymentsReady(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -80,13 +78,17 @@ func TestDeploymentsReady(t *testing.T) {
 // WHEN the target Deployment object has a minimum of number of containers ready
 // THEN false is returned
 func TestDeploymentsContainerNotReady(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	checks := []PodReadyCheck{
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -94,6 +96,9 @@ func TestDeploymentsContainerNotReady(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: selector,
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 1,
@@ -134,13 +139,17 @@ func TestDeploymentsContainerNotReady(t *testing.T) {
 // WHEN the target Deployment object has a minimum of number of init containers ready
 // THEN false is returned
 func TestDeploymentsInitContainerNotReady(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	checks := []PodReadyCheck{
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -148,6 +157,9 @@ func TestDeploymentsInitContainerNotReady(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: selector,
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 1,
@@ -194,7 +206,6 @@ func TestMultipleReplicasReady(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -265,7 +276,6 @@ func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -384,13 +394,17 @@ func TestDeploymentsNoneUpdated(t *testing.T) {
 // WHEN the target Deployment object has less than the minimum desired replicas available
 // THEN false is returned
 func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	checks := []PodReadyCheck{
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -398,6 +412,9 @@ func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: selector,
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 3,
@@ -455,13 +472,17 @@ func TestDeploymentsReadyDeploymentNotFound(t *testing.T) {
 // WHEN the target ReplicaSet object is not found
 // THEN false is returned
 func TestDeploymentsReadyReplicaSetNotFound(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	checks := []PodReadyCheck{
 		{
 			NamespacedName: types.NamespacedName{
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -469,6 +490,9 @@ func TestDeploymentsReadyReplicaSetNotFound(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: selector,
 			},
 			Status: appsv1.DeploymentStatus{
 				AvailableReplicas: 1,

--- a/platform-operator/internal/k8s/status/deployment_ready_test.go
+++ b/platform-operator/internal/k8s/status/deployment_ready_test.go
@@ -20,12 +20,10 @@ import (
 // WHEN the target Deployment object has a minimum of desired available replicas
 // THEN true is returned
 func TestDeploymentsReady(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -70,7 +68,7 @@ func TestDeploymentsReady(t *testing.T) {
 			},
 		},
 	)
-	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestDeploymentsContainerNotReady tests a deployment ready status check
@@ -83,12 +81,10 @@ func TestDeploymentsContainerNotReady(t *testing.T) {
 			"app": "foo",
 		},
 	}
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -131,7 +127,7 @@ func TestDeploymentsContainerNotReady(t *testing.T) {
 			},
 		},
 	)
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestDeploymentsInitContainerNotReady tests a deployment ready status check
@@ -144,12 +140,10 @@ func TestDeploymentsInitContainerNotReady(t *testing.T) {
 			"app": "foo",
 		},
 	}
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -192,7 +186,7 @@ func TestDeploymentsInitContainerNotReady(t *testing.T) {
 			},
 		},
 	)
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestMultipleReplicasReady tests a deployment ready status check
@@ -200,12 +194,10 @@ func TestDeploymentsInitContainerNotReady(t *testing.T) {
 // WHEN the target Deployment object has met the minimum of desired available replicas > 1
 // THEN true is returned
 func TestMultipleReplicasReady(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -262,7 +254,7 @@ func TestMultipleReplicasReady(t *testing.T) {
 			},
 		},
 	)
-	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 2, ""))
+	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 2, ""))
 }
 
 // TestMultipleReplicasReadyAboveThreshold tests a deployment ready status check
@@ -270,12 +262,10 @@ func TestMultipleReplicasReady(t *testing.T) {
 // WHEN the target Deployment object has more than the minimum desired replicas available
 // THEN true is returned
 func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -332,7 +322,7 @@ func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
 			},
 		},
 	)
-	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.True(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestDeploymentsNoneAvailable tests a deployment ready status check
@@ -340,12 +330,10 @@ func TestMultipleReplicasReadyAboveThreshold(t *testing.T) {
 // WHEN the target Deployment object does not have a minimum number of desired available replicas
 // THEN false is returned
 func TestDeploymentsNoneAvailable(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
@@ -359,7 +347,7 @@ func TestDeploymentsNoneAvailable(t *testing.T) {
 			UpdatedReplicas:   1,
 		},
 	})
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestDeploymentsNoneUpdated tests a deployment ready status check
@@ -367,12 +355,10 @@ func TestDeploymentsNoneAvailable(t *testing.T) {
 // WHEN the target Deployment object does not have a minimum number of desired updated replicas
 // THEN false is returned
 func TestDeploymentsNoneUpdated(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &appsv1.Deployment{
@@ -386,7 +372,7 @@ func TestDeploymentsNoneUpdated(t *testing.T) {
 			UpdatedReplicas:   0,
 		},
 	})
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestMultipleReplicasReadyBelowThreshold tests a deployment ready status check
@@ -399,12 +385,10 @@ func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
 			"app": "foo",
 		},
 	}
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -447,7 +431,7 @@ func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
 			},
 		},
 	)
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 3, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 3, ""))
 }
 
 // TestDeploymentsReadyDeploymentNotFound tests a deployment ready status check
@@ -455,16 +439,14 @@ func TestMultipleReplicasReadyBelowThreshold(t *testing.T) {
 // WHEN the target Deployment object is not found
 // THEN false is returned
 func TestDeploymentsReadyDeploymentNotFound(t *testing.T) {
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme)
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }
 
 // TestDeploymentsReadyReplicaSetNotFound tests a deployment ready status check
@@ -477,12 +459,10 @@ func TestDeploymentsReadyReplicaSetNotFound(t *testing.T) {
 			"app": "foo",
 		},
 	}
-	checks := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
@@ -518,5 +498,5 @@ func TestDeploymentsReadyReplicaSetNotFound(t *testing.T) {
 			},
 		},
 	)
-	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, checks, 1, ""))
+	assert.False(t, DeploymentsAreReady(vzlog.DefaultLogger(), client, namespacedName, 1, ""))
 }

--- a/platform-operator/internal/k8s/status/pod_ready.go
+++ b/platform-operator/internal/k8s/status/pod_ready.go
@@ -6,10 +6,9 @@ package status
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/platform-operator/internal/k8s/status/pod_ready.go
+++ b/platform-operator/internal/k8s/status/pod_ready.go
@@ -22,22 +22,18 @@ const podTemplateHashLabel = "pod-template-hash"
 // annotation used to identify the revision of a replicaset
 const deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
 
-type PodReadyCheck struct {
-	NamespacedName types.NamespacedName
-}
-
 // getPodsList retrieves a list of pods for a given namespace and labels selector
-func getPodsList(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector) *corev1.PodList {
+func getPodsList(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector) *corev1.PodList {
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		log.Errorf("Failed to convert LabelSelector %v for %v: %v", selector, check.NamespacedName, err)
+		log.Errorf("Failed to convert LabelSelector %v for %v: %v", selector, namespacedName, err)
 		return nil
 	}
 	var pods corev1.PodList
 	err = client.List(context.TODO(), &pods,
-		&clipkg.ListOptions{Namespace: check.NamespacedName.Namespace, LabelSelector: labelSelector})
+		&clipkg.ListOptions{Namespace: namespacedName.Namespace, LabelSelector: labelSelector})
 	if err != nil {
-		log.Errorf("Failed listing pods in namespace %s: %v", check.NamespacedName.Namespace, err)
+		log.Errorf("Failed listing pods in namespace %s: %v", namespacedName.Namespace, err)
 		return nil
 	}
 

--- a/platform-operator/internal/k8s/status/pod_ready.go
+++ b/platform-operator/internal/k8s/status/pod_ready.go
@@ -30,7 +30,7 @@ type PodReadyCheck struct {
 func getPodsList(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector) *corev1.PodList {
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		log.Errorf("Failed to convert LabelSelector: %v", check.NamespacedName.Namespace, err)
+		log.Errorf("Failed to convert LabelSelector %v for %v: %v", selector, check.NamespacedName, err)
 		return nil
 	}
 	var pods corev1.PodList

--- a/platform-operator/internal/k8s/status/statefulset_ready.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready.go
@@ -17,48 +17,48 @@ import (
 )
 
 // StatefulSetsAreReady Check that the named statefulsets have the minimum number of specified replicas ready and available
-func StatefulSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, checks []PodReadyCheck, expectedReplicas int32, prefix string) bool {
-	for _, check := range checks {
+func StatefulSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, namespacedNames []types.NamespacedName, expectedReplicas int32, prefix string) bool {
+	for _, namespacedName := range namespacedNames {
 		statefulset := appsv1.StatefulSet{}
-		if err := client.Get(context.TODO(), check.NamespacedName, &statefulset); err != nil {
+		if err := client.Get(context.TODO(), namespacedName, &statefulset); err != nil {
 			if errors.IsNotFound(err) {
-				log.Progressf("%s is waiting for statefulset %v to exist", prefix, check.NamespacedName)
+				log.Progressf("%s is waiting for statefulset %v to exist", prefix, namespacedName)
 				// StatefulSet not found
 				return false
 			}
-			log.Errorf("Failed getting statefulset %v: %v", check.NamespacedName, err)
+			log.Errorf("Failed getting statefulset %v: %v", namespacedName, err)
 			return false
 		}
 		if statefulset.Status.UpdatedReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for statefulset %s replicas to be %v. Current updated replicas is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for statefulset %s replicas to be %v. Current updated replicas is %v", prefix, namespacedName,
 				expectedReplicas, statefulset.Status.ReadyReplicas)
 			return false
 		}
 		if statefulset.Status.ReadyReplicas < expectedReplicas {
-			log.Progressf("%s is waiting for statefulset %s replicas to be %v. Current ready replicas is %v", prefix, check.NamespacedName,
+			log.Progressf("%s is waiting for statefulset %s replicas to be %v. Current ready replicas is %v", prefix, namespacedName,
 				expectedReplicas, statefulset.Status.ReadyReplicas)
 			return false
 		}
-		if !podsReadyStatefulSet(log, client, check, statefulset.Spec.Selector, expectedReplicas, prefix) {
+		if !podsReadyStatefulSet(log, client, namespacedName, statefulset.Spec.Selector, expectedReplicas, prefix) {
 			return false
 		}
-		log.Oncef("%s has enough replicas for statefulsets %v", prefix, check.NamespacedName)
+		log.Oncef("%s has enough replicas for statefulsets %v", prefix, namespacedName)
 	}
 	return true
 }
 
 // podsReadyStatefulSet checks for an expected number of pods to be using the latest controllerRevision resource and are
 // running and ready
-func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client clipkg.Client, check PodReadyCheck, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
+func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := getPodsList(log, client, check, selector)
+	pods := getPodsList(log, client, namespacedName, selector)
 	if pods == nil {
 		return false
 	}
 
 	// If no pods found log a progress message and return
 	if len(pods.Items) == 0 {
-		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, check.NamespacedName.Namespace)
+		log.Progressf("Found no pods with matching labels selector %v for namespace %s", selector, namespacedName.Namespace)
 		return true
 	}
 
@@ -80,9 +80,9 @@ func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client clipkg.Client, chec
 
 		// Get the controllerRevision resource for the pod given the controller-revision-hash label
 		var cr appsv1.ControllerRevision
-		err := client.Get(context.TODO(), types.NamespacedName{Namespace: check.NamespacedName.Namespace, Name: pod.Labels[controllerRevisionHashLabel]}, &cr)
+		err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespacedName.Namespace, Name: pod.Labels[controllerRevisionHashLabel]}, &cr)
 		if err != nil {
-			log.Errorf("Failed to get controllerRevision %s: %v", check.NamespacedName, err)
+			log.Errorf("Failed to get controllerRevision %s: %v", namespacedName, err)
 			return false
 		}
 
@@ -101,7 +101,7 @@ func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client clipkg.Client, chec
 	}
 
 	if podsReady < expectedReplicas {
-		log.Progressf("%s is waiting for statefulset %s pods to be %v. Current available pods are %v", prefix, check.NamespacedName,
+		log.Progressf("%s is waiting for statefulset %s pods to be %v. Current available pods are %v", prefix, namespacedName,
 			expectedReplicas, podsReady)
 		return false
 	}

--- a/platform-operator/internal/k8s/status/statefulset_ready.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready.go
@@ -6,12 +6,11 @@ package status
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/internal/k8s/status/statefulset_ready_test.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready_test.go
@@ -6,13 +6,11 @@ package status
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/internal/k8s/status/statefulset_ready_test.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready_test.go
@@ -6,8 +6,6 @@ package status
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	corev1 "k8s.io/api/core/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,10 +21,18 @@ import (
 
 func TestStatefulsetReady(t *testing.T) {
 
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "foo",
+		},
+	}
 	enoughReplicas := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: selector,
 		},
 		Status: appsv1.StatefulSetStatus{
 			ReadyReplicas:   1,
@@ -38,6 +44,9 @@ func TestStatefulsetReady(t *testing.T) {
 			Name:      "foo",
 			Namespace: "bar",
 		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: selector,
+		},
 		Status: appsv1.StatefulSetStatus{
 			ReadyReplicas:   2,
 			UpdatedReplicas: 2,
@@ -48,6 +57,9 @@ func TestStatefulsetReady(t *testing.T) {
 			Name:      "foo",
 			Namespace: "bar",
 		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: selector,
+		},
 		Status: appsv1.StatefulSetStatus{
 			ReadyReplicas:   0,
 			UpdatedReplicas: 1,
@@ -57,6 +69,9 @@ func TestStatefulsetReady(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: selector,
 		},
 		Status: appsv1.StatefulSetStatus{
 			ReadyReplicas:   1,
@@ -146,7 +161,6 @@ func TestStatefulsetReady(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			LabelSelector: labels.Set{"app": "foo"}.AsSelector(),
 		},
 	}
 

--- a/platform-operator/internal/k8s/status/statefulset_ready_test.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready_test.go
@@ -153,96 +153,94 @@ func TestStatefulsetReady(t *testing.T) {
 		Revision: 1,
 	}
 
-	podCheckValid := []PodReadyCheck{
+	namespacedName := []types.NamespacedName{
 		{
-			NamespacedName: types.NamespacedName{
-				Name:      "foo",
-				Namespace: "bar",
-			},
+			Name:      "foo",
+			Namespace: "bar",
 		},
 	}
 
 	var tests = []struct {
 		name     string
 		c        client.Client
-		n        []PodReadyCheck
+		n        []types.NamespacedName
 		ready    bool
 		expected int32
 	}{
 		{
 			"should be ready when statefulset has enough replicas and pod is ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			true,
 			1,
 		},
 		{
 			"should be ready when statefulset has enough replicas and one pod of two pods is ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicasMultiple, notReadyContainerPod, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			true,
 			1,
 		},
 		{
 			"should be not ready when expected pods ready not reached",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicasMultiple, readyPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			2,
 		},
 		{
 			"should be not ready when statefulset has enough replicas but pod init container pods is not ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, notReadyInitContainerPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when statefulset has enough replicas but pod container pods is not ready",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, notReadyContainerPod, controllerRevision),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when statefulset not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when controller-revision-hash label not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, noPodHashLabel),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when controllerrevision resource not found",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, enoughReplicas, readyPod),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when statefulset doesn't have enough ready replicas",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, notEnoughReadyReplicas),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be not ready when statefulset doesn't have enough updated replicas",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme, notEnoughUpdatedReplicas),
-			podCheckValid,
+			namespacedName,
 			false,
 			1,
 		},
 		{
 			"should be ready when no PodReadyCheck provided",
 			fake.NewFakeClientWithScheme(k8scheme.Scheme),
-			[]PodReadyCheck{},
+			[]types.NamespacedName{},
 			true,
 			1,
 		},


### PR DESCRIPTION
# Description

This pull request is a followup pull request to remove the need to explicitly specify a label selector for is ready checking.  The label selector is retrieved from the workload resource instead.  Also, removed the use of the PodReadyCheck type that is not needed.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
