### PR TITLE
Create a separate linter target to just run Go linter tools

### DIFF
--- a/make/quality.mk
+++ b/make/quality.mk
@@ -10,7 +10,10 @@ GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.b
 ##@ Linting and coverage
 
 .PHONY: check
-check: install-linter word-linter url-linter ## run all linters
+check: install-linter word-linter url-linter check-linter ## run all linters
+
+.PHONY: check-linter
+check-linter: install-linter ## run Go linters
 	$(LINTER) --color never run
 
 # find or download golangci-lint


### PR DESCRIPTION
# Description

Break out the Go linter checks into their own `check-linter` target, for running locally (without the URL checks).

The `check` target will call this one in addition to all the others it does now.

```
# run just the Go linters
make check-linter

# run all linters/checks
make check
```

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
