### PR TITLE
VZ-5282 removed deletion of crds during vz uninstall 

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -48,12 +48,6 @@ function uninstall_istio() {
   log "Deleting Istio Cluster Roles"
   delete_k8s_resources clusterrole ":metadata.name" "Could not delete ClusterRoles from Istio" '/istio-system|istio-reader|istiocoredns/ {print $1}' \
     || return $? # return on pipefail
-
-      # delete istio crds
-  #log "Deleting Istio Custom Resource Definitions"
-  #delete_k8s_resources crd ":metadata.name" "Could not delete CustomResourceDefinition from Istio" '/istio.io/ {print $1}' \
-  #  || return $? # return on pipefail
-
 }
 
 function delete_secrets() {

--- a/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/1-uninstall-istio.sh
@@ -50,9 +50,9 @@ function uninstall_istio() {
     || return $? # return on pipefail
 
       # delete istio crds
-  log "Deleting Istio Custom Resource Definitions"
-  delete_k8s_resources crd ":metadata.name" "Could not delete CustomResourceDefinition from Istio" '/istio.io/ {print $1}' \
-    || return $? # return on pipefail
+  #log "Deleting Istio Custom Resource Definitions"
+  #delete_k8s_resources crd ":metadata.name" "Could not delete CustomResourceDefinition from Istio" '/istio.io/ {print $1}' \
+  #  || return $? # return on pipefail
 
 }
 

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -44,9 +44,9 @@ function delete_cert_manager() {
     || err_return $? "Could not delete cert-manager from helm" || return $? # return on pipefail
 
   # delete the custom resource definition for cert manager
-  log "Deleting the custom resource definition for cert manager"
-  kubectl delete -f "${MANIFESTS_DIR}/cert-manager/cert-manager.crds.yaml" --ignore-not-found=true \
-    || err_return $? "Could not delete CustomResourceDefinition from cert-manager" || return $?
+  #log "Deleting the custom resource definition for cert manager"
+  #kubectl delete -f "${MANIFESTS_DIR}/cert-manager/cert-manager.crds.yaml" --ignore-not-found=true \
+  #  || err_return $? "Could not delete CustomResourceDefinition from cert-manager" || return $?
 
   # delete cert manager config map
   log "Deleting config map for cert manager"
@@ -112,25 +112,25 @@ function delete_rancher() {
     | sh \
     || err_return $? "There were errors deleting rancher CRs"  # Continue if failures
 
-  log "Deleting CRDs from Rancher"
+  #log "Deleting CRDs from Rancher"
 
-  local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
+  #local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
 
-  while [ "$crd_content" ]
-  do
+  #while [ "$crd_content" ]
+  #do
     # remove finalizers from crds
     # Ignore patch failures and attempt to delete the resources anyway.
-    patch_k8s_resources crds ":metadata.name,:spec.group" "Could not remove finalizers from CustomResourceDefinitions in Rancher" '/coreos.com|cattle.io/ {print $1}' '{"metadata":{"finalizers":null}}' \
-      || true
+  #  patch_k8s_resources crds ":metadata.name,:spec.group" "Could not remove finalizers from CustomResourceDefinitions in Rancher" '/coreos.com|cattle.io/ {print $1}' '{"metadata":{"finalizers":null}}' \
+  #    || true
 
     # delete crds
     # This process is backgrounded in order to timeout due to finalizers hanging
-    delete_k8s_resources crds ":metadata.name,:spec.group" "Could not delete CustomResourceDefinitions from Rancher" '/coreos.com|management.cattle.io|cattle.io|fleet/ {print $1}' \
-      || return $? &# return on pipefail
-    sleep 30
-    kill $! || true
-    crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
-  done
+  #  delete_k8s_resources crds ":metadata.name,:spec.group" "Could not delete CustomResourceDefinitions from Rancher" '/coreos.com|management.cattle.io|cattle.io|fleet/ {print $1}' \
+  #    || return $? &# return on pipefail
+  #  sleep 30
+  #  kill $! || true
+  #  crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
+  #done
 
   # delete ClusterRoleBindings deployed by rancher
   log "Deleting ClusterRoleBindings"

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -43,11 +43,6 @@ function delete_cert_manager() {
     | xargsr helm uninstall -n cert-manager \
     || err_return $? "Could not delete cert-manager from helm" || return $? # return on pipefail
 
-  # delete the custom resource definition for cert manager
-  #log "Deleting the custom resource definition for cert manager"
-  #kubectl delete -f "${MANIFESTS_DIR}/cert-manager/cert-manager.crds.yaml" --ignore-not-found=true \
-  #  || err_return $? "Could not delete CustomResourceDefinition from cert-manager" || return $?
-
   # delete cert manager config map
   log "Deleting config map for cert manager"
   kubectl delete configmap cert-manager-controller -n kube-system --ignore-not-found=true || err_return $? "Could not delete ConfigMap from cert-manager-controller" || return $?
@@ -111,26 +106,6 @@ function delete_rancher() {
     | awk '{res="";if ($1 != "") res=tolower($1)".management.cattle.io "tolower($2); if ($3 != "<none>" && res != "") res=res" -n "$3; if (res != "") cmd="kubectl patch "res" -p \x027{\"metadata\":{\"finalizers\":null}}\x027 --type=merge;kubectl delete --ignore-not-found "res; print cmd}' \
     | sh \
     || err_return $? "There were errors deleting rancher CRs"  # Continue if failures
-
-  #log "Deleting CRDs from Rancher"
-
-  #local crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
-
-  #while [ "$crd_content" ]
-  #do
-    # remove finalizers from crds
-    # Ignore patch failures and attempt to delete the resources anyway.
-  #  patch_k8s_resources crds ":metadata.name,:spec.group" "Could not remove finalizers from CustomResourceDefinitions in Rancher" '/coreos.com|cattle.io/ {print $1}' '{"metadata":{"finalizers":null}}' \
-  #    || true
-
-    # delete crds
-    # This process is backgrounded in order to timeout due to finalizers hanging
-  #  delete_k8s_resources crds ":metadata.name,:spec.group" "Could not delete CustomResourceDefinitions from Rancher" '/coreos.com|management.cattle.io|cattle.io|fleet/ {print $1}' \
-  #    || return $? &# return on pipefail
-  #  sleep 30
-  #  kill $! || true
-  #  crd_content=$(kubectl get crds --no-headers -o custom-columns=":metadata.name,:spec.group" | awk '/coreos.com|cattle.io/')
-  #done
 
   # delete ClusterRoleBindings deployed by rancher
   log "Deleting ClusterRoleBindings"

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -36,10 +36,6 @@ function delete_verrazzano() {
   patch_k8s_resources crds ":metadata.name" "Could not remove finalizers from CustomResourceDefinitions in Verrazzano" '/verrazzano.io/' '{"metadata":{"finalizers":null}}' \
     || return $? # return on pipefail
 
-  #log "Deleting Verrazzano crds"
-  #delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/ && ! /verrazzanos.install.verrazzano.io/ && ! /verrazzanomanagedclusters.clusters.verrazzano.io/' \
-  #  || return $? # return on pipefail
-
   log "Deleting ClusterRoleBindings"
   # deleting clusterrolebindings
   delete_k8s_resources clusterrolebinding ":metadata.name,:metadata.labels" "Could not delete ClusterRoleBindings from Verrazzano" '/verrazzano/ && ! /verrazzano-platform-operator/ && ! /verrazzano-install/ && ! /verrazzano-managed-cluster/ {print $1}' \
@@ -137,8 +133,6 @@ function delete_kiali {
       error "Failed to uninstall Kiali."
     fi
   fi
-  # log "Deleting Kiali Custom Resource Definitions"
-  # kubectl delete -f ${KIALI_CHART_DIR}/crds || true
 }
 
 function delete_prometheus_adapter {

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -36,9 +36,9 @@ function delete_verrazzano() {
   patch_k8s_resources crds ":metadata.name" "Could not remove finalizers from CustomResourceDefinitions in Verrazzano" '/verrazzano.io/' '{"metadata":{"finalizers":null}}' \
     || return $? # return on pipefail
 
-  log "Deleting Verrazzano crds"
-  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/ && ! /verrazzanos.install.verrazzano.io/ && ! /verrazzanomanagedclusters.clusters.verrazzano.io/' \
-    || return $? # return on pipefail
+  #log "Deleting Verrazzano crds"
+  #delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Verrazzano" '/verrazzano.io/ && ! /verrazzanos.install.verrazzano.io/ && ! /verrazzanomanagedclusters.clusters.verrazzano.io/' \
+  #  || return $? # return on pipefail
 
   log "Deleting ClusterRoleBindings"
   # deleting clusterrolebindings
@@ -137,8 +137,8 @@ function delete_kiali {
       error "Failed to uninstall Kiali."
     fi
   fi
-  log "Deleting Kiali Custom Resource Definitions"
-  kubectl delete -f ${KIALI_CHART_DIR}/crds || true
+  # log "Deleting Kiali Custom Resource Definitions"
+  # kubectl delete -f ${KIALI_CHART_DIR}/crds || true
 }
 
 function delete_prometheus_adapter {


### PR DESCRIPTION
# Description

Verrazzano uninstallation should not delete crds of multiple components. eg Kiali, Rancher, Istio etc  

Fixes [VZ-5282](https://jira.oraclecorp.com/jira/browse/VZ-5282)

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
