### PR TITLE
Move e2e verify-install/kubernetes_test.go namespace checks into Eventually, and don't check for the 'local' namespace since that is not always created

### DIFF
--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -77,6 +77,7 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 					Expect(nsListContains(namespaces.Items, "cattle-system")).To(BeTrue())
 					Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(BeTrue())
 					Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(BeTrue())
+					Expect(nsListContains(namespaces.Items, "local")).To(BeTrue())
 				}
 				Expect(nsListContains(namespaces.Items, "istio-system")).To(BeTrue())
 				Expect(nsListContains(namespaces.Items, "gitlab")).To(BeFalse())

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -58,43 +58,33 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 			}, timeout5Min, pollingInterval).Should(BeTrue())
 		})
 
-		t.It("the expected namespaces exist", func() {
-			var namespaces *v1.NamespaceList
-			Eventually(func() (bool, error) {
-				var err error
-				namespaces, err = pkg.ListNamespaces(metav1.ListOptions{})
-				if err != nil {
-					return false, err
-				}
-				if isManagedClusterProfile {
-					Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(BeFalse())
-					Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(BeFalse())
-					// Even though we do not install Rancher on managed clusters, we do create the namespace
-					// so we can create network policies. Rancher will run pods in this namespace once
-					// the managed cluster manifest YAML is applied to the managed cluster.
-					Expect(nsListContains(namespaces.Items, "cattle-system")).To(BeTrue())
-				} else {
-					Expect(nsListContains(namespaces.Items, "cattle-system")).To(BeTrue())
-					Expect(nsListContains(namespaces.Items, "cattle-global-data")).To(BeTrue())
-					Expect(nsListContains(namespaces.Items, "cattle-global-nt")).To(BeTrue())
-					Expect(nsListContains(namespaces.Items, "local")).To(BeTrue())
-				}
-				Expect(nsListContains(namespaces.Items, "istio-system")).To(BeTrue())
-				Expect(nsListContains(namespaces.Items, "gitlab")).To(BeFalse())
-				if isManagedClusterProfile {
-					Expect(nsListContains(namespaces.Items, "keycloak")).To(BeFalse())
-				} else {
-					Expect(nsListContains(namespaces.Items, "keycloak")).To(BeTrue())
-				}
-				Expect(nsListContains(namespaces.Items, "verrazzano-system")).To(BeTrue())
-				Expect(nsListContains(namespaces.Items, "verrazzano-mc")).To(BeTrue())
-				Expect(nsListContains(namespaces.Items, "cert-manager")).To(BeTrue())
-				Expect(nsListContains(namespaces.Items, "ingress-nginx")).To(BeTrue())
-
-				// If we get here, all assertions passed, so return true
-				return true, nil
-			}, timeout5Min, pollingInterval).Should(BeTrue())
-		})
+		t.DescribeTable("the expected namespaces exist",
+			func(namespace string, expected bool) {
+				Eventually(func() (bool, error) {
+					var err error
+					var namespaces *v1.NamespaceList
+					namespaces, err = pkg.ListNamespaces(metav1.ListOptions{})
+					if err != nil {
+						return false, err
+					}
+					return nsListContains(namespaces.Items, namespace) == expected, nil
+				}, timeout5Min, pollingInterval).Should(BeTrue())
+			},
+			t.Entry("cattle-global-data", "cattle-global-data", !isManagedClusterProfile),
+			t.Entry("cattle-global-nt", "cattle-global-nt", !isManagedClusterProfile),
+			// Even though we do not install Rancher on managed clusters, we do create the namespace
+			// so we can create network policies. Rancher will run pods in this namespace once
+			// the managed cluster manifest YAML is applied to the managed cluster. So expect cattle-system
+			// to exist on all clusters
+			t.Entry("cattle-system", "cattle-system", true),
+			t.Entry("istio-system", "istio-system", true),
+			t.Entry("gitlab", "gitlab", false),
+			t.Entry("keycloak", "keycloak", !isManagedClusterProfile),
+			t.Entry("verrazzano-system", "verrazzano-system", true),
+			t.Entry("verrazzano-mc", "verrazzano-mc", true),
+			t.Entry("cert-manager", "cert-manager", true),
+			t.Entry("ingress-nginx", "ingress-nginx", true),
+		)
 
 		kubeconfigPath, _ := k8sutil.GetKubeConfigLocation()
 		componentsArgs := []interface{}{


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
