### PR TITLE
NO JIRA: Fix OCI Logging

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -919,7 +919,7 @@ data:
 {{- if .Values.fluentd.oci }}
   oci-logging-system.conf: |
     # Match all "system" namespaces so system log records are sent to a separate OCI Log object
-    <match kubernetes.**kube-** kubernetes.**verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** fluentd.monitor.metrics>
+    <match kubernetes.**_kube-** kubernetes.**verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** fluentd.monitor.metrics>
       @type oci_logging
       log_object_id {{ .Values.fluentd.oci.systemLogId }}
       <buffer>

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -919,7 +919,7 @@ data:
 {{- if .Values.fluentd.oci }}
   oci-logging-system.conf: |
     # Match all "system" namespaces so system log records are sent to a separate OCI Log object
-    <match kubernetes.**kube-** kubernetes.**verrazzano-system** kubernetes.**verrazzano-install** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** systemd.** fluentd.monitor.metrics>
+    <match kubernetes.**kube-** kubernetes.**verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** fluentd.monitor.metrics>
       @type oci_logging
       log_object_id {{ .Values.fluentd.oci.systemLogId }}
       <buffer>

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -919,7 +919,7 @@ data:
 {{- if .Values.fluentd.oci }}
   oci-logging-system.conf: |
     # Match all "system" namespaces so system log records are sent to a separate OCI Log object
-    <match kubernetes.**_kube-** kubernetes.**verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** fluentd.monitor.metrics>
+    <match kubernetes.**_kube-** kubernetes.**_verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** fluentd.monitor.metrics>
       @type oci_logging
       log_object_id {{ .Values.fluentd.oci.systemLogId }}
       <buffer>

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -132,32 +132,32 @@ var _ = t.Describe("OCI Logging", Label("f:oci-integration.logging"), func() {
 					// GIVEN a Verrazzano installation with no applications installed
 					// WHEN I search for log records in the default app Log object
 					// THEN I expect to find no records
-					Consistently(func() (int, error) {
+					Consistently(func() int {
 						logs, err := getLogRecordsFromOCI(&logSearchClient, compartmentID, logGroupID, defaultAppLogID, "")
 						if err != nil {
 							pkg.Log(pkg.Error, fmt.Sprintf("Error getting log records: %+v", err))
-							return 0, err
+							return 0
 						}
 						if *logs.Summary.ResultCount > 0 {
-							pkg.Log(pkg.Info, fmt.Sprintf("Log records: %+v", logs.Results))
+							pkg.Log(pkg.Error, fmt.Sprintf("Log records: %+v", logs.Results))
 						}
-						return *logs.Summary.ResultCount, nil
+						return *logs.Summary.ResultCount
 					}, shortWaitTimeout, pollingInterval).Should(BeZero(), "Expected no default app logs but found at least one")
 				},
 				func() {
 					// GIVEN a Verrazzano installation with no applications installed
 					// WHEN I search for log records in the namespace-specific app Log object
 					// THEN I expect to find no records
-					Consistently(func() (int, error) {
+					Consistently(func() int {
 						logs, err := getLogRecordsFromOCI(&logSearchClient, compartmentID, logGroupID, nsLogID, "")
 						if err != nil {
 							pkg.Log(pkg.Error, fmt.Sprintf("Error getting log records: %+v", err))
-							return 0, err
+							return 0
 						}
 						if *logs.Summary.ResultCount > 0 {
-							pkg.Log(pkg.Info, fmt.Sprintf("Log records: %+v", logs.Results))
+							pkg.Log(pkg.Error, fmt.Sprintf("Log records: %+v", logs.Results))
 						}
-						return *logs.Summary.ResultCount, nil
+						return *logs.Summary.ResultCount
 					}, shortWaitTimeout, pollingInterval).Should(BeZero(), "Expected no namespace-specific app logs but found at least one")
 				},
 			)
@@ -266,6 +266,8 @@ func getLogRecordsFromOCI(client *loggingsearch.LogSearchClient, compartmentID, 
 // use an instance principal auth provider, otherwise use the default provider (auth config comes from
 // an OCI config file or environment variables).
 func getLogSearchClient(region string) (loggingsearch.LogSearchClient, error) {
+	os.Setenv("OCI_GO_SDK_DEBUG", "v")
+
 	var provider common.ConfigurationProvider
 	var err error
 

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -135,6 +135,7 @@ var _ = t.Describe("OCI Logging", Label("f:oci-integration.logging"), func() {
 					Consistently(func() (int, error) {
 						logs, err := getLogRecordsFromOCI(&logSearchClient, compartmentID, logGroupID, defaultAppLogID, "")
 						if err != nil {
+							pkg.Log(pkg.Error, fmt.Sprintf("Error getting log records: %+v", err))
 							return 0, err
 						}
 						if *logs.Summary.ResultCount > 0 {
@@ -150,6 +151,7 @@ var _ = t.Describe("OCI Logging", Label("f:oci-integration.logging"), func() {
 					Consistently(func() (int, error) {
 						logs, err := getLogRecordsFromOCI(&logSearchClient, compartmentID, logGroupID, nsLogID, "")
 						if err != nil {
+							pkg.Log(pkg.Error, fmt.Sprintf("Error getting log records: %+v", err))
 							return 0, err
 						}
 						if *logs.Summary.ResultCount > 0 {

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -138,7 +138,7 @@ var _ = t.Describe("OCI Logging", Label("f:oci-integration.logging"), func() {
 							return 0, err
 						}
 						if *logs.Summary.ResultCount > 0 {
-							t.Logs.Infof("Log records: %+v", logs.Results)
+							pkg.Log(pkg.Info, fmt.Sprintf("Log records: %+v", logs.Results))
 						}
 						return *logs.Summary.ResultCount, nil
 					}, shortWaitTimeout, pollingInterval).Should(BeZero(), "Expected no default app logs but found at least one")
@@ -153,7 +153,7 @@ var _ = t.Describe("OCI Logging", Label("f:oci-integration.logging"), func() {
 							return 0, err
 						}
 						if *logs.Summary.ResultCount > 0 {
-							t.Logs.Infof("Log records: %+v", logs.Results)
+							pkg.Log(pkg.Info, fmt.Sprintf("Log records: %+v", logs.Results))
 						}
 						return *logs.Summary.ResultCount, nil
 					}, shortWaitTimeout, pollingInterval).Should(BeZero(), "Expected no namespace-specific app logs but found at least one")
@@ -279,5 +279,7 @@ func getLogSearchClient(region string) (loggingsearch.LogSearchClient, error) {
 		return loggingsearch.LogSearchClient{}, err
 	}
 
+	defaultRetryPolicy := common.DefaultRetryPolicy()
+	common.GlobalRetry = &defaultRetryPolicy
 	return loggingsearch.NewLogSearchClientWithConfigurationProvider(provider)
 }

--- a/tests/e2e/oci/logging/ocilogging_test.go
+++ b/tests/e2e/oci/logging/ocilogging_test.go
@@ -266,8 +266,6 @@ func getLogRecordsFromOCI(client *loggingsearch.LogSearchClient, compartmentID, 
 // use an instance principal auth provider, otherwise use the default provider (auth config comes from
 // an OCI config file or environment variables).
 func getLogSearchClient(region string) (loggingsearch.LogSearchClient, error) {
-	os.Setenv("OCI_GO_SDK_DEBUG", "v")
-
 	var provider common.ConfigurationProvider
 	var err error
 


### PR DESCRIPTION
# Description

The OCI Logging AT pipeline has been failing for some time. The root cause was that the logs for pods in the `verrazzano-monitoring` namespace were being sent to the default application log object instead of the system log object. The fix was to adjust the Fluentd pattern for system logs.

The tests were failing intermittently because the check for "logs do not exist" was a one-time check, and it can take a few minutes to show up in OCI. My theory is that sometimes the check happened to find logs and sometimes it didn't. To help mitigate this, I enclosed the "logs do not exist" checks in a `Consistently` block so that the check is repeated and only succeeds if the "logs do not exist" condition is satisfied for the entire duration.

While testing, I did encounter some intermittent failures in the OCI SDK and noticed that the SDK client was not configured with a retry policy, so I added retries to the client.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
