### PR TITLE
VZ-5623: Update VMO with new labelling scheme

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -197,7 +197,7 @@
             },
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "1.3.0-20220405201853-318e510",
+              "tag": "1.3.0-20220406210419-47c491d",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
# Description

Adding component specific labels for filtering 

Today under verrazzano-system , there is no way to filter objects based on the component 
This change will add those filters 

```
kubectl get all -n verrazzano-system -l verrazzano-component=opensearch
NAME                                        READY   STATUS    RESTARTS   AGE
pod/vmi-system-es-data-0-7458748ddb-8ngt4   2/2     Running   0          50m
pod/vmi-system-es-data-1-65486b5cd7-jfqwl   2/2     Running   0          50m
pod/vmi-system-es-data-2-d8699f5d9-wqmd5    2/2     Running   0          50m
pod/vmi-system-es-ingest-76f9cf577-snb27    2/2     Running   0          50m
pod/vmi-system-es-master-0                  2/2     Running   0          44m
pod/vmi-system-es-master-1                  2/2     Running   0          46m
pod/vmi-system-es-master-2                  2/2     Running   0          49m

NAME                                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/vmi-system-es-data          ClusterIP   10.96.58.108    <none>        9200/TCP   36m
service/vmi-system-es-ingest        ClusterIP   10.96.189.199   <none>        9200/TCP   37m
service/vmi-system-es-master        ClusterIP   None            <none>        9300/TCP   37m
service/vmi-system-es-master-http   ClusterIP   10.96.196.63    <none>        9200/TCP   36m

NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/vmi-system-es-data-0   1/1     1            1           64m
deployment.apps/vmi-system-es-data-1   1/1     1            1           64m
deployment.apps/vmi-system-es-data-2   1/1     1            1           64m
deployment.apps/vmi-system-es-ingest   1/1     1            1           64m

NAME                                              DESIRED   CURRENT   READY   AGE
replicaset.apps/vmi-system-es-data-0-7458748ddb   1         1         1       50m
replicaset.apps/vmi-system-es-data-1-65486b5cd7   1         1         1       50m
replicaset.apps/vmi-system-es-data-2-d8699f5d9    1         1         1       50m
replicaset.apps/vmi-system-es-ingest-76f9cf577    1         1         1       50m

NAME                                    READY   AGE
statefulset.apps/vmi-system-es-master   3/3     64m


kubectl get all -n verrazzano-system -l verrazzano-component=prometheus
NAME                                          READY   STATUS    RESTARTS   AGE
pod/vmi-system-prometheus-0-899b5b458-hhglz   3/3     Running   0          50m

NAME                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/vmi-system-prometheus   ClusterIP   10.96.118.102   <none>        9090/TCP   37m

NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/vmi-system-prometheus-0   1/1     1            1           64m

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/vmi-system-prometheus-0-899b5b458   1         1         1       50m


kubectl get all -n verrazzano-system -l verrazzano-component=grafana
NAME                                     READY   STATUS    RESTARTS   AGE
pod/vmi-system-grafana-64f66cbbf-9wzhg   2/2     Running   0          50m

NAME                         TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
service/vmi-system-grafana   ClusterIP   10.96.65.90   <none>        3000/TCP   37m

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/vmi-system-grafana   1/1     1            1           65m

NAME                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/vmi-system-grafana-64f66cbbf   1         1         1       50m

```


- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
