### PR TITLE
No JIRA.  Remove Rancher additional images from BOM validator ignore list

### DIFF
--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 )
 
 const tagLen = 10                                                          // The number of unique tags for a specific image
@@ -40,8 +42,18 @@ type imageError struct {
 	clusterImageTags [tagLen]string
 }
 
-var ignoreSubComponents = []string{
-	"additional-rancher",
+var ignoreSubComponents = []string{}
+
+// Hack to work around an issue with the 1.2 upgrade; Rancher does not always update the webhook image
+type knownIssues struct {
+	alternateTags  []string
+	warningMessage string
+}
+
+// Mainly a workaround for Rancher additional images; Rancher does not always update to the latest version
+// in the BOM file, if their minimum-version requirements are met by what's deployed at upgrade time
+var knownImageIssues = map[string]knownIssues{
+	"rancher-webhook": {alternateTags: []string{"v0.1.1", "v0.1.2", "v0.1.4"}, warningMessage: "VZ-5937 - Known issue, Rancher webhook not at expected version"},
 }
 
 func main() {
@@ -49,6 +61,7 @@ func main() {
 	var imagesInstalled = make(map[string][tagLen]string) // Map that contains the images installed into the cluster with associated set of tags
 	var imageTagErrors = make(map[string]imageError)      // Map of image names that match but tags don't  Failure Condition
 	var imagesNotFound = make(map[string]string)          // Map of image names not found in cluster. Informational.  This may be valid based on profile
+	var imageWarnings = make(map[string]string)           // Map of image names not found in cluster. Informational.  This may be valid based on profile
 
 	// Validate KubeConfig
 	if !validateKubeConfig() {
@@ -66,10 +79,10 @@ func main() {
 	populateMapWithInitContainerImages(imagesInstalled)
 
 	//  Loop through BOM and check against cluster images
-	isBOMValid := validateBOM(&vBom, imagesInstalled, imagesNotFound, imageTagErrors)
+	isBOMValid := validateBOM(&vBom, imagesInstalled, imagesNotFound, imageTagErrors, imageWarnings)
 
 	// Write to stdout
-	reportResults(imagesNotFound, imageTagErrors, isBOMValid)
+	reportResults(imagesNotFound, imageTagErrors, imageWarnings, isBOMValid)
 
 	//Failure
 	if !isBOMValid {
@@ -129,7 +142,7 @@ func getBOM(vBom *verrazzanoBom) {
 		log.Fatal("Error retrieving BOM from platform operator, zero length\n")
 	}
 
-	json.Unmarshal([]byte(out), &vBom)
+	json.Unmarshal(out, &vBom)
 
 }
 
@@ -162,7 +175,7 @@ func populateMapWithInitContainerImages(clusterImageMap map[string][tagLen]strin
 //    Valid, Tags match
 //    Not Found, OK based on profile
 //    InValid, image tags between BOM and cluster image do not match
-func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][tagLen]string, imagesNotFound map[string]string, imageTagErrors map[string]imageError) bool {
+func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][10]string, imagesNotFound map[string]string, imageTagErrors map[string]imageError, imageWarnings map[string]string) bool {
 	var errorsFound bool = false
 	for _, component := range vBom.Components {
 		for _, subcomponent := range component.Subcomponents {
@@ -172,9 +185,15 @@ func validateBOM(vBom *verrazzanoBom, clusterImageMap map[string][tagLen]string,
 			}
 			for _, image := range subcomponent.Images {
 				if tags, ok := clusterImageMap[image.Image]; ok {
-					var tagFound bool = false
+					var tagFound = false
 					for _, tag := range tags {
 						if tag == image.Tag {
+							tagFound = true
+							break
+						}
+						imageWarning, hasKnownIssues := knownImageIssues[image.Image]
+						if hasKnownIssues && vzstring.SliceContainsString(imageWarning.alternateTags, tag) {
+							imageWarnings[image.Image] = fmt.Sprintf("Known issue for image %s, tag: %s, message: %s", image.Image, tag, imageWarning.warningMessage)
 							tagFound = true
 							break
 						}
@@ -206,20 +225,28 @@ func ignoreSubComponent(name string) bool {
 // Report out the findings
 // ImagesNotFound is informational
 // imageTagErrors is a failure condition
-func reportResults(imagesNotFound map[string]string, imageTagErrors map[string]imageError, isBOMValid bool) {
+func reportResults(imagesNotFound map[string]string, imageTagErrors map[string]imageError, warnings map[string]string, isBOMValid bool) {
 	// Dump Images Not Found to Console, Informational
 
-	fmt.Println("Images From BOM not found in the cluster")
+	fmt.Println()
+	fmt.Println("Images From BOM not installed in cluster")
 	fmt.Println("----------------------------------------")
 	for name, tag := range imagesNotFound {
-		fmt.Printf("Image From BOM not found in cluster! Image Name = %s, Tag from BOM = %s\n", name, tag)
+		fmt.Printf("Image not installed: %s:%s\n", name, tag)
 	}
+	fmt.Println()
+	fmt.Println("Image Warnings - Tags not at expected BOM level due to known issues")
+	fmt.Println("----------------------------------------")
+	for name, msg := range warnings {
+		fmt.Printf("Warning: Image Name = %s: %s\n", name, msg)
+	}
+	fmt.Println()
 	// Dump Images that don't match BOM, Failure
 	if !isBOMValid {
-		fmt.Println("BOM Images that don't match Cluster Images")
+		fmt.Println("Image Errors: BOM Images that don't match Cluster Images")
 		fmt.Println("----------------------------------------")
 		for name, tags := range imageTagErrors {
-			fmt.Printf("Verrazzano Image Check Failure! Image Name = %s, Tag from BOM = %s  Tag from Cluster = %+v\n", name, tags.bomImageTag, tags.clusterImageTags)
+			fmt.Printf("Check failed! Image Name = %s, Tag from BOM = %s  Tag from Cluster = %v\n", name, tags.bomImageTag, tags.clusterImageTags)
 		}
 	}
 }


### PR DESCRIPTION
# Description

Remove Rancher additional-images from BOM validator ignore list.

This also repurposes ignore list for "known-issues" tracking for cases that we are tracking.  This will allow putting a set of images/tags in a "known issues" struct, and we'll spit out non-fatal warnings for those cases.

Current issue causing the need for this:
- when upgrading from 1.0.0, Rancher will not update rancher-webhook to the version in the BOM `v0.1.2`
- We don't have control over this at present; all patch lines up to 1.2.1 use v0.1.2, so it's mainly for cases upgrading from v1.0.x
- We have an open issue to track getting more control over the Rancher additional images that they use like this


# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
