### PR TITLE
backport VZ-5319 Support weblogic-monitoring-exporter in private registry configurations

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -4,17 +4,20 @@
 package wlsworkload
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"math/big"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+	"text/template"
+
+	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
@@ -61,8 +64,9 @@ const (
 	controllerName                        = "weblogicworkload"
 )
 
-const defaultMonitoringExporterData = `
+const defaultMonitoringExporterTemplate = `
   {
+    {{.ImageSetting}}"imagePullPolicy": "IfNotPresent",
     "configuration": {
       "domainQualifier": true,
       "metricsNameSnakeCase": true,
@@ -169,10 +173,14 @@ const defaultMonitoringExporterData = `
            }
         }
       ]
-    },
-    "imagePullPolicy": "IfNotPresent"
+    }
   }
 `
+
+type defaultMonitoringExporterTemplateData struct {
+	ImageSetting string
+}
+
 const defaultWDTConfigMapData = `
   {
     "resources": {
@@ -863,9 +871,32 @@ func addDefaultMonitoringExporter(weblogic *unstructured.Unstructured) error {
 }
 
 func getDefaultMonitoringExporter() (interface{}, error) {
-	bytes := []byte(defaultMonitoringExporterData)
+	// get ImageSetting
+	imageSetting := ""
+	if value := os.Getenv("WEBLOGIC_MONITORING_EXPORTER_IMAGE"); len(value) > 0 {
+		imageSetting = fmt.Sprintf("\"image\": \"%s\",\n    ", value)
+	}
+
+	// Create the buffer and the cluster issuer data struct
+	templateData := defaultMonitoringExporterTemplateData{
+		ImageSetting: imageSetting,
+	}
+
+	// Parse the template string and create the template object
+	template, err := template.New("defaultMonitoringExporter").Parse(defaultMonitoringExporterTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the template object with the given data
+	var buff bytes.Buffer
+	err = template.Execute(&buff, &templateData)
+	if err != nil {
+		return nil, err
+	}
+
 	var monitoringExporter map[string]interface{}
-	json.Unmarshal(bytes, &monitoringExporter)
+	json.Unmarshal(buff.Bytes(), &monitoringExporter)
 	result, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&monitoringExporter)
 	if err != nil {
 		return nil, err

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -76,6 +76,27 @@ func AppendApplicationOperatorOverrides(compContext spi.ComponentContext, _ stri
 		Value: istioProxyImage,
 	})
 
+	// get weblogicMonitoringExporter image
+	var weblogicMonitoringExporterImage string
+	images, err = bomFile.BuildImageOverrides("weblogic-operator")
+	if err != nil {
+		return nil, err
+	}
+	for _, image := range images {
+		if image.Key == "weblogicMonitoringExporterImage" {
+			weblogicMonitoringExporterImage = image.Value
+		}
+	}
+	if len(weblogicMonitoringExporterImage) == 0 {
+		return nil, compContext.Log().ErrorNewErr("Failed to find weblogicMonitoringExporterImage in BOM")
+	}
+
+	// weblogicMonitoringExporterImage for ENV WEBLOGIC_MONITORING_EXPORTER_IMAGE
+	kvs = append(kvs, bom.KeyValue{
+		Key:   "weblogicMonitoringExporterImage",
+		Value: weblogicMonitoringExporterImage,
+	})
+
 	return kvs, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_test.go
@@ -32,14 +32,17 @@ func TestAppendAppOperatorOverrides(t *testing.T) {
 
 	const expectedFluentdImage = "ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.12.3-20210517195222-f345ec2"
 	const expectedIstioProxyImage = "ghcr.io/verrazzano/proxyv2:1.7.3"
+	const expectedWeblogicMonitoringExporterImage = "ghcr.io/oracle/weblogic-monitoring-exporter:2.0.4"
 
 	kvs, err := AppendApplicationOperatorOverrides(nil, "", "", "", nil)
 	assert.NoError(err, "AppendApplicationOperatorOverrides returned an error ")
-	assert.Len(kvs, 2, "AppendApplicationOperatorOverrides returned an unexpected number of Key:Value pairs")
+	assert.Len(kvs, 3, "AppendApplicationOperatorOverrides returned an unexpected number of Key:Value pairs")
 	assert.Equalf("fluentdImage", kvs[0].Key, "Did not get expected fluentdImage Key")
 	assert.Equalf(expectedFluentdImage, kvs[0].Value, "Did not get expected fluentdImage Value")
 	assert.Equalf("istioProxyImage", kvs[1].Key, "Did not get expected istioProxyImage Key")
 	assert.Equalf(expectedIstioProxyImage, kvs[1].Value, "Did not get expected istioProxyImage Value")
+	assert.Equalf("weblogicMonitoringExporterImage", kvs[2].Key, "Did not get expected weblogicMonitoringExporterImage Key")
+	assert.Equalf(expectedWeblogicMonitoringExporterImage, kvs[2].Value, "Did not get expected weblogicMonitoringExporterImage Value")
 
 	customImage := "myreg.io/myrepo/v8o/verrazzano-application-operator-dev:local-20210707002801-b7449154"
 	os.Setenv(constants.VerrazzanoAppOperatorImageEnvVar, customImage)
@@ -47,13 +50,15 @@ func TestAppendAppOperatorOverrides(t *testing.T) {
 
 	kvs, err = AppendApplicationOperatorOverrides(nil, "", "", "", nil)
 	assert.NoError(err, "AppendApplicationOperatorOverrides returned an error ")
-	assert.Len(kvs, 3, "AppendApplicationOperatorOverrides returned wrong number of Key:Value pairs")
+	assert.Len(kvs, 4, "AppendApplicationOperatorOverrides returned wrong number of Key:Value pairs")
 	assert.Equalf("image", kvs[0].Key, "Did not get expected image Key")
 	assert.Equalf(customImage, kvs[0].Value, "Did not get expected image Value")
 	assert.Equalf("fluentdImage", kvs[1].Key, "Did not get expected fluentdImage Key")
 	assert.Equalf(expectedFluentdImage, kvs[1].Value, "Did not get expected fluentdImage Value")
 	assert.Equalf("istioProxyImage", kvs[2].Key, "Did not get expected istioProxyImage Key")
 	assert.Equalf(expectedIstioProxyImage, kvs[2].Value, "Did not get expected istioProxyImage Value")
+	assert.Equalf("weblogicMonitoringExporterImage", kvs[3].Key, "Did not get expected weblogicMonitoringExporterImage Key")
+	assert.Equalf(expectedWeblogicMonitoringExporterImage, kvs[3].Value, "Did not get expected weblogicMonitoringExporterImage Value")
 }
 
 // TestIsApplicationOperatorReady tests the IsApplicationOperatorReady function

--- a/platform-operator/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/controllers/verrazzano/testdata/test_bom.json
@@ -327,6 +327,11 @@
               "image": "weblogic-kubernetes-operator",
               "tag": "3.2.2",
               "helmFullImageKey": "image"
+            },
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]
         }

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -346,6 +346,8 @@ spec:
               value: {{ .Values.fluentdImage }}
             - name: ISTIO_PROXY_IMAGE
               value: {{ .Values.istioProxyImage }}
+            - name: WEBLOGIC_MONITORING_EXPORTER_IMAGE
+              value: {{ .Values.weblogicMonitoringExporterImage }}
       volumes:
         - name: webhook-certs
           emptyDir: {}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -321,6 +321,11 @@
               "image": "weblogic-kubernetes-operator",
               "tag": "3.3.7",
               "helmFullImageKey": "image"
+            },
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]
         }

--- a/tests/e2e/config/scripts/create_ocir_repositories.sh
+++ b/tests/e2e/config/scripts/create_ocir_repositories.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Create a Docker repository in a specific compartment using an exploded tarball of Verrazzano images; useful for
@@ -176,7 +176,9 @@ function create_image_repos_from_archives() {
 
     # When OCIR_SCAN_TARGET_ID is set, all of the repositories used for scanning are created as private (we only use them for scanning)
     local is_public="false"
-    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
+    if [ "$from_repository" == "rancher" ] || [ "$from_image_name" == "verrazzano-platform-operator" ] \
+      || [ "$from_image_name" == "fluentd-kubernetes-daemonset" ] || [ "$from_image_name" == "proxyv2" ] \
+      || [ "$from_image_name" == "weblogic-monitoring-exporter" ] && [ -z $OCIR_SCAN_TARGET_ID ]; then
       # Rancher repos must be public
       is_public="true"
     fi

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -43,6 +43,18 @@ Although most images can be protected using credentials stored in an image pull 
     ```
     $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
     ```
+* The fluentd kubernetes daemonset image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "fluentd-kubernetes-daemonset") | "\(.image):\(.tag)"'
+    ```
+* The istio proxy image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[] |  select(.name == "istiod") | .images[] | select(.image == "proxyv2") | "\(.image):\(.tag)"'
+    ```
+* The WebLogic Monitoring Exporter image.
+    ```
+    $ cat verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "weblogic-monitoring-exporter") | "\(.image):\(.tag)"'
+    ```
 * The Verrazzano Platform Operator image identified by `$VPO_IMAGE`, as defined above.
 
 ## Install Verrazzano


### PR DESCRIPTION
# Description

Backport https://github.com/verrazzano/verrazzano/pull/2765

Fixes VZ-5319 in release 1.2

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
