### PR TITLE
VZ-5829 Do not allow updates during upgrade if the upgrade version is less than 1.3.0

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -213,6 +213,9 @@ pipeline {
         VERSION_FOR_INSTALL = "${params.VERSION_FOR_INSTALL}"
 
         TARGET_UPGRADE_OPERATOR_YAML = "${WORKSPACE}/target-upgrade-operator.yaml"
+
+        //Setting to empty since the upgrade version will be calculated later
+        VERRAZZANO_DEV_VERSION = ""
     }
 
     stages {
@@ -283,6 +286,8 @@ pipeline {
                     // update the description with some meaningful info
                     setDisplayName()
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    //Compute Verrazzano upgrade version
+                    computeVerrazzanoUpgradeVersion()
                     if (params.TEST_ENV != "KIND") {
                         // derive the prefix for the OKE cluster
                         OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()
@@ -444,6 +449,9 @@ pipeline {
                     }
                 }
                 stage("verify-upgrade-required") {
+                    environment {
+                        VERRAZZANO_UPGRADE_VERSION="${VERRAZZANO_DEV_VERSION}"
+                    }
                     steps {
                         runGinkgoRandomize('upgrade/pre-upgrade/verify-upgrade-required')
                     }
@@ -918,8 +926,7 @@ def upgradePlatformOperatorOnCluster(count) {
     }
 }
 
-// Upgrade Verrazzano
-def upgradeVerrazzano() {
+def computeVerrazzanoUpgradeVersion() {
     script {
         // Download the bom for the target version that we are upgrading to, then extract the version
         // Note, this version will have a semver suffix which is generated for each build, e.g. 1.0.1-33+d592fed6
@@ -930,7 +937,12 @@ def upgradeVerrazzano() {
         } else if(VERSION_FOR_UPGRADE != "NONE" && VERSION_FOR_UPGRADE != "master"){
             VERRAZZANO_DEV_VERSION = VERSION_FOR_UPGRADE
         }
+    }
+}
 
+// Upgrade Verrazzano
+def upgradeVerrazzano() {
+    script {
         // Create a dictionary of Verrazzano upgrade steps to be executed in parallel
         // - the first one will always be the Admin cluster
         // - clusters 2-max are managed clusters

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -216,6 +216,8 @@ pipeline {
 
         //Setting to empty since the upgrade version will be calculated later
         VERRAZZANO_DEV_VERSION = ""
+
+        ALLOW_UPDATES_DURING_UPGRADE = "true"
     }
 
     stages {
@@ -981,10 +983,12 @@ def upgradeVerrazzanoOnCluster(count, verrazzanoDevVersion) {
                 cd ${GO_REPO_PATH}/verrazzano
                 cp ${v8oInstallFile} ${v8oUpgradeFile}
                 ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${verrazzanoDevVersion}  ${v8oUpgradeFile}
-
-                # Add some simple additional updates to validate update during an upgrade
-                yq -i eval '.spec.components.istio.ingress.kubernetes.replicas = 3' ${v8oUpgradeFile}
-                yq -i eval '.spec.components.istio.egress.kubernetes.replicas = 3' ${v8oUpgradeFile}
+                
+                if [ "${ALLOW_UPDATES_DURING_UPGRADE}" == "true" ]; then
+                    # Add some simple additional updates to validate update during an upgrade
+                    yq -i eval '.spec.components.istio.ingress.kubernetes.replicas = 3' ${v8oUpgradeFile}
+                    yq -i eval '.spec.components.istio.egress.kubernetes.replicas = 3' ${v8oUpgradeFile}
+                fi
 
                 # Do the upgrade
                 echo "Following is the verrazzano CR file with the new version:"

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -217,7 +217,7 @@ pipeline {
         //Setting to empty since the upgrade version will be calculated later
         VERRAZZANO_DEV_VERSION = ""
 
-        ALLOW_UPDATES_DURING_UPGRADE = "true"
+        PREVENT_UPDATES_DURING_UPGRADE_FILE = "${WORKSPACE}/prevent_updates_during_upgrade_file.txt"
     }
 
     stages {
@@ -984,7 +984,7 @@ def upgradeVerrazzanoOnCluster(count, verrazzanoDevVersion) {
                 cp ${v8oInstallFile} ${v8oUpgradeFile}
                 ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${verrazzanoDevVersion}  ${v8oUpgradeFile}
                 
-                if [ "${ALLOW_UPDATES_DURING_UPGRADE}" == "true" ]; then
+                if [ ! -f "${PREVENT_UPDATES_DURING_UPGRADE_FILE}" ]; then
                     # Add some simple additional updates to validate update during an upgrade
                     yq -i eval '.spec.components.istio.ingress.kubernetes.replicas = 3' ${v8oUpgradeFile}
                     yq -i eval '.spec.components.istio.egress.kubernetes.replicas = 3' ${v8oUpgradeFile}

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -22,7 +22,7 @@ import (
 var upgradeVersion = os.Getenv("VERRAZZANO_UPGRADE_VERSION")
 
 const (
-	allowUpdatesDuringUpgradeEnvVar = "ALLOW_UPDATES_DURING_UPGRADE"
+	preventUpdatesDuringUpgradeFileEnvVar = "PREVENT_UPDATES_DURING_UPGRADE_FILE"
 )
 
 var t = framework.NewTestFramework("verify")
@@ -75,7 +75,12 @@ var _ = t.Describe("Verify upgrade required before update is allowed", Label("f:
 					return
 				}
 				if upgradeSemVer.IsLessThan(minimumVerrazzanoVersion) {
-					os.Setenv(allowUpdatesDuringUpgradeEnvVar, "false")
+					if _, exists := os.LookupEnv(preventUpdatesDuringUpgradeFileEnvVar); exists {
+						_, err = os.Create(preventUpdatesDuringUpgradeFileEnvVar)
+						if err != nil {
+							t.Logs.Warnf("Failed to create file %s", os.Getenv(preventUpdatesDuringUpgradeFileEnvVar))
+						}
+					}
 					Skip(fmt.Sprintf("Skipping the upgrade-required check spec since the upgrade Verrazzano "+
 						"version %s is less than version %s", upgradeVersion, minimumVersion))
 				}

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -75,11 +75,9 @@ var _ = t.Describe("Verify upgrade required before update is allowed", Label("f:
 					return
 				}
 				if upgradeSemVer.IsLessThan(minimumVerrazzanoVersion) {
-					if _, exists := os.LookupEnv(preventUpdatesDuringUpgradeFileEnvVar); exists {
-						_, err = os.Create(preventUpdatesDuringUpgradeFileEnvVar)
-						if err != nil {
-							t.Fail(fmt.Sprintf("Failed to create file %s", os.Getenv(preventUpdatesDuringUpgradeFileEnvVar)))
-						}
+					_, err = os.Create(preventUpdatesDuringUpgradeFileEnvVar)
+					if err != nil {
+						t.Fail(fmt.Sprintf("Failed to create file %s", os.Getenv(preventUpdatesDuringUpgradeFileEnvVar)))
 					}
 					Skip(fmt.Sprintf("Skipping the upgrade-required check spec since the upgrade Verrazzano "+
 						"version %s is less than version %s", upgradeVersion, minimumVersion))

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -78,7 +78,7 @@ var _ = t.Describe("Verify upgrade required before update is allowed", Label("f:
 					if _, exists := os.LookupEnv(preventUpdatesDuringUpgradeFileEnvVar); exists {
 						_, err = os.Create(preventUpdatesDuringUpgradeFileEnvVar)
 						if err != nil {
-							t.Logs.Warnf("Failed to create file %s", os.Getenv(preventUpdatesDuringUpgradeFileEnvVar))
+							t.Fail(fmt.Sprintf("Failed to create file %s", os.Getenv(preventUpdatesDuringUpgradeFileEnvVar)))
 						}
 					}
 					Skip(fmt.Sprintf("Skipping the upgrade-required check spec since the upgrade Verrazzano "+

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -21,6 +21,10 @@ import (
 
 var upgradeVersion = os.Getenv("VERRAZZANO_UPGRADE_VERSION")
 
+const (
+	allowUpdatesDuringUpgradeEnvVar = "ALLOW_UPDATES_DURING_UPGRADE"
+)
+
 var t = framework.NewTestFramework("verify")
 
 var _ = t.BeforeSuite(func() {
@@ -71,8 +75,9 @@ var _ = t.Describe("Verify upgrade required before update is allowed", Label("f:
 					return
 				}
 				if upgradeSemVer.IsLessThan(minimumVerrazzanoVersion) {
+					os.Setenv(allowUpdatesDuringUpgradeEnvVar, "false")
 					Skip(fmt.Sprintf("Skipping the upgrade-required check spec since the upgrade Verrazzano "+
-						"version %s is less than %s version", upgradeVersion, minimumVersion))
+						"version %s is less than version %s", upgradeVersion, minimumVersion))
 				}
 			}
 			vz, err := pkg.GetVerrazzano()


### PR DESCRIPTION
# Description

Do not allow updates during upgrade if the upgrade version is less than 1.3.0

Fixes VZ-5829

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
