### PR TITLE
NO-JIRA: BOM image upgrades

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -207,7 +207,7 @@
             },
             {
               "image": "prometheus",
-              "tag": "v2.31.1",
+              "tag": "v2.34.0",
               "helmFullImageKey": "monitoringOperator.prometheusImage"
             },
             {
@@ -477,7 +477,7 @@
           "images": [
             {
               "image": "prometheus-adapter",
-              "tag": "v0.9.1-2",
+              "tag": "v0.9.1-3",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -42,7 +42,6 @@ type imageError struct {
 
 var ignoreSubComponents = []string{
 	"additional-rancher",
-	"prometheus",
 }
 
 func main() {


### PR DESCRIPTION
# Description

Image upgrades:

- prometheus-adapter
- prometheus (to sync the version of prometheus used in the old and new monitoring stacks)

Since the prometheus images are now in sync, we can remove the setting to ignore the image when doing BOM validation.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
