### PR TITLE
VZ-5254 only restart apps if they have the old Istio sidecar proxy

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -143,7 +143,7 @@ func startDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, wlNam
 
 // RestartAllApps restarts all the applications
 func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
-	log.Progressf("RestartApps: restarting all apps")
+	log.Progressf("Restarting all OAM applications that have an old Istio proxy sidecar")
 
 	// Get the latest Istio proxy image name from the bom
 	istioProxyImage, err := getIstioProxyImageFromBom()
@@ -165,7 +165,7 @@ func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVer
 
 	// check each app config to see if any of the pods have old Istio proxy images
 	for _, appConfig := range appConfigs.Items {
-		log.Debugf("RestartApps: found appConfig %s", appConfig.Name)
+		log.Oncef("Checking OAM Application %s pods for an old Istio proxy sidecar", appConfig.Name)
 
 		// Get the pods for this appconfig
 		appConfNameReq, _ := labels.NewRequirement("app.oam.dev/name", selection.Equals, []string{appConfig.Name})
@@ -181,7 +181,7 @@ func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVer
 			continue
 		}
 
-		log.Oncef("Restarting OAM Application %s which has a pod with an old Istio proxy %s", appConfig.Name, oldImage)
+		log.Oncef("Restarting OAM Application %s which has a pod with an old Istio proxy sidecar %s", appConfig.Name, oldImage)
 
 		// Set the update the restart version
 		var ac oam.ApplicationConfiguration
@@ -191,7 +191,7 @@ func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVer
 			if ac.ObjectMeta.Annotations == nil {
 				ac.ObjectMeta.Annotations = make(map[string]string)
 			}
-			log.Progressf("RestartApps: setting restart version for appconfig %s to %s ...  Old version is %s", appConfig.Name,
+			log.Progressf("Setting restart version for appconfig %s to %s. Previous version is %s", appConfig.Name,
 				restartVersion, ac.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
 			ac.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
 			return nil

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -67,7 +67,7 @@ func stopDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, appCon
 	// Get the pods using the label selector
 	podList, err := goClient.CoreV1().Pods(appConfig.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return log.ErrorfNewErr("Failed to list pods for Domain %s in namespace %s: %v", wlName, appConfig.Namespace, err)
+		return log.ErrorfNewErr("Failed to list pods for Domain %s/%s: %v", appConfig.Namespace, wlName, err)
 	}
 
 	// Check if any pods contain the old Istio proxy image
@@ -177,6 +177,9 @@ func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVer
 
 		// Get the pods using the label selector
 		podList, err := goClient.CoreV1().Pods(appConfig.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+		if err != nil {
+			return log.ErrorfNewErr("Failed to list pods for AppConfig %s/%s: %v", appConfig.Namespace, appConfig.Name, err)
+		}
 
 		// Check if any pods contain the old Istio proxy image
 		found, oldImage := doesPodContainOldIstioSidecar(podList, istioProxyImage)

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -24,7 +24,7 @@ func StopDomainsUsingOldEnvoy(log vzlog.VerrazzanoLogger, client clipkg.Client) 
 	// Get the latest Istio proxy image name from the bom
 	istioProxyImage, err := getIstioProxyImageFromBom()
 	if err != nil {
-		return log.ErrorfNewErr("Restart components cannot find Istio proxy image in BOM: %v", err)
+		return log.ErrorfNewErr("Failed, restart components cannot find Istio proxy image in BOM: %v", err)
 	}
 
 	// get all the app configs
@@ -66,6 +66,9 @@ func stopDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, appCon
 
 	// Get the pods using the label selector
 	podList, err := goClient.CoreV1().Pods(appConfig.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return log.ErrorfNewErr("Failed to list pods for Domain %s in namespace %s: %v", wlName, appConfig.Namespace, err)
+	}
 
 	// Check if any pods contain the old Istio proxy image
 	found, oldImage := doesPodContainOldIstioSidecar(podList, istioProxyImage)
@@ -148,7 +151,7 @@ func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVer
 	// Get the latest Istio proxy image name from the bom
 	istioProxyImage, err := getIstioProxyImageFromBom()
 	if err != nil {
-		return log.ErrorfNewErr("Restart components cannot find Istio proxy image in BOM: %v", err)
+		return log.ErrorfNewErr("Failed, restart components cannot find Istio proxy image in BOM: %v", err)
 	}
 
 	// get the go client so we can bypass the cache and get directly from etcd

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -5,13 +5,14 @@ package istio
 
 import (
 	"context"
-	"strings"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +21,12 @@ import (
 
 // StopDomainsUsingOldEnvoy stops all the WebLogic domains using Envoy 1.7.3
 func StopDomainsUsingOldEnvoy(log vzlog.VerrazzanoLogger, client clipkg.Client) error {
+	// Get the latest Istio proxy image name from the bom
+	istioProxyImage, err := getIstioProxyImageFromBom()
+	if err != nil {
+		return log.ErrorfNewErr("Restart components cannot find Istio proxy image in BOM: %v", err)
+	}
+
 	// get all the app configs
 	appConfigs := oam.ApplicationConfigurationList{}
 	if err := client.List(context.TODO(), &appConfigs, &clipkg.ListOptions{}); err != nil {
@@ -31,7 +38,7 @@ func StopDomainsUsingOldEnvoy(log vzlog.VerrazzanoLogger, client clipkg.Client) 
 		log.Debugf("StopWebLogicApps: found appConfig %s", appConfig.Name)
 		for _, wl := range appConfig.Status.Workloads {
 			if wl.Reference.Kind == vzconst.VerrazzanoWebLogicWorkloadKind {
-				if err := stopDomainIfNeeded(log, client, appConfig, wl.Reference.Name); err != nil {
+				if err := stopDomainIfNeeded(log, client, appConfig, wl.Reference.Name, istioProxyImage); err != nil {
 					return err
 				}
 			}
@@ -40,9 +47,15 @@ func StopDomainsUsingOldEnvoy(log vzlog.VerrazzanoLogger, client clipkg.Client) 
 	return nil
 }
 
-// Determine if the WebLogic operator needs to be stopped, if so then stop it
-func stopDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, appConfig oam.ApplicationConfiguration, wlName string) error {
+// Determine if the WebLogic domain needs to be stopped, if so then stop it
+func stopDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, appConfig oam.ApplicationConfiguration, wlName string, istioProxyImage string) error {
 	log.Progressf("StopWebLogicApps: checking if domain for workload %s needs to be stopped", wlName)
+
+	// Get the go client so we can bypass the cache and get directly from etcd
+	goClient, err := k8sutil.GetGoClient(log)
+	if err != nil {
+		return err
+	}
 
 	// Get the domain pods for this workload
 	weblogicReq, _ := labels.NewRequirement("verrazzano.io/workload-type", selection.Equals, []string{"weblogic"})
@@ -51,26 +64,17 @@ func stopDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, appCon
 	selector := labels.NewSelector()
 	selector = selector.Add(*weblogicReq).Add(*compReq).Add(*appConfNameReq)
 
-	var podList corev1.PodList
-	if err := client.List(context.TODO(), &podList, &clipkg.ListOptions{Namespace: appConfig.Namespace, LabelSelector: selector}); err != nil {
-		return err
+	// Get the pods using the label selector
+	podList, err := goClient.CoreV1().Pods(appConfig.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+
+	// Check if any pods contain the old Istio proxy image
+	found, oldImage := doesPodContainOldIstioSidecar(podList, istioProxyImage)
+	if !found {
+		return nil
 	}
 
-	// If any pod is using Isito 1.7.3 then stop the domain and return
-	for _, pod := range podList.Items {
-		log.Debugf("StopWebLogicApps: found pod %s in namespace %s ", pod.Name, pod.Namespace)
-		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "proxyv2:1.7.3") {
-				log.Progressf("StopWebLogicApps: stopping domain for workload %s ", wlName)
-				err := stopDomain(client, appConfig.Namespace, wlName)
-				if err != nil {
-					return log.ErrorfNewErr("Failed annotating VerrazzanoWebLogicWorkload %s to stop the domain: %v", wlName, err)
-				}
-				return err
-			}
-		}
-	}
-	return nil
+	log.Oncef("Restarting OAM WebLogic Domain %s which has a pod with an old Istio proxy %s", wlName, oldImage)
+	return stopDomain(client, appConfig.Namespace, wlName)
 }
 
 // Stop the WebLogic domain
@@ -141,20 +145,49 @@ func startDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, wlNam
 func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
 	log.Progressf("RestartApps: restarting all apps")
 
+	// Get the latest Istio proxy image name from the bom
+	istioProxyImage, err := getIstioProxyImageFromBom()
+	if err != nil {
+		return log.ErrorfNewErr("Restart components cannot find Istio proxy image in BOM: %v", err)
+	}
+
+	// get the go client so we can bypass the cache and get directly from etcd
+	goClient, err := k8sutil.GetGoClient(log)
+	if err != nil {
+		return err
+	}
+
 	// get all the app configs
 	appConfigs := oam.ApplicationConfigurationList{}
 	if err := client.List(context.TODO(), &appConfigs, &clipkg.ListOptions{}); err != nil {
 		return log.ErrorfNewErr("Failed to listing appConfigs %v", err)
 	}
 
+	// check each app config to see if any of the pods have old Istio proxy images
 	for _, appConfig := range appConfigs.Items {
 		log.Debugf("RestartApps: found appConfig %s", appConfig.Name)
+
+		// Get the pods for this appconfig
+		appConfNameReq, _ := labels.NewRequirement("app.oam.dev/name", selection.Equals, []string{appConfig.Name})
+		selector := labels.NewSelector()
+		selector = selector.Add(*appConfNameReq)
+
+		// Get the pods using the label selector
+		podList, err := goClient.CoreV1().Pods(appConfig.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+
+		// Check if any pods contain the old Istio proxy image
+		found, oldImage := doesPodContainOldIstioSidecar(podList, istioProxyImage)
+		if !found {
+			continue
+		}
+
+		log.Oncef("Restarting OAM Application %s which has a pod with an old Istio proxy %s", appConfig.Name, oldImage)
 
 		// Set the update the restart version
 		var ac oam.ApplicationConfiguration
 		ac.Namespace = appConfig.Namespace
 		ac.Name = appConfig.Name
-		_, err := controllerutil.CreateOrUpdate(context.TODO(), client, &ac, func() error {
+		_, err = controllerutil.CreateOrUpdate(context.TODO(), client, &ac, func() error {
 			if ac.ObjectMeta.Annotations == nil {
 				ac.ObjectMeta.Annotations = make(map[string]string)
 			}

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package istio
+
+import (
+	"context"
+	"testing"
+
+	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+
+	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNoRestart(t *testing.T) {
+	asserts := assert.New(t)
+	config.SetDefaultBomFilePath(unitTestBomFile)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	// Setup fake client to provide workloads for restart platform testing
+	clientSet := fake.NewSimpleClientset(initFakePod(oldIstioImage), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
+	k8sutil.SetFakeClient(clientSet)
+
+	StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), getNoAppRestartMock(t))
+
+	namespaces := []string{constants.VerrazzanoSystemNamespace}
+	err := RestartComponents(vzlog.DefaultLogger(), namespaces, 1)
+
+	// Validate the results
+	asserts.NoError(err)
+}
+
+func TestRestartWebLogic(t *testing.T) {
+	asserts := assert.New(t)
+	config.SetDefaultBomFilePath(unitTestBomFile)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	// Setup fake client to provide workloads for restart platform testing
+	clientSet := fake.NewSimpleClientset(initFakePod(oldIstioImage), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
+	k8sutil.SetFakeClient(clientSet)
+
+	StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), getWebLogicAppMock(t, "test", constants.VerrazzanoSystemNamespace))
+
+	namespaces := []string{constants.VerrazzanoSystemNamespace}
+	err := RestartComponents(vzlog.DefaultLogger(), namespaces, 1)
+
+	// Validate the results
+	asserts.NoError(err)
+}
+
+func getNoAppRestartMock(t *testing.T) *mocks.MockClient {
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oam.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		})
+
+	return mock
+}
+
+func getWebLogicAppMock(t *testing.T, name string, namespace string) *mocks.MockClient {
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oam.ApplicationConfigurationList, opts ...client.ListOption) error {
+			appconfig := oam.ApplicationConfiguration{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: oam.ApplicationConfigurationSpec{},
+				Status: oam.ApplicationConfigurationStatus{
+					Workloads: []oam.WorkloadStatus{{
+						Reference: oamrt.TypedReference{
+							Kind: vzconst.VerrazzanoWebLogicWorkloadKind,
+						},
+					}},
+				},
+			}
+
+			list.Items = append(list.Items, appconfig)
+			return nil
+		})
+
+	return mock
+}

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
@@ -34,9 +34,12 @@ type testAppConfigInfo struct {
 
 // TestWebLogicStopStart tests the starting and stopping of WebLogic
 // GIVEN a AppConfig that contains WebLogic workloads
-// WHEN the WebLogic pods have old Istio envoy sidecar, then the domain should be stopped
-// AND WHEN the  WebLogic pods do NOT have an old Istio envoy sidecar, then the domain should NOT be stopped
-// THEN IF the domain was stopped, then it should be started
+// WHEN the WebLogic pods have old Istio envoy sidecar
+// THEN the domain should be stopped
+// WHEN the WebLogic pods do NOT have an old Istio envoy sidecar
+// THEN the domain should NOT be stopped
+// IF the domain was stopped
+// THEN it should be started after upgrade
 func TestWebLogicStopStart(t *testing.T) {
 	asserts := assert.New(t)
 	config.SetDefaultBomFilePath(unitTestBomFile)
@@ -132,9 +135,10 @@ func TestWebLogicStopStart(t *testing.T) {
 
 // TestHelidonStopStart tests the starting and stopping of Helidon
 // GIVEN a AppConfig that contains Helidon workloads
-// WHEN the Helidon pods have old Istio envoy sidecar, then the pods should be restarted
-// AND WHEN the Helidon pods do NOT have old Istio envoy sidecar, then the pods should NOT be restarted
-// THEN IF the domain was stopped, then it should be started
+// WHEN the Helidon pods have old Istio envoy sidecar
+// THEN the pods should be restarted
+// WHEN the Helidon pods do NOT have old Istio envoy sidecar
+// THEN the pods should NOT be restarted
 func TestHelidonStopStart(t *testing.T) {
 	asserts := assert.New(t)
 	config.SetDefaultBomFilePath(unitTestBomFile)

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
@@ -30,7 +30,18 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestNoRestart(t *testing.T) {
+type testAppConfigInfo struct {
+	namespace     string
+	appConfigName string
+	workloadKind  string
+	workloadName  string
+}
+
+// TestDoNotStopWebLogic tests the StopDomainsUsingOldEnvoy method for the following use case
+// GIVEN a request to StopDomainsUsingOldEnvoy
+// WHEN where there are no WebLogic domains with an old Istio sidecar
+// THEN the WebLogic workloads should not be updated with a stop annotation
+func TestDoNotStopWebLogic(t *testing.T) {
 	asserts := assert.New(t)
 	config.SetDefaultBomFilePath(unitTestBomFile)
 
@@ -41,15 +52,16 @@ func TestNoRestart(t *testing.T) {
 	clientSet := fake.NewSimpleClientset(initFakePod(oldIstioImage), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
 	k8sutil.SetFakeClient(clientSet)
 
-	StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), getNoAppRestartMock(t))
-
-	namespaces := []string{constants.VerrazzanoSystemNamespace}
-	err := RestartComponents(vzlog.DefaultLogger(), namespaces, 1)
+	err := StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), getNoAppRestartMock(t))
 
 	// Validate the results
 	asserts.NoError(err)
 }
 
+// TestStopWebLogic tests the StopDomainsUsingOldEnvoy method for the following use case
+// GIVEN a request to StopDomainsUsingOldEnvoy
+// WHEN where there are WebLogic domains with an old Istio sidecar
+// THEN the WebLogic workloads should be updated with a stop annotation
 func TestStopWebLogic(t *testing.T) {
 	asserts := assert.New(t)
 	config.SetDefaultBomFilePath(unitTestBomFile)
@@ -69,19 +81,140 @@ func TestStopWebLogic(t *testing.T) {
 	clientSet := fake.NewSimpleClientset(initFakePodWithLabels(oldIstioImage, podLabels), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
 	k8sutil.SetFakeClient(clientSet)
 
-	expectListWebLogicAppConfigs(t, mock, appConfigName, wlName, constants.VerrazzanoSystemNamespace)
+	config := testAppConfigInfo{
+		namespace:     constants.VerrazzanoSystemNamespace,
+		appConfigName: appConfigName,
+		workloadKind:  vzconst.VerrazzanoWebLogicWorkloadKind,
+		workloadName:  wlName,
+	}
+	expectListAppConfigs(t, mock, config)
 	expectGetWebLogicWorkload(t, mock, wlName, "")
 	expectUpdateWebLogicWorkload(t, mock, wlName, vzconst.LifecycleActionStop)
 
-	StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), mock)
-
-	namespaces := []string{constants.VerrazzanoSystemNamespace}
-	err := RestartComponents(vzlog.DefaultLogger(), namespaces, 1)
+	err := StopDomainsUsingOldEnvoy(vzlog.DefaultLogger(), mock)
 
 	// Validate the results
 	asserts.NoError(err)
 }
 
+// TestStartWebLogic tests the StartDomainsStoppedByUpgrade method for the following use case
+// GIVEN a request to StartDomainsStoppedByUpgrade
+// WHEN where there are WebLogic domains were stopped by upgrade
+// THEN the WebLogic workloads should be updated with a start annotation
+func TestStartWebLogic(t *testing.T) {
+	asserts := assert.New(t)
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	// Setup fake client to provide workloads for restart platform testing
+	wlName := "test"
+	appConfigName := "myApp"
+	podLabels := map[string]string{"verrazzano.io/workload-type": "weblogic",
+		"app.oam.dev/component": wlName,
+		"app.oam.dev/name":      appConfigName}
+
+	clientSet := fake.NewSimpleClientset(initFakePodWithLabels(oldIstioImage, podLabels), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
+	k8sutil.SetFakeClient(clientSet)
+
+	config := testAppConfigInfo{
+		namespace:     constants.VerrazzanoSystemNamespace,
+		appConfigName: appConfigName,
+		workloadKind:  vzconst.VerrazzanoWebLogicWorkloadKind,
+		workloadName:  wlName,
+	}
+	expectListAppConfigs(t, mock, config)
+	expectGetWebLogicWorkload(t, mock, wlName, vzconst.LifecycleActionStop)
+	expectUpdateWebLogicWorkload(t, mock, wlName, vzconst.LifecycleActionStart)
+
+	version := "1"
+	err := StartDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, version)
+
+	// Validate the results
+	asserts.NoError(err)
+}
+
+// TestStartWebLogic tests the StartDomainsStoppedByUpgrade method for the following use case
+// GIVEN a request to StartDomainsStoppedByUpgrade
+// WHEN where there are not WebLogic domains were stopped by upgrade
+// THEN the WebLogic workloads should not be updated with a start annotation
+func TestDoNotStartWebLogic(t *testing.T) {
+	asserts := assert.New(t)
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	// Setup fake client to provide workloads for restart platform testing
+	wlName := "test"
+	appConfigName := "myApp"
+	podLabels := map[string]string{"verrazzano.io/workload-type": "weblogic",
+		"app.oam.dev/component": wlName,
+		"app.oam.dev/name":      appConfigName}
+
+	clientSet := fake.NewSimpleClientset(initFakePodWithLabels(oldIstioImage, podLabels), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
+	k8sutil.SetFakeClient(clientSet)
+
+	config := testAppConfigInfo{
+		namespace:     constants.VerrazzanoSystemNamespace,
+		appConfigName: appConfigName,
+		workloadKind:  vzconst.VerrazzanoWebLogicWorkloadKind,
+		workloadName:  wlName,
+	}
+	expectListAppConfigs(t, mock, config)
+	expectGetWebLogicWorkload(t, mock, wlName, "")
+
+	version := "1"
+	err := StartDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, version)
+
+	// Validate the results
+	asserts.NoError(err)
+}
+
+// TestRestartHelidonApps tests the RestartAllApps method for the following use case
+// GIVEN a request to RestartAllApps
+// WHEN where there are Helidon applications
+// THEN the AppConfig should be annotated with a restart version
+func TestRestartHelidonApps(t *testing.T) {
+	asserts := assert.New(t)
+	config.SetDefaultBomFilePath(unitTestBomFile)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+
+	defer config.Set(config.Get())
+	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
+
+	// Setup fake client to provide workloads for restart platform testing
+	wlName := "test"
+	appConfigName := "myApp"
+	podLabels := map[string]string{"verrazzano.io/workload-type": "weblogic",
+		"app.oam.dev/component": wlName,
+		"app.oam.dev/name":      appConfigName}
+
+	clientSet := fake.NewSimpleClientset(initFakePodWithLabels(oldIstioImage, podLabels), initFakeDeployment(), initFakeStatefulSet(), initFakeDaemonSet())
+	k8sutil.SetFakeClient(clientSet)
+
+	config := testAppConfigInfo{
+		namespace:     constants.VerrazzanoSystemNamespace,
+		appConfigName: appConfigName,
+		workloadKind:  vzconst.VerrazzanoHelidonWorkloadKind,
+		workloadName:  wlName,
+	}
+	version := "1"
+	expectListAppConfigs(t, mock, config)
+	expectGetAppConfig(t, mock, appConfigName, vzconst.RestartVersionAnnotation, version)
+	expectUpdateAppConfig(t, mock, vzconst.RestartVersionAnnotation, version)
+
+	err := RestartAllApps(vzlog.DefaultLogger(), mock, version)
+
+	// Validate the results
+	asserts.NoError(err)
+}
 func getNoAppRestartMock(t *testing.T) *mocks.MockClient {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -95,27 +228,50 @@ func getNoAppRestartMock(t *testing.T) *mocks.MockClient {
 	return mock
 }
 
-func expectListWebLogicAppConfigs(_ *testing.T, mock *mocks.MockClient, appConfigName string, wlName string, namespace string) {
+func expectListAppConfigs(_ *testing.T, mock *mocks.MockClient, config testAppConfigInfo) {
 	mock.EXPECT().
 		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, list *oam.ApplicationConfigurationList, opts ...client.ListOption) error {
 			appconfig := oam.ApplicationConfiguration{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      appConfigName,
-					Namespace: namespace,
+					Name:      config.appConfigName,
+					Namespace: config.namespace,
 				},
 				Status: oam.ApplicationConfigurationStatus{
 					Workloads: []oam.WorkloadStatus{{
 						Reference: oamrt.TypedReference{
-							Kind: vzconst.VerrazzanoWebLogicWorkloadKind,
-							Name: wlName,
+							Kind: config.workloadKind,
+							Name: config.workloadName,
 						},
 					}},
 				},
 			}
 
 			list.Items = append(list.Items, appconfig)
+			return nil
+		})
+}
+
+func expectGetAppConfig(_ *testing.T, mock *mocks.MockClient, appConfigName string, annotationKey string, annotationVal string) {
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: appConfigName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, appConfig *oam.ApplicationConfiguration) error {
+			if len(annotationVal) > 0 {
+				appConfig.Annotations = map[string]string{}
+				appConfig.Annotations[annotationKey] = annotationVal
+			}
+			return nil
+		})
+}
+
+func expectUpdateAppConfig(t *testing.T, mock *mocks.MockClient, annotationKey string, annotationVal string) {
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, appConfig *oam.ApplicationConfiguration, opts ...client.UpdateOption) error {
+			if len(annotationVal) > 0 {
+				assert.Equal(t, annotationVal, appConfig.Annotations[annotationKey], "Incorrect Appconfig lifecycle annotation")
+			}
 			return nil
 		})
 }

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	"github.com/golang/mock/gomock"
@@ -27,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gofake "k8s.io/client-go/kubernetes/fake"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -253,6 +256,10 @@ func TestPostUpgrade(t *testing.T) {
 	assert := assert.New(t)
 
 	comp := istioComponent{}
+
+	// Setup fake client to provide workloads for restart platform testing
+	clientSet := gofake.NewSimpleClientset()
+	k8sutil.SetFakeClient(clientSet)
 
 	config.SetDefaultBomFilePath(testBomFilePath)
 	helm.SetCmdRunner(fakeRunner{})

--- a/platform-operator/controllers/verrazzano/component/istio/platform_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/platform_restart.go
@@ -36,7 +36,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 	}
 
 	// Restart all the deployments in the injected system namespaces
-	log.Oncef("Restarting system Deployments that have an old Istio sidecar so that the pods get the new Isio sidecar")
+	log.Oncef("Restarting system Deployments that have an old Istio proxy sidecar so that the pods get the new Isio sidecar")
 	deploymentList, err := goClient.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 		if !vzString.SliceContainsString(namespaces, deployment.Namespace) {
 			continue
 		}
-		log.Oncef("Checking if Deployment %s has a pod with an old Istio sidecar proxy", deployment.Name)
+		log.Oncef("Checking if Deployment %s has a pod with an old Istio proxy sidecar", deployment.Name)
 
 		// Get the pods for this deployment
 		podList, err := getMatchingPods(log, goClient, deployment.Namespace, deployment.Spec.Selector)
@@ -76,7 +76,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 	log.Oncef("Finished restarting system Deployments to pick up the new Isio sidecar")
 
 	// Restart all the StatefulSets in the injected system namespaces
-	log.Oncef("Restarting system StatefulSets that have an old Istio sidecar so that the pods get the new Isio sidecar")
+	log.Oncef("Restarting system StatefulSets that have an old Istio proxy sidecar so that the pods get the new Isio sidecar")
 	statefulSetList, err := goClient.AppsV1().StatefulSets("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 		if !vzString.SliceContainsString(namespaces, sts.Namespace) {
 			continue
 		}
-		log.Oncef("Checking if StatefulSet %s has a pod with an old Istio sidecar proxy", sts.Name)
+		log.Oncef("Checking if StatefulSet %s has a pod with an old Istio proxy sidecar", sts.Name)
 
 		// Get the pods for this StatefulSet
 		podList, err := getMatchingPods(log, goClient, sts.Namespace, sts.Spec.Selector)
@@ -112,7 +112,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 	log.Oncef("Finished restarting system Statefulsets to pick up new Isio sidecar")
 
 	// Restart all the DaemonSets in the injected system namespaces
-	log.Oncef("Restarting system DaemonSets that have an old Istio sidecar so that the pods get the new Isio sidecar")
+	log.Oncef("Restarting system DaemonSets that have an old Istio proxy sidecar so that the pods get the new Isio sidecar")
 	daemonSetList, err := goClient.AppsV1().DaemonSets("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func RestartComponents(log vzlog.VerrazzanoLogger, namespaces []string, generati
 		if !vzString.SliceContainsString(namespaces, daemonSet.Namespace) {
 			continue
 		}
-		log.Oncef("Checking if DaemonSet %s has a pod with an old Istio sidecar proxy", daemonSet.Name)
+		log.Oncef("Checking if DaemonSet %s has a pod with an old Istio proxy sidecar", daemonSet.Name)
 
 		// Get the pods for this DaemonSet
 		podList, err := getMatchingPods(log, goClient, daemonSet.Namespace, daemonSet.Spec.Selector)

--- a/platform-operator/controllers/verrazzano/component/istio/platform_restart_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/platform_restart_test.go
@@ -142,13 +142,18 @@ func initFakeDaemonSet() *appsv1.DaemonSet {
 	}
 }
 
-// initFakePod inits a fake Pod
+// initFakePod inits a fake Pod with specified image
 func initFakePod(image string) *v1.Pod {
+	return initFakePodWithLabels(image, map[string]string{"app": "foo"})
+}
+
+// initFakePodWithLabels inits a fake Pod with specified image and labels
+func initFakePodWithLabels(image string, labels map[string]string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testPod",
 			Namespace: "verrazzano-system",
-			Labels:    map[string]string{"app": "foo"},
+			Labels:    labels,
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{


### PR DESCRIPTION
During upgrade, if Verrazzano installs a new Istio version with a new proxyv2 image, then all apps with the old Istio sidecar must be restarted.  Previously, we always restarted the apps.
Also, make some log messages consistent.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
