### PR TITLE
VZ-5278: Bug fix - Do not overwrite WebLogic domain logHome (#2816)

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogic_logging.go
+++ b/application-operator/controllers/wlsworkload/weblogic_logging.go
@@ -130,7 +130,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 `
 
 // getWlsSpecificContainerEnv builds WLS specific env vars
-func getWlsSpecificContainerEnv(name string) []v1.EnvVar {
+func getWlsSpecificContainerEnv(logHome string, domainName string) []v1.EnvVar {
 	return []v1.EnvVar{
 		{
 			Name: "DOMAIN_UID",
@@ -150,44 +150,51 @@ func getWlsSpecificContainerEnv(name string) []v1.EnvVar {
 		},
 		{
 			Name:  "SERVER_LOG_PATH",
-			Value: getWLSServerLogPath(name),
+			Value: getWLSServerLogPath(logHome, domainName),
 		},
 		{
 			Name:  "ACCESS_LOG_PATH",
-			Value: getWLSServerAccessLogPath(name),
+			Value: getWLSServerAccessLogPath(logHome, domainName),
 		},
 		{
 			Name:  "NODEMANAGER_LOG_PATH",
-			Value: getWLSServerNodeManagerPath(name),
+			Value: getWLSServerNodeManagerPath(logHome, domainName),
 		},
 		{
 			Name:  "DOMAIN_LOG_PATH",
-			Value: getWLSDomainLogPath(name),
+			Value: getWLSDomainLogPath(logHome, domainName),
 		},
 	}
 }
 
-func getWLSLogPath(name string) string {
-	return getWLSServerLogPath(name) + "," + getWLSServerAccessLogPath(name) + "," + getWLSServerNodeManagerPath(name) + "," + getWLSDomainLogPath(name)
+func getWLSLogPath(logHome string, domainName string) string {
+	return getWLSServerLogPath(logHome, domainName) + "," + getWLSServerAccessLogPath(logHome, domainName) + "," + getWLSServerNodeManagerPath(logHome, domainName) + "," + getWLSDomainLogPath(logHome, domainName)
 }
 
-func getWLSServerLogPath(name string) string {
-	return fmt.Sprintf("%s/$(SERVER_NAME).log", getWLSLogHome(name))
+func getWLSServerLogPath(logHome string, domainName string) string {
+	return getLogPath(logHome, domainName, "$(SERVER_NAME)")
 }
 
-func getWLSServerAccessLogPath(name string) string {
-	return fmt.Sprintf("%s/$(SERVER_NAME)_access.log", getWLSLogHome(name))
+func getWLSServerAccessLogPath(logHome string, domainName string) string {
+	return getLogPath(logHome, domainName, "$(SERVER_NAME)_access")
 }
 
-func getWLSServerNodeManagerPath(name string) string {
-	return fmt.Sprintf("%s/$(SERVER_NAME)_nodemanager.log", getWLSLogHome(name))
+func getWLSServerNodeManagerPath(logHome string, domainName string) string {
+	return getLogPath(logHome, domainName, "$(SERVER_NAME)_nodemanager")
 }
 
-func getWLSDomainLogPath(name string) string {
-	return fmt.Sprintf("%s/$(DOMAIN_UID).log", getWLSLogHome(name))
+func getWLSDomainLogPath(logHome string, domainName string) string {
+	return getLogPath(logHome, domainName, "$(DOMAIN_UID)")
 }
 
-// getWLSLogHome builds a log home give a resource name
-func getWLSLogHome(name string) string {
-	return fmt.Sprintf("%s/logs/%s", scratchVolMountPath, name)
+func getLogPath(logHome string, domainName string, logName string) string {
+	if logHome == "" {
+		logHome = getWLSLogHome(domainName)
+	}
+	return fmt.Sprintf("%s/%s.log", logHome, logName)
+}
+
+// getWLSLogHome builds a log home give a WebLogic domain name
+func getWLSLogHome(domainName string) string {
+	return fmt.Sprintf("%s/logs/%s", scratchVolMountPath, domainName)
 }

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -203,6 +203,8 @@ var specConfigurationWDTConfigMap = []string{specField, "configuration", "model"
 var specMonitoringExporterFields = []string{specField, "monitoringExporter"}
 var specRestartVersionFields = []string{specField, "restartVersion"}
 var specServerStartPolicyFields = []string{specField, "serverStartPolicy"}
+var specLogHomeFields = []string{specField, "logHome"}
+var specLogHomeEnabledFields = []string{specField, "logHomeEnabled"}
 
 // this struct allows us to extract information from the unstructured WebLogic spec
 // so we can interface with the FLUENTD code
@@ -503,21 +505,45 @@ func (r *Reconciler) addLogging(ctx context.Context, log vzlog.VerrazzanoLogger,
 		return errors.New("expected to find metadata name in WebLogic spec")
 	}
 
+	// get the existing logHome setting - if it's set we use it otherwise we'll generate a logs location
+	// using an emptydir volume
+	volumeMountPath := scratchVolMountPath
+	volumeName := storageVolumeName
+	foundVolumeMount := false
+	logHome, _, _ := unstructured.NestedString(weblogic.Object, specLogHomeFields...)
+	if logHome != "" {
+		// find the existing volume mount for the logHome - the Fluentd volume mount needs to match
+		for _, mount := range extracted.VolumeMounts {
+			if strings.HasPrefix(logHome, mount.MountPath) {
+				volumeMountPath = mount.MountPath
+				volumeName = mount.Name
+				foundVolumeMount = true
+				break
+			}
+		}
+
+		if !foundVolumeMount {
+			// user specified logHome but it's not on any volume, Fluentd sidecar won't be able to collect logs
+			log.Info("Unable to find a volume mount for domain logHome, log collection will not work")
+		}
+	}
+	_, logHomeEnabledSet, _ := unstructured.NestedBool(weblogic.Object, specLogHomeEnabledFields...)
+
 	// fluentdPod starts with what's in the spec and we add in the FLUENTD things when Apply is
 	// called on the fluentdManager
 	fluentdPod := &logging.FluentdPod{
 		Containers:   extracted.Containers,
 		Volumes:      extracted.Volumes,
 		VolumeMounts: extracted.VolumeMounts,
-		LogPath:      getWLSLogPath(name),
-		HandlerEnv:   getWlsSpecificContainerEnv(name),
+		LogPath:      getWLSLogPath(logHome, name),
+		HandlerEnv:   getWlsSpecificContainerEnv(logHome, name),
 	}
 	fluentdManager := &logging.Fluentd{Context: ctx,
 		Log:                    zap.S(),
 		Client:                 r.Client,
 		ParseRules:             WlsFluentdParsingRules,
-		StorageVolumeName:      storageVolumeName,
-		StorageVolumeMountPath: scratchVolMountPath,
+		StorageVolumeName:      volumeName,
+		StorageVolumeMountPath: volumeMountPath,
 		WorkloadType:           workloadType,
 	}
 
@@ -554,16 +580,21 @@ func (r *Reconciler) addLogging(ctx context.Context, log vzlog.VerrazzanoLogger,
 		return err
 	}
 
-	// logHome and logHomeEnabled fields need to be set to turn on logging
-	err = unstructured.SetNestedField(weblogic.Object, getWLSLogHome(name), specField, "logHome")
-	if err != nil {
-		log.Errorf("Failed to set logHome: %v", err)
-		return err
+	// set logHome if it was not already specified in the domain spec
+	if logHome == "" {
+		err = unstructured.SetNestedField(weblogic.Object, getWLSLogHome(name), specLogHomeFields...)
+		if err != nil {
+			log.Errorf("Failed to set logHome: %v", err)
+			return err
+		}
 	}
-	err = unstructured.SetNestedField(weblogic.Object, true, specField, "logHomeEnabled")
-	if err != nil {
-		log.Errorf("Failed to set logHomeEnabled: %v", err)
-		return err
+	// set logHomeEnabled if it was not already specified in the domain spec
+	if !logHomeEnabledSet {
+		err = unstructured.SetNestedField(weblogic.Object, true, specLogHomeEnabledFields...)
+		if err != nil {
+			log.Errorf("Failed to set logHomeEnabled: %v", err)
+			return err
+		}
 	}
 
 	return nil

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller_test.go
@@ -97,6 +97,33 @@ const weblogicDomainWithWDTConfigMap = `
    }
 }
 `
+const weblogicDomainWithLogHome = `
+{
+   "metadata": {
+      "name": "unit-test-cluster"
+   },
+   "spec": {
+      "domainUID": "unit-test-domain",
+      "logHome": "/unit_test/log_home",
+      "serverPod": {
+         "volumes": [
+            {
+               "name": "unit-test-logging-volume",
+               "persistentVolumeClaim": {
+                  "claimName": "unit-test-pvc"
+               }
+            }
+         ],
+         "volumeMounts": [
+            {
+               "name": "unit-test-logging-volume",
+               "mountPath": "/unit_test"
+            }
+         ]
+      }
+   }
+}
+`
 const loggingTrait = `
 {
 	"apiVersion": "oam.verrazzano.io/v1alpha1",
@@ -155,7 +182,7 @@ func TestReconcileCreateWebLogicDomain(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -287,7 +314,7 @@ func TestReconcileCreateWebLogicDomainWithMonitoringExporter(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -425,7 +452,7 @@ func TestReconcileCreateWebLogicDomainWithLogging(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -561,7 +588,7 @@ func TestReconcileCreateWebLogicDomainWithCustomLogging(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -778,7 +805,7 @@ func TestReconcileCreateWebLogicDomainWithCustomLoggingConfigMapExists(t *testin
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -956,7 +983,7 @@ func TestReconcileCreateWebLogicDomainWithWDTConfigMap(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -1080,7 +1107,7 @@ func TestReconcileUpdateFluentdImage(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			// return nil error to simulate domain existing
 			return nil
 		})
@@ -1131,7 +1158,7 @@ func TestReconcileUpdateFluentdImage(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to attempt to get the Coherence CR
+	// expect a call to attempt to get the VerrazzanoWebLogicWorkload CR
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, u *unstructured.Unstructured) error {
@@ -1139,7 +1166,7 @@ func TestReconcileUpdateFluentdImage(t *testing.T) {
 			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
 			unstructured.SetNestedField(containers[0].(map[string]interface{}), "unit-test-image:existing", "image")
 			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
-			// return nil error because Coherence StatefulSet exists
+			// return nil error because the VerrazzanoWebLogicWorkload CR exists
 			return nil
 		})
 	// expect a call to get the application configuration for the workload
@@ -1217,7 +1244,7 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 	// expect call to fetch existing WebLogic Domain
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, coherence *wls.Domain) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
 			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
 		})
 	// expect a call to fetch the VerrazzanoWebLogicWorkload
@@ -1752,13 +1779,21 @@ func newTrue() *bool {
 	return &b
 }
 
-// TestGetWLSLogPath tests getWLSLogPath correctly.
-// GIVEN a weblogic env
-// THEN the log path is built
+// TestGetWLSLogPath tests building the WebLogic log path
 func TestGetWLSLogPath(t *testing.T) {
 	assert := asserts.New(t)
-	logPath := getWLSLogPath("test-domain")
+
+	// GIVEN a call to getWLSLogPath
+	// WHEN the logHome is not set
+	// THEN the returned log path uses a generated base log path
+	logPath := getWLSLogPath("", "test-domain")
 	assert.Equal("/scratch/logs/test-domain/$(SERVER_NAME).log,/scratch/logs/test-domain/$(SERVER_NAME)_access.log,/scratch/logs/test-domain/$(SERVER_NAME)_nodemanager.log,/scratch/logs/test-domain/$(DOMAIN_UID).log", logPath)
+
+	// GIVEN a call to getWLSLogPath
+	// WHEN the logHome is set
+	// THEN the returned log path uses the provided logHome as the base path
+	logPath = getWLSLogPath("/unit_test/log_home", "test-domain")
+	assert.Equal("/unit_test/log_home/$(SERVER_NAME).log,/unit_test/log_home/$(SERVER_NAME)_access.log,/unit_test/log_home/$(SERVER_NAME)_nodemanager.log,/unit_test/log_home/$(DOMAIN_UID).log", logPath)
 }
 
 // TestReconcileRestart tests reconciling a VerrazzanoWebLogicWorkload when the WebLogic
@@ -1841,7 +1876,7 @@ func TestReconcileRestart(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
 			return nil
 		})
-	// expect a call to attempt to get the Coherence CR
+	// expect a call to attempt to get the domain CR
 	cli.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, u *unstructured.Unstructured) error {
@@ -1849,7 +1884,7 @@ func TestReconcileRestart(t *testing.T) {
 			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
 			unstructured.SetNestedField(containers[0].(map[string]interface{}), "unit-test-image:existing", "image")
 			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
-			// return nil error because Coherence StatefulSet exists
+			// return nil error because the VerrazzanoWebLogicWorkload CR StatefulSet exists
 			return nil
 		})
 	// expect a call to get the application configuration for the workload
@@ -1992,7 +2027,7 @@ func TestReconcileStopDomain(t *testing.T) {
 			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
 			unstructured.SetNestedField(containers[0].(map[string]interface{}), "unit-test-image:existing", "image")
 			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
-			// return nil error because Coherence StatefulSet exists
+			// return nil error because the VerrazzanoWebLogicWorkload CR StatefulSet exists
 			return nil
 		})
 	// expect a call to get the application configuration for the workload
@@ -2124,7 +2159,7 @@ func TestReconcileStartDomain(t *testing.T) {
 			containers, _, _ := unstructured.NestedSlice(u.Object, "spec", "serverPod", "containers")
 			unstructured.SetNestedField(containers[0].(map[string]interface{}), "unit-test-image:existing", "image")
 			unstructured.SetNestedSlice(u.Object, containers, "spec", "serverPod", "containers")
-			// return nil error because Coherence StatefulSet exists
+			// return nil error because the VerrazzanoWebLogicWorkload CR StatefulSet exists
 			return nil
 		})
 	// expect a call to get the application configuration for the workload
@@ -2186,4 +2221,223 @@ func TestReconcileKubeSystem(t *testing.T) {
 	mocker.Finish()
 	assert.Nil(err)
 	assert.True(result.IsZero())
+}
+
+// GIVEN a VerrazzanoWebLogicWorkload with a domain spec that has a logHome set
+// WHEN we reconcile the workload
+// THEN the Fluentd sidecar has the correct log paths, environment variable settings, volume, and volume mount
+// AND we do not overwrite the logHome setting
+func TestReconcileUserProvidedLogHome(t *testing.T) {
+	assert := asserts.New(t)
+
+	var mocker = gomock.NewController(t)
+	var cli = mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+
+	appConfigName := "unit-test-app-config"
+	componentName := "unit-test-component"
+	labels := map[string]string{oam.LabelAppComponent: componentName, oam.LabelAppName: appConfigName,
+		constants.LabelWorkloadType: constants.WorkloadTypeWeblogic}
+
+	// expect call to fetch existing WebLogic Domain
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-cluster"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, domain *wls.Domain) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "test")
+		})
+	// expect a call to fetch the VerrazzanoWebLogicWorkload
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: "unit-test-verrazzano-weblogic-workload"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, workload *vzapi.VerrazzanoWebLogicWorkload) error {
+			workload.Spec.Template = runtime.RawExtension{Raw: []byte(strings.ReplaceAll(strings.ReplaceAll(weblogicDomainWithLogHome, " ", ""), "\n", ""))}
+			workload.ObjectMeta.Labels = labels
+			workload.APIVersion = vzapi.SchemeGroupVersion.String()
+			workload.Kind = "VerrazzanoWebLogicWorkload"
+			workload.Namespace = namespace
+			workload.ObjectMeta.Generation = 2
+			workload.Status.LastGeneration = "1"
+			return nil
+		})
+	// expect a call to list the FLUENTD config maps
+	cli.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			// return no resources
+			return nil
+		})
+	// no config maps found, so expect a call to create a config map with our parsing rules
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap, opts ...client.CreateOption) error {
+			assert.Equal(strings.Join(strings.Split(WlsFluentdParsingRules, "{{ .CAFile}}"), ""), configMap.Data["fluentd.conf"])
+			return nil
+		})
+	// expect call to fetch the WDT config Map
+	cli.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: getWDTConfigMapName(weblogicDomainName)}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, configMap *corev1.ConfigMap) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, getWDTConfigMapName(weblogicDomainName))
+		})
+	// no WDT config maps found, so expect a call to create a WDT config map
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, configMap *corev1.ConfigMap) error {
+			bytes, _ := yaml.JSONToYAML([]byte(defaultWDTConfigMapData))
+			assert.Equal(string(bytes), configMap.Data[webLogicPluginConfigYamlKey])
+			return nil
+		})
+	// expect a call to get the namespace for the domain
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(client.ObjectKey{Namespace: "", Name: namespace}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, namespace *corev1.Namespace) error {
+			return nil
+		})
+	// expect a call to get the application configuration for the workload
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: namespace, Name: appConfigName}), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, appConfig *oamcore.ApplicationConfiguration) error {
+			appConfig.Spec.Components = []oamcore.ApplicationConfigurationComponent{{ComponentName: componentName}}
+			return nil
+		}).Times(2)
+	// expect a call to attempt to get the WebLogic CR - return not found
+	cli.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, key client.ObjectKey, u *unstructured.Unstructured) error {
+			return k8serrors.NewNotFound(k8sschema.GroupResource{}, "")
+		})
+	// expect a call to create the WebLogic domain CR
+	cli.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, u *unstructured.Unstructured, opts ...client.CreateOption) error {
+			assert.Equal(weblogicAPIVersion, u.GetAPIVersion())
+			assert.Equal(weblogicKind, u.GetKind())
+
+			const (
+				expectedLogHome         = "/unit_test/log_home"
+				expectedVolumeName      = "unit-test-logging-volume"
+				expectedVolumeMountPath = "/unit_test"
+			)
+
+			// make sure the user-specified logHome is set correctly
+			logHome, _, _ := unstructured.NestedString(u.Object, specLogHomeFields...)
+			assert.Equal(expectedLogHome, logHome)
+
+			// find the Fluentd container
+			foundFluentdContainer := false
+			containers, _, _ := unstructured.NestedSlice(u.Object, specServerPodContainersFields...)
+			for _, container := range containers {
+				c := container.(map[string]interface{})
+				if c["name"] == logging.FluentdStdoutSidecarName {
+					foundFluentdContainer = true
+
+					// make sure the Fluentd container environment variables reference the correct logHome
+					envs := c["env"].([]interface{})
+					assertEnvValueStartsWith(t, envs, "SERVER_LOG_PATH", expectedLogHome)
+					assertEnvValueStartsWith(t, envs, "ACCESS_LOG_PATH", expectedLogHome)
+					assertEnvValueStartsWith(t, envs, "NODEMANAGER_LOG_PATH", expectedLogHome)
+					assertEnvValueStartsWith(t, envs, "DOMAIN_LOG_PATH", expectedLogHome)
+					assertPathsStartWith(t, envs, "LOG_PATH", expectedLogHome)
+
+					// make sure the Fluentd container has the correct volume mount
+					mounts := c["volumeMounts"].([]interface{})
+					assertVolumeMount(t, "Fluentd container", mounts, expectedVolumeName, expectedVolumeMountPath, expectedLogHome)
+				}
+			}
+			assert.True(foundFluentdContainer, "Expected to find container with name %s", logging.FluentdStdoutSidecarName)
+
+			// make sure the serverPod volume mount is correct
+			serverPod, _, _ := unstructured.NestedMap(u.Object, specServerPodFields...)
+			assertVolumeMount(t, "serverPod", serverPod["volumeMounts"].([]interface{}), expectedVolumeName, expectedVolumeMountPath, expectedLogHome)
+
+			// make sure the serverPod volume has not been overwritten
+			assertVolume(t, serverPod["volumes"].([]interface{}), expectedVolumeName, "unit-test-pvc")
+
+			return nil
+		})
+
+	// expect a call to status update
+	cli.EXPECT().Status().Return(mockStatus).AnyTimes()
+
+	// expect a call to update the status of the Verrazzano resource to update components
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, wl *vzapi.VerrazzanoWebLogicWorkload, opts ...client.UpdateOption) error {
+			return nil
+		})
+
+	// create a request and reconcile it
+	request := newRequest(namespace, "unit-test-verrazzano-weblogic-workload")
+	reconciler := newReconciler(cli)
+	result, err := reconciler.Reconcile(request)
+
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(false, result.Requeue)
+}
+
+// assertEnvValueStartsWith asserts that the named environment variable value starts with the specified string
+func assertEnvValueStartsWith(t *testing.T, envs []interface{}, name string, startsWith string) {
+	assert := asserts.New(t)
+
+	for _, env := range envs {
+		e := env.(map[string]interface{})
+		if e["name"] == name {
+			v := e["value"].(string)
+			assert.True(strings.HasPrefix(v, startsWith), "Expected %s value %s to start with %s", name, v, startsWith)
+			return
+		}
+	}
+	assert.Fail("Failed", "Unable to find env var named %s", name)
+}
+
+// assertPathsStartWith asserts that each path in the comma-delimited string value (identified by the env var name) starts
+// with the specified string
+func assertPathsStartWith(t *testing.T, envs []interface{}, name string, startsWith string) {
+	assert := asserts.New(t)
+
+	for _, env := range envs {
+		e := env.(map[string]interface{})
+		if e["name"] == name {
+			for _, path := range strings.Split(e["value"].(string), ",") {
+				assert.True(strings.HasPrefix(path, startsWith), "Expected %s path %s to start with %s", name, path, startsWith)
+				return
+			}
+		}
+	}
+	assert.Fail("Failed", "Unable to find env var named %s", name)
+}
+
+// assertVolumeMount asserts that the volume mount mount path is correct and is a prefix of the log path
+func assertVolumeMount(t *testing.T, context string, mounts []interface{}, volumeName string, mountPath string, logPath string) {
+	assert := asserts.New(t)
+
+	for _, mount := range mounts {
+		m := mount.(map[string]interface{})
+		if m["name"] == volumeName {
+			mp := m["mountPath"].(string)
+			assert.Equal(mountPath, mp)
+			assert.True(strings.HasPrefix(logPath, mp), "Expected %s volume mount %s mount path %s to be a prefix of %s", context, volumeName, mp, logPath)
+			return
+		}
+	}
+	assert.Fail("Failed", "Unable to find volume mount named %s in %s", volumeName, context)
+}
+
+// assertVolume asserts that the specified volume has the specified persistent volume claim name
+func assertVolume(t *testing.T, volumes []interface{}, volumeName string, claimName string) {
+	assert := asserts.New(t)
+
+	for _, volume := range volumes {
+		v := volume.(map[string]interface{})
+		if v["name"] == volumeName {
+			if pvc, ok := v["persistentVolumeClaim"]; ok {
+				pvcName := pvc.(map[string]interface{})["claimName"]
+				assert.Equal(claimName, pvcName)
+				return
+			}
+			assert.Fail("Failed", "Unable to find persistentVolumeClaim in volume named %s", volumeName)
+			return
+		}
+	}
+	assert.Fail("Failed", "Unable to find volume named %s", volumeName)
 }


### PR DESCRIPTION
# Description

Backport WebLogic logHome bug fix to the release-1.2 branch. 

See https://github.com/verrazzano/verrazzano/pull/2816 for details.

Fixes VZ-5278

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
