### PR TITLE
Increase timeout on intermittent failing test

### DIFF
--- a/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_test.go
+++ b/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_test.go
@@ -5,17 +5,17 @@ package weblogicworkload
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
-	"github.com/verrazzano/verrazzano/tests/e2e/loggingtrait"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/loggingtrait"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -136,7 +136,7 @@ var _ = t.Describe("Test WebLogic loggingtrait application", Label("f:app-lcm.oa
 			Eventually(func() bool {
 				configMap, err := pkg.GetConfigMap(configMapName, namespace)
 				return (configMap != nil) && (err == nil)
-			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
# Description

Increase timeout on intermittent failing test.  This error is sometimes reported, but the cluster dump does contain the ConfigMap that is reported not found.

Failed to get Config Map logging-stdout-todo-domain-domain from namespace weblogic-logging-trait-fe78d7a: configmaps "logging-stdout-todo-domain-domain" not found 


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
