### PR TITLE
VZ-5343: remove ignore_key_not_exist from fluentd config

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -776,7 +776,6 @@ data:
       @id stdout_log_text
       key_name log
       reserve_data true
-      ignore_key_not_exist true
       emit_invalid_record_to_error true
       <parse>
          @type multi_format
@@ -795,7 +794,6 @@ data:
       @id parse_log_to_json
       key_name log
       reserve_data true
-      ignore_key_not_exist true
       emit_invalid_record_to_error true
       <parse>
         @type multi_format


### PR DESCRIPTION
# Description

This pull request removes the setting of the field `ignore_key_not_exist` from the Fluent configuration.  This field is no longer supported and produced a warning.

Fixes Jira VZ-5343

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
