### PR TITLE
VZ-4588: partial backport from master to release-1.2

### DIFF
--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -23,8 +23,9 @@ func GeneratePassword(length int) (string, error) {
 	return GeneratePasswordUsingMode(length, modeAlphaNum)
 }
 
-//GeneratePassword will generate a password of length
-func GeneratePasswordAlphaLower(length int) (string, error) {
+//GenerateRandomAlphaLower will generate a lower-case alpha string of length
+//Should be used only for generating semi-unique, non-cryptographic, non-secret strings -- NOT passwords!
+func GenerateRandomAlphaLower(length int) (string, error) {
 	return GeneratePasswordUsingMode(length, modeAlphaLower)
 }
 
@@ -61,7 +62,7 @@ func makeAlphaNumeric(input string) (string, error) {
 	return reg.ReplaceAllString(input, ""), nil
 }
 
-// makeAlphaLower removes all non-lower-case-alpha characters
+// makeAlphaLower removes all special characters and numbers from a string, and lowercases the result
 func makeAlphaLower(input string) (string, error) {
 	// Make a Regex to say we only want letters
 	reg, err := regexp.Compile("[^a-zA-Z]+")

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -13,19 +13,38 @@ import (
 
 const mask = "******"
 
+const (
+	modeAlphaNum   = 0
+	modeAlphaLower = 1
+)
+
 //GeneratePassword will generate a password of length
 func GeneratePassword(length int) (string, error) {
+	return GeneratePasswordUsingMode(length, modeAlphaNum)
+}
+
+//GeneratePassword will generate a password of length
+func GeneratePasswordAlphaLower(length int) (string, error) {
+	return GeneratePasswordUsingMode(length, modeAlphaLower)
+}
+
+//GeneratePasswordUsingMode will generate a password of length with mode
+func GeneratePasswordUsingMode(length int, mode int) (string, error) {
 	if length < 1 {
 		return "", fmt.Errorf("cannot create password of length %d", length)
 	}
 	// Enlarge buffer so plenty of room is left when special characters are stripped out
-	b := make([]byte, length*3)
+	b := make([]byte, length*4)
 	_, err := rand.Read(b)
 	if err != nil {
 		return "", err
 	}
 	pw := b64.StdEncoding.EncodeToString(b)
-	pw, err = makeAlphaNumeric(pw)
+	if mode == modeAlphaNum {
+		pw, err = makeAlphaNumeric(pw)
+	} else {
+		pw, err = makeAlphaLower(pw)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -40,6 +59,16 @@ func makeAlphaNumeric(input string) (string, error) {
 		return "", err
 	}
 	return reg.ReplaceAllString(input, ""), nil
+}
+
+// makeAlphaLower removes all non-lower-case-alpha characters
+func makeAlphaLower(input string) (string, error) {
+	// Make a Regex to say we only want letters
+	reg, err := regexp.Compile("[^a-zA-Z]+")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(reg.ReplaceAllString(input, "")), nil
 }
 
 //MaskFunction creates a function intended to mask passwords which are substrings in other strings

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -443,7 +443,7 @@ func createCAResources(compContext spi.ComponentContext) error {
 				Namespace: vzCertCA.ClusterResourceNamespace,
 			},
 		}
-		commonNameSuffix, err := password.GeneratePassword(10)
+		commonNameSuffix, err := password.GeneratePasswordAlphaLower(8)
 		if err != nil {
 			return compContext.Log().ErrorfNewErr("Failed to generate CA common name suffix: %v", err)
 		}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -443,7 +443,7 @@ func createCAResources(compContext spi.ComponentContext) error {
 				Namespace: vzCertCA.ClusterResourceNamespace,
 			},
 		}
-		commonNameSuffix, err := password.GeneratePasswordAlphaLower(8)
+		commonNameSuffix, err := password.GenerateRandomAlphaLower(8)
 		if err != nil {
 			return compContext.Log().ErrorfNewErr("Failed to generate CA common name suffix: %v", err)
 		}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -15,6 +15,11 @@ import (
 	"strings"
 	"text/template"
 
+	certmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/verrazzano/verrazzano/pkg/security/password"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzos "github.com/verrazzano/verrazzano/pkg/os"
@@ -23,11 +28,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 
-	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	certmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -440,17 +442,21 @@ func createCAResources(compContext spi.ComponentContext) error {
 				Name:      caCertificateName,
 				Namespace: vzCertCA.ClusterResourceNamespace,
 			},
-			Spec: certv1.CertificateSpec{
+		}
+		commonNameSuffix, err := password.GeneratePassword(10)
+		if err != nil {
+			return compContext.Log().ErrorfNewErr("Failed to generate CA common name suffix: %v", err)
+		}
+		if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &certObject, func() error {
+			certObject.Spec = certv1.CertificateSpec{
 				SecretName: vzCertCA.SecretName,
-				CommonName: caCertCommonName,
+				CommonName: fmt.Sprintf("%s-%s", caCertCommonName, commonNameSuffix),
 				IsCA:       true,
 				IssuerRef: certmetav1.ObjectReference{
 					Name: issuer.Name,
 					Kind: issuer.Kind,
 				},
-			},
-		}
-		if _, err := controllerutil.CreateOrUpdate(context.TODO(), compContext.Client(), &certObject, func() error {
+			}
 			return nil
 		}); err != nil {
 			return compContext.Log().ErrorfNewErr("Failed to create or update the Certificate: %v", err)

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -18,7 +18,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,12 +119,10 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// If OCI DNS, update annotation on Keycloak Ingress
-	if vzconfig.IsExternalDNSEnabled(ctx.EffectiveCR()) {
-		err := updateKeycloakIngress(ctx)
-		if err != nil {
-			return err
-		}
+	// Update annotations on Keycloak Ingress
+	err = updateKeycloakIngress(ctx)
+	if err != nil {
+		return err
 	}
 
 	return c.HelmComponent.PostInstall(ctx)

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -112,6 +112,7 @@ func createOrUpdateKialiIngress(ctx spi.ComponentContext, namespace string) erro
 		ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTP"
 		ingress.Annotations["nginx.ingress.kubernetes.io/service-upstream"] = "true"
 		ingress.Annotations["nginx.ingress.kubernetes.io/upstream-vhost"] = "${service_name}.${namespace}.svc.cluster.local"
+		ingress.Annotations["cert-manager.io/common-name"] = kialiHostName
 		if vzconfig.IsExternalDNSEnabled(ctx.EffectiveCR()) {
 			ingress.Annotations["external-dns.alpha.kubernetes.io/target"] = ingressTarget
 			ingress.Annotations["external-dns.alpha.kubernetes.io/ttl"] = "60"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher
@@ -86,4 +86,5 @@ func addAcmeIngressAnnotations(name, dnsSuffix string, ingress *networking.Ingre
 func addCAIngressAnnotations(name, dnsSuffix string, ingress *networking.Ingress) {
 	ingress.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = fmt.Sprintf("%s.%s auth", name, dnsSuffix)
 	ingress.Annotations["cert-manager.io/cluster-issuer"] = "verrazzano-cluster-issuer"
+	ingress.Annotations["cert-manager.io/common-name"] = fmt.Sprintf("%s.%s.%s", common.RancherName, name, dnsSuffix)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
@@ -1,10 +1,12 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -14,7 +16,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const (
@@ -61,6 +62,7 @@ func TestAddCAIngressAnnotations(t *testing.T) {
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/auth-realm": fmt.Sprintf("%s.%s auth", name, dnsSuffix),
 				"cert-manager.io/cluster-issuer":         "verrazzano-cluster-issuer",
+				"cert-manager.io/common-name":            fmt.Sprintf("%s.%s.%s", common.RancherName, name, dnsSuffix),
 			},
 		},
 	}

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ---

--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-ingress.yaml
@@ -33,6 +33,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/upstream-vhost: "${service_name}.${namespace}.svc.cluster.local"
+    cert-manager.io/common-name: verrazzano.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
   name: verrazzano-ingress
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
# Description

This is a partial backport of changes for VZ-4588. It includes everything except the related VMO changes. With this change, root certificates get unique names, and system ingress certs generated in verrazzano repo code get non-empty Subject fields. Ingress certs for ingresses managed by the VMO will not get non-empty Subject fields unless/until the related change in the VMO repo is backported.

Partial backport of VZ-4588.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
