### PR TITLE
Revert VZ-5214 Move Prometheus Operator namespace to PreInstall

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheusoper/prometheus.go
+++ b/platform-operator/controllers/verrazzano/component/prometheusoper/prometheus.go
@@ -4,15 +4,11 @@
 package prometheusoper
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 const deploymentName = "prometheus-operator-kube-p-operator"
@@ -27,23 +23,4 @@ func isPrometheusOperatorReady(ctx spi.ComponentContext) bool {
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
 	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
-}
-
-// PreInstall implementation for the Prometheus Operator Component
-func preInstall(ctx spi.ComponentContext) error {
-	// Do nothing if dry run
-	if ctx.IsDryRun() {
-		ctx.Log().Debug("Prometheus Operator PreInstall dry run")
-		return nil
-	}
-
-	// Create the verrazzano-monitoring namespace
-	ctx.Log().Debugf("Creating namespace %s for the Prometheus Operator", ComponentNamespace)
-	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ComponentNamespace}}
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &namespace, func() error {
-		return nil
-	}); err != nil {
-		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)
-	}
-	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/prometheusoper/prometheus_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheusoper/prometheus_component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/verrazzano"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 )
 
@@ -41,7 +42,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0].name",
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "prometheus-values.yaml"),
-			Dependencies:            []string{certmanager.ComponentName},
+			Dependencies:            []string{certmanager.ComponentName, verrazzano.ComponentName},
 		},
 	}
 }
@@ -62,9 +63,4 @@ func (c prometheusComponent) IsReady(ctx spi.ComponentContext) bool {
 		return isPrometheusOperatorReady(ctx)
 	}
 	return false
-}
-
-// PreInstall updates resources necessary for the Prometheus Operator Component installation
-func (c prometheusComponent) PreInstall(ctx spi.ComponentContext) error {
-	return preInstall(ctx)
 }

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring.yaml
@@ -1,0 +1,9 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+{{- if .Values.prometheusOperator.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.monitoring.namespace }}
+{{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -139,3 +139,6 @@ externaldns:
 
 prometheusOperator:
   enabled: true
+
+monitoring:
+  namespace: verrazzano-monitoring

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -148,9 +148,6 @@ function delete_prometheus_operator {
       error "Failed to uninstall the Prometheus operator."
     fi
   fi
-
-  log "Deleting the ${VERRAZZANO_MONITORING_NS} namespace"
-  kubectl delete namespace "${VERRAZZANO_MONITORING_NS}" --ignore-not-found=true || err_return $? "Could not delete the ${VERRAZZANO_MONITORING_NS} namespace"
 }
 
 action "Deleting Prometheus operator " delete_prometheus_operator || exit 1


### PR DESCRIPTION
# Description

Reverting this commit to investigate uninstall failures

Fixes VZ-5214

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
