### PR TITLE
VZ-5370.  Trigger app ingress trait reconciles during DNS update

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -463,9 +463,6 @@ func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.In
 	if err != nil {
 		return err
 	}
-	if len(gateway.Spec.Servers) > 0 {
-		hosts = appendToConfiguredHosts(hosts, gateway.Spec.Servers[0].Hosts)
-	}
 
 	// Set the spec content.
 	gateway.Spec.Selector = map[string]string{"istio": "ingressgateway"}

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -463,6 +463,9 @@ func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.In
 	if err != nil {
 		return err
 	}
+	//if len(gateway.Spec.Servers) > 0 {
+	//	hosts = appendToConfiguredHosts(hosts, gateway.Spec.Servers[0].Hosts)
+	//}
 
 	// Set the spec content.
 	gateway.Spec.Selector = map[string]string{"istio": "ingressgateway"}
@@ -497,15 +500,15 @@ func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.In
 }
 
 // appendToConfiguredHosts appends the host lists ensuring uniqueness of entries
-func appendToConfiguredHosts(hostsToAppend []string, existingHosts []string) []string {
-	for _, newHost := range hostsToAppend {
-		_, hostFound := findHost(existingHosts, newHost)
-		if !hostFound {
-			existingHosts = append(existingHosts, strings.ToLower(newHost))
-		}
-	}
-	return existingHosts
-}
+//func appendToConfiguredHosts(hostsToAppend []string, existingHosts []string) []string {
+//	for _, newHost := range hostsToAppend {
+//		_, hostFound := findHost(existingHosts, newHost)
+//		if !hostFound {
+//			existingHosts = append(existingHosts, strings.ToLower(newHost))
+//		}
+//	}
+//	return existingHosts
+//}
 
 // findHost searches for a host in the provided list. If found it will
 // return it's key, otherwise it will return -1 and a bool of false.
@@ -855,10 +858,15 @@ func createHostsFromIngressTraitRule(cli client.Reader, rule vzapi.IngressRule, 
 	var validHosts []string
 	for _, h := range rule.Hosts {
 		h = strings.TrimSpace(h)
+		if _, hostAlreadyPresent := findHost(validHosts, h); hostAlreadyPresent {
+			// Avoid duplicates
+			continue
+		}
 		// Ignore empty or wildcard hostname
 		if len(h) == 0 || strings.Contains(h, "*") {
 			continue
 		}
+		h = strings.ToLower(strings.TrimSpace(h))
 		validHosts = append(validHosts, h)
 	}
 	// Use default hostname if none of the user specified hosts were valid

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -458,7 +458,7 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 						Name:     "https",
 						Number:   443,
 						Protocol: "HTTPS"},
-					Hosts: []string{"test-host", "test2-host", "test3-host"},
+					Hosts: []string{"test-host" /*, "test2-host", "test3-host"*/},
 				}}}
 			return nil
 		})
@@ -469,8 +469,8 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
 			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
 			assert.Contains(gateway.Spec.Servers[0].Hosts, "test-host", "doesn't contain expected host")
-			assert.Contains(gateway.Spec.Servers[0].Hosts, "test2-host", "doesn't contain expected host")
-			assert.Contains(gateway.Spec.Servers[0].Hosts, "test3-host", "doesn't contain expected host")
+			//assert.Contains(gateway.Spec.Servers[0].Hosts, "test2-host", "doesn't contain expected host")
+			//assert.Contains(gateway.Spec.Servers[0].Hosts, "test3-host", "doesn't contain expected host")
 			return nil
 		})
 	// Expect a call to get the app config and return that it is not found.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,9 @@ const RestartVersionAnnotation = "verrazzano.io/restart-version"
 // VerrazzanoRestartAnnotation is the annotation used to restart platform workloads
 const VerrazzanoRestartAnnotation = "verrazzano.io/restartedAt"
 
+// UpdateIngressTraitAnnotation Annotation applied to trigger an IngressTrait reconcile
+const UpdateIngressTraitAnnotation = "verrazzano.io/update-ingresstrait"
+
 // LifecycleActionAnnotation - the annotation perform lifecycle actions on a workload
 const LifecycleActionAnnotation = "verrazzano.io/lifecycle-action"
 

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
@@ -5,13 +5,12 @@ package nginx
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	k8s "github.com/verrazzano/verrazzano/platform-operator/internal/nodeport"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"reflect"
-
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -6,6 +6,7 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"io/ioutil"
 	"os/exec"
 	"strconv"
@@ -457,6 +458,39 @@ func cleanTempFiles(ctx spi.ComponentContext) {
 	if err := vzos.RemoveTempFiles(ctx.Log().GetZapLogger(), tmpFileCleanPattern); err != nil {
 		ctx.Log().Errorf("Failed deleting temp files: %v", err)
 	}
+}
+
+//annotateIngressTraits Adds an annotation to existing IngressTrait objects to force them to reconcile;
+//  this is necessary when the DNS domain has been updated and we need to generate new records for applications using
+//  default hostnames that we generate.  Default hostnames are generated based on the main console/authproxy ingress,
+//  so we do it PostInstall/PostUpgrade of the Verrazzano component, which manages that ingress.
+func annotateIngressTraits(ctx spi.ComponentContext) error {
+	client := ctx.Client()
+	log := ctx.Log()
+	ingressList := vzapp.IngressTraitList{}
+	if err := client.List(context.TODO(), &ingressList, &clipkg.ListOptions{}); err != nil {
+		return log.ErrorfNewErr("Failed to listing ingress traits: %v", err)
+	}
+
+	for _, ingressTrait := range ingressList.Items {
+		updateIngressTrait := vzapp.IngressTrait{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ingressTrait.Name,
+				Namespace: ingressTrait.Namespace,
+			},
+		}
+		if _, err := controllerruntime.CreateOrUpdate(context.TODO(), client, &updateIngressTrait, func() error {
+			log.Infof("Updating ingress trait %s/%s", updateIngressTrait.Namespace, updateIngressTrait.Name)
+			if updateIngressTrait.Annotations == nil {
+				updateIngressTrait.Annotations = make(map[string]string)
+			}
+			updateIngressTrait.Annotations[globalconst.UpdateIngressTraitAnnotation] = fmt.Sprintf("%v", metav1.Now())
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // fixupElasticSearchReplicaCount fixes the replica count set for single node Elasticsearch cluster

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -5,9 +5,6 @@ package verrazzano
 
 import (
 	"fmt"
-	"path/filepath"
-	"reflect"
-
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
@@ -18,6 +15,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	"reflect"
 )
 
 const (
@@ -115,17 +114,31 @@ func (c verrazzanoComponent) PostInstall(ctx spi.ComponentContext) error {
 	// populate the ingress and certificate names before calling PostInstall on Helm component because those will be needed there
 	c.HelmComponent.IngressNames = c.GetIngressNames(ctx)
 	c.HelmComponent.Certificates = c.GetCertificateNames(ctx)
-	return c.HelmComponent.PostInstall(ctx)
+	if err := c.HelmComponent.PostInstall(ctx); err != nil {
+		return err
+	}
+	if err := annotateIngressTraits(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // PostUpgrade Verrazzano-post-upgrade processing
 func (c verrazzanoComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	ctx.Log().Debugf("Verrazzano component post-upgrade")
+	c.HelmComponent.IngressNames = c.GetIngressNames(ctx)
+	c.HelmComponent.Certificates = c.GetCertificateNames(ctx)
 	if err := c.HelmComponent.PostUpgrade(ctx); err != nil {
 		return err
 	}
 	cleanTempFiles(ctx)
-	return c.updateElasticsearchResources(ctx)
+	if err := c.updateElasticsearchResources(ctx); err != nil {
+		return err
+	}
+	if err := annotateIngressTraits(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // updateElasticsearchResources updates elasticsearch resources


### PR DESCRIPTION

# Description

Trigger app ingress trait reconciles during DNS update
- Add post-install/post-upgrade logic to annotate any ingress traits to force them
  to reconcile new generated hostnames if necessary
- Fix a bug in the ingresstrait controller to not let the gateway hosts list grow out of bounds;
  new generated hostnames would just keep appending to the host list and leak DNS records

Fixes VZ-5370

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
