### PR TITLE
JIRA:VZ-5682 fix component parameter to align with VZ API standards

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,13 +1,13 @@
 github.com/verrazzano/verrazzano
 -------- Copyrights
-Copyright (c) 2022, Oracle and/or its affiliates.
-Copyright (c) 2021, Oracle and/or its affiliates.
-Copyright (c) 2021, 2022, Oracle and/or its affiliates.
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
-Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Copyright (c) 2020, 2021, Oracle America, Inc. and its affiliates.
-Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, Oracle and/or its affiliates.
 Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
 Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (C) 2022, Oracle and/or its affiliates.
@@ -22,6 +22,7 @@ fmt.Println("// Copyright (c) 2021, Oracle and/or its affiliates.")
 fmt.Println("-- Copyright (c) 2021, Oracle and/or its affiliates.")
 fmt.Println("<!-- Copyright (c) 2021, Oracle and/or its affiliates. -->")
 fmt.Println("# Copyright (c) 2021, Oracle and/or its affiliates.")
+Copyright Fixer
 Copyright Scanner
 Copyright scanning target .
 Copyright scanning target platform-operator/scripts
@@ -33,7 +34,6 @@ Copyright scanning target platform-operator/run-vpo.sh
 Copyright scanning target Jenkinsfile
 Copyright scanning target Makefile
 Copyright scanning target tools/copyright/copyright.go
-Copyright Fixer
 
 -------- License
 Copyright (c) 2020, 2021, Oracle America, Inc. and its affiliates.
@@ -80,11 +80,11 @@ THE SOFTWARE.
 -------- Dependency
 gopkg.in/yaml.v3
 -------- Copyrights
-Copyright (c) 2011-2019 Canonical Ltd
-Copyright (c) 2006-2010 Kirill Simonov
 Copyright 2011-2016 Canonical Ltd.
 copyright staring in 2011 when the project was ported over:
+Copyright (c) 2006-2010 Kirill Simonov
 Copyright (c) 2006-2011 Kirill Simonov
+Copyright (c) 2011-2019 Canonical Ltd
 -------- Notices
 Copyright 2011-2016 Canonical Ltd.
 
@@ -266,9 +266,9 @@ Copyright © 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 Copyright © 2013 The Go Authors. All rights reserved.
 Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 Copyright (c) 2013 The Go Authors. All rights reserved.
+Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
-Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
 -------- Notices
 Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.
 
@@ -364,16 +364,16 @@ END OF TERMS AND CONDITIONS
 -------- Dependency
 github.com/verrazzano/verrazzano-monitoring-operator
 -------- Copyrights
-Copyright (C) 2020, Oracle and/or its affiliates.
-Copyright (c) 2020, 2022, Oracle and/or its affiliates.
-Copyright (C) 2020, 2022, Oracle and/or its affiliates.
-Copyright 2019 The Kubernetes Authors.
 Copyright (c) 2020 Oracle America, Inc. and its affiliates. 
+Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+Copyright (C) 2020, Oracle and/or its affiliates.
+Copyright 2019 The Kubernetes Authors.
 Copyright (C) 2022, Oracle and/or its affiliates.
 Copyright (c) 2022, Oracle and/or its affiliates.
 Copyright (C) 2020, 2021, Oracle and/or its affiliates.
-Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
+Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 
 -------- Dependencies Summary
@@ -425,12 +425,12 @@ sigs.k8s.io/json
 -------- Copyrights
 Copyright 2021 The Kubernetes Authors.
 Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 
 -------- Dependencies Summary
 sigs.k8s.io/json
@@ -680,10 +680,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------- Dependency
 github.com/davecgh/go-spew
 -------- Copyrights
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
 Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
 Copyright (c) 2013 Dave Collins <dave@davec.name>
-Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 
 -------- Dependencies Summary
 github.com/davecgh/go-spew
@@ -711,23 +711,23 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 cloud.google.com/go
 -------- Copyrights
 Copyright 2021 Google LLC
-Copyright 2018 Google LLC
-Copyright 2016 Google LLC
-Copyright 2014 Google LLC
 Copyright 2019 Google LLC
 Copyright 2020 Google LLC
+Copyright 2016 Google LLC
+Copyright 2018 Google LLC
 Copyright (c) 1996-1998 John D. Polstra.  All rights reserved.
 Copyright (c) 2001 David E. O'Brien
 Portions Copyright 2018 Google LLC.
+Copyright 2014 Google LLC
 Copyright 2017 Google LLC
 Copyright 2018 Google Inc. All Rights Reserved.
 Copyright 2020, Google LLC
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright (c) 2020 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 {"Copyright 2012 Google, Inc. Package foo does bar.", 27, ""},
 Copyright 2013 The Go Authors. All rights reserved.
+Copyright (c) 2020 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2017, Google LLC
@@ -736,8 +736,8 @@ Copyright 2017, Google LLC
 github.com/crossplane/crossplane-runtime
 -------- Copyrights
 Copyright 2019 The Crossplane Authors.
-Copyright 2020 The Crossplane Authors.
 Copyright 2016 The Crossplane Authors. All rights reserved.
+Copyright 2020 The Crossplane Authors.
 
 -------- Dependency
 github.com/crossplane/oam-kubernetes-runtime
@@ -756,8 +756,8 @@ Copyright 2019 The logr Authors.
 -------- Dependency
 github.com/go-logr/zapr
 -------- Copyrights
-Copyright 2021 The logr Authors.
 Copyright 2019 The logr Authors.
+Copyright 2021 The logr Authors.
 Copyright 2018 Solly Ross
 Copyright 2020 The Kubernetes Authors.
 
@@ -779,16 +779,16 @@ Copyright 2015 go-swagger maintainers
 -------- Dependency
 github.com/golang/groupcache
 -------- Copyrights
-Copyright 2013 Google Inc.
 Copyright 2012 Google Inc.
+Copyright 2013 Google Inc.
 
 -------- Dependency
 github.com/golang/mock
 -------- Copyrights
-Copyright 2020 Google LLC
 Copyright 2011 Google Inc.
-Copyright 2010 Google Inc.
+Copyright 2020 Google LLC
 Copyright 2020 Google Inc.
+Copyright 2010 Google Inc.
 Copyright 2019 Google LLC
 Copyright 2012 Google Inc.
 
@@ -810,10 +810,10 @@ Copyright 2012 Google Inc. All Rights Reserved.
 -------- Dependency
 github.com/googleapis/gnostic
 -------- Copyrights
-Copyright 2017 Google LLC. All Rights Reserved.
-Copyright 2020 Google LLC. All Rights Reserved.
 Copyright 2017-2020, Google LLC.
 Copyright 2019 Google LLC. All Rights Reserved.
+Copyright 2017 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.
 Copyright 2018 Google LLC. All Rights Reserved.
 Copyright 2020 Google LLC. All Rights Reserved.\n" +
 
@@ -822,7 +822,11 @@ github.com/jetstack/cert-manager
 -------- Copyrights
 Copyright 2020 The cert-manager Authors.
 Copyright 2021 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
+Copyright YEAR The cert-manager Authors.
 Copyright The cert-manager Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright (c) 2015-2017 Sebastian Erhart
 Copyright (c) 2014 Alex Saskevich
 Copyright (c) 2021 Microsoft
 Copyright (c) 2015 Microsoft Corporation
@@ -950,19 +954,15 @@ Copyright 2014 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors
 Copyright (c) 2014 Sam Ghods
 Copyright (c) 2015, 2018, 2019 Opsmate, Inc. All rights reserved.
-Copyright 2022 The cert-manager Authors.
-Copyright YEAR The cert-manager Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright (c) 2015-2017 Sebastian Erhart
 Copyright 2017 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 
 -------- Dependency
 github.com/matttproud/golang_protobuf_extensions
 -------- Copyrights
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 Copyright 2013 Matt T. Proud
 Copyright 2016 Matt T. Proud
-Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 -------- Notices
 Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 
@@ -971,9 +971,9 @@ Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 github.com/moby/spdystream
 -------- Copyrights
 Copyright 2014-2021 Docker Inc.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2013-2021 Docker, inc. Released under the [Apache 2.0 license](LICENSE).
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 -------- Notices
 SpdyStream
 Copyright 2014-2021 Docker Inc.
@@ -995,15 +995,15 @@ github.com/modern-go/reflect2
 -------- Dependency
 github.com/prometheus/client_golang
 -------- Copyrights
+Copyright 2018 The Prometheus Authors
 Copyright 2012-2015 The Prometheus Authors
 Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
 Copyright 2010 The Go Authors
 Copyright 2013 Matt T. Proud
-Copyright 2018 The Prometheus Authors
+Copyright 2015 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
 Copyright 2021 The Prometheus Authors
 Copyright 2014 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2015 The Prometheus Authors
 Copyright 2016 The Prometheus Authors
 Copyright 2020 The Prometheus Authors
 Copyright 2017 The Prometheus Authors
@@ -1038,8 +1038,8 @@ Licensed under the Apache License, Version 2.0
 -------- Dependency
 github.com/prometheus/client_model
 -------- Copyrights
-Copyright 2013 Prometheus Team
 Copyright 2012-2015 The Prometheus Authors
+Copyright 2013 Prometheus Team
 -------- Notices
 Data model artifacts for Prometheus.
 Copyright 2012-2015 The Prometheus Authors
@@ -1051,15 +1051,15 @@ SoundCloud Ltd. (http://soundcloud.com/).
 -------- Dependency
 github.com/prometheus/common
 -------- Copyrights
-Copyright 2015 The Prometheus Authors
 Copyright 2018 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
+Copyright 2015 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
 Copyright 2014 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
 Copyright 2019 The Prometheus Authors
 Copyright (c) 2011, Open Knowledge Foundation Ltd.
 Copyright 2013 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
 Copyright 2017 The Prometheus Authors
 -------- Notices
 Common libraries shared by Prometheus Go components.
@@ -1072,12 +1072,12 @@ SoundCloud Ltd. (http://soundcloud.com/).
 -------- Dependency
 github.com/prometheus/procfs
 -------- Copyrights
-Copyright 2019 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2018 The Prometheus Authors
 Copyright 2014-2015 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
 Copyright 2014 Prometheus Team
 Copyright 2017 Prometheus Team
 -------- Notices
@@ -1093,16 +1093,16 @@ SoundCloud Ltd. (http://soundcloud.com/).
 -------- Dependency
 github.com/spf13/cobra
 -------- Copyrights
-Copyright © 2013 Steve Francia <spf@spf13.com>.
 Copyright © 2015 Steve Francia <spf@spf13.com>.
 Copyright © 2020 Steve Francia <spf@spf13.com>
 Copyright:    copyrightLine(),
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+Copyright © 2013 Steve Francia <spf@spf13.com>.
 Copyright    string
 copyright": copyrightLine(),
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
 Copyright 2015 Red Hat Inc. All rights reserved.
-Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
 Copyright 2016 French Ben. All rights reserved.
 
 -------- Dependency
@@ -1117,8 +1117,8 @@ Copyright 2020 Google LLC
 Copyright 2020 Google LLC.
 Copyright 2021 Google LLC
 Copyright 2015 Google LLC
-Copyright 2018 Google LLC
 Copyright 2019 Google LLC.
+Copyright 2018 Google LLC
 Copyright 2016 Google LLC
 Copyright 2017 Google Inc.
 Copyright 2018 Google Inc.
@@ -1133,18 +1133,18 @@ Copyright (c) 2015, Google Inc.
 google.golang.org/grpc
 -------- Copyrights
 Copyright 2021 gRPC authors.
-Copyright 2014 gRPC authors.
-Copyright 2020 gRPC authors.
-Copyright 2019 gRPC authors.
 Copyright 2017 gRPC authors.
+Copyright 2014 gRPC authors.
+Copyright 2019 gRPC authors.
+Copyright 2020 gRPC authors.
 Copyright 2018 gRPC authors.
 Copyright 2016 gRPC authors.
 Copyright 2015 The gRPC Authors
 Copyright 2018 The gRPC Authors
 Copyright 2015 gRPC authors.
-Copyright 2015-2016 gRPC authors.
 Copyright 2020 The gRPC Authors
 Copyright 2016 The gRPC Authors
+Copyright 2015-2016 gRPC authors.
 -------- Notices
 Copyright 2014 gRPC authors.
 
@@ -1185,15 +1185,15 @@ limitations under the License.
 -------- Dependency
 helm.sh/helm/v3
 -------- Copyrights
-Copyright The Helm Authors.
 Copyright 2016 The Kubernetes Authors All Rights Reserved
-Copyright 2016 The Kubernetes Authors.
-Copyright (c) for portions of walk.go are held by The Go Authors, 2009 and are
+Copyright The Helm Authors.
 Copyright (c) for portions of walk_test.go are held by The Go Authors, 2009 and are
+Copyright (c) for portions of walk.go are held by The Go Authors, 2009 and are
 Copyright (c) for portions of rename.go are held by The Go Authors, 2016 and are provided under
 Copyright (c) for portions of rename_windows.go are held by The Go Authors, 2016 and are provided under
 Copyright (c) for portions of fs.go are held by The Go Authors, 2016 and are provided under
 Copyright (c) for portions of fs_test.go are held by The Go Authors, 2016 and are provided under
+Copyright 2016 The Kubernetes Authors.
 
 -------- Dependency
 istio.io/api
@@ -1201,108 +1201,108 @@ istio.io/api
 Copyright 2019 Istio Authors
 Copyright Istio Authors
 Copyright 2016-2020 Istio Authors
-Copyright (c) 2013 TOML authors
 Copyright 2020 Istio Authors
-Copyright (c) 2012,2013 Ernest Micklei
-Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2013 TOML authors
 Copyright (c) 2015 The New York Times Company
 Copyright (c) 2012, Martin Angers
+Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2015-2017 Nick Galbreath
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2012 Elazar Leibovich. All rights reserved.
+Copyright (c) 2012,2013 Ernest Micklei
 Copyright 2014-2015 Docker, Inc.
-Copyright (c) 2012 fsnotify Authors. All rights reserved.
 Copyright (c) 2014, Evan Phoenix
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
+Copyright (c) 2014 Sam Ghods
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright (c) 2014 Sam Ghods
-Copyright (c) 2012 Elazar Leibovich. All rights reserved.
-Copyright (c) 2013 Kamil Kisiel
 Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+Copyright (C) 2013 99designs
 © Copyright 2015 Hewlett Packard Enterprise Development LP
 Copyright (c) 2014 ActiveState
-Copyright 2012 Keith Rarick
-Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
-Copyright (c) 2009,2014 Google Inc. All rights reserved.
 Copyright (c) 2016 json-iterator
+Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
+Copyright 2012 Keith Rarick
 Copyright (c) 2011 Keith Rarick
-Copyright (c) 2013-2014 Onsi Fakhouri
+Copyright (c) 2013 Kamil Kisiel
+Copyright (c) 2016 Mail.Ru Group
 Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved.
+Copyright (c) 2013-2014 Onsi Fakhouri
 Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 Copyright (c) 2013, Patrick Mezard
-Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
 Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright (c) 2013 The Go Authors. All rights reserved.
 Copyright (c) 2014 Stretchr, Inc.
 Copyright (c) 2017-2018 objx contributors
-Copyright (C) 2013 99designs
-Copyright (c) 2016 Mail.Ru Group
-Copyright (c) 2016 Dominik Honnef. All rights reserved.
-Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
+Copyright (c) 2013 The Go Authors. All rights reserved.
 Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
 Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
 Copyright (c) 2016 Dominik Honnef
-Copyright 2014 The Kubernetes Authors.
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+Copyright (c) 2016 Dominik Honnef. All rights reserved.
 Copyright 2016-2019 Istio Authors
+Copyright 2014 The Kubernetes Authors.
 
 -------- Dependency
 istio.io/client-go
 -------- Copyrights
 Copyright 2019 Istio Authors
 Copyright Istio Authors
-Copyright 2015 Microsoft Corporation
 Copyright 2016-2020 Istio Authors
-Copyright (c) 2015 The New York Times Company
+Copyright 2015 Microsoft Corporation
 Copyright (c) 2013 TOML authors
+Copyright (c) 2015 The New York Times Company
+Copyright (c) 2012, Martin Angers
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2015-2017 Nick Galbreath
-Copyright (c) 2012, Martin Angers
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2012,2013 Ernest Micklei
-Copyright (c) 2014, Evan Phoenix
-Copyright (c) 2012 fsnotify Authors. All rights reserved.
+Copyright (c) 2012 Dave Grijalva
 Copyright (c) 2012 Elazar Leibovich. All rights reserved.
-Copyright (c) 2014 Sam Ghods
+Copyright (c) 2012,2013 Ernest Micklei
 Copyright 2014-2015 Docker, Inc.
+Copyright (c) 2014, Evan Phoenix
+Copyright (c) 2014 Sam Ghods
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright (c) 2012 Dave Grijalva
-Copyright (c) 2009,2014 Google Inc. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright 2009-2017 Andrea Leofreddi <a.leofreddi@vleo.net>. All rights reserved.
-Copyright 2016, Google Inc.
 Copyright 2010-2017 Mike Bostock
+Copyright 2009-2017 Andrea Leofreddi <a.leofreddi@vleo.net>. All rights reserved.
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+Copyright 2016, Google Inc.
 Copyright 2012-2013 Rackspace, Inc.
+Copyright (C) 2013 99designs
+Copyright © 2012 Greg Jones (greg.jones@gmail.com)
 © Copyright 2015 Hewlett Packard Enterprise Development LP
 Copyright (c) 2014 ActiveState
-Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2016 json-iterator
-Copyright (c) 2012 Joel Stemmer
-Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
-Copyright (c) 2011 Keith Rarick
+Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2013 Kamil Kisiel
+Copyright (c) 2012 Joel Stemmer
+Copyright (c) 2011 Keith Rarick
+Copyright 2012 Keith Rarick
+Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
+Copyright (c) 2016 Mail.Ru Group
 Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved.
 Copyright (c) 2013-2014 Onsi Fakhouri
-Copyright 2012 Keith Rarick
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright (c) 2011-2012 Peter Bourgon
-Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 Copyright (c) 2013, Patrick Mezard
-Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
+Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2014 Stretchr, Inc.
 Copyright (c) 2017-2018 objx contributors
-Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright © 2012 Greg Jones (greg.jones@gmail.com)
+Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
 Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright (C) 2013 99designs
-Copyright (c) 2016 Mail.Ru Group
 Copyright (c) 2013 The Go Authors. All rights reserved.
-Copyright (c) 2011 Google Inc. All rights reserved.
-Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
-Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
 Copyright (c) 2013 Joshua Tacoma
+Copyright (c) 2011 Google Inc. All rights reserved.
+Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
 Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
 Copyright (c) 2016 Dominik Honnef. All rights reserved.
 Copyright (c) 2016 Dominik Honnef
 Copyright 2016-2019 Istio Authors
@@ -1318,9 +1318,9 @@ Copyright 2016-2019 Istio Authors
 -------- Dependency
 k8s.io/api
 -------- Copyrights
+Copyright 2019 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
 Copyright The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
@@ -1330,8 +1330,8 @@ Copyright 2020 The Kubernetes Authors.
 -------- Dependency
 k8s.io/apiextensions-apiserver
 -------- Copyrights
-Copyright 2017 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
@@ -1342,27 +1342,27 @@ Copyright 2020 Google LLC
 -------- Dependency
 k8s.io/apimachinery
 -------- Copyrights
-Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright The Kubernetes Authors.
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 
 -------- Dependency
 k8s.io/cli-runtime
 -------- Copyrights
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 
@@ -1370,12 +1370,12 @@ Copyright 2016 The Kubernetes Authors.
 k8s.io/client-go
 -------- Copyrights
 Copyright The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -1383,29 +1383,29 @@ Copyright (c) 2009 The Go Authors. All rights reserved.
 -------- Dependency
 k8s.io/component-base
 -------- Copyrights
-Copyright 2018 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 
 -------- Dependency
 k8s.io/klog/v2
 -------- Copyrights
-Copyright 2013 Google Inc. All Rights Reserved.
 Copyright 2020 The Kubernetes Authors.
+Copyright 2013 Google Inc. All Rights Reserved.
 
 -------- Dependency
 k8s.io/kube-aggregator
 -------- Copyrights
-Copyright 2016 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
@@ -1413,14 +1413,14 @@ Copyright 2021 The Kubernetes Authors.
 -------- Dependency
 k8s.io/kube-openapi
 -------- Copyrights
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
-Copyright 2015 go-swagger maintainers
 Copyright 2019 The Kubernetes Authors.
+Copyright 2015 go-swagger maintainers
 Copyright 2017 go-swagger maintainers
 Copyright (C) MongoDB, Inc. 2017-present.
 
@@ -1429,17 +1429,17 @@ k8s.io/utils
 -------- Copyrights
 Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2013 Google Inc.
 Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2013 Google Inc.
+Copyright 2009 The Go Authors. All rights reserved.
 
 -------- Dependency
 sigs.k8s.io/controller-runtime
@@ -1447,19 +1447,19 @@ sigs.k8s.io/controller-runtime
 Copyright 2018 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
 Copyright 2018 The Kubernetes authors.
-Copyright 2017 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
 
 -------- Dependency
 sigs.k8s.io/kustomize/api
 -------- Copyrights
+Copyright 2021 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 
 -------- Dependency
@@ -1468,18 +1468,18 @@ sigs.k8s.io/kustomize/kyaml
 Copyright 2019 The Kubernetes Authors.
 Copyright {{.Year}} {{.Holder}}
 Copyright 2021 The Kubernetes Authors.
-Copyright (c) 2011-2019 Canonical Ltd
 Copyright 2020 The Kubernetes Authors.
-Copyright (c) 2018 QRI, Inc.
-Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2011-2019 Canonical Ltd
 Copyright 2011-2016 Canonical Ltd.
 copyright staring in 2011 when the project was ported over:
+Copyright (c) 2006-2010 Kirill Simonov
 Copyright (c) 2006-2011 Kirill Simonov
+Copyright (c) 2018 QRI, Inc.
+Copyright 2018 The Kubernetes Authors.
 Copyright The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
 
 -------- Dependency
 sigs.k8s.io/structured-merge-diff/v4
@@ -1749,11 +1749,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------- Dependency
 go.starlark.net
 -------- Copyrights
-Copyright 2017 The Bazel Authors. All rights reserved.
-Copyright 2018 The Bazel Authors. All rights reserved.
-Copyright 2019 The Bazel Authors. All rights reserved.
 Copyright (c) 2017 The Bazel Authors.  All rights reserved.
 Starlark in Go is Copyright (c) 2018 The Bazel Authors.
+Copyright 2017 The Bazel Authors. All rights reserved.
+Copyright 2019 The Bazel Authors. All rights reserved.
+Copyright 2018 The Bazel Authors. All rights reserved.
 
 -------- Dependencies Summary
 go.starlark.net
@@ -1787,37 +1787,37 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------- Dependency
 github.com/PuerkitoBio/urlesc
 -------- Copyrights
-Copyright 2009 The Go Authors. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/fsnotify/fsnotify
 -------- Copyrights
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/gogo/protobuf
 -------- Copyrights
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
-Copyright (c) 2015, The GoGo Authors. All rights reserved.
-Copyright 2015 The Go Authors.  All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
+Copyright (c) 2015, The GoGo Authors. All rights reserved.
 Copyright 2016 The Go Authors.  All rights reserved.
+Copyright 2010 The Go Authors.
+Copyright 2015 The Go Authors.  All rights reserved.
 Copyright (c) 2018, The GoGo Authors. All rights reserved.
 Copyright (c) 2016, The GoGo Authors. All rights reserved.
-Copyright 2018 The Go Authors.  All rights reserved.
 Copyright 2011 The Go Authors.  All rights reserved.
+Copyright 2018 The Go Authors.  All rights reserved.
 Copyright 2017 The Go Authors.  All rights reserved.
-Copyright 2014 The Go Authors.  All rights reserved.
 Copyright 2012 The Go Authors.  All rights reserved.
-Copyright 2010 The Go Authors.
+Copyright 2014 The Go Authors.  All rights reserved.
 Copyright 2013 The Go Authors.  All rights reserved.
 Copyright (c) 2019, The GoGo Authors. All rights reserved.
 Copyright (c) 2017, The GoGo Authors. All rights reserved.
@@ -1826,27 +1826,27 @@ Copyright (c) 2015, The GoGo Authors.  rights reserved.
 -------- Dependency
 github.com/golang/protobuf
 -------- Copyrights
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors.  All rights reserved.
 
 -------- Dependency
 github.com/google/go-cmp
 -------- Copyrights
+Copyright (c) 2017 The Go Authors. All rights reserved.
 Copyright 2021, The Go Authors. All rights reserved.
-Copyright 2017, The Go Authors. All rights reserved.
-Copyright 2019, The Go Authors. All rights reserved.
 Copyright 2020, The Go Authors. All rights reserved.
 Copyright 2018, The Go Authors. All rights reserved.
-Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright 2017, The Go Authors. All rights reserved.
+Copyright 2019, The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/google/uuid
@@ -1854,41 +1854,41 @@ github.com/google/uuid
 Copyright 2016 Google Inc.  All rights reserved.
 Copyright 2017 Google Inc.  All rights reserved.
 Copyright 2021 Google Inc.  All rights reserved.
-Copyright 2018 Google Inc.  All rights reserved.
 Copyright (c) 2009,2014 Google Inc. All rights reserved.
+Copyright 2018 Google Inc.  All rights reserved.
 
 -------- Dependency
 github.com/imdario/mergo
 -------- Copyrights
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright 2013 Dario Castañé. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2014 Dario Castañé. All rights reserved.
-Copyright (c) 2013 Dario Castañé. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/liggitt/tabwriter
 -------- Copyrights
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/spf13/pflag
 -------- Copyrights
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
 
 -------- Dependency
 golang.org/x/mod
 -------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
@@ -1918,21 +1918,21 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/net
 -------- Copyrights
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
+Copyright (C) 2009 Apple Inc. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
-Copyright (C) 2009 Apple Inc. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -1961,36 +1961,36 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/oauth2
 -------- Copyrights
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2017 The oauth2 Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2017 The oauth2 Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2015 The oauth2 Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The oauth2 Authors. All rights reserved.
 
 -------- Dependency
 golang.org/x/sys
 -------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2009,2010 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All right reserved.
 -------- Patents
@@ -2021,11 +2021,11 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/term
 -------- Copyrights
-Copyright 2013 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -2054,17 +2054,17 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/text
 -------- Copyrights
-Copyright 2014 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -2093,8 +2093,8 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/time
 -------- Copyrights
-Copyright 2015 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -2123,22 +2123,21 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/tools
 -------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.  All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors.  All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors.  All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors.  All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 Copyright © 1994-1999 Lucent Technologies Inc.  All rights reserved.
 Portions Copyright © 1995-1997 C H Forsyth (forsyth@terzarima.net)
 Portions Copyright © 1997-1999 Vita Nuova Limited
@@ -2149,6 +2148,7 @@ Revisions Copyright © 2000-2007 Lucent Technologies Inc. and others
 Portions Copyright © 2009 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors.  All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 const license = `// Copyright 2013 The Go Authors. All rights reserved.
 -------- Patents
@@ -2180,8 +2180,8 @@ shall terminate as of the date such litigation is filed.
 golang.org/x/xerrors
 -------- Copyrights
 Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 Copyright (c) 2019 The Go Authors. All rights reserved.
 -------- Patents
@@ -2212,13 +2212,13 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 google.golang.org/protobuf
 -------- Copyrights
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
 Copyright (c) 2018 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2008 Google Inc.  All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.",
 Copyright 2018 The Go Authors. All rights reserved.",
+Copyright 2019 The Go Authors. All rights reserved.",
+Copyright 2008 Google Inc.  All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
@@ -2356,8 +2356,8 @@ Copyright (c) [2015] [go-gitignore]
 -------- Dependency
 github.com/onsi/ginkgo/v2
 -------- Copyrights
-Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright (c) 2013-2014 Onsi Fakhouri
+Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright 2013 The Go Authors. All rights reserved.
 
 -------- Dependency
@@ -2396,20 +2396,20 @@ Copyright (c) 2016-2020 Uber Technologies, Inc.
 -------- Dependency
 go.uber.org/multierr
 -------- Copyrights
-Copyright (c) 2019 Uber Technologies, Inc.
 Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
 
 -------- Dependency
 go.uber.org/zap
 -------- Copyrights
 Copyright (c) 2016 Uber Technologies, Inc.
 Copyright (c) 2020 Uber Technologies, Inc.
-Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2016-2017 Uber Technologies, Inc.
-Copyright (c) 2021 Uber Technologies, Inc.
 Copyright (c) "*" Uber Technologies, Inc.")
-Copyright (c) 2018 Uber Technologies, Inc.
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2021 Uber Technologies, Inc.
 Copyright (c) 2016, 2017 Uber Technologies, Inc.
+Copyright (c) 2018 Uber Technologies, Inc.
 
 -------- Dependencies Summary
 github.com/Jeffail/gabs/v2
@@ -2907,4 +2907,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 69a9c475c1e9e4bd327fc7292b039858
+License file based on go.mod with md5 sum: 23a5d5f9d44076086057dd0f1d4640be

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -581,7 +581,7 @@ type IstioComponent struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 	// +optional
-	InjectionEnabled *bool `json:"injection-enabled,omitempty"`
+	InjectionEnabled *bool `json:"injectionEnabled,omitempty"`
 	// +optional
 	Ingress *IstioIngressSection `json:"ingress,omitempty"`
 	// +optional

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -3579,7 +3579,7 @@ spec:
                             description: Type of ingress.  Default is LoadBalancer
                             type: string
                         type: object
-                      injection-enabled:
+                      injectionEnabled:
                         type: boolean
                       istioInstallArgs:
                         description: Arguments for installing Istio
@@ -4106,20 +4106,19 @@ spec:
                                   when the pod is removed. \n Use this if: a) the
                                   volume is only needed while the pod runs, b) features
                                   of normal volumes like restoring from snapshot or
-                                  capacity    tracking are needed, c) the storage
-                                  driver is specified through a storage class, and
-                                  d) the storage driver supports dynamic volume provisioning
-                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more    information on the connection between
-                                  this volume type    and PersistentVolumeClaim).
-                                  \n Use PersistentVolumeClaim or one of the vendor-specific
-                                  APIs for volumes that persist for longer than the
-                                  lifecycle of an individual pod. \n Use CSI for light-weight
-                                  local ephemeral volumes if the CSI driver is meant
-                                  to be used that way - see the documentation of the
-                                  driver for more information. \n A pod can use both
-                                  types of ephemeral volumes and persistent volumes
-                                  at the same time."
+                                  capacity tracking are needed, c) the storage driver
+                                  is specified through a storage class, and d) the
+                                  storage driver supports dynamic volume provisioning
+                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more information on the connection between this
+                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                  or one of the vendor-specific APIs for volumes that
+                                  persist for longer than the lifecycle of an individual
+                                  pod. \n Use CSI for light-weight local ephemeral
+                                  volumes if the CSI driver is meant to be used that
+                                  way - see the documentation of the driver for more
+                                  information. \n A pod can use both types of ephemeral
+                                  volumes and persistent volumes at the same time."
                                 properties:
                                   volumeClaimTemplate:
                                     description: "Will be used to create a stand-alone
@@ -4221,14 +4220,15 @@ spec:
                                               is non-empty. There are two important
                                               differences between DataSource and DataSourceRef:
                                               * While DataSource only allows two specific
-                                              types of objects, DataSourceRef   allows
+                                              types of objects, DataSourceRef allows
                                               any non-core object, as well as PersistentVolumeClaim
                                               objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef   preserves
-                                              all values, and generates an error if
-                                              a disallowed value is   specified. (Alpha)
-                                              Using this field requires the AnyVolumeDataSource
-                                              feature gate to be enabled.'
+                                              disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates
+                                              an error if a disallowed value is specified.
+                                              (Alpha) Using this field requires the
+                                              AnyVolumeDataSource feature gate to
+                                              be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -5833,18 +5833,18 @@ spec:
                       the pod that defines it - it will be created before the pod
                       starts, and deleted when the pod is removed. \n Use this if:
                       a) the volume is only needed while the pod runs, b) features
-                      of normal volumes like restoring from snapshot or capacity    tracking
+                      of normal volumes like restoring from snapshot or capacity tracking
                       are needed, c) the storage driver is specified through a storage
                       class, and d) the storage driver supports dynamic volume provisioning
-                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                      for more    information on the connection between this volume
-                      type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                      or one of the vendor-specific APIs for volumes that persist
-                      for longer than the lifecycle of an individual pod. \n Use CSI
-                      for light-weight local ephemeral volumes if the CSI driver is
-                      meant to be used that way - see the documentation of the driver
-                      for more information. \n A pod can use both types of ephemeral
-                      volumes and persistent volumes at the same time."
+                      through a PersistentVolumeClaim (see EphemeralVolumeSource for
+                      more information on the connection between this volume type
+                      and PersistentVolumeClaim). \n Use PersistentVolumeClaim or
+                      one of the vendor-specific APIs for volumes that persist for
+                      longer than the lifecycle of an individual pod. \n Use CSI for
+                      light-weight local ephemeral volumes if the CSI driver is meant
+                      to be used that way - see the documentation of the driver for
+                      more information. \n A pod can use both types of ephemeral volumes
+                      and persistent volumes at the same time."
                     properties:
                       volumeClaimTemplate:
                         description: "Will be used to create a stand-alone PVC to
@@ -5929,13 +5929,13 @@ spec:
                                   automatically if one of them is empty and the other
                                   is non-empty. There are two important differences
                                   between DataSource and DataSourceRef: * While DataSource
-                                  only allows two specific types of objects, DataSourceRef   allows
-                                  any non-core object, as well as PersistentVolumeClaim
+                                  only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim
                                   objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef   preserves all values,
-                                  and generates an error if a disallowed value is   specified.
-                                  (Alpha) Using this field requires the AnyVolumeDataSource
-                                  feature gate to be enabled.'
+                                  (dropping them), DataSourceRef preserves all values,
+                                  and generates an error if a disallowed value is
+                                  specified. (Alpha) Using this field requires the
+                                  AnyVolumeDataSource feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -7036,12 +7036,12 @@ spec:
                             if one of them is empty and the other is non-empty. There
                             are two important differences between DataSource and DataSourceRef:
                             * While DataSource only allows two specific types of objects,
-                            DataSourceRef   allows any non-core object, as well as
-                            PersistentVolumeClaim objects. * While DataSource ignores
-                            disallowed values (dropping them), DataSourceRef   preserves
-                            all values, and generates an error if a disallowed value
-                            is   specified. (Alpha) Using this field requires the
-                            AnyVolumeDataSource feature gate to be enabled.'
+                            DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
+                            objects. * While DataSource ignores disallowed values
+                            (dropping them), DataSourceRef preserves all values, and
+                            generates an error if a disallowed value is specified.
+                            (Alpha) Using this field requires the AnyVolumeDataSource
+                            feature gate to be enabled.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource

--- a/tests/e2e/config/scripts/install-verrazzano-kind-no-injection.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind-no-injection.yaml
@@ -19,5 +19,5 @@ spec:
     prometheusNodeExporter:
       enabled: true
     istio:
-      injection-enabled: false
+      injectionEnabled: false
 


### PR DESCRIPTION
# Description

Modified "injection-enabled" json representation of Istio component injectionEnabled parameter to be "injectionEnabled".  The generation of associated artifacts modified go.mod/go.sum files and required generation of new 3rd party licenses file as well.

Fixes VZ-5682

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
