### PR TITLE
VZ-5780 -  When managed cluster is updated to use Let's Encrypt staging certs, make sure CA sync to admin cluster works (i.e. use tls-additional-ca secret when it exists instead of the verrazzano-tls secret)

### DIFF
--- a/application-operator/mcagent/mcagent_clusterca.go
+++ b/application-operator/mcagent/mcagent_clusterca.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,19 +77,31 @@ func (s *Syncer) syncAdminClusterCA() error {
 // syncLocalClusterCA - synchronize the local cluster CA cert -- update admin copy if local CA changes
 func (s *Syncer) syncLocalClusterCA() error {
 
-	// Get the local cluster CA secret
+	// Get the local cluster CA secret - this could be in the Additional TLS secret in Rancher NS
+	// (for Let's Encrypt staging CA) or the Verrazzano ingress TLS secret in Verrazzano System NS
 	localCASecret := corev1.Secret{}
-	err := s.LocalClient.Get(s.Context, client.ObjectKey{
-		Namespace: constants.VerrazzanoSystemNamespace,
-		Name:      constants.VerrazzanoIngressTLSSecret,
+
+	errAddlTLS := s.LocalClient.Get(s.Context, client.ObjectKey{
+		Namespace: globalconst.RancherSystemNamespace,
+		Name:      globalconst.AdditionalTLS,
 	}, &localCASecret)
-	if err != nil {
-		return err
+	if client.IgnoreNotFound(errAddlTLS) != nil {
+		return errAddlTLS
+	}
+
+	if errAddlTLS != nil { // additional TLS secret not found, check for Verrazzano TLS secret
+		err := s.LocalClient.Get(s.Context, client.ObjectKey{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      constants.VerrazzanoIngressTLSSecret,
+		}, &localCASecret)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Get the managed cluster CA secret from the admin cluster
 	vmc := platformopclusters.VerrazzanoManagedCluster{}
-	err = s.AdminClient.Get(s.Context, client.ObjectKey{
+	err := s.AdminClient.Get(s.Context, client.ObjectKey{
 		Name:      s.ManagedClusterName,
 		Namespace: constants.VerrazzanoMultiClusterNamespace,
 	}, &vmc)

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -161,7 +161,7 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 
 	newRegCA := testAdminCASecret.Data["ca-bundle"]
 	// Managed cluster additional TLS secret is the one to sync to admin cluster
-	newMCCA := testMCAdditionalTLSSecret.Data["ca.crt"]
+	newMCCA := testMCAdditionalTLSSecret.Data["ca-additional.pem"]
 
 	adminClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testAdminCASecret, &testMCCASecret, &testVMC)
 

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -30,8 +30,8 @@ const (
 	sampleMCTLSReadErrMsg      = "failed to read sample MC TLS Secret"
 	sampleMCCAReadErrMsg       = "failed to read sample MC CA Secret"
 	sampleVMCReadErrMsg        = "failed to read sample VMC"
-	regSecretChangedErrMsg     = "registration secret was changed"
-	mcCASecretChangedErrMsg    = "MC CA secret was changed"
+	regSecChangedErrMsg        = "registration secret was changed"
+	mcCASecChangedErrMsg       = "MC CA secret was changed"
 )
 
 // TestSyncAdminCANoDifference tests the synchronization method for the following use case.
@@ -82,12 +82,12 @@ func TestSyncCACertsNoDifference(t *testing.T) {
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(origRegCA, localSecret.Data["ca-bundle"], regSecretChangedErrMsg)
+	assert.Equal(origRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
 	assert.NoError(err)
-	assert.Equal(origMCCA, adminSecret.Data["cacrt"], mcCASecretChangedErrMsg)
+	assert.Equal(origMCCA, adminSecret.Data["cacrt"], mcCASecChangedErrMsg)
 }
 
 // TestSyncCACertsAreDifferent tests the synchronization method for the following use case.
@@ -138,12 +138,12 @@ func TestSyncCACertsAreDifferent(t *testing.T) {
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecretChangedErrMsg)
+	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
 	assert.NoError(err)
-	assert.Equal(newMCCA, adminSecret.Data["cacrt"], mcCASecretChangedErrMsg)
+	assert.Equal(newMCCA, adminSecret.Data["cacrt"], mcCASecChangedErrMsg)
 }
 
 // Test the case when managed cluster uses Let's Encrypt staging (i.e. tls-ca-additional secret
@@ -198,7 +198,7 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecretChangedErrMsg)
+	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)

--- a/application-operator/mcagent/testdata/clusterca-mc-additionaltls-secret.yaml
+++ b/application-operator/mcagent/testdata/clusterca-mc-additionaltls-secret.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: cattle-system
 data:
   # cleartext: ThisIsTheManagedClusterLEStagingCA
-  ca.crt: VGhpc0lzVGhlTWFuYWdlZENsdXN0ZXJMRVN0YWdpbmdDQQo=
+  ca-additional.pem: VGhpc0lzVGhlTWFuYWdlZENsdXN0ZXJMRVN0YWdpbmdDQQo=

--- a/application-operator/mcagent/testdata/clusterca-mc-additionaltls-secret.yaml
+++ b/application-operator/mcagent/testdata/clusterca-mc-additionaltls-secret.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-ca-additional
+  namespace: cattle-system
+data:
+  # cleartext: ThisIsTheManagedClusterLEStagingCA
+  ca.crt: VGhpc0lzVGhlTWFuYWdlZENsdXN0ZXJMRVN0YWdpbmdDQQo=


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-5780

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
