### PR TITLE
VZ-5514 install Alertmanager image for the Prometheus Operator

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -54,7 +54,7 @@ func preInstall(ctx spi.ComponentContext) error {
 func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	// Append custom images from the subcomponents in the bom
 	ctx.Log().Debug("Appending the image overrides for the Prometheus Operator components")
-	subcomponents := []string{"prometheus-config-reloader"}
+	subcomponents := []string{"prometheus-config-reloader", "alertmanager"}
 	kvs, err := appendCustomImageOverrides(ctx, kvs, subcomponents)
 	if err != nil {
 		return kvs, err

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -441,6 +441,18 @@
               "helmTagKey": "prometheusOperator.prometheusConfigReloader.image.tag"
             }
           ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "alertmanager",
+          "images": [
+            {
+              "image": "alertmanager",
+              "tag": "v0.24.0",
+              "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
+              "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
# Description

Introduce the Verrazzano Alertmanager image with the Prometheus Operator install.

Fixes VZ-5514

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
