### PR TITLE
NO JIRA: framework.Log.x() tees to Stdout

### DIFF
--- a/pkg/test/framework/ginkgo_wrapper.go
+++ b/pkg/test/framework/ginkgo_wrapper.go
@@ -22,7 +22,7 @@ func NewTestFramework(pkg string) *TestFramework {
 	t := new(TestFramework)
 	t.Pkg = pkg
 	t.Metrics, _ = metrics.NewLogger(pkg, metrics.MetricsIndex)
-	t.Logs, _ = metrics.NewLogger(pkg, metrics.TestLogIndex)
+	t.Logs, _ = metrics.NewLogger(pkg, metrics.TestLogIndex, "stdout")
 	return t
 }
 

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -5,16 +5,14 @@ package metrics
 
 import (
 	"fmt"
-	neturl "net/url"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	neturl "net/url"
+	"os"
+	"strings"
 )
 
 const (
@@ -63,7 +61,7 @@ func internalLogger() *zap.SugaredLogger {
 }
 
 //NewLogger generates a new logger, and tees ginkgo output to the search db
-func NewLogger(pkg string, ind string) (*zap.SugaredLogger, error) {
+func NewLogger(pkg string, ind string, paths ...string) (*zap.SugaredLogger, error) {
 	var messageKey = zapcore.OmitKey
 	if ind == TestLogIndex {
 		messageKey = "msg"
@@ -90,7 +88,7 @@ func NewLogger(pkg string, ind string) (*zap.SugaredLogger, error) {
 		logger.Errorf("failed to configure outputs: %v", err)
 		return nil, err
 	}
-	cfg.OutputPaths = outputPaths
+	cfg.OutputPaths = append(outputPaths, paths...)
 	log, err := cfg.Build()
 	if err != nil {
 		logger.Errorf("error creating %s logger %v", pkg, err)
@@ -141,10 +139,6 @@ func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 	}
 
 	return log
-}
-
-func Millis() int64 {
-	return time.Now().UnixNano() / int64(time.Millisecond)
 }
 
 //configureOutputs configures the search output path if it is available

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -90,7 +90,7 @@ func NewDefaultFrameworkWithKubeConfig(baseName string, kubeConfig string) *Fram
 // NewFramework creates a test framework.
 func NewFramework(baseName string, kubeconfig string, client *clientset.Clientset) *Framework {
 	metricsIndex, _ := metrics.NewLogger(baseName, metrics.MetricsIndex)
-	logIndex, _ := metrics.NewLogger(baseName, metrics.TestLogIndex)
+	logIndex, _ := metrics.NewLogger(baseName, metrics.TestLogIndex, "stdout")
 
 	f := &Framework{
 		BaseName:   strings.ToLower(baseName),


### PR DESCRIPTION
Calls to framework.Log were only exported to the log db, and not visible in the console. This change tees output from framework.Log to `stdout`.