### PR TITLE
log indexTemplate and indices

### DIFF
--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -186,6 +186,10 @@ func (e *Elastic) CheckHealth(kubeconfigPath string) bool {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error extracting health status from response body: %v", err))
 		return false
 	}
+	indexTemplate, _ := e.getResponseBody("/_index_template")
+	pkg.Log(pkg.Info, fmt.Sprintf("IndexTemplate: %v", string(indexTemplate)))
+	catIndices, _ := e.getResponseBody("/_cat/indices")
+	pkg.Log(pkg.Info, fmt.Sprintf("Indices: \n%v", string(catIndices)))
 	if status == "green" {
 		pkg.Log(pkg.Info, "Elasticsearch cluster health status is green")
 		return true


### PR DESCRIPTION
# Description

More logging info for Opensearch status
* index_templates for "auto_expand_replicas":"0-1","number_of_replicas":"0" 
* /_cat/indices to display status of each individual index

Fixes VZ-5371

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
