### PR TITLE
VZ-5076 Cleanup errors in AuthProxy log during install

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -697,11 +697,11 @@ data:
         end
         if not res then
             me.info("Failed requesting token from Keycloak: response is nil")
-            me.unauthorized("Error requesting token: response was nil")
+            me.unauthorized("Error requesting token: response is nil")
         end
         if not (res.status == 200) then
             me.info("Failed requesting token from Keycloak: response status code is "..res.status.." and response body is "..res.body)
-            me.unauthorized("Error requesting token: response status code was "..res.status.." and response body was "..res.body)
+            me.unauthorized("Error requesting token: response status code is "..res.status.." and response body is "..res.body)
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -298,6 +298,13 @@ data:
         ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
 
+    function me.service_unavailable(msg, err)
+        me.audit(msg, err)
+        ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+        ngx.say("503 Service Unavailable")
+        ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
+    end
+
     function me.unauthorized(msg, err)
         me.deleteCookies("vz_authn", "vz_userinfo", "vz_state")
         me.audit(msg, err)
@@ -698,6 +705,10 @@ data:
         if not res then
             me.info("Failed requesting token from Keycloak: response is nil")
             me.unauthorized("Error requesting token: response was nil")
+        end
+        if res.status >= 500 then
+            me.info("Failed requesting token from Keycloak: response body is "..res.body)
+            me.service_unavailable("Error requesting token: response status code was "..res.status)
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -298,13 +298,6 @@ data:
         ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
 
-    function me.service_unavailable(msg, err)
-        me.audit(msg, err)
-        ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
-        ngx.say("503 Service Unavailable")
-        ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
-    end
-
     function me.unauthorized(msg, err)
         me.deleteCookies("vz_authn", "vz_userinfo", "vz_state")
         me.audit(msg, err)
@@ -706,14 +699,14 @@ data:
             me.info("Failed requesting token from Keycloak: response is nil")
             me.unauthorized("Error requesting token: response was nil")
         end
-        if res.status >= 500 then
-            me.info("Failed requesting token from Keycloak: response body is "..res.body)
-            me.service_unavailable("Error requesting token: response status code was "..res.status)
+        if not (res.status == 200) then
+            me.info("Failed requesting token from Keycloak: response status code is "..res.status.." and response body is "..res.body)
+            me.unauthorized("Error requesting token: response status code was "..res.status.." and response body was "..res.body)
         end
         local tokenRes = cjson.decode(res.body)
         if tokenRes.error or tokenRes.error_description then
             me.info("Failed requesting token from Keycloak: "..tokenRes.error_description)
-            me.unauthorized(tokenRes.error_description)
+            me.unauthorized("Error requesting token: "..tokenRes.error_description)
         end
         return tokenRes
     end


### PR DESCRIPTION
# Description

Added code to return Service Unavailable error (503) from AuthProxy for 5xx errors from Keycloak. 

Fixes VZ-5076

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
