### PR TITLE
JIRA: VZ-5469 Add "superseded" as a helm status to ignore when unblocking an upgrade

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         choice (name: 'CHAOS_TEST_TYPE',
                 description: 'Type of chaos to inflict',
                 // 1st choice is the default value
-                choices: [ "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed", "ephemeral.storage.upgrade", "upgrade.failed.upgrade", "upgrade.failing.upgrade" ])
+                choices: [ "upgrade.failed.upgrade", "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed", "ephemeral.storage.upgrade", "upgrade.failing.upgrade" ])
     }
 
     environment {

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         choice (name: 'CHAOS_TEST_TYPE',
                 description: 'Type of chaos to inflict',
                 // 1st choice is the default value
-                choices: [ "upgrade.failed.upgrade", "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed", "ephemeral.storage.upgrade", "upgrade.failing.upgrade" ])
+                choices: [ "uninstall.failed.upgrade", "helm.chart.corrupted", "vpo.killed", "ephemeral.storage.upgrade", "upgrade.failed.upgrade", "upgrade.failing.upgrade" ])
     }
 
     environment {
@@ -903,4 +903,3 @@ def restartExampleApps() {
         kubectl rollout restart deployment -n hello-helidon
     """
 }
-

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -903,3 +903,4 @@ def restartExampleApps() {
         kubectl rollout restart deployment -n hello-helidon
     """
 }
+

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -164,6 +164,10 @@ func (r *Reconciler) resolvePendingUpgrades(compName string, compLog vzlog.Verra
 	}
 	// remove any pending upgrade secrets
 	for i := range helmSecrets.Items {
+		compLog.Infof("%s labels:", helmSecrets.Items[i].Name)
+		for k, v := range helmSecrets.Items[i].Labels {
+			compLog.Infof("key: %s, value: %s", k, v)
+		}
 		err := r.Client.Delete(context.TODO(), &helmSecrets.Items[i], &clipkg.DeleteOptions{})
 		if err != nil {
 			compLog.Errorf("Unable to remove pending upgrade helm secret for component %s: %v", compName, err)

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -150,9 +150,10 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 // resolvePendingUpgrdes will delete any helm secrets with a status other than "deployed" for the given component
 func (r *Reconciler) resolvePendingUpgrades(compName string, compLog vzlog.VerrazzanoLogger) {
 	nameReq, _ := kblabels.NewRequirement("name", selection.Equals, []string{compName})
-	statusReq, _ := kblabels.NewRequirement("status", selection.NotEquals, []string{"deployed"})
+	notDeployedReq, _ := kblabels.NewRequirement("status", selection.NotEquals, []string{"deployed"})
+	notSupersededReq, _ := kblabels.NewRequirement("status", selection.NotEquals, []string{"superseded"})
 	labelSelector := kblabels.NewSelector()
-	labelSelector = labelSelector.Add(*nameReq, *statusReq)
+	labelSelector = labelSelector.Add(*nameReq, *notDeployedReq, *notSupersededReq)
 	helmSecrets := v1.SecretList{}
 	err := r.Client.List(context.TODO(), &helmSecrets, &clipkg.ListOptions{LabelSelector: labelSelector})
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -165,9 +165,9 @@ func (r *Reconciler) resolvePendingUpgrades(compName string, compLog vzlog.Verra
 	}
 	// remove any pending upgrade secrets
 	for i := range helmSecrets.Items {
-		compLog.Infof("%s labels:", helmSecrets.Items[i].Name)
+		compLog.Debugf("%s labels:", helmSecrets.Items[i].Name)
 		for k, v := range helmSecrets.Items[i].Labels {
-			compLog.Infof("key: %s, value: %s", k, v)
+			compLog.Debugf("key: %s, value: %s", k, v)
 		}
 		err := r.Client.Delete(context.TODO(), &helmSecrets.Items[i], &clipkg.DeleteOptions{})
 		if err != nil {


### PR DESCRIPTION
# Description

In certain situations, all OAM Kubernetes runtime helm release secrets were being deleted therefore disabling the upgrade/installation of OAM.  Secrets with helm status "superseded" are now also ignored when searching for secrets with a status that may block upgrades (previously only "deployed" secrets were being ignored).

Fixes VZ-5469

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
