### PR TITLE
VZ-5386.  Fix imagePullSecret preservation during upgrade in private reg scenarios

### DIFF
--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -254,11 +254,11 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 		return nil
 	}
 
-	// Resolve the namespace
-	namespace := h.resolveNamespace(context.EffectiveCR().Namespace)
+	// Resolve the resolvedNamespace
+	resolvedNamespace := h.resolveNamespace(context.EffectiveCR().Namespace)
 
 	// Check if the component is installed before trying to upgrade
-	found, err := helm.IsReleaseInstalled(h.ReleaseName, namespace)
+	found, err := helm.IsReleaseInstalled(h.ReleaseName, resolvedNamespace)
 	if err != nil {
 		return err
 	}
@@ -270,18 +270,25 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Do the preUpgrade if the function is defined
 	if h.PreUpgradeFunc != nil && UpgradePrehooksEnabled {
 		context.Log().Infof("Running preUpgrade function for %s", h.ReleaseName)
-		err := h.PreUpgradeFunc(context.Log(), context.Client(), h.ReleaseName, namespace, h.ChartDir)
+		err := h.PreUpgradeFunc(context.Log(), context.Client(), h.ReleaseName, resolvedNamespace, h.ChartDir)
 		if err != nil {
 			return err
 		}
 	}
 
-	overrides, err := h.buildCustomHelmOverrides(context, namespace)
+	// check for global image pull secret
+	var kvs []bom.KeyValue
+	kvs, err = secret.AddGlobalImagePullSecretHelmOverride(context.Log(), context.Client(), resolvedNamespace, kvs, h.ImagePullSecretKeyname)
 	if err != nil {
 		return err
 	}
 
-	stdout, err := helm.GetValues(context.Log(), h.ReleaseName, namespace)
+	overrides, err := h.buildCustomHelmOverrides(context, resolvedNamespace, kvs...)
+	if err != nil {
+		return err
+	}
+
+	stdout, err := helm.GetValues(context.Log(), h.ReleaseName, resolvedNamespace)
 	if err != nil {
 		return err
 	}
@@ -306,7 +313,7 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Generate a list of component-specified override files if present
 	overrides.FileOverrides = append(overrides.FileOverrides, tmpFile.Name())
 
-	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, namespace, h.ChartDir, true, context.IsDryRun(), overrides)
+	_, _, err = upgradeFunc(context.Log(), h.ReleaseName, resolvedNamespace, h.ChartDir, true, context.IsDryRun(), overrides)
 	return err
 }
 

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"os/exec"
 	"strings"
@@ -91,8 +92,16 @@ func TestUpgrade(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	err := comp.Upgrade(spi.NewFakeContext(nil, &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
+
+	err := comp.Upgrade(spi.NewFakeContext(newFakeClient(), &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.NoError(err, "Upgrade returned an error")
+}
+
+func newFakeClient() clipkg.Client {
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: constants.GlobalImagePullSecName, Namespace: "default"}},
+	)
+	return client
 }
 
 // TestUpgradeIsInstalledUnexpectedError tests the component upgrade
@@ -137,7 +146,7 @@ func TestUpgradeReleaseNotInstalled(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
 	defer config.SetDefaultBomFilePath("")
 
-	err := comp.Upgrade(spi.NewFakeContext(nil, &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
+	err := comp.Upgrade(spi.NewFakeContext(newFakeClient(), &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.NoError(err)
 }
 
@@ -176,7 +185,7 @@ func TestUpgradeWithEnvOverrides(t *testing.T) {
 		return helm.ChartStatusDeployed, nil
 	})
 	defer helm.SetDefaultChartStatusFunction()
-	err := comp.Upgrade(spi.NewFakeContext(nil, &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
+	err := comp.Upgrade(spi.NewFakeContext(newFakeClient(), &v1alpha1.Verrazzano{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}}, false))
 	assert.NoError(err, "Upgrade returned an error")
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -6,6 +6,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -48,6 +49,9 @@ const IstioCoreDNSReleaseName = "istiocoredns"
 
 // HelmScrtType is the secret type that helm uses to specify its releases
 const HelmScrtType = "helm.sh/release.v1"
+
+// This IstioOperator YAML uses this imagePullSecret key
+const imagePullSecretHelmKey = "values.global.imagePullSecrets[0]"
 
 // istioComponent represents an Istio component
 type istioComponent struct {
@@ -147,8 +151,15 @@ func (i istioComponent) Upgrade(context spi.ComponentContext) error {
 		log.Debugf("Created values file from Istio install args: %s", tmpFile.Name())
 	}
 
+	// check for global image pull secret
+	var kvs []bom.KeyValue
+	kvs, err = secret.AddGlobalImagePullSecretHelmOverride(log, context.Client(), IstioNamespace, kvs, imagePullSecretHelmKey)
+	if err != nil {
+		return err
+	}
+
 	// images overrides to get passed into the istioctl command
-	imageOverrides, err := buildImageOverridesString(log)
+	imageOverrides, err := buildOverridesString(kvs...)
 	if err != nil {
 		return log.ErrorfNewErr("Error building image overrides from BOM for Istio: %v", err)
 	}
@@ -333,30 +344,6 @@ func removeIstioHelmSecrets(compContext spi.ComponentContext) error {
 	return nil
 }
 
-func buildImageOverridesString(_ vzlog.VerrazzanoLogger) (string, error) {
-	// Get the image overrides from the BOM
-	var kvs []bom.KeyValue
-	var err error
-	kvs, err = getImageOverrides()
-	if err != nil {
-		return "", err
-	}
-
-	// If there are overridesString the create a comma separated string
-	var overridesString string
-	if len(kvs) > 0 {
-		bldr := strings.Builder{}
-		for i, kv := range kvs {
-			if i > 0 {
-				bldr.WriteString(",")
-			}
-			bldr.WriteString(fmt.Sprintf("%s=%s", kv.Key, kv.Value))
-		}
-		overridesString = bldr.String()
-	}
-	return overridesString, nil
-}
-
 // AppendIstioOverrides appends the Keycloak theme for the Key keycloak.extraInitContainers.
 // A go template is used to replace the image in the init container spec.
 func AppendIstioOverrides(_ spi.ComponentContext, releaseName string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
@@ -396,7 +383,7 @@ func IstiodReadyCheck(ctx spi.ComponentContext, _ string, namespace string) bool
 	return status.DeploymentsReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
-func buildOverridesString(log vzlog.VerrazzanoLogger, client clipkg.Client, namespace string, additionalValues ...bom.KeyValue) (string, error) {
+func buildOverridesString(additionalValues ...bom.KeyValue) (string, error) {
 	// Get the image overrides from the BOM
 	kvs, err := getImageOverrides()
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"os/exec"
 	"strings"
@@ -154,6 +155,18 @@ func getMock(t *testing.T) *mocks.MockClient {
 			secretList.Items = []v1.Secret{{Type: HelmScrtType}, {Type: "generic"}, {Type: HelmScrtType}}
 			return nil
 		})
+
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, _ client.ObjectKey, _ *v1.Secret) error {
+			return nil
+		}).AnyTimes()
+
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: IstioNamespace}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, _ client.ObjectKey, _ *v1.Secret) error {
+			return nil
+		}).AnyTimes()
 
 	mock.EXPECT().
 		Delete(gomock.Any(), gomock.Not(gomock.Nil())).

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -192,9 +192,6 @@ func (i istioComponent) Install(compContext spi.ComponentContext) error {
 		compContext.Log().Debug("Error during istio install, retrying")
 	}
 
-	// This IstioOperator YAML uses this imagePullSecret key
-	const imagePullSecretHelmKey = "values.global.imagePullSecrets[0]"
-
 	var userFileCR *os.File
 	var kvs []bom.KeyValue
 	var err error
@@ -232,7 +229,7 @@ func (i istioComponent) Install(compContext spi.ComponentContext) error {
 	// Build comma separated string of overrides that will be passed to
 	// isioctl as --set values.
 	// This include BOM image overrides as well as other overrides
-	overrideStrings, err := buildOverridesString(log, client, IstioNamespace, kvs...)
+	overrideStrings, err := buildOverridesString(kvs...)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/secret/image_pull_secret_test.go
+++ b/platform-operator/controllers/verrazzano/secret/image_pull_secret_test.go
@@ -55,9 +55,9 @@ func TestCopyGlobalPullSecretDoesNotExist(t *testing.T) {
 // THEN true is returned
 func TestTargetPullSecretAlreadyExists(t *testing.T) {
 	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
-	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
-	},
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: "default"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace}},
 	)
 	copied, err := CheckImagePullSecret(client, constants.VerrazzanoSystemNamespace)
 	assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestTargetPullSecretAlreadyExists(t *testing.T) {
 
 // TestUnexpectedErrorGetTargetSecret tests a deployment ready status check
 // GIVEN a call to checkImagePullSecret
-// WHEN an unexpected error is returned on the target namespace check
+// WHEN an unexpected error is returned on the global secret check
 // THEN false and an error are returned
 func TestUnexpectedErrorGetTargetSecret(t *testing.T) {
 	asserts := assert.New(t)
@@ -75,7 +75,7 @@ func TestUnexpectedErrorGetTargetSecret(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
 
 	// Expect a call to get an existing configmap, but return a NotFound error.
 	mock.EXPECT().
@@ -169,21 +169,21 @@ func TestAddImagePullSecretUnexpectedError(t *testing.T) {
 	mockStatus := mocks.NewMockStatusWriter(mocker)
 	asserts.NotNil(mockStatus)
 
-	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
+	targetSecretName := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: "default"}
 
 	// Expect a call to get the target ns secret first, return not found
 	mock.EXPECT().
 		Get(gomock.Any(), targetSecretName, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret) error {
 			return fmt.Errorf("unexpected error")
-		})
+		}).AnyTimes()
 
 	kvs := []bom.KeyValue{
 		{Key: "key1", Value: "value1"},
 		{Key: "key2", Value: "value2"},
 	}
 	retKVs, err := AddGlobalImagePullSecretHelmOverride(vzlog.DefaultLogger(), mock, constants.VerrazzanoSystemNamespace, kvs, "helmKey")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, kvs, retKVs)
 }
 
@@ -194,9 +194,9 @@ func TestAddImagePullSecretUnexpectedError(t *testing.T) {
 func TestAddImagePullSecretTargetSecretAlreadyExists(t *testing.T) {
 
 	name := types.NamespacedName{Name: constants.GlobalImagePullSecName, Namespace: constants.VerrazzanoSystemNamespace}
-	client := fake.NewFakeClientWithScheme(k8scheme.Scheme, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
-	},
+	client := fake.NewFakeClientWithScheme(k8scheme.Scheme,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: constants.GlobalImagePullSecName, Namespace: "default"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace}},
 	)
 	kvs := []bom.KeyValue{
 		{Key: "key1", Value: "value1"},


### PR DESCRIPTION

# Description

Fix imagePullSecret preservation during upgrade in private registry scenarios
- logic to update secret and add key was missing from upgrade path
- Also use CreateOrUpdate() to propagate secret

Fixes VZ-5386.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
