### PR TITLE
Backporting rancher + Fleet images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4",
+              "tag": "v2.6.3-20220318142324-84d023acd",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4"
+              "tag": "v2.6.3-20220318142324-84d023acd"
             }
           ]
         },
@@ -142,7 +142,7 @@
           "images": [
             {
               "image": "shell",
-              "tag": "v0.1.6"
+              "tag": "v0.1.14"
             },
             {
               "image": "kubectl",
@@ -154,15 +154,15 @@
             },
             {
               "image": "fleet-agent",
-              "tag": "v0.3.5"
+              "tag": "v0.3.8"
             },
             {
               "image": "fleet",
-              "tag": "v0.3.5"
+              "tag": "v0.3.8"
             },
             {
               "image": "gitjob",
-              "tag": "v0.1.15"
+              "tag": "v0.1.23"
             },
             {
               "image": "rancher-operator",


### PR DESCRIPTION
# Description

Updating the rancher and fleet images to Rancher 2.6.3

Fixes VZ-5357 VZ-5358 VZ-4897

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
