### PR TITLE
Create verrazzano_images.txt from verrazzano-examples pipeline

### DIFF
--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -78,6 +78,7 @@ pipeline {
         CLUSTER_NAME = 'verrazzano'
         POST_DUMP_FAILED_FILE = "${WORKSPACE}/post_dump_failed_file.tmp"
         TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
+        IMG_LIST_FILE = "${WORKSPACE}/verrazzano_images.txt"
         KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
         OCR_CREDS = credentials('ocr-pull-and-push-account')
@@ -217,6 +218,12 @@ pipeline {
                         failure {
                             archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
                         }
+                        success {
+                            sh """
+                                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/generated-verrazzano-bom.json --file ${WORKSPACE}/downloaded-verrazzano-bom.json
+                                ${GO_REPO_PATH}/verrazzano/tools/scripts/generate_image_list.sh $WORKSPACE/downloaded-verrazzano-bom.json $WORKSPACE/verrazzano_images.txt
+                            """
+                        }
                         always {
                             archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml", allowEmptyArchive: true
                             sh """
@@ -331,14 +338,7 @@ pipeline {
                             }
                         }
                     }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-dumps/**,**/Screenshot*.png', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                    }
                 }
-
             }
 
             post {
@@ -381,6 +381,18 @@ pipeline {
                 mkdir -p ${TEST_REPORT_DIR}
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
+
+                # Append the images for the examples to verrazzano_images.txt
+                ${WORKSPACE}/tests/e2e/config/scripts/get_examples_image.sh ${WORKSPACE}/examples/todo-list/todo-list-components.yaml ${IMG_LIST_FILE}
+                ${WORKSPACE}/tests/e2e/config/scripts/get_examples_image.sh ${WORKSPACE}/examples/springboot-app/springboot-comp.yaml ${IMG_LIST_FILE}
+                ${WORKSPACE}/tests/e2e/config/scripts/get_examples_image.sh ${WORKSPACE}/examples/hello-helidon/hello-helidon-comp.yaml ${IMG_LIST_FILE}
+                ${WORKSPACE}/tests/e2e/config/scripts/get_examples_image.sh ${WORKSPACE}/examples/bobs-books/bobs-books-comp.yaml ${IMG_LIST_FILE}
+
+                echo "sorting the images file prior to archiving"
+                if [ -f ${IMG_LIST_FILE} ];
+                then
+                 sort -u -o ${IMG_LIST_FILE} ${IMG_LIST_FILE}
+                fi
             """
             archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/Screenshot*.png,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true

--- a/tests/e2e/config/scripts/get_examples_image.sh
+++ b/tests/e2e/config/scripts/get_examples_image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+OAM_COMP_FILE=$1
+IMG_LIST_FILE=$2
+
+if [ -z "${OAM_COMP_FILE}" ] ; then
+    echo "The script requires OAM component file defining the image(s) for the example"
+    exit 1
+fi
+
+if [ -z "${IMG_LIST_FILE}" ] ; then
+    echo "The script requires a file to append the example image(s)"
+    exit 1
+fi
+
+cat ${OAM_COMP_FILE} | grep image: | grep example |\tr -s '[[:space:]]' '\n' |\sort |\uniq | grep verrazzano | grep / | cut -d/ -f2- | tr -d '"' >> ${IMG_LIST_FILE} || exit 1


### PR DESCRIPTION
# Description

This PR contains the change to create the verrazzano_images.txt from verrazzano-examples pipeline. The file verrazzano_images.txt will contain the images which are part of verrazzano-bom.json and the examples which are tested by verrazzano-examples job.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
