### PR TITLE
VZ-5293 allow update during install

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -43,6 +43,8 @@ const (
 	InstancePrincipalDelegationToken authenticationType = "instance_principle_delegation_token"
 	// UnknownAuthenticationType is used for none meaningful auth type
 	UnknownAuthenticationType authenticationType = "unknown_auth_type"
+	// ValidateInProgress error message
+	ValidateInProgressError = "Updates to resource not allowed while uninstall or upgrade is in progress"
 
 	ociDNSSecretFileName            = "oci.yaml"
 	fluentdOCISecretConfigEntry     = "config"
@@ -193,19 +195,10 @@ func ValidateActiveInstall(client client.Client) error {
 
 // ValidateInProgress makes sure there is not an install, uninstall or upgrade in progress
 func ValidateInProgress(old *Verrazzano, new *Verrazzano) error {
-	if old.Status.State == "" || old.Status.State == VzStateReady || old.Status.State == VzStateFailed || old.Status.State == VzStatePaused {
+	if old.Status.State == "" || old.Status.State == VzStateReady || old.Status.State == VzStateFailed || old.Status.State == VzStatePaused || old.Status.State == VzStateInstalling {
 		return nil
 	}
-	// Allow enable component during install
-	if old.Status.State == VzStateInstalling {
-		if isCoherenceEnabled(new.Spec.Components.CoherenceOperator) && !isCoherenceEnabled(old.Spec.Components.CoherenceOperator) {
-			return nil
-		}
-		if isWebLogicEnabled(new.Spec.Components.WebLogicOperator) && !isWebLogicEnabled(old.Spec.Components.WebLogicOperator) {
-			return nil
-		}
-	}
-	return fmt.Errorf("Updates to resource not allowed while install, uninstall or upgrade is in progress")
+	return fmt.Errorf(ValidateInProgressError)
 }
 
 // validateOCISecrets - Validate that the OCI DNS and Fluentd OCI secrets required by install exists, if configured
@@ -377,22 +370,6 @@ func validateSecretContents(secretName string, bytes []byte, target interface{})
 		return err
 	}
 	return nil
-}
-
-// isCoherenceEnabled returns true if the component is enabled, which is the default
-func isCoherenceEnabled(comp *CoherenceOperatorComponent) bool {
-	if comp == nil || comp.Enabled == nil {
-		return true
-	}
-	return *comp.Enabled
-}
-
-// isWebLogicEnabled returns true if the component is enabled, which is the default
-func isWebLogicEnabled(comp *WebLogicOperatorComponent) bool {
-	if comp == nil || comp.Enabled == nil {
-		return true
-	}
-	return *comp.Enabled
 }
 
 //ValidateVersionHigherOrEqual checks that currentVersion matches requestedVersion or is a higher version

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -536,20 +536,18 @@ func TestValidateInProgress(t *testing.T) {
 
 	vzOld.Status.State = VzStateInstalling
 	err := ValidateInProgress(&vzOld, &vzNew)
-	if assert.Error(t, err) {
-		assert.Equal(t, "Updates to resource not allowed while install, uninstall or upgrade is in progress", err.Error())
-	}
+	assert.NoError(t, err)
 
 	vzOld.Status.State = VzStateUninstalling
 	err = ValidateInProgress(&vzOld, &vzNew)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Updates to resource not allowed while install, uninstall or upgrade is in progress", err.Error())
+		assert.Equal(t, ValidateInProgressError, err.Error())
 	}
 
 	vzOld.Status.State = VzStateUpgrading
 	err = ValidateInProgress(&vzOld, &vzNew)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Updates to resource not allowed while install, uninstall or upgrade is in progress", err.Error())
+		assert.Equal(t, ValidateInProgressError, err.Error())
 	}
 }
 
@@ -612,13 +610,13 @@ func TestValidateEnable(t *testing.T) {
 			test.vzOld.Status.State = VzStateUpgrading
 			err = ValidateInProgress(&test.vzOld, &vzNew)
 			if assert.Error(t, err) {
-				assert.Equal(t, "Updates to resource not allowed while install, uninstall or upgrade is in progress", err.Error())
+				assert.Equal(t, ValidateInProgressError, err.Error())
 			}
 
 			test.vzOld.Status.State = VzStateUninstalling
 			err = ValidateInProgress(&test.vzOld, &vzNew)
 			if assert.Error(t, err) {
-				assert.Equal(t, "Updates to resource not allowed while install, uninstall or upgrade is in progress", err.Error())
+				assert.Equal(t, ValidateInProgressError, err.Error())
 			}
 		})
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -165,6 +165,8 @@ type ComponentStatusDetails struct {
 	Version string `json:"version,omitempty"`
 	// The generation of the last VZ resource the Component was reconciled against
 	LastReconciledGeneration int64 `json:"lastReconciledGeneration,omitempty"`
+	// The generation of the last VZ resource the Component is being installed against
+	InstallingGeneration int64 `json:"installingGeneration,omitempty"`
 }
 
 // ConditionType identifies the condition of the install/uninstall/upgrade which can be checked with kubectl wait

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -163,9 +163,9 @@ type ComponentStatusDetails struct {
 	State CompStateType `json:"state,omitempty"`
 	// The version of Verrazzano that is installed
 	Version string `json:"version,omitempty"`
-	// The generation of the last VZ resource the Component was reconciled against
+	// The generation of the last VZ resource the Component was successfully reconciled against
 	LastReconciledGeneration int64 `json:"lastReconciledGeneration,omitempty"`
-	// The generation of the last VZ resource the Component is being reconciled against
+	// The generation of the VZ resource the Component is currently being reconciled against
 	ReconcilingGeneration int64 `json:"reconcilingGeneration,omitempty"`
 }
 

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -165,8 +165,8 @@ type ComponentStatusDetails struct {
 	Version string `json:"version,omitempty"`
 	// The generation of the last VZ resource the Component was reconciled against
 	LastReconciledGeneration int64 `json:"lastReconciledGeneration,omitempty"`
-	// The generation of the last VZ resource the Component is being installed against
-	InstallingGeneration int64 `json:"installingGeneration,omitempty"`
+	// The generation of the last VZ resource the Component is being reconciled against
+	ReconcilingGeneration int64 `json:"reconcilingGeneration,omitempty"`
 }
 
 // ConditionType identifies the condition of the install/uninstall/upgrade which can be checked with kubectl wait

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -689,15 +689,15 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 	}
 	if conditionType == installv1alpha1.CondInstallComplete {
 		cr.Status.VerrazzanoInstance = vzinstance.GetInstanceInfo(compContext)
-		if componentStatus.InstallingGeneration > 0 {
-			componentStatus.LastReconciledGeneration = componentStatus.InstallingGeneration
-			componentStatus.InstallingGeneration = 0
+		if componentStatus.ReconcilingGeneration > 0 {
+			componentStatus.LastReconciledGeneration = componentStatus.ReconcilingGeneration
+			componentStatus.ReconcilingGeneration = 0
 		} else {
 			componentStatus.LastReconciledGeneration = cr.Generation
 		}
 	} else {
-		if componentStatus.InstallingGeneration == 0 {
-			componentStatus.InstallingGeneration = cr.Generation
+		if componentStatus.ReconcilingGeneration == 0 {
+			componentStatus.ReconcilingGeneration = cr.Generation
 		}
 	}
 	componentStatus.Conditions = appendConditionIfNecessary(log, componentStatus, condition)

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -6,7 +6,6 @@ package verrazzano
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/semver"
 	"os"
 	"strings"
 	"time"
@@ -14,6 +13,7 @@ import (
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -689,7 +689,16 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 	}
 	if conditionType == installv1alpha1.CondInstallComplete {
 		cr.Status.VerrazzanoInstance = vzinstance.GetInstanceInfo(compContext)
-		componentStatus.LastReconciledGeneration = cr.Generation
+		if componentStatus.InstallingGeneration > 0 {
+			componentStatus.LastReconciledGeneration = componentStatus.InstallingGeneration
+			componentStatus.InstallingGeneration = 0
+		} else {
+			componentStatus.LastReconciledGeneration = cr.Generation
+		}
+	} else {
+		if componentStatus.InstallingGeneration == 0 {
+			componentStatus.InstallingGeneration = cr.Generation
+		}
 	}
 	componentStatus.Conditions = appendConditionIfNecessary(log, componentStatus, condition)
 

--- a/platform-operator/controllers/verrazzano/install_test.go
+++ b/platform-operator/controllers/verrazzano/install_test.go
@@ -31,9 +31,9 @@ func TestUpdate(t *testing.T) {
 	namespace := "verrazzano"
 	name := "TestUpdate"
 	lastReconciledGeneration := int64(2)
-	installingGen := int64(0)
+	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
-		lastReconciledGeneration+1, installingGen, lastReconciledGeneration,
+		lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
 		"1.3.0", "1.3.0", namespace, name)
 	defer reset()
 	asserts.NoError(err)
@@ -51,8 +51,8 @@ func TestNoUpdateSameGeneration(t *testing.T) {
 	namespace := "verrazzano"
 	name := "TestSameGeneration"
 	lastReconciledGeneration := int64(2)
-	installingGen := int64(0)
-	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration, installingGen, lastReconciledGeneration,
+	reconcilingGen := int64(0)
+	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration, reconcilingGen, lastReconciledGeneration,
 		"1.3.1", "1.3.1", namespace, name)
 	defer reset()
 	asserts.NoError(err)
@@ -70,8 +70,8 @@ func TestUpdateWithUpgrade(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
 	lastReconciledGeneration := int64(2)
-	installingGen := int64(0)
-	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration+1, installingGen, lastReconciledGeneration,
+	reconcilingGen := int64(0)
+	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
 		"1.3.0", "1.2.0", namespace, name)
 	defer reset()
 	asserts.NoError(err)
@@ -89,9 +89,9 @@ func TestUpdateOnUpdate(t *testing.T) {
 	namespace := "verrazzano"
 	name := "test"
 	lastReconciledGeneration := int64(2)
-	installingGen := int64(3)
+	reconcilingGen := int64(3)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
-		installingGen+1, installingGen, lastReconciledGeneration,
+		reconcilingGen+1, reconcilingGen, lastReconciledGeneration,
 		"1.3.3", "1.3.3", namespace, name)
 	defer reset()
 	asserts.NoError(err)
@@ -111,7 +111,7 @@ func reset() {
 
 func testUpdate(t *testing.T,
 	//mocker *gomock.Controller, mock *mocks.MockClient,
-	vzCrGen, installingGen, lastReconciledGeneration int64,
+	vzCrGen, reconcilingGen, lastReconciledGeneration int64,
 	//mockStatus *mocks.MockStatusWriter,
 	specVer, statusVer, namespace, name string) (*assert.Assertions, *vzapi.Verrazzano, ctrl.Result, *bool, error) {
 	asserts := assert.New(t)
@@ -138,7 +138,7 @@ func testUpdate(t *testing.T,
 	})
 	compStatusMap := makeVerrazzanoComponentStatusMap()
 	for _, status := range compStatusMap {
-		status.InstallingGeneration = installingGen
+		status.ReconcilingGeneration = reconcilingGen
 		status.LastReconciledGeneration = lastReconciledGeneration
 	}
 	var vz *vzapi.Verrazzano

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
+
 	"k8s.io/apimachinery/pkg/selection"
 
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -130,7 +132,8 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			for _, comp := range registry.GetComponents() {
 				compName := comp.Name()
 				componentStatus := cr.Status.Components[compName]
-				if componentStatus != nil {
+				effectiveCR, _ := transform.GetEffectiveCR(cr)
+				if componentStatus != nil && (effectiveCR != nil && comp.IsEnabled(effectiveCR)) {
 					log.Oncef("Component %s has been upgraded from generation %v to %v %v", compName, componentStatus.LastReconciledGeneration, cr.Generation, componentStatus.State)
 					componentStatus.LastReconciledGeneration = cr.Generation
 				}

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -129,10 +129,10 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", cr.Spec.Version)
 			log.Once(msg)
 			cr.Status.Version = targetVersion
+			effectiveCR, _ := transform.GetEffectiveCR(cr)
 			for _, comp := range registry.GetComponents() {
 				compName := comp.Name()
 				componentStatus := cr.Status.Components[compName]
-				effectiveCR, _ := transform.GetEffectiveCR(cr)
 				if componentStatus != nil && (effectiveCR != nil && comp.IsEnabled(effectiveCR)) {
 					log.Oncef("Component %s has been upgraded from generation %v to %v %v", compName, componentStatus.LastReconciledGeneration, cr.Generation, componentStatus.State)
 					componentStatus.LastReconciledGeneration = cr.Generation

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -1155,6 +1155,7 @@ func TestUpgradeComponent(t *testing.T) {
 
 	// Set mock component expectations
 	mockComp.EXPECT().IsInstalled(gomock.Any()).Return(true, nil).AnyTimes()
+	mockComp.EXPECT().IsEnabled(gomock.Any()).Return(true).AnyTimes()
 	mockComp.EXPECT().PreUpgrade(gomock.Any()).Return(nil).Times(1)
 	mockComp.EXPECT().Upgrade(gomock.Any()).Return(nil).Times(1)
 	mockComp.EXPECT().PostUpgrade(gomock.Any()).Return(nil).Times(1)
@@ -1341,7 +1342,7 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 
 	// Set enabled mock component expectations
 	mockEnabledComp.EXPECT().Name().Return("EnabledComponent").AnyTimes()
-	mockEnabledComp.EXPECT().IsInstalled(gomock.Any()).Return(true, nil).AnyTimes()
+	mockEnabledComp.EXPECT().IsInstalled(gomock.Any()).Return(true, nil).Times(2)
 	mockEnabledComp.EXPECT().PreUpgrade(gomock.Any()).Return(nil).Times(1)
 	mockEnabledComp.EXPECT().Upgrade(gomock.Any()).Return(nil).Times(1)
 	mockEnabledComp.EXPECT().PostUpgrade(gomock.Any()).Return(nil).Times(1)

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -5987,15 +5987,15 @@ spec:
                       type: array
                     lastReconciledGeneration:
                       description: The generation of the last VZ resource the Component
-                        was reconciled against
+                        was successfully reconciled against
                       format: int64
                       type: integer
                     name:
                       description: Name of the component
                       type: string
                     reconcilingGeneration:
-                      description: The generation of the last VZ resource the Component
-                        is being reconciled against
+                      description: The generation of the VZ resource the Component
+                        is currently being reconciled against
                       format: int64
                       type: integer
                     state:

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -5985,11 +5985,6 @@ spec:
                         - type
                         type: object
                       type: array
-                    installingGeneration:
-                      description: The generation of the last VZ resource the Component
-                        is being installed against
-                      format: int64
-                      type: integer
                     lastReconciledGeneration:
                       description: The generation of the last VZ resource the Component
                         was reconciled against
@@ -5998,6 +5993,11 @@ spec:
                     name:
                       description: Name of the component
                       type: string
+                    reconcilingGeneration:
+                      description: The generation of the last VZ resource the Component
+                        is being reconciled against
+                      format: int64
+                      type: integer
                     state:
                       description: The version of Verrazzano that is installed
                       type: string

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -5985,6 +5985,11 @@ spec:
                         - type
                         type: object
                       type: array
+                    installingGeneration:
+                      description: The generation of the last VZ resource the Component
+                        is being installed against
+                      format: int64
+                      type: integer
                     lastReconciledGeneration:
                       description: The generation of the last VZ resource the Component
                         was reconciled against


### PR DESCRIPTION
# Description

* This is to allow config update during installation or another update operation
* MySQL component currently does not have changeable config in CR and should not allow update. Rerunning MySQL installation very often cause Keycloak failure.

Fixes VZ-5293

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
