### PR TITLE
VZ-5717 Verify Install test for arbitrary Helm values

### DIFF
--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -109,12 +109,11 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Creating Override Secret"
-kubectl create secret test-overrides --from-file=${TEST_OVERRIDE_SECRET_FILE}
+kubectl create secret generic test-overrides --from-file=${TEST_OVERRIDE_SECRET_FILE}
 if [ $? -ne 0 ]; then
   echo "Could not create Override Secret"
   exit 1
 fi
-
 
 echo "Installing Verrazzano on Kind"
 install_retries=0

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -18,6 +18,7 @@ fi
 INSTALL_CALICO=${1:-false}
 WILDCARD_DNS_DOMAIN=${2:-"x=nip.io"}
 KIND_NODE_COUNT=${KIND_NODE_COUNT:-1}
+TEST_OVERRIDES_FILE="./tests/e2e/config/scripts/test-overrides.yaml"
 
 cd ${GO_REPO_PATH}/verrazzano
 echo "tests will execute" > ${TESTS_EXECUTED_FILE}
@@ -96,6 +97,13 @@ cd ${GO_REPO_PATH}/verrazzano
 kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
 if [ $? -ne 0 ]; then
   echo "Operator is not ready"
+  exit 1
+fi
+
+echo "Creating Override ConfigMap"
+kubectl create cm test-overrides --from-file=${TEST_OVERRIDES_FILE}
+if [ $? -ne 0 ]; then
+  echo "Could not create Override ConfigMap"
   exit 1
 fi
 

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -18,7 +18,8 @@ fi
 INSTALL_CALICO=${1:-false}
 WILDCARD_DNS_DOMAIN=${2:-"x=nip.io"}
 KIND_NODE_COUNT=${KIND_NODE_COUNT:-1}
-TEST_OVERRIDES_FILE="./tests/e2e/config/scripts/test-overrides.yaml"
+TEST_OVERRIDE_CONFIGMAP_FILE="./tests/e2e/config/scripts/test-overrides-configmap.yaml"
+TEST_OVERRIDE_SECRET_FILE="./tests/e2e/config/scripts/test-overrides-secret.yaml"
 
 cd ${GO_REPO_PATH}/verrazzano
 echo "tests will execute" > ${TESTS_EXECUTED_FILE}
@@ -101,11 +102,19 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Creating Override ConfigMap"
-kubectl create cm test-overrides --from-file=${TEST_OVERRIDES_FILE}
+kubectl create cm test-overrides --from-file=${TEST_OVERRIDE_CONFIGMAP_FILE}
 if [ $? -ne 0 ]; then
   echo "Could not create Override ConfigMap"
   exit 1
 fi
+
+echo "Creating Override Secret"
+kubectl create secret test-overrides --from-file=${TEST_OVERRIDE_SECRET_FILE}
+if [ $? -ne 0 ]; then
+  echo "Could not create Override Secret"
+  exit 1
+fi
+
 
 echo "Installing Verrazzano on Kind"
 install_retries=0

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -10,6 +10,10 @@ spec:
   components:
     prometheusOperator:
       enabled: true
+      overrides:
+        - configMapRef:
+            name: test-overrides
+            key: test-overrides.yaml
     prometheusAdapter:
       enabled: true
     kubeStateMetrics:

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -13,7 +13,10 @@ spec:
       overrides:
         - configMapRef:
             name: test-overrides
-            key: test-overrides.yaml
+            key: test-overrides-configmap.yaml
+        - secretRef:
+            name: test-overrides
+            key: test-overrides-secret.yaml
     prometheusAdapter:
       enabled: true
     kubeStateMetrics:

--- a/tests/e2e/config/scripts/test-overrides-configmap.yaml
+++ b/tests/e2e/config/scripts/test-overrides-configmap.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+prometheusOperator:
+  podLabels:
+    override: "true"

--- a/tests/e2e/config/scripts/test-overrides-secret.yaml
+++ b/tests/e2e/config/scripts/test-overrides-secret.yaml
@@ -2,5 +2,5 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 prometheusOperator:
-  podLabels:
-    label-override: "true"
+  podAnnotations:
+    override: "true"

--- a/tests/e2e/config/scripts/test-overrides.yaml
+++ b/tests/e2e/config/scripts/test-overrides.yaml
@@ -3,4 +3,4 @@
 
 prometheusOperator:
   podLabels:
-    label-override: true
+    label-override: "true"

--- a/tests/e2e/config/scripts/test-overrides.yaml
+++ b/tests/e2e/config/scripts/test-overrides.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+prometheusOperator:
+  podLabels:
+    - label-override: true

--- a/tests/e2e/config/scripts/test-overrides.yaml
+++ b/tests/e2e/config/scripts/test-overrides.yaml
@@ -3,4 +3,4 @@
 
 prometheusOperator:
   podLabels:
-    - label-override: true
+    label-override: true

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -25,7 +25,6 @@ const (
 	prometheusOperatorDeployment    = "prometheus-operator-kube-p-operator"
 	prometheusOperatorContainerName = "kube-prometheus-stack"
 	overrideConfigMap               = "test-overrides"
-	overrideKey                     = "test-overrides.yaml"
 )
 
 type enabledFunc func(string) bool

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -152,9 +152,11 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 						}
 						foundAnnotation := false
 						for _, pod := range pods {
-							if pod.Annotations[]
+							if val, ok := pod.Annotations[overrideKey]; ok && val == overrideValue {
+								foundAnnotation = true
+							}
 						}
-						return len(result) == 1
+						return len(pods) == 1 && foundAnnotation
 					} else if !k8serrors.IsNotFound(err) {
 						AbortSuite(fmt.Sprintf("Error retrieving the override ConfigMap: %v", err))
 					}

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -5,16 +5,16 @@ package promstack
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -137,8 +137,8 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 		})
 
 		// GIVEN the Prometheus stack is installed
-		// WHEN we check to make sure the pods are running
-		// THEN we successfully find the running pods
+		// WHEN we check to make sure the operator overrides get applied
+		// THEN we see that the correct pod labels and annotations exist
 		WhenPromStackInstalledIt("should have Prometheus Operator pod labeled and annotated", func() {
 			promStackPodsRunning := func() bool {
 				if isPrometheusOperatorEnabled() {


### PR DESCRIPTION
# Description
This adds a verify install test for Arbitrary helm values. If they are present, the newly created label and annotation should be available.

Fixes VZ-5717

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
