### PR TITLE
No JIRA.  Align install/upgrade logic.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -65,7 +65,7 @@ func AppendOverrides(context spi.ComponentContext, _ string, _ string, _ string,
 }
 
 // PreInstall Create and label the NGINX namespace, and create any override helm args needed
-func PreInstall(compContext spi.ComponentContext, name string, namespace string, dir string) error {
+func PreInstall(compContext spi.ComponentContext, namespace string) error {
 	if compContext.IsDryRun() {
 		compContext.Log().Debug("NGINX PostInstall dry run")
 		return nil
@@ -86,7 +86,7 @@ func PreInstall(compContext spi.ComponentContext, name string, namespace string,
 }
 
 // PostInstall Patch the controller service ports based on any user-supplied overrides
-func PostInstall(ctx spi.ComponentContext, _ string, _ string) error {
+func PostInstall(ctx spi.ComponentContext) error {
 	if ctx.IsDryRun() {
 		ctx.Log().Debug("NGINX PostInstall dry run")
 		return nil

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -64,10 +64,10 @@ func AppendOverrides(context spi.ComponentContext, _ string, _ string, _ string,
 	return newKvs, nil
 }
 
-// PreInstall Create and label the NGINX namespace, and create any override helm args needed
-func PreInstall(compContext spi.ComponentContext, namespace string) error {
+// preInstall Create and label the NGINX namespace, and create any override helm args needed
+func preInstall(compContext spi.ComponentContext, namespace string) error {
 	if compContext.IsDryRun() {
-		compContext.Log().Debug("NGINX PostInstall dry run")
+		compContext.Log().Debug("NGINX postInstall dry run")
 		return nil
 	}
 	compContext.Log().Debug("Adding label needed by network policies to ingress-nginx namespace")
@@ -85,10 +85,10 @@ func PreInstall(compContext spi.ComponentContext, namespace string) error {
 	return nil
 }
 
-// PostInstall Patch the controller service ports based on any user-supplied overrides
-func PostInstall(ctx spi.ComponentContext) error {
+// postInstall Patch the controller service ports based on any user-supplied overrides
+func postInstall(ctx spi.ComponentContext) error {
 	if ctx.IsDryRun() {
-		ctx.Log().Debug("NGINX PostInstall dry run")
+		ctx.Log().Debug("NGINX postInstall dry run")
 		return nil
 	}
 	// Add any port specs needed to the service after boot

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
@@ -85,9 +85,9 @@ func (c nginxComponent) ValidateInstall(vz *vzapi.Verrazzano) error {
 }
 
 func (c nginxComponent) PreInstall(context spi.ComponentContext) error {
-	return PreInstall(context, c.HelmComponent.ResolveNamespace(c.ChartNamespace))
+	return preInstall(context, c.HelmComponent.ResolveNamespace(c.ChartNamespace))
 }
 
 func (c nginxComponent) PostInstall(context spi.ComponentContext) error {
-	return PostInstall(context)
+	return postInstall(context)
 }

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
@@ -48,9 +48,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall: true,
 			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), ValuesFileOverride),
-			PreInstallFunc:          PreInstall,
 			AppendOverridesFunc:     AppendOverrides,
-			PostInstallFunc:         PostInstall,
 			Dependencies:            []string{istio.ComponentName},
 		},
 	}
@@ -84,4 +82,12 @@ func (c nginxComponent) ValidateUpdate(old *vzapi.Verrazzano, new *vzapi.Verrazz
 // ValidateInstall checks if the specified Verrazzano CR is valid for this component to be installed
 func (c nginxComponent) ValidateInstall(vz *vzapi.Verrazzano) error {
 	return k8s.ValidateForExternalIPSWithNodePort(&vz.Spec, c.Name())
+}
+
+func (c nginxComponent) PreInstall(context spi.ComponentContext) error {
+	return PreInstall(context, c.HelmComponent.ResolveNamespace(c.ChartNamespace))
+}
+
+func (c nginxComponent) PostInstall(context spi.ComponentContext) error {
+	return PostInstall(context)
 }

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -109,13 +109,13 @@ func TestAppendNGINXOverridesExtraKVs(t *testing.T) {
 	assert.Len(t, kvs, 2)
 }
 
-// TestNGINXPreInstall tests the PreInstall fn
+// TestNGINXPreInstall tests the preInstall fn
 // GIVEN a call to this fn
-//  WHEN I call PreInstall
+//  WHEN I call preInstall
 //  THEN no errors are returned
 func TestNGINXPreInstall(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	err := PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), ComponentNamespace)
+	err := preInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), ComponentNamespace)
 	assert.NoError(t, err)
 }
 
@@ -183,8 +183,8 @@ func TestIsNGINXNotReady(t *testing.T) {
 	assert.False(t, isNginxReady(spi.NewFakeContext(fakeClient, nil, false)))
 }
 
-// TestPostInstallWithPorts tests the PostInstall function
-// GIVEN a call to PostInstall
+// TestPostInstallWithPorts tests the postInstall function
+// GIVEN a call to postInstall
 //  WHEN the VZ ingress has port overrides configured
 //  THEN no error is returned
 func TestPostInstallWithPorts(t *testing.T) {
@@ -235,12 +235,12 @@ func TestPostInstallWithPorts(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(svc).Build()
-	err := PostInstall(spi.NewFakeContext(fakeClient, vz, false))
+	err := postInstall(spi.NewFakeContext(fakeClient, vz, false))
 	assert.NoError(t, err)
 }
 
-// TestPostInstallNoPorts tests the PostInstall function
-// GIVEN a call to PostInstall
+// TestPostInstallNoPorts tests the postInstall function
+// GIVEN a call to postInstall
 //  WHEN the VZ ingress has no port overrides configured
 //  THEN no error is returned
 func TestPostInstallNoPorts(t *testing.T) {
@@ -255,16 +255,16 @@ func TestPostInstallNoPorts(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, vz, false)))
+	assert.NoError(t, postInstall(spi.NewFakeContext(fakeClient, vz, false)))
 }
 
-// TestPostInstallDryRun tests the PostInstall function
-// GIVEN a call to PostInstall
+// TestPostInstallDryRun tests the postInstall function
+// GIVEN a call to postInstall
 //  WHEN the context DryRun flag is true
 //  THEN no error is returned
 func TestPostInstallDryRun(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)))
+	assert.NoError(t, postInstall(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)))
 }
 
 // TestNewComponent tests the NewComponent function

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -115,7 +115,7 @@ func TestAppendNGINXOverridesExtraKVs(t *testing.T) {
 //  THEN no errors are returned
 func TestNGINXPreInstall(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	err := PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), ComponentName, ComponentNamespace, "")
+	err := PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), ComponentNamespace)
 	assert.NoError(t, err)
 }
 
@@ -235,7 +235,7 @@ func TestPostInstallWithPorts(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(svc).Build()
-	err := PostInstall(spi.NewFakeContext(fakeClient, vz, false), ComponentName, ComponentNamespace)
+	err := PostInstall(spi.NewFakeContext(fakeClient, vz, false))
 	assert.NoError(t, err)
 }
 
@@ -255,7 +255,7 @@ func TestPostInstallNoPorts(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, vz, false), ComponentName, ComponentNamespace))
+	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, vz, false)))
 }
 
 // TestPostInstallDryRun tests the PostInstall function
@@ -264,7 +264,7 @@ func TestPostInstallNoPorts(t *testing.T) {
 //  THEN no error is returned
 func TestPostInstallDryRun(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false), ComponentName, ComponentNamespace))
+	assert.NoError(t, PostInstall(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)))
 }
 
 // TestNewComponent tests the NewComponent function

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
@@ -93,6 +93,8 @@ func TestInstall(t *testing.T) {
 		},
 	}, false)
 	config.SetDefaultBomFilePath(testBomFilePath)
+	helmcli.SetCmdRunner(genericTestRunner{})
+	defer helmcli.SetDefaultRunner()
 	helm.SetUpgradeFunc(fakeUpgrade)
 	defer helm.SetDefaultUpgradeFunc()
 	helmcli.SetChartStateFunction(func(releaseName string, namespace string) (string, error) {

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_component.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_component.go
@@ -41,7 +41,6 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall: true,
 			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
 			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "weblogic-values.yaml"),
-			PreInstallFunc:          WeblogicOperatorPreInstall,
 			AppendOverridesFunc:     AppendWeblogicOperatorOverrides,
 			Dependencies:            []string{istio.ComponentName},
 		},
@@ -72,4 +71,12 @@ func (c weblogicComponent) IsReady(ctx spi.ComponentContext) bool {
 		return isWeblogicOperatorReady(ctx)
 	}
 	return false
+}
+
+func (c weblogicComponent) PreInstall(context spi.ComponentContext) error {
+	return WeblogicOperatorPreInstall(context, c.HelmComponent.ResolveNamespace(c.ChartNamespace))
+}
+
+func (c weblogicComponent) PreUpgrade(context spi.ComponentContext) error {
+	return WeblogicOperatorPreInstall(context, c.HelmComponent.ResolveNamespace(c.ChartNamespace))
 }

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
@@ -46,7 +46,7 @@ func AppendWeblogicOperatorOverrides(_ spi.ComponentContext, _ string, _ string,
 	return kvs, nil
 }
 
-func WeblogicOperatorPreInstall(ctx spi.ComponentContext, _ string, namespace string, _ string) error {
+func WeblogicOperatorPreInstall(ctx spi.ComponentContext, namespace string) error {
 	var serviceAccount corev1.ServiceAccount
 	const accountName = "weblogic-operator-sa"
 	c := ctx.Client()

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator_test.go
@@ -45,7 +45,7 @@ func Test_appendWeblogicOperatorOverridesExtraKVs(t *testing.T) {
 //  THEN no errors are returned
 func Test_weblogicOperatorPreInstall(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	err := WeblogicOperatorPreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), "weblogic-operator", "verrazzano-system", "")
+	err := WeblogicOperatorPreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, false), "verrazzano-system")
 	assert.NoError(t, err)
 }
 

--- a/platform-operator/controllers/verrazzano/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/fake_component_test.go
@@ -50,10 +50,7 @@ func (f fakeComponent) GetDependencies() []string {
 	return f.Dependencies
 }
 
-func (f fakeComponent) PreUpgrade(ctx spi.ComponentContext) error {
-	if f.PreUpgradeFunc != nil {
-		return f.PreUpgrade(ctx)
-	}
+func (f fakeComponent) PreUpgrade(_ spi.ComponentContext) error {
 	return nil
 }
 
@@ -69,9 +66,6 @@ func (f fakeComponent) PostUpgrade(_ spi.ComponentContext) error {
 }
 
 func (f fakeComponent) PreInstall(ctx spi.ComponentContext) error {
-	if f.PreInstallFunc != nil {
-		return f.PreInstallFunc(ctx, f.ReleaseName, f.ChartNamespace, f.ChartDir)
-	}
 	return nil
 }
 
@@ -83,9 +77,6 @@ func (f fakeComponent) Install(ctx spi.ComponentContext) error {
 }
 
 func (f fakeComponent) PostInstall(ctx spi.ComponentContext) error {
-	if f.PostInstallFunc != nil {
-		return f.PostInstallFunc(ctx, f.ReleaseName, f.ChartNamespace)
-	}
 	return nil
 }
 
@@ -96,11 +87,11 @@ func (f fakeComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return getBool(f.installed, "installed"), nil
 }
 
-func (f fakeComponent) IsReady(x spi.ComponentContext) bool {
+func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
 	return getBool(f.ready, "ready")
 }
 
-func (f fakeComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
+func (f fakeComponent) IsEnabled(_ *vzapi.Verrazzano) bool {
 	return getBool(f.enabled, "enabled")
 }
 


### PR DESCRIPTION
# Description

Consolidate the `HelmComponent` `Upgrade` and `Install` methods.  Largely, these methods do the same thing with the exception that during upgrade, we get the existing values for an installed release.  Both use `helm upgrade --install` under the covers.

Consolidating them around the same impl should limit the potential for bugs due to different logic between the upgrade and install paths, until we can do more consolidation there.

Change details:

- Refactor Upgrade and Install calls to share the same logic
- If the helm release exists, build the existing values overrides file (upgrade existing install case)
- Remove remaining obsolete `HelmComponent` func callback hooks
- Update related components


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
