### PR TITLE
VZ-5553- Update cert-manager oci dns settings 

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -15,7 +15,6 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
-	"html/template"
 	"io"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"net/mail"
@@ -23,6 +22,7 @@ import (
 	"path/filepath"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"strings"
+	"text/template"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"


### PR DESCRIPTION
Currently externalDNS can operate in two modes - instance_principal and user_principal. However cert_manager challenges were always being issued with user_principal irrespective of what externalDNS mode was. This is a fix for that scenario. 
