### PR TITLE
VZ-4290 pick up console fix to display SprintBoot application correctly when workload metadata has no namespace

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -242,7 +242,7 @@
             },
             {
               "image": "console",
-              "tag": "1.1.0-20211207211335-65467cb",
+              "tag": "1.1.3-20220318171727-5fef618",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
…ly when workload metadata has no namespace

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
