### PR TITLE
VZ-5749 - Fix intermittent Rancher reinstall failure

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -110,7 +110,7 @@ function delete_rancher() {
     | xargsr -n 1 kubectl get --all-namespaces --ignore-not-found -o custom-columns=":kind,:metadata.name,:metadata.namespace" \
     | awk '{res="";if ($1 != "") res=tolower($1)".management.cattle.io "tolower($2); if ($3 != "<none>" && res != "") res=res" -n "$3; if (res != "") cmd="kubectl patch "res" -p \x027{\"metadata\":{\"finalizers\":null}}\x027 --type=merge;kubectl delete --ignore-not-found "res; print cmd}' \
     | sh \
-    || err_return $? "Could not delete rancher CRs" || return 0 # ignore failures
+    || err_return $? "There were errors deleting rancher CRs"  # Continue if failures
 
   log "Deleting CRDs from Rancher"
 

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -73,13 +73,24 @@ function delete_rancher() {
     return 0
   fi
 
-  # Clean up the local rancher cluster object if necessary
-#  cleanup_rancher_local_cluster
   log "Running Rancher system-tools remove"
   /usr/local/bin/system-tools remove -c /home/verrazzano/kubeconfig --force || err_return $? "Failed to run Rancher system-tools remove"
 
   # wait for the cleanup to be complete (enough) for us to proceed
+  log "Waiting for namespace cattle-system to be deleted"
   kubectl wait --for=delete ns/cattle-system --timeout=120s
+
+  log "Delete the Rancher webhooks"
+  # delete mutatingwebhookconfigurations
+  delete_k8s_resources mutatingwebhookconfigurations ":metadata.name,:metadata.labels" "Could not delete MutatingWebhookConfigurations from Rancher" '/cattle.io|app:rancher/ {print $1}' \
+    || return $? # return on pipefail
+  # delete validatingwebhookconfigurations
+  delete_k8s_resources validatingwebhookconfigurations ":metadata.name,:metadata.labels" "Could not delete ValidatingWebhookConfigurations from Rancher" '/cattle.io|app:rancher/ {print $1}' \
+    || return $? # return on pipefail
+
+  log "Removing Rancher MutatingWebhookConfiguration"
+  kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io rancher.cattle.io --ignore-not-found \
+    || err_return $? "Failed to delete MutatingWebhookConfiguration rancher.cattle.io"
 
   # Deleting rancher components
   log "Deleting rancher helm charts (if any left over)"
@@ -94,11 +105,14 @@ function delete_rancher() {
   helm ls -n cattle-system | awk '/rancher/ {print $1}' | xargsr helm uninstall -n cattle-system \
     || err_return $? "Could not delete cattle-system from helm" || return $? # return on pipefail
 
-  log "Delete the additional CA secret for Rancher"
-  kubectl -n cattle-system delete secret tls-ca-additional 2>&1 > /dev/null || true
-  kubectl -n cattle-system delete secret tls-ca --ignore-not-found=true
+  log "Deleting CRs from Rancher"
+  kubectl api-resources --api-group=management.cattle.io --verbs=delete -o name \
+    | xargsr -n 1 kubectl get --all-namespaces --ignore-not-found -o custom-columns=":kind,:metadata.name,:metadata.namespace" \
+    | awk '{res="";if ($1 != "") res=tolower($1)".management.cattle.io "tolower($2); if ($3 != "<none>" && res != "") res=res" -n "$3; if (res != "") cmd="kubectl patch "res" -p \x027{\"metadata\":{\"finalizers\":null}}\x027 --type=merge;kubectl delete --ignore-not-found "res; print cmd}' \
+    | sh \
+    || err_return $? "Could not delete rancher CRs" || return 0 # ignore failures
 
-  log "Deleting CRDs from rancher"
+  log "Deleting CRDs from Rancher"
 
   local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
 
@@ -118,18 +132,18 @@ function delete_rancher() {
     crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
   done
 
-  # delete clusterrolebindings deployed by rancher
+  # delete ClusterRoleBindings deployed by rancher
   log "Deleting ClusterRoleBindings"
   delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Rancher" '/cattle.io|app:rancher|rancher-webhook|fleetworkspace-|fleet-|gitjob/ {print $1}' \
     || return $? # return on pipefail
 
-  # delete clusterroles
-  log "Deleting ClusterRoles"
+  # delete ClusterRoleBindings
+  log "Deleting ClusterRoleBindings"
   delete_k8s_resources clusterrole ":metadata.name,:metadata.labels" "Could not delete ClusterRoles from Rancher" '/cattle.io|app:rancher|fleetworkspace-|fleet-|gitjob/ {print $1}' \
     || return $? # return on pipefail
 
-  # delete rolebinding
-  log "Deleting RoleBindings"
+  # delete ClusterRoleBindings
+  log "Deleting ClusterRoleBindings"
   local default_names=("default" "kube-node-lease" "kube-public" "kube-system")
   for namespace in "${default_names[@]}"
   do
@@ -143,14 +157,6 @@ function delete_rancher() {
   log "Deleting ConfigMap"
   kubectl delete configmap cattle-controllers -n kube-system  --ignore-not-found=true || err_return $? "Could not delete ConfigMap from Rancher in namespace kube-system" || return $?
   kubectl delete configmap rancher-controller-lock -n kube-system --ignore-not-found=true || err_return $? "Could not delete ConfigMap rancher-controller-lock in namespace kube-system" || return $?
-
-  log "Delete the Rancher webhooks and left over charts"
-  # delete mutatingwebhookconfigurations
-  delete_k8s_resources mutatingwebhookconfigurations ":metadata.name,:metadata.labels" "Could not delete MutatingWebhookConfigurations from Rancher" '/cattle.io|app:rancher/ {print $1}' \
-    || return $? # return on pipefail
-  # delete validatingwebhookconfigurations
-  delete_k8s_resources validatingwebhookconfigurations ":metadata.name,:metadata.labels" "Could not delete ValidatingWebhookConfigurations from Rancher" '/cattle.io|app:rancher/ {print $1}' \
-    || return $? # return on pipefail
 
   log "Removing Rancher namespace finalizers"
   # delete namespace finalizers
@@ -199,9 +205,6 @@ function delete_rancher() {
     | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
     || err_return $? "Could not remove Rancher finalizers from all namespaces" || return $? # return on pipefail
 
-  log "Removing Rancher MutatingWebhookConfiguration"
-  kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io rancher.cattle.io --ignore-not-found \
-    || err_return $? "Failed to delete MutatingWebhookConfiguration rancher.cattle.io"
 }
 
 action "Deleting Rancher Components" delete_rancher || exit 1

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.4-BFS",
+              "tag": "v2.6.4-20220405163327-b3e14d996",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.4-BFS"
+              "tag": "v2.6.4-20220405163327-b3e14d996"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.4-20220405163327-b3e14d996",
+              "tag": "v2.6.4-BFS",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.4-20220405163327-b3e14d996"
+              "tag": "v2.6.4-BFS"
             }
           ]
         },


### PR DESCRIPTION
# Description

Resolve issue of a re-install of Verrazzano sometimes failing due to a Rancher configuration issue.

* Put back some uninstall logic that was removed when support was added for Rancher 2.5.9
* Reordered some of the uninstall steps for Rancher

Fixes VZ-5749

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
