### PR TITLE
VZ-5671 uninstall cleanup CRDs

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -71,6 +71,15 @@ function delete_verrazzano() {
   delete_managed_k8s_resources traitdefinitions.core.oam.dev
   delete_managed_k8s_resources workloaddefinitions.core.oam.dev
   delete_managed_k8s_resources scopedefinitions.core.oam.dev
+
+  # Delete coherence.coherence.oracle.com and domains.weblogic.oracle CRDs
+  log "Deleting Oracle crds"
+  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from Oracle" '/oracle/' \
+    || return $? # return on pipefail
+  # Delete coherence.coherence.oracle.com and domains.weblogic.oracle CRDs
+  log "Deleting core.oam.dev crds"
+  delete_k8s_resources crds ":metadata.name" "Could not delete CustomResourceDefinitions from core.oam.dev" '/core.oam.dev/' \
+    || return $? # return on pipefail
 }
 
 function delete_oam_operator {

--- a/tests/e2e/config/scripts/looping-test/types.txt
+++ b/tests/e2e/config/scripts/looping-test/types.txt
@@ -6,3 +6,5 @@ APIService
 ClusterRoleBinding
 ClusterRole
 RoleBinding
+TraitDefinition
+WorkloadDefinition

--- a/tests/e2e/config/scripts/looping-test/verify_uninstall.sh
+++ b/tests/e2e/config/scripts/looping-test/verify_uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 if [ -z "$1" ] ; then
@@ -22,5 +22,17 @@ else
 fi
 
 if [ "$DIFF_FOUND" == true ] ; then
+  exit 1
+fi
+
+OAM_CRD=$(kubectl get crds | grep "core.oam.dev")
+echo "Remaining core.oam.dev CRDs:"
+echo $OAM_CRD
+if [ -z "$OAM_CRD" ] ; then
+  echo "No core.oam.dev CRDs found as expected"
+else
+  OAM_CRD_FOUND=true
+fi
+if [ "$OAM_CRD_FOUND" == true ] ; then
   exit 1
 fi


### PR DESCRIPTION
# Description

Fix uninstall to cleanup CRDs:
- applicationconfigurations.core.oam.dev  
- coherence.coherence.oracle.com           
- components.core.oam.dev                 
- containerizedworkloads.core.oam.dev    
- domains.weblogic.oracle               
- healthscopes.core.oam.dev               
- manualscalertraits.core.oam.dev       
- scopedefinitions.core.oam.dev          
- traitdefinitions.core.oam.dev         
- workloaddefinitions.core.oam.dev      


Fixes VZ-5671

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
