### PR TITLE
VZ-5694 Disable all Prometheus Operator components by default

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
@@ -50,7 +50,7 @@ func NewComponent() spi.Component {
 func (c prometheusAdapterComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusAdapter
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Adapter enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
@@ -50,7 +50,7 @@ func NewComponent() spi.Component {
 func (c kubeStateMetricsComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.KubeStateMetrics
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with KubeStateMetrics enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -52,7 +52,7 @@ func NewComponent() spi.Component {
 func (c prometheusComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusOperator
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Operator enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
@@ -51,7 +51,7 @@ func NewComponent() spi.Component {
 func (c prometheusPushgatewayComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusPushgateway
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway enabled
@@ -62,7 +62,7 @@ func TestIsEnabled(t *testing.T) {
 					},
 				},
 			},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway having empty section
@@ -76,7 +76,7 @@ func TestIsEnabled(t *testing.T) {
 					},
 				},
 			},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway disabled

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevDefault.yaml
@@ -39,10 +39,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevWithOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevWithOverrides.yaml
@@ -39,10 +39,10 @@ rancher:
 nodeExporter:
   enabled: false
 prometheusOperator:
-  enabled: false
+  enabled: true
 prometheusAdapter:
-  enabled: false
+  enabled: true
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 prometheusPushgateway:
-  enabled: false
+  enabled: true

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesManagedClusterDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesManagedClusterDefault.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdDefault.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminAndMonitorRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminAndMonitorRoleOverrides.yaml
@@ -40,10 +40,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminRoleOverrides.yaml
@@ -39,10 +39,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithExternaDNSEnabled.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithExternaDNSEnabled.yaml
@@ -30,10 +30,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdEmptyExtraVolumeMountsOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdEmptyExtraVolumeMountsOverrides.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOCILoggingOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOCILoggingOverrides.yaml
@@ -34,10 +34,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOverrides.yaml
@@ -40,10 +40,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithMonitorRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithMonitorRoleOverrides.yaml
@@ -39,10 +39,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevWithOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevWithOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: false
 prometheusOperator:
-  enabled: false
+  enabled: true
 prometheusAdapter:
-  enabled: false
+  enabled: true
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 prometheusPushgateway:
-  enabled: false
+  enabled: true

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesMgdClusterNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesMgdClusterNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 NodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdWithExternalDNS.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdWithExternalDNS.yaml
@@ -16,10 +16,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -241,6 +241,7 @@ func Test_appendCustomImageOverrides(t *testing.T) {
 //  THEN the correct KeyValue objects and overrides file snippets are generated
 func Test_appendVerrazzanoValues(t *testing.T) {
 	falseValue := false
+	trueValue := true
 	tests := []struct {
 		name         string
 		description  string
@@ -285,10 +286,10 @@ func Test_appendVerrazzanoValues(t *testing.T) {
 						Keycloak:              &vzapi.KeycloakComponent{Enabled: &falseValue},
 						Rancher:               &vzapi.RancherComponent{Enabled: &falseValue},
 						DNS:                   &vzapi.DNSComponent{Wildcard: &vzapi.Wildcard{Domain: "xip.io"}},
-						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &falseValue},
-						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
+						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &trueValue},
+						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
 					},
 				},
 			},
@@ -588,10 +589,10 @@ func Test_appendVerrazzanoOverrides(t *testing.T) {
 						Keycloak:              &vzapi.KeycloakComponent{Enabled: &falseValue},
 						Rancher:               &vzapi.RancherComponent{Enabled: &falseValue},
 						DNS:                   &vzapi.DNSComponent{Wildcard: &vzapi.Wildcard{Domain: "xip.io"}},
-						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &falseValue},
-						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
+						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &trueValue},
+						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
 					},
 				},
 			},

--- a/platform-operator/controllers/verrazzano/validator/ComponentValidatorImpl_test.go
+++ b/platform-operator/controllers/verrazzano/validator/ComponentValidatorImpl_test.go
@@ -43,7 +43,7 @@ func TestComponentValidatorImpl_ValidateInstall(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 9,
+			numberOfErrors: 8,
 		},
 	}
 	config.TestProfilesDir = "../../../manifests/profiles"
@@ -102,7 +102,7 @@ func TestComponentValidatorImpl_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 6,
+			numberOfErrors: 5,
 		},
 		{
 			name: "disabled cert and ingress",
@@ -119,7 +119,7 @@ func TestComponentValidatorImpl_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 11,
+			numberOfErrors: 10,
 		},
 	}
 	config.TestProfilesDir = "../../../manifests/profiles"
@@ -160,7 +160,7 @@ func Test_dependencyValidation(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 9,
+			numberOfErrors: 8,
 		},
 		{
 			name: "disabled istio",

--- a/platform-operator/internal/vzconfig/enabled.go
+++ b/platform-operator/internal/vzconfig/enabled.go
@@ -120,7 +120,7 @@ func IsPrometheusOperatorEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusOperator != nil && vz.Spec.Components.PrometheusOperator.Enabled != nil {
 		return *vz.Spec.Components.PrometheusOperator.Enabled
 	}
-	return true
+	return false
 }
 
 // IsPrometheusAdapterEnabled returns false only if the Prometheus Adapter is explicitly disabled in the CR
@@ -128,7 +128,7 @@ func IsPrometheusAdapterEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusAdapter != nil && vz.Spec.Components.PrometheusAdapter.Enabled != nil {
 		return *vz.Spec.Components.PrometheusAdapter.Enabled
 	}
-	return true
+	return false
 }
 
 // IsKubeStateMetricsEnabled returns false only if Kube State Metrics is explicitly disabled in the CR
@@ -136,7 +136,7 @@ func IsKubeStateMetricsEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.KubeStateMetrics != nil && vz.Spec.Components.KubeStateMetrics.Enabled != nil {
 		return *vz.Spec.Components.KubeStateMetrics.Enabled
 	}
-	return true
+	return false
 }
 
 // IsPrometheusPushgatewayEnabled returns false only if the Prometheus Pushgateway is explicitly disabled in the CR
@@ -144,5 +144,5 @@ func IsPrometheusPushgatewayEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusPushgateway != nil && vz.Spec.Components.PrometheusPushgateway.Enabled != nil {
 		return *vz.Spec.Components.PrometheusPushgateway.Enabled
 	}
-	return true
+	return false
 }

--- a/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -7,3 +7,12 @@ metadata:
   name: my-verrazzano
 spec:
   profile: dev
+  components:
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-nipio-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio-with-persistence.yaml
@@ -21,3 +21,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
@@ -11,3 +11,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml
@@ -19,3 +19,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql


### PR DESCRIPTION
# Description

We are disabling all Prometheus Operator components by default. Now, the Prometheus Operator components will have to be explicitly set `enabled=true` for all components.

Fixes VZ-5694

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
