### PR TITLE
VZ-5414 rename tls secret for verrazzano and keycloak

### DIFF
--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1413,7 +1413,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 
 	// Expect a call to get the tls secret, return the secret with the fields set
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "default-secret"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "verrazzano-tls"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				CaCrtKey: []byte(vzCaData),

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -37,21 +37,21 @@ import (
 )
 
 const (
-	dnsTarget          = "dnsTarget"
-	rulesHost          = "rulesHost"
-	tlsHosts           = "tlsHosts"
-	tlsSecret          = "tlsSecret"
-	tlsSecretName      = "keycloak-tls"
-	vzSysRealm         = "verrazzano-system"
-	vzUsersGroup       = "verrazzano-users"
-	vzAdminGroup       = "verrazzano-admins"
-	vzMonitorGroup     = "verrazzano-monitors"
-	vzSystemGroup      = "verrazzano-system-users"
-	vzAPIAccessRole    = "vz_api_access"
-	vzUserName         = "verrazzano"
-	vzInternalPromUser = "verrazzano-prom-internal"
-	vzInternalEsUser   = "verrazzano-es-internal"
-	keycloakPodName    = "keycloak-0"
+	dnsTarget               = "dnsTarget"
+	rulesHost               = "rulesHost"
+	tlsHosts                = "tlsHosts"
+	tlsSecret               = "tlsSecret"
+	keycloakCertificateName = "keycloak-tls"
+	vzSysRealm              = "verrazzano-system"
+	vzUsersGroup            = "verrazzano-users"
+	vzAdminGroup            = "verrazzano-admins"
+	vzMonitorGroup          = "verrazzano-monitors"
+	vzSystemGroup           = "verrazzano-system-users"
+	vzAPIAccessRole         = "vz_api_access"
+	vzUserName              = "verrazzano"
+	vzInternalPromUser      = "verrazzano-prom-internal"
+	vzInternalEsUser        = "verrazzano-es-internal"
+	keycloakPodName         = "keycloak-0"
 )
 
 // Define the keycloak Key:Value pair for init container.
@@ -416,7 +416,7 @@ func AppendKeycloakOverrides(compContext spi.ComponentContext, _ string, _ strin
 	// this secret contains the keycloak TLS certificate created by cert-manager during the original keycloak installation
 	kvs = append(kvs, bom.KeyValue{
 		Key:   tlsSecret,
-		Value: tlsSecretName,
+		Value: keycloakCertificateName,
 	})
 
 	return kvs, nil
@@ -1284,9 +1284,9 @@ func getClientID(keycloakClients KeycloakClients, clientName string) string {
 func isKeycloakReady(ctx spi.ComponentContext) bool {
 	// TLS cert from Cert Manager should be in Ready state
 	secret := &corev1.Secret{}
-	namespacedName := types.NamespacedName{Name: tlsSecretName, Namespace: ComponentNamespace}
+	namespacedName := types.NamespacedName{Name: keycloakCertificateName, Namespace: ComponentNamespace}
 	if err := ctx.Client().Get(context.TODO(), namespacedName, secret); err != nil {
-		ctx.Log().Progressf("Component Keycloak waiting for Certificate %v to exist", tlsSecretName)
+		ctx.Log().Progressf("Component Keycloak waiting for Certificate %v to exist", keycloakCertificateName)
 		return false
 	}
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -190,12 +190,10 @@ func (c KeycloakComponent) getInstallArgs(vz *vzapi.Verrazzano) []vzapi.InstallA
 
 // GetCertificateNames - gets the names of the ingresses associated with this component
 func (c KeycloakComponent) GetCertificateNames(ctx spi.ComponentContext) []types.NamespacedName {
-	var certificateNames []types.NamespacedName
-
-	certificateNames = append(certificateNames, types.NamespacedName{
-		Namespace: ComponentNamespace,
-		Name:      fmt.Sprintf("%s-secret", ctx.EffectiveCR().Spec.EnvironmentName),
-	})
-
-	return certificateNames
+	return []types.NamespacedName{
+		{
+			Namespace: ComponentNamespace,
+			Name:      tlsSecretName,
+		},
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -44,6 +44,10 @@ type KeycloakComponent struct {
 // Verify that KeycloakComponent implements Component
 var _ spi.Component = KeycloakComponent{}
 
+var certificates = []types.NamespacedName{
+	{Namespace: ComponentNamespace, Name: keycloakCertificateName},
+}
+
 // NewComponent returns a new Keycloak component
 func NewComponent() spi.Component {
 	return KeycloakComponent{
@@ -58,6 +62,7 @@ func NewComponent() spi.Component {
 			Dependencies:            []string{istio.ComponentName, nginx.ComponentName, certmanager.ComponentName},
 			SupportsOperatorInstall: true,
 			AppendOverridesFunc:     AppendKeycloakOverrides,
+			Certificates:            certificates,
 			IngressNames: []types.NamespacedName{
 				{
 					Namespace: ComponentNamespace,
@@ -135,15 +140,11 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 		}
 	}
 
-	// populate the certificate names before calling PostInstall on Helm component because those will be needed there
-	c.HelmComponent.Certificates = c.GetCertificateNames(ctx)
 	return c.HelmComponent.PostInstall(ctx)
 }
 
 // PostUpgrade Keycloak-post-upgrade processing, create or update the Kiali ingress
 func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
-	// populate the certificate names before calling PostInstall on Helm component because those will be needed there
-	c.HelmComponent.Certificates = c.GetCertificateNames(ctx)
 	if err := c.HelmComponent.PostUpgrade(ctx); err != nil {
 		return err
 	}
@@ -186,14 +187,4 @@ func (c KeycloakComponent) getInstallArgs(vz *vzapi.Verrazzano) []vzapi.InstallA
 		return vz.Spec.Components.Keycloak.KeycloakInstallArgs
 	}
 	return nil
-}
-
-// GetCertificateNames - gets the names of the ingresses associated with this component
-func (c KeycloakComponent) GetCertificateNames(ctx spi.ComponentContext) []types.NamespacedName {
-	return []types.NamespacedName{
-		{
-			Namespace: ComponentNamespace,
-			Name:      keycloakCertificateName,
-		},
-	}
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -193,7 +193,7 @@ func (c KeycloakComponent) GetCertificateNames(ctx spi.ComponentContext) []types
 	return []types.NamespacedName{
 		{
 			Namespace: ComponentNamespace,
-			Name:      tlsSecretName,
+			Name:      keycloakCertificateName,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
@@ -226,5 +226,5 @@ func TestKeycloakComponent_GetCertificateNames(t *testing.T) {
 	ctx := spi.NewFakeContext(client, vz, false)
 	names := NewComponent().GetCertificateNames(ctx)
 	assert.Len(t, names, 1)
-	assert.Equal(t, types.NamespacedName{Name: tlsSecretName, Namespace: ComponentNamespace}, names[0])
+	assert.Equal(t, types.NamespacedName{Name: keycloakCertificateName, Namespace: ComponentNamespace}, names[0])
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
@@ -4,8 +4,9 @@
 package keycloak
 
 import (
-	"k8s.io/apimachinery/pkg/types"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -225,5 +226,5 @@ func TestKeycloakComponent_GetCertificateNames(t *testing.T) {
 	ctx := spi.NewFakeContext(client, vz, false)
 	names := NewComponent().GetCertificateNames(ctx)
 	assert.Len(t, names, 1)
-	assert.Equal(t, types.NamespacedName{Name: "myenv-secret", Namespace: ComponentNamespace}, names[0])
+	assert.Equal(t, types.NamespacedName{Name: tlsSecretName, Namespace: ComponentNamespace}, names[0])
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -608,7 +608,7 @@ func TestAppendKeycloakOverrides(t *testing.T) {
 	})
 	assert.Contains(kvs, bom.KeyValue{
 		Key:   tlsSecret,
-		Value: tlsSecretName,
+		Value: keycloakCertificateName,
 	})
 }
 
@@ -634,7 +634,7 @@ func TestAppendKeycloakOverridesNoEnvironmentName(t *testing.T) {
 
 	assert.Contains(kvs, bom.KeyValue{
 		Key:   tlsSecret,
-		Value: tlsSecretName,
+		Value: keycloakCertificateName,
 	})
 }
 
@@ -1180,7 +1180,7 @@ func TestUpdateKeycloakIngress(t *testing.T) {
 func TestIsKeycloakReady(t *testing.T) {
 	readySecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tlsSecretName,
+			Name:      keycloakCertificateName,
 			Namespace: ComponentNamespace,
 		},
 	}
@@ -1200,7 +1200,7 @@ func TestIsKeycloakReady(t *testing.T) {
 			"should not be ready when certificate has no status",
 			fake.NewFakeClientWithScheme(scheme, &certmanager.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      tlsSecretName,
+					Name:      keycloakCertificateName,
 					Namespace: ComponentNamespace,
 				},
 			}),

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -608,7 +608,7 @@ func TestAppendKeycloakOverrides(t *testing.T) {
 	})
 	assert.Contains(kvs, bom.KeyValue{
 		Key:   tlsSecret,
-		Value: env + "-secret",
+		Value: tlsSecretName,
 	})
 }
 
@@ -634,7 +634,7 @@ func TestAppendKeycloakOverridesNoEnvironmentName(t *testing.T) {
 
 	assert.Contains(kvs, bom.KeyValue{
 		Key:   tlsSecret,
-		Value: "default-secret",
+		Value: tlsSecretName,
 	})
 }
 
@@ -1180,7 +1180,7 @@ func TestUpdateKeycloakIngress(t *testing.T) {
 func TestIsKeycloakReady(t *testing.T) {
 	readySecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getSecretName(testVZ),
+			Name:      tlsSecretName,
 			Namespace: ComponentNamespace,
 		},
 	}
@@ -1200,7 +1200,7 @@ func TestIsKeycloakReady(t *testing.T) {
 			"should not be ready when certificate has no status",
 			fake.NewFakeClientWithScheme(scheme, &certmanager.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getSecretName(testVZ),
+					Name:      tlsSecretName,
 					Namespace: ComponentNamespace,
 				},
 			}),

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -31,7 +31,7 @@ const (
 	vzImagePullSecretKeyName = "global.imagePullSecrets[0]"
 
 	// Certificate names
-	tlsSecretName             = "verrazzano-tls"
+	verrazzanoCertificateName = "verrazzano-tls"
 	osCertificateName         = "system-tls-es-ingest"
 	grafanaCertificateName    = "system-tls-grafana"
 	osdCertificateName        = "system-tls-kibana"
@@ -304,7 +304,7 @@ func (c verrazzanoComponent) GetCertificateNames(ctx spi.ComponentContext) []typ
 
 	certificateNames = append(certificateNames, types.NamespacedName{
 		Namespace: ComponentNamespace,
-		Name:      tlsSecretName,
+		Name:      verrazzanoCertificateName,
 	})
 
 	if vzconfig.IsElasticsearchEnabled(ctx.EffectiveCR()) {

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -31,6 +31,7 @@ const (
 	vzImagePullSecretKeyName = "global.imagePullSecrets[0]"
 
 	// Certificate names
+	tlsSecretName             = "verrazzano-tls"
 	osCertificateName         = "system-tls-es-ingest"
 	grafanaCertificateName    = "system-tls-grafana"
 	osdCertificateName        = "system-tls-kibana"
@@ -303,7 +304,7 @@ func (c verrazzanoComponent) GetCertificateNames(ctx spi.ComponentContext) []typ
 
 	certificateNames = append(certificateNames, types.NamespacedName{
 		Namespace: ComponentNamespace,
-		Name:      fmt.Sprintf("%s-secret", ctx.EffectiveCR().Spec.EnvironmentName),
+		Name:      tlsSecretName,
 	})
 
 	if vzconfig.IsElasticsearchEnabled(ctx.EffectiveCR()) {

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -55,7 +55,7 @@ spec:
                 items:
                   - key: ca.crt
                     path: default-ca-bundle
-                name:  {{ .Values.config.envName }}-secret
+                name:  verrazzano-tls
                 optional: true
             - secret:
                 name: verrazzano-cluster-registration

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
@@ -50,4 +50,4 @@ spec:
   tls:
     - hosts:
         - verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
-      secretName: {{ .Values.config.envName }}-secret
+      secretName: verrazzano-tls

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -22,10 +22,6 @@ if [ -z "${MANAGED_KUBECONFIG}" ] ; then
     echo "MANAGED_KUBECONFIG env var must be set!'"
     exit 1
 fi
-if [ -z "${MANAGED_CLUSTER_ENV}" ] ; then
-    echo "MANAGED_CLUSTER_ENV env var must be set!'"
-    exit 1
-fi
 
 if [ -z "${ACME_ENVIRONMENT}" ] ; then
   ACME_ENVIRONMENT="staging"
@@ -34,7 +30,6 @@ fi
 echo ADMIN_KUBECONFIG: ${ADMIN_KUBECONFIG}
 echo MANAGED_CLUSTER_NAME: ${MANAGED_CLUSTER_NAME}
 echo MANAGED_KUBECONFIG: ${MANAGED_KUBECONFIG}
-echo MANAGED_CLUSTER_ENV: ${MANAGED_CLUSTER_ENV}
 echo ACME_ENVIRONMENT: ${ACME_ENVIRONMENT}
 
 # create configmap "verrazzano-admin-cluster" on admin
@@ -45,9 +40,9 @@ fi
 
 # create managed cluster ca secret yaml on managed
 CA_SECRET_FILE=${MANAGED_CLUSTER_NAME}.yaml
-TLS_SECRET=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret ${MANAGED_CLUSTER_ENV}-secret -o json | jq -r '.data."ca.crt"')
+TLS_SECRET=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret verrazzano-tls -o json | jq -r '.data."ca.crt"')
 if [ ! -z "${TLS_SECRET%%*( )}" ] && [ "null" != "${TLS_SECRET}" ] ; then
-  CA_CERT=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret ${MANAGED_CLUSTER_ENV}-secret -o json | jq -r '.data."ca.crt"' | base64 --decode)
+  CA_CERT=$(kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system get secret verrazzano-tls -o json | jq -r '.data."ca.crt"' | base64 --decode)
 fi
 
 if [ ! -z "${CA_CERT}" ] ; then

--- a/tests/e2e/pkg/api.go
+++ b/tests/e2e/pkg/api.go
@@ -42,7 +42,7 @@ func GetAPIEndpoint(kubeconfigPath string) (*APIEndpoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	keycloakHTTPClient, err := GetKeycloakHTTPClient(kubeconfigPath)
+	keycloakHTTPClient, err := GetVerrazzanoHTTPClient(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/keycloak.go
+++ b/tests/e2e/pkg/keycloak.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/pkg/keycloak.go
+++ b/tests/e2e/pkg/keycloak.go
@@ -50,7 +50,7 @@ func NewKeycloakAdminRESTClient() (*KeycloakRESTClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient, err := GetKeycloakHTTPClient(kubeconfigPath)
+	httpClient, err := GetVerrazzanoHTTPClient(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -143,32 +143,6 @@ func GetVerrazzanoHTTPClient(kubeconfigPath string) (*retryablehttp.Client, erro
 	return retryableClient, nil
 }
 
-// GetRancherHTTPClient returns a retryable Http client configured with the Rancher CA cert
-func GetRancherHTTPClient(kubeconfigPath string) (*retryablehttp.Client, error) {
-	caCert, err := getRancherCACert(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	rawClient, err := getHTTPClientWithCABundle(caCert, kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	return newRetryableHTTPClient(rawClient), nil
-}
-
-// GetKeycloakHTTPClient returns a retryable Http client configured with the Keycloak CA cert
-func GetKeycloakHTTPClient(kubeconfigPath string) (*retryablehttp.Client, error) {
-	caCert, err := getKeycloakCACert(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	keycloakRawClient, err := getHTTPClientWithCABundle(caCert, kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	return newRetryableHTTPClient(keycloakRawClient), nil
-}
-
 // CheckNoServerHeader validates that the response does not include a Server header.
 func CheckNoServerHeader(resp *HTTPResponse) bool {
 	// HTTP Server headers should never be returned.
@@ -360,17 +334,15 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) (*http.Clie
 
 // getVerrazzanoCACert returns the Verrazzano CA cert in the specified cluster
 func getVerrazzanoCACert(kubeconfigPath string) ([]byte, error) {
-	return doGetCACertFromSecret("verrazzano-tls", "verrazzano-system", kubeconfigPath)
-}
-
-// getRancherCACert returns the Rancher CA cert
-func getRancherCACert(kubeconfigPath string) ([]byte, error) {
-	return doGetCACertFromSecret("tls-rancher-ingress", "cattle-system", kubeconfigPath)
-}
-
-// getKeycloakCACert returns the keycloak CA cert
-func getKeycloakCACert(kubeconfigPath string) ([]byte, error) {
-	return doGetCACertFromSecret("keycloak-tls", "keycloak", kubeconfigPath)
+	cacert, err := doGetCACertFromSecret("verrazzano-tls", "verrazzano-system", kubeconfigPath)
+	if err != nil {
+		envName, err := GetEnvName(kubeconfigPath)
+		if err != nil {
+			return nil, err
+		}
+		return doGetCACertFromSecret(envName+"-secret", "verrazzano-system", kubeconfigPath)
+	}
+	return cacert, nil
 }
 
 // doGetCACertFromSecret returns the CA cert from the specified kubernetes secret in the given cluster

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -360,10 +360,6 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) (*http.Clie
 
 // getVerrazzanoCACert returns the Verrazzano CA cert in the specified cluster
 func getVerrazzanoCACert(kubeconfigPath string) ([]byte, error) {
-	envName, err := GetEnvName(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
 	return doGetCACertFromSecret("verrazzano-tls", "verrazzano-system", kubeconfigPath)
 }
 
@@ -374,10 +370,6 @@ func getRancherCACert(kubeconfigPath string) ([]byte, error) {
 
 // getKeycloakCACert returns the keycloak CA cert
 func getKeycloakCACert(kubeconfigPath string) ([]byte, error) {
-	envName, err := GetEnvName(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
 	return doGetCACertFromSecret("keycloak-tls", "keycloak", kubeconfigPath)
 }
 

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -364,7 +364,7 @@ func getVerrazzanoCACert(kubeconfigPath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return doGetCACertFromSecret(envName+"-secret", "verrazzano-system", kubeconfigPath)
+	return doGetCACertFromSecret("verrazzano-tls", "verrazzano-system", kubeconfigPath)
 }
 
 // getRancherCACert returns the Rancher CA cert
@@ -378,7 +378,7 @@ func getKeycloakCACert(kubeconfigPath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return doGetCACertFromSecret(envName+"-secret", "keycloak", kubeconfigPath)
+	return doGetCACertFromSecret("keycloak-tls", "keycloak", kubeconfigPath)
 }
 
 // doGetCACertFromSecret returns the CA cert from the specified kubernetes secret in the given cluster

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -55,7 +55,7 @@ var _ = t.Describe("rancher", Label("f:infra-lcm",
 				Expect(rancherURL).NotTo(BeEmpty())
 				var httpClient *retryablehttp.Client
 				Eventually(func() error {
-					httpClient, err = pkg.GetRancherHTTPClient(kubeconfigPath)
+					httpClient, err = pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
 					if err != nil {
 						t.Logs.Error(fmt.Sprintf("Error getting HTTP client: %v", err))
 						return err

--- a/tools/cli/vz/cmd/login/login.go
+++ b/tools/cli/vz/cmd/login/login.go
@@ -235,7 +235,7 @@ func checkNonEmptyJWTData(jwtData map[string]interface{}) bool {
 }
 
 // Obtain the certificate authority data
-// certificate authority data is stored as a secret named tls-rancher-ingress in cattle-system namespace
+// certificate authority data is stored as a secret named verrazzano-tls in verrazzano-system namespace
 // Use client cmd to extract the secret
 func extractCAData(kubernetesInterface helpers.Kubernetes) ([]byte, error) {
 	var cert []byte
@@ -245,8 +245,8 @@ func extractCAData(kubernetesInterface helpers.Kubernetes) ([]byte, error) {
 		return cert, err
 	}
 
-	secret, err := kclientset.CoreV1().Secrets("cattle-system").Get(context.Background(),
-		"tls-rancher-ingress",
+	secret, err := kclientset.CoreV1().Secrets("verrazzano-system").Get(context.Background(),
+		"verrazzano-tls",
 		metav1.GetOptions{},
 	)
 

--- a/tools/cli/vz/cmd/login/login_test.go
+++ b/tools/cli/vz/cmd/login/login_test.go
@@ -309,8 +309,8 @@ func newFakeSecret(fakek8sClient kubernetes.Interface) error {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-rancher-ingress",
-			Namespace: "cattle-system",
+			Name:      "verrazzano-tls",
+			Namespace: "verrazzano-system",
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: "clusters.verrazzano.io/v1alpha1",
 				Kind:       "VerrazzanoSystemCluster",
@@ -322,6 +322,6 @@ func newFakeSecret(fakek8sClient kubernetes.Interface) error {
 			"ca.crt": []byte("LS0tCmFwaVZlcnNpb246IHYxCmRhdGE6CiAgYWRtaW4ta3ViZWNvbmZpZzogWTJ4MWMzUmxjbk02Q2kwZ1kyeDFjM1JsY2pvS0lDQWdJR05sY25ScFptbGpZWFJsTFdGMWRHaHZjbWwwZVMxa1lYUmhPaUJNVXpCMFRGTXhRMUpWWkVwVWFVSkVVbFpL"),
 		},
 	}
-	_, err := fakek8sClient.CoreV1().Secrets("cattle-system").Create(context.Background(), fakeSecret, metav1.CreateOptions{})
+	_, err := fakek8sClient.CoreV1().Secrets("verrazzano-system").Create(context.Background(), fakeSecret, metav1.CreateOptions{})
 	return err
 }


### PR DESCRIPTION
# Description

rename the tls secret from env-secret to verrazzano-tls and keycloak-tls

Fixes VZ-5414

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
