### PR TITLE
VZ-5349: add Istio annotation to VMO deployment to prevent CrashLoopBackOff

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-monitoring-operator.yaml
@@ -339,6 +339,8 @@ spec:
       k8s-app: {{ .Values.monitoringOperator.name }}
   template:
     metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "443"
       labels:
         k8s-app: {{ .Values.monitoringOperator.name }}
     spec:


### PR DESCRIPTION
# Description

This pull request adds the istio annotation to the VMO deployment
```
traffic.sidecar.istio.io/excludeOutboundPorts: "443"
```
to prevent CrashLoopBackOff of VMO

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
