### PR TITLE
VZ-5728 upgrade complete 2

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -191,25 +191,11 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(actualCR.Status) {
-		// If the version is specified and different from the current version of the installation
-		// then proceed with upgrade
 		if len(actualCR.Spec.Version) > 0 && actualCR.Spec.Version != actualCR.Status.Version {
-			result, err := r.reconcileUpgrade(log, actualCR)
-			// Keep retrying the upgrade until it completes.
-			if err != nil {
-				return newRequeueWithDelay(), err
-			} else if vzctrl.ShouldRequeue(result) {
-				return result, nil
-			}
-		}
-		// Keep retrying to reconcile components until it completes
-		if result, err := r.reconcileComponents(vzctx); err != nil {
+			// Transition to upgrade state
+			r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
 			return newRequeueWithDelay(), err
-		} else if vzctrl.ShouldRequeue(result) {
-			return result, nil
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// if an OCI DNS installation, make sure the secret required exists before proceeding
@@ -322,9 +308,21 @@ func (r *Reconciler) ProcUpgradingState(vzctx vzcontext.VerrazzanoContext) (ctrl
 	} else if vzctrl.ShouldRequeue(result) {
 		return result, nil
 	}
-	// Upgrade should always requeue to ensure that reconciler runs post upgrade to install
-	// components that may have been waiting for upgrade
-	return newRequeueWithDelay(), nil
+
+	// Install any new components and do any updates to existing components
+	if result, err := r.reconcileComponents(vzctx); err != nil {
+		return newRequeueWithDelay(), err
+	} else if vzctrl.ShouldRequeue(result) {
+		return result, nil
+	}
+
+	// Upgrade done along with any post-upgrade installations of new components that are enabled by default.
+	msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", vz.Spec.Version)
+	log.Once(msg)
+	if err := r.updateStatus(log, vz, msg, installv1alpha1.CondUpgradeComplete); err != nil {
+		return newRequeueWithDelay(), err
+	}
+	return ctrl.Result{}, nil
 }
 
 // ProcPausedUpgradeState processes the CR while in the paused upgrade state

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -196,6 +196,14 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 			r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
 			return newRequeueWithDelay(), err
 		}
+		// Keep retrying to reconcile components until it completes
+		if result, err := r.reconcileComponents(vzctx); err != nil {
+			return newRequeueWithDelay(), err
+		} else if vzctrl.ShouldRequeue(result) {
+			return result, nil
+		}
+
+		return ctrl.Result{}, nil
 	}
 
 	// if an OCI DNS installation, make sure the secret required exists before proceeding

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -138,8 +138,6 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			tracker.vzState = vzStateUpgradeDone
 
 		case vzStateUpgradeDone:
-			msg := fmt.Sprintf("Verrazzano successfully upgraded to version %s", cr.Spec.Version)
-			log.Once(msg)
 			cr.Status.Version = targetVersion
 			effectiveCR, _ := transform.GetEffectiveCR(cr)
 			for _, comp := range registry.GetComponents() {
@@ -150,9 +148,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 					componentStatus.LastReconciledGeneration = cr.Generation
 				}
 			}
-			if err := r.updateStatus(log, cr, msg, installv1alpha1.CondUpgradeComplete); err != nil {
-				return newRequeueWithDelay(), err
-			}
+
 			// Upgrade completely done
 			deleteUpgradeTracker(cr)
 			tracker.vzState = vzStateEnd

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -138,8 +138,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			tracker.vzState = vzStateUpgradeDone
 
 		case vzStateUpgradeDone:
-			msg := fmt.Sprintf("Verrazzano successfully upgraded all existing components and will now install any new components")
-			log.Once(msg)
+			log.Once("Verrazzano successfully upgraded all existing components and will now install any new components")
 			cr.Status.Version = targetVersion
 			effectiveCR, _ := transform.GetEffectiveCR(cr)
 			for _, comp := range registry.GetComponents() {

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -138,13 +138,15 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			tracker.vzState = vzStateUpgradeDone
 
 		case vzStateUpgradeDone:
+			msg := fmt.Sprintf("Verrazzano successfully upgraded all existing components and will now install any new components")
+			log.Once(msg)
 			cr.Status.Version = targetVersion
 			effectiveCR, _ := transform.GetEffectiveCR(cr)
 			for _, comp := range registry.GetComponents() {
 				compName := comp.Name()
 				componentStatus := cr.Status.Components[compName]
 				if componentStatus != nil && (effectiveCR != nil && comp.IsEnabled(effectiveCR)) {
-					log.Oncef("Component %s has been upgraded from generation %v to %v %v", compName, componentStatus.LastReconciledGeneration, cr.Generation, componentStatus.State)
+					log.Debugf("Component %s has been upgraded from generation %v to %v %v", compName, componentStatus.LastReconciledGeneration, cr.Generation, componentStatus.State)
 					componentStatus.LastReconciledGeneration = cr.Generation
 				}
 			}


### PR DESCRIPTION
During upgrade, Verrazzano upgrades components that are already installed, then installs new components.  However, the Verrazzano status is set to UpgradeComplete before the new components are installed.  Don't set UpradeComplete until all new components have been installed.

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
