### PR TITLE
VZ-5224 Verify the Prometheus Operator default image arguments

### DIFF
--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -329,27 +329,22 @@ func SlicesContainSameStrings(strings1, strings2 []string) bool {
 	return reflect.DeepEqual(m1, m2)
 }
 
-// SlicesContainSubsectionStrings compares two slices and returns true if the first slice is a subsection of the second slice
-func SlicesContainSubsectionStrings(strings1, strings2 []string) bool {
+// SlicesContainSubsetSubstring returns true if the strings in the first slice are substrings of any string in the second slice
+func SlicesContainSubsetSubstring(strings1, strings2 []string) bool {
 	if len(strings1) >= len(strings2) {
 		return false
 	}
 	if len(strings1) == 0 {
 		return true
 	}
-	// count how many times each string occurs in case there are duplicates
-	m1 := map[string]int32{}
-	for _, s := range strings1 {
-		m1[s]++
-	}
-	m2 := map[string]int32{}
-	for _, s := range strings2 {
-		m2[s]++
-	}
-
-	// See if all keys value pairs in map1 match the pairs in map2
-	for k, v := range m1 {
-		if m2[k] != v {
+	for _, s1 := range strings1 {
+		found := false
+		for _, s2 := range strings1 {
+			if strings.Contains(s1, s2) {
+				found = true
+			}
+		}
+		if !found {
 			return false
 		}
 	}

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -337,7 +337,7 @@ func SlicesContainSubsetSubstring(strings1, strings2 []string) bool {
 	for _, s1 := range strings1 {
 		found := false
 		for _, s2 := range strings2 {
-			if strings.Contains(s1, s2) {
+			if strings.Contains(s2, s1) {
 				found = true
 				break
 			}

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -329,6 +329,33 @@ func SlicesContainSameStrings(strings1, strings2 []string) bool {
 	return reflect.DeepEqual(m1, m2)
 }
 
+// SlicesContainSubsectionStrings compares two slices and returns true if the first slice is a subsection of the second slice
+func SlicesContainSubsectionStrings(strings1, strings2 []string) bool {
+	if len(strings1) >= len(strings2) {
+		return false
+	}
+	if len(strings1) == 0 {
+		return true
+	}
+	// count how many times each string occurs in case there are duplicates
+	m1 := map[string]int32{}
+	for _, s := range strings1 {
+		m1[s]++
+	}
+	m2 := map[string]int32{}
+	for _, s := range strings2 {
+		m2[s]++
+	}
+
+	// See if all keys value pairs in map1 match the pairs in map2
+	for k, v := range m1 {
+		if m2[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 // PolicyRulesEqual compares two RBAC PolicyRules for semantic equality
 func PolicyRulesEqual(rule1, rule2 rbacv1.PolicyRule) bool {
 	if SlicesContainSameStrings(rule1.Verbs, rule2.Verbs) &&

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -339,6 +339,7 @@ func SlicesContainSubsetSubstring(strings1, strings2 []string) bool {
 		for _, s2 := range strings2 {
 			if strings.Contains(s1, s2) {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -331,15 +331,12 @@ func SlicesContainSameStrings(strings1, strings2 []string) bool {
 
 // SlicesContainSubsetSubstring returns true if the strings in the first slice are substrings of any string in the second slice
 func SlicesContainSubsetSubstring(strings1, strings2 []string) bool {
-	if len(strings1) >= len(strings2) {
-		return false
-	}
 	if len(strings1) == 0 {
 		return true
 	}
 	for _, s1 := range strings1 {
 		found := false
-		for _, s2 := range strings1 {
+		for _, s2 := range strings2 {
 			if strings.Contains(s1, s2) {
 				found = true
 			}

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -1085,3 +1085,18 @@ func DoesVerrazzanoProjectExistInCluster(name string, kubeconfigPath string) (bo
 
 	return vp != nil && len(vp.Name) > 0, nil
 }
+
+// ContainerHasExpectedArgs returns true if each of the arguments matches a substring of one of the arguments found in the deployment
+func ContainerHasExpectedArgs(namespace string, deploymentName string, containerName string, arguments []string) (bool, error) {
+	deployment, err := GetDeployment(namespace, deploymentName)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Deployment %v is not found in the namespace: %v, error: %v", deploymentName, namespace, err))
+		return false, nil
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			return SlicesContainSubsetSubstring(arguments, container.Args), nil
+		}
+	}
+	return false, nil
+}

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -21,7 +21,6 @@ const (
 	prometheusTLSSecret             = "prometheus-operator-kube-p-admission"
 	prometheusOperatorDeployment    = "prometheus-operator-kube-p-operator"
 	prometheusOperatorContainerName = "kube-prometheus-stack"
-	bomFilepath                     = "../../../../platform-operator/verrazzano-bom.json"
 )
 
 var (


### PR DESCRIPTION
# Description

This introduces a test to verify that the Prometheus Operator default images are populated properly.

Fixes VZ-5224

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
