### PR TITLE
VZ-5677: Add BFS kube-webhook-certgen image

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -76,7 +76,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	// If the cert-manager component is enabled, use it for webhook certificates, otherwise Prometheus Operator
 	// will use the kube-webhook-certgen image
 	kvs = append(kvs, bom.KeyValue{
-		Key:   "prometheusOperator.admissionWebhooks.certManager",
+		Key:   "prometheusOperator.admissionWebhooks.certManager.enabled",
 		Value: strconv.FormatBool(vzconfig.IsCertManagerEnabled(ctx.EffectiveCR())),
 	})
 

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -6,11 +6,13 @@ package operator
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -70,6 +72,13 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	if err != nil {
 		return kvs, err
 	}
+
+	// If the cert-manager component is enabled, use it for webhook certificates, otherwise Prometheus Operator
+	// will use the kube-webhook-certgen image
+	kvs = append(kvs, bom.KeyValue{
+		Key:   "prometheusOperator.admissionWebhooks.certManager",
+		Value: strconv.FormatBool(vzconfig.IsCertManagerEnabled(ctx.EffectiveCR())),
+	})
 
 	return kvs, nil
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -8,7 +8,6 @@ import (
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -41,7 +40,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0].name",
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "prometheus-values.yaml"),
-			Dependencies:            []string{certmanager.ComponentName},
+			Dependencies:            []string{},
 			AppendOverridesFunc:     AppendOverrides,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -140,7 +140,7 @@ func TestAppendOverrides(t *testing.T) {
 	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.alertmanagerDefaultBaseImage"), "ghcr.io/verrazzano/alertmanager:"))
 	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.prometheusDefaultBaseImage"), "ghcr.io/verrazzano/prometheus:"))
 
-	assert.Equal(t, "true", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager"))
+	assert.Equal(t, "true", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 
 	// GIVEN a Verrazzano CR with the CertManager component disabled
 	// WHEN the AppendOverrides function is called
@@ -163,7 +163,7 @@ func TestAppendOverrides(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 7)
 
-	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager"))
+	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 }
 
 // TestPreInstall tests the preInstall function.

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -4,20 +4,35 @@
 package operator
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var testScheme = runtime.NewScheme()
+const (
+	testBomFilePath = "../../../testdata/test_bom.json"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+
+	falseValue = false
+	trueValue  = true
+)
 
 func init() {
 	_ = clientgoscheme.AddToScheme(testScheme)
@@ -84,4 +99,85 @@ func TestIsPrometheusOperatorReady(t *testing.T) {
 			assert.Equal(t, tt.expectTrue, isPrometheusOperatorReady(ctx))
 		})
 	}
+}
+
+// TestAppendOverrides tests that helm overrides are set properly
+func TestAppendOverrides(t *testing.T) {
+	oldBomPath := config.GetDefaultBOMFilePath()
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer config.SetDefaultBomFilePath(oldBomPath)
+
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	kvs := make([]bom.KeyValue, 0)
+
+	// GIVEN a Verrazzano CR with the CertManager component enabled
+	// WHEN the AppendOverrides function is called
+	// THEN the key/value slice contains the expected helm override keys and values
+	// AND the admission webhook cert manager helm override is set to true
+	vz := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				CertManager: &vzapi.CertManagerComponent{
+					Enabled: &trueValue,
+				},
+			},
+		},
+	}
+
+	ctx := spi.NewFakeContext(client, vz, false)
+
+	var err error
+	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 7)
+
+	assert.Equal(t, "ghcr.io/verrazzano/prometheus-config-reloader", bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.repository"))
+	assert.NotEmpty(t, bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.tag"))
+
+	assert.Equal(t, "ghcr.io/verrazzano/alertmanager", bom.FindKV(kvs, "alertmanager.alertmanagerSpec.image.repository"))
+	assert.NotEmpty(t, bom.FindKV(kvs, "alertmanager.alertmanagerSpec.image.tag"))
+
+	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.alertmanagerDefaultBaseImage"), "ghcr.io/verrazzano/alertmanager:"))
+	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.prometheusDefaultBaseImage"), "ghcr.io/verrazzano/prometheus:"))
+
+	assert.Equal(t, "true", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager"))
+
+	// GIVEN a Verrazzano CR with the CertManager component disabled
+	// WHEN the AppendOverrides function is called
+	// THEN the key/value slice contains the expected helm override keys and values
+	// AND the admission webhook cert manager helm override is set to false
+	vz = &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				CertManager: &vzapi.CertManagerComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+
+	ctx = spi.NewFakeContext(client, vz, false)
+	kvs = make([]bom.KeyValue, 0)
+
+	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 7)
+
+	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager"))
+}
+
+// TestPreInstall tests the preInstall function.
+func TestPreInstall(t *testing.T) {
+	// GIVEN the Prometheus Operator is being installed
+	// WHEN the preInstall function is called
+	// THEN the component namespace is created in the cluster
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := preInstall(ctx)
+	assert.NoError(t, err)
+
+	ns := v1.Namespace{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: ComponentNamespace}, &ns)
+	assert.NoError(t, err)
 }

--- a/platform-operator/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/controllers/verrazzano/testdata/test_bom.json
@@ -403,6 +403,116 @@
           ]
         }
       ]
+    },
+    {
+      "name": "prometheus-operator",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-operator",
+          "images": [
+            {
+              "image": "prometheus-operator",
+              "tag": "v0.55.1",
+              "helmFullImageKey": "prometheusOperator.image.repository",
+              "helmTagKey": "prometheusOperator.image.tag"
+            },
+            {
+              "image": "kube-webhook-certgen",
+              "tag": "1.1.1-20220414195226-864e56292",
+              "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
+              "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-config-reloader",
+          "images": [
+            {
+              "image": "prometheus-config-reloader",
+              "tag": "v0.55.1",
+              "helmFullImageKey": "prometheusOperator.prometheusConfigReloader.image.repository",
+              "helmTagKey": "prometheusOperator.prometheusConfigReloader.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "alertmanager",
+          "images": [
+            {
+              "image": "alertmanager",
+              "tag": "v0.24.0",
+              "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
+              "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "prometheus",
+          "images": [
+            {
+              "image": "prometheus",
+              "tag": "v2.34.0",
+              "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
+              "helmTagKey": "prometheus.prometheusSpec.image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "prometheus-adapter",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-adapter",
+          "images": [
+            {
+              "image": "prometheus-adapter",
+              "tag": "v0.9.1-3",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "kube-state-metrics",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "kube-state-metrics",
+          "images": [
+            {
+              "image": "kube-state-metrics",
+              "tag": "v2.4.2",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "prometheus-pushgateway",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-pushgateway",
+          "images": [
+            {
+              "image": "prometheus-pushgateway",
+              "tag": "v1.4.2",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/platform-operator/helm_config/overrides/prometheus-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-values.yaml
@@ -14,8 +14,6 @@ alertmanager:
 prometheusOperator:
   admissionWebhooks:
     enabled: true
-    certManager:
-      enabled: true
     patch:
       enabled: true
   tls:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -427,6 +427,12 @@
               "tag": "v0.55.1",
               "helmFullImageKey": "prometheusOperator.image.repository",
               "helmTagKey": "prometheusOperator.image.tag"
+            },
+            {
+              "image": "kube-webhook-certgen",
+              "tag": "1.1.1-20220414195226-864e56292",
+              "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
+              "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
             }
           ]
         },


### PR DESCRIPTION
# Description

This image is used to generate webhook certificates for the Prometheus Operator in the event that Cert Manager is disabled. The Prometheus Operator install checks to see if Cert Manager is enabled, and if so sets the helm flag to enable the use of Cert Manager. If Cert Manager is not enabled, this kube-webhook-certgen image will be used to generate the certificates.

While I was in here I also added additional unit test coverage for the promoperator component.

Implements VZ-5677

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
