### PR TITLE
VZ-5614 Upgrade Istio before WebLogic

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -6,12 +6,13 @@ package istio
 import (
 	"context"
 	"fmt"
-	k8s "github.com/verrazzano/verrazzano/platform-operator/internal/nodeport"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	k8s "github.com/verrazzano/verrazzano/platform-operator/internal/nodeport"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
@@ -258,22 +259,6 @@ func (i istioComponent) PostUpgrade(context spi.ComponentContext) error {
 		return err
 	}
 
-	// Generate a restart version that will not change for this Verrazzano version
-	// Valid labels cannot contain + sign
-	restartVersion := context.EffectiveCR().Spec.Version + "-upgrade"
-	restartVersion = strings.ReplaceAll(restartVersion, "+", "-")
-
-	// Start WebLogic domains that were shutdown
-	context.Log().Infof("Starting WebLogic domains that were stopped pre-upgrade")
-	if err := StartDomainsStoppedByUpgrade(context.Log(), context.Client(), restartVersion); err != nil {
-		return err
-	}
-
-	// Restart all other apps
-	context.Log().Infof("Restarting all applications so they can get the new Envoy sidecar")
-	if err := RestartAllApps(context.Log(), context.Client(), restartVersion); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 
-	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -294,12 +293,6 @@ func getMock(t *testing.T) *mocks.MockClient {
 	mock.EXPECT().
 		Delete(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, secret *v1.Secret) error {
-			return nil
-		}).Times(2)
-
-	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *oam.ApplicationConfigurationList, opts ...client.ListOption) error {
 			return nil
 		}).Times(2)
 

--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -50,9 +50,9 @@ func getComponents() []spi.Component {
 	if len(componentsRegistry) == 0 {
 		componentsRegistry = []spi.Component{
 			oam.NewComponent(),
-			weblogic.NewComponent(),
 			appoper.NewComponent(),
 			istio.NewComponent(),
+			weblogic.NewComponent(),
 			nginx.NewComponent(),
 			certmanager.NewComponent(),
 			externaldns.NewComponent(),

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -6,6 +6,8 @@ package registry
 import (
 	"testing"
 
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -25,7 +27,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/verrazzano"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,9 +52,9 @@ func TestGetComponents(t *testing.T) {
 
 	assert.Len(comps, 15, "Wrong number of components")
 	assert.Equal(comps[0].Name(), oam.ComponentName)
-	assert.Equal(comps[1].Name(), weblogic.ComponentName)
-	assert.Equal(comps[2].Name(), appoper.ComponentName)
-	assert.Equal(comps[3].Name(), istio.ComponentName)
+	assert.Equal(comps[1].Name(), appoper.ComponentName)
+	assert.Equal(comps[2].Name(), istio.ComponentName)
+	assert.Equal(comps[3].Name(), weblogic.ComponentName)
 	assert.Equal(comps[4].Name(), nginx.ComponentName)
 	assert.Equal(comps[5].Name(), certmanager.ComponentName)
 	assert.Equal(comps[6].Name(), externaldns.ComponentName)

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	oamapi "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/helm"
@@ -28,6 +29,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/rbac"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/vzinstance"
+
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	appsv1 "k8s.io/api/apps/v1"
@@ -706,6 +708,12 @@ func TestUpgradeCompleted(t *testing.T) {
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oamapi.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		}).Times(2)
+
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -804,6 +812,12 @@ func TestUpgradeCompletedMultipleReconcile(t *testing.T) {
 	// Expect calls to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oamapi.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		}).AnyTimes()
+
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -898,6 +912,12 @@ func TestUpgradeCompletedStatusReturnsError(t *testing.T) {
 
 	// Expect a call to get the ClusterRoleBinding
 	expectClusterRoleBindingExists(mock, verrazzanoToUse, namespace, name)
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oamapi.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		}).AnyTimes()
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
@@ -1162,6 +1182,12 @@ func TestUpgradeComponent(t *testing.T) {
 	mockComp.EXPECT().Name().Return(componentName).AnyTimes()
 	mockComp.EXPECT().IsReady(gomock.Any()).Return(true).AnyTimes()
 
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oamapi.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		}).AnyTimes()
+
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
 
@@ -1357,6 +1383,12 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 
 	// Expect a call to get the status writer and return a mock.
 	mock.EXPECT().Status().Return(mockStatus).AnyTimes()
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *oamapi.ApplicationConfigurationList, opts ...client.ListOption) error {
+			return nil
+		}).AnyTimes()
 
 	// Expect a call to update the status of the Verrazzano resource
 	mockStatus.EXPECT().


### PR DESCRIPTION
During upgrade WebLogic operator is not starting because the Istio proxy is failing with a SIGSEGV

This is happening during upgrade from 1.0.* to 1.3, where Isito is moving from 1.7.3 to 1.11.4.  The problem is that WebLogic is being upgraded before Istio, and there is a timing issue where WebLogic is using the old 1.7.3 proxy sidecar, but Istiod is using 1.11.4 pilot.  They appear to be incompatible.

The solution is to upgrade Istio first, but there is some WebLogic nuance where we don't want to start domains until both Istio and the WebLogic operator are both using the new Istio (see notes).  Therefore, we should not restart apps until the system-level post-upgrade.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
