### PR TITLE
VZ-3681: Fix chaos test pipeline

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.20", "1.21", "1.22" ])
         string (name: 'VERSION_FOR_INSTALL',
-                defaultValue: 'v1.0.2',
+                defaultValue: 'v1.1.2',
                 description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',
                 trim: true)
         string (name: 'GIT_COMMIT_FOR_UPGRADE',

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -234,9 +234,6 @@ pipeline {
         }
     }
     post {
-        success {
-            storePipelineArtifacts()
-        }
         failure {
             script {
                 if (env.JOB_NAME == "verrazzano-upgrade-resiliency-tests/master" || env.JOB_NAME ==~ "verrazzano-upgrade-resiliency-tests/release-1.*") {
@@ -260,19 +257,6 @@ def isPagerDutyEnabled() {
         return true
     }
     return false
-}
-
-// Called in final post success block of pipeline
-def storePipelineArtifacts() {
-    script {
-        // If this was clean, record the commit in object store so the periodic test jobs can run against that rather than the head of the branch
-        // NOTE: Normally master and release-* branches are the only ones doing this, but when we need to test out pipeline changes we can make use
-        // as well
-        sh """
-            echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-stable-commit.txt
-            oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-stable-commit.txt --file $WORKSPACE/last-stable-commit.txt
-        """
-    }
 }
 
 // Called in Stage Clean workspace and checkout steps


### PR DESCRIPTION
# Description

Chaos test pipeline needed to have the upgrade starting point changed to Verrazzano 1.2.1.

Also remove call to store artifacts, it was a cut and paste carryover and overwriting information from another pipeline.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
