### PR TITLE
VZ-5810.  Fix VMC controller verbose logging

### DIFF
--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -291,7 +291,7 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatusReady(ctx context.Conte
 
 func (r *VerrazzanoManagedClusterReconciler) handleError(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, msg string, err error, log vzlog.VerrazzanoLogger) {
 	fullMsg := fmt.Sprintf("%s: %v", msg, err)
-	log.Errorf(fullMsg)
+	log.ErrorfThrottled(fullMsg)
 	statusErr := r.updateStatusNotReady(ctx, vmc, fullMsg)
 	if statusErr != nil {
 		log.Errorf("Failed to update status for VMC %s: %v", vmc.Name, statusErr)

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -133,35 +133,35 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 	err := r.syncServiceAccount(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the ServiceAccount", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	log.Debugf("Syncing the RoleBinding for VMC %s", vmc.Name)
 	_, err = r.syncManagedRoleBinding(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the RoleBinding", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	log.Debugf("Syncing the Agent secret for VMC %s", vmc.Name)
 	err = r.syncAgentSecret(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the agent secret", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	log.Debugf("Syncing the Registration secret for VMC %s", vmc.Name)
 	err = r.syncRegistrationSecret(vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the registration secret", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	log.Debugf("Syncing the Manifest secret for VMC %s", vmc.Name)
 	err = r.syncManifestSecret(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to sync the Manifest secret", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	statusErr := r.updateStatusReady(ctx, vmc, "Ready")
@@ -178,7 +178,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 	err = r.syncPrometheusScraper(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)
-		return ctrl.Result{}, err
+		return newRequeueWithDelay(), err
 	}
 
 	return ctrl.Result{Requeue: true, RequeueAfter: constants.ReconcileLoopRequeueInterval}, nil


### PR DESCRIPTION
# Description

Fixes another spot where we need throttled error logging.

Fixes VZ-5810.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
