### PR TITLE
VZ-5714: check for app operator and istio enabled before restarting apps

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/app_restart.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart.go
@@ -28,13 +28,13 @@ func RestartApps(log vzlog.VerrazzanoLogger, client clipkg.Client, generation in
 
 	// Start WebLogic domains that were shutdown
 	log.Infof("Starting WebLogic domains that were stopped pre-upgrade")
-	if err := StartDomainsStoppedByUpgrade(log, client, restartVersion); err != nil {
+	if err := startDomainsStoppedByUpgrade(log, client, restartVersion); err != nil {
 		return err
 	}
 
 	// Restart all other apps
 	log.Infof("Restarting all applications so they can get the new Envoy sidecar")
-	if err := RestartAllApps(log, client, restartVersion); err != nil {
+	if err := restartAllApps(log, client, restartVersion); err != nil {
 		return err
 	}
 	return nil
@@ -117,8 +117,8 @@ func stopDomain(client clipkg.Client, wlNamespace string, wlName string) error {
 	return err
 }
 
-// StartDomainsStoppedByUpgrade starts all the WebLogic domains that upgrade previously stopped
-func StartDomainsStoppedByUpgrade(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
+// startDomainsStoppedByUpgrade starts all the WebLogic domains that upgrade previously stopped
+func startDomainsStoppedByUpgrade(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
 	log.Progressf("RestartApps: checking if any domains need to be started")
 
 	// get all the app configs
@@ -165,8 +165,8 @@ func startDomainIfNeeded(log vzlog.VerrazzanoLogger, client clipkg.Client, wlNam
 	return err
 }
 
-// RestartAllApps restarts all the applications
-func RestartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
+// restartAllApps restarts all the applications
+func restartAllApps(log vzlog.VerrazzanoLogger, client clipkg.Client, restartVersion string) error {
 	log.Progressf("Restarting all OAM applications that have an old Istio proxy sidecar")
 
 	// Get the latest Istio proxy image name from the bom

--- a/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/app_restart_test.go
@@ -81,7 +81,7 @@ func TestWebLogicStopStart(t *testing.T) {
 			initialLifeCycleAction: vzconst.LifecycleActionStop,
 			updatedLifeCycleAction: vzconst.LifecycleActionStart,
 			f: func(mock *mocks.MockClient) error {
-				return StartDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, "1")
+				return startDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, "1")
 			},
 		},
 		// Test NOT starting WebLogic because workload is missing stop annotation
@@ -91,7 +91,7 @@ func TestWebLogicStopStart(t *testing.T) {
 			expectGetAndUpdate:     true,
 			initialLifeCycleAction: "",
 			f: func(mock *mocks.MockClient) error {
-				return StartDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, "1")
+				return startDomainsStoppedByUpgrade(vzlog.DefaultLogger(), mock, "1")
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestHelidonStopStart(t *testing.T) {
 			expectGetAndUpdate: true,
 			image:              oldIstioImage,
 			f: func(mock *mocks.MockClient) error {
-				return RestartAllApps(vzlog.DefaultLogger(), mock, "1")
+				return restartAllApps(vzlog.DefaultLogger(), mock, "1")
 			},
 		},
 		// Test restarting Helidon workload because it doesn't have an old Istio image
@@ -164,7 +164,7 @@ func TestHelidonStopStart(t *testing.T) {
 			expectGetAndUpdate: false,
 			image:              "randomImage",
 			f: func(mock *mocks.MockClient) error {
-				return RestartAllApps(vzlog.DefaultLogger(), mock, "1")
+				return restartAllApps(vzlog.DefaultLogger(), mock, "1")
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -232,6 +232,9 @@ func (i istioComponent) GetDependencies() []string {
 }
 
 func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
+	if !vzconfig.IsApplicationOperatorEnabled(context.ActualCR()) {
+		return nil
+	}
 	context.Log().Infof("Stopping WebLogic domains that are have Envoy 1.7.3 sidecar")
 	return StopDomainsUsingOldEnvoy(context.Log(), context.Client())
 }

--- a/platform-operator/internal/vzconfig/enabled.go
+++ b/platform-operator/internal/vzconfig/enabled.go
@@ -171,3 +171,11 @@ func IsAuthProxyEnabled(vz *vzapi.Verrazzano) bool {
 	}
 	return true
 }
+
+// IsApplicationOperatorEnabled returns false only if Application Operator is explicitly disabled in the CR
+func IsApplicationOperatorEnabled(vz *vzapi.Verrazzano) bool {
+	if vz != nil && vz.Spec.Components.ApplicationOperator != nil && vz.Spec.Components.ApplicationOperator.Enabled != nil {
+		return *vz.Spec.Components.ApplicationOperator.Enabled
+	}
+	return true
+}

--- a/platform-operator/internal/vzconfig/enabled_test.go
+++ b/platform-operator/internal/vzconfig/enabled_test.go
@@ -453,3 +453,34 @@ func TestIsJaegerOperatorEnabled(t *testing.T) {
 			},
 		}}))
 }
+
+// TestIsApplicationOperatorEnabled tests the IsApplicationOperatorEnabled function
+// GIVEN a call to IsApplicationOperatorEnabled
+//  THEN the value of the Enabled flag is returned if present, false otherwise (disabled by default)
+func TestIsApplicationOperatorEnabled(t *testing.T) {
+	asserts := assert.New(t)
+	asserts.True(IsApplicationOperatorEnabled(nil))
+	asserts.True(IsApplicationOperatorEnabled(&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{}}))
+	asserts.True(IsApplicationOperatorEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ApplicationOperator: &vzapi.ApplicationOperatorComponent{},
+			},
+		}}))
+	asserts.True(IsApplicationOperatorEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ApplicationOperator: &vzapi.ApplicationOperatorComponent{
+					Enabled: &trueValue,
+				},
+			},
+		}}))
+	asserts.False(IsApplicationOperatorEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ApplicationOperator: &vzapi.ApplicationOperatorComponent{
+					Enabled: &falseValue,
+				},
+			},
+		}}))
+}


### PR DESCRIPTION
This change checks that the Istio and Application Operator components are enabled before restarting user apps. This caused a failure for the minimum install during upgrade because the VPO checked for CRDs during the app restart that are deployed by the VAO, which was disabled. This also changes some of the functions in the app restart code to local if they don't need to be exported.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
