### PR TITLE
VZ-5601: Fix the parameters for verrazzano-examples in JenkinsfilePeriodicTests

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -367,8 +367,8 @@ pipeline {
                         script {
                             build job: "/verrazzano-examples/${CLEAN_BRANCH_NAME}",
                                 parameters: [
+                                    string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.20'),
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                     string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                     string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)


### PR DESCRIPTION
# Description

This change sets removes VERRAZZANO_OPERATOR_IMAGE as the parameter for job verrazzano-examples, triggered from periodic tests. Without this change, a null was passed to verrazzano-examples as VERRAZZANO_OPERATOR_IMAGE is not one of the parameters supported by CI job verrazzano-periodic-triggered-tests, resulting in the validation failure from the script which installs Verrazzano

Contributes to VZ-5601

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
