### PR TITLE
VZ-5278: Add end-to-end test for WebLogic logHome bug fix (release-1.2)

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -280,13 +280,7 @@ pipeline {
 
         stage("create-image-pull-secrets") {
             steps {
-                sh """
-                    # Create image pull secret for Verrazzano docker images
-                    cd ${WORKSPACE}
-                    ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${GHCR_REPO}" "${GITHUB_PKGS_CREDS_USR}" "${GITHUB_PKGS_CREDS_PSW}"
-                    ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh github-packages "${GHCR_REPO}" "${GITHUB_PKGS_CREDS_USR}" "${GITHUB_PKGS_CREDS_PSW}"
-                    ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh ocr "${OCR_REPO}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}"
-                """
+                createImagePullSecrets()
             }
         }
 
@@ -607,6 +601,16 @@ pipeline {
                                     dumpSockLogs()
                               }
                            }
+                        }
+                        stage('WebLogic logging') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-logging"
+                            }
+                            steps {
+                                script {
+                                    runGinkgoFailFast('logging/weblogic')
+                                }
+                            }
                         }
                     }
 
@@ -983,4 +987,14 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
+}
+
+def createImagePullSecrets() {
+    sh """
+        # Create image pull secrets for Verrazzano docker images
+        cd ${WORKSPACE}
+        ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${GHCR_REPO}" "${GITHUB_PKGS_CREDS_USR}" "${GITHUB_PKGS_CREDS_PSW}"
+        ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh github-packages "${GHCR_REPO}" "${GITHUB_PKGS_CREDS_USR}" "${GITHUB_PKGS_CREDS_PSW}"
+        ${WORKSPACE}/tests/e2e/config/scripts/create-image-pull-secret.sh ocr "${OCR_REPO}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}"
+    """
 }

--- a/tests/e2e/logging/weblogic/weblogic_logging_suite_test.go
+++ b/tests/e2e/logging/weblogic/weblogic_logging_suite_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package weblogic
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
+
+func TestWebLogicLogging(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "WebLogic Logging Suite")
+}

--- a/tests/e2e/logging/weblogic/weblogic_logging_test.go
+++ b/tests/e2e/logging/weblogic/weblogic_logging_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package weblogic
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	pkgweblogic "github.com/verrazzano/verrazzano/tests/e2e/pkg/weblogic"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	longWaitTimeout          = 20 * time.Minute
+	longPollingInterval      = 20 * time.Second
+	shortWaitTimeout         = 5 * time.Minute
+	shortPollingInterval     = 10 * time.Second
+	imagePullWaitTimeout     = 30 * time.Minute
+	imagePullPollingInterval = 30 * time.Second
+)
+
+var (
+	t                  = framework.NewTestFramework("weblogic-logging")
+	generatedNamespace = pkg.GenerateNamespace("weblogic-logging")
+
+	failed            = false
+	beforeSuitePassed = false
+
+	expectedPods = []string{"weblogicloggingdomain-adminserver"}
+)
+
+var _ = t.AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+// Create all of the resources to deploy the application and wait for the pods to run
+var _ = t.BeforeSuite(func() {
+	start := time.Now()
+
+	t.Logs.Info("Deploy WebLogic logging application")
+	wlsUser := "weblogic"
+	wlsPass := pkg.GetRequiredEnvVarOrFail("WEBLOGIC_PSW")
+	regServ := pkg.GetRequiredEnvVarOrFail("OCR_REPO")
+	regUser := pkg.GetRequiredEnvVarOrFail("OCR_CREDS_USR")
+	regPass := pkg.GetRequiredEnvVarOrFail("OCR_CREDS_PSW")
+
+	t.Logs.Info("Create namespace")
+	Eventually(func() (*v1.Namespace, error) {
+		nsLabels := map[string]string{
+			"verrazzano-managed": "true",
+			"istio-injection":    "enabled"}
+		return pkg.CreateNamespace(namespace, nsLabels)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
+
+	t.Logs.Info("Create repository secret")
+	Eventually(func() (*v1.Secret, error) {
+		return pkg.CreateDockerSecret(namespace, "weblogicloggingdomain-repo-credentials", regServ, regUser, regPass)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
+
+	t.Logs.Info("Create WebLogic credentials secret")
+	Eventually(func() (*v1.Secret, error) {
+		return pkg.CreateCredentialsSecret(namespace, "weblogicloggingdomain-weblogic-credentials", wlsUser, wlsPass, nil)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
+
+	t.Logs.Info("Create persistent volume claim")
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/pvc.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Create component resources")
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/weblogic-logging-comp.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Create application resources")
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/weblogic-logging-app.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for image pulls")
+	Eventually(func() bool {
+		return pkg.ContainerImagePullWait(namespace, expectedPods)
+	}, imagePullWaitTimeout, imagePullPollingInterval).Should(BeTrue())
+
+	t.Logs.Info("Wait for running pods")
+	Eventually(func() bool {
+		result, err := pkg.PodsRunning(namespace, expectedPods)
+		if err != nil {
+			AbortSuite(fmt.Sprintf("One or more pods are not running in namespace: %v, error: %v", namespace, err))
+		}
+		return result
+	}, longWaitTimeout, longPollingInterval).Should(BeTrue())
+
+	beforeSuitePassed = true
+	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+// Delete all of the resources to undeploy the application
+var _ = t.AfterSuite(func() {
+	if failed || !beforeSuitePassed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
+	start := time.Now()
+
+	t.Logs.Info("Delete component resources")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/weblogic-logging-app.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Delete application resources")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/weblogic-logging-comp.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for application pods to terminate")
+	Eventually(func() bool {
+		podsTerminated, _ := pkg.PodsNotRunning(namespace, expectedPods)
+		return podsTerminated
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+
+	t.Logs.Info("Delete persistent volume claim")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/pvc.yaml", namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Delete namespace")
+	Eventually(func() error {
+		return pkg.DeleteNamespace(namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for namespace to be deleted")
+	Eventually(func() bool {
+		_, err := pkg.GetNamespace(namespace)
+		return err != nil && errors.IsNotFound(err)
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+
+	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var _ = t.Describe("WebLogic logging test", Label("f:app-lcm.oam", "f:app-lcm.weblogic-workload"), func() {
+
+	t.Context("WebLogic domain is configured properly.", func() {
+		// GIVEN the WebLogic domain resource has been created by the Verrazzano Application Operator
+		// WHEN we fetch the domain
+		// THEN the logHome in the spec has not been overwritten with a /scratch directory
+		t.It("logHome has not been overwritten", func() {
+			domain, err := pkgweblogic.GetDomain(namespace, "weblogic-logging-domain")
+			Expect(domain, err).ShouldNot(BeNil())
+
+			logHome, _, err := unstructured.NestedString(domain.Object, "spec", "logHome")
+			Expect(logHome, err).To(Equal("/mnt/shared/logs"))
+		})
+	})
+
+	t.Context("Logging.", Label("f:observability.logging.es"), func() {
+		indexName := "verrazzano-namespace-" + namespace
+
+		// GIVEN a WebLogic application with logging enabled
+		// WHEN the Elasticsearch index is retrieved
+		// THEN verify that it is found
+		t.It("Verify Elasticsearch index exists", func() {
+			Eventually(func() bool {
+				return pkg.LogIndexFound(indexName)
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find log index")
+		})
+
+		// GIVEN a WebLogic application with logging enabled
+		// WHEN the log records are retrieved from the Elasticsearch index
+		// THEN verify that at least one recent log record is found
+		const k8sContainerNameKeyword = "kubernetes.container_name.keyword"
+		const fluentdStdoutSidecarName = "fluentd-stdout-sidecar"
+
+		pkg.Concurrently(
+			func() {
+				t.It("Verify recent adminserver log record exists", func() {
+					Eventually(func() bool {
+						return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
+							"kubernetes.labels.weblogic_domainUID":  "weblogicloggingdomain",
+							"kubernetes.labels.app_oam_dev\\/name":  "weblogicloggingdomain-appconf",
+							"kubernetes.labels.weblogic_serverName": "AdminServer",
+							"kubernetes.container_name":             "weblogic-server",
+						})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent adminserver log record")
+				})
+			},
+			func() {
+				t.It("Verify recent pattern-matched AdminServer log record exists", func() {
+					Eventually(func() bool {
+						return pkg.FindLog(indexName,
+							[]pkg.Match{
+								{Key: k8sContainerNameKeyword, Value: fluentdStdoutSidecarName},
+								{Key: "messageID", Value: "BEA-"},
+								{Key: "serverName", Value: "weblogicloggingdomain-adminserver"},
+								{Key: "serverName2", Value: "AdminServer"}},
+							[]pkg.Match{})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent pattern-matched adminserver log record")
+				})
+			},
+			func() {
+				t.It("Verify recent pattern-matched WebLogic Server log record exists", func() {
+					Eventually(func() bool {
+						return pkg.FindLog(indexName,
+							[]pkg.Match{
+								{Key: k8sContainerNameKeyword, Value: fluentdStdoutSidecarName},
+								{Key: "messageID", Value: "BEA-"},
+								{Key: "message", Value: "WebLogic Server"},
+								{Key: "subSystem", Value: "WebLogicServer"}},
+							[]pkg.Match{})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent pattern-matched WebLogic Server log record")
+				})
+			},
+			func() {
+				t.It("Verify recent fluentd-stdout-sidecar server log record exists", func() {
+					Eventually(func() bool {
+						return pkg.FindLog(indexName,
+							[]pkg.Match{
+								{Key: k8sContainerNameKeyword, Value: fluentdStdoutSidecarName},
+								{Key: "wls_log_stream", Value: "server_log"},
+								{Key: "stream", Value: "stdout"}},
+							[]pkg.Match{})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent fluentd-stdout-sidecar server log record")
+				})
+			},
+			func() {
+				t.It("Verify recent fluentd-stdout-sidecar domain log record exists", func() {
+					Eventually(func() bool {
+						return pkg.FindLog(indexName,
+							[]pkg.Match{
+								{Key: k8sContainerNameKeyword, Value: fluentdStdoutSidecarName},
+								{Key: "wls_log_stream", Value: "domain_log"},
+								{Key: "stream", Value: "stdout"}},
+							[]pkg.Match{})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent fluentd-stdout-sidecar domain log record")
+				})
+			},
+			func() {
+				t.It("Verify recent fluentd-stdout-sidecar nodemanager log record exists", func() {
+					Eventually(func() bool {
+						return pkg.FindLog(indexName,
+							[]pkg.Match{
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecarName},
+								{Key: "wls_log_stream", Value: "server_nodemanager_log"},
+								{Key: "stream", Value: "stdout"}},
+							[]pkg.Match{})
+					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent server fluentd-stdout-sidecar nodemanager log record")
+				})
+			},
+		)
+	})
+})

--- a/tests/e2e/logging/weblogic/weblogic_logging_test.go
+++ b/tests/e2e/logging/weblogic/weblogic_logging_test.go
@@ -4,7 +4,6 @@
 package weblogic
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,12 +18,10 @@ import (
 )
 
 const (
-	longWaitTimeout          = 20 * time.Minute
-	longPollingInterval      = 20 * time.Second
-	shortWaitTimeout         = 5 * time.Minute
-	shortPollingInterval     = 10 * time.Second
-	imagePullWaitTimeout     = 30 * time.Minute
-	imagePullPollingInterval = 30 * time.Second
+	longWaitTimeout      = 20 * time.Minute
+	longPollingInterval  = 20 * time.Second
+	shortWaitTimeout     = 5 * time.Minute
+	shortPollingInterval = 10 * time.Second
 )
 
 var (
@@ -85,18 +82,9 @@ var _ = t.BeforeSuite(func() {
 		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace("testdata/logging/weblogic/weblogic-logging-app.yaml", namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
-	t.Logs.Info("Wait for image pulls")
-	Eventually(func() bool {
-		return pkg.ContainerImagePullWait(namespace, expectedPods)
-	}, imagePullWaitTimeout, imagePullPollingInterval).Should(BeTrue())
-
 	t.Logs.Info("Wait for running pods")
 	Eventually(func() bool {
-		result, err := pkg.PodsRunning(namespace, expectedPods)
-		if err != nil {
-			AbortSuite(fmt.Sprintf("One or more pods are not running in namespace: %v, error: %v", namespace, err))
-		}
-		return result
+		return pkg.PodsRunning(namespace, expectedPods)
 	}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 
 	beforeSuitePassed = true

--- a/tests/testdata/logging/weblogic/pvc.yaml
+++ b/tests/testdata/logging/weblogic/pvc.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wls-pv-claim
+spec:
+  storageClassName: "oci-bv"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/tests/testdata/logging/weblogic/weblogic-logging-app.yaml
+++ b/tests/testdata/logging/weblogic/weblogic-logging-app.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: weblogic-logging-appconf
+  annotations:
+    version: v1.0.0
+    description: "Sample application to test VerrazzanoWebLogicWorkload logging"
+spec:
+  components:
+    - componentName: weblogic-logging-domain
+      traits:
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: MetricsTrait
+            spec:
+              scraper: verrazzano-system/vmi-system-prometheus-0
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: IngressTrait
+            spec:
+              rules:
+                - paths:
+                    - path: "/hello"
+                      pathType: Prefix

--- a/tests/testdata/logging/weblogic/weblogic-logging-comp.yaml
+++ b/tests/testdata/logging/weblogic/weblogic-logging-comp.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
+metadata:
+  name: weblogic-logging-domain
+spec:
+  workload:
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoWebLogicWorkload
+    spec:
+      template:
+        metadata:
+          name: weblogic-logging-domain
+        spec:
+          adminServer:
+            adminChannelPortForwardingEnabled: true
+          domainUID: weblogicloggingdomain
+          domainHome: /u01/domains/weblogicloggingdomain
+          auxiliaryImageVolumes:
+            - name: auxiliaryImageVolume1
+              mountPath: /auxiliary
+          image: container-registry.oracle.com/middleware/weblogic:12.2.1.4
+          imagePullSecrets:
+            - name: weblogicloggingdomain-repo-credentials
+          domainHomeSourceType: "FromModel"
+          includeServerOutInPodLog: true
+          replicas: 1
+          webLogicCredentialsSecret:
+            name: weblogicloggingdomain-weblogic-credentials
+          configuration:
+            introspectorJobActiveDeadlineSeconds: 900
+            model:
+              domainType: WLS
+              modelHome: /auxiliary/models
+              wdtInstallHome: /auxiliary/weblogic-deploy
+              runtimeEncryptionSecret: weblogicloggingdomain-runtime-encrypt-secret
+          logHome: /mnt/shared/logs
+          serverPod:
+            podSecurityContext:
+              fsGroup: 0
+            labels:
+              app: weblogic-logging-domain
+              version: v1
+            auxiliaryImages:
+                - image: ghcr.io/verrazzano/weblogic-app:1.0.0-1-20220319111617-b157b52a
+                  volume: auxiliaryImageVolume1
+            env:
+              - name: JAVA_OPTIONS
+                value: "-Dweblogic.StdoutDebugEnabled=false"
+              - name: USER_MEM_ARGS
+                value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
+              - name: WL_HOME
+                value: /u01/oracle/wlserver
+              - name: MW_HOME
+                value: /u01/oracle
+            volumeMounts:
+              - mountPath: /mnt/shared
+                name: weblogic-domain-storage-volume
+            volumes:
+              - name: weblogic-domain-storage-volume
+                persistentVolumeClaim:
+                  claimName: wls-pv-claim


### PR DESCRIPTION
# Description

Backport of the end-to-end test for the WebLogic logHome bug fix to the release-1.2 branch. See https://github.com/verrazzano/verrazzano/pull/2828 for details.

I started with a cherry pick of the commit from master, but there was a function the test was using that doesn't exist on the release-1.2 branch, so I removed it (it was a check for slow image pulls). There was also another function with a slightly different signature, so I fixed that in the test as well.

Fixes VZ-5278

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
