### PR TITLE
Run pre-upgrade verify test in chaos tests

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -228,9 +228,10 @@ pipeline {
             }
         }
 
-        stage('Pre-upgrade examples helidon') {
+        stage('Pre-upgrade tests') {
             steps {
                 runGinkgoNamespace('examples/helidon', "false", "true", "hello-helidon")
+                runGinkgoRandomize('upgrade/pre-upgrade/verify')
             }
             post {
                 always {


### PR DESCRIPTION
# Description

As part of #2839 , a new pre upgrade test was added that updates the prometheus configmap which is later verified in post upgrade tests. The chaos pipeline does not run all pre upgrade tests and hence this new test was getting skipped and therefore the post upgrade tests were failing. This change to add that test to be run before upgrade in chaos pipelines


# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
