### PR TITLE
Corrected the typo in the Opensearch Policies attribute in VZ CR

### DIFF
--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -167,7 +167,7 @@ func (r *Reconciler) syncAll(ctx context.Context, vp clustersv1alpha1.Verrazzano
 	}
 
 	// Sync the network policies
-	err = r.syncNetworkPolices(ctx, &vp, log)
+	err = r.syncNetworkPolicies(ctx, &vp, log)
 	if err != nil {
 		return err
 	}
@@ -355,8 +355,8 @@ func (r *Reconciler) getDefaultRoleBindingSubjects(vp clustersv1alpha1.Verrazzan
 	return adminSubjects, monitorSubjects
 }
 
-// syncNetworkPolices syncs the NetworkPolicies specified in the project
-func (r *Reconciler) syncNetworkPolices(ctx context.Context, project *clustersv1alpha1.VerrazzanoProject, log vzlog2.VerrazzanoLogger) error {
+// syncNetworkPolicies syncs the NetworkPolicies specified in the project
+func (r *Reconciler) syncNetworkPolicies(ctx context.Context, project *clustersv1alpha1.VerrazzanoProject, log vzlog2.VerrazzanoLogger) error {
 	// Create or update policies that are in the project spec
 	// The project webhook validates that the network policies use project namespaces
 	desiredPolicySet := make(map[string]bool)

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -370,7 +370,7 @@ type ElasticsearchComponent struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	ESInstallArgs []InstallArgs                 `json:"installArgs,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
-	Polices       []vmov1.IndexManagementPolicy `json:"policies,omitempty"`
+	Policies      []vmov1.IndexManagementPolicy `json:"policies,omitempty"`
 }
 
 // KibanaComponent specifies the Kibana configuration.

--- a/platform-operator/apis/verrazzano/v1alpha1/zz_generated.deepcopy.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/zz_generated.deepcopy.go
@@ -419,8 +419,8 @@ func (in *ElasticsearchComponent) DeepCopyInto(out *ElasticsearchComponent) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Polices != nil {
-		in, out := &in.Polices, &out.Polices
+	if in.Policies != nil {
+		in, out := &in.Policies, &out.Policies
 		*out = make([]vmcontrollerv1.IndexManagementPolicy, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
@@ -187,7 +187,7 @@ func newOpenSearch(cr *vzapi.Verrazzano, storage *resourceRequestValues, vmi *vm
 	}
 
 	// Proxy any ISM policies to the VMI
-	for _, policy := range opensearchComponent.Polices {
+	for _, policy := range opensearchComponent.Policies {
 		opensearch.Policies = append(opensearch.Policies, *policy.DeepCopy())
 	}
 

--- a/platform-operator/controllers/verrazzano/component/verrazzano/vmi_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/vmi_test.go
@@ -138,7 +138,7 @@ func TestNewOpenSearchValuesAreCopied(t *testing.T) {
 			Components: vzapi.ComponentSpec{
 				Elasticsearch: &vzapi.ElasticsearchComponent{
 					ESInstallArgs: []vzapi.InstallArgs{},
-					Polices: []vmov1.IndexManagementPolicy{
+					Policies: []vmov1.IndexManagementPolicy{
 						{
 							PolicyName:   "my-policy",
 							IndexPattern: "pattern",
@@ -162,7 +162,7 @@ func TestNewOpenSearchValuesAreCopied(t *testing.T) {
 	openSearch, err := newOpenSearch(testvz, r, testvmi, false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "1Gi", openSearch.MasterNode.Storage.Size)
-	assert.EqualValues(t, testvz.Spec.Components.Elasticsearch.Polices, openSearch.Policies)
+	assert.EqualValues(t, testvz.Spec.Components.Elasticsearch.Policies, openSearch.Policies)
 }
 
 // TestNewGrafanaWithExistingVMI tests that storage values in the VMI are not erased when a new Grafana is created


### PR DESCRIPTION
Signed-off-by: anajosep <anand.francis.joseph.augustin@oracle.com>

# Description

This PR to correct a minor typo in the VZ CR attribute name which was added for including ISM policies for opensearch.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
