### PR TITLE
No JIRA.  Remove the verify-upgrade-required/update-on-upgrade scenario from new upgrade paths pipeline

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -443,11 +443,6 @@ pipeline {
                         upgradePlatformOperator()
                     }
                 }
-                stage("verify-upgrade-required") {
-                    steps {
-                        runGinkgoRandomize('upgrade/pre-upgrade/verify-upgrade-required')
-                    }
-                }
                 stage("upgrade-verrazzano") {
                     steps {
                         upgradeVerrazzano()
@@ -969,10 +964,6 @@ def upgradeVerrazzanoOnCluster(count, verrazzanoDevVersion) {
                 cd ${GO_REPO_PATH}/verrazzano
                 cp ${v8oInstallFile} ${v8oUpgradeFile}
                 ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${verrazzanoDevVersion}  ${v8oUpgradeFile}
-
-                # Add some simple additional updates to validate update during an upgrade
-                yq -i eval '.spec.components.istio.ingress.kubernetes.replicas = 3' ${v8oUpgradeFile}
-                yq -i eval '.spec.components.istio.egress.kubernetes.replicas = 3' ${v8oUpgradeFile}
 
                 # Do the upgrade
                 echo "Following is the verrazzano CR file with the new version:"


### PR DESCRIPTION

# Description

Removes the recently-added verify-upgrade-required and update-during-upgrade scenario from the new upgrade paths pipeline.  We will need to re-introduce these in a way that safely allows version-specific testing of these scenarios.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
