### PR TITLE
VZ-5087 Rebuild keycloak config on upgrade using ephemeral storage

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -2,6 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
+def INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
@@ -83,9 +84,7 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
-        INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
-        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
@@ -186,7 +185,7 @@ pipeline {
                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                     OPERATOR_YAML_FILE = "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml"
                     if (params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade")) {
-                        env.INSTALL_CONFIG_FILE_KIND = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
+                        INSTALL_CONFIG_FILE_KIND = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
                     }
                 }
             }

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -2,7 +2,6 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
 def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
@@ -84,7 +83,9 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
+        INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
+        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -186,7 +186,8 @@ pipeline {
                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                     OPERATOR_YAML_FILE = "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml"
                     if (params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade")) {
-                        INSTALL_CONFIG_FILE_KIND = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
+                        echo "Setting INSTALL_CONFIG_FILE_KIND"
+                        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL}"
                     }
                 }
             }

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         choice (name: 'CHAOS_TEST_TYPE',
                 description: 'Type of chaos to inflict',
                 // 1st choice is the default value
-                choices: [ "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed" ])
+                choices: [ "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed", "ephemeral.storage.upgrade" ])
     }
 
     environment {
@@ -83,7 +83,9 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
-        INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml"
+        INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
+        INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
+        INSTALL_CONFIG_FILE = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
@@ -183,6 +185,9 @@ pipeline {
                     currentBuild.description = params.KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_FOR_UPGRADE
                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                     OPERATOR_YAML_FILE = "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml"
+                    if (params.CHAOS_TEST_TYPE == "ephemeral.storage.upgrade") {
+                        env.INSTALL_CONFIG_FILE = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
+                    }
                 }
             }
         }
@@ -209,7 +214,7 @@ pipeline {
                         mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
                         kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano --tail -1 > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log
                         kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
-                        cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
+                        cp ${INSTALL_CONFIG_FILE} ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
                         echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"
@@ -219,7 +224,7 @@ pipeline {
                         VZ_TEST_METRIC = metricJobName('')
                         metricTimerStart("${VZ_TEST_METRIC}")
                     }
-                    archiveArtifacts artifacts: "**/logs/**,${env.INSTALL_CONFIG_FILE_KIND}", allowEmptyArchive: true
+                    archiveArtifacts artifacts: "**/logs/**,${env.INSTALL_CONFIG_FILE}", allowEmptyArchive: true
                 }
             }
         }
@@ -330,7 +335,7 @@ pipeline {
                     echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
                     # Modify the version field in the Verrazzano CR file to be this new Verrazzano version
                     cd ${GO_REPO_PATH}/verrazzano
-                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                    cp ${INSTALL_CONFIG_FILE} ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                     ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                     # Copy upgrade CR where it will be archived
                     cp ${WORKSPACE}/verrazzano-upgrade-cr.yaml ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
         INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
-        INSTALL_CONFIG_FILE = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
+        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
@@ -185,8 +185,8 @@ pipeline {
                     currentBuild.description = params.KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_FOR_UPGRADE
                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                     OPERATOR_YAML_FILE = "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml"
-                    if (params.CHAOS_TEST_TYPE == "ephemeral.storage.upgrade") {
-                        env.INSTALL_CONFIG_FILE = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
+                    if (params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade")) {
+                        env.INSTALL_CONFIG_FILE_KIND = env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL
                     }
                 }
             }
@@ -214,7 +214,7 @@ pipeline {
                         mkdir -p ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
                         kubectl -n verrazzano-install logs --selector=job-name=verrazzano-install-my-verrazzano --tail -1 > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install.log
                         kubectl -n verrazzano-install describe pod --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-install-job-pod.out
-                        cp ${INSTALL_CONFIG_FILE} ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
+                        cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs
                         echo "Verrazzano Installation logs dumped to verrazzano-install.log"
                         echo "Verrazzano Install pod description dumped to verrazzano-install-job-pod.out"
                         echo "------------------------------------------"
@@ -224,7 +224,7 @@ pipeline {
                         VZ_TEST_METRIC = metricJobName('')
                         metricTimerStart("${VZ_TEST_METRIC}")
                     }
-                    archiveArtifacts artifacts: "**/logs/**,${env.INSTALL_CONFIG_FILE}", allowEmptyArchive: true
+                    archiveArtifacts artifacts: "**/logs/**,${env.INSTALL_CONFIG_FILE_KIND}", allowEmptyArchive: true
                 }
             }
         }
@@ -335,7 +335,7 @@ pipeline {
                     echo "Upgrading the Verrazzano installation to version" $VERRAZZANO_DEV_VERSION
                     # Modify the version field in the Verrazzano CR file to be this new Verrazzano version
                     cd ${GO_REPO_PATH}/verrazzano
-                    cp ${INSTALL_CONFIG_FILE} ${WORKSPACE}/verrazzano-upgrade-cr.yaml
+                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                     ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${WORKSPACE}/verrazzano-upgrade-cr.yaml
                     # Copy upgrade CR where it will be archived
                     cp ${WORKSPACE}/verrazzano-upgrade-cr.yaml ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
         INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
-        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
+        INSTALL_CONFIG_FILE_KIND = "${params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade") ? env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL : env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
@@ -185,10 +185,6 @@ pipeline {
                     currentBuild.description = params.KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_FOR_UPGRADE
                     echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
                     OPERATOR_YAML_FILE = "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml"
-                    if (params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade")) {
-                        echo "Setting INSTALL_CONFIG_FILE_KIND"
-                        INSTALL_CONFIG_FILE_KIND = "${env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL}"
-                    }
                 }
             }
         }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -145,6 +145,23 @@ pipeline {
                         }
                     }
                 }
+                stage('Upgrade using ephemeral storage') {
+                    steps {
+                        script {
+                            build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                            string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                            booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
+                                            string(name: 'CHAOS_TEST_TYPE', value: 'ephemeral.storage.upgrade')
+                                    ], wait: true
+                        }
+                    }
+                }
                 stage('Component helm install failure') {
                     steps {
                         script {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1307,7 +1307,7 @@ func rebuildKeycloakConfiguration(ctx spi.ComponentContext) error {
 	err = loginKeycloak(ctx, cfg, cli)
 	if err != nil {
 		pod.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = strconv.Itoa(int(pod.Generation))
-		err = ctx.Client().Update(context.TODO(), &pod)
+		err = ctx.Client().Delete(context.TODO(), &pod)
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1317,7 +1317,7 @@ func checkConfiguration(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// Try getting the Keycloak groups.  If they exist, a configuration exists.
+	// Try getting the Keycloak groups.  If they exist, a configuration exists, no need to recreate.
 	_, err = getKeycloakGroups(ctx)
 	if err == nil {
 		return nil

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -518,7 +518,7 @@ func configureKeycloakRealms(ctx spi.ComponentContext) error {
 
 	// If ephemeral storage is configured, additional steps may be required to
 	// rebuild the configuration lost due to MySQL pod getting restarted.
-	if ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource == nil {
+	if (ctx.EffectiveCR().Spec.Components.Keycloak != nil) && (ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource == nil) {
 		// When the MySQL pod restarts and using ephemeral storage, the
 		// login to Keycloak will fail.  Need to recycle the Keycloak pod
 		// to resolve the condition.

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1298,6 +1298,7 @@ func checkConfiguration(ctx spi.ComponentContext) error {
 		ctx.Log().Progressf("Component Keycloak waiting for pod %s to be ready", pod.Name)
 		return fmt.Errorf("Waiting for pod %s to be ready", pod.Name)
 	}
+	ctx.Log().Infof("Component Keycloak pod %s is ready", pod.Name)
 
 	cfg, cli, err := k8sutil.ClientConfig()
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -682,7 +682,7 @@ func bashCMD(command string) []string {
 func keycloakPod() *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "keycloak-0",
+			Name:      keycloakPodName,
 			Namespace: ComponentNamespace,
 		},
 	}
@@ -786,7 +786,7 @@ func createVerrazzanoUsersGroup(ctx spi.ComponentContext) (string, error) {
 	}
 
 	userGroup := "name=" + vzUsersGroup
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", "groups", "-r", vzSysRealm, "-s", userGroup)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", "groups", "-r", vzSysRealm, "-s", userGroup)
 	ctx.Log().Debugf("createVerrazzanoUsersGroup: Create Verrazzano Users Group Cmd = %s", cmd.String())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -816,7 +816,7 @@ func createVerrazzanoAdminGroup(ctx spi.ComponentContext, userGroupID string) (s
 	}
 	adminGroup := "groups/" + userGroupID + "/children"
 	adminGroupName := "name=" + vzAdminGroup
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", adminGroup, "-r", vzSysRealm, "-s", adminGroupName)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", adminGroup, "-r", vzSysRealm, "-s", adminGroupName)
 	ctx.Log().Debugf("createVerrazzanoAdminGroup: Create Verrazzano Admin Group Cmd = %s", cmd.String())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -846,7 +846,7 @@ func createVerrazzanoMonitorsGroup(ctx spi.ComponentContext, userGroupID string)
 	}
 	monitorGroup := "groups/" + userGroupID + "/children"
 	monitorGroupName := "name=" + vzMonitorGroup
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", monitorGroup, "-r", vzSysRealm, "-s", monitorGroupName)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "create", monitorGroup, "-r", vzSysRealm, "-s", monitorGroupName)
 	ctx.Log().Debugf("createVerrazzanoProjectMonitorsGroup: Create Verrazzano Monitors Group Cmd = %s", cmd.String())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1102,7 +1102,7 @@ func removeLoginConfigFile(ctx spi.ComponentContext, cfg *restclient.Config, cli
 func getKeycloakGroups(ctx spi.ComponentContext) (KeycloakGroups, error) {
 	var keycloakGroups KeycloakGroups
 	// Get the Client ID JSON array
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "groups", "-r", vzSysRealm)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "groups", "-r", vzSysRealm)
 	out, err := cmd.Output()
 	if err != nil {
 		ctx.Log().Errorf("Component Keycloak failed retrieving Groups: %s", err)
@@ -1154,7 +1154,7 @@ func getGroupID(keycloakGroups KeycloakGroups, groupName string) string {
 func getKeycloakRoles(ctx spi.ComponentContext) (KeycloakRoles, error) {
 	var keycloakRoles KeycloakRoles
 	// Get the Client ID JSON array
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get-roles", "-r", vzSysRealm)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get-roles", "-r", vzSysRealm)
 	out, err := cmd.Output()
 	if err != nil {
 		ctx.Log().Errorf("Component Keycloak failed retrieving Roles: %s", err)
@@ -1187,7 +1187,7 @@ func roleExists(keycloakRoles KeycloakRoles, roleName string) bool {
 func getKeycloakUsers(ctx spi.ComponentContext) (KeycloakUsers, error) {
 	var keycloakUsers KeycloakUsers
 	// Get the Client ID JSON array
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "users", "-r", vzSysRealm)
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "users", "-r", vzSysRealm)
 	out, err := cmd.Output()
 	if err != nil {
 		ctx.Log().Errorf("Component Keycloak failed retrieving Users: %s", err)
@@ -1219,7 +1219,7 @@ func userExists(keycloakUsers KeycloakUsers, userName string) bool {
 func getKeycloakClients(ctx spi.ComponentContext) (KeycloakClients, error) {
 	var keycloakClients KeycloakClients
 	// Get the Client ID JSON array
-	cmd := execCommand("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "clients", "-r", "verrazzano-system", "--fields", "id,clientId")
+	cmd := execCommand("kubectl", "exec", keycloakPodName, "-n", ComponentNamespace, "-c", "keycloak", "--", "/opt/jboss/keycloak/bin/kcadm.sh", "get", "clients", "-r", "verrazzano-system", "--fields", "id,clientId")
 	out, err := cmd.Output()
 	if err != nil {
 		ctx.Log().Errorf("Component Keycloak failed retrieving clients: %s", err)
@@ -1278,39 +1278,47 @@ func isKeycloakReady(ctx spi.ComponentContext) bool {
 	return status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulset, 1, prefix)
 }
 
-// rebuildKeycloakConfiguration - rebuild the Keycloak configuration when using ephemeral storage
-// and settings have been lost.  For example, if the MySQL pod restarts the configuration is lost.
-func rebuildKeycloakConfiguration(ctx spi.ComponentContext) error {
+// checkConfiguration - check the Keycloak configuration when using ephemeral storage and if
+// necessary, restore it to the default settings.
+func checkConfiguration(ctx spi.ComponentContext) error {
 	// Skip if using persistent storage
 	if ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource != nil {
+		ctx.Log().Progress("Component Keycloak skipped checking configuration because persistent storage is being used")
 		return nil
 	}
 
-	// Wait for the Keycloak to be ready
-	pod := corev1.Pod{}
-	err := ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: keycloakPodName}, &pod)
+	// Wait for the Keycloak pod to be ready
+	pod := keycloakPod()
+	err := ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, pod)
 	if err != nil {
+		ctx.Log().Errorf("Component Keycloak failed to get pod %s:", pod.Name, err)
 		return err
 	}
 	if !isPodReady(pod) {
-		return fmt.Errorf("Waiting for pod %s to be ready", keycloakPodName)
+		ctx.Log().Progressf("Component Keycloak waiting for pod %s to be ready", pod.Name)
+		return fmt.Errorf("Waiting for pod %s to be ready", pod.Name)
 	}
 
-	// Recycle the Keycloak pod if login fails
 	cfg, cli, err := k8sutil.ClientConfig()
 	if err != nil {
-		return err
-	}
-	// Login to Keycloak
-	err = loginKeycloak(ctx, cfg, cli)
-	if err != nil {
-		// Restart the Keycloak pod when the login fails
-		err = ctx.Client().Delete(context.TODO(), &pod)
+		ctx.Log().Errorf("Component Keycloak failed to create client config: %v", err)
 		return err
 	}
 
-	// Recreate the keycloak realms when using ephemeral storage, the configuration
-	// is lost when the MySQL pod recycles.
+	// When the MySQL pod restarts and using ephemeral storage, the
+	// login to Keycloak will fail.  Need to recycle the Keycloak pod
+	// to resolve the condition.
+	err = loginKeycloak(ctx, cfg, cli)
+	if err != nil {
+		err2 := ctx.Client().Delete(context.TODO(), pod)
+		if err2 != nil {
+			ctx.Log().Errorf("Component Keycloak failed to recycle pod %s: %v", pod.Name, err2)
+		}
+		return err
+	}
+
+	// Recreate the Keycloak configuration if it has been lost.  The configureKeycloakRealms
+	// function will not recreate anything that already exists.
 	err = configureKeycloakRealms(ctx)
 	if err != nil {
 		return err
@@ -1320,7 +1328,7 @@ func rebuildKeycloakConfiguration(ctx spi.ComponentContext) error {
 }
 
 // isPodReady determines if the pod is running by checking for a Ready condition with Status equal True
-func isPodReady(pod v1.Pod) bool {
+func isPodReady(pod *v1.Pod) bool {
 	conditions := pod.Status.Conditions
 	for j := range conditions {
 		if conditions[j].Type == "Ready" && conditions[j].Status == "True" {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package keycloak
 
 import (
@@ -147,13 +148,9 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// Recreate the keycloak realms when using ephemeral storage, the configuration
-	// is lost when the MySQL pod recycles. temp
-	if ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource == nil {
-		err := configureKeycloakRealms(ctx)
-		if err != nil {
-			return err
-		}
+	// Determine if the Keycloak configuration needs to be rebuilt
+	if err := rebuildKeycloakConfiguration(ctx); err != nil {
+		return err
 	}
 
 	return updateKeycloakUris(ctx)

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -68,11 +68,6 @@ func NewComponent() spi.Component {
 	}
 }
 
-func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
-	ctx.Log().Infof("Component %s is reconciling", ComponentName)
-	return nil
-}
-
 func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 	// Check Verrazzano Secret. return error which will cause reque
 	secret := &corev1.Secret{}
@@ -172,6 +167,7 @@ func (c KeycloakComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 
 // IsReady component check
 func (c KeycloakComponent) IsReady(ctx spi.ComponentContext) bool {
+	ctx.Log().Errorf("Component %s checking IsReady", ComponentName)
 	if c.HelmComponent.IsReady(ctx) {
 		return isKeycloakReady(ctx)
 	}

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -146,6 +146,16 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	if err := c.HelmComponent.PostUpgrade(ctx); err != nil {
 		return err
 	}
+
+	// Recreate the keycloak realms when using ephemeral storage, the configuration
+	// is lost when the MySQL pod recycles.
+	if ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource == nil {
+		err := configureKeycloakRealms(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	return updateKeycloakUris(ctx)
 }
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -149,7 +149,7 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	}
 
 	// Determine if the Keycloak configuration needs to be rebuilt
-	if err := rebuildKeycloakConfiguration(ctx); err != nil {
+	if err := checkConfiguration(ctx); err != nil {
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -68,6 +68,11 @@ func NewComponent() spi.Component {
 	}
 }
 
+func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
+	ctx.Log().Infof("Component %s is running Reconcile override", ComponentName)
+	return nil
+}
+
 func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 	// Check Verrazzano Secret. return error which will cause reque
 	secret := &corev1.Secret{}
@@ -167,7 +172,6 @@ func (c KeycloakComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 
 // IsReady component check
 func (c KeycloakComponent) IsReady(ctx spi.ComponentContext) bool {
-	ctx.Log().Errorf("Component %s checking IsReady", ComponentName)
 	if c.HelmComponent.IsReady(ctx) {
 		return isKeycloakReady(ctx)
 	}

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -68,11 +68,6 @@ func NewComponent() spi.Component {
 	}
 }
 
-func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
-	ctx.Log().Infof("Component %s is running Reconcile override", ComponentName)
-	return nil
-}
-
 func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 	// Check Verrazzano Secret. return error which will cause reque
 	secret := &corev1.Secret{}

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -148,7 +148,7 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	}
 
 	// Recreate the keycloak realms when using ephemeral storage, the configuration
-	// is lost when the MySQL pod recycles.
+	// is lost when the MySQL pod recycles. temp
 	if ctx.EffectiveCR().Spec.Components.Keycloak.MySQL.VolumeSource == nil {
 		err := configureKeycloakRealms(ctx)
 		if err != nil {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -68,6 +68,11 @@ func NewComponent() spi.Component {
 	}
 }
 
+func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
+	ctx.Log().Infof("Component %s is reconciling", ComponentName)
+	return nil
+}
+
 func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 	// Check Verrazzano Secret. return error which will cause reque
 	secret := &corev1.Secret{}

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -148,12 +148,7 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// Determine if the Keycloak configuration needs to be rebuilt
-	if err := checkConfiguration(ctx); err != nil {
-		return err
-	}
-
-	return updateKeycloakUris(ctx)
+	return configureKeycloakRealms(ctx)
 }
 
 // IsEnabled Keycloak-specific enabled check for installation

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -10,13 +10,12 @@ import (
 	"os/exec"
 	"testing"
 
-	vzos "github.com/verrazzano/verrazzano/pkg/os"
-
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	k8sutilfake "github.com/verrazzano/verrazzano/pkg/k8sutil/fake"
+	vzos "github.com/verrazzano/verrazzano/pkg/os"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -92,7 +92,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		zap.S().Errorf("Failed to create controller logger for Verrazzano controller: %v", err)
 	}
-	log.Info("MGIANATA entering Reconcile")
 
 	log.Oncef("Reconciling Verrazzano resource %v, generation %v, version %s", req.NamespacedName, vz.Generation, vz.Status.Version)
 	res, err := r.doReconcile(log, vz)
@@ -113,7 +112,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 // doReconcile the Verrazzano CR
 func (r *Reconciler) doReconcile(log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	ctx := context.TODO()
-	log.Info("MGIANATA entering doReconcile")
 
 	// Initialize once for this Verrazzano resource when the operator starts
 	result, err := r.initForVzResource(vz, log)
@@ -199,7 +197,6 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 			}
 		}
 		// Keep retrying to reconcile components until it completes
-		log.Info("MGIANATA calling reconcileComponents from ProcReadyState")
 		if result, err := r.reconcileComponents(vzctx); err != nil {
 			return newRequeueWithDelay(), err
 		} else if vzctrl.ShouldRequeue(result) {
@@ -260,7 +257,6 @@ func (r *Reconciler) ProcInstallingState(vzctx vzcontext.VerrazzanoContext) (ctr
 	if !actualCR.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.procDelete(ctx, log, actualCR)
 	}
-	log.Info("MGIANATA calling reconcileComponents from ProcInstallingState")
 
 	if result, err := r.reconcileComponents(vzctx); err != nil {
 		return newRequeueWithDelay(), err

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -92,6 +92,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		zap.S().Errorf("Failed to create controller logger for Verrazzano controller: %v", err)
 	}
+	log.Info("MGIANATA entering Reconcile")
 
 	log.Oncef("Reconciling Verrazzano resource %v, generation %v, version %s", req.NamespacedName, vz.Generation, vz.Status.Version)
 	res, err := r.doReconcile(log, vz)
@@ -112,6 +113,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 // doReconcile the Verrazzano CR
 func (r *Reconciler) doReconcile(log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 	ctx := context.TODO()
+	log.Info("MGIANATA entering doReconcile")
 
 	// Initialize once for this Verrazzano resource when the operator starts
 	result, err := r.initForVzResource(vz, log)
@@ -197,6 +199,7 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 			}
 		}
 		// Keep retrying to reconcile components until it completes
+		log.Info("MGIANATA calling reconcileComponents from ProcReadyState")
 		if result, err := r.reconcileComponents(vzctx); err != nil {
 			return newRequeueWithDelay(), err
 		} else if vzctrl.ShouldRequeue(result) {
@@ -257,6 +260,7 @@ func (r *Reconciler) ProcInstallingState(vzctx vzcontext.VerrazzanoContext) (ctr
 	if !actualCR.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.procDelete(ctx, log, actualCR)
 	}
+	log.Info("MGIANATA calling reconcileComponents from ProcInstallingState")
 
 	if result, err := r.reconcileComponents(vzctx); err != nil {
 		return newRequeueWithDelay(), err


### PR DESCRIPTION
# Description

When upgrading an environment configured to use ephemeral storage, rebuild the keycloak configuration to it's default settings.  Previous to this change the upgrade would fail because the Keycloak configuration is lost when the MySQL pod recycles.

A subsequent PR will address the issue of the MySQL pod unexpectedly getting recycled at any time.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
