### PR TITLE
VZ-5362: backport POKO metrics not scraped when istio-injection was disabled to release-1.2

### DIFF
--- a/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller_test.go
@@ -5,7 +5,6 @@ package metricsbinding
 
 import (
 	"context"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"os"
 	"strings"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
 	k8sapps "k8s.io/api/apps/v1"
@@ -182,8 +182,6 @@ func TestUpdateScrapeConfig(t *testing.T) {
 
 	localMetricsTemplate.Spec.PrometheusConfig.ScrapeConfigTemplate = string(scrapeConfigTemplate)
 
-	mock.EXPECT().Update(gomock.Any(), gomock.Not(gomock.Nil())).Return(nil)
-
 	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: testMetricsTemplateNamespace, Name: testMetricsTemplateName}), gomock.Not(gomock.Nil())).DoAndReturn(
 		func(ctx context.Context, key client.ObjectKey, template *vzapi.MetricsTemplate) error {
 			template.SetNamespace(metricsTemplate.Namespace)
@@ -203,10 +201,10 @@ func TestUpdateScrapeConfig(t *testing.T) {
 			return nil
 		})
 
-	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Name: testDeploymentNamespace}), gomock.Not(gomock.Nil())).DoAndReturn(
+	mock.EXPECT().Get(gomock.Any(), gomock.Eq(client.ObjectKey{Name: testExistsDeploymentNamespace}), gomock.Not(gomock.Nil())).DoAndReturn(
 		func(ctx context.Context, key client.ObjectKey, namespace *k8score.Namespace) error {
 			namespace.Labels = map[string]string{"istio-injection": "enabled"}
-			namespace.Name = testDeploymentNamespace
+			namespace.Name = testExistsDeploymentNamespace
 			return nil
 		})
 

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -761,11 +761,13 @@ spec:
           source_labels:
             - name
           target_label: webapp
+      {{`{{ if index .namespace.metadata.labels "istio-injection" }}`}}
+      {{`{{ if eq (index .namespace.metadata.labels "istio-injection" ) "enabled" }}`}}
       scheme: https
-      {{`{{ if eq ( index .namespace.metadata.labels "istio-injection" ) "enabled" }}`}}
       tls_config:
         ca_file: /etc/istio-certs/root-cert.pem
         cert_file: /etc/istio-certs/cert-chain.pem
         insecure_skip_verify: true
         key_file: /etc/istio-certs/key.pem
+      {{`{{ end }}`}}
       {{`{{ end }}`}}

--- a/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
+++ b/tests/e2e/metricsbinding/helidon-deployment/helidon_deployment_test.go
@@ -29,7 +29,7 @@ var t = framework.NewTestFramework("deploymentworkload")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath)
+	metricsbinding.DeployApplication(namespace, yamlPath, true)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod-annotation-overrides/helidon_pod_annotation_overrides_test.go
@@ -39,7 +39,7 @@ var t = framework.NewTestFramework("helidonpodannotation")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath)
+	metricsbinding.DeployApplication(namespace, yamlPath, true)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
+++ b/tests/e2e/metricsbinding/helidon-pod/helidon_pod_test.go
@@ -29,7 +29,7 @@ var t = framework.NewTestFramework("podworkload")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath)
+	metricsbinding.DeployApplication(namespace, yamlPath, true)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
+++ b/tests/e2e/metricsbinding/helidon-replicaset/helidon_replicaset_test.go
@@ -29,7 +29,7 @@ var t = framework.NewTestFramework("replicasetworkload")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath)
+	metricsbinding.DeployApplication(namespace, yamlPath, false)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
+++ b/tests/e2e/metricsbinding/helidon-statefulset/helidon_statefulset_test.go
@@ -29,7 +29,7 @@ var t = framework.NewTestFramework("statefulsetworkload")
 
 var _ = t.BeforeSuite(func() {
 	start := time.Now()
-	metricsbinding.DeployApplication(namespace, yamlPath)
+	metricsbinding.DeployApplication(namespace, yamlPath, true)
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 

--- a/tests/e2e/metricsbinding/metrics_binding_helper.go
+++ b/tests/e2e/metricsbinding/metrics_binding_helper.go
@@ -17,7 +17,7 @@ const (
 	shortPollingInterval = 10 * time.Second
 )
 
-func DeployApplication(namespace string, yamlPath string) {
+func DeployApplication(namespace string, yamlPath string, istioEnabled bool) {
 	pkg.Log(pkg.Info, "Deploy test application")
 	// Wait for namespace to finish deletion possibly from a prior run.
 	gomega.Eventually(func() bool {
@@ -27,9 +27,10 @@ func DeployApplication(namespace string, yamlPath string) {
 
 	pkg.Log(pkg.Info, "Create namespace")
 	gomega.Eventually(func() (*v1.Namespace, error) {
-		nsLabels := map[string]string{
-			"verrazzano-managed": "true",
-			"istio-injection":    "enabled"}
+		nsLabels := map[string]string{"verrazzano-managed": "true"}
+		if istioEnabled {
+			nsLabels["istio-injection"] = "enabled"
+		}
 		return pkg.CreateNamespace(namespace, nsLabels)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.BeNil())
 


### PR DESCRIPTION
Backport of commit 35a0ec3cef2b9f71efb34e42f3d4fe9bf9ec6307 to release-1.2

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
