### PR TITLE
VZ 5801: Configure Istio Tracing

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -178,7 +178,7 @@ func (i istioComponent) Upgrade(context spi.ComponentContext) error {
 	vz := context.EffectiveCR()
 	defer os.Remove(tmpFile.Name())
 	if vz.Spec.Components.Istio != nil {
-		istioOperatorYaml, err := BuildIstioOperatorYaml(vz.Spec.Components.Istio)
+		istioOperatorYaml, err := BuildIstioOperatorYaml(context, vz.Spec.Components.Istio)
 		if err != nil {
 			return log.ErrorfNewErr("Failed to Build IstioOperator YAML: %v", err)
 		}
@@ -306,46 +306,6 @@ func removeIstioHelmSecrets(compContext spi.ComponentContext) error {
 	return nil
 }
 
-func appendJaegerCollectorArg(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
-	if !vzconfig.IsJaegerOperatorEnabled(ctx.EffectiveCR()) {
-		return kvs, nil
-	}
-
-	services := &v1.ServiceList{}
-	selector := clipkg.MatchingLabels{
-		constants.KubernetesAppLabel: constants.JaegerCollectorService,
-	}
-	if err := ctx.Client().List(context.TODO(), services, selector); err != nil {
-		return kvs, err
-	}
-
-	for _, service := range services.Items {
-		// do not use the headless service
-		if !strings.Contains(service.Name, "headless") {
-			port := zipkinPort(service)
-			collectorURL := fmt.Sprintf("%s.%s.svc.cluster.local:%d",
-				service.Name,
-				service.Namespace,
-				port,
-			)
-			kvs = append(kvs, bom.KeyValue{
-				Key:   "meshConfig.defaultConfig.tracing.zipkin.address",
-				Value: collectorURL,
-			},
-				bom.KeyValue{
-					Key:   "meshConfig.defaultConfig.tracing.tlsSettings.mode",
-					Value: "ISTIO_MUTUAL",
-				},
-				bom.KeyValue{
-					Key:   "meshConfig.enableTracing",
-					Value: "true",
-				})
-			return kvs, nil
-		}
-	}
-	return kvs, nil
-}
-
 //zipkinPort retrieves the zipkin port from the service, if it is present. Defaults to 9411 for Jaeger collector
 func zipkinPort(service v1.Service) int32 {
 	for _, port := range service.Spec.Ports {
@@ -360,10 +320,6 @@ func getOverridesString(ctx spi.ComponentContext) (string, error) {
 	var kvs []bom.KeyValue
 	// check for global image pull secret
 	kvs, err := secret.AddGlobalImagePullSecretHelmOverride(ctx.Log(), ctx.Client(), IstioNamespace, kvs, imagePullSecretHelmKey)
-	if err != nil {
-		return "", err
-	}
-	kvs, err = appendJaegerCollectorArg(ctx, kvs)
 	if err != nil {
 		return "", err
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -6,7 +6,6 @@ package istio
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/bom"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/types"
 	"os/exec"
@@ -780,94 +779,6 @@ func Test_istioComponent_ValidateInstall(t *testing.T) {
 			if err := c.ValidateInstall(tt.vz); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateInstall() error = %v, wantErr %v", err, tt.wantErr)
 			}
-		})
-	}
-}
-
-func TestAppendJaegerCollectorArg(t *testing.T) {
-	c1 := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	collectorLabels := map[string]string{
-		constants.KubernetesAppLabel: constants.JaegerCollectorService,
-	}
-	namespace := "foo"
-	cWithServices := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).
-		WithObjects(&v1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "jaeger-collector-headless",
-				Labels:    collectorLabels,
-			},
-		},
-			&v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "jaeger-collector",
-					Labels:    collectorLabels,
-				},
-				Spec: v1.ServiceSpec{
-					Ports: []v1.ServicePort{
-						{
-							Name: "http-foo",
-							Port: 1234,
-						},
-						{
-							Name: "http-zipkin",
-							Port: 5555,
-						},
-					},
-				},
-			}).Build()
-	tb := true
-	jaegerEnabled := &vzapi.Verrazzano{
-		Spec: vzapi.VerrazzanoSpec{
-			Components: vzapi.ComponentSpec{
-				JaegerOperator: &vzapi.JaegerOperatorComponent{
-					Enabled: &tb,
-				},
-			},
-		},
-	}
-
-	var tests = []struct {
-		name string
-		ctx  spi.ComponentContext
-		kvs  []bom.KeyValue
-	}{
-		{
-			"no collector args when Jaeger disabled",
-			spi.NewFakeContext(c1, &vzapi.Verrazzano{}, false),
-			[]bom.KeyValue{},
-		},
-		{
-			"no collector args when Jaeger enabled but no services present",
-			spi.NewFakeContext(c1, jaegerEnabled, false),
-			[]bom.KeyValue{},
-		},
-		{
-			"collector args when Jaeger enabled and services present",
-			spi.NewFakeContext(cWithServices, jaegerEnabled, false),
-			[]bom.KeyValue{
-				{
-					Key:   "meshConfig.defaultConfig.tracing.zipkin.address",
-					Value: fmt.Sprintf("jaeger-collector.%s.svc.cluster.local:5555", namespace),
-				},
-				{
-					Key:   "meshConfig.defaultConfig.tracing.tlsSettings.mode",
-					Value: "ISTIO_MUTUAL",
-				},
-				{
-					Key:   "meshConfig.enableTracing",
-					Value: "true",
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			kvs, err := appendJaegerCollectorArg(tt.ctx, []bom.KeyValue{})
-			assert.NoError(t, err)
-			assert.EqualValues(t, tt.kvs, kvs)
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
@@ -4,6 +4,11 @@
 package istio
 
 import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -18,6 +23,87 @@ import (
 const ComponentInstallArgShape = `gateways.istio-ingressgateway.serviceAnnotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"`
 
 var enabled = true
+
+var prodIstioIngress = &vzapi.IstioIngressSection{
+	Kubernetes: &vzapi.IstioKubernetesSection{
+		CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+			Replicas: 2,
+			Affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: nil,
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							Weight: 100,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: nil,
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "app",
+											Operator: "In",
+											Values: []string{
+												"istio-ingressgateway",
+											},
+										},
+									},
+								},
+								Namespaces:  nil,
+								TopologyKey: "kubernetes.io/hostname",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	Type: vzapi.NodePort,
+	Ports: []corev1.ServicePort{
+		{
+			Name:     "port1",
+			Protocol: "TCP",
+			Port:     8000,
+			NodePort: 32443,
+			TargetPort: intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 2000,
+			},
+		},
+	},
+}
+
+var prodIstioEgress = &vzapi.IstioEgressSection{
+	Kubernetes: &vzapi.IstioKubernetesSection{
+		CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+			Replicas: 2,
+			Affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: nil,
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							Weight: 100,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: nil,
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "app",
+											Operator: "In",
+											Values: []string{
+												"istio-egressgateway",
+											},
+										},
+									},
+								},
+								Namespaces:  nil,
+								TopologyKey: "kubernetes.io/hostname",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
 
 // Prod Profile defaults for replicas and affinity
 // Extra Install Args
@@ -41,85 +127,8 @@ var cr1 = vzapi.IstioComponent{
 		},
 	},
 	Enabled: &enabled,
-	Ingress: &vzapi.IstioIngressSection{
-		Kubernetes: &vzapi.IstioKubernetesSection{
-			CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
-				Replicas: 2,
-				Affinity: &corev1.Affinity{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: nil,
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: nil,
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "app",
-												Operator: "In",
-												Values: []string{
-													"istio-ingressgateway",
-												},
-											},
-										},
-									},
-									Namespaces:  nil,
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		Type: vzapi.NodePort,
-		Ports: []corev1.ServicePort{
-			{
-				Name:     "port1",
-				Protocol: "TCP",
-				Port:     8000,
-				NodePort: 32443,
-				TargetPort: intstr.IntOrString{
-					Type:   intstr.Int,
-					IntVal: 2000,
-				},
-			},
-		},
-	},
-	Egress: &vzapi.IstioEgressSection{
-		Kubernetes: &vzapi.IstioKubernetesSection{
-			CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
-				Replicas: 2,
-				Affinity: &corev1.Affinity{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: nil,
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: nil,
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "app",
-												Operator: "In",
-												Values: []string{
-													"istio-egressgateway",
-												},
-											},
-										},
-									},
-									Namespaces:  nil,
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	},
+	Ingress: prodIstioIngress,
+	Egress:  prodIstioEgress,
 }
 
 // Resulting YAML after the merge
@@ -180,6 +189,8 @@ spec:
     global:
       defaultPodDisruptionBudget:
         enabled: false
+    meshConfig:
+        enableTracing: false
     pilot:
       resources:
         requests:
@@ -328,6 +339,8 @@ spec:
     global:
       defaultPodDisruptionBudget:
         enabled: false
+    meshConfig:
+        enableTracing: false
     pilot:
       resources:
         requests:
@@ -432,49 +445,127 @@ kind: IstioOperator
 spec:
   components:
     egressGateways:
-      - name: istio-egressgateway
-        enabled: true
-        k8s:
-          replicaCount: 3
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms: null
-            podAffinity: {}
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app
-                      operator: NotIn
-                      values:
-                      - istio-egressgateway
-                  topologyKey: kubernetes.io/hostname
-                weight: 30
+    - enabled: true
+      k8s:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms: null
+          podAffinity: {}
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: NotIn
+                    values:
+                    - istio-egressgateway
+                topologyKey: kubernetes.io/hostname
+              weight: 30
+        replicaCount: 3
+      name: istio-egressgateway
     ingressGateways:
-      - name: istio-ingressgateway
-        enabled: true
-        k8s:
-          service:
-            type: LoadBalancer
-          replicaCount: 3
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms: null
-            podAffinity: {}
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app
-                      operator: NotIn
-                      values:
-                      - istio-ingressgateway
-                  topologyKey: kubernetes.io/hostname
-                weight: 30
+    - enabled: true
+      k8s:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms: null
+          podAffinity: {}
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: NotIn
+                    values:
+                    - istio-ingressgateway
+                topologyKey: kubernetes.io/hostname
+              weight: 30
+        replicaCount: 3
+        service:
+          type: LoadBalancer
+      name: istio-ingressgateway
+  values:
+    meshConfig:
+      enableTracing: false
+`
+
+var cr4 = &vzapi.IstioComponent{
+	Enabled: &enabled,
+	Ingress: prodIstioIngress,
+	Egress:  prodIstioEgress,
+	IstioInstallArgs: []vzapi.InstallArgs{
+		{
+			Name:  "meshConfig.enableTracing",
+			Value: "true",
+		},
+		{
+			Name:  "meshConfig.defaultConfig.tracing.sampling",
+			Value: "100",
+		},
+	},
+}
+
+var cr4Yaml = `
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    egressGateways:
+    - enabled: true
+      k8s:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - istio-egressgateway
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        replicaCount: 2
+      name: istio-egressgateway
+    ingressGateways:
+    - enabled: true
+      k8s:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - istio-ingressgateway
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        replicaCount: 2
+        service:
+          ports:
+          - name: port1
+            nodePort: 32443
+            port: 8000
+            protocol: TCP
+            targetPort: 2000
+          type: NodePort
+      name: istio-ingressgateway
+  values:
+    meshConfig:
+      defaultConfig:
+        tracing:
+          sampling: 100
+          tlsSettings:
+            mode: ISTIO_MUTUAL
+          zipkin:
+            address: jaeger-collector.foo.svc.cluster.local:5555
+      enableTracing: true
 `
 
 // TestBuildIstioOperatorYaml tests the BuildIstioOperatorYaml function
@@ -482,32 +573,82 @@ spec:
 // WHEN BuildIstioOperatorYaml is called
 // THEN ensure that the result is correct.
 func TestBuildIstioOperatorYaml(t *testing.T) {
-
+	fakeCtx := spi.NewFakeContext(fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build(), &vzapi.Verrazzano{}, false)
+	collectorLabels := map[string]string{
+		constants.KubernetesAppLabel: constants.JaegerCollectorService,
+	}
+	namespace := "foo"
+	clientForJaeger := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).
+		WithObjects(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "jaeger-collector-headless",
+				Labels:    collectorLabels,
+			},
+		},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "jaeger-collector",
+					Labels:    collectorLabels,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "http-foo",
+							Port: 1234,
+						},
+						{
+							Name: "http-zipkin",
+							Port: 5555,
+						},
+					},
+				},
+			}).Build()
 	tests := []struct {
 		testName string
 		value    *vzapi.IstioComponent
 		expected string
+		ctx      spi.ComponentContext
 	}{
 		{
 			testName: "Default Prod Profile Install",
 			value:    &cr1,
 			expected: cr1Yaml,
+			ctx:      fakeCtx,
 		},
 		{
 			testName: "Default Dev and Managed-Cluster Profile Install",
 			value:    &cr2,
 			expected: cr2Yaml,
+			ctx:      fakeCtx,
 		},
 		{
 			testName: "Override Affinity and Replica",
 			value:    &cr3,
 			expected: cr3Yaml,
+			ctx:      fakeCtx,
+		},
+		{
+			testName: "Override Jaeger when enabled and present",
+			value:    cr4,
+			expected: cr4Yaml,
+			ctx: spi.NewFakeContext(clientForJaeger, &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						JaegerOperator: &vzapi.JaegerOperatorComponent{
+							Enabled: &enabled,
+						},
+					},
+				},
+			}, false),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			a := assert.New(t)
-			s, err := BuildIstioOperatorYaml(test.value)
+			s, err := BuildIstioOperatorYaml(test.ctx, test.value)
+			fmt.Println(s)
 			a.NoError(err, s, "error merging yamls")
 			a.YAMLEq(test.expected, s, "Result does not match expected value")
 		})

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -197,7 +197,7 @@ func (i istioComponent) Install(compContext spi.ComponentContext) error {
 
 	// Only create override file if the CR has an Istio component
 	if cr.Spec.Components.Istio != nil {
-		istioOperatorYaml, err := BuildIstioOperatorYaml(cr.Spec.Components.Istio)
+		istioOperatorYaml, err := BuildIstioOperatorYaml(compContext, cr.Spec.Components.Istio)
 		if err != nil {
 			return log.ErrorfNewErr("Failed to Build IstioOperator YAML: %v", err)
 		}


### PR DESCRIPTION
Configures tracing sampling rate, and whether Istio mesh tracing is enabled. By default, mesh tracing will be disabled.
Moved some code around from CLI args to be in the Istio operator YAML file. 

The user may enable mesh tracing and adjust the sampling rate via istio install args.