### PR TITLE
VZ-5672.  Add update scenario to new upgrade pipeline

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -563,9 +563,7 @@ def runGinkgoRandomize(testSuitePath, kubeConfig = '') {
                 export KUBECONFIG="${kubeConfig}"
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
-            fi
+            ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -563,7 +563,9 @@ def runGinkgoRandomize(testSuitePath, kubeConfig = '') {
                 export KUBECONFIG="${kubeConfig}"
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            if [ -d "${testSuitePath}" ]; then
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            fi
         """
     }
 }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -961,6 +961,11 @@ def upgradeVerrazzanoOnCluster(count, verrazzanoDevVersion) {
                 cd ${GO_REPO_PATH}/verrazzano
                 cp ${v8oInstallFile} ${v8oUpgradeFile}
                 ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${verrazzanoDevVersion}  ${v8oUpgradeFile}
+
+                # Add some simple additional updates to validate update during an upgrade
+                yq -i eval '.spec.components.istio.ingress.kubernetes.replicas = 3' ${v8oUpgradeFile}
+                yq -i eval '.spec.components.istio.egress.kubernetes.replicas = 3' ${v8oUpgradeFile}
+
                 # Do the upgrade
                 echo "Following is the verrazzano CR file with the new version:"
                 cat ${v8oUpgradeFile}

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -445,6 +445,11 @@ pipeline {
                         upgradePlatformOperator()
                     }
                 }
+                stage("verify-upgrade-required") {
+                    steps {
+                        runGinkgoRandomize('upgrade/pre-upgrade/verify-upgrade-required')
+                    }
+                }
                 stage("upgrade-verrazzano") {
                     steps {
                         upgradeVerrazzano()

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -322,7 +322,11 @@ pipeline {
                 }
             }
         }
-
+        stage("Verify Upgrade Required") {
+            steps {
+                runGinkgoSerial('upgrade/pre-upgrade/verify-upgrade-required')
+            }
+        }
         stage("Upgrade Verrazzano") {
             environment {
                 UPGRADE_CR="${WORKSPACE}/verrazzano-upgrade-cr.yaml"

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -297,6 +297,15 @@ func GetVerrazzanoManagedClusterClientset() (*vmcClient.Clientset, error) {
 	return vmcClient.NewForConfig(config)
 }
 
+// GetVerrazzanoClientset returns the Kubernetes clientset for the Verrazzano CRD
+func GetVerrazzanoClientset() (*vpoClient.Clientset, error) {
+	config, err := k8sutil.GetKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return vpoClient.NewForConfig(config)
+}
+
 // GetVerrazzanoProjectClientsetInCluster returns the Kubernetes clientset for the VerrazzanoProject
 func GetVerrazzanoProjectClientsetInCluster(kubeconfigPath string) (*vpClient.Clientset, error) {
 	config, err := k8sutil.GetKubeConfigGivenPath(kubeconfigPath)

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verify
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestVerifyUpgradeRequiredWithUpdate(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Verify upgrade required checks.")
+}

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verify
+
+import (
+	"context"
+	"fmt"
+	vzalpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const minimumVersion = "1.3.0"
+
+//var waitTimeout = 15 * time.Minute
+//var pollingInterval = 30 * time.Second
+//var shortPollingInterval = 10 * time.Second
+
+var t = framework.NewTestFramework("verify")
+
+var _ = t.BeforeSuite(func() {
+	start := time.Now()
+	beforeSuitePassed = true
+	metrics.Emit(t.Metrics.With("before_suite_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var failed = false
+var beforeSuitePassed = false
+
+var _ = t.AfterEach(func() {
+	failed = failed || framework.VzCurrentGinkgoTestDescription().Failed()
+})
+
+var _ = t.AfterSuite(func() {
+	start := time.Now()
+	if failed || !beforeSuitePassed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
+	metrics.Emit(t.Metrics.With("after_suite_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var _ = t.Describe("Verify upgrade required before update is allowed", Label("f:platform-lcm.upgrade", "f:observability.monitoring.prom"), func() {
+
+	// This is a very-specific check, which expects to run in the situation where we've updated the VPO to a
+	// newer version but have not yet run an upgrade.
+
+	// This is only valid for Release 1.3+, but we have no way to guard that in code since we don't have visibility into the
+	// BOM version in the platform operator; we only have what's in the Spec and the Status version fields.
+
+	// Verify that an edit to the system configuration is rejected when an upgrade is available but not yet applied
+	// GIVEN a Verrazzano install
+	// WHEN an edit is made without an upgrade, but an upgrade to a newer version is available
+	// THEN the edit is rejected by the webhook
+	t.Context("Verify upgrade-required checks", func() {
+		t.It("Upgrade required check", func() {
+			vz, err := pkg.GetVerrazzano()
+			if err != nil {
+				t.Fail(fmt.Sprintf("Error getting Verrazzano instance: %s", err.Error()))
+				return
+			}
+
+			if vz.Spec.Components.Istio == nil {
+				vz.Spec.Components.Istio = &vzalpha1.IstioComponent{}
+			}
+			istio := vz.Spec.Components.Istio
+			if istio.Ingress == nil {
+				istio.Ingress = &vzalpha1.IstioIngressSection{
+					Kubernetes: &vzalpha1.IstioKubernetesSection{},
+				}
+			}
+			if istio.Egress == nil {
+				istio.Egress = &vzalpha1.IstioEgressSection{
+					Kubernetes: &vzalpha1.IstioKubernetesSection{},
+				}
+			}
+			istio.Ingress.Kubernetes.Replicas = 3
+			istio.Egress.Kubernetes.Replicas = 3
+
+			vzclient, err := pkg.GetVerrazzanoClientset()
+			if err != nil {
+				t.Fail(fmt.Sprintf("Error getting Verrazzano client: %s", err.Error()))
+				return
+			}
+
+			// This should fail with a webhook validation error
+			_, err = vzclient.VerrazzanoV1alpha1().Verrazzanos(vz.Namespace).Update(context.TODO(), vz, v1.UpdateOptions{})
+			Expect(err).Should(Not(BeNil()))
+		})
+	})
+})

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-const minimumVersion = "1.3.0"
-
 //var waitTimeout = 15 * time.Minute
 //var pollingInterval = 30 * time.Second
 //var shortPollingInterval = 10 * time.Second

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-//var waitTimeout = 15 * time.Minute
-//var pollingInterval = 30 * time.Second
-//var shortPollingInterval = 10 * time.Second
-
 var t = framework.NewTestFramework("verify")
 
 var _ = t.BeforeSuite(func() {


### PR DESCRIPTION
# Description

Add update scenario to new upgrade pipeline, and add a new e2e test to test the upgrade validator logic.
- adds simple update-during-upgrade config change to upgrade CR
- New test validates that an upgrade is required before any other update can be applied; runs post-VPO upgrade, but before we upgrade the VZ install

Fixes VZ-5762.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
