### PR TITLE
VZ-5494. Skip cert renewal checks on initial install

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -161,8 +161,9 @@ func (c certManagerComponent) createOrUpdateClusterIssuer(compContext spi.Compon
 		}
 	}
 	if opResult == controllerutil.OperationResultCreated {
-		// We're in the initial install phase, and created the ClusterIssuer for the first time
-		compContext.Log().Oncef("Initial install, skipping certficate renewal checks")
+		// We're in the initial install phase, and created the ClusterIssuer for the first time,
+		// so skip the renewal checks
+		compContext.Log().Oncef("Initial install, skipping certificate renewal checks")
 		return nil
 	}
 	if err := checkRenewAllCertificates(compContext, isCAValue); err != nil {

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -148,17 +148,22 @@ func (c certManagerComponent) createOrUpdateClusterIssuer(compContext spi.Compon
 	if err != nil {
 		return compContext.Log().ErrorfNewErr("Failed to verify the config type: %v", err)
 	}
-	//var opResult controllerutil.OperationResult
+	var opResult controllerutil.OperationResult
 	if !isCAValue {
 		// Create resources needed for Acme certificates
-		if _, err = createOrUpdateAcmeResources(compContext); err != nil {
+		if opResult, err = createOrUpdateAcmeResources(compContext); err != nil {
 			return compContext.Log().ErrorfNewErr("Failed creating Acme resources: %v", err)
 		}
 	} else {
 		// Create resources needed for CA certificates
-		if _, err = createOrUpdateCAResources(compContext); err != nil {
+		if opResult, err = createOrUpdateCAResources(compContext); err != nil {
 			return compContext.Log().ErrorfNewErr("Failed creating CA resources: %v", err)
 		}
+	}
+	if opResult == controllerutil.OperationResultCreated {
+		// We're in the initial install phase, and created the ClusterIssuer for the first time
+		compContext.Log().Oncef("Initial install, skipping certficate renewal checks")
+		return nil
 	}
 	if err := checkRenewAllCertificates(compContext, isCAValue); err != nil {
 		compContext.Log().Errorf("Error requesting certificate renewal: %s", err.Error())


### PR DESCRIPTION

# Description

Skip the new cert renewal checks on initial install in the cert-manager component code.  Fixes an edge condition where the certs can take some time to be issued, like when using Let's Encrypt as the cert signer.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
