### PR TITLE
VZ-5436: AuthPolicy vmi-system-es-ingress-authzpol is incorrect and has the wrong name

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -87,15 +87,15 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: vmi-system-es-ingress-authzpol
+  name: vmi-system-es-ingest-authzpol
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: system-es-ingress
+      app: system-es-ingest
   action: ALLOW
   rules:
-    # vmi-system-es-ingress:9200 <- verrazzano-authproxy
+    # vmi-system-es-ingest:9200 <- verrazzano-authproxy
     - from:
         - source:
             namespaces: ["{{ .Release.Namespace }}"]
@@ -103,7 +103,7 @@ spec:
       to:
         - operation:
             ports: ["9200"]
-    # vmi-system-es-ingress:9200,9300 <- vmi-system-kibana (uses VMO SA)
+    # vmi-system-es-ingest:9200,9300 <- vmi-system-kibana (uses VMO SA)
     - from:
         - source:
             namespaces: ["{{ .Release.Namespace }}"]
@@ -111,7 +111,7 @@ spec:
       to:
         - operation:
             ports: ["9200","9300"]
-    # vmi-system-es-ingress:15090 <- vmi-system-prometheus (uses VMO SA)
+    # vmi-system-es-ingest:15090 <- vmi-system-prometheus (uses VMO SA)
     - from:
         - source:
             namespaces: ["{{ .Release.Namespace }}"]


### PR DESCRIPTION
Corrected app selector from system-es-ingress to system-es-ingest.
Corrected authorization policy name from vmi-system-es-ingress-authzpol to vmi-system-es-ingest-authzpol.

Fixes VZ-5436
# Description

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
