### PR TITLE
VZ-5361: Change service port names for use with Kiali

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -296,7 +296,7 @@ metadata:
     app: {{ .Values.name }}
 spec:
   ports:
-    - name: webhook
+    - name: https-webhook
       port: 443
       targetPort: 9443
   selector:
@@ -323,6 +323,10 @@ spec:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - containerPort: 9443
+              name: https-webhook
+              protocol: TCP
           args:
             - --zap-log-level={{ .Values.logLevel }}
           startupProbe:

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -116,7 +116,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: api
+  - name: http-api
     port: {{ .Values.port }}
     protocol: TCP
     targetPort: {{ .Values.port }}
@@ -130,7 +130,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - name: auth-proxy
+    - name: http-authproxy
       port: {{ .Values.port }}
       protocol: TCP
       targetPort: {{ .Values.port }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-console.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-console.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
   {{- if .Values.console.enabled }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-console.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-console.yaml
@@ -34,6 +34,8 @@ spec:
         name: {{ .Values.console.name }}
         ports:
             - containerPort: 8000
+              name: http-console
+              protocol: TCP
         env:
           - name: VZ_API_URL
             value: "https://verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}"
@@ -46,7 +48,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: console
+  - name: http-console
     port: 8000
     protocol: TCP
     targetPort: 8000

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
@@ -351,7 +351,7 @@ spec:
               name: http
               protocol: TCP
             - containerPort: {{ .Values.monitoringOperator.metricsPort }}
-              name: metrics
+              name: http-metrics
               protocol: TCP
           resources:
             requests:
@@ -421,7 +421,7 @@ spec:
   ports:
     - port: {{ .Values.monitoringOperator.metricsPort }}
       targetPort: {{ .Values.monitoringOperator.metricsPort }}
-      name: metrics
+      name: http-metrics
   selector:
     k8s-app: {{ .Values.monitoringOperator.name }}
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- if .Values.monitoringOperator.enabled }}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -197,7 +197,7 @@
             },
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "1.3.0-20220324155310-c5e6f9e",
+              "tag": "1.3.0-20220329145541-9bc558a",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
# Description

This pull request changes the service port names for verrazzano-system services to include the protocol as a prefix. This is required by Kiali.  Also, pickup the latest version of VMO which has the Kiali changes for VMI.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
