### PR TITLE
Refine IngressTrait controller Ingress watch

### DIFF
--- a/application-operator/controllers/ingresstrait/ingress_watch_test.go
+++ b/application-operator/controllers/ingresstrait/ingress_watch_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	vzoam "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	corev1 "k8s.io/api/core/v1"
 	k8net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,11 +21,22 @@ import (
 
 // Test_isConsoleIngressUpdated tests the isConsoleIngressUpdated func for the following use case.
 // GIVEN a request to isConsoleIngressUpdated
-// WHEN the old and new ingress objects have been changed
+// WHEN the only the Verrazzano Console ingress has changed
 // THEN true is returned only when the TLS fields differ, false otherwise
 func Test_isConsoleIngressUpdated(t *testing.T) {
 
+	asserts := assert.New(t)
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	vzapi.AddToScheme(scheme)
+	vzoam.AddToScheme(scheme)
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	r := newIngressTraitReconciler(client)
+
 	oldIngress := &k8net.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.VzConsoleIngress, Namespace: constants.VerrazzanoSystemNamespace},
 		Spec: k8net.IngressSpec{
 			Rules: []k8net.IngressRule{
 				{Host: "host1"},
@@ -37,7 +49,7 @@ func Test_isConsoleIngressUpdated(t *testing.T) {
 	}
 	newIngress := oldIngress.DeepCopyObject().(*k8net.Ingress)
 
-	assert.False(t, isConsoleIngressUpdated(event.UpdateEvent{
+	asserts.False(r.isConsoleIngressUpdated(event.UpdateEvent{
 		ObjectOld: oldIngress,
 		ObjectNew: newIngress,
 	}))
@@ -48,9 +60,27 @@ func Test_isConsoleIngressUpdated(t *testing.T) {
 	newIngress.Spec.TLS = []k8net.IngressTLS{
 		{Hosts: []string{"host3"}},
 	}
-	assert.True(t, isConsoleIngressUpdated(event.UpdateEvent{
+	asserts.True(r.isConsoleIngressUpdated(event.UpdateEvent{
 		ObjectOld: oldIngress,
 		ObjectNew: newIngress,
+	}))
+
+	oldOtherIngress := &k8net.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "someingress", Namespace: constants.VerrazzanoSystemNamespace},
+		Spec: k8net.IngressSpec{
+			Rules: []k8net.IngressRule{
+				{Host: "host1"},
+				{Host: "host2"},
+			},
+			TLS: []k8net.IngressTLS{
+				{Hosts: []string{"host1", "host2"}},
+			},
+		},
+	}
+	newOtherIngress := oldIngress.DeepCopyObject().(*k8net.Ingress)
+	asserts.False(r.isConsoleIngressUpdated(event.UpdateEvent{
+		ObjectOld: oldOtherIngress,
+		ObjectNew: newOtherIngress,
 	}))
 }
 

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -174,11 +174,8 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 			if err != nil {
 				status.Errors = append(status.Errors, err)
 			} else {
-				vsName := fmt.Sprintf("%s-rule-%d-vs", trait.Name, index)
-				drName := fmt.Sprintf("%s-rule-%d-dr", trait.Name, index)
-
 				// Must create GW before service so that external DNS sees the GW once the service is created
-				gateway := r.createOrUpdateGateway(ctx, trait, rule, gwName, vsName, secretName, &status, log)
+				gateway := r.createOrUpdateGateway(ctx, trait, rule, gwName, secretName, &status, log)
 
 				// Find the services associated with the trait in the application configuration.
 				var services []*corev1.Service
@@ -190,6 +187,8 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 					return &status, reconcile.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}, err
 				}
 
+				vsName := fmt.Sprintf("%s-rule-%d-vs", trait.Name, index)
+				drName := fmt.Sprintf("%s-rule-%d-dr", trait.Name, index)
 				r.createOrUpdateVirtualService(ctx, trait, rule, vsName, services, gateway, &status, log)
 				r.createOrUpdateDestinationRule(ctx, trait, rule, drName, &status, log)
 			}
@@ -435,8 +434,8 @@ func (r *Reconciler) validateConfiguredSecret(trait *vzapi.IngressTrait, status 
 
 // createOrUpdateGateway creates or updates the Gateway child resource of the trait.
 // Results are added to the status object.
-func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, gwName string, vsName string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) *istioclient.Gateway {
-	// Create a gateway populating only gwName metadata.
+func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, name string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) *istioclient.Gateway {
+	// Create a gateway populating only name metadata.
 	// This is used as default if the gateway needs to be created.
 	gateway := &istioclient.Gateway{
 		TypeMeta: metav1.TypeMeta{
@@ -444,18 +443,18 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 			Kind:       gatewayKind},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: trait.Namespace,
-			Name:      gwName}}
+			Name:      name}}
 
 	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, gateway, func() error {
-		return r.mutateGateway(gateway, trait, rule, vsName, secretName)
+		return r.mutateGateway(gateway, trait, rule, secretName)
 	})
 
 	// Return if no changes
-	if err == nil && res == controllerutil.OperationResultNone {
+	if res == controllerutil.OperationResultNone {
 		return gateway
 	}
 
-	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: gwName, Role: "gateway"}
+	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: name, Role: "gateway"}
 	status.Relations = append(status.Relations, ref)
 	status.Results = append(status.Results, res)
 	status.Errors = append(status.Errors, err)
@@ -468,32 +467,31 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 }
 
 // mutateGateway mutates the output Gateway child resource.
-func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.IngressTrait, rule vzapi.IngressRule, vsName string, secretName string) error {
+func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.IngressTrait, rule vzapi.IngressRule, secretName string) error {
 	hosts, err := createHostsFromIngressTraitRule(r, rule, trait)
 	if err != nil {
 		return err
 	}
-
-	// Add a server entry for each IngressTrait/VS to the Gateway
-	server := &istionet.Server{
-		Name:  vsName,
-		Hosts: hosts,
-		Port: &istionet.Port{
-			Name:     fmt.Sprintf("https-%s", vsName),
-			Number:   443,
-			Protocol: "HTTPS",
-		},
-		Tls: &istionet.ServerTLSSettings{
-			Mode:           istionet.ServerTLSSettings_SIMPLE,
-			CredentialName: secretName,
-		},
+	if len(gateway.Spec.Servers) > 0 {
+		hosts = appendToConfiguredHosts(hosts, gateway.Spec.Servers[0].Hosts)
 	}
-	updatedServers := r.updateGatewayServersList(gateway.Spec.Servers, server)
-	gateway.Spec.Servers = updatedServers
 
 	// Set the spec content.
 	gateway.Spec.Selector = map[string]string{"istio": "ingressgateway"}
-
+	gateway.Spec.Servers = []*istionet.Server{
+		{
+			Hosts: hosts,
+			Port: &istionet.Port{
+				Name:     "https",
+				Number:   443,
+				Protocol: "HTTPS",
+			},
+			Tls: &istionet.ServerTLSSettings{
+				Mode:           istionet.ServerTLSSettings_SIMPLE,
+				CredentialName: secretName,
+			},
+		},
+	}
 	// Set the owner reference.
 	appName, ok := trait.Labels[oam.LabelAppName]
 	if ok {
@@ -510,31 +508,15 @@ func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.In
 	return nil
 }
 
-// updateGatewayServersList Update/add the Server entry for the IngressTrait VirtualService to the gateway servers list
-//   - There will be a 1:1 mapping of Server-to-VirtualService
-func (r *Reconciler) updateGatewayServersList(existingServers []*istionet.Server, server *istionet.Server) []*istionet.Server {
-	servers := existingServers
-	if len(servers) == 0 {
-		servers = append(servers, server)
-		r.Log.Infof("Added new server for %s", server.Name)
-		return servers
-	}
-	if len(servers) == 1 && len(servers[0].Name) == 0 {
-		// upgrade case, before 1.3 all VirtualServices associated with a Gateway shared a single unnamed Server object
-		// - replace the empty name server with the named one
-		servers[0] = server
-		r.Log.Infof("Replaced server %s", server.Name)
-		return servers
-	}
-	for index, existingServer := range servers {
-		if existingServer.Name == server.Name {
-			r.Log.Infof("Updating server %s", server.Name)
-			servers[index] = server
-			return servers
+// appendToConfiguredHosts appends the host lists ensuring uniqueness of entries
+func appendToConfiguredHosts(hostsToAppend []string, existingHosts []string) []string {
+	for _, newHost := range hostsToAppend {
+		_, hostFound := findHost(existingHosts, newHost)
+		if !hostFound {
+			existingHosts = append(existingHosts, strings.ToLower(newHost))
 		}
 	}
-	servers = append(servers, server)
-	return servers
+	return existingHosts
 }
 
 // findHost searches for a host in the provided list. If found it will
@@ -942,15 +924,10 @@ func createHostsFromIngressTraitRule(cli client.Reader, rule vzapi.IngressRule, 
 	var validHosts []string
 	for _, h := range rule.Hosts {
 		h = strings.TrimSpace(h)
-		if _, hostAlreadyPresent := findHost(validHosts, h); hostAlreadyPresent {
-			// Avoid duplicates
-			continue
-		}
 		// Ignore empty or wildcard hostname
 		if len(h) == 0 || strings.Contains(h, "*") {
 			continue
 		}
-		h = strings.ToLower(strings.TrimSpace(h))
 		validHosts = append(validHosts, h)
 	}
 	// Use default hostname if none of the user specified hosts were valid


### PR DESCRIPTION
# Description

The ingress watch added for the IngressTrait controller only filters on type; this fixes the filtering to happen in the watch predicate to limit the amount of reconciles triggered by an DNS change.

Fixes VZ-5370.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
