### PR TITLE
VZ-5319 Support weblogic-monitoring-exporter in private registry configurations

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -873,7 +873,7 @@ func addDefaultMonitoringExporter(weblogic *unstructured.Unstructured) error {
 func getDefaultMonitoringExporter() (interface{}, error) {
 	// get ImageSetting
 	imageSetting := ""
-	if value, ok := os.LookupEnv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); ok {
+	if value := os.Getenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); len(value) > 0 {
 		imageSetting = fmt.Sprintf("\"image\": \"%s\",\n    ", value)
 	}
 

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -772,7 +772,7 @@ func TestReconcileCreateWebLogicDomainWithCustomLoggingConfigMapExists(t *testin
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
 		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
 
-	os.Setenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE", "my-weblogic-monitoring-exporter:b")
+	os.Setenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE", "")
 	defer os.Unsetenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE")
 
 	// expect call to fetch existing WebLogic Domain
@@ -1692,7 +1692,7 @@ func validateDefaultMonitoringExporter(u *unstructured.Unstructured, t *testing.
 	asserts.Nil(t, err, "Expect no error finding monitoringExporter in WebLogic domain CR")
 	asserts.True(t, found, "Found monitoringExporter in WebLogic domain CR")
 	imageName, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "image")...)
-	if value, ok := os.LookupEnv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); ok {
+	if value := os.Getenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); len(value) > 0 {
 		asserts.Equal(t, value, imageName, "monitoringExporter.image should match in WebLogic domain CR")
 	} else {
 		asserts.Equal(t, nil, imageName, "monitoringExporter.image should match in WebLogic domain CR")

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -5,9 +5,11 @@ package wlsworkload
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	oamrt "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core"
@@ -62,6 +64,7 @@ const weblogicDomainWithMonitoringExporter = `
    "spec": {
       "domainUID": "unit-test-domain",
       "monitoringExporter": {
+         "image": "my-weblogic-monitoring-exporter:1.0.0",
          "imagePullPolicy": "IfNotPresent",
          "configuration": {
             "metricsNameSnakeCase": true,
@@ -410,6 +413,9 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	fluentdImage := "unit-test-image:latest"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
 		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
+
+	os.Setenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE", "my-weblogic-monitoring-exporter:a")
+	defer os.Unsetenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE")
 
 	// set the Fluentd image which is obtained via env then reset at end of test
 	initialDefaultFluentdImage := logging.DefaultFluentdImage
@@ -765,6 +771,9 @@ func TestReconcileCreateWebLogicDomainWithCustomLoggingConfigMapExists(t *testin
 	workloadName := "unit-test-verrazzano-weblogic-workload"
 	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
 		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
+
+	os.Setenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE", "my-weblogic-monitoring-exporter:b")
+	defer os.Unsetenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE")
 
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
@@ -1682,6 +1691,12 @@ func validateDefaultMonitoringExporter(u *unstructured.Unstructured, t *testing.
 	_, found, err := unstructured.NestedFieldNoCopy(u.Object, specMonitoringExporterFields...)
 	asserts.Nil(t, err, "Expect no error finding monitoringExporter in WebLogic domain CR")
 	asserts.True(t, found, "Found monitoringExporter in WebLogic domain CR")
+	imageName, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "image")...)
+	if value, ok := os.LookupEnv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); ok {
+		asserts.Equal(t, value, imageName, "monitoringExporter.image should match in WebLogic domain CR")
+	} else {
+		asserts.Equal(t, nil, imageName, "monitoringExporter.image should match in WebLogic domain CR")
+	}
 	imagePullPolicy, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "imagePullPolicy")...)
 	asserts.Equal(t, "IfNotPresent", imagePullPolicy, "monitoringExporter.imagePullPolicy should be IfNotPresent in WebLogic domain CR")
 	domainQualifier, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "domainQualifier")...)
@@ -1700,6 +1715,8 @@ func validateTestMonitoringExporter(u *unstructured.Unstructured, t *testing.T) 
 	_, found, err := unstructured.NestedFieldNoCopy(u.Object, specMonitoringExporterFields...)
 	asserts.Nil(t, err, "Expect no error finding monitoringExporter in WebLogic domain CR")
 	asserts.True(t, found, "Found monitoringExporter in WebLogic domain CR")
+	imageName, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "image")...)
+	asserts.Equal(t, "my-weblogic-monitoring-exporter:1.0.0", imageName, "monitoringExporter.image should match in WebLogic domain CR")
 	imagePullPolicy, _, _ := unstructured.NestedFieldNoCopy(u.Object, append(specMonitoringExporterFields, "imagePullPolicy")...)
 	asserts.Equal(t, "IfNotPresent", imagePullPolicy, "monitoringExporter.imagePullPolicy should be IfNotPresent in WebLogic domain CR")
 	domainQualifier, _, _ := unstructured.NestedBool(u.Object, append(specMonitoringExporterFields, "configuration", "domainQualifier")...)

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -264,9 +264,6 @@ pipeline {
                     # Run the image-helper to load the images into the OCIR registry in the runner's region
                     cd ${TARBALL_DIR}
                     ${TARBALL_DIR}/vz-registry-image-helper.sh -t ${ocirRegistry} -l . -r ${baseImageRepo}
-                    docker rmi phx.ocir.io/stevengreenberginc/verrazzano-private-registry/gz/wls_monitoringexporter/b4/oracle/weblogic-monitoring-exporter:2.0.4
-                    docker pull phx.ocir.io/stevengreenberginc/verrazzano-private-registry/gz/wls_monitoringexporter/b4/oracle/weblogic-monitoring-exporter:2.0.4
-                    docker images | grep exporter
                 """
             }
         }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -264,6 +264,9 @@ pipeline {
                     # Run the image-helper to load the images into the OCIR registry in the runner's region
                     cd ${TARBALL_DIR}
                     ${TARBALL_DIR}/vz-registry-image-helper.sh -t ${ocirRegistry} -l . -r ${baseImageRepo}
+                    docker rmi phx.ocir.io/stevengreenberginc/verrazzano-private-registry/gz/wls_monitoringexporter/b4/oracle/weblogic-monitoring-exporter:2.0.4
+                    docker pull phx.ocir.io/stevengreenberginc/verrazzano-private-registry/gz/wls_monitoringexporter/b4/oracle/weblogic-monitoring-exporter:2.0.4
+                    docker images | grep exporter
                 """
             }
         }

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -76,6 +76,27 @@ func AppendApplicationOperatorOverrides(compContext spi.ComponentContext, _ stri
 		Value: istioProxyImage,
 	})
 
+	// get weblogicMonitoringExporter image
+	var weblogicMonitoringExporterImage string
+	images, err = bomFile.BuildImageOverrides("weblogic-operator")
+	if err != nil {
+		return nil, err
+	}
+	for _, image := range images {
+		if image.Key == "weblogicMonitoringExporterImage" {
+			weblogicMonitoringExporterImage = image.Value
+		}
+	}
+	if len(weblogicMonitoringExporterImage) == 0 {
+		return nil, compContext.Log().ErrorNewErr("Failed to find weblogicMonitoringExporterImage in BOM")
+	}
+
+	// weblogicMonitoringExporterImage for ENV WEBLOGIC_MONITORING_EXPORTER_IMAGE
+	kvs = append(kvs, bom.KeyValue{
+		Key:   "weblogicMonitoringExporterImage",
+		Value: weblogicMonitoringExporterImage,
+	})
+
 	return kvs, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
@@ -35,14 +35,17 @@ func TestAppendAppOperatorOverrides(t *testing.T) {
 
 	const expectedFluentdImage = "ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.12.3-20210517195222-f345ec2"
 	const expectedIstioProxyImage = "ghcr.io/verrazzano/proxyv2:1.7.3"
+	const expectedWeblogicMonitoringExporterImage = "ghcr.io/oracle/weblogic-monitoring-exporter:2.0.4"
 
 	kvs, err := AppendApplicationOperatorOverrides(nil, "", "", "", nil)
 	assert.NoError(err, "AppendApplicationOperatorOverrides returned an error ")
-	assert.Len(kvs, 2, "AppendApplicationOperatorOverrides returned an unexpected number of Key:Value pairs")
+	assert.Len(kvs, 3, "AppendApplicationOperatorOverrides returned an unexpected number of Key:Value pairs")
 	assert.Equalf("fluentdImage", kvs[0].Key, "Did not get expected fluentdImage Key")
 	assert.Equalf(expectedFluentdImage, kvs[0].Value, "Did not get expected fluentdImage Value")
 	assert.Equalf("istioProxyImage", kvs[1].Key, "Did not get expected istioProxyImage Key")
 	assert.Equalf(expectedIstioProxyImage, kvs[1].Value, "Did not get expected istioProxyImage Value")
+	assert.Equalf("weblogicMonitoringExporterImage", kvs[2].Key, "Did not get expected weblogicMonitoringExporterImage Key")
+	assert.Equalf(expectedWeblogicMonitoringExporterImage, kvs[2].Value, "Did not get expected weblogicMonitoringExporterImage Value")
 
 	customImage := "myreg.io/myrepo/v8o/verrazzano-application-operator-dev:local-20210707002801-b7449154"
 	os.Setenv(constants.VerrazzanoAppOperatorImageEnvVar, customImage)
@@ -50,13 +53,15 @@ func TestAppendAppOperatorOverrides(t *testing.T) {
 
 	kvs, err = AppendApplicationOperatorOverrides(nil, "", "", "", nil)
 	assert.NoError(err, "AppendApplicationOperatorOverrides returned an error ")
-	assert.Len(kvs, 3, "AppendApplicationOperatorOverrides returned wrong number of Key:Value pairs")
+	assert.Len(kvs, 4, "AppendApplicationOperatorOverrides returned wrong number of Key:Value pairs")
 	assert.Equalf("image", kvs[0].Key, "Did not get expected image Key")
 	assert.Equalf(customImage, kvs[0].Value, "Did not get expected image Value")
 	assert.Equalf("fluentdImage", kvs[1].Key, "Did not get expected fluentdImage Key")
 	assert.Equalf(expectedFluentdImage, kvs[1].Value, "Did not get expected fluentdImage Value")
 	assert.Equalf("istioProxyImage", kvs[2].Key, "Did not get expected istioProxyImage Key")
 	assert.Equalf(expectedIstioProxyImage, kvs[2].Value, "Did not get expected istioProxyImage Value")
+	assert.Equalf("weblogicMonitoringExporterImage", kvs[3].Key, "Did not get expected weblogicMonitoringExporterImage Key")
+	assert.Equalf(expectedWeblogicMonitoringExporterImage, kvs[3].Value, "Did not get expected weblogicMonitoringExporterImage Value")
 }
 
 // TestIsApplicationOperatorReady tests the isApplicationOperatorReady function

--- a/platform-operator/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/controllers/verrazzano/testdata/test_bom.json
@@ -327,6 +327,11 @@
               "image": "weblogic-kubernetes-operator",
               "tag": "3.2.2",
               "helmFullImageKey": "image"
+            },
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]
         }

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -346,6 +346,8 @@ spec:
               value: {{ .Values.fluentdImage }}
             - name: ISTIO_PROXY_IMAGE
               value: {{ .Values.istioProxyImage }}
+            - name: WEBLOGIC_MONITORING_EXPORTER_IMAGE
+              value: {{ .Values.weblogicMonitoringExporterImage }}
       volumes:
         - name: webhook-certs
           emptyDir: {}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -308,17 +308,6 @@
               "helmFullImageKey": "image"
             }
           ]
-        },
-        {
-          "repository": "oracle",
-          "name": "weblogic-monitoring-exporter",
-          "images": [
-            {
-              "image": "weblogic-monitoring-exporter",
-              "tag": "2.0.4",
-              "helmFullImageKey": "weblogicMonitoringExporterImage"
-            }
-          ]
         }
       ]
     },
@@ -333,6 +322,11 @@
               "image": "weblogic-kubernetes-operator",
               "tag": "3.3.8",
               "helmFullImageKey": "image"
+            },
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]
         }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -308,6 +308,17 @@
               "helmFullImageKey": "image"
             }
           ]
+        },
+        {
+          "repository": "oracle",
+          "name": "weblogic-monitoring-exporter",
+          "images": [
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
+            }
+          ]
         }
       ]
     },

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Create a Docker repository in a specific compartment using an exploded tarball of Verrazzano images; useful for
@@ -176,7 +176,9 @@ function create_image_repos_from_archives() {
 
     # When OCIR_SCAN_TARGET_ID is set, all of the repositories used for scanning are created as private (we only use them for scanning)
     local is_public="false"
-    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] \
+      || [ "$from_image_name" == "fluentd-kubernetes-daemonset" ] || [ "$from_image_name" == "proxyv2" ] \
+      || [ "$from_image_name" == "weblogic-monitoring-exporter" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
       # Rancher repos must be public
       is_public="true"
     fi

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Create a Docker repository in a specific compartment using an exploded tarball of Verrazzano images; useful for
@@ -176,7 +176,7 @@ function create_image_repos_from_archives() {
 
     # When OCIR_SCAN_TARGET_ID is set, all of the repositories used for scanning are created as private (we only use them for scanning)
     local is_public="false"
-    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] || [ "$from_image_name" == "weblogic-monitoring-exporter" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
       # Rancher repos must be public
       is_public="true"
     fi

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Create a Docker repository in a specific compartment using an exploded tarball of Verrazzano images; useful for

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -176,7 +176,7 @@ function create_image_repos_from_archives() {
 
     # When OCIR_SCAN_TARGET_ID is set, all of the repositories used for scanning are created as private (we only use them for scanning)
     local is_public="false"
-    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] || [ "$from_image_name" == "weblogic-monitoring-exporter" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
       # Rancher repos must be public
       is_public="true"
     fi

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -43,6 +43,18 @@ Although most images can be protected using credentials stored in an image pull 
     ```
     $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
     ```
+* The fluentd kubernetes daemonset image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "fluentd-kubernetes-daemonset") | "\(.image):\(.tag)"'
+    ```
+* The istio proxy image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[] |  select(.name == "istiod") | .images[] | select(.image == "proxyv2") | "\(.image):\(.tag)"'
+    ```
+* The WebLogic Monitoring Exporter image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "weblogic-monitoring-exporter") | "\(.image):\(.tag)"'
+    ```
 * The Verrazzano Platform Operator image identified by `$VPO_IMAGE`, as defined above.
 
 ## Install Verrazzano


### PR DESCRIPTION
# Description

- add weblogic-monitoring-exporter image to BOM
-  weblogic-monitoring-exporter image in BOM is passed to VPO as env WEBLOGIC_MONITORING_EXPORTER_IMAGE
- VAO set spec.monitoringExporter.image in domain to the specified WEBLOGIC_MONITORING_EXPORTER_IMAGE; unset spec.monitoringExporter.image for empty WEBLOGIC_MONITORING_EXPORTER_IMAGE, which means WebLogic Monitoring Exporter uses its default image.
- update private registry instruction to add more public images

Fixes VZ-5319

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
