### PR TITLE
Fix bom validator to ignore the new Prometheus Image

### DIFF
--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -42,6 +42,7 @@ type imageError struct {
 
 var ignoreSubComponents = []string{
 	"additional-rancher",
+	"prometheus",
 }
 
 func main() {


### PR DESCRIPTION
# Description

This is due to a test failure because the BOM validator conflated the two Prometheus images.

Fixes No JIRA

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
