### PR TITLE
VZ-5377: Opensearch backup preparedness

### DIFF
--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -35,6 +35,9 @@ const (
 	grafanaCertificateName    = "system-tls-grafana"
 	osdCertificateName        = "system-tls-kibana"
 	prometheusCertificateName = "system-tls-prometheus"
+
+	ociaccessKey = "oci_access_key"
+	ociSecretKey = "oci_access_secret_key"
 )
 
 // ComponentJSONName is the josn name of the verrazzano component in CRD

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -36,8 +36,8 @@ const (
 	osdCertificateName        = "system-tls-kibana"
 	prometheusCertificateName = "system-tls-prometheus"
 
-	ociaccessKey = "oci_access_key"
-	ociSecretKey = "oci_access_secret_key"
+	objectstoreAccessKey       = "object_store_access_key"
+	objectstoreAccessSecretKey = "object_store_access_secret_key"
 )
 
 // ComponentJSONName is the josn name of the verrazzano component in CRD

--- a/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
@@ -297,6 +297,15 @@ func ensureVMISecret(cli client.Client) error {
 			}
 			secret.Data["password"] = []byte(pw)
 		}
+		// Populating dummy keys for access and secret key so that they are never empty
+		if secret.Data[ociaccessKey] == nil || secret.Data[ociSecretKey] == nil {
+			key, err := password.GeneratePassword(32)
+			if err != nil {
+				return err
+			}
+			secret.Data[ociaccessKey] = []byte(key)
+			secret.Data[ociSecretKey] = []byte(key)
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
@@ -298,13 +298,13 @@ func ensureVMISecret(cli client.Client) error {
 			secret.Data["password"] = []byte(pw)
 		}
 		// Populating dummy keys for access and secret key so that they are never empty
-		if secret.Data[ociaccessKey] == nil || secret.Data[ociSecretKey] == nil {
+		if secret.Data[objectstoreAccessKey] == nil || secret.Data[objectstoreAccessSecretKey] == nil {
 			key, err := password.GeneratePassword(32)
 			if err != nil {
 				return err
 			}
-			secret.Data[ociaccessKey] = []byte(key)
-			secret.Data[ociSecretKey] = []byte(key)
+			secret.Data[objectstoreAccessKey] = []byte(key)
+			secret.Data[objectstoreAccessSecretKey] = []byte(key)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
This is required for backing up OpenSearch. This will allow the repository-s3 plugin to backup indicess to an S3 compatible object store

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
