### PR TITLE
VZ-5454.  Revise IngressTrait hosts to Gateway Server mapping

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -399,10 +399,6 @@ func (r *Reconciler) createGatewayCertificate(ctx context.Context, trait *vzapi.
 		}}
 
 	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, certificate, func() error {
-		//hosts, err := createHostsFromIngressTraitRule(r, rule, trait)
-		//if err != nil {
-		//	return err
-		//}
 		certificate.Spec = certapiv1.CertificateSpec{
 			DNSNames:   hostsForTrait,
 			SecretName: secretName,

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -66,6 +66,7 @@ const (
 	destinationRuleAPIVersion = "networking.istio.io/v1alpha3"
 	destinationRuleKind       = "DestinationRule"
 	controllerName            = "ingresstrait"
+	httpsProtocol             = "HTTPS"
 )
 
 // The port names used by WebLogic operator that do not have http prefix.
@@ -167,19 +168,23 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 	if len(rules) == 0 {
 		rules = []vzapi.IngressRule{{}}
 	}
-	for index, rule := range rules {
-		secretName := r.createOrUseGatewaySecret(ctx, trait, rule, &status, log)
-		if secretName != "" {
-			gwName, err := getGatewayName(trait)
-			if err != nil {
-				status.Errors = append(status.Errors, err)
-			} else {
-				// Must create GW before service so that external DNS sees the GW once the service is created
-				gateway := r.createOrUpdateGateway(ctx, trait, rule, gwName, secretName, &status, log)
 
+	// Create a list of unique hostnames across all rules in the trait
+	allHostsForTrait := r.coallateAllHostsForTrait(trait, status)
+	// Generate the certificate and secret for all hosts in the trait rules
+	secretName := r.createOrUseGatewaySecret(ctx, trait, allHostsForTrait, &status, log)
+	if secretName != "" {
+		gwName, err := getGatewayName(trait)
+		if err != nil {
+			status.Errors = append(status.Errors, err)
+		} else {
+			// The Gateway is shared across all traits, update it with all known hosts for the trait
+			// - Must create GW before service so that external DNS sees the GW once the service is created
+			gateway := r.createOrUpdateGateway(ctx, trait, allHostsForTrait, gwName, secretName, &status, log)
+			for index, rule := range rules {
 				// Find the services associated with the trait in the application configuration.
 				var services []*corev1.Service
-				services, err = r.fetchServicesFromTrait(ctx, trait, log)
+				services, err := r.fetchServicesFromTrait(ctx, trait, log)
 				if err != nil {
 					return &status, reconcile.Result{}, err
 				} else if len(services) == 0 {
@@ -189,12 +194,23 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 
 				vsName := fmt.Sprintf("%s-rule-%d-vs", trait.Name, index)
 				drName := fmt.Sprintf("%s-rule-%d-dr", trait.Name, index)
-				r.createOrUpdateVirtualService(ctx, trait, rule, vsName, services, gateway, &status, log)
+				r.createOrUpdateVirtualService(ctx, trait, rule, allHostsForTrait, vsName, services, gateway, &status, log)
 				r.createOrUpdateDestinationRule(ctx, trait, rule, drName, &status, log)
 			}
 		}
 	}
 	return &status, ctrl.Result{}, nil
+}
+
+func (r *Reconciler) coallateAllHostsForTrait(trait *vzapi.IngressTrait, status reconcileresults.ReconcileResults) []string {
+	allHosts := []string{}
+	var err error
+	for _, rule := range trait.Spec.Rules {
+		if allHosts, err = createHostsFromIngressTraitRule(r, rule, trait, allHosts...); err != nil {
+			status.Errors = append(status.Errors, err)
+		}
+	}
+	return allHosts
 }
 
 // getGatewayName will generate a gateway name from the namespace and application name of the provided trait. Returns
@@ -326,13 +342,13 @@ func (r *Reconciler) fetchChildResourcesByAPIVersionKinds(ctx context.Context, n
 
 // createOrUseGatewaySecret will create a certificate that will be embedded in an secret or leverage an existing secret
 // if one is configured in the ingress.
-func (r *Reconciler) createOrUseGatewaySecret(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) string {
+func (r *Reconciler) createOrUseGatewaySecret(ctx context.Context, trait *vzapi.IngressTrait, hostsForTrait []string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) string {
 	var secretName string
 
 	if trait.Spec.TLS != (vzapi.IngressSecurity{}) {
 		secretName = r.validateConfiguredSecret(trait, status)
 	} else {
-		secretName = r.createGatewayCertificate(ctx, trait, rule, status, log)
+		secretName = r.createGatewayCertificate(ctx, trait, hostsForTrait, status, log)
 	}
 
 	return secretName
@@ -343,7 +359,7 @@ func (r *Reconciler) createOrUseGatewaySecret(ctx context.Context, trait *vzapi.
 // There will be one gateway generated per application.  The generated virtual services will be routed via the
 // application-wide gateway.  This implementation addresses a known Istio traffic management issue
 // (see https://istio.io/v1.7/docs/ops/common-problems/network-issues/#404-errors-occur-when-multiple-gateways-configured-with-same-tls-certificate)
-func (r *Reconciler) createGatewayCertificate(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) string {
+func (r *Reconciler) createGatewayCertificate(ctx context.Context, trait *vzapi.IngressTrait, hostsForTrait []string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) string {
 	var secretName string
 	var err error
 	var certName string
@@ -383,12 +399,12 @@ func (r *Reconciler) createGatewayCertificate(ctx context.Context, trait *vzapi.
 		}}
 
 	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, certificate, func() error {
-		hosts, err := createHostsFromIngressTraitRule(r, rule, trait)
-		if err != nil {
-			return err
-		}
+		//hosts, err := createHostsFromIngressTraitRule(r, rule, trait)
+		//if err != nil {
+		//	return err
+		//}
 		certificate.Spec = certapiv1.CertificateSpec{
-			DNSNames:   hosts,
+			DNSNames:   hostsForTrait,
 			SecretName: secretName,
 			IssuerRef: certv1.ObjectReference{
 				Name: verrazzanoClusterIssuer,
@@ -434,8 +450,8 @@ func (r *Reconciler) validateConfiguredSecret(trait *vzapi.IngressTrait, status 
 
 // createOrUpdateGateway creates or updates the Gateway child resource of the trait.
 // Results are added to the status object.
-func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, name string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) *istioclient.Gateway {
-	// Create a gateway populating only name metadata.
+func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, hostsForTrait []string, gwName string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) *istioclient.Gateway {
+	// Create a gateway populating only gwName metadata.
 	// This is used as default if the gateway needs to be created.
 	gateway := &istioclient.Gateway{
 		TypeMeta: metav1.TypeMeta{
@@ -443,18 +459,18 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 			Kind:       gatewayKind},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: trait.Namespace,
-			Name:      name}}
+			Name:      gwName}}
 
 	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, gateway, func() error {
-		return r.mutateGateway(gateway, trait, rule, secretName)
+		return r.mutateGateway(gateway, trait, hostsForTrait, secretName)
 	})
 
 	// Return if no changes
-	if res == controllerutil.OperationResultNone {
+	if err == nil && res == controllerutil.OperationResultNone {
 		return gateway
 	}
 
-	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: name, Role: "gateway"}
+	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: gwName, Role: "gateway"}
 	status.Relations = append(status.Relations, ref)
 	status.Results = append(status.Results, res)
 	status.Errors = append(status.Errors, err)
@@ -467,31 +483,26 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 }
 
 // mutateGateway mutates the output Gateway child resource.
-func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.IngressTrait, rule vzapi.IngressRule, secretName string) error {
-	hosts, err := createHostsFromIngressTraitRule(r, rule, trait)
-	if err != nil {
-		return err
+func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.IngressTrait, hostsForTrait []string, secretName string) error {
+	// Create/update the server entry related to the IngressTrait in the Gateway
+	server := &istionet.Server{
+		Name:  trait.Name,
+		Hosts: hostsForTrait,
+		Port: &istionet.Port{
+			Name:     formatGatewaySeverPortName(trait.Name),
+			Number:   443,
+			Protocol: httpsProtocol,
+		},
+		Tls: &istionet.ServerTLSSettings{
+			Mode:           istionet.ServerTLSSettings_SIMPLE,
+			CredentialName: secretName,
+		},
 	}
-	if len(gateway.Spec.Servers) > 0 {
-		hosts = appendToConfiguredHosts(hosts, gateway.Spec.Servers[0].Hosts)
-	}
+	gateway.Spec.Servers = r.updateGatewayServersList(gateway.Spec.Servers, server)
 
 	// Set the spec content.
 	gateway.Spec.Selector = map[string]string{"istio": "ingressgateway"}
-	gateway.Spec.Servers = []*istionet.Server{
-		{
-			Hosts: hosts,
-			Port: &istionet.Port{
-				Name:     "https",
-				Number:   443,
-				Protocol: "HTTPS",
-			},
-			Tls: &istionet.ServerTLSSettings{
-				Mode:           istionet.ServerTLSSettings_SIMPLE,
-				CredentialName: secretName,
-			},
-		},
-	}
+
 	// Set the owner reference.
 	appName, ok := trait.Labels[oam.LabelAppName]
 	if ok {
@@ -508,15 +519,34 @@ func (r *Reconciler) mutateGateway(gateway *istioclient.Gateway, trait *vzapi.In
 	return nil
 }
 
-// appendToConfiguredHosts appends the host lists ensuring uniqueness of entries
-func appendToConfiguredHosts(hostsToAppend []string, existingHosts []string) []string {
-	for _, newHost := range hostsToAppend {
-		_, hostFound := findHost(existingHosts, newHost)
-		if !hostFound {
-			existingHosts = append(existingHosts, strings.ToLower(newHost))
+func formatGatewaySeverPortName(traitName string) string {
+	return fmt.Sprintf("https-%s", traitName)
+}
+
+// updateGatewayServersList Update/add the Server entry for the IngressTrait to the gateway servers list
+//   - There will be a 1:1 mapping of Server-to-VirtualService
+func (r *Reconciler) updateGatewayServersList(servers []*istionet.Server, server *istionet.Server) []*istionet.Server {
+	if len(servers) == 0 {
+		servers = append(servers, server)
+		r.Log.Debugf("Added new server for %s", server.Name)
+		return servers
+	}
+	if len(servers) == 1 && len(servers[0].Name) == 0 && servers[0].Port.Name == "https" {
+		// upgrade case, before 1.3 all VirtualServices associated with a Gateway shared a single unnamed Server object
+		// - replace the empty name server with the named one
+		servers[0] = server
+		r.Log.Debugf("Replaced server %s", server.Name)
+		return servers
+	}
+	for index, existingServer := range servers {
+		if existingServer.Name == server.Name {
+			r.Log.Debugf("Updating server %s", server.Name)
+			servers[index] = server
+			return servers
 		}
 	}
-	return existingHosts
+	servers = append(servers, server)
+	return servers
 }
 
 // findHost searches for a host in the provided list. If found it will
@@ -532,7 +562,7 @@ func findHost(hosts []string, newHost string) (int, bool) {
 
 // createOrUpdateVirtualService creates or updates the VirtualService child resource of the trait.
 // Results are added to the status object.
-func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, name string, services []*corev1.Service, gateway *istioclient.Gateway, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
+func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, allHostsForTrait []string, name string, services []*corev1.Service, gateway *istioclient.Gateway, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
 	// Create a virtual service populating only name metadata.
 	// This is used as default if the virtual service needs to be created.
 	virtualService := &istioclient.VirtualService{
@@ -544,7 +574,7 @@ func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vz
 			Name:      name}}
 
 	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, virtualService, func() error {
-		return r.mutateVirtualService(virtualService, trait, rule, services, gateway)
+		return r.mutateVirtualService(virtualService, trait, rule, allHostsForTrait, services, gateway)
 	})
 
 	ref := vzapi.QualifiedResourceRelation{APIVersion: virtualServiceAPIVersion, Kind: virtualServiceKind, Name: name, Role: "virtualservice"}
@@ -558,14 +588,11 @@ func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vz
 }
 
 // mutateVirtualService mutates the output virtual service resource
-func (r *Reconciler) mutateVirtualService(virtualService *istioclient.VirtualService, trait *vzapi.IngressTrait, rule vzapi.IngressRule, services []*corev1.Service, gateway *istioclient.Gateway) error {
+func (r *Reconciler) mutateVirtualService(virtualService *istioclient.VirtualService, trait *vzapi.IngressTrait, rule vzapi.IngressRule, allHostsForTrait []string, services []*corev1.Service, gateway *istioclient.Gateway) error {
 	// Set the spec content.
 	var err error
 	virtualService.Spec.Gateways = []string{gateway.Name}
-	virtualService.Spec.Hosts, err = createHostsFromIngressTraitRule(r, rule, trait)
-	if err != nil {
-		return err
-	}
+	virtualService.Spec.Hosts = allHostsForTrait // We may set this multiple times if there are multiple rules, but should be OK
 	matches := []*istionet.HTTPMatchRequest{}
 	paths := getPathsFromRule(rule)
 	for _, path := range paths {
@@ -917,17 +944,23 @@ func createVirtualServiceMatchURIFromIngressTraitPath(path vzapi.IngressPath) *i
 	}
 }
 
-// createHostsFromIngressTraitRule creates an array of hosts from an ingress rule.
-// It filters out wildcard hosts or hosts that are empty. If there are no valid hosts provided,
-// then a DNS host name is automatically generated and used.
-func createHostsFromIngressTraitRule(cli client.Reader, rule vzapi.IngressRule, trait *vzapi.IngressTrait) ([]string, error) {
-	var validHosts []string
+// createHostsFromIngressTraitRule creates an array of hosts from an ingress rule, appending to an optionally provided input list
+// - It filters out wildcard hosts or hosts that are empty.
+// - If there are no valid hosts provided, then a DNS host name is automatically generated and used.
+// - A hostname can only appear once
+func createHostsFromIngressTraitRule(cli client.Reader, rule vzapi.IngressRule, trait *vzapi.IngressTrait, toList ...string) ([]string, error) {
+	validHosts := toList
 	for _, h := range rule.Hosts {
 		h = strings.TrimSpace(h)
+		if _, hostAlreadyPresent := findHost(validHosts, h); hostAlreadyPresent {
+			// Avoid duplicates
+			continue
+		}
 		// Ignore empty or wildcard hostname
 		if len(h) == 0 || strings.Contains(h, "*") {
 			continue
 		}
+		h = strings.ToLower(strings.TrimSpace(h))
 		validHosts = append(validHosts, h)
 	}
 	// Use default hostname if none of the user specified hosts were valid

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -562,7 +562,9 @@ func findHost(hosts []string, newHost string) (int, bool) {
 
 // createOrUpdateVirtualService creates or updates the VirtualService child resource of the trait.
 // Results are added to the status object.
-func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, allHostsForTrait []string, name string, services []*corev1.Service, gateway *istioclient.Gateway, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
+func (r *Reconciler) createOrUpdateVirtualService(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule,
+	allHostsForTrait []string, name string, services []*corev1.Service, gateway *istioclient.Gateway,
+	status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
 	// Create a virtual service populating only name metadata.
 	// This is used as default if the virtual service needs to be created.
 	virtualService := &istioclient.VirtualService{

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -2923,9 +2923,8 @@ func TestMutateGatewayAddTrait(t *testing.T) {
 	trait1Server := createGatewayServer(trait1Name, trait1Hosts, secretName)
 
 	const appName = "myapp"
-	const gwName = "test-space-myapp-gw"
 	gw := &istioclient.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: expectedAppGWName, Namespace: testNamespace},
 		Spec: istionet.Gateway{
 			Servers: []*istionet.Server{
 				trait1Server,
@@ -2990,10 +2989,9 @@ func TestMutateGatewayHostsAddRemoveTraitRule(t *testing.T) {
 	trait2Server := createGatewayServer(trait2Name, trait2Hosts, secretName)
 
 	const appName = "myapp"
-	const gwName = "test-space-myapp-gw"
 
 	gw := &istioclient.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: expectedAppGWName, Namespace: testNamespace},
 		Spec: istionet.Gateway{
 			Servers: []*istionet.Server{
 				trait1Server,
@@ -3027,7 +3025,7 @@ func TestMutateGatewayHostsAddRemoveTraitRule(t *testing.T) {
 	assert.NoError(err)
 
 	updatedGateway := &istioclient.Gateway{}
-	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: gwName, Namespace: testNamespace}, updatedGateway))
+	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: expectedAppGWName, Namespace: testNamespace}, updatedGateway))
 	updatedServers := updatedGateway.Spec.Servers
 	assert.Len(updatedServers, 2)
 	assert.Equal(updatedServers[0].Hosts, trait1UpdatedHosts)
@@ -3054,7 +3052,7 @@ func TestMutateGatewayHostsAddRemoveTraitRule(t *testing.T) {
 	assert.NoError(err2)
 
 	updatedGatewayRemovedRule := &istioclient.Gateway{}
-	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: gwName, Namespace: testNamespace}, updatedGatewayRemovedRule))
+	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: expectedAppGWName, Namespace: testNamespace}, updatedGatewayRemovedRule))
 	updatedServersRemovedRule := updatedGatewayRemovedRule.Spec.Servers
 	assert.Len(updatedServers, 2)
 	assert.Equal(updatedServersRemovedRule[0].Hosts, trait1Hosts)

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -47,6 +48,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	testTraitName           = "test-trait"
+	testTraitPortName       = "https-test-trait"
+	apiVersion              = "oam.verrazzano.io/v1alpha1"
+	traitKind               = "IngressTrait"
+	testNamespace           = "test-space"
+	expectedTraitVSName     = "test-trait-rule-0-vs"
+	expectedAppGWName       = "test-space-myapp-gw"
+	testWorkloadName        = "test-workload-name"
+	testWorkloadID          = "test-workload-uid"
+	istioIngressGatewayName = "istio-ingressgateway"
+	istioSystemNamespace    = "istio-system"
+	testName                = "test-name"
+)
+
+var (
+	httpsLower = strings.ToLower(httpsProtocol)
 )
 
 // GIVEN a controller implementation
@@ -87,56 +107,17 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
-	// Expect a call to get the ingress trait resource.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
-			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
-			trait.ObjectMeta = metav1.ObjectMeta{
-				Namespace: name.Namespace,
-				Name:      name.Name,
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
-			trait.Spec.Rules = []vzapi.IngressRule{{
-				Hosts: []string{"test-host"},
-				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
-			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "core.oam.dev/v1alpha2",
-				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
-			return nil
-		})
-	// Expect a call to get the containerized workload resource
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("core.oam.dev/v1alpha2")
-			workload.SetKind("ContainerizedWorkload")
-			workload.SetNamespace(name.Namespace)
-			workload.SetName(name.Name)
-			workload.SetUID("test-workload-uid")
-			return nil
-		})
-	// Expect a call to get the containerized workload resource definition
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
-			workloadDef.Namespace = name.Namespace
-			workloadDef.Name = name.Name
-			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
-				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
-				{APIVersion: "v1", Kind: "Service", Selector: nil},
-			}
-			return nil
-		})
-	// Expect a call to list the child Deployment resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("DeploymentList", list.GetKind())
-			return nil
-		})
+	getIngressTraitResourceExpectations(mock)
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	createCertSuccessExpectations(mock)
+	appCertificateExpectations(mock)
+	getGatewayForTraitNotFoundExpectations(mock)
+	traitVSNotFoundExpectation(mock)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
 	// Expect a call to list the child Service resources of the containerized workload definition
 	mock.EXPECT().
 		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
@@ -151,26 +132,16 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "core.oam.dev/v1alpha2",
 						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
+						Name:       testWorkloadName,
+						UID:        testWorkloadID,
 					}}},
 				Spec: k8score.ServiceSpec{
 					ClusterIP: "10.11.12.13",
 					Ports:     []k8score.ServicePort{{Port: 42}}}})
 		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -178,29 +149,18 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 			}
 			return nil
 		})
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
 	// Expect a call to create the Gateway resource and return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
 			return nil
 		})
-	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
-
 	// Expect a call to create the VirtualService resource and return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
 			return nil
 		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 	// Expect a call to update the status of the IngressTrait.
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -211,7 +171,7 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -233,11 +193,11 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name,
@@ -249,65 +209,16 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 			trait.Spec.WorkloadReference = oamrt.TypedReference{
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
+				Name:       testWorkloadName}
 			return nil
 		})
-	// Expect a call to get the containerized workload resource
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("core.oam.dev/v1alpha2")
-			workload.SetKind("ContainerizedWorkload")
-			workload.SetNamespace(name.Namespace)
-			workload.SetName(name.Name)
-			workload.SetUID("test-workload-uid")
-			return nil
-		})
-	// Expect a call to get the containerized workload resource definition
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
-			workloadDef.Namespace = name.Namespace
-			workloadDef.Name = name.Name
-			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
-				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
-				{APIVersion: "v1", Kind: "Service", Selector: nil},
-			}
-			return nil
-		})
-	// Expect a call to list the child Deployment resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("DeploymentList", list.GetKind())
-			return nil
-		})
-	// Expect a call to list the child Service resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("ServiceList", list.GetKind())
-			return appendAsUnstructured(list, k8score.Service{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Service",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion: "core.oam.dev/v1alpha2",
-						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
-					}}},
-				Spec: k8score.ServiceSpec{
-					ClusterIP: "10.11.12.13",
-					Ports:     []k8score.ServicePort{{Port: 42}}},
-			})
-		})
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	getGatewayForTraitNotFoundExpectations(mock)
+
 	// Expect a call to create the ingress/gateway resource and return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
@@ -318,7 +229,7 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 		})
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -326,30 +237,14 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 			}
 			return nil
 		})
-	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
 
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
-	// Expect a call to update the status of the ingress trait.
-	mockStatus.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
-			assert.Len(trait.Status.Conditions, 1)
-			assert.Len(trait.Status.Resources, 2)
-			return nil
-		})
+	traitVSNotFoundExpectation(mock)
+	createIngressSuccessExpectations(mock)
+	getMockStatusWriterExpectations(mock, mockStatus)
+	updateMockStatusExpectations(mockStatus, assert)
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -369,97 +264,61 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
+
+	// As of 1.3, this represents an older configuration; since the IngressTrait only defines 1 host that
+	// is what will result in the end.
+	expectedHosts := []string{"test-host", "test2-host", "test3-host"}
+
+	appName := "myapp"
+	workloadRef := oamrt.TypedReference{
+		APIVersion: "core.oam.dev/v1alpha2",
+		Kind:       "ContainerizedWorkload",
+		Name:       testWorkloadName}
+	rules := []vzapi.IngressRule{{
+		Hosts: []string{"Test-host", "test2-host", "test3-host"},
+		Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+	tls := vzapi.IngressSecurity{SecretName: "cert-secret"}
+
+	gatewayName := expectedAppGWName
+
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name,
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
-			trait.Spec.Rules = []vzapi.IngressRule{{
-				Hosts: []string{"Test-host"},
-				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
-			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
-			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "core.oam.dev/v1alpha2",
-				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
+				Labels:    map[string]string{oam.LabelAppName: appName}}
+			trait.Spec.Rules = rules
+			trait.Spec.TLS = tls
+			trait.Spec.WorkloadReference = workloadRef
 			return nil
 		})
-	// Expect a call to get the containerized workload resource
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("core.oam.dev/v1alpha2")
-			workload.SetKind("ContainerizedWorkload")
-			workload.SetNamespace(name.Namespace)
-			workload.SetName(name.Name)
-			workload.SetUID("test-workload-uid")
-			return nil
-		})
-	// Expect a call to get the containerized workload resource definition
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
-			workloadDef.Namespace = name.Namespace
-			workloadDef.Name = name.Name
-			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
-				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
-				{APIVersion: "v1", Kind: "Service", Selector: nil},
-			}
-			return nil
-		})
-	// Expect a call to list the child Deployment resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("DeploymentList", list.GetKind())
-			return nil
-		})
-	// Expect a call to list the child Service resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("ServiceList", list.GetKind())
-			return appendAsUnstructured(list, k8score.Service{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Service",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion: "core.oam.dev/v1alpha2",
-						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
-					}}},
-				Spec: k8score.ServiceSpec{
-					ClusterIP: "10.11.12.13",
-					Ports:     []k8score.ServicePort{{Port: 42}}},
-			})
-		})
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+
+	traitVSNotFoundExpectation(mock)
+	createIngressSuccessExpectations(mock)
+
+	getMockStatusWriterExpectations(mock, mockStatus)
+	updateMockStatusExpectations(mockStatus, assert)
+
 	// Expect a call to get the gateway resource related to the ingress trait and return it.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: gatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, gateway *istioclient.Gateway) error {
 			gateway.TypeMeta = metav1.TypeMeta{
 				APIVersion: gatewayAPIVersion,
 				Kind:       gatewayKind}
 			gateway.ObjectMeta = metav1.ObjectMeta{
-				Namespace: "test-space",
-				Name:      "test-space-myapp-gw"}
-			gateway.Spec = istionet.Gateway{
-				Servers: []*istionet.Server{{
-					Port: &istionet.Port{
-						Name:     "https",
-						Number:   443,
-						Protocol: "HTTPS"},
-					Hosts: []string{"test-host", "test2-host", "test3-host"},
-				}}}
+				Namespace: testNamespace,
+				Name:      gatewayName}
 			return nil
 		})
 	// Expect a call to create the ingress/gateway resource and return success
@@ -468,14 +327,15 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
 			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
 			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
-			assert.Contains(gateway.Spec.Servers[0].Hosts, "test-host", "doesn't contain expected host")
-			assert.Contains(gateway.Spec.Servers[0].Hosts, "test2-host", "doesn't contain expected host")
-			assert.Contains(gateway.Spec.Servers[0].Hosts, "test3-host", "doesn't contain expected host")
+			assert.Len(gateway.Spec.Servers, 1)
+			assert.Equal(testTraitName, gateway.Spec.Servers[0].Name)
+			assert.Equal(testTraitPortName, gateway.Spec.Servers[0].Port.Name)
+			assert.Equal(expectedHosts, gateway.Spec.Servers[0].Hosts)
 			return nil
 		})
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: appName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -483,30 +343,9 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 			}
 			return nil
 		})
-	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
-
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
-	// Expect a call to update the status of the ingress trait.
-	mockStatus.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
-			assert.Len(trait.Status.Conditions, 1)
-			assert.Len(trait.Status.Resources, 2)
-			return nil
-		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -526,13 +365,27 @@ func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
+
+	// Expect a call to get the Verrazzano ingress and return the ingress.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzConsoleIngress}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ingress *k8net.Ingress) error {
+			ingress.TypeMeta = metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "ingress"}
+			ingress.ObjectMeta = metav1.ObjectMeta{
+				Namespace:   name.Namespace,
+				Name:        name.Name,
+				Annotations: map[string]string{"external-dns.alpha.kubernetes.io/target": "verrazzano-ingress.my.host.com"}}
+			return nil
+		})
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name,
@@ -543,11 +396,10 @@ func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
 			trait.Spec.WorkloadReference = oamrt.TypedReference{
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
+				Name:       testWorkloadName}
 			return nil
 		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	getMockStatusWriterExpectations(mock, mockStatus)
 	// Expect a call to update the status of the ingress trait.  The status is checked for the expected error condition.
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -559,7 +411,7 @@ func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -581,11 +433,11 @@ func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name}
@@ -595,12 +447,11 @@ func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
 			trait.Spec.WorkloadReference = oamrt.TypedReference{
 				APIVersion: "core.oam.dev/v1alpha2",
 				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
+				Name:       testWorkloadName}
 			return nil
 		})
 
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	getMockStatusWriterExpectations(mock, mockStatus)
 	// Expect a call to update the status of the ingress trait.  The status is checked for the expected error condition.
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -612,7 +463,7 @@ func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -634,11 +485,11 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name,
@@ -651,9 +502,9 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 					Port: 0,
 				}}}
 			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
+				APIVersion: apiVersion,
 				Kind:       "VerrazzanoCoherenceWorkload",
-				Name:       "test-workload-name"}
+				Name:       testWorkloadName}
 			return nil
 		})
 
@@ -666,9 +517,9 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 
 	// Expect a call to get the Verrazzano Coherence workload resource
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testWorkloadName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("oam.verrazzano.io/v1alpha1")
+			workload.SetAPIVersion(apiVersion)
 			workload.SetKind("VerrazzanoCoherenceWorkload")
 			workload.SetNamespace(name.Namespace)
 			workload.SetName(name.Name)
@@ -677,13 +528,13 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 		})
 	// Expect a call to get the contained Coherence resource
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: containedName}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: containedName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
 			workload.SetUnstructuredContent(containedResource)
 			workload.SetNamespace(name.Namespace)
 			workload.SetAPIVersion("coherence.oracle.com/v1")
 			workload.SetKind("Coherence")
-			workload.SetUID("test-workload-uid")
+			workload.SetUID(testWorkloadID)
 			return nil
 		})
 	// Expect a call to get the containerized workload resource definition
@@ -705,10 +556,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 			assert.Equal("DeploymentList", list.GetKind())
 			return nil
 		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
+	appCertificateExpectations(mock)
 	// Expect a call to list the child Service resources of the Coherence workload definition
 	mock.EXPECT().
 		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
@@ -723,8 +571,8 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "core.oam.dev/v1alpha2",
 						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
+						Name:       testWorkloadName,
+						UID:        testWorkloadID,
 					}}},
 				Spec: k8score.ServiceSpec{
 					ClusterIP: "10.11.12.13",
@@ -733,7 +581,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 		})
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -741,37 +589,13 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 			}
 			return nil
 		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
-			assert.Len(virtualservice.Spec.Http, 1)
-			assert.Len(virtualservice.Spec.Http[0].Route, 1)
-			assert.Equal("test-service.test-space.svc.local", virtualservice.Spec.Http[0].Route[0].Destination.Host)
-			return nil
-		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+	createCertSuccessExpectations(mock)
+	getGatewayForTraitNotFoundExpectations(mock)
+	createIngressResourceSuccessExpectations(mock)
+	traitVSNotFoundExpectation(mock)
+
+	createIngressResSuccessExpectations(mock, assert)
+	getMockStatusWriterExpectations(mock, mockStatus)
 	// Expect a call to update the status of the ingress trait.
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -782,7 +606,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -801,41 +625,11 @@ func TestFailureToGetWorkload(t *testing.T) {
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	// Expect a call to get the ingress trait resource.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
-			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
-			trait.ObjectMeta = metav1.ObjectMeta{
-				Namespace: name.Namespace,
-				Name:      name.Name,
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
-			trait.Spec.Rules = []vzapi.IngressRule{{
-				Hosts: []string{"test-host"},
-				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
-			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "core.oam.dev/v1alpha2",
-				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
-			return nil
-		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
+	getIngressTraitResourceExpectations(mock)
+	createCertSuccessExpectations(mock)
+	appCertificateExpectations(mock)
 
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
+	getGatewayForTraitNotFoundExpectations(mock)
 	// Expect a call to create the gateway and return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
@@ -845,7 +639,7 @@ func TestFailureToGetWorkload(t *testing.T) {
 
 	// Expect a call to get the app config
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -855,13 +649,13 @@ func TestFailureToGetWorkload(t *testing.T) {
 		})
 	// Expect a call to get the containerized workload resource and return an error
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testWorkloadName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			return k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "ContainerizedWorkload"}, "test-workload-name")
+			return k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "ContainerizedWorkload"}, testWorkloadName)
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -880,41 +674,11 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	// Expect a call to get the ingress trait resource.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
-			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
-			trait.ObjectMeta = metav1.ObjectMeta{
-				Namespace: name.Namespace,
-				Name:      name.Name,
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
-			trait.Spec.Rules = []vzapi.IngressRule{{
-				Hosts: []string{"test-host"},
-				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
-			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "core.oam.dev/v1alpha2",
-				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
-			return nil
-		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
+	getIngressTraitResourceExpectations(mock)
+	createCertSuccessExpectations(mock)
+	appCertificateExpectations(mock)
+	gatewayNotFoundExpectations(mock)
 
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
 	// Expect a call to create the gateway and return success
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any()).
@@ -924,7 +688,7 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 
 	// Expect a call to get the app config
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -933,17 +697,8 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 			return nil
 		})
 
-	// Expect a call to get the containerized workload resource
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("core.oam.dev/v1alpha2")
-			workload.SetKind("ContainerizedWorkload")
-			workload.SetNamespace(name.Namespace)
-			workload.SetName(name.Name)
-			workload.SetUID("test-workload-uid")
-			return nil
-		})
+	workLoadResourceExpectations(mock)
+
 	// Expect a call to get the containerized workload resource definition and return an error
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
@@ -952,7 +707,7 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -972,85 +727,17 @@ func TestFailureToUpdateStatus(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
-	// Expect a call to get the ingress trait resource.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
-			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
-			trait.ObjectMeta = metav1.ObjectMeta{
-				Namespace: name.Namespace,
-				Name:      name.Name,
-				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
-			trait.Spec.Rules = []vzapi.IngressRule{{
-				Hosts: []string{"test-host"},
-				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
-			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "core.oam.dev/v1alpha2",
-				Kind:       "ContainerizedWorkload",
-				Name:       "test-workload-name"}
-			return nil
-		})
-	// Expect a call to get the containerized workload resource
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("core.oam.dev/v1alpha2")
-			workload.SetKind("ContainerizedWorkload")
-			workload.SetNamespace(name.Namespace)
-			workload.SetName(name.Name)
-			workload.SetUID("test-workload-uid")
-			return nil
-		})
-	// Expect a call to get the containerized workload resource definition
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
-			workloadDef.Namespace = name.Namespace
-			workloadDef.Name = name.Name
-			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
-				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
-				{APIVersion: "v1", Kind: "Service", Selector: nil},
-			}
-			return nil
-		})
-	// Expect a call to list the child Deployment resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("DeploymentList", list.GetKind())
-			return nil
-		})
-	// Expect a call to list the child Service resources of the containerized workload definition
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
-			assert.Equal("ServiceList", list.GetKind())
-			return appendAsUnstructured(list, k8score.Service{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Service",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion: "core.oam.dev/v1alpha2",
-						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
-					}}},
-				Spec: k8score.ServiceSpec{
-					ClusterIP: "10.11.12.13",
-					Ports:     []k8score.ServicePort{{Port: 42}}},
-			})
-		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
+
+	getIngressTraitResourceExpectations(mock)
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	appCertificateExpectations(mock)
+
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -1058,32 +745,15 @@ func TestFailureToUpdateStatus(t *testing.T) {
 			}
 			return nil
 		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
+	createCertSuccessExpectations(mock)
+	getGatewayForTraitNotFoundExpectations(mock)
+	createIngressResourceSuccessExpectations(mock)
 	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Virtualservice"}, "test-trait-name-rule-0-vs"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, virtualService *istioclient.VirtualService, opts ...client.CreateOption) error {
-			return nil
-		})
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: expectedTraitVSName}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "Virtualservice"}, expectedTraitVSName))
+	createIngressSuccessExpectations(mock)
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus)
 	// Expect a call to update the status of the ingress trait.
@@ -1094,7 +764,7 @@ func TestFailureToUpdateStatus(t *testing.T) {
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -1117,8 +787,8 @@ func TestBuildAppHostNameForDNS(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
-			Kind:       "IngressTrait",
+			APIVersion: apiVersion,
+			Kind:       traitKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1160,8 +830,8 @@ func TestBuildAppHostNameIgnoreWildcardForDNS(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
-			Kind:       "IngressTrait",
+			APIVersion: apiVersion,
+			Kind:       traitKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1209,8 +879,8 @@ func TestFailureBuildAppHostNameForDNS(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
-			Kind:       "IngressTrait",
+			APIVersion: apiVersion,
+			Kind:       traitKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1251,7 +921,7 @@ func TestBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1278,7 +948,7 @@ func TestBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1"}
@@ -1310,7 +980,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIP(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1337,7 +1007,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIP(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "extensions/v1beta1"}
@@ -1367,7 +1037,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIPNotFound(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1394,7 +1064,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIPNotFound(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "extensions/v1beta1"}
@@ -1422,7 +1092,7 @@ func TestFailureBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1449,7 +1119,7 @@ func TestFailureBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1"}
@@ -1478,7 +1148,7 @@ func TestBuildAppHostNameNodePortNIP(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1505,7 +1175,7 @@ func TestBuildAppHostNameNodePortNIP(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1"}
@@ -1546,7 +1216,7 @@ func TestFailureBuildAppHostNameNodePortNIP(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
+			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -1573,7 +1243,7 @@ func TestFailureBuildAppHostNameNodePortNIP(t *testing.T) {
 
 	// Expect a call to get the Istio service
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "istio-ingressgateway"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: istioIngressGatewayName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, service *k8score.Service) error {
 			service.TypeMeta = metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1"}
@@ -1606,11 +1276,11 @@ func TestGetTraitFailurePropagated(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-name"}, gomock.Any()).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testName}, gomock.Any()).
 		Return(fmt.Errorf("test-error")).
 		AnyTimes()
 	reconciler := newIngressTraitReconciler(mock)
-	request := newRequest("test-space", "test-name")
+	request := newRequest(testNamespace, testName)
 	result, err := reconciler.Reconcile(request)
 	mocker.Finish()
 	assert.Nil(err)
@@ -1627,10 +1297,10 @@ func TestGetNotFoundResource(t *testing.T) {
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-name"}, gomock.Any()).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "oam.verrazzano.io", Resource: "IngressTrait"}, "test-name"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testName}, gomock.Any()).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "oam.verrazzano.io", Resource: traitKind}, testName))
 	reconciler := newIngressTraitReconciler(mock)
-	request := newRequest("test-space", "test-name")
+	request := newRequest(testNamespace, testName)
 	result, err := reconciler.Reconcile(request)
 	mocker.Finish()
 	assert.NoError(err)
@@ -1707,8 +1377,8 @@ func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
 	ns := "myns"
 	trait := vzapi.IngressTrait{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "oam.verrazzano.io/v1alpha1",
-			Kind:       "IngressTrait",
+			APIVersion: apiVersion,
+			Kind:       traitKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -2140,7 +1810,7 @@ func TestExtractServicesOnlyOneService(t *testing.T) {
 	workload := &unstructured.Unstructured{}
 	workload.SetAPIVersion("apps/v1")
 	workload.SetKind("Deployment")
-	workload.SetOwnerReferences([]metav1.OwnerReference{{APIVersion: "oam.verrazzano.io/v1alpha1", Kind: "VerrazzanoHelidonWorkload"}})
+	workload.SetOwnerReferences([]metav1.OwnerReference{{APIVersion: apiVersion, Kind: "VerrazzanoHelidonWorkload"}})
 
 	var serviceID types.UID = "test-service-1"
 	u, err := newUnstructuredService(serviceID, "11.12.13.14", 777)
@@ -2269,7 +1939,7 @@ func TestSelectExistingServiceForVirtualServiceDestination(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("ingressgateway", gw.Spec.Selector["istio"])
 	assert.Equal("test-appconf.test-namespace.1.2.3.4.nip.io", gw.Spec.Servers[0].Hosts[0])
-	assert.Equal("https", gw.Spec.Servers[0].Port.Name)
+	assert.Equal(testTraitPortName, gw.Spec.Servers[0].Port.Name)
 	assert.Equal(uint32(443), gw.Spec.Servers[0].Port.Number)
 	assert.Equal("HTTPS", gw.Spec.Servers[0].Port.Protocol)
 	assert.Equal("test-namespace-test-appconf-cert-secret", gw.Spec.Servers[0].Tls.CredentialName)
@@ -2304,7 +1974,7 @@ func TestExplicitServiceProvidedForVirtualServiceDestination(t *testing.T) {
 		"APPCONF_NAMESPACE":   "test-namespace",
 		"COMPONENT_NAME":      "test-comp",
 		"COMPONENT_NAMESPACE": "test-namespace",
-		"TRAIT_NAME":          "test-trait",
+		"TRAIT_NAME":          testTraitName,
 		"TRAIT_NAMESPACE":     "test-namespace",
 		"WORKLOAD_NAME":       "test-workload",
 		"WORKLOAD_NAMESPACE":  "test-namespace",
@@ -2369,14 +2039,14 @@ func TestExplicitServiceProvidedForVirtualServiceDestination(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("ingressgateway", gw.Spec.Selector["istio"])
 	assert.Equal("test-appconf.test-namespace.1.2.3.4.nip.io", gw.Spec.Servers[0].Hosts[0])
-	assert.Equal("https", gw.Spec.Servers[0].Port.Name)
+	assert.Equal(testTraitPortName, gw.Spec.Servers[0].Port.Name)
 	assert.Equal(uint32(443), gw.Spec.Servers[0].Port.Number)
 	assert.Equal("HTTPS", gw.Spec.Servers[0].Port.Protocol)
 	assert.Equal("test-namespace-test-appconf-cert-secret", gw.Spec.Servers[0].Tls.CredentialName)
 	assert.Equal("SIMPLE", gw.Spec.Servers[0].Tls.Mode.String())
 
 	vs := istioclient.VirtualService{}
-	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: "test-trait-rule-0-vs"}, &vs)
+	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: expectedTraitVSName}, &vs)
 	assert.NoError(err)
 	assert.Equal("test-namespace-test-appconf-gw", vs.Spec.Gateways[0])
 	assert.Len(vs.Spec.Gateways, 1)
@@ -2405,7 +2075,7 @@ func TestMultiplePortsOnDiscoveredService(t *testing.T) {
 		"APPCONF_NAMESPACE":   "test-namespace",
 		"COMPONENT_NAME":      "test-comp",
 		"COMPONENT_NAMESPACE": "test-namespace",
-		"TRAIT_NAME":          "test-trait",
+		"TRAIT_NAME":          testTraitName,
 		"TRAIT_NAMESPACE":     "test-namespace",
 		"WORKLOAD_NAME":       "test-workload",
 		"WORKLOAD_NAMESPACE":  "test-namespace",
@@ -2474,14 +2144,14 @@ func TestMultiplePortsOnDiscoveredService(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("ingressgateway", gw.Spec.Selector["istio"])
 	assert.Equal("test-appconf.test-namespace.1.2.3.4.nip.io", gw.Spec.Servers[0].Hosts[0])
-	assert.Equal("https", gw.Spec.Servers[0].Port.Name)
+	assert.Equal(testTraitPortName, gw.Spec.Servers[0].Port.Name)
 	assert.Equal(uint32(443), gw.Spec.Servers[0].Port.Number)
 	assert.Equal("HTTPS", gw.Spec.Servers[0].Port.Protocol)
 	assert.Equal("test-namespace-test-appconf-cert-secret", gw.Spec.Servers[0].Tls.CredentialName)
 	assert.Equal("SIMPLE", gw.Spec.Servers[0].Tls.Mode.String())
 
 	vs := istioclient.VirtualService{}
-	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: "test-trait-rule-0-vs"}, &vs)
+	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: expectedTraitVSName}, &vs)
 	assert.NoError(err)
 	assert.Equal("test-namespace-test-appconf-gw", vs.Spec.Gateways[0])
 	assert.Len(vs.Spec.Gateways, 1)
@@ -2511,11 +2181,11 @@ func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination
 		"APPCONF_UID":           "test-appconf-uid",
 		"COMPONENT_NAME":        "test-comp",
 		"COMPONENT_NAMESPACE":   "test-namespace",
-		"TRAIT_NAME":            "test-trait",
+		"TRAIT_NAME":            testTraitName,
 		"TRAIT_NAMESPACE":       "test-namespace",
 		"WORKLOAD_NAME":         "test-workload",
 		"WORKLOAD_NAMESPACE":    "test-namespace",
-		"WORKLOAD_UID":          "test-workload-uid",
+		"WORKLOAD_UID":          testWorkloadID,
 		"WORKLOAD_KIND":         "VerrazzanoHelidonWorkload",
 		"DEPLOYMENT_NAME":       "test-deployment",
 		"DEPLOYMENT_NAMESPACE":  "test-namespace",
@@ -2548,7 +2218,7 @@ func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination
 			Name:      "test-service-1",
 			Namespace: params["APPCONF_NAMESPACE"],
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
+				APIVersion: apiVersion,
 				Kind:       "VerrazzanoHelidonWorkload",
 				Name:       params["WORKLOAD_NAME"],
 				UID:        types.UID(params["WORKLOAD_UID"]),
@@ -2572,7 +2242,7 @@ func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination
 			Name:      "test-service-2",
 			Namespace: params["APPCONF_NAMESPACE"],
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
+				APIVersion: apiVersion,
 				Kind:       "VerrazzanoHelidonWorkload",
 				Name:       params["WORKLOAD_NAME"],
 				UID:        types.UID(params["WORKLOAD_UID"]),
@@ -2603,14 +2273,14 @@ func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination
 	assert.NoError(err)
 	assert.Equal("ingressgateway", gw.Spec.Selector["istio"])
 	assert.Equal("test-appconf.test-namespace.1.2.3.4.nip.io", gw.Spec.Servers[0].Hosts[0])
-	assert.Equal("https", gw.Spec.Servers[0].Port.Name)
+	assert.Equal(testTraitPortName, gw.Spec.Servers[0].Port.Name)
 	assert.Equal(uint32(443), gw.Spec.Servers[0].Port.Number)
 	assert.Equal("HTTPS", gw.Spec.Servers[0].Port.Protocol)
 	assert.Equal("test-namespace-test-appconf-cert-secret", gw.Spec.Servers[0].Tls.CredentialName)
 	assert.Equal("SIMPLE", gw.Spec.Servers[0].Tls.Mode.String())
 
 	vs := istioclient.VirtualService{}
-	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: "test-trait-rule-0-vs"}, &vs)
+	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: expectedTraitVSName}, &vs)
 	assert.NoError(err)
 	assert.Equal("test-namespace-test-appconf-gw", vs.Spec.Gateways[0])
 	assert.Len(vs.Spec.Gateways, 1)
@@ -2641,7 +2311,7 @@ func TestSelectExistingServiceForVirtualServiceDestinationAfterRetry(t *testing.
 		"APPCONF_NAMESPACE":   "test-namespace",
 		"COMPONENT_NAME":      "test-comp",
 		"COMPONENT_NAMESPACE": "test-namespace",
-		"TRAIT_NAME":          "test-trait",
+		"TRAIT_NAME":          testTraitName,
 		"TRAIT_NAMESPACE":     "test-namespace",
 		"WORKLOAD_NAME":       "test-workload",
 		"WORKLOAD_NAMESPACE":  "test-namespace",
@@ -2682,7 +2352,7 @@ func TestSelectExistingServiceForVirtualServiceDestinationAfterRetry(t *testing.
 	assert.False(k8serrors.IsNotFound(err), "Gateway should have been created.")
 
 	vs := istioclient.VirtualService{}
-	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: "test-trait-rule-0-vs"}, &vs)
+	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: expectedTraitVSName}, &vs)
 	assert.True(k8serrors.IsNotFound(err), "No VirtualService should have been created.")
 
 	// Update a service. Update the ClusterIP of the service.
@@ -2721,7 +2391,7 @@ func TestSelectExistingServiceForVirtualServiceDestinationAfterRetry(t *testing.
 	assert.NoError(err)
 	assert.Equal("ingressgateway", gw.Spec.Selector["istio"])
 	assert.Equal("test-appconf.test-namespace.1.2.3.4.nip.io", gw.Spec.Servers[0].Hosts[0])
-	assert.Equal("https", gw.Spec.Servers[0].Port.Name)
+	assert.Equal(testTraitPortName, gw.Spec.Servers[0].Port.Name)
 	assert.Equal(uint32(443), gw.Spec.Servers[0].Port.Number)
 	assert.Equal("HTTPS", gw.Spec.Servers[0].Port.Protocol)
 	assert.Equal("test-namespace-test-appconf-cert-secret", gw.Spec.Servers[0].Tls.CredentialName)
@@ -2729,7 +2399,7 @@ func TestSelectExistingServiceForVirtualServiceDestinationAfterRetry(t *testing.
 
 	// Verify the VirtualService was created and is valid.
 	vs = istioclient.VirtualService{}
-	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: "test-trait-rule-0-vs"}, &vs)
+	err = cli.Get(context.Background(), client.ObjectKey{Namespace: "test-namespace", Name: expectedTraitVSName}, &vs)
 	assert.NoError(err)
 	assert.Equal("test-namespace-test-appconf-gw", vs.Spec.Gateways[0])
 	assert.Len(vs.Spec.Gateways, 1)
@@ -2755,6 +2425,7 @@ func newScheme() *runtime.Scheme {
 	certapiv1.AddToScheme(scheme)
 	k8net.AddToScheme(scheme)
 	istioclient.AddToScheme(scheme)
+	v1alpha2.SchemeBuilder.AddToScheme(scheme)
 	return scheme
 }
 
@@ -2824,8 +2495,8 @@ func newVerrazzanoIngress(ipAddress string) *k8net.Ingress {
 func newIstioLoadBalancerService(clusterIPAddress string, loadBalancerIPAddress string) *k8score.Service {
 	istioService := k8score.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "istio-ingressgateway",
-			Namespace: "istio-system",
+			Name:      istioIngressGatewayName,
+			Namespace: istioSystemNamespace,
 		},
 		Spec: k8score.ServiceSpec{
 			ClusterIP: clusterIPAddress,
@@ -2932,11 +2603,11 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	// Expect a call to get the ingress trait resource.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
 			trait.TypeMeta = metav1.TypeMeta{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
-				Kind:       "IngressTrait"}
+				APIVersion: apiVersion,
+				Kind:       traitKind}
 			trait.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name,
@@ -2953,9 +2624,9 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 						TTL:  30},
 				}}}
 			trait.Spec.WorkloadReference = oamrt.TypedReference{
-				APIVersion: "oam.verrazzano.io/v1alpha1",
+				APIVersion: apiVersion,
 				Kind:       "VerrazzanoCoherenceWorkload",
-				Name:       "test-workload-name"}
+				Name:       testWorkloadName}
 			return nil
 		})
 
@@ -2968,9 +2639,9 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 
 	// Expect a call to get the Verrazzano Coherence workload resource
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-workload-name"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testWorkloadName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
-			workload.SetAPIVersion("oam.verrazzano.io/v1alpha1")
+			workload.SetAPIVersion(apiVersion)
 			workload.SetKind("VerrazzanoCoherenceWorkload")
 			workload.SetNamespace(name.Namespace)
 			workload.SetName(name.Name)
@@ -2979,13 +2650,13 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 		})
 	// Expect a call to get the contained Coherence resource
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: containedName}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: containedName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
 			workload.SetUnstructuredContent(containedResource)
 			workload.SetNamespace(name.Namespace)
 			workload.SetAPIVersion("coherence.oracle.com/v1")
 			workload.SetKind("Coherence")
-			workload.SetUID("test-workload-uid")
+			workload.SetUID(testWorkloadID)
 			return nil
 		})
 	// Expect a call to get the containerized workload resource definition
@@ -3007,10 +2678,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 			assert.Equal("DeploymentList", list.GetKind())
 			return nil
 		})
-	// Expect a call to get the certificate related to the ingress trait
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "istio-system", Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Certificate"}, "test-space-myapp-cert"))
+	appCertificateExpectations(mock)
 	// Expect a call to list the child Service resources of the Coherence workload definition
 	mock.EXPECT().
 		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
@@ -3025,8 +2693,8 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "core.oam.dev/v1alpha2",
 						Kind:       "ContainerizedWorkload",
-						Name:       "test-workload-name",
-						UID:        "test-workload-uid",
+						Name:       testWorkloadName,
+						UID:        testWorkloadID,
 					}}},
 				Spec: k8score.ServiceSpec{
 					ClusterIP: "10.11.12.13",
@@ -3035,7 +2703,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 		})
 	// Expect a call to get the app config and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "myapp"}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
 			app.TypeMeta = metav1.TypeMeta{
 				APIVersion: "core.oam.dev/v1alpha2",
@@ -3043,39 +2711,18 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 			}
 			return nil
 		})
-	// Expect a call to create the certificate and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-space-myapp-gw"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "Gateway"}, "test-space-myapp-gw"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
-			return nil
-		})
-	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-vs"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "VirtualService"}, "test-trait-name-rule-0-vs"))
-	// Expect a call to create the ingress resource and return success
-	mock.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
-			assert.Len(virtualservice.Spec.Http, 1)
-			assert.Len(virtualservice.Spec.Http[0].Route, 1)
-			assert.Equal("test-service.test-space.svc.local", virtualservice.Spec.Http[0].Route[0].Destination.Host)
-			return nil
-		})
+
+	createCertSuccessExpectations(mock)
+	getGatewayForTraitNotFoundExpectations(mock)
+	createIngressResourceSuccessExpectations(mock)
+	traitVSNotFoundExpectation(mock)
+	createIngressResSuccessExpectations(mock, assert)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
 	// Expect a call to get the destination rule resource related to the ingress trait and return that it is not found.
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "test-space", Name: "test-trait-name-rule-0-dr"}, gomock.Not(gomock.Nil())).
-		Return(k8serrors.NewNotFound(schema.GroupResource{Group: "test-space", Resource: "DestinationRule"}, "test-trait-name-rule-0-dr"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: fmt.Sprintf("%s-rule-0-dr", testTraitName)}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "DestinationRule"}, fmt.Sprintf("%s-rule-0-dr", testTraitName)))
 
 	// Expect a call to create the DestinationRule resource and return success
 	mock.EXPECT().
@@ -3084,8 +2731,6 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 			assert.Equal("test-service.test-space.svc.local", destinationrule.Spec.Host)
 			return nil
 		})
-	// Expect a call to get the status writer and return a mock.
-	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 	// Expect a call to update the status of the ingress trait.
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -3096,7 +2741,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookie(t *test
 		})
 
 	// Create and make the request
-	request := newRequest("test-space", "test-trait-name")
+	request := newRequest(testNamespace, testTraitName)
 	reconciler := newIngressTraitReconciler(mock)
 	result, err := reconciler.Reconcile(request)
 
@@ -3123,4 +2768,529 @@ func TestReconcileKubeSystem(t *testing.T) {
 	mocker.Finish()
 	assert.Nil(err)
 	assert.True(result.IsZero())
+}
+
+// TestUpdateGatewayServersList tests the updateGatewayServersList method for the following use case.
+// GIVEN a request to update the gateway servers list for an ingress trait resource
+// WHEN no existing Servers are present in the Gateway
+// THEN ensure that a new Gateway is appended to the servers list
+func TestUpdateGatewayServersList(t *testing.T) {
+	assert := asserts.New(t)
+
+	reconciler := createReconcilerWithFake()
+	servers := reconciler.updateGatewayServersList([]*istionet.Server{}, &istionet.Server{Name: "server", Port: &istionet.Port{Name: "port"}})
+	assert.Len(servers, 1)
+	assert.Equal("server", servers[0].Name)
+}
+
+// TestUpdateGatewayServersUpgrade tests the updateGatewayServersList method for the upgrade to 1.3 case.
+//
+// Prior to 1.3, a single Server object was used to accumulate all hosts related to an app across all
+// IngressTrait definitions.  Post-1.3, we replace this with a 1:1 mapping of Server objects to IngressTrait.
+// Each Server object will define port settings for all hosts in the IngressTrait and be recomputed on each reconcile.
+//
+// On startup, the operator will reconcile all existing IngressTraits which will create the new mappings
+//
+// GIVEN a request to update the gateway servers list for an ingress trait resource
+// WHEN we are upgrading from a release before 1.3 where the Gateway maintains a single Server object for all hosts for an application
+// THEN ensure that the resulting servers list contains only an entry for the single IngressTrait being reconciled
+func TestUpdateGatewayServersUpgrade(t *testing.T) {
+	assert := asserts.New(t)
+
+	reconciler := createReconcilerWithFake()
+
+	trait1Hosts := []string{"trait1host1", "trait1host2"}
+
+	existingServerHosts := trait1Hosts
+	existingServerHosts = append(existingServerHosts, []string{"trait2host1", "trait3host1"}...)
+
+	existingServersPre13 := []*istionet.Server{
+		{
+			Hosts: existingServerHosts,
+			Port: &istionet.Port{
+				Name:     httpsLower,
+				Number:   443,
+				Protocol: httpsProtocol,
+			},
+		},
+	}
+
+	trait1Server := &istionet.Server{
+		Name:  testTraitName,
+		Hosts: trait1Hosts,
+		Port: &istionet.Port{
+			Name:     fmt.Sprintf("%s-%s", httpsLower, testTraitName),
+			Protocol: httpsProtocol,
+		},
+	}
+	expectedServers := []*istionet.Server{trait1Server}
+	servers := reconciler.updateGatewayServersList(existingServersPre13, trait1Server)
+	assert.Len(servers, 1)
+	assert.Equal(expectedServers, servers)
+}
+
+// TestUpdateGatewayServersUpdateTraitHosts tests the updateGatewayServersList
+// GIVEN a request to update the gateway servers list
+// WHEN when the Server object for existing Trait has an updated hosts list
+// THEN ensure the returned Servers list has the new Server for the IngressTrait
+func TestUpdateGatewayServersUpdateTraitHosts(t *testing.T) {
+	assert := asserts.New(t)
+
+	reconciler := createReconcilerWithFake()
+
+	trait1Hosts := []string{"trait1host1", "trait1host2"}
+	trait2Hosts := []string{"trait2host1"}
+	trait3Hosts := []string{"trait3host1", "trait3host2", "trait3host3"}
+
+	const trait1Name = "trait1"
+	const trait2Name = "trait2"
+	const trait3Name = "trait3"
+
+	existingServers := []*istionet.Server{
+		createGatewayServer(trait1Name, trait1Hosts),
+		createGatewayServer(trait2Name, trait2Hosts),
+		createGatewayServer(trait3Name, trait3Hosts),
+	}
+
+	// Add a host to trait2
+	updatedTrait2Server := createGatewayServer(trait2Name, append(trait2Hosts, "trait2Host2"))
+	expectedServers := []*istionet.Server{
+		existingServers[0],
+		updatedTrait2Server,
+		existingServers[2],
+	}
+	servers := reconciler.updateGatewayServersList(existingServers, updatedTrait2Server)
+	assert.Len(servers, 3)
+	assert.Equal(expectedServers, servers)
+
+	// Prune the new host from trait2
+	updatedTrait2ServerRemovedHost := createGatewayServer(trait2Name, trait2Hosts)
+	expectedServers2 := []*istionet.Server{
+		existingServers[0],
+		updatedTrait2ServerRemovedHost,
+		existingServers[2],
+	}
+	servers2 := reconciler.updateGatewayServersList(existingServers, updatedTrait2ServerRemovedHost)
+	assert.Len(servers2, 3)
+	assert.Equal(expectedServers2, servers)
+
+}
+
+// TestUpdateGatewayServersNewTraitHost tests the updateGatewayServersList method when a new Trait Server is added
+// GIVEN a request to update the gateway servers list
+// WHEN we are adding a new IngressTrait
+// THEN ensure the returned Servers list has the new Server for the IngressTrait
+func TestUpdateGatewayServersNewTraitHost(t *testing.T) {
+	assert := asserts.New(t)
+
+	reconciler := createReconcilerWithFake()
+
+	trait1Hosts := []string{"trait1host1", "trait1host2"}
+	trait2Hosts := []string{"trait2host1"}
+	trait3Hosts := []string{"trait3host1", "trait3host2", "trait3host3"}
+
+	const trait1Name = "trait1"
+	const trait2Name = "trait2"
+	const trait3Name = "trait3"
+
+	existingServers := []*istionet.Server{
+		createGatewayServer(trait1Name, trait1Hosts),
+		createGatewayServer(trait2Name, trait2Hosts),
+	}
+
+	trait3Server := createGatewayServer(trait3Name, trait3Hosts)
+	expectedServers := append(existingServers, trait3Server)
+
+	servers := reconciler.updateGatewayServersList(existingServers, trait3Server)
+	assert.Len(servers, 3)
+	assert.Equal(expectedServers, servers)
+}
+
+// TestMutateGatewayAddTrait tests the mutateGateway method
+// GIVEN a request to mutate the app gateway
+// WHEN a new Trate/TraitRule is added
+// THEN ensure the returned Servers list has the new Server for the IngressTrait
+func TestMutateGatewayAddTrait(t *testing.T) {
+	assert := asserts.New(t)
+
+	trait1Hosts := []string{"trait1host1", "trait1host2"}
+	trait2Hosts := []string{"trait2host1"}
+
+	const trait1Name = "trait1"
+	const trait2Name = "trait2"
+	const secretName = "secretName"
+
+	trait1Server := createGatewayServer(trait1Name, trait1Hosts, secretName)
+
+	const appName = "myapp"
+	const gwName = "test-space-myapp-gw"
+	gw := &istioclient.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: testNamespace},
+		Spec: istionet.Gateway{
+			Servers: []*istionet.Server{
+				trait1Server,
+			},
+		},
+	}
+
+	trait := &vzapi.IngressTrait{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trait2Name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				oam.LabelAppName: appName,
+			},
+		},
+		Spec: vzapi.IngressTraitSpec{
+			Rules: []vzapi.IngressRule{
+				{Hosts: trait2Hosts},
+			},
+			WorkloadReference: createWorkloadReference(appName),
+		},
+	}
+
+	reconciler := setupTraitTestFakes(appName, gw)
+
+	_, _, err := reconciler.createOrUpdateChildResources(context.TODO(), trait, vzlog.DefaultLogger())
+	assert.NoError(err)
+
+	updatedGateway := &istioclient.Gateway{}
+	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: gw.Name, Namespace: testNamespace}, updatedGateway))
+	updatedServers := updatedGateway.Spec.Servers
+	assert.Len(updatedServers, 2)
+	assert.Equal(updatedServers[0].Hosts, trait1Hosts)
+	assert.Equal(updatedServers[1].Hosts, trait2Hosts)
+
+}
+
+func createWorkloadReference(appName string) oamrt.TypedReference {
+	return oamrt.TypedReference{
+		APIVersion: "core.oam.dev/v1alpha2",
+		Kind:       "ContainerizedWorkload",
+		Name:       appName,
+	}
+}
+
+// TestMutateGatewayHostsAddRemoveTraitRule tests the createOrUpdateChildResources method
+// GIVEN a request to createOrUpdateChildResources
+// WHEN a new TraitRule has been added or remvoed to an existing Trait with new hosts
+// THEN ensure the gateway Server hosts lists for the Trait has been updated accordingly
+func TestMutateGatewayHostsAddRemoveTraitRule(t *testing.T) {
+	assert := asserts.New(t)
+
+	trait1Hosts := []string{"trait1host1", "trait1host2"}
+	trait1NewHosts := []string{"trait1host3", "trait1host4", "trait1host2"}
+	trait2Hosts := []string{"trait2host1"}
+
+	const trait1Name = "trait1"
+	const trait2Name = "trait2"
+	const secretName = "secretName"
+
+	trait1Server := createGatewayServer(trait1Name, trait1Hosts, secretName)
+	trait2Server := createGatewayServer(trait2Name, trait2Hosts, secretName)
+
+	const appName = "myapp"
+	const gwName = "test-space-myapp-gw"
+
+	gw := &istioclient.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: testNamespace},
+		Spec: istionet.Gateway{
+			Servers: []*istionet.Server{
+				trait1Server,
+				trait2Server,
+			},
+		},
+	}
+
+	reconciler := setupTraitTestFakes(appName, gw)
+
+	// Test updating a trait to add hosts
+	trait1UpdatedHosts := append(trait1Hosts, []string{"trait1host3", "trait1host4"}...)
+	updatedTrait := &vzapi.IngressTrait{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trait1Name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				oam.LabelAppName: appName,
+			},
+		},
+		Spec: vzapi.IngressTraitSpec{
+			Rules: []vzapi.IngressRule{
+				{Hosts: trait1Hosts},
+				{Hosts: trait1NewHosts},
+			},
+			WorkloadReference: createWorkloadReference(appName),
+		},
+	}
+
+	_, _, err := reconciler.createOrUpdateChildResources(context.TODO(), updatedTrait, vzlog.DefaultLogger())
+	assert.NoError(err)
+
+	updatedGateway := &istioclient.Gateway{}
+	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: gwName, Namespace: testNamespace}, updatedGateway))
+	updatedServers := updatedGateway.Spec.Servers
+	assert.Len(updatedServers, 2)
+	assert.Equal(updatedServers[0].Hosts, trait1UpdatedHosts)
+	assert.Equal(updatedServers[1].Hosts, trait2Hosts)
+
+	// Test removing the added rule and that the hosts list is restored
+	updatedTraitRemovedRule := &vzapi.IngressTrait{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trait1Name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				oam.LabelAppName: appName,
+			},
+		},
+		Spec: vzapi.IngressTraitSpec{
+			Rules: []vzapi.IngressRule{
+				{Hosts: trait1Hosts},
+			},
+			WorkloadReference: createWorkloadReference(appName),
+		},
+	}
+
+	_, _, err2 := reconciler.createOrUpdateChildResources(context.TODO(), updatedTraitRemovedRule, vzlog.DefaultLogger())
+	assert.NoError(err2)
+
+	updatedGatewayRemovedRule := &istioclient.Gateway{}
+	assert.NoError(reconciler.Get(context.TODO(), types.NamespacedName{Name: gwName, Namespace: testNamespace}, updatedGatewayRemovedRule))
+	updatedServersRemovedRule := updatedGatewayRemovedRule.Spec.Servers
+	assert.Len(updatedServers, 2)
+	assert.Equal(updatedServersRemovedRule[0].Hosts, trait1Hosts)
+	assert.Equal(updatedServersRemovedRule[1].Hosts, trait2Hosts)
+}
+
+func setupTraitTestFakes(appName string, gw *istioclient.Gateway) Reconciler {
+	appConfig := &v1alpha2.ApplicationConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: testNamespace},
+	}
+
+	workload := &v1alpha2.ContainerizedWorkload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appName,
+			Namespace: testNamespace,
+			UID:       testWorkloadID,
+		},
+	}
+
+	workloadDef := &v1alpha2.WorkloadDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "containerizedworkloads.core.oam.dev"},
+		Spec: v1alpha2.WorkloadDefinitionSpec{
+			ChildResourceKinds: []v1alpha2.ChildResourceKind{
+				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
+				{APIVersion: "v1", Kind: "Service", Selector: nil},
+			},
+		},
+	}
+
+	workloadService := &k8score.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testService",
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName,
+				UID:        testWorkloadID,
+			}}},
+		Spec: k8score.ServiceSpec{
+			ClusterIP: "10.11.12.13",
+			Ports:     []k8score.ServicePort{{Port: 42}}},
+	}
+
+	reconciler := createReconcilerWithFake(appConfig, workload, workloadDef, workloadService, gw)
+	return reconciler
+}
+
+func createGatewayServer(traitName string, traitHosts []string, secretName ...string) *istionet.Server {
+	server := &istionet.Server{
+		Name:  traitName,
+		Hosts: traitHosts,
+		Port: &istionet.Port{
+			Name:     formatGatewaySeverPortName(traitName),
+			Number:   443,
+			Protocol: httpsProtocol,
+		},
+	}
+	if len(secretName) > 0 {
+		server.Tls = &istionet.ServerTLSSettings{
+			Mode:           istionet.ServerTLSSettings_SIMPLE,
+			CredentialName: secretName[0],
+		}
+	}
+	return server
+}
+
+func createIngressResSuccessExpectations(mock *mocks.MockClient, assert *asserts.Assertions) {
+	// Expect a call to create the ingress resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
+			assert.Len(virtualservice.Spec.Http, 1)
+			assert.Len(virtualservice.Spec.Http[0].Route, 1)
+			assert.Equal("test-service.test-space.svc.local", virtualservice.Spec.Http[0].Route[0].Destination.Host)
+			return nil
+		})
+}
+
+func createIngressResourceSuccessExpectations(mock *mocks.MockClient) {
+	// Expect a call to create the ingress resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
+			return nil
+		})
+}
+
+func getGatewayForTraitNotFoundExpectations(mock *mocks.MockClient) {
+	// Expect a call to get the gateway resource related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: expectedAppGWName}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "Gateway"}, expectedAppGWName))
+}
+
+func appCertificateExpectations(mock *mocks.MockClient) {
+	// Expect a call to get the certificate related to the ingress trait
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: "test-space-myapp-cert"}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "Certificate"}, "test-space-myapp-cert"))
+}
+
+func createCertSuccessExpectations(mock *mocks.MockClient) {
+	// Expect a call to create the certificate and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, certificate *certapiv1.Certificate, opts ...client.CreateOption) error {
+			return nil
+		})
+}
+
+func gatewayNotFoundExpectations(mock *mocks.MockClient) {
+	getGatewayForTraitNotFoundExpectations(mock)
+}
+
+func updateMockStatusExpectations(mockStatus *mocks.MockStatusWriter, assert *asserts.Assertions) {
+	// Expect a call to update the status of the ingress trait.
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 2)
+			return nil
+		})
+}
+
+func getMockStatusWriterExpectations(mock *mocks.MockClient, mockStatus *mocks.MockStatusWriter) {
+	// Expect a call to get the status writer and return a mock.
+	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+}
+
+func createIngressSuccessExpectations(mock *mocks.MockClient) {
+	// Expect a call to create the ingress resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, virtualservice *istioclient.VirtualService, opts ...client.CreateOption) error {
+			return nil
+		})
+}
+
+func traitVSNotFoundExpectation(mock *mocks.MockClient) {
+	// Expect a call to get the virtual service resource related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: expectedTraitVSName}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "VirtualService"}, expectedTraitVSName))
+}
+
+func childServiceExpectations(mock *mocks.MockClient, assert *asserts.Assertions) {
+	// Expect a call to list the child Service resources of the containerized workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("ServiceList", list.GetKind())
+			return appendAsUnstructured(list, k8score.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "core.oam.dev/v1alpha2",
+						Kind:       "ContainerizedWorkload",
+						Name:       testWorkloadName,
+						UID:        testWorkloadID,
+					}}},
+				Spec: k8score.ServiceSpec{
+					ClusterIP: "10.11.12.13",
+					Ports:     []k8score.ServicePort{{Port: 42}}},
+			})
+		})
+}
+
+func listChildDeploymentExpectations(mock *mocks.MockClient, assert *asserts.Assertions) {
+	// Expect a call to list the child Deployment resources of the containerized workload definition
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *unstructured.UnstructuredList, opts ...client.ListOption) error {
+			assert.Equal("DeploymentList", list.GetKind())
+			return nil
+		})
+}
+
+func workloadResourceDefinitionExpectations(mock *mocks.MockClient) {
+	// Expect a call to get the containerized workload resource definition
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workloadDef *v1alpha2.WorkloadDefinition) error {
+			workloadDef.Namespace = name.Namespace
+			workloadDef.Name = name.Name
+			workloadDef.Spec.ChildResourceKinds = []v1alpha2.ChildResourceKind{
+				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
+				{APIVersion: "v1", Kind: "Service", Selector: nil},
+			}
+			return nil
+		})
+}
+
+func workLoadResourceExpectations(mock *mocks.MockClient) {
+	// Expect a call to get the containerized workload resource
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testWorkloadName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *unstructured.Unstructured) error {
+			workload.SetAPIVersion("core.oam.dev/v1alpha2")
+			workload.SetKind("ContainerizedWorkload")
+			workload.SetNamespace(name.Namespace)
+			workload.SetName(name.Name)
+			workload.SetUID(testWorkloadID)
+			return nil
+		})
+}
+
+func getIngressTraitResourceExpectations(mock *mocks.MockClient) {
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       traitKind}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Labels:    map[string]string{oam.LabelAppName: "myapp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{{Path: "test-path"}}}}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName}
+			return nil
+		})
+}
+
+func createReconcilerWithFake(initObjs ...runtime.Object) Reconciler {
+	cli := fake.NewFakeClientWithScheme(newScheme(), initObjs...)
+	reconciler := newIngressTraitReconciler(cli)
+	return reconciler
 }


### PR DESCRIPTION
# Description


Currently the application operator maps the hosts of all `IngressTrait` rules for an application to a single `Server` object in an Istio `Gateway` object.  Any existing hosts in the `Gateway` object are appended to the set of hosts calculated, to preserve hosts from previously reconciled `IngressTrait` rules.  

Now that the DNS domain for a Verrazzano install can be changed, a case exists where an application using the default generated hostname can leak DNS names/records.  When the domain changes, the application's old host name is appended to the new one, which will leak DNS records when `external-dns` is in play, or continue to resolve the old wildcard DNS name if that is being used.

In order to prevent this while ensuring port definitions are unique and deterministically generated, this change revises `IngressTrait` controller `Gateway` reconcile to 

- Create a 1:1 `Server` to `IngressTrait` relationship, where each server tracks the host/port/TLS configuration for an `IngressTrait`
- On each reconcile, the Server associated with an `IngressTrait` is re-computed and updated during the `mutateGatway` method
- All hosts associated with an `IngressTrait` are computed across all `IngressRules` for that trait, and the `Gateway` is updated only once instead of for each `IngressRule`.  This is so that as rules are added/removed we can re-build the list across all rules once and treat them as a whole.

In the upgrade case, because the mappings are rebuilt on each reconcile, the initial reconcile should replace the previous `https` Gateway Server singleton configuration with the new format.

While it is still not ideal to have potentially repeated host/port entries, it remains functional.  We may need to revisit how we map `ApplicationConfigurations` and `IngressTraits` to optimize this down the road.

**NOTE:** There is an issue with updating the Gateway configuration when an `IngressTrait` is removed from an updated application configuration, currently the VAO is not tracking that.  That will be resolved via a separate PR.

### Old Gateway Mapping Example

```yaml
  spec:
    selector:
      istio: ingressgateway
    servers:
    - hosts:
      - bobs-books.bobs-books.172.18.0.230.nip.io
      port:
        name: https
        number: 443
        protocol: HTTPS
      tls:
        credentialName: bobs-books-bobs-books-cert-secret
        mode: SIMPLE
```

### New Gateway Mapping Example

```yaml
  spec:
    selector:
      istio: ingressgateway
    servers:
    - hosts:
      - bobs-books.bobs-books.172.18.0.230.nip.io
      name: bobs-orders-wls-trait-57b4d8cb4b
      port:
        name: https-bobs-orders-wls-trait-57b4d8cb4b
        number: 443
        protocol: HTTPS
      tls:
        credentialName: bobs-books-bobs-books-cert-secret
        mode: SIMPLE
    - hosts:
      - bobs-books.bobs-books.172.18.0.230.nip.io
      name: robert-helidon-trait-54d7bcd54b
      port:
        name: https-robert-helidon-trait-54d7bcd54b
        number: 443
        protocol: HTTPS
      tls:
        credentialName: bobs-books-bobs-books-cert-secret
        mode: SIMPLE
    - hosts:
      - bobs-books.bobs-books.172.18.0.230.nip.io
      name: bobby-wls-trait-79b67d9d88
      port:
        name: https-bobby-wls-trait-79b67d9d88
        number: 443
        protocol: HTTPS
      tls:
        credentialName: bobs-books-bobs-books-cert-secret
        mode: SIMPLE
```

Fixes VZ-5454

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
