### PR TITLE
VZ-5357 VZ-5358 VZ-4897 Update rancher image to use docker v19

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20220503225511-0dccdd5f4",
+              "tag": "20220503225511-0dccdd5f4",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20220503225511-0dccdd5f4"
+              "tag": "20220503225511-0dccdd5f4"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4",
+              "tag": "v2.5.9-20220503225511-0dccdd5f4",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.5.9-20211209021347-2e57ce2a4"
+              "tag": "v2.5.9-20220503225511-0dccdd5f4"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20220503225511-0dccdd5f4",
+              "tag": "20220505191813-e049e83ce",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20220503225511-0dccdd5f4"
+              "tag": "20220505191813-e049e83ce"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -154,15 +154,15 @@
             },
             {
               "image": "fleet-agent",
-              "tag": "v0.3.5"
+              "tag": "v0.3.9"
             },
             {
               "image": "fleet",
-              "tag": "v0.3.5"
+              "tag": "v0.3.9"
             },
             {
               "image": "gitjob",
-              "tag": "v0.1.15"
+              "tag": "v0.1.26"
             },
             {
               "image": "rancher-operator",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -150,7 +150,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.1.2"
+              "tag": "v0.1.4"
             },
             {
               "image": "fleet-agent",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20220505191813-e049e83ce",
+              "tag": "v2.5.9-20220506124723-e049e83ce",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20220505191813-e049e83ce"
+              "tag": "v2.5.9-20220506124723-e049e83ce"
             }
           ]
         },


### PR DESCRIPTION
# Description

This PR uses an updated image of rancher to use docker v19.0.3 which also updates additional rancher image versions

Fixes VZ-5357 VZ-5358 VZ-4897

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
