### PR TITLE
VZ-4969: Add cluster role to allow OAM operator to manage PVC workloads

### DIFF
--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -4,11 +4,21 @@
 package oam
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	pvcClusterRoleName         = "oam-kubernetes-runtime-pvc"
+	aggregateToControllerLabel = "rbac.oam.dev/aggregate-to-controller"
 )
 
 // isOAMReady checks if the OAM operator deployment is ready
@@ -21,4 +31,34 @@ func isOAMReady(context spi.ComponentContext) bool {
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())
 	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+}
+
+// ensureClusterRoles creates or updates additional OAM cluster roles during install and upgrade
+func ensureClusterRoles(ctx spi.ComponentContext) error {
+	// add a cluster role that allows the OAM operator to manage persistent volume claim workloads
+	pvcClusterRole := rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: pvcClusterRoleName}}
+
+	_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &pvcClusterRole, func() error {
+		if pvcClusterRole.Labels == nil {
+			pvcClusterRole.Labels = make(map[string]string)
+		}
+		// this label triggers cluster role aggregation into the oam-kubernetes-runtime cluster role
+		pvcClusterRole.Labels[aggregateToControllerLabel] = "true"
+		pvcClusterRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{corev1.ResourcePersistentVolumeClaims.String()},
+				Verbs: []string{
+					"create",
+					"delete",
+					"get",
+					"list",
+					"patch",
+					"update",
+				},
+			},
+		}
+		return nil
+	})
+	return err
 }

--- a/platform-operator/controllers/verrazzano/component/oam/oam_component.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam_component.go
@@ -75,3 +75,19 @@ func (c oamComponent) ValidateUpdate(old *vzapi.Verrazzano, new *vzapi.Verrazzan
 func (c oamComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	return common.ApplyCRDYaml(ctx, config.GetHelmOamChartsDir())
 }
+
+// PostInstall runs post-install processing for the OAM component
+func (c oamComponent) PostInstall(ctx spi.ComponentContext) error {
+	if err := ensureClusterRoles(ctx); err != nil {
+		return err
+	}
+	return c.HelmComponent.PostInstall(ctx)
+}
+
+// PostUpgrade runs post-upgrade processing for the OAM component
+func (c oamComponent) PostUpgrade(ctx spi.ComponentContext) error {
+	if err := ensureClusterRoles(ctx); err != nil {
+		return err
+	}
+	return c.HelmComponent.PostUpgrade(ctx)
+}

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -80,6 +80,10 @@ function delete_oam_operator {
       error "Failed to uninstall the OAM Kubernetes operator."
     fi
   fi
+
+  # Delete the additional cluster roles we created during install
+  log "Deleting additional OAM cluster roles"
+  kubectl delete clusterrole oam-kubernetes-runtime-pvc --ignore-not-found
 }
 
 function delete_application_operator {


### PR DESCRIPTION
# Description

This PR fixes a bug reported by a customer. When wrapping a persistent volume claim in an OAM component, the associated application fails to deploy because the OAM operator doesn't have sufficient privileges to create the PVC. This PR adds a cluster role during install and upgrade that will allow the operator to manage PVCs.

I manually tested the fix in an OKE cluster using YAML provided by the customer. I will extend an end-to-end test to add a PVC component in a subsequent PR.

Fixes VZ-4969

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
