### PR TITLE
VZ-5673.  Cleanup unused CM resources on update

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -11,18 +11,19 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"net/mail"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
 	cmutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
-	"io"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"net/mail"
-	"os"
-	"path/filepath"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"strings"
-	"text/template"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -32,7 +33,6 @@ import (
 	certv1client "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	vzos "github.com/verrazzano/verrazzano/pkg/os"
 	"github.com/verrazzano/verrazzano/pkg/security/password"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -41,7 +41,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
@@ -69,9 +69,15 @@ const (
 	letsEncryptStageEndpoint = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 	certRequestNameAnnotation = "cert-manager.io/certificate-name"
+
+	/* #nosec */
+	defaultCACertificateSecretName = "verrazzano-ca-certificate-secret"
+	/* #nosec */
+	caAcmeSecretName = "verrazzano-cert-acme-secret"
 )
 
 var (
+	// Statically define the well-known Let's Encrypt CA Common Names
 	letsEncryptProductionCACommonNames = []string{"R3", "E1", "R4", "E2"}
 	letsEncryptStagingCACommonNames    = []string{"(STAGING) Artificial Apricot R3", "(STAGING) Bogus Broccoli X2", "(STAGING) Ersatz Edamame E1"}
 )
@@ -95,7 +101,7 @@ spec:
     server: "{{.Server}}"
     preferredChain: ""
     privateKeySecretRef:
-      name: verrazzano-cert-acme-secret
+      name: {{.AcmeSecretName}}
     solvers:
       - dns01:
           ocidns:
@@ -139,6 +145,7 @@ var ociDNSSnippet = strings.Split(`ocidns:
 // Template data for ClusterIssuer
 type templateData struct {
 	ClusterIssuerName string
+	AcmeSecretName    string
 	Email             string
 	Server            string
 	SecretName        string
@@ -147,15 +154,6 @@ type templateData struct {
 
 // CertIssuerType identifies the certificate issuer type
 type CertIssuerType string
-
-// Define bash function here for testing purposes
-type bashFuncSig func(inArgs ...string) (string, string, error)
-
-var bashFunc bashFuncSig = vzos.RunBash
-
-func setBashFunc(f bashFuncSig) {
-	bashFunc = f
-}
 
 type getCoreV1ClientFuncType func(log ...vzlog.VerrazzanoLogger) (corev1.CoreV1Interface, error)
 
@@ -524,7 +522,10 @@ func isLetsEncryptStaging(compContext spi.ComponentContext) bool {
 	return acmeEnvironment != "" && strings.ToLower(acmeEnvironment) != "production"
 }
 
-// createOrUpdateAcmeResources creates all of the post install resources necessary for cert-manager
+//createOrUpdateAcmeResources Create or update the ACME ClusterIssuer
+// - returns OperationResultNone/error on error
+// - returns OperationResultCreated/nil if the CI is created (initial install)
+// - returns OperationResultUpdated/nil if the CI is updated
 func createOrUpdateAcmeResources(compContext spi.ComponentContext) (opResult controllerutil.OperationResult, err error) {
 	opResult = controllerutil.OperationResultNone
 	// Create a lookup object
@@ -559,7 +560,7 @@ func createACMEIssuerObject(compContext spi.ComponentContext) (*unstructured.Uns
 	}
 	// Verify that the secret exists
 	secret := v1.Secret{}
-	if err := compContext.Client().Get(context.TODO(), client.ObjectKey{Name: ociDNSConfigSecret, Namespace: ComponentNamespace}, &secret); err != nil {
+	if err := compContext.Client().Get(context.TODO(), crtclient.ObjectKey{Name: ociDNSConfigSecret, Namespace: ComponentNamespace}, &secret); err != nil {
 		return nil, compContext.Log().ErrorfNewErr("Failed to retrieve the OCI DNS config secret: %v", err)
 	}
 
@@ -574,6 +575,7 @@ func createACMEIssuerObject(compContext spi.ComponentContext) (*unstructured.Uns
 	// Create the buffer and the cluster issuer data struct
 	clusterIssuerData := templateData{
 		ClusterIssuerName: verrazzanoClusterIssuerName,
+		AcmeSecretName:    caAcmeSecretName,
 		Email:             emailAddress,
 		Server:            acmeServer,
 		SecretName:        ociDNSConfigSecret,
@@ -587,13 +589,13 @@ func createACMEIssuerObject(compContext spi.ComponentContext) (*unstructured.Uns
 func createAcmeClusterIssuer(log vzlog.VerrazzanoLogger, clusterIssuerData templateData) (*unstructured.Unstructured, error) {
 	var buff bytes.Buffer
 	// Parse the template string and create the template object
-	template, err := template.New("clusterIssuer").Parse(clusterIssuerTemplate)
+	issuerTemplate, err := template.New("clusterIssuer").Parse(clusterIssuerTemplate)
 	if err != nil {
 		return nil, log.ErrorfNewErr("Failed to parse the ClusterIssuer yaml template: %v", err)
 	}
 
 	// Execute the template object with the given data
-	err = template.Execute(&buff, &clusterIssuerData)
+	err = issuerTemplate.Execute(&buff, &clusterIssuerData)
 	if err != nil {
 		return nil, log.ErrorfNewErr("Failed to execute the ClusterIssuer template: %v", err)
 	}
@@ -615,12 +617,16 @@ func createAcmeCusterIssuerLookupObject(log vzlog.VerrazzanoLogger) (*unstructur
 
 }
 
+//createOrUpdateCAResources Create or update the CA ClusterIssuer
+// - returns OperationResultNone/error on error
+// - returns OperationResultCreated/nil if the CI is created (initial install)
+// - returns OperationResultUpdated/nil if the CI is updated
 func createOrUpdateCAResources(compContext spi.ComponentContext) (controllerutil.OperationResult, error) {
 	vzCertCA := compContext.EffectiveCR().Spec.Components.CertManager.Certificate.CA
 
 	// if the CA cert secret does not exist, create the Issuer and Certificate resources
 	secret := v1.Secret{}
-	secretKey := client.ObjectKey{Name: vzCertCA.SecretName, Namespace: vzCertCA.ClusterResourceNamespace}
+	secretKey := crtclient.ObjectKey{Name: vzCertCA.SecretName, Namespace: vzCertCA.ClusterResourceNamespace}
 	if err := compContext.Client().Get(context.TODO(), secretKey, &secret); err != nil {
 		// Create the issuer resource for CA certs
 		compContext.Log().Debug("Applying Issuer for CA cert")
@@ -743,4 +749,41 @@ func extractCommonNameFromCertSecret(secret *v1.Secret) (string, error) {
 		return "", err
 	}
 	return cert.Issuer.CommonName, nil
+}
+
+func deleteObject(client crtclient.Client, name string, namespace string, object crtclient.Object) error {
+	object.SetName(name)
+	object.SetNamespace(namespace)
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, object); err != nil {
+		return client.Delete(context.TODO(), object)
+	}
+	return nil
+}
+
+func cleanupUnusedResources(compContext spi.ComponentContext, isCAValue bool) error {
+	defaultCANotUsed := func() bool {
+		// We're not using the default CA if we're either configured for ACME or it's a Customer-provided CA
+		return !isCAValue || compContext.EffectiveCR().Spec.Components.CertManager.Certificate.CA.SecretName == defaultCACertificateSecretName
+	}
+	client := compContext.Client()
+	log := compContext.Log()
+	if isCAValue {
+		log.Oncef("Clean up ACME issuer secret")
+		// clean up ACME secret if present
+		if err := deleteObject(client, caAcmeSecretName, ComponentNamespace, &v1.Secret{}); err != nil {
+			return err
+		}
+	}
+	if !defaultCANotUsed() {
+		// Issuer is either the default or Custom issuer; clean up the default Verrazzano issuer secret
+		// and self-signed issuer
+		log.Oncef("Clean up Verrazzano self-signed issuer resources")
+		if err := deleteObject(client, defaultCACertificateSecretName, ComponentNamespace, &v1.Secret{}); err != nil {
+			return err
+		}
+		if err := deleteObject(client, caSelfSignedIssuerName, ComponentNamespace, &certv1.Issuer{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -55,12 +55,15 @@ const (
 	caCertificateName           = "verrazzano-ca-certificate"
 	caCertCommonName            = "verrazzano-root-ca"
 	verrazzanoClusterIssuerName = "verrazzano-cluster-issuer"
+	clusterResourceNamespaceKey = "clusterResourceNamespace"
 
 	crdDirectory  = "/cert-manager/"
 	crdInputFile  = "cert-manager.crds.yaml"
 	crdOutputFile = "output.crd.yaml"
 
-	clusterResourceNamespaceKey = "clusterResourceNamespace"
+	// ACME-related constants
+	defaultCACertificateSecretName = "verrazzano-ca-certificate-secret" //nolint:gosec //#gosec G101
+	caAcmeSecretName               = "verrazzano-cert-acme-secret"      //nolint:gosec //#gosec G101
 
 	// Valid Let's Encrypt environment values
 	letsencryptProduction    = "production"
@@ -69,11 +72,6 @@ const (
 	letsEncryptStageEndpoint = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 	certRequestNameAnnotation = "cert-manager.io/certificate-name"
-
-	/* #nosec */
-	defaultCACertificateSecretName = "verrazzano-ca-certificate-secret"
-	/* #nosec */
-	caAcmeSecretName = "verrazzano-cert-acme-secret"
 )
 
 var (

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -166,6 +166,9 @@ func (c certManagerComponent) createOrUpdateClusterIssuer(compContext spi.Compon
 		compContext.Log().Oncef("Initial install, skipping certificate renewal checks")
 		return nil
 	}
+	if err := cleanupUnusedResources(compContext, isCAValue); err != nil {
+		return err
+	}
 	if err := checkRenewAllCertificates(compContext, isCAValue); err != nil {
 		compContext.Log().Errorf("Error requesting certificate renewal: %s", err.Error())
 		return err

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -166,6 +166,8 @@ func (c certManagerComponent) createOrUpdateClusterIssuer(compContext spi.Compon
 		compContext.Log().Oncef("Initial install, skipping certificate renewal checks")
 		return nil
 	}
+	// CertManager configuration was updated, cleanup any old resources from previous configuration
+	// and renew certificates against the new ClusterIssuer
 	if err := cleanupUnusedResources(compContext, isCAValue); err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
@@ -53,7 +53,7 @@ func TestValidateUpdate(t *testing.T) {
 //  WHEN for various CM configurations
 //  THEN an error is returned if anything is misconfigured
 func TestValidateInstall(t *testing.T) {
-	validationTests(t, true)
+	validationTests(t, false)
 }
 
 // TestPostInstallCA tests the PostInstall function
@@ -61,11 +61,11 @@ func TestValidateInstall(t *testing.T) {
 //  WHEN the cert type is CA
 //  THEN no error is returned
 func TestPostInstallCA(t *testing.T) {
-	localvz := vz.DeepCopy()
+	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Certificate.CA = ca
 
 	defer func() { getClientFunc = k8sutil.GetCoreV1Client }()
-	getClientFunc = createClientFunc(localvz.Spec.Components.CertManager.Certificate.CA, "vz-cn")
+	getClientFunc = createClientFunc(localvz.Spec.Components.CertManager.Certificate.CA, "defaultVZConfig-cn")
 
 	defer func() { getCMClientFunc = GetCertManagerClientset }()
 	getCMClientFunc = func() (certv1client.CertmanagerV1Interface, error) {
@@ -95,20 +95,20 @@ func TestPostInstallUpdateCA(t *testing.T) {
 }
 
 func runCAUpdateTest(t *testing.T, upgrade bool) {
-	localvz := vz.DeepCopy()
+	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Certificate.CA = ca
 
-	updatedVZ := vz.DeepCopy()
+	updatedVZ := defaultVZConfig.DeepCopy()
 	newCA := vzapi.CA{
 		SecretName:               "newsecret",
 		ClusterResourceNamespace: "newnamespace",
 	}
 	updatedVZ.Spec.Components.CertManager.Certificate.CA = newCA
 
-	//vzCertSecret := createCertSecret("verrazzano-ca-certificate-secret", constants2.CertManagerNamespace, "vz-cn")
-	//caSecret := createCertSecret("newsecret", "newnamespace", "vz-cn")
+	//vzCertSecret := createCertSecret("verrazzano-ca-certificate-secret", constants2.CertManagerNamespace, "defaultVZConfig-cn")
+	//caSecret := createCertSecret("newsecret", "newnamespace", "defaultVZConfig-cn")
 	defer func() { getClientFunc = k8sutil.GetCoreV1Client }()
-	getClientFunc = createClientFunc(updatedVZ.Spec.Components.CertManager.Certificate.CA, "vz-cn")
+	getClientFunc = createClientFunc(updatedVZ.Spec.Components.CertManager.Certificate.CA, "defaultVZConfig-cn")
 
 	defer func() { getCMClientFunc = GetCertManagerClientset }()
 	cmClient := certv1fake.NewSimpleClientset()
@@ -147,7 +147,7 @@ func runCAUpdateTest(t *testing.T, upgrade bool) {
 //  WHEN the cert type is Acme
 //  THEN no error is returned
 func TestPostInstallAcme(t *testing.T) {
-	localvz := vz.DeepCopy()
+	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Certificate.Acme = acme
 	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	// set OCI DNS secret value and create secret
@@ -184,7 +184,7 @@ func TestPostInstallAcmeUpdate(t *testing.T) {
 }
 
 func runAcmeUpdateTest(t *testing.T, upgrade bool) {
-	localvz := vz.DeepCopy()
+	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Certificate.Acme = acme
 	// set OCI DNS secret value and create secret
 	oci := &vzapi.OCI{
@@ -217,7 +217,7 @@ func runAcmeUpdateTest(t *testing.T, upgrade bool) {
 		OCIZoneName:    oci.DNSZoneName,
 	})
 
-	updatedVz := vz.DeepCopy()
+	updatedVz := defaultVZConfig.DeepCopy()
 	newAcme := vzapi.Acme{
 		Provider:     "letsEncrypt",
 		EmailAddress: "slbronkowitz@gmail.com",
@@ -263,7 +263,7 @@ func runAcmeUpdateTest(t *testing.T, upgrade bool) {
 func TestClusterIssuerUpdated(t *testing.T) {
 	asserts := assert.New(t)
 
-	localvz := vz.DeepCopy()
+	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Certificate.Acme = acme
 	// set OCI DNS secret value and create secret
 	oci := &vzapi.OCI{
@@ -430,7 +430,7 @@ func TestClusterIssuerUpdated(t *testing.T) {
 //  THEN no error is returned
 func TestDryRun(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	ctx := spi.NewFakeContext(client, vz, true)
+	ctx := spi.NewFakeContext(client, defaultVZConfig, true)
 
 	assert.NoError(t, fakeComponent.PreInstall(ctx))
 	assert.NoError(t, fakeComponent.PostInstall(ctx))
@@ -861,7 +861,8 @@ func runValidationTest(t *testing.T, tt validationTestStruct, isUpdate bool, c s
 			t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
 		}
 	} else {
-		if err := c.ValidateInstall(tt.new); (err != nil) != tt.wantErr {
+		wantErr := tt.name != "disable" && tt.wantErr // hack for disable validation, allowed on initial install but not on update
+		if err := c.ValidateInstall(tt.new); (err != nil) != wantErr {
 			t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
 		}
 	}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
@@ -210,10 +210,11 @@ func runAcmeUpdateTest(t *testing.T, upgrade bool) {
 	}
 
 	existingIssuer, _ := createAcmeClusterIssuer(vzlog.DefaultLogger(), templateData{
-		Email:       acme.EmailAddress,
-		Server:      acme.Environment,
-		SecretName:  oci.OCIConfigSecret,
-		OCIZoneName: oci.DNSZoneName,
+		Email:          acme.EmailAddress,
+		AcmeSecretName: caAcmeSecretName,
+		Server:         acme.Environment,
+		SecretName:     oci.OCIConfigSecret,
+		OCIZoneName:    oci.DNSZoneName,
 	})
 
 	updatedVz := vz.DeepCopy()
@@ -231,10 +232,11 @@ func runAcmeUpdateTest(t *testing.T, upgrade bool) {
 	updatedVz.Spec.Components.DNS = &vzapi.DNSComponent{OCI: newOCI}
 
 	expectedIssuer, _ := createAcmeClusterIssuer(vzlog.DefaultLogger(), templateData{
-		Email:       newAcme.EmailAddress,
-		Server:      letsEncryptProdEndpoint,
-		SecretName:  newOCI.OCIConfigSecret,
-		OCIZoneName: newOCI.DNSZoneName,
+		Email:          newAcme.EmailAddress,
+		AcmeSecretName: caAcmeSecretName,
+		Server:         letsEncryptProdEndpoint,
+		SecretName:     newOCI.OCIConfigSecret,
+		OCIZoneName:    newOCI.DNSZoneName,
 	})
 
 	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(localvz, oldSecret, newSecret, existingIssuer).Build()

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
@@ -188,7 +188,6 @@ func TestCertManagerPreInstall(t *testing.T) {
 		VerrazzanoRootDir: "../../../../..", //since we are running inside the cert manager package, root is up 5 directories
 	})
 	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	setBashFunc(fakeBash)
 	err := fakeComponent.PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false))
 	assert.NoError(t, err)
 }
@@ -377,11 +376,6 @@ func certificateExists(client clipkg.Client, name string, namespace string) (boo
 		return false, clipkg.IgnoreNotFound(err)
 	}
 	return true, nil
-}
-
-// fakeBash verifies that the correct parameter values are passed to upgrade
-func fakeBash(_ ...string) (string, string, error) {
-	return "success", "", nil
 }
 
 // Create a new deployment object for testing


### PR DESCRIPTION
# Description

Clean up unused Cert-Manager resources on update, when we switch configurations.

Other changes
- Clean up the unit tests a little, and fix the validateInstall unit tests
- Also cleans up a little cruft.

# Details 
If we update to Let's Encrypt:
- Clean up the Verrazzano self-signed resources

If we update to a Custom CA
- Clean up the Verrazzano self-signed resources
- Clean up any ACME/LetsEncrypt resources

A Custom CA (customer-provided CA secret) is never cleaned up.

### Self-signed resources:
- `Issuer` (used to seed the `ClusterIssuer` in the default self-signed case)
- `Certificate` object for the self-signed CA
- Self-signed CA secret created by the platform operator

### ACME/LetsEncrypt resources
- the `verrazzano-acme-ca-secret` used by the `ClusterIssuer` when ACME/Let's Encrypt is configured

Fixes VZ-5673.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
