### PR TITLE
VZ-5373: Update opensearch image with s3 plugin

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -218,7 +218,7 @@
             },
             {
               "image": "opensearch",
-              "tag": "1.2.3-20220225102914-833b159de83",
+              "tag": "1.2.3-20220321223518-c480e8ed25d",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {


### PR DESCRIPTION
Enabled S3 plugin in open-search repository. This image will have the s3 plugin enabled by default which we will be using for backup and restore . 

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
