### PR TITLE
Update Rancher image tag to fix upgrade from 1.0.n to tip of master

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -165,13 +165,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20211013170111-ec72f6a2f",
+              "tag": "v2.5.9-20211209021347-2e57ce2a4",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20211013170111-ec72f6a2f"
+              "tag": "v2.5.9-20211209021347-2e57ce2a4"
             }
           ]
         },
@@ -190,7 +190,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.1"
+              "tag": "v0.1.2"
             },
             {
               "image": "fleet-agent",


### PR DESCRIPTION
# Description

Use the Rancher 2.5.9 image tag that Verrazzano 1.1.n is using to fix a problem of not being able to upgrade from Verrazzano 1.0.n to the tip of master.


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
