### PR TITLE
Remove duplicate cert check from isKeycloakReady

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1282,14 +1282,6 @@ func getClientID(keycloakClients KeycloakClients, clientName string) string {
 }
 
 func isKeycloakReady(ctx spi.ComponentContext) bool {
-	// TLS cert from Cert Manager should be in Ready state
-	secret := &corev1.Secret{}
-	namespacedName := types.NamespacedName{Name: keycloakCertificateName, Namespace: ComponentNamespace}
-	if err := ctx.Client().Get(context.TODO(), namespacedName, secret); err != nil {
-		ctx.Log().Progressf("Component Keycloak waiting for Certificate %v to exist", keycloakCertificateName)
-		return false
-	}
-
 	statefulset := []types.NamespacedName{
 		{
 			Name:      ComponentName,


### PR DESCRIPTION
# Description

Remove duplicate cert check from isKeycloakReady.  This check is already being done in the common HelmComponent checks.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
