### PR TITLE
VZ-5810.  Fix noisy controller message part 2

### DIFF
--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -100,11 +100,6 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return nil
 	})
 
-	if !r.multiclusterNamespaceExists() {
-		// Multicluster namespace doesn't exist yet, requeue
-		return newRequeueWithDelay(), nil
-	}
-
 	if err != nil {
 		r.log.ErrorfThrottled("Failed to create or update secret %s/%s: %s",
 			constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoLocalCABundleSecret, err.Error())

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -5,6 +5,7 @@ package secrets
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
 	"time"
 
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
@@ -68,6 +69,11 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	r.log = log
 
+	if !r.multiclusterNamespaceExists() {
+		// Multicluster namespace doesn't exist yet, nothing to do so requeue
+		return newRequeueWithDelay(), nil
+	}
+
 	// Get the local ca-bundle secret
 	mcCASecret := corev1.Secret{}
 	err = r.Get(context.TODO(), client.ObjectKey{
@@ -93,6 +99,12 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		mcCASecret.Data["ca-bundle"] = caSecret.Data["ca.crt"]
 		return nil
 	})
+
+	if !r.multiclusterNamespaceExists() {
+		// Multicluster namespace doesn't exist yet, requeue
+		return newRequeueWithDelay(), nil
+	}
+
 	if err != nil {
 		r.log.ErrorfThrottled("Failed to create or update secret %s/%s: %s",
 			constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoLocalCABundleSecret, err.Error())
@@ -102,6 +114,19 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	r.log.Infof("Created or updated secret %s/%s (result: %v)",
 		constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoLocalCABundleSecret, result)
 	return ctrl.Result{}, nil
+}
+
+func (r *VerrazzanoSecretsReconciler) multiclusterNamespaceExists() bool {
+	ns := corev1.Namespace{}
+	err := r.Get(context.TODO(), types.NamespacedName{Name: constants.VerrazzanoMultiClusterNamespace}, &ns)
+	if err == nil {
+		return true
+	}
+	if !apierrors.IsNotFound(err) {
+		r.log.ErrorfThrottled("Unexpected error checking for namespace %s: %v", constants.VerrazzanoMultiClusterNamespace, err)
+	}
+	r.log.Progressf("Namespace %s does not exist, nothing to do", constants.VerrazzanoMultiClusterNamespace)
+	return false
 }
 
 // Create a new Result that will cause a reconcile requeue after a short delay


### PR DESCRIPTION
# Description

Checks for verrazzano-mc namespace existence before doing any other processing in the secrets controller.
- Also contains some minor updates to the VZ logger per previous PR comments.

Fixes VZ-5810.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
