### PR TITLE
VZ-4588: make root ca name prettier

### DIFF
--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -14,8 +14,8 @@ import (
 const mask = "******"
 
 const (
-	modeAlphaNum   = iota
-	modeAlphaLower = iota
+	modeAlphaNum   = 0
+	modeAlphaLower = 1
 )
 
 //GeneratePassword will generate a password of length
@@ -42,8 +42,7 @@ func GeneratePasswordUsingMode(length int, mode int) (string, error) {
 	pw := b64.StdEncoding.EncodeToString(b)
 	if mode == modeAlphaNum {
 		pw, err = makeAlphaNumeric(pw)
-	}
-	else {
+	} else {
 		pw, err = makeAlphaLower(pw)
 	}
 	if err != nil {

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -13,19 +13,39 @@ import (
 
 const mask = "******"
 
+const (
+	modeAlphaNum   = iota
+	modeAlphaLower = iota
+)
+
 //GeneratePassword will generate a password of length
 func GeneratePassword(length int) (string, error) {
+	return GeneratePasswordUsingMode(length, modeAlphaNum)
+}
+
+//GeneratePassword will generate a password of length
+func GeneratePasswordAlphaLower(length int) (string, error) {
+	return GeneratePasswordUsingMode(length, modeAlphaLower)
+}
+
+//GeneratePasswordUsingMode will generate a password of length with mode
+func GeneratePasswordUsingMode(length int, mode int) (string, error) {
 	if length < 1 {
 		return "", fmt.Errorf("cannot create password of length %d", length)
 	}
 	// Enlarge buffer so plenty of room is left when special characters are stripped out
-	b := make([]byte, length*3)
+	b := make([]byte, length*4)
 	_, err := rand.Read(b)
 	if err != nil {
 		return "", err
 	}
 	pw := b64.StdEncoding.EncodeToString(b)
-	pw, err = makeAlphaNumeric(pw)
+	if mode == modeAlphaNum {
+		pw, err = makeAlphaNumeric(pw)
+	}
+	else {
+		pw, err = makeAlphaLower(pw)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -40,6 +60,16 @@ func makeAlphaNumeric(input string) (string, error) {
 		return "", err
 	}
 	return reg.ReplaceAllString(input, ""), nil
+}
+
+// makeAlphaLower removes all non-lower-case-alpha characters
+func makeAlphaLower(input string) (string, error) {
+	// Make a Regex to say we only want letters
+	reg, err := regexp.Compile("[^a-zA-Z]+")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(reg.ReplaceAllString(input, "")), nil
 }
 
 //MaskFunction creates a function intended to mask passwords which are substrings in other strings

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -446,7 +446,7 @@ func createOrUpdateCAResources(compContext spi.ComponentContext) error {
 				Namespace: vzCertCA.ClusterResourceNamespace,
 			},
 		}
-		commonNameSuffix, err := password.GeneratePassword(10)
+		commonNameSuffix, err := password.GeneratePasswordAlphaLower(8)
 		if err != nil {
 			return compContext.Log().ErrorfNewErr("Failed to generate CA common name suffix: %v", err)
 		}


### PR DESCRIPTION
# Description

Tweak the method used to generate random suffix for name, to use only lower-case letters, rather than full alpha-numeric with upper and lower case. This doesn't need to be cryptographically secure or unguessable, so making it prettier at the expense of randomness seems OK.

Fixes VZ-4588

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
