### PR TITLE
VZ-5029 pick up console fix to remove error when VMC has no apiUrl in status, and show component status info if all apps pending

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -242,7 +242,7 @@
             },
             {
               "image": "console",
-              "tag": "1.2.1-20220321142857-df26046",
+              "tag": "1.2.1-20220325012042-033f18a",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-5029

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
