### PR TITLE
NO JIRA: Target index no longer used with data streams

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -763,9 +763,6 @@ data:
       @id kubernetes_record_transformer
       enable_ruby true
       <record>
-        target_index verrazzano-namespace-${record["kubernetes"]["namespace_name"]}
-      </record>
-      <record>
         kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["container_name"]}
       </record>
     </filter>


### PR DESCRIPTION
Fluentd record transformation to add `target_index` field to records is no longer used after the switch to Data Streams.
Historically we used this field to select the index in the output plugin. The output data stream name is now based on the output plugin match.