### PR TITLE
VZ-5050 Remove all Verrazzano Ingresses before uninstall of ExternalDNS

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)

--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -77,6 +77,23 @@ function delete_istio_namepsace() {
   kubectl delete namespace istio-system --ignore-not-found=true || err_return $? "Could not delete namespace istio-system" || return $?
 }
 
+function delete_external_dns() {
+  log "Deleting external-dns"
+
+  # delete all ExternalDNS ingresses before deleting ExternalDNS
+  delete_k8s_resources ingress ":metadata.name,:metadata.annotations" "Could not delete Ingresses managed by ExternalDNS" '/external-dns/ {print $1}' \
+
+  helm ls -n cert-manager \
+    | awk '/external-dns/ {print $1}' \
+    | xargsr helm uninstall -n cert-manager \
+    || err_return $? "Could not delete external-dns from helm" || return $? # return on pipefail
+
+  # delete clusterrole and clusterrolebinding
+  log "Deleting ClusterRoles and ClusterRoleBindings for external-dns"
+  kubectl delete clusterrole external-dns --ignore-not-found=true || err_return $? "Could not delete ClusterRole external-dns" || return $?
+  kubectl delete clusterrolebinding external-dns --ignore-not-found=true || err_return $? "Could not delete ClusterRoleBinding external-dns" || return $?
+}
+
 function finalize() {
   # Removing possible reference to verrazzano in clusterroles and clusterrolebindings
   log "Removing Verrazzano ClusterRoles and ClusterRoleBindings"
@@ -110,4 +127,5 @@ function finalize() {
 action "Deleting Istio Components" uninstall_istio || exit 1
 action "Deleting Istio Secrets" delete_secrets || exit 1
 action "Deleting Istio Namespace" delete_istio_namepsace || exit 1
+action "Deleting External DNS Components" delete_external_dns || exit 1
 action "Finalizing Uninstall" finalize || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -13,23 +13,6 @@ UNINSTALL_DIR=$SCRIPT_DIR/..
 
 set -o pipefail
 
-function delete_external_dns() {
-  log "Deleting external-dns"
-
-  # delete all ExternalDNS ingresses before deleting ExternalDNS
-  delete_k8s_resources ingress ":metadata.name,:metadata.annotations" "Could not delete Ingresses managed by ExternalDNS" '/external-dns/ {print $1}' \
-
-  helm ls -n cert-manager \
-    | awk '/external-dns/ {print $1}' \
-    | xargsr helm uninstall -n cert-manager \
-    || err_return $? "Could not delete external-dns from helm" || return $? # return on pipefail
-
-  # delete clusterrole and clusterrolebinding
-  log "Deleting ClusterRoles and ClusterRoleBindings for external-dns"
-  kubectl delete clusterrole external-dns --ignore-not-found=true || err_return $? "Could not delete ClusterRole external-dns" || return $?
-  kubectl delete clusterrolebinding external-dns --ignore-not-found=true || err_return $? "Could not delete ClusterRoleBinding external-dns" || return $?
-}
-
 function delete_nginx() {
   # uninstall ingress-nginx
   log "Deleting ingress-nginx"
@@ -232,6 +215,5 @@ function delete_rancher() {
 }
 
 action "Deleting Rancher Components" delete_rancher || exit 1
-action "Deleting External DNS Components" delete_external_dns || exit 1
 action "Deleting NGINX Components" delete_nginx || exit 1
 action "Deleting Cert Manager Components" delete_cert_manager || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -15,6 +15,10 @@ set -o pipefail
 
 function delete_external_dns() {
   log "Deleting external-dns"
+
+  # delete all ExternalDNS ingresses before deleting ExternalDNS
+  delete_k8s_resources ingress ":metadata.name,:metadata.annotations" "Could not delete Ingresses managed by ExternalDNS" '/external-dns/ {print $1}' \
+
   helm ls -n cert-manager \
     | awk '/external-dns/ {print $1}' \
     | xargsr helm uninstall -n cert-manager \


### PR DESCRIPTION
# Description
This will remove all the ingress from ExternalDNS so that the DNS records get deleted before ExternalDNS is uninstalled.

Fixes VZ-5050

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
