### PR TITLE
VZ-5362: Fix scraping of POKO metrics when istio-injection is not enabled

### DIFF
--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -142,15 +142,13 @@ func (r *Reconciler) updateMetricsBinding(metricsBinding *vzapi.MetricsBinding, 
 	// Retrieve the workload object from the MetricsBinding
 	workloadObject, err := r.getWorkloadObject(metricsBinding)
 	if err != nil {
-		log.Errorf("Failed to get the Workload from the MetricsBinding %s: %v", metricsBinding.Spec.Workload.Name, err)
-		return err
+		return log.ErrorfNewErr("Failed to get the Workload from the MetricsBinding %s: %v", metricsBinding.Spec.Workload.Name, err)
 	}
 
 	// Return error if UID is not found
 	if len(workloadObject.GetUID()) == 0 {
 		err = fmt.Errorf("could not get UID from workload resource: %s, %s", workloadObject.GetKind(), workloadObject.GetName())
-		log.Errorf("Failed to find UID for workload %s: %v", workloadObject.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to find UID for workload %s: %v", workloadObject.GetName(), err)
 	}
 
 	// Set the owner reference for the MetricsBinding so that it gets deleted with the workload
@@ -207,8 +205,7 @@ func (r *Reconciler) deleteScrapeConfig(metricsBinding *vzapi.MetricsBinding, co
 		if existingJobName == createdJobName {
 			err = promConfig.ArrayRemoveP(index, prometheusScrapeConfigsLabel)
 			if err != nil {
-				log.Errorf("Failed to remove array slice from Prometheus config: %v", err)
-				return err
+				return log.ErrorfNewErr("Failed to remove array slice from Prometheus config: %v", err)
 			}
 		}
 	}
@@ -216,8 +213,7 @@ func (r *Reconciler) deleteScrapeConfig(metricsBinding *vzapi.MetricsBinding, co
 	// Repopulate the configmap data
 	newPromConfigData, err := yaml.JSONToYAML(promConfig.Bytes())
 	if err != nil {
-		log.Errorf("Failed to convert Prometheus config data to YAML: %v", err)
-		return err
+		return log.ErrorfNewErr("Failed to convert Prometheus config data to YAML: %v", err)
 	}
 	configMap.Data[prometheusConfigKey] = string(newPromConfigData)
 	return nil
@@ -236,31 +232,27 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 	// Get data from the configmap
 	promConfig, err := getConfigData(configMap)
 	if err != nil {
-		log.Errorf("Failed to get Prometheus config map %s: %v", configMap.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to get Prometheus config map %s: %v", configMap.GetName(), err)
 	}
 
 	// Get the namespace for the metrics binding
 	workloadNamespace := k8scorev1.Namespace{}
 	err = r.Client.Get(context.TODO(), k8sclient.ObjectKey{Name: metricsBinding.GetNamespace()}, &workloadNamespace)
 	if err != nil {
-		log.Errorf("Failed to get metrics binding namespace %s: %v", metricsBinding.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to get metrics binding namespace %s: %v", metricsBinding.GetName(), err)
 	}
 
 	// Create Unstructured Namespace
 	workloadNamespaceUnstructuredMap, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(&workloadNamespace)
 	if err != nil {
-		log.Errorf("Failed to get the unstructured for namespace %s: %v", workloadNamespace.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to get the unstructured for namespace %s: %v", workloadNamespace.GetName(), err)
 	}
 	workloadNamespaceUnstructured := unstructured.Unstructured{Object: workloadNamespaceUnstructuredMap}
 
 	// Get the workload object for the template processor
 	workloadObject, err := r.getWorkloadObject(metricsBinding)
 	if err != nil {
-		log.Errorf("Failed to get the workload object for metrics binding %s: %v", metricsBinding.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to get the workload object for metrics binding %s: %v", metricsBinding.GetName(), err)
 	}
 
 	// Organize inputs for template processor
@@ -273,8 +265,7 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 	templateProcessor := vztemplate.NewProcessor(r.Client, template.Spec.PrometheusConfig.ScrapeConfigTemplate)
 	scrapeConfigString, err := templateProcessor.Process(templateInputs)
 	if err != nil {
-		log.Errorf("Failed to process metrics template %s: %v", template.GetName(), err)
-		return err
+		return log.ErrorfNewErr("Failed to process metrics template %s: %v", template.GetName(), err)
 	}
 
 	// Prepend job name to the scrape config
@@ -284,13 +275,11 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 	// Format scrape config into readable container
 	configYaml, err := yaml.YAMLToJSON([]byte(scrapeConfigString))
 	if err != nil {
-		log.Errorf("Failed to convert scrape config YAML to JSON: %v", err)
-		return err
+		return log.ErrorfNewErr("Failed to convert scrape config YAML to JSON: %v", err)
 	}
 	newScrapeConfig, err := gabs.ParseJSON(configYaml)
 	if err != nil {
-		log.Errorf("Failed to convert scrape config JSON to container: %v", err)
-		return err
+		return log.ErrorfNewErr("Failed to convert scrape config JSON to container: %v", err)
 	}
 
 	// Create or Update scrape config with job name matching resource
@@ -302,13 +291,11 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 			// Remove and recreate scrape config
 			err = promConfig.ArrayRemoveP(index, prometheusScrapeConfigsLabel)
 			if err != nil {
-				log.Errorf("Failed to remove scrape config: %v", err)
-				return err
+				return log.ErrorfNewErr("Failed to remove scrape config: %v", err)
 			}
 			err = promConfig.ArrayAppendP(newScrapeConfig.Data(), prometheusScrapeConfigsLabel)
 			if err != nil {
-				log.Errorf("Failed to append scrape config: %v", err)
-				return err
+				return log.ErrorfNewErr("Failed to append scrape config: %v", err)
 			}
 			existingUpdated = true
 			break
@@ -317,16 +304,14 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 	if !existingUpdated {
 		err = promConfig.ArrayAppendP(newScrapeConfig.Data(), prometheusScrapeConfigsLabel)
 		if err != nil {
-			log.Errorf("Failed to append scrape config: %v", err)
-			return err
+			return log.ErrorfNewErr("Failed to append scrape config: %v", err)
 		}
 	}
 
 	// Repopulate the ConfigMap data
 	newPromConfigData, err := yaml.JSONToYAML(promConfig.Bytes())
 	if err != nil {
-		log.Errorf("Failed to convert scrape config JSON to YAML: %v", err)
-		return err
+		return log.ErrorfNewErr("Failed to convert scrape config JSON to YAML: %v", err)
 	}
 	configMap.Data[prometheusConfigKey] = string(newPromConfigData)
 	return nil
@@ -345,8 +330,7 @@ func (r *Reconciler) getMetricsTemplate(metricsBinding *vzapi.MetricsBinding, lo
 	namespacedName := types.NamespacedName{Name: templateSpec.Name, Namespace: templateSpec.Namespace}
 	err := r.Client.Get(context.Background(), namespacedName, &template)
 	if err != nil {
-		log.Errorf("Failed to get the MetricsTemplate %s: %v", templateSpec.Name, err)
-		return nil, err
+		return nil, log.ErrorfNewErr("Failed to get the MetricsTemplate %s: %v", templateSpec.Name, err)
 	}
 
 	return &template, nil

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -240,7 +240,7 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 		return err
 	}
 
-	// Get the namespace for the template
+	// Get the namespace for the metrics binding
 	workloadNamespace := k8scorev1.Namespace{}
 	err = r.Client.Get(context.TODO(), k8sclient.ObjectKey{Name: metricsBinding.GetNamespace()}, &workloadNamespace)
 	if err != nil {

--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -5,10 +5,11 @@ package metricsbinding
 
 import (
 	"context"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"os"
 	"strings"
 	"testing"
+
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
@@ -182,8 +183,6 @@ func TestUpdateScrapeConfig(t *testing.T) {
 
 	localMetricsTemplate.Spec.PrometheusConfig.ScrapeConfigTemplate = string(scrapeConfigTemplate)
 
-	mock.EXPECT().Update(gomock.Any(), gomock.Not(gomock.Nil())).Return(nil)
-
 	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: testMetricsTemplateNamespace, Name: testMetricsTemplateName}), gomock.Not(gomock.Nil())).DoAndReturn(
 		func(ctx context.Context, key client.ObjectKey, template *vzapi.MetricsTemplate) error {
 			template.SetNamespace(metricsTemplate.Namespace)
@@ -203,10 +202,10 @@ func TestUpdateScrapeConfig(t *testing.T) {
 			return nil
 		})
 
-	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Name: testDeploymentNamespace}), gomock.Not(gomock.Nil())).DoAndReturn(
+	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Name: testExistsDeploymentNamespace}), gomock.Not(gomock.Nil())).DoAndReturn(
 		func(ctx context.Context, key client.ObjectKey, namespace *k8score.Namespace) error {
 			namespace.Labels = map[string]string{"istio-injection": "enabled"}
-			namespace.Name = testDeploymentNamespace
+			namespace.Name = testExistsDeploymentNamespace
 			return nil
 		})
 

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -761,11 +761,13 @@ spec:
           source_labels:
             - name
           target_label: webapp
+      {{`{{ if index .namespace.metadata.labels "istio-injection" }}`}}
+      {{`{{ if eq (index .namespace.metadata.labels "istio-injection" ) "enabled" }}`}}
       scheme: https
-      {{`{{ if eq ( index .namespace.metadata.labels "istio-injection" ) "enabled" }}`}}
       tls_config:
         ca_file: /etc/istio-certs/root-cert.pem
         cert_file: /etc/istio-certs/cert-chain.pem
         insecure_skip_verify: true
         key_file: /etc/istio-certs/key.pem
+      {{`{{ end }}`}}
       {{`{{ end }}`}}

--- a/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
+++ b/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
@@ -30,7 +30,7 @@ var (
 
 var _ = clusterDump.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, *t)
+	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, true, *t)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -39,7 +39,7 @@ var (
 
 var _ = clusterDump.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, *t)
+	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, true, *t)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
@@ -30,7 +30,7 @@ var (
 
 var _ = clusterDump.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, *t)
+	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, true, *t)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
+++ b/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
@@ -30,7 +30,8 @@ var (
 
 var _ = clusterDump.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, *t)
+	// Setting Istio disabled results in the Prometheus scrape target using http instead of https
+	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, false, *t)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
+++ b/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
@@ -30,7 +30,7 @@ var (
 
 var _ = clusterDump.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, *t)
+	metricsbinding.DeployApplication(namespace, yamlPath, applicationPodPrefix, true, *t)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/metrics_binding_helper.go
+++ b/tests/e2e/metricsbinding/metrics_binding_helper.go
@@ -22,14 +22,15 @@ const (
 	longPollingInterval  = 20 * time.Second
 )
 
-func DeployApplication(namespace, yamlPath, podPrefix string, t framework.TestFramework) {
+func DeployApplication(namespace, yamlPath, podPrefix string, istioEnabled bool, t framework.TestFramework) {
 	t.Logs.Info("Deploy test application")
 
 	t.Logs.Info("Create namespace")
 	gomega.Eventually(func() (*v1.Namespace, error) {
-		nsLabels := map[string]string{
-			"verrazzano-managed": "true",
-			"istio-injection":    "enabled"}
+		nsLabels := map[string]string{"verrazzano-managed": "true"}
+		if istioEnabled {
+			nsLabels["istio-injection"] = "enabled"
+		}
 		return pkg.CreateNamespace(namespace, nsLabels)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
 


### PR DESCRIPTION
This pull request fixes scraping of POKO metrics with the namespace the workload is running in has istio-injection disabled.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
