### PR TITLE
VZ-5760.  Allow updates during upgrade

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/testdata/rollback_bom.json
+++ b/platform-operator/apis/verrazzano/v1alpha1/testdata/rollback_bom.json
@@ -1,0 +1,4 @@
+{
+  "registry": "ghcr.io",
+  "version": "1.0.0"
+}

--- a/platform-operator/apis/verrazzano/v1alpha1/testdata/test_bom.json
+++ b/platform-operator/apis/verrazzano/v1alpha1/testdata/test_bom.json
@@ -1,6 +1,6 @@
 {
   "registry": "ghcr.io",
-  "version": "0.17.0",
+  "version": "1.1.0",
   "components": [
     {
       "name": "verrazzano-platform-operator",
@@ -98,59 +98,19 @@
       "subcomponents": [
         {
           "repository": "verrazzano",
-          "name": "istiocoredns",
-          "images": [
-            {
-              "image": "coredns",
-              "tag": "1.6.2",
-              "helmFullImageKey": "istiocoredns.coreDNSImage",
-              "helmTagKey": "istiocoredns.coreDNSTag"
-            },
-            {
-              "image": "istio-coredns-plugin",
-              "tag": "0.2-20201016204812-23723dcb",
-              "helmFullImageKey": "istiocoredns.coreDNSPluginImage"
-            }
-          ]
-        },
-        {
-          "repository": "verrazzano",
           "name": "istiod",
           "images": [
             {
               "image": "pilot",
-              "tag": "1.7.3",
-              "helmFullImageKey": "pilot.image"
+              "tag": "1.10.4",
+              "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.7.3",
-              "helmImageKey": "global.proxy.image",
-              "helmTagKey": "global.tag"
-            }
-          ]
-        },
-        {
-          "repository": "verrazzano",
-          "name": "istio-ingress",
-          "images": [
-            {
-              "image": "proxyv2",
-              "tag": "1.7.3",
-              "helmImageKey": "global.proxy.image",
-              "helmTagKey": "global.tag"
-            }
-          ]
-        },
-        {
-          "repository": "verrazzano",
-          "name": "istio-egress",
-          "images": [
-            {
-              "image": "proxyv2",
-              "tag": "1.7.3",
-              "helmImageKey": "global.proxy.image",
-              "helmTagKey": "global.tag"
+              "tag": "1.10.4",
+              "helmImageKey": "values.global.proxy.image",
+              "helmTagKey": "values.global.tag",
+              "helmRegistryAndRepoKey": "values.global.hub"
             }
           ]
         }
@@ -362,6 +322,11 @@
               "image": "weblogic-kubernetes-operator",
               "tag": "3.2.2",
               "helmFullImageKey": "image"
+            },
+            {
+              "image": "weblogic-monitoring-exporter",
+              "tag": "2.0.4",
+              "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]
         }
@@ -434,6 +399,248 @@
             {
               "image": "keycloak-oracle-theme",
               "tag": "0.15.0-20210510085250-01638c7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "prometheus-operator",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-operator",
+          "images": [
+            {
+              "image": "prometheus-operator",
+              "tag": "v0.55.1",
+              "helmFullImageKey": "prometheusOperator.image.repository",
+              "helmTagKey": "prometheusOperator.image.tag"
+            },
+            {
+              "image": "kube-webhook-certgen",
+              "tag": "1.1.1-20220414195226-864e56292",
+              "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
+              "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-config-reloader",
+          "images": [
+            {
+              "image": "prometheus-config-reloader",
+              "tag": "v0.55.1",
+              "helmFullImageKey": "prometheusOperator.prometheusConfigReloader.image.repository",
+              "helmTagKey": "prometheusOperator.prometheusConfigReloader.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "alertmanager",
+          "images": [
+            {
+              "image": "alertmanager",
+              "tag": "v0.24.0",
+              "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
+              "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "prometheus",
+          "images": [
+            {
+              "image": "prometheus",
+              "tag": "v2.34.0",
+              "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
+              "helmTagKey": "prometheus.prometheusSpec.image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "prometheus-adapter",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-adapter",
+          "images": [
+            {
+              "image": "prometheus-adapter",
+              "tag": "v0.9.1-3",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "kube-state-metrics",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "kube-state-metrics",
+          "images": [
+            {
+              "image": "kube-state-metrics",
+              "tag": "v2.4.2",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "prometheus-pushgateway",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "prometheus-pushgateway",
+          "images": [
+            {
+              "image": "prometheus-pushgateway",
+              "tag": "v1.4.2",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger-operator",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-operator",
+          "images": [
+            {
+              "image": "jaeger-operator",
+              "tag": "1.32.0",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger-agent",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-agent",
+          "images": [
+            {
+              "image": "jaeger-agent",
+              "tag": "1.32.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger-collector",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-collector",
+          "images": [
+            {
+              "image": "jaeger-collector",
+              "tag": "1.32.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger-query",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-query",
+          "images": [
+            {
+              "image": "jaeger-query",
+              "tag": "1.32.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger-ingester",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-ingester",
+          "images": [
+            {
+              "image": "jaeger-ingester",
+              "tag": "1.32.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "jaeger",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-operator",
+          "images": [
+            {
+              "image": "jaeger-operator",
+              "tag": "1.32.0"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-agent",
+          "images": [
+            {
+              "image": "jaeger-agent",
+              "tag": "1.32.0"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-collector",
+          "images": [
+            {
+              "image": "jaeger-collector",
+              "tag": "1.32.0"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-query",
+          "images": [
+            {
+              "image": "jaeger-query",
+              "tag": "1.32.0"
+            }
+          ]
+        },
+        {
+          "repository": "verrazzano",
+          "name": "jaeger-ingester",
+          "images": [
+            {
+              "image": "jaeger-ingester",
+              "tag": "1.32.0"
             }
           ]
         }

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -132,11 +132,23 @@ func ValidateProfile(requestedProfile ProfileType) error {
 }
 
 // ValidateUpgradeRequest Ensures that for the upgrade case only the version field has changed
-func ValidateUpgradeRequest(currentSpec *VerrazzanoSpec, newSpec *VerrazzanoSpec) error {
+func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
+	installedVersion := current.Status.Version
+	currentSpec := current.Spec
+	newSpec := new.Spec
+
 	if !config.Get().VersionCheckEnabled {
 		zap.S().Infof("Version validation disabled")
 		return nil
 	}
+
+	// if the installed version is not == BOM version and newspec versiom isn't set,
+	// reject the update; upgrade needs to happen before any update
+	//
+	if len(newSpec.Version) == 0 {
+		semver.NewSemVersion(installedVersion)
+	}
+
 	// Short-circuit if the version strings are the same
 	if currentSpec.Version == newSpec.Version {
 		return nil

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -163,9 +163,9 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 	}
 
 	// New version is a non-zero-len string, short-circuit if the version strings are the same
-	if currentSpec.Version == newSpec.Version {
-		return nil
-	}
+	//if currentSpec.Version == newSpec.Version {
+	//	return nil
+	//}
 
 	// Make sure the requested version matches what's in the BOM
 	newSpecVer, err := semver.NewSemVersion(newSpec.Version)

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -131,7 +131,6 @@ func ValidateProfile(requestedProfile ProfileType) error {
 
 // ValidateUpgradeRequest Ensures hat an upgrade is requested as part of an update if necessary,
 // and that the version of an upgrade request is valid.
-// - an upgrade must be performed with or before the next update to the configuration after the VPO has been updated
 func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 	if !config.Get().VersionCheckEnabled {
 		zap.S().Infof("Version validation disabled")
@@ -144,13 +143,14 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 		return err
 	}
 
-	// Make sure the requested version matches what's in the BOM
+	// Make sure the requested version matches what's in the BOM and is not < the current spec version
 	newVerString := strings.TrimSpace(new.Spec.Version)
 	if len(newVerString) > 0 {
 		return validateNewVersion(current, newVerString, bomVersion)
 	}
 
 	// No new version set, check if an upgrade is needed before we allow any edits
+	// - this happens when we have a new version available and an edit has happened before an upgrade
 	if err := checkUpgradeRequired(current.Status.Version, bomVersion); err != nil {
 		return err
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -133,9 +133,6 @@ func ValidateProfile(requestedProfile ProfileType) error {
 // and that the version of an upgrade request is valid.
 // - an upgrade must be performed with or before the next update to the configuration after the VPO has been updated
 func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
-	currentSpec := current.Spec
-	newSpec := new.Spec
-
 	if !config.Get().VersionCheckEnabled {
 		zap.S().Infof("Version validation disabled")
 		return nil
@@ -146,6 +143,9 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 		// Boundary condition -- likely just created and install hasn't started yet
 		return nil
 	}
+
+	currentSpec := current.Spec
+	newSpec := new.Spec
 
 	// if the installed version is not == BOM version and newspec versiom isn't set,
 	// reject the update; upgrade needs to happen before any update

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -168,25 +168,25 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 	}
 
 	// Make sure the requested version matches what's in the BOM
-	requestedSemVer, err := semver.NewSemVersion(newSpec.Version)
+	newSpecVer, err := semver.NewSemVersion(newSpec.Version)
 	if err != nil {
 		return err
 	}
-	if !requestedSemVer.IsEqualTo(bomVersion) {
+	if !newSpecVer.IsEqualTo(bomVersion) {
 		return fmt.Errorf("Requested version %s does not match BOM version %s",
-			requestedSemVer.ToString(), bomVersion.ToString())
+			newSpecVer.ToString(), bomVersion.ToString())
 	}
 
 	// Verify that the new version request is > than the current version
 	// - in reality, this should probably never happen
 	if len(currentSpec.Version) > 0 {
-		currentSemVer, err := semver.NewSemVersion(currentSpec.Version)
+		currentSpecVer, err := semver.NewSemVersion(currentSpec.Version)
 		if err != nil {
 			return err
 		}
-		if requestedSemVer.IsLessThan(currentSemVer) {
+		if newSpecVer.IsLessThan(currentSpecVer) {
 			return fmt.Errorf("Requested version %s is not newer than current version %s",
-				requestedSemVer.ToString(), currentSemVer.ToString())
+				newSpecVer.ToString(), currentSpecVer.ToString())
 		}
 	}
 	return nil

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -173,7 +173,7 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 		return err
 	}
 	if !newSpecVer.IsEqualTo(bomVersion) {
-		return fmt.Errorf("Requested version %s does not match BOM version %s",
+		return fmt.Errorf("Requested version %s does not match BOM version %s, please upgrade to the current BOM version",
 			newSpecVer.ToString(), bomVersion.ToString())
 	}
 

--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -141,13 +141,19 @@ func ValidateUpgradeRequest(current *Verrazzano, new *Verrazzano) error {
 		return nil
 	}
 
+	installedVerString := current.Status.Version
+	if len(strings.TrimSpace(installedVerString)) == 0 {
+		// Boundary condition -- likely just created and install hasn't started yet
+		return nil
+	}
+
 	// if the installed version is not == BOM version and newspec versiom isn't set,
 	// reject the update; upgrade needs to happen before any update
 	bomVersion, err := GetCurrentBomVersion()
 	if err != nil {
 		return err
 	}
-	installedVersion, err := semver.NewSemVersion(current.Status.Version)
+	installedVersion, err := semver.NewSemVersion(installedVerString)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -37,6 +37,9 @@ const testBomFilePath = "../../../controllers/verrazzano/testdata/test_bom.json"
 const invalidTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom.json"
 const invalidPathTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom_path.json"
 
+const v1_0_0 = "v1.0.0"
+const v1_1_0 = "v1.1.0"
+
 // TestValidUpgradeRequestNoCurrentVersion Tests the condition for valid upgrade where the version is not specified in the current spec
 // GIVEN an edit to update a Verrazzano spec to a new version
 // WHEN the new version is valid and the current version is not specified
@@ -51,12 +54,12 @@ func TestValidUpgradeRequestNoCurrentVersion(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.0.0",
+			Version: v1_0_0,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
+			Version: v1_1_0,
 			Profile: "dev",
 		},
 	}
@@ -77,7 +80,7 @@ func TestUpdateBeforeUpgrade(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.0.0",
+			Version: v1_0_0,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -109,13 +112,13 @@ func TestUpdateWithUpgrade(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.0.0",
+			Version: v1_0_0,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Profile: "dev",
-			Version: "v1.1.0",
+			Version: v1_1_0,
 			Components: ComponentSpec{
 				DNS: &DNSComponent{
 					Wildcard: &Wildcard{
@@ -142,7 +145,7 @@ func TestUpgradeNewVerDoesNotMatchBOMVer(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.0.0",
+			Version: v1_0_0,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -164,19 +167,20 @@ func TestUpgradeNewVerLessThanCurrentCer(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
+	const v1_2_0 = "v1.2.0"
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.2.0",
-			Profile: "dev",
+			Version: v1_2_0,
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.2.0",
+			Version: v1_2_0,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
-			Version: "v1.1.0",
+			Profile: Dev,
+			Version: v1_1_0,
 		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -194,7 +198,7 @@ func TestValidUpgradeRequestCurrentVersionExists(t *testing.T) {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
 			Version: "v0.16.0",
@@ -202,8 +206,8 @@ func TestValidUpgradeRequestCurrentVersionExists(t *testing.T) {
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -221,7 +225,7 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
 			Version: "v0.17.0",
@@ -230,7 +234,7 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -248,13 +252,13 @@ func TestValidateUpgradeBadOldVersion(t *testing.T) {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "blah",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -272,13 +276,13 @@ func TestValidateUpgradeBadNewVersion(t *testing.T) {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "blah",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -295,15 +299,15 @@ func TestNoVersionsSpecified(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.1.0",
+			Version: v1_1_0,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -320,13 +324,13 @@ func TestValidVersionWithProfileChange(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "prod",
+			Profile: Prod,
 		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -343,13 +347,13 @@ func TestValidVersionWithEnvNameChange(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version:         "v0.17.0",
-			Profile:         "dev",
+			Profile:         Dev,
 			EnvironmentName: "newEnv",
 		},
 	}
@@ -367,7 +371,7 @@ func TestValidVersionWithCertManagerChange(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
 					Certificate: Certificate{
@@ -384,7 +388,7 @@ func TestValidVersionWithCertManagerChange(t *testing.T) {
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
 					Certificate: Certificate{
@@ -412,7 +416,7 @@ func TestValidVersionWithNewDNS(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
 					Certificate: Certificate{
@@ -429,7 +433,7 @@ func TestValidVersionWithNewDNS(t *testing.T) {
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
 					Certificate: Certificate{
@@ -480,7 +484,7 @@ func runValidateWithIngressChangeTest() error {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				Ingress: &IngressNginxComponent{
 					Type: "sometype",
@@ -505,7 +509,7 @@ func runValidateWithIngressChangeTest() error {
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.17.0",
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				Ingress: &IngressNginxComponent{
 					Type: "sometype",
@@ -545,7 +549,7 @@ func TestGetCurrentBomVersion(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	expectedVersion, err := semver.NewSemVersion("v1.1.0")
+	expectedVersion, err := semver.NewSemVersion(v1_1_0)
 	assert.NoError(t, err)
 
 	version, err := GetCurrentBomVersion()
@@ -1560,7 +1564,7 @@ func TestValidateProfileEmptyProfile(t *testing.T) {
 // WHEN the profile provided is dev
 // THEN no error is returned
 func TestValidateProfileDevProfile(t *testing.T) {
-	assert.NoError(t, ValidateProfile("dev"))
+	assert.NoError(t, ValidateProfile(Dev))
 }
 
 // TestValidateProfileInvalidProfile Tests ValidateProfile() for invalid profile

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -226,11 +226,11 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
+			Version: "v0.17.0",
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: v110,
+			Version: "v0.17.0",
 		},
 	}
 	newSpec := &Verrazzano{

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -46,12 +46,19 @@ func TestValidUpgradeRequestNoCurrentVersion(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v1.0.0",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v1.1.0",
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v1.1.0",
+			Profile: "dev",
+		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -65,13 +72,20 @@ func TestValidUpgradeRequestCurrentVersionExists(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Version: "v0.16.0",
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.16.0",
+			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v1.1.0",
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v1.1.0",
+			Profile: "dev",
+		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -85,13 +99,17 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -105,13 +123,17 @@ func TestValidateUpgradeBadOldVersion(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Version: "blah",
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "blah",
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -125,13 +147,17 @@ func TestValidateUpgradeBadNewVersion(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Version: "v0.16.0",
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.16.0",
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "blah",
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "blah",
+			Profile: "dev",
+		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -145,11 +171,15 @@ func TestNoVersionsSpecified(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -163,12 +193,16 @@ func TestValidVersionWithProfileChange(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "prod",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "prod",
+		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -182,11 +216,15 @@ func TestProfileChangeOnlyNoVersions(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Profile: "prod",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "prod",
+		},
 	}
 	assert.NoError(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -200,12 +238,16 @@ func TestProfileChangeOnlyNoNewVersionString(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
-		Version: "v0.16.0",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+			Version: "v0.16.0",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Profile: "prod",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "prod",
+		},
 	}
 	err := ValidateUpgradeRequest(currentSpec, newSpec)
 	assert.Error(t, err)
@@ -221,13 +263,17 @@ func TestValidVersionWithEnvNameChange(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version:         "v0.17.0",
-		Profile:         "dev",
-		EnvironmentName: "newEnv",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version:         "v0.17.0",
+			Profile:         "dev",
+			EnvironmentName: "newEnv",
+		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
 }
@@ -241,30 +287,34 @@ func TestValidVersionWithCertManagerChange(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
-		Components: ComponentSpec{
-			CertManager: &CertManagerComponent{
-				Certificate: Certificate{
-					Acme: Acme{
-						Provider:     "MyProvider",
-						EmailAddress: "email1@mycompany.com",
-						Environment:  "someEnv",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+			Components: ComponentSpec{
+				CertManager: &CertManagerComponent{
+					Certificate: Certificate{
+						Acme: Acme{
+							Provider:     "MyProvider",
+							EmailAddress: "email1@mycompany.com",
+							Environment:  "someEnv",
+						},
 					},
 				},
 			},
 		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
-		Components: ComponentSpec{
-			CertManager: &CertManagerComponent{
-				Certificate: Certificate{
-					Acme: Acme{
-						Provider:     "MyProvider",
-						EmailAddress: "email2@mycompany.com",
-						Environment:  "someEnv",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+			Components: ComponentSpec{
+				CertManager: &CertManagerComponent{
+					Certificate: Certificate{
+						Acme: Acme{
+							Provider:     "MyProvider",
+							EmailAddress: "email2@mycompany.com",
+							Environment:  "someEnv",
+						},
 					},
 				},
 			},
@@ -282,39 +332,43 @@ func TestValidVersionWithNewDNS(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
-		Components: ComponentSpec{
-			CertManager: &CertManagerComponent{
-				Certificate: Certificate{
-					Acme: Acme{
-						Provider:     "MyProvider",
-						EmailAddress: "email1@mycompany.com",
-						Environment:  "someEnv",
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+			Components: ComponentSpec{
+				CertManager: &CertManagerComponent{
+					Certificate: Certificate{
+						Acme: Acme{
+							Provider:     "MyProvider",
+							EmailAddress: "email1@mycompany.com",
+							Environment:  "someEnv",
+						},
 					},
 				},
 			},
 		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
-		Components: ComponentSpec{
-			CertManager: &CertManagerComponent{
-				Certificate: Certificate{
-					Acme: Acme{
-						Provider:     "MyProvider",
-						EmailAddress: "email1@mycompany.com",
-						Environment:  "someEnv",
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+			Components: ComponentSpec{
+				CertManager: &CertManagerComponent{
+					Certificate: Certificate{
+						Acme: Acme{
+							Provider:     "MyProvider",
+							EmailAddress: "email1@mycompany.com",
+							Environment:  "someEnv",
+						},
 					},
 				},
-			},
-			DNS: &DNSComponent{
-				OCI: &OCI{
-					OCIConfigSecret:        "secret",
-					DNSZoneCompartmentOCID: "zonecompocid",
-					DNSZoneOCID:            "zoneOcid",
-					DNSZoneName:            "zoneName",
+				DNS: &DNSComponent{
+					OCI: &OCI{
+						OCIConfigSecret:        "secret",
+						DNSZoneCompartmentOCID: "zonecompocid",
+						DNSZoneOCID:            "zoneOcid",
+						DNSZoneName:            "zoneName",
+					},
 				},
 			},
 		},
@@ -346,51 +400,55 @@ func runValidateWithIngressChangeTest() error {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	currentSpec := &VerrazzanoSpec{
-		Profile: "dev",
-		Components: ComponentSpec{
-			Ingress: &IngressNginxComponent{
-				Type: "sometype",
-				NGINXInstallArgs: []InstallArgs{
-					{
-						Name:      "arg1",
-						Value:     "val1",
-						SetString: false,
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+			Components: ComponentSpec{
+				Ingress: &IngressNginxComponent{
+					Type: "sometype",
+					NGINXInstallArgs: []InstallArgs{
+						{
+							Name:      "arg1",
+							Value:     "val1",
+							SetString: false,
+						},
 					},
-				},
-				Ports: []corev1.ServicePort{
-					{
-						Name:     "port1",
-						Protocol: "TCP",
-						Port:     8000,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "port1",
+							Protocol: "TCP",
+							Port:     8000,
+						},
 					},
 				},
 			},
 		},
 	}
-	newSpec := &VerrazzanoSpec{
-		Version: "v0.17.0",
-		Profile: "dev",
-		Components: ComponentSpec{
-			Ingress: &IngressNginxComponent{
-				Type: "sometype",
-				NGINXInstallArgs: []InstallArgs{
-					{
-						Name:      "arg1",
-						Value:     "val1",
-						SetString: false,
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: "v0.17.0",
+			Profile: "dev",
+			Components: ComponentSpec{
+				Ingress: &IngressNginxComponent{
+					Type: "sometype",
+					NGINXInstallArgs: []InstallArgs{
+						{
+							Name:      "arg1",
+							Value:     "val1",
+							SetString: false,
+						},
 					},
-				},
-				Ports: []corev1.ServicePort{
-					{
-						Name:     "port1",
-						Protocol: "TCP",
-						Port:     8000,
-					},
-					{
-						Name:     "port2",
-						Protocol: "TCP",
-						Port:     9000,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "port1",
+							Protocol: "TCP",
+							Port:     8000,
+						},
+						{
+							Name:     "port2",
+							Protocol: "TCP",
+							Port:     9000,
+						},
 					},
 				},
 			},

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -32,13 +32,16 @@ import (
 )
 
 // For unit testing
-const actualBomFilePath = "../../../verrazzano-bom.json"
-const testBomFilePath = "../../../controllers/verrazzano/testdata/test_bom.json"
-const invalidTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom.json"
-const invalidPathTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom_path.json"
+const (
+	actualBomFilePath          = "../../../verrazzano-bom.json"
+	testBomFilePath            = "../../../controllers/verrazzano/testdata/test_bom.json"
+	invalidTestBomFilePath     = "../../../controllers/verrazzano/testdata/invalid_test_bom.json"
+	invalidPathTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom_path.json"
 
-const v1_0_0 = "v1.0.0"
-const v1_1_0 = "v1.1.0"
+	v100 = "v1.0.0"
+	v110 = "v1.1.0"
+	v120 = "v1.2.0"
+)
 
 // TestValidUpgradeRequestNoCurrentVersion Tests the condition for valid upgrade where the version is not specified in the current spec
 // GIVEN an edit to update a Verrazzano spec to a new version
@@ -54,12 +57,12 @@ func TestValidUpgradeRequestNoCurrentVersion(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_0_0,
+			Version: v100,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: "dev",
 		},
 	}
@@ -80,7 +83,7 @@ func TestUpdateBeforeUpgrade(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_0_0,
+			Version: v100,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -112,13 +115,13 @@ func TestUpdateWithUpgrade(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_0_0,
+			Version: v100,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Profile: "dev",
-			Version: v1_1_0,
+			Version: v110,
 			Components: ComponentSpec{
 				DNS: &DNSComponent{
 					Wildcard: &Wildcard{
@@ -145,7 +148,7 @@ func TestUpgradeNewVerDoesNotMatchBOMVer(t *testing.T) {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_0_0,
+			Version: v100,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -167,20 +170,19 @@ func TestUpgradeNewVerLessThanCurrentCer(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	const v1_2_0 = "v1.2.0"
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_2_0,
+			Version: v120,
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_2_0,
+			Version: v120,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Profile: Dev,
-			Version: v1_1_0,
+			Version: v110,
 		},
 	}
 	assert.Error(t, ValidateUpgradeRequest(currentSpec, newSpec))
@@ -206,7 +208,7 @@ func TestValidUpgradeRequestCurrentVersionExists(t *testing.T) {
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}
@@ -302,7 +304,7 @@ func TestNoVersionsSpecified(t *testing.T) {
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_1_0,
+			Version: v110,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -549,7 +551,7 @@ func TestGetCurrentBomVersion(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	expectedVersion, err := semver.NewSemVersion(v1_1_0)
+	expectedVersion, err := semver.NewSemVersion(v110)
 	assert.NoError(t, err)
 
 	version, err := GetCurrentBomVersion()

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -226,16 +226,16 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v110,
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.17.0",
+			Version: v110,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v110,
 			Profile: Dev,
 		},
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -256,6 +256,9 @@ func TestValidateUpgradeBadOldVersion(t *testing.T) {
 			Version: "blah",
 			Profile: Dev,
 		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
+		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -279,6 +282,9 @@ func TestValidateUpgradeBadNewVersion(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
 			Profile: Dev,
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
@@ -328,6 +334,9 @@ func TestValidVersionWithProfileChange(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Profile: Dev,
 		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
+		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -350,6 +359,9 @@ func TestValidVersionWithEnvNameChange(t *testing.T) {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Profile: Dev,
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
@@ -385,6 +397,9 @@ func TestValidVersionWithCertManagerChange(t *testing.T) {
 					},
 				},
 			},
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
@@ -430,6 +445,9 @@ func TestValidVersionWithNewDNS(t *testing.T) {
 					},
 				},
 			},
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
@@ -506,6 +524,9 @@ func runValidateWithIngressChangeTest() error {
 					},
 				},
 			},
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{

--- a/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate_test.go
@@ -34,13 +34,17 @@ import (
 // For unit testing
 const (
 	actualBomFilePath          = "../../../verrazzano-bom.json"
-	testBomFilePath            = "../../../controllers/verrazzano/testdata/test_bom.json"
-	invalidTestBomFilePath     = "../../../controllers/verrazzano/testdata/invalid_test_bom.json"
-	invalidPathTestBomFilePath = "../../../controllers/verrazzano/testdata/invalid_test_bom_path.json"
+	testBomFilePath            = "testdata/test_bom.json"
+	testRollbackBomFilePath    = "testdata/rollback_bom.json"
+	invalidTestBomFilePath     = "testdata/invalid_test_bom.json"
+	invalidPathTestBomFilePath = "testdata/invalid_test_bom_path.json"
 
-	v100 = "v1.0.0"
-	v110 = "v1.1.0"
-	v120 = "v1.2.0"
+	v0160 = "v0.16.0"
+	v0170 = "v0.17.0"
+	v0180 = "v0.18.0"
+	v100  = "v1.0.0"
+	v110  = "v1.1.0"
+	v120  = "v1.2.0"
 )
 
 // TestValidUpgradeRequestNoCurrentVersion Tests the condition for valid upgrade where the version is not specified in the current spec
@@ -199,11 +203,11 @@ func TestValidUpgradeRequestCurrentVersionExists(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.16.0",
+			Version: v0160,
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -226,11 +230,11 @@ func TestValidUpgradeNotNecessary(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.17.0",
+			Version: v0170,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -257,12 +261,12 @@ func TestValidateUpgradeBadOldVersion(t *testing.T) {
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Dev,
 		},
 	}
@@ -280,11 +284,11 @@ func TestValidateUpgradeBadNewVersion(t *testing.T) {
 	}()
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.16.0",
+			Version: v0160,
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
@@ -335,12 +339,12 @@ func TestValidVersionWithProfileChange(t *testing.T) {
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Prod,
 		},
 	}
@@ -361,12 +365,12 @@ func TestValidVersionWithEnvNameChange(t *testing.T) {
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version:         "v0.17.0",
+			Version:         v0170,
 			Profile:         Dev,
 			EnvironmentName: "newEnv",
 		},
@@ -399,12 +403,12 @@ func TestValidVersionWithCertManagerChange(t *testing.T) {
 			},
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
@@ -447,12 +451,12 @@ func TestValidVersionWithNewDNS(t *testing.T) {
 			},
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Dev,
 			Components: ComponentSpec{
 				CertManager: &CertManagerComponent{
@@ -526,12 +530,12 @@ func runValidateWithIngressChangeTest() error {
 			},
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.17.0",
+			Version: v0170,
 			Profile: Dev,
 			Components: ComponentSpec{
 				Ingress: &IngressNginxComponent{
@@ -650,7 +654,7 @@ func TestValidateVersionBadBomfile(t *testing.T) {
 	defer func() {
 		config.SetDefaultBomFilePath("")
 	}()
-	err := ValidateVersion("v0.17.0")
+	err := ValidateVersion(v0170)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected end of JSON input")
 }

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -125,7 +125,7 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	}
 
 	// Check to see if the update is an upgrade request, and if it is valid and allowable
-	err := ValidateUpgradeRequest(&oldResource.Spec, &v.Spec)
+	err := ValidateUpgradeRequest(oldResource, v)
 	if err != nil {
 		log.Errorf("Invalid upgrade request: %s", err.Error())
 		return err

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -34,8 +34,8 @@ func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 	assert.NoError(t, currentSpec.ValidateCreate())
@@ -58,7 +58,7 @@ func TestCreateCallbackSuccessWithoutVersion(t *testing.T) {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	assert.NoError(t, currentSpec.ValidateCreate())
@@ -97,7 +97,7 @@ func runCreateCallbackWithInvalidVersion(t *testing.T) error {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.18.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	err := currentSpec.ValidateCreate()
@@ -115,16 +115,16 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: "v1.0.0",
+			Version: v1_0_0,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 
@@ -148,7 +148,7 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
 			Version: "v0.16.0",
@@ -156,8 +156,8 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 
@@ -181,13 +181,13 @@ func TestUpdateCallbackFailsWithOldGreaterThanNewVersion(t *testing.T) {
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v1.2.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 	assert.Error(t, newSpec.ValidateUpdate(oldSpec))
@@ -219,13 +219,13 @@ func runUpdateWithInvalidVersionTest(t *testing.T) error {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.18.0",
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	return newSpec.ValidateUpdate(oldSpec)
@@ -257,12 +257,12 @@ func runUpdateCallbackChangedProfileTest() error {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "prod",
+			Profile: Prod,
 		},
 	}
 	err := newSpec.ValidateUpdate(oldSpec)
@@ -291,8 +291,8 @@ func TestDeleteCallbackDisabled(t *testing.T) {
 func runDeleteCallbackTest() error {
 	deletedSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.1.0",
-			Profile: "dev",
+			Version: v1_1_0,
+			Profile: Dev,
 		},
 	}
 	return deletedSpec.ValidateDelete()
@@ -394,10 +394,10 @@ func Test_combineErrors(t *testing.T) {
 // THEN validation error is returned
 func TestUpdateMissingOciLoggingApiSecret(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
-	oldSpec := &Verrazzano{Spec: VerrazzanoSpec{Profile: "dev"}}
+	oldSpec := &Verrazzano{Spec: VerrazzanoSpec{Profile: Dev}}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: "dev",
+			Profile: Dev,
 			Components: ComponentSpec{
 				Fluentd: &FluentdComponent{
 					OCI: &OciLoggingConfiguration{

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -96,7 +96,7 @@ func runCreateCallbackWithInvalidVersion(t *testing.T) error {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.18.0",
+			Version: v0180,
 			Profile: "dev",
 		},
 	}
@@ -117,6 +117,9 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Profile: "dev",
 		},
+		Status: VerrazzanoStatus{
+			Version: v110,
+		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -133,7 +136,7 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 	assert.NoError(t, newSpec.ValidateUpdate(oldSpec))
 }
 
-// TestUpdateCallbackSuccessWithNewVersion Tests the create callback with valid spec versions in both
+// TestUpdateCallbackSuccessWithNewVersion Tests the update callback with valid spec versions in both
 // GIVEN a ValidateUpdate() request
 // WHEN valid versions exist in both specs, and the new version > old version
 // THEN no error is returned
@@ -146,6 +149,9 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
 			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
@@ -161,6 +167,40 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	defer func() { getControllerRuntimeClient = getClient }()
 
 	assert.NoError(t, newSpec.ValidateUpdate(oldSpec))
+}
+
+// TestRollbackRejected Tests the update callback with valid spec versions in both
+// GIVEN a ValidateUpdate() request
+// WHEN no upgrade happened before (current spec ver empty), BOM ver is older than installed ver, and newSpec ver is older version
+// THEN no error is returned
+func TestRollbackRejected(t *testing.T) {
+	config.SetDefaultBomFilePath(testRollbackBomFilePath)
+	defer func() {
+		config.SetDefaultBomFilePath("")
+	}()
+	oldSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: v110,
+		},
+	}
+	newSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Version: v100,
+			Profile: "dev",
+		},
+	}
+
+	getControllerRuntimeClient = func() (client.Client, error) {
+		return fake.NewFakeClientWithScheme(newScheme()), nil
+	}
+	defer func() { getControllerRuntimeClient = getClient }()
+
+	err := newSpec.ValidateUpdate(oldSpec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rollback is not supported")
 }
 
 // TestUpdateCallbackFailsWithOldGreaterThanNewVersion Tests the create callback with old version > new
@@ -219,12 +259,12 @@ func runUpdateWithInvalidVersionTest(t *testing.T) error {
 			Profile: "dev",
 		},
 		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Version: v0160,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v0.18.0",
+			Version: v0180,
 			Profile: "dev",
 		},
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -34,8 +34,8 @@ func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
-			Profile: Dev,
+			Version: "v1.1.0",
+			Profile: "dev",
 		},
 	}
 	assert.NoError(t, currentSpec.ValidateCreate())
@@ -58,7 +58,7 @@ func TestCreateCallbackSuccessWithoutVersion(t *testing.T) {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Dev,
+			Profile: "dev",
 		},
 	}
 	assert.NoError(t, currentSpec.ValidateCreate())
@@ -97,7 +97,7 @@ func runCreateCallbackWithInvalidVersion(t *testing.T) error {
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.18.0",
-			Profile: Dev,
+			Profile: "dev",
 		},
 	}
 	err := currentSpec.ValidateCreate()
@@ -115,16 +115,13 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Dev,
-		},
-		Status: VerrazzanoStatus{
-			Version: v100,
+			Profile: "dev",
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
-			Profile: Dev,
+			Version: "v1.1.0",
+			Profile: "dev",
 		},
 	}
 
@@ -148,16 +145,13 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
-			Profile: Dev,
-		},
-		Status: VerrazzanoStatus{
-			Version: "v0.16.0",
+			Profile: "dev",
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
-			Profile: Dev,
+			Version: "v1.1.0",
+			Profile: "dev",
 		},
 	}
 
@@ -180,14 +174,17 @@ func TestUpdateCallbackFailsWithOldGreaterThanNewVersion(t *testing.T) {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v120,
-			Profile: Dev,
+			Version: "v1.2.0",
+			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v1.2.0",
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
-			Profile: Dev,
+			Version: "v1.1.0",
+			Profile: "dev",
 		},
 	}
 	assert.Error(t, newSpec.ValidateUpdate(oldSpec))
@@ -219,13 +216,16 @@ func runUpdateWithInvalidVersionTest(t *testing.T) error {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Dev,
+			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
 			Version: "v0.18.0",
-			Profile: Dev,
+			Profile: "dev",
 		},
 	}
 	return newSpec.ValidateUpdate(oldSpec)
@@ -257,12 +257,12 @@ func runUpdateCallbackChangedProfileTest() error {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Dev,
+			Profile: "dev",
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Prod,
+			Profile: "prod",
 		},
 	}
 	err := newSpec.ValidateUpdate(oldSpec)
@@ -291,8 +291,8 @@ func TestDeleteCallbackDisabled(t *testing.T) {
 func runDeleteCallbackTest() error {
 	deletedSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v110,
-			Profile: Dev,
+			Version: "v1.1.0",
+			Profile: "dev",
 		},
 	}
 	return deletedSpec.ValidateDelete()
@@ -394,10 +394,10 @@ func Test_combineErrors(t *testing.T) {
 // THEN validation error is returned
 func TestUpdateMissingOciLoggingApiSecret(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
-	oldSpec := &Verrazzano{Spec: VerrazzanoSpec{Profile: Dev}}
+	oldSpec := &Verrazzano{Spec: VerrazzanoSpec{Profile: "dev"}}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Profile: Dev,
+			Profile: "dev",
 			Components: ComponentSpec{
 				Fluentd: &FluentdComponent{
 					OCI: &OciLoggingConfiguration{

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -117,6 +117,9 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Profile: "dev",
 		},
+		Status: VerrazzanoStatus{
+			Version: "v1.0.0",
+		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -146,6 +149,9 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 		Spec: VerrazzanoSpec{
 			Version: "v0.16.0",
 			Profile: "dev",
+		},
+		Status: VerrazzanoStatus{
+			Version: "v0.16.0",
 		},
 	}
 	newSpec := &Verrazzano{

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -34,7 +34,7 @@ func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 
 	currentSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}
@@ -118,12 +118,12 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 			Profile: Dev,
 		},
 		Status: VerrazzanoStatus{
-			Version: v1_0_0,
+			Version: v100,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}
@@ -156,7 +156,7 @@ func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}
@@ -180,13 +180,13 @@ func TestUpdateCallbackFailsWithOldGreaterThanNewVersion(t *testing.T) {
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: "v1.2.0",
+			Version: v120,
 			Profile: Dev,
 		},
 	}
 	newSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}
@@ -291,7 +291,7 @@ func TestDeleteCallbackDisabled(t *testing.T) {
 func runDeleteCallbackTest() error {
 	deletedSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
-			Version: v1_1_0,
+			Version: v110,
 			Profile: Dev,
 		},
 	}


### PR DESCRIPTION
# Description

Update the validation around upgrade to
- Allow component updates during upgrade
- Require that first CR update after a VPO update includes an upgrade request

Fixes VZ-5760.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
