### PR TITLE
VZ-5810. Introduce throttled error logging, use with Rancher component and secrets controller.

### DIFF
--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -88,6 +88,12 @@ type ProgressLogger interface {
 	// ErrorfNewErr formats an error, logs it, then returns the formatted error
 	ErrorfNewErr(template string, args ...interface{}) error
 
+	// ErrorfThrottledNewErr Records a formatted error message throttled at the ProgressLogger frequency then returns the formatted error
+	ErrorfThrottledNewErr(template string, args ...interface{}) error
+
+	// ErrorfThrottled Records a formatted error message throttled at the ProgressLogger frequency then
+	ErrorfThrottled(template string, args ...interface{})
+
 	// SetFrequency sets the logging frequency of a progress message
 	SetFrequency(secs int) VerrazzanoLogger
 }
@@ -283,22 +289,42 @@ func (v *verrazzanoLogger) Progress(args ...interface{}) {
 // If the log message is new or has changed then it is logged immediately.
 func (v *verrazzanoLogger) doLog(once bool, args ...interface{}) {
 	msg := fmt.Sprint(args...)
-	now := time.Now()
+	cacheUpdated := v.checkLogCache(once, msg)
+	if cacheUpdated {
+		v.sLogger.Info(msg)
+	}
+}
 
+//doError Logs an error message first checking against the log cache; same behavior as doLog() except that messages
+// are recorded as errors at the throttling frequency.  Errors are never once-only.
+func (v *verrazzanoLogger) doError(args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	cacheUpdated := v.checkLogCache(false, msg)
+	if cacheUpdated {
+		v.sLogger.Error(msg)
+	}
+}
+
+//checkLogCache Checks if a message exists in the log cache; returns true if the cache is updated.  The cache is updated
+// when
+// - A message is a log-once type that has not been recorded yet
+// - A message is throttled, but it has not exceeded it's frequency threshold since the last occurrence
+// - A message is newly added to the cache
+func (v *verrazzanoLogger) checkLogCache(once bool, msg string) bool {
 	// If the message is in the trash, that means it should never be logged again.
 	_, ok := v.trashMessages[msg]
 	if ok {
-		return
+		return false
 	}
 
 	// If this is log "once", log it and save in trash so it is never logged again, then return
 	if once {
-		v.sLogger.Info(msg)
 		v.trashMessages[msg] = true
-		return
+		return true
 	}
 
 	// If this message has already been logged, then check if time to log again
+	now := time.Now()
 	history := v.progressHistory[msg]
 	if history != nil {
 		waitSecs := time.Duration(v.frequencySecs) * time.Second
@@ -306,17 +332,18 @@ func (v *verrazzanoLogger) doLog(once bool, args ...interface{}) {
 
 		// Log now if the message wait time exceeded
 		if now.Equal(nextLogTime) || now.After(nextLogTime) {
-			v.sLogger.Info(msg)
 			history.logTime = &now
+			return true
 		}
 	} else {
 		// This is a new message log it
-		v.sLogger.Info(msg)
 		v.progressHistory[msg] = &logEvent{
 			logTime:   &now,
 			msgLogged: msg,
 		}
+		return true
 	}
+	return false
 }
 
 // SetFrequency sets the log frequency
@@ -359,6 +386,17 @@ func (v *verrazzanoLogger) ErrorfNewErr(template string, args ...interface{}) er
 	err := fmt.Errorf(template, args...)
 	v.Error2(err)
 	return err
+}
+
+func (v *verrazzanoLogger) ErrorfThrottledNewErr(template string, args ...interface{}) error {
+	err := fmt.Errorf(template, args...)
+	v.doError(err.Error())
+	return err
+}
+
+func (v *verrazzanoLogger) ErrorfThrottled(template string, args ...interface{}) {
+	s := fmt.Sprintf(template, args...)
+	v.doError(s)
 }
 
 // Debug is a wrapper for SugaredLogger Debug

--- a/pkg/log/vzlog/vzlog.go
+++ b/pkg/log/vzlog/vzlog.go
@@ -91,7 +91,7 @@ type ProgressLogger interface {
 	// ErrorfThrottledNewErr Records a formatted error message throttled at the ProgressLogger frequency then returns the formatted error
 	ErrorfThrottledNewErr(template string, args ...interface{}) error
 
-	// ErrorfThrottled Records a formatted error message throttled at the ProgressLogger frequency then
+	// ErrorfThrottled Records a formatted error message throttled at the ProgressLogger frequency
 	ErrorfThrottled(template string, args ...interface{})
 
 	// SetFrequency sets the logging frequency of a progress message

--- a/pkg/log/vzlog/vzlog_test.go
+++ b/pkg/log/vzlog/vzlog_test.go
@@ -118,18 +118,20 @@ func TestErrorfThrottled(t *testing.T) {
 // WHEN ErrorfThrottledNewErr is called 5 times with 1 message and no sleep
 // THEN ensure that 1 message is logged
 func TestErrorfThrottledNewErr(t *testing.T) {
-	msg := fmt.Sprintf("Mymessage %s", "test2")
+	const messageTemplate = "Mymessage %s"
+	const messageParameter = "test2"
+	msg := fmt.Sprintf(messageTemplate, messageParameter)
 	logger := fakeLogger{expectedMsg: msg}
 	const rKey = "testns/errorsNew"
 	rl := EnsureContext(rKey)
 	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(30)
 
 	// Calls to log should result in only 1 log messages being written
-	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
-	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
-	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
-	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
-	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Error(t, l.ErrorfThrottledNewErr(messageTemplate, messageParameter))
+	assert.Error(t, l.ErrorfThrottledNewErr(messageTemplate, messageParameter))
+	assert.Error(t, l.ErrorfThrottledNewErr(messageTemplate, messageParameter))
+	assert.Error(t, l.ErrorfThrottledNewErr(messageTemplate, messageParameter))
+	assert.Error(t, l.ErrorfThrottledNewErr(messageTemplate, messageParameter))
 	assert.Equal(t, 1, logger.count)
 	assert.Equal(t, msg, logger.actualMsg)
 	DeleteLogContext(rKey)

--- a/pkg/log/vzlog/vzlog_test.go
+++ b/pkg/log/vzlog/vzlog_test.go
@@ -91,6 +91,50 @@ func TestLogRepeat(t *testing.T) {
 	DeleteLogContext(rKey)
 }
 
+// TestErrorfThrottled tests the ProgressLogger function throttle repeated error messages
+// GIVEN a ProgressLogger with a frequency of 30 seconds
+// WHEN ErrorfThrottled is called 5 times with 1 message and no sleep
+// THEN ensure that 1 message is logged
+func TestErrorfThrottled(t *testing.T) {
+	msg := "test1"
+	logger := fakeLogger{expectedMsg: msg}
+	const rKey = "testns/errors"
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(30)
+
+	// Calls to log should result in only 1 log messages being written
+	l.ErrorfThrottled(msg)
+	l.ErrorfThrottled(msg)
+	l.ErrorfThrottled(msg)
+	l.ErrorfThrottled(msg)
+	l.ErrorfThrottled(msg)
+	assert.Equal(t, 1, logger.count)
+	assert.Equal(t, msg, logger.actualMsg)
+	DeleteLogContext(rKey)
+}
+
+// TestErrorfThrottledNewErr tests the ProgressLogger function throttle repeated error messages
+// GIVEN a ProgressLogger with a frequency of 30 seconds
+// WHEN ErrorfThrottledNewErr is called 5 times with 1 message and no sleep
+// THEN ensure that 1 message is logged
+func TestErrorfThrottledNewErr(t *testing.T) {
+	msg := fmt.Sprintf("Mymessage %s", "test2")
+	logger := fakeLogger{expectedMsg: msg}
+	const rKey = "testns/errorsNew"
+	rl := EnsureContext(rKey)
+	l := rl.EnsureLogger("comp1", &logger, zap.S()).SetFrequency(30)
+
+	// Calls to log should result in only 1 log messages being written
+	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Error(t, l.ErrorfThrottledNewErr("Mymessage %s", "test2"))
+	assert.Equal(t, 1, logger.count)
+	assert.Equal(t, msg, logger.actualMsg)
+	DeleteLogContext(rKey)
+}
+
 // TestHistory tests the ProgressLogger function ignore previous progrsss messages
 // GIVEN a ProgressLogger with a frequency of 2 seconds
 // WHEN log is called 5 times with 2 message using repeats, and no sleep
@@ -259,10 +303,12 @@ func (l *fakeLogger) Debugw(msg string, keysAndValues ...interface{}) {
 
 // Error is a wrapper for SugaredLogger Error
 func (l *fakeLogger) Error(args ...interface{}) {
+	l.Info(args...)
 }
 
 // Errorf is a wrapper for SugaredLogger Errorf
 func (l *fakeLogger) Errorf(template string, args ...interface{}) {
+	l.Infof(template, args...)
 }
 
 // Errorw formats a message and logs it

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -94,8 +94,8 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return nil
 	})
 	if err != nil {
-		r.log.Errorf("Failed to create or update secret %s/%s: %v",
-			constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoLocalCABundleSecret, err)
+		r.log.ErrorfThrottled("Failed to create or update secret %s/%s: %s",
+			constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoLocalCABundleSecret, err.Error())
 		return newRequeueWithDelay(), nil
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -233,39 +233,29 @@ func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 	log := ctx.Log()
 
 	if err := createAdminSecretIfNotExists(log, c); err != nil {
-		ctx.Log().Progressf("Error creating Rancher admin secret: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error creating Rancher admin secret: %s", err.Error())
 	}
 	password, err := common.GetAdminSecret(c)
 	if err != nil {
-		ctx.Log().Progressf("Error getting Rancher admin secret: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error getting Rancher admin secret: %s", err.Error())
 	}
 	rancherHostName, err := getRancherHostname(c, vz)
 	if err != nil {
-		ctx.Log().Progressf("Error getting Rancher hostname: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error getting Rancher hostname: %s", err.Error())
 	}
 
 	rest, err := common.NewClient(c, rancherHostName, password)
 	if err != nil {
-		ctx.Log().Progressf("Error getting Rancher client: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error getting Rancher client: %s", err.Error())
 	}
 	if err := rest.SetAccessToken(); err != nil {
-		ctx.Log().Progressf("Error setting Rancher access token: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error setting Rancher access token: %s", err.Error())
 	}
-
 	if err := rest.PutServerURL(); err != nil {
-		ctx.Log().Progressf("Error setting Rancher server URL: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error setting Rancher server URL: %s", err.Error())
 	}
-
 	if err := removeBootstrapSecretIfExists(log, c); err != nil {
-		ctx.Log().Progressf("Error removing Rancher bootstrap secret: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error removing Rancher bootstrap secret: %s", err.Error())
 	}
-
 	return r.HelmComponent.PostInstall(ctx)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -199,6 +199,7 @@ func (r rancherComponent) Install(ctx spi.ComponentContext) error {
 	c := ctx.Client()
 	// Set MKNOD Cap on Rancher deployment
 	if err := patchRancherDeployment(c); err != nil {
+		log.Progressf("Error patching Rancher deployment: %s", err.Error())
 		return err
 	}
 	log.Debugf("Patched Rancher deployment to support MKNOD")
@@ -232,31 +233,37 @@ func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 	log := ctx.Log()
 
 	if err := createAdminSecretIfNotExists(log, c); err != nil {
+		ctx.Log().Progressf("Error creating Rancher admin secret: %s", err.Error())
 		return err
 	}
 	password, err := common.GetAdminSecret(c)
 	if err != nil {
+		ctx.Log().Progressf("Error getting Rancher admin secret: %s", err.Error())
 		return err
 	}
 	rancherHostName, err := getRancherHostname(c, vz)
 	if err != nil {
+		ctx.Log().Progressf("Error getting Rancher hostname: %s", err.Error())
 		return err
 	}
 
 	rest, err := common.NewClient(c, rancherHostName, password)
 	if err != nil {
+		ctx.Log().Progressf("Error getting Rancher client: %s", err.Error())
 		return err
 	}
 	if err := rest.SetAccessToken(); err != nil {
+		ctx.Log().Progressf("Error setting Rancher access token: %s", err.Error())
 		return err
 	}
 
 	if err := rest.PutServerURL(); err != nil {
-		ctx.Log().Error(err)
+		ctx.Log().Progressf("Error setting Rancher server URL: %s", err.Error())
 		return err
 	}
 
 	if err := removeBootstrapSecretIfExists(log, c); err != nil {
+		ctx.Log().Progressf("Error removing Rancher bootstrap secret: %s", err.Error())
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -199,13 +199,12 @@ func (r rancherComponent) Install(ctx spi.ComponentContext) error {
 	c := ctx.Client()
 	// Set MKNOD Cap on Rancher deployment
 	if err := patchRancherDeployment(c); err != nil {
-		log.Progressf("Error patching Rancher deployment: %s", err.Error())
-		return err
+		return log.ErrorfThrottledNewErr("Error patching Rancher deployment: %s", err.Error())
 	}
 	log.Debugf("Patched Rancher deployment to support MKNOD")
 	// Annotate Rancher ingress for NGINX/TLS
 	if err := patchRancherIngress(c, ctx.EffectiveCR()); err != nil {
-		return err
+		return log.ErrorfThrottledNewErr("Error patching Rancher ingress: %s", err.Error())
 	}
 	log.Debugf("Patched Rancher ingress")
 


### PR DESCRIPTION
# Description

Adds throttled error logging capabilities to the `VerrazzanoLogger`
- Refactor the cache usage to be shared between Info and Error logs
- Instrument rancher PostInstall with progress/error messages
- Use throttled logging for secrets controller errors when the namespace doesn't exist

Fixes VZ-5810.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
