### PR TITLE
VZ-5563: Retire tests using example images in OCI DNS pipeline

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -109,7 +109,6 @@ pipeline {
         TF_VAR_tenancy_id = credentials('oci-tenancy')
         TF_VAR_user_id = credentials('oci-user-ocid')
 
-
         TF_VAR_kubernetes_version = "${params.OKE_CLUSTER_VERSION}"
         TF_VAR_nodepool_config = "${params.OKE_NODE_POOL}"
         TF_VAR_api_fingerprint = credentials('oci-api-key-fingerprint')
@@ -129,14 +128,6 @@ pipeline {
         KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
 
-        SOCKS_MODEL_FILE = "${WORKSPACE}/examples/sock-shop/sock-shop-model.yaml"
-        SOCKS_BINDING_FILE = "${WORKSPACE}/examples/sock-shop/sock-shop-binding.yaml"
-        BOBS_MODEL_FILE = "${WORKSPACE}/examples/bobs-books/bobs-books-model.yaml"
-        BOBS_BINDING_FILE = "${WORKSPACE}/examples/bobs-books/bobs-books-binding.yaml"
-        BOBS_MYSQL_DEPLOY_FILE = "${WORKSPACE}/examples/bobs-books/mysql.yaml"
-        HELIDON_UPGRADE_MODEL_FILE = "${WORKSPACE}/examples/hello-helidon/hello-world-model.yaml"
-        HELIDON_UPGRADE_BINDING_FILE = "${WORKSPACE}/examples/hello-helidon/hello-world-binding.yaml"
-
         DISABLE_SPINNER=1
         OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING = 'True'
 
@@ -144,7 +135,6 @@ pipeline {
         SHORT_TIME_STAMP = sh(returnStdout: true, script: "date +%m%d%H%M%S").trim()
         GITHUB_API_TOKEN = credentials('github-api-token-release-assets')
 
-        IMG_LIST_FILE = "${WORKSPACE}/verrazzano_images.txt"
         POST_DUMP_FAILED_FILE = "${WORKSPACE}/post_dump_failed_file.tmp"
 
         INSTALL_CONFIG_FILE_OCIDNS = "${WORKSPACE}/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml"
@@ -447,180 +437,106 @@ pipeline {
             }
         }
 
-        stage('acceptance-tests-1') {
-            stages {
-                stage('verify-install') {
-                    steps {
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh """
-                                cd ${WORKSPACE}/tests/e2e
-                                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" verify-install/...
-                            """
-                        }
-                    }
-                }
-                stage('springboot') {
-                    parallel {
-                        // Quick fix for Bob's Books test failure that reports "Webpage is NOT Robert's Books Greetings from Verrazzano!"
-                        //     Do not run this in parallel with Bob's Books because both specify a mapping for "/" path.
-                        // Real fix may be to have each app use a different dnsName in the ingress binding section of the binding file
-                        // and put a host header in the corresponding calls to the app.
-                        stage('generic-springboot') {
-                            environment {
-                                DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/generic-springboot-test.log"
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-springboot"
-                            }
-                            steps {
-                                script {
-                                    runGinkgo('examples/springboot')
-                                }
-                            }
-                            post {
-                                always {
-                                    dumpGenericSpringbootObjects()
-                                    dumpGenericSpringbootLogs()
-                                }
-                            }
-                        }
-                    }
+        stage('verify-install') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                        cd ${WORKSPACE}/tests/e2e
+                        ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" verify-install/...
+                    """
                 }
             }
         }
 
-        stage('acceptance-tests-2') {
-            stages {
-                stage('run-acceptance-tests') {
-                    parallel {
-                        stage('metrics') {
-                            steps {
-                                script {
-                                    runGinkgo('metrics/syscomponents')
-                                }
-                            }
-                        }
-                        stage('hello-helidon') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-hello-helidon"
-                            }
-                            steps {
-                                script {
-                                    runGinkgoFailFast('examples/helidon')
-                                }
-                            }
-                        }
-                        stage('restapi') {
-                            steps {
-                                script {
-                                    runGinkgo('verify-infra/restapi')
-                                }
-                            }
-                        }
-                        stage('vmi') {
-                            steps {
-                                script {
-                                    runGinkgo('verify-infra/vmi')
-                                }
-                            }
-                        }
-                        stage('oam') {
-                            steps {
-                                script {
-                                    runGinkgo('verify-infra/oam')
-                                }
-                            }
-                        }
-                        stage('system logging') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/system-logging"
-                            }
-                            steps {
-                                runGinkgo('logging/system')
-                            }
-                        }
-                        stage('lift-and-shift') {
-                            environment {
-                                DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/lift-and-shift-test.log"
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-lift-and-shift"
-                            }
-                            steps {
-                                script {
-                                    runGinkgoFailFast('examples/todo')
-                                }
-                            }
-                        }
-                        stage('istio authorization policy') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-istio-auth-policy"
-                            }
-                            steps {
-                                runGinkgo('istio/authz')
-                            }
-                        }
-                        stage('security role based access') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-rbac"
-                            }
-                            steps {
-                                runGinkgo('security/rbac')
-                            }
-                        }
-                        stage('bobs-books') {
-                            environment {
-                                DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-book-test.log"
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-bobs-books-dump"
-                            }
-                            steps {
-                                script {
-                                    runGinkgoFailFast('examples/bobsbooks')
-                                }
-                                sh """
-                                    ${WORKSPACE}/tests/e2e/config/scripts/get_verrazzano_image.sh bob >> ${IMG_LIST_FILE}
-                                    ${WORKSPACE}/tests/e2e/config/scripts/get_verrazzano_image.sh bobby >> ${IMG_LIST_FILE}
-                                    ${WORKSPACE}/tests/e2e/config/scripts/get_verrazzano_image.sh robert >> ${IMG_LIST_FILE}
-                                """
-                            }
-                            post {
-                                always {
-                                    dumpBobObjects()
-                                    dumpBobLogs()
-                                }
-                            }
-                        }
-                        stage('socks') {
-                            environment {
-                                DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/socks-test.log"
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-socks"
-                            }
-                            steps {
-                                script {
-                                    runGinkgo('examples/socks')
-                                }
-                                sh """
-                                    ${WORKSPACE}/tests/e2e/config/scripts/create_verrazzano_image_list.sh ${IMG_LIST_FILE}
-                                    # make necessary substitutions
-                                    sed -i 's/example-hello-world-helidon/example-helidon-greet-app-v1/' ${IMG_LIST_FILE}
-                                    sed -i 's/example-bobs-books-order-manager/example-bobs-bookstore-order-manager/' ${IMG_LIST_FILE}
-                                """
-                           }
-                           post {
-                              always {
-                                    dumpSockObjects()
-                                    dumpSockLogs()
-                              }
-                           }
-                        }
-                        stage('WebLogic logging') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-logging"
-                            }
-                            steps {
-                                script {
-                                    runGinkgoFailFast('logging/weblogic')
-                                }
-                            }
+        stage('acceptance-tests') {
+            parallel {
+                stage('metrics') {
+                    steps {
+                        script {
+                            runGinkgo('metrics/syscomponents')
                         }
                     }
-
+                }
+                stage('restapi') {
+                    steps {
+                        script {
+                            runGinkgo('verify-infra/restapi')
+                        }
+                    }
+                }
+                stage('vmi') {
+                    steps {
+                        script {
+                            runGinkgo('verify-infra/vmi')
+                        }
+                    }
+                }
+                stage('oam') {
+                    steps {
+                        script {
+                            runGinkgo('verify-infra/oam')
+                        }
+                    }
+                }
+                stage('system logging') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/system-logging"
+                    }
+                    steps {
+                        runGinkgo('logging/system')
+                    }
+                }
+                stage('istio authorization policy') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-istio-auth-policy"
+                    }
+                    steps {
+                        runGinkgo('istio/authz')
+                    }
+                }
+                stage('security role based access') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-rbac"
+                    }
+                    steps {
+                        runGinkgo('security/rbac')
+                    }
+                }
+                stage('WebLogic logging') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-logging"
+                    }
+                    steps {
+                        script {
+                            runGinkgoFailFast('logging/weblogic')
+                        }
+                    }
+                }
+                stage('helidon workload') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/helidon-workload"
+                    }
+                    steps {
+                        script {
+                            runGinkgoFailFast('examples/helidon')
+                        }
+                    }
+                }
+                stage('weblogic workload') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-workload"
+                    }
+                    steps {
+                        runGinkgoFailFast('workloads/weblogic')
+                    }
+                }
+                stage('coherence workload') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/coherence-workload"
+                    }
+                    steps {
+                        runGinkgoFailFast('workloads/coherence')
+                    }
                 }
             }
         }
@@ -638,14 +554,7 @@ pipeline {
             dumpNginxIngressControllerLogs()
             dumpVerrazzanoPlatformOperatorLogs()
 
-            sh """
-                echo "sorting the images file prior to archiving"
-                if [ -f ${IMG_LIST_FILE} ];
-                then
-                    sort -u -o ${IMG_LIST_FILE} ${IMG_LIST_FILE}
-                fi
-            """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/test-cluster-dumps/**/,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/*-cluster-dump/**,**/test-cluster-dumps/**/,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -732,85 +641,6 @@ def dumpK8sCluster(dumpDirectory) {
     sh """
         ${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
     """
-}
-
-def dumpBobObjects() {
-    sh """
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-helidon-stock-application-*" -m "bobby helidon stock apps" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-coherence-storage-*" -m "bobbys coherence storage" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n robert -r "roberts-helidon-stock-application-*" -m "robert helidon stock apps" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n robert -r "roberts-coherence-storage-*" -m "robert coherence storage" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-bobs-books-binding-es-*" -m "bob elastic search" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bob -r "bobs-bookstore-*" -m "bob's servers" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-front-end-*" -m "bobby's weblogic servers" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o nodes -n default -m "describing nodes" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        kubectl get event -A || echo "failed" > ${POST_DUMP_FAILED_FILE}
-    """
-}
-
-def dumpBobLogs() {
-    dumpVerrazzanoApiLogs()
-    sh """
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-bookstore-adminserver.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bob -r "bobs-bookstore-adminserver*" -m "bob admin server" -l -c weblogic-server || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-bookstore-managed-server1.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bob -r "bobs-bookstore-managed-server1*" -m "bob managed server 1" -l -c weblogic-server || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobs-bookstore-managed-server2.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bob -r "bobs-bookstore-managed-server2*" -m "bob managed server 2" -l -c weblogic-server || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobbys-front-end-adminserver.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-front-end-adminserver*" -m "bobby admin server" -l -c weblogic-server || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobbys-front-end-managed-server1.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-front-end-managed-server1*" -m "bobby managed server 1" -l -c weblogic-server || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/bobbys-helidon-stock-application.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n bobby -r "bobbys-helidon-stock-application-*" -m "bobby helidon stock apps" -l -c bobbys-helidon-stock-application || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/roberts-helidon-stock-application.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n robert -r "roberts-helidon-stock-application-*" -m "robert helidon stock apps" -l -c roberts-helidon-stock-application || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/weblogic-operator.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "weblogic-operator-*" -m "weblogic operator" -l -c weblogic-operator || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-system-ingresses.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o ingress -n verrazzano-system -m "verrazzano system ingresses" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-system-prometheus.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-prometheus-0-*" -m "verrazzano system bobs books binding prometheus log" -l -c prometheus || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-system-prometheus-gw.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-prometheus-gw-*" -m "verrazzano system bobs books binding prometheus-gw log" -l -c prometheus-gw || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/monitoring-prom-pusher-system.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n monitoring -r "prom-pusher-system-*" -m "monitoring prom pusher bobs books binding" -l -c prometheus-pusher || echo "failed" > ${POST_DUMP_FAILED_FILE}
-     """
-}
-
-def dumpGenericSpringbootObjects() {
-    sh """
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n springboot -r "verrazzano-springboot-*" -m "generic springboot app" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o nodes -n default -m "describing nodes" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        kubectl get event -A || echo "failed" > ${POST_DUMP_FAILED_FILE}
-    """
-}
-
-def dumpGenericSpringbootLogs() {
-    dumpVerrazzanoApiLogs()
-    sh """
-        export DIAGNOSTIC_LOG="${WORKSPACE}/platform-operator/scripts/install/build/logs/verrazzano-springboot.log"
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n springboot -r "verrazzano-springboot-*" -m "verrazzano springboot" -l -c verrazzano-springboot || echo "failed" > ${POST_DUMP_FAILED_FILE}
-     """
-}
-
-def dumpSockObjects() {
-    sh """
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n sockshop -m "sockshop" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-sock-shop-binding-es-*" -m "sock elastic search" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        ${WORKSPACE}/platform-operator/scripts/install/k8s-dump-objects.sh -o nodes -n default -m "describing nodes" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-
-        kubectl get event -A || echo "failed" > ${POST_DUMP_FAILED_FILE}
-    """
-}
-
-def dumpSockLogs() {
-    dumpVerrazzanoApiLogs()
 }
 
 def dumpVerrazzanoSystemPods() {


### PR DESCRIPTION
# Description

This change removes the tests using the images from the examples repository, in OCI DNS CI job. With this change, OCI DNS job will not create verrazzano_images.txt. The verrazzano-examples job will create verrazzano_images.txt from here onwards.

Contributes to VZ-5563

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
