### PR TITLE
VZ-5694 disable the Prometheus Operator Components by default

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
         INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
-        INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
+        INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND = "${params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade") ? env.INSTALL_CONFIG_FILE_KIND_EPHEMERAL : env.INSTALL_CONFIG_FILE_KIND_PERSISTENCE}"
         INSTALL_PROFILE = "${params.CHAOS_TEST_TYPE.equals("ephemeral.storage.upgrade") ? "dev" : "prod"}"
         VZ_ENVIRONMENT_NAME = "default"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
         OCI_CLI_REGION = "${params.OKE_CLUSTER_REGION}"
         OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING = 'True'
 
-        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml"
+        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-vz-prod-kind-upgrade.yaml"
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-nipio.yaml"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
-        INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml"
+        INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-vz-prod-kind-upgrade.yaml"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
@@ -50,7 +50,7 @@ func NewComponent() spi.Component {
 func (c prometheusAdapterComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusAdapter
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Adapter enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
@@ -50,7 +50,7 @@ func NewComponent() spi.Component {
 func (c kubeStateMetricsComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.KubeStateMetrics
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with KubeStateMetrics enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -52,7 +52,7 @@ func NewComponent() spi.Component {
 func (c prometheusComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusOperator
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Operator enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
@@ -51,7 +51,7 @@ func NewComponent() spi.Component {
 func (c prometheusPushgatewayComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	comp := effectiveCR.Spec.Components.PrometheusPushgateway
 	if comp == nil || comp.Enabled == nil {
-		return true
+		return false
 	}
 	return *comp.Enabled
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
@@ -28,7 +28,7 @@ func TestIsEnabled(t *testing.T) {
 			// THEN the call returns true
 			name:       "Test IsEnabled when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway enabled
@@ -62,7 +62,7 @@ func TestIsEnabled(t *testing.T) {
 					},
 				},
 			},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway having empty section
@@ -76,7 +76,7 @@ func TestIsEnabled(t *testing.T) {
 					},
 				},
 			},
-			expectTrue: true,
+			expectTrue: false,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Pushgateway disabled

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevDefault.yaml
@@ -39,10 +39,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevWithOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesDevWithOverrides.yaml
@@ -39,10 +39,10 @@ rancher:
 nodeExporter:
   enabled: false
 prometheusOperator:
-  enabled: false
+  enabled: true
 prometheusAdapter:
-  enabled: false
+  enabled: true
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 prometheusPushgateway:
-  enabled: false
+  enabled: true

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesManagedClusterDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesManagedClusterDefault.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdDefault.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdDefault.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminAndMonitorRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminAndMonitorRoleOverrides.yaml
@@ -40,10 +40,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithAdminRoleOverrides.yaml
@@ -39,10 +39,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithExternaDNSEnabled.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithExternaDNSEnabled.yaml
@@ -30,10 +30,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdEmptyExtraVolumeMountsOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdEmptyExtraVolumeMountsOverrides.yaml
@@ -31,10 +31,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOCILoggingOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOCILoggingOverrides.yaml
@@ -34,10 +34,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithFluentdOverrides.yaml
@@ -40,10 +40,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithMonitorRoleOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzOverridesProdWithMonitorRoleOverrides.yaml
@@ -39,10 +39,10 @@ security:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevWithOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesDevWithOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: false
 prometheusOperator:
-  enabled: false
+  enabled: true
 prometheusAdapter:
-  enabled: false
+  enabled: true
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 prometheusPushgateway:
-  enabled: false
+  enabled: true

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesMgdClusterNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesMgdClusterNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdNoOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdNoOverrides.yaml
@@ -17,10 +17,10 @@ rancher:
 NodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdWithExternalDNS.yaml
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/testdata/vzValuesProdWithExternalDNS.yaml
@@ -16,10 +16,10 @@ rancher:
 nodeExporter:
   enabled: true
 prometheusOperator:
-  enabled: true
+  enabled: false
 prometheusAdapter:
-  enabled: true
+  enabled: false
 kubeStateMetrics:
-  enabled: true
+  enabled: false
 prometheusPushgateway:
-  enabled: true
+  enabled: false

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -241,6 +241,7 @@ func Test_appendCustomImageOverrides(t *testing.T) {
 //  THEN the correct KeyValue objects and overrides file snippets are generated
 func Test_appendVerrazzanoValues(t *testing.T) {
 	falseValue := false
+	trueValue := true
 	tests := []struct {
 		name         string
 		description  string
@@ -285,10 +286,10 @@ func Test_appendVerrazzanoValues(t *testing.T) {
 						Keycloak:              &vzapi.KeycloakComponent{Enabled: &falseValue},
 						Rancher:               &vzapi.RancherComponent{Enabled: &falseValue},
 						DNS:                   &vzapi.DNSComponent{Wildcard: &vzapi.Wildcard{Domain: "xip.io"}},
-						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &falseValue},
-						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
+						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &trueValue},
+						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
 					},
 				},
 			},
@@ -588,10 +589,10 @@ func Test_appendVerrazzanoOverrides(t *testing.T) {
 						Keycloak:              &vzapi.KeycloakComponent{Enabled: &falseValue},
 						Rancher:               &vzapi.RancherComponent{Enabled: &falseValue},
 						DNS:                   &vzapi.DNSComponent{Wildcard: &vzapi.Wildcard{Domain: "xip.io"}},
-						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &falseValue},
-						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
-						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &falseValue}},
+						PrometheusOperator:    &vzapi.PrometheusOperatorComponent{Enabled: &trueValue},
+						PrometheusAdapter:     &vzapi.PrometheusAdapterComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						KubeStateMetrics:      &vzapi.KubeStateMetricsComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{MonitoringComponent: vzapi.MonitoringComponent{Enabled: &trueValue}},
 					},
 				},
 			},

--- a/platform-operator/controllers/verrazzano/validator/ComponentValidatorImpl_test.go
+++ b/platform-operator/controllers/verrazzano/validator/ComponentValidatorImpl_test.go
@@ -43,7 +43,7 @@ func TestComponentValidatorImpl_ValidateInstall(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 9,
+			numberOfErrors: 8,
 		},
 	}
 	config.TestProfilesDir = "../../../manifests/profiles"
@@ -102,7 +102,7 @@ func TestComponentValidatorImpl_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 6,
+			numberOfErrors: 5,
 		},
 		{
 			name: "disabled cert and ingress",
@@ -119,7 +119,7 @@ func TestComponentValidatorImpl_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 11,
+			numberOfErrors: 10,
 		},
 	}
 	config.TestProfilesDir = "../../../manifests/profiles"
@@ -160,7 +160,7 @@ func Test_dependencyValidation(t *testing.T) {
 					},
 				},
 			},
-			numberOfErrors: 9,
+			numberOfErrors: 8,
 		},
 		{
 			name: "disabled istio",

--- a/platform-operator/internal/vzconfig/enabled.go
+++ b/platform-operator/internal/vzconfig/enabled.go
@@ -120,7 +120,7 @@ func IsPrometheusOperatorEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusOperator != nil && vz.Spec.Components.PrometheusOperator.Enabled != nil {
 		return *vz.Spec.Components.PrometheusOperator.Enabled
 	}
-	return true
+	return false
 }
 
 // IsPrometheusAdapterEnabled returns false only if the Prometheus Adapter is explicitly disabled in the CR
@@ -128,7 +128,7 @@ func IsPrometheusAdapterEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusAdapter != nil && vz.Spec.Components.PrometheusAdapter.Enabled != nil {
 		return *vz.Spec.Components.PrometheusAdapter.Enabled
 	}
-	return true
+	return false
 }
 
 // IsKubeStateMetricsEnabled returns false only if Kube State Metrics is explicitly disabled in the CR
@@ -136,7 +136,7 @@ func IsKubeStateMetricsEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.KubeStateMetrics != nil && vz.Spec.Components.KubeStateMetrics.Enabled != nil {
 		return *vz.Spec.Components.KubeStateMetrics.Enabled
 	}
-	return true
+	return false
 }
 
 // IsPrometheusPushgatewayEnabled returns false only if the Prometheus Pushgateway is explicitly disabled in the CR
@@ -144,5 +144,5 @@ func IsPrometheusPushgatewayEnabled(vz *vzapi.Verrazzano) bool {
 	if vz != nil && vz.Spec.Components.PrometheusPushgateway != nil && vz.Spec.Components.PrometheusPushgateway.Enabled != nil {
 		return *vz.Spec.Components.PrometheusPushgateway.Enabled
 	}
-	return true
+	return false
 }

--- a/tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: my-verrazzano
+spec:
+  profile: dev
+

--- a/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-upgrade.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
@@ -16,14 +16,6 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
-    prometheusOperator:
-      enabled: true
-    prometheusAdapter:
-      enabled: true
-    kubeStateMetrics:
-      enabled: true
-    prometheusPushgateway:
-      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -7,3 +7,12 @@ metadata:
   name: my-verrazzano
 spec:
   profile: dev
+  components:
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-nipio-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio-with-persistence.yaml
@@ -21,3 +21,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1alpha1

--- a/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-nipio.yaml
@@ -11,3 +11,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-ocidns.yaml
@@ -19,3 +19,11 @@ spec:
     fluentd:
       extraVolumeMounts:
         - source: /u01/data
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true

--- a/tests/e2e/config/scripts/install-vz-prod-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/install-vz-prod-kind-upgrade.yaml
@@ -16,14 +16,7 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
-    prometheusOperator:
-      enabled: true
-    prometheusAdapter:
-      enabled: true
-    kubeStateMetrics:
-      enabled: true
-    prometheusPushgateway:
-      enabled: true
+    # Prometheus Operator components are not included to account for upgrade tests
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml
+++ b/tests/e2e/config/scripts/install-vz-prod-kind-with-persistence.yaml
@@ -16,6 +16,14 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    prometheusOperator:
+      enabled: true
+    prometheusAdapter:
+      enabled: true
+    kubeStateMetrics:
+      enabled: true
+    prometheusPushgateway:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -463,6 +463,58 @@ func IsWebLogicOperatorEnabled(kubeconfigPath string) bool {
 	return *vz.Spec.Components.WebLogicOperator.Enabled
 }
 
+// IsPrometheusAdapterEnabled returns false if the Prometheus Adapter component is not set, or the value of its Enabled field otherwise
+func IsPrometheusAdapterEnabled(kubeconfigPath string) bool {
+	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
+		return false
+	}
+	if vz.Spec.Components.PrometheusAdapter == nil || vz.Spec.Components.PrometheusAdapter.Enabled == nil {
+		return false
+	}
+	return *vz.Spec.Components.WebLogicOperator.Enabled
+}
+
+// IsPrometheusOperatorEnabled returns false if the Prometheus Operator component is not set, or the value of its Enabled field otherwise
+func IsPrometheusOperatorEnabled(kubeconfigPath string) bool {
+	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
+		return false
+	}
+	if vz.Spec.Components.PrometheusOperator == nil || vz.Spec.Components.PrometheusOperator.Enabled == nil {
+		return false
+	}
+	return *vz.Spec.Components.PrometheusOperator.Enabled
+}
+
+// IsKubeStateMetricsEnabled returns false if the Kube State Metrics component is not set, or the value of its Enabled field otherwise
+func IsKubeStateMetricsEnabled(kubeconfigPath string) bool {
+	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
+		return false
+	}
+	if vz.Spec.Components.KubeStateMetrics == nil || vz.Spec.Components.KubeStateMetrics.Enabled == nil {
+		return false
+	}
+	return *vz.Spec.Components.KubeStateMetrics.Enabled
+}
+
+// IsPrometheusPushgatewayEnabled returns false if the Prometheus Pushgateway component is not set, or the value of its Enabled field otherwise
+func IsPrometheusPushgatewayEnabled(kubeconfigPath string) bool {
+	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
+		return false
+	}
+	if vz.Spec.Components.PrometheusPushgateway == nil || vz.Spec.Components.PrometheusPushgateway.Enabled == nil {
+		return false
+	}
+	return *vz.Spec.Components.PrometheusPushgateway.Enabled
+}
+
 // APIExtensionsClientSet returns a Kubernetes ClientSet for this cluster.
 func APIExtensionsClientSet() (*apiextv1.ApiextensionsV1Client, error) {
 	config, err := k8sutil.GetKubeConfig()

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -473,7 +473,7 @@ func IsPrometheusAdapterEnabled(kubeconfigPath string) bool {
 	if vz.Spec.Components.PrometheusAdapter == nil || vz.Spec.Components.PrometheusAdapter.Enabled == nil {
 		return false
 	}
-	return *vz.Spec.Components.WebLogicOperator.Enabled
+	return *vz.Spec.Components.PrometheusAdapter.Enabled
 }
 
 // IsPrometheusOperatorEnabled returns false if the Prometheus Operator component is not set, or the value of its Enabled field otherwise

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -163,7 +163,10 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 
 		WhenPromStackInstalledIt("should have the TLS secret", func() {
 			Eventually(func() bool {
-				return pkg.SecretsCreated(verrazzanoMonitoringNamespace, prometheusTLSSecret)
+				if isPrometheusOperatorEnabled() {
+					return pkg.SecretsCreated(verrazzanoMonitoringNamespace, prometheusTLSSecret)
+				}
+				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -21,7 +21,6 @@ const (
 	prometheusTLSSecret             = "prometheus-operator-kube-p-admission"
 	prometheusOperatorDeployment    = "prometheus-operator-kube-p-operator"
 	prometheusOperatorContainerName = "kube-prometheus-stack"
-	prometheusOperatorPodName       = "prometheus-operator-kube-p-operator"
 )
 
 type enabledFunc func(string) bool

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -23,15 +23,15 @@ const (
 	prometheusOperatorContainerName = "kube-prometheus-stack"
 )
 
-type EnabledFunc func(string) bool
+type enabledFunc func(string) bool
 
-type EnabledComponents struct {
+type enabledComponents struct {
 	podName     string
-	enabledFunc EnabledFunc
+	enabledFunc enabledFunc
 }
 
 var (
-	promStackEnabledComponents = []EnabledComponents{
+	promStackEnabledComponents = []enabledComponents{
 		{podName: "prometheus-adapter", enabledFunc: pkg.IsPrometheusAdapterEnabled},
 		{podName: "prometheus-operator-kube-p-operator", enabledFunc: pkg.IsPrometheusOperatorEnabled},
 		{podName: "kube-state-metrics", enabledFunc: pkg.IsKubeStateMetricsEnabled},

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -58,9 +58,7 @@ var t = framework.NewTestFramework("promstack")
 func listEnabledComponents() []string {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
-		t.It("should be able to find the cluster kubeconfig", func() {
-			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-		})
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	var enabledPods []string
 	for _, component := range promStackEnabledComponents {
@@ -74,9 +72,7 @@ func listEnabledComponents() []string {
 func isPrometheusOperatorEnabled() bool {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
-		t.It("should be able to find the cluster kubeconfig", func() {
-			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-		})
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	return pkg.IsPrometheusOperatorEnabled(kubeconfigPath)
 }

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -58,7 +58,7 @@ var t = framework.NewTestFramework("promstack")
 func listEnabledComponents() []string {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
-		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		AbortSuite(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	var enabledPods []string
 	for _, component := range promStackEnabledComponents {
@@ -72,7 +72,7 @@ func listEnabledComponents() []string {
 func isPrometheusOperatorEnabled() bool {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
-		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		AbortSuite(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	return pkg.IsPrometheusOperatorEnabled(kubeconfigPath)
 }


### PR DESCRIPTION
# Description

re-re-merge of disabling the Prometheus Operator defaults. Now, the chaos tests are updated.

Fixes VZ-5694

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
