### PR TITLE
VZ-5622: only run jobmetrics on admin cluster

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1115,6 +1115,19 @@ def runGinkgoRandomize(testSuitePath) {
     }
 }
 
+// Run a test suite against just the admin cluster
+def runGinkgoRandomizeAdmin(testSuitePath) {
+                sh """
+                    export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+                    export CLUSTER_NAME="admin"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+                """
+            }
+        }
+    }
+}
+
 // Configure the Admin and Managed cluster installer custom resources
 def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript, String... extraArgs) {
     script {
@@ -1557,5 +1570,5 @@ def emitJobMetrics() {
     long timeInMillis = "${currentBuild.timeInMillis}" as long;
     long startTimeInMillis = "${currentBuild.startTimeInMillis}" as long;
     env.TIME_WAITING = startTimeInMillis-timeInMillis
-    runGinkgoRandomize('jobmetrics')
+    runGinkgoRandomizeAdmin('jobmetrics')
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1117,15 +1117,12 @@ def runGinkgoRandomize(testSuitePath) {
 
 // Run a test suite against just the admin cluster
 def runGinkgoRandomizeAdmin(testSuitePath) {
-                sh """
-                    export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
-                    export CLUSTER_NAME="admin"
-                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
-                """
-            }
-        }
-    }
+    sh """
+        export KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+        export CLUSTER_NAME="admin"
+        cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+        ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+    """
 }
 
 // Configure the Admin and Managed cluster installer custom resources


### PR DESCRIPTION
what the title says

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
