### PR TITLE
add nginx/istio service ports update tests

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/uuid"
 	vpClient "github.com/verrazzano/verrazzano/application-operator/clients/clusters/clientset/versioned"
@@ -211,6 +212,21 @@ func GetDaemonSet(namespace string, daemonSetName string) (*appsv1.DaemonSet, er
 		return nil, err
 	}
 	return daemonset, nil
+}
+
+// GetService returns a Service with the given name and namespace
+func GetService(namespace string, serviceName string) (*corev1.Service, error) {
+	// Get the Kubernetes clientset
+	clientSet, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	svc, err := clientSet.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get Service %s from namespace %s: %v ", serviceName, namespace, err))
+		return nil, err
+	}
+	return svc, nil
 }
 
 // ListNodes returns the list of nodes for the cluster

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -34,7 +34,7 @@ const (
 	pollingInterval        = 5 * time.Second
 )
 
-var nginxIngressPorts = []corev1.ServicePort{
+var testNginxIngressPorts = []corev1.ServicePort{
 	{
 		Name:     "https",
 		Protocol: "TCP",
@@ -47,7 +47,7 @@ var nginxIngressPorts = []corev1.ServicePort{
 	},
 }
 
-var istioIngressPorts = []corev1.ServicePort{
+var testIstioIngressPorts = []corev1.ServicePort{
 	{
 		Name:       "https",
 		Protocol:   "TCP",
@@ -163,14 +163,14 @@ func (u NginxIstioServicePortsModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	if cr.Spec.Components.Ingress == nil {
 		cr.Spec.Components.Ingress = &vzapi.IngressNginxComponent{}
 	}
-	cr.Spec.Components.Ingress.Ports = nginxIngressPorts
+	cr.Spec.Components.Ingress.Ports = testNginxIngressPorts
 	if cr.Spec.Components.Istio == nil {
 		cr.Spec.Components.Istio = &vzapi.IstioComponent{}
 	}
 	if cr.Spec.Components.Istio.Ingress == nil {
 		cr.Spec.Components.Istio.Ingress = &vzapi.IstioIngressSection{}
 	}
-	cr.Spec.Components.Istio.Ingress.Ports = istioIngressPorts
+	cr.Spec.Components.Istio.Ingress.Ports = testIstioIngressPorts
 }
 
 var t = framework.NewTestFramework("update nginx-istio")
@@ -248,15 +248,15 @@ func validateServicePorts() {
 		if err != nil {
 			return err
 		}
-		if !reflect.DeepEqual(nginxIngressPorts, nginxIngress.Spec.Ports) {
-			return fmt.Errorf("expect nginx with ports %v, but got %v", nginxIngressPorts, nginxIngress.Spec.Ports)
+		if !reflect.DeepEqual(testNginxIngressPorts, nginxIngress.Spec.Ports) {
+			return fmt.Errorf("expect nginx with ports %v, but got %v", testNginxIngressPorts, nginxIngress.Spec.Ports)
 		}
 		istioIngress, err := pkg.GetService(constants.IstioSystemNamespace, "istio-ingressgateway")
 		if err != nil {
 			return err
 		}
-		if !reflect.DeepEqual(istioIngressPorts, istioIngress.Spec.Ports) {
-			return fmt.Errorf("expect nginx with ports %v, but got %v", nginxIngressPorts, istioIngress.Spec.Ports)
+		if !reflect.DeepEqual(testIstioIngressPorts, istioIngress.Spec.Ports) {
+			return fmt.Errorf("expect nginx with ports %v, but got %v", testNginxIngressPorts, istioIngress.Spec.Ports)
 		}
 		return nil
 	}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "expect to get correct ports setting from nginx and istio services")

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -6,7 +6,15 @@ package nginxistio
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
@@ -22,7 +30,32 @@ const (
 	istioAppLabelKey       = "app"
 	istioIngressLabelValue = "istio-ingressgateway"
 	istioEgressLabelValue  = "istio-egressgateway"
+	waitTimeout            = 5 * time.Minute
+	pollingInterval        = 5 * time.Second
 )
+
+var nginxIngressPorts = []corev1.ServicePort{
+	{
+		Name:     "https",
+		Protocol: "TCP",
+		Port:     443,
+		NodePort: 31443,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.String,
+			StrVal: "https",
+		},
+	},
+}
+
+var istioIngressPorts = []corev1.ServicePort{
+	{
+		Name:       "https",
+		Protocol:   "TCP",
+		Port:       443,
+		NodePort:   32443,
+		TargetPort: intstr.FromInt(8443),
+	},
+}
 
 type NginxAutoscalingIstioRelicasAffintyModifier struct {
 	nginxReplicas        uint32
@@ -31,6 +64,9 @@ type NginxAutoscalingIstioRelicasAffintyModifier struct {
 }
 
 type NginxIstioDefaultModifier struct {
+}
+
+type NginxIstioServicePortsModifier struct {
 }
 
 func (m NginxAutoscalingIstioRelicasAffintyModifier) ModifyCR(cr *vzapi.Verrazzano) {
@@ -123,6 +159,20 @@ func (u NginxIstioDefaultModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	cr.Spec.Components.Istio = &vzapi.IstioComponent{}
 }
 
+func (u NginxIstioServicePortsModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	if cr.Spec.Components.Ingress == nil {
+		cr.Spec.Components.Ingress = &vzapi.IngressNginxComponent{}
+	}
+	cr.Spec.Components.Ingress.Ports = nginxIngressPorts
+	if cr.Spec.Components.Istio == nil {
+		cr.Spec.Components.Istio = &vzapi.IstioComponent{}
+	}
+	if cr.Spec.Components.Istio.Ingress == nil {
+		cr.Spec.Components.Istio.Ingress = &vzapi.IstioIngressSection{}
+	}
+	cr.Spec.Components.Istio.Ingress.Ports = istioIngressPorts
+}
+
 var t = framework.NewTestFramework("update nginx-istio")
 
 var nodeCount uint32 = 1
@@ -166,8 +216,8 @@ var _ = t.Describe("Update nginx-istio", Label("f:platform-lcm.update"), func() 
 		})
 	})
 
-	t.Describe("verrazzano-nginx-istio update", Label("f:platform-lcm.nginx-istio-update"), func() {
-		t.It("nginx-istio update", func() {
+	t.Describe("verrazzano-nginx-istio update replicas", Label("f:platform-lcm.nginx-istio-update-replicas"), func() {
+		t.It("nginx-istio update replicas", func() {
 			istioCount := nodeCount - 1
 			if nodeCount == 1 {
 				istioCount = nodeCount
@@ -180,4 +230,34 @@ var _ = t.Describe("Update nginx-istio", Label("f:platform-lcm.update"), func() 
 			update.ValidatePods(istioEgressLabelValue, istioAppLabelKey, constants.IstioSystemNamespace, istioCount, false)
 		})
 	})
+
+	t.Describe("verrazzano-nginx-istio update service ports", Label("f:platform-lcm.nginx-istio-update-ports"), func() {
+		t.It("nginx-istio update service ports", func() {
+			m := NginxIstioServicePortsModifier{}
+			update.UpdateCR(m)
+
+			validateServicePorts()
+		})
+	})
 })
+
+func validateServicePorts() {
+	gomega.Eventually(func() error {
+		var err error
+		nginxIngress, err := pkg.GetService(constants.IngressNamespace, "ingress-controller-ingress-nginx-controller")
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(nginxIngressPorts, nginxIngress.Spec.Ports) {
+			return fmt.Errorf("expect nginx with ports %v, but got %v", nginxIngressPorts, nginxIngress.Spec.Ports)
+		}
+		istioIngress, err := pkg.GetService(constants.IstioSystemNamespace, "istio-ingressgateway")
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(istioIngressPorts, istioIngress.Spec.Ports) {
+			return fmt.Errorf("expect nginx with ports %v, but got %v", nginxIngressPorts, istioIngress.Spec.Ports)
+		}
+		return nil
+	}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "expect to get correct ports setting from nginx and istio services")
+}


### PR DESCRIPTION
# Description

Add Nginx and Istio Ingress Service Ports update tests cases to verrazzano-dynamic-config-tests.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
