### PR TITLE
Use verrazzano-examples to copy verrazzano_images file

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -12,7 +12,7 @@ def branchSpecificSchedule = getCronSchedule()
 
 // The job name from which the verrazzano_images file is available to be copied to this job
 // We will copy over and make it part of the artifacts of the periodic job, available when we want to release a candidate
-def verrazzanoImagesJobProjectName = "verrazzano-new-oci-dns-acceptance-tests"
+def verrazzanoImagesJobProjectName = "verrazzano-examples"
 def verrazzanoImagesFile = "verrazzano_images.txt"
 def verrazzanoImagesBuildNumber = 0 // will be set to actual build number when the job is run
 


### PR DESCRIPTION
# Description

An earlier change updated the verrazzano-examples pipeline to generate verrazzano_images.txt. This change updates the job in JenkinsfilePeriodicTests


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
