### PR TITLE
VZ-5304 Prometheus Operator install e2e test

### DIFF
--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_suite_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheusoper
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestPrometheusOperator(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Prometheus Operator Suite")
+}

--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheusoper
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	verrazzanoMonitoringNamespace = "verrazzano-monitoring"
+	prometheusOperatorPod         = "prometheus-operator-kube-p-operator"
+	waitTimeout                   = 3 * time.Minute
+	pollingInterval               = 10 * time.Second
+)
+
+var t = framework.NewTestFramework("prometheusoper")
+
+// 'It' Wrapper to only run spec if the Prometheus Operator is supported on the current Verrazzano installation
+func WhenPrometheusOperatorInstalledIt(description string, f interface{}) {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+	if err != nil {
+		Fail(err.Error())
+	}
+	if supported {
+		t.It(description, f)
+	} else {
+		t.Logs.Infof("Skipping check '%v', the Proemtheus Operator is not supported", description)
+	}
+}
+
+func VerifyCRDList(crds []string) bool {
+	for _, crd := range crds {
+		exists, err := pkg.DoesCRDExist(crd)
+		if err != nil || !exists {
+			return false
+		}
+	}
+	return true
+}
+
+var _ = t.AfterEach(func() {})
+
+var _ = t.Describe("Prometheus Operator", Label("f:platform-lcm.install"), func() {
+	t.Context("after successful installation", func() {
+		WhenPrometheusOperatorInstalledIt("should have a verrazzano-monitoring namespace", func() {
+			Eventually(func() (bool, error) {
+				return pkg.DoesNamespaceExist(verrazzanoMonitoringNamespace)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+		})
+
+		WhenPrometheusOperatorInstalledIt("should have a running pod", func() {
+			prometheusOperatorPodsRunning := func() bool {
+				result, err := pkg.PodsRunning(verrazzanoMonitoringNamespace, []string{prometheusOperatorPod})
+				if err != nil {
+					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", prometheusOperatorPod, verrazzanoMonitoringNamespace, err))
+				}
+				return result
+			}
+			Eventually(prometheusOperatorPodsRunning, waitTimeout, pollingInterval).Should(BeTrue())
+		})
+
+		WhenPrometheusOperatorInstalledIt("should have the correct CRDs", func() {
+			crds := []string{
+				"alertmanagerconfigs.monitoring.coreos.com",
+				"alertmanagers.monitoring.coreos.com",
+				"podmonitors.monitoring.coreos.com",
+				"probes.monitoring.coreos.com",
+				"prometheuses.monitoring.coreos.com",
+				"prometheusrules.monitoring.coreos.com",
+				"servicemonitors.monitoring.coreos.com",
+				"thanosrulers.monitoring.coreos.com",
+			}
+			Eventually(VerifyCRDList(crds), waitTimeout, pollingInterval).Should(BeTrue())
+		})
+
+	})
+})

--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
@@ -42,13 +42,7 @@ func WhenPrometheusOperatorInstalledIt(description string, f interface{}) {
 }
 
 func VerifyCRDList(crds []string) (bool, error) {
-	for _, crd := range crds {
-		exists, err := pkg.DoesCRDExist(crd)
-		if err != nil || !exists {
-			return exists, err
-		}
-	}
-	return true, nil
+
 }
 
 var _ = t.AfterEach(func() {})
@@ -83,9 +77,16 @@ var _ = t.Describe("Prometheus Operator", Label("f:platform-lcm.install"), func(
 				"servicemonitors.monitoring.coreos.com",
 				"thanosrulers.monitoring.coreos.com",
 			}
-			Eventually(func() (bool, error) {
-				return VerifyCRDList(crds)
-			}, waitTimeout, pollingInterval).Should(BeTrue())
+			verifyCRDList := func() (bool, error) {
+				for _, crd := range crds {
+					exists, err := pkg.DoesCRDExist(crd)
+					if err != nil || !exists {
+						return exists, err
+					}
+				}
+				return true, nil
+			}
+			Eventually(verifyCRDList, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		WhenPrometheusOperatorInstalledIt("should have the TLS secret", func() {

--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
@@ -41,10 +41,6 @@ func WhenPrometheusOperatorInstalledIt(description string, f interface{}) {
 	}
 }
 
-func VerifyCRDList(crds []string) (bool, error) {
-
-}
-
 var _ = t.AfterEach(func() {})
 
 var _ = t.Describe("Prometheus Operator", Label("f:platform-lcm.install"), func() {

--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
@@ -37,7 +37,7 @@ func WhenPrometheusOperatorInstalledIt(description string, f interface{}) {
 	if supported {
 		t.It(description, f)
 	} else {
-		t.Logs.Infof("Skipping check '%v', the Proemtheus Operator is not supported", description)
+		t.Logs.Infof("Skipping check '%v', the Prometheus Operator is not supported", description)
 	}
 }
 

--- a/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
+++ b/tests/e2e/verify-install/prometheusoper/prometheusoper_test.go
@@ -17,6 +17,7 @@ import (
 const (
 	verrazzanoMonitoringNamespace = "verrazzano-monitoring"
 	prometheusOperatorPod         = "prometheus-operator-kube-p-operator"
+	prometheusTLSSecret           = "prometheus-operator-kube-p-admission"
 	waitTimeout                   = 3 * time.Minute
 	pollingInterval               = 10 * time.Second
 )
@@ -85,5 +86,8 @@ var _ = t.Describe("Prometheus Operator", Label("f:platform-lcm.install"), func(
 			Eventually(VerifyCRDList(crds), waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
+		WhenPrometheusOperatorInstalledIt("should have the TLS secret", func() {
+			Eventually(pkg.SecretsCreated(verrazzanoMonitoringNamespace, prometheusTLSSecret), waitTimeout, pollingInterval).Should(BeTrue())
+		})
 	})
 })


### PR DESCRIPTION
# Description

This adds a test to verify the Prometheus Operator install. The resources to be verified are as follows:
- The `verrazzano-monitoring` namespace exists
- The Prometheus Operator pod is running
- The CRDs for the Prometheus Operator exist
- The TLS secret for the stack webhook exists

Fixes VZ-5304

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
