### PR TITLE
NO JIRA: OCI service integration pipeline fixes

### DIFF
--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
+def agentLabel = ""
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = ""
+def agentLabel = "VM.Standard2.8"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = "VM.Standard2.8"
+def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -80,17 +80,10 @@ if [ ${status_code:-1} -eq 0 ]; then
     # if the cluster has been created with private endpoints then setup the ssh tunnel through the bastion host
     if [ "$TF_VAR_bastion_enabled" = true ] ; then
       echo "Setting up ssh tunnel through bastion host."
-      retries=0
-      until [ "$retries" -ge 3 ]
-      do
-        ../../setup_ssh_tunnel.sh && break
-        echo "Failed setting up ssh tunnel, retrying in 30 seconds..."
-        retries=$(($retries+1))
-        sleep 30
-      done
-      if [ "$retries" -ge 3 ] ; then
-        echo "Can't setup ssh tunnel through bastion host!"
-        exit 1
+      ../../setup_ssh_tunnel.sh
+      if [ $? -ne 0 ]; then
+          echo "Can't setup ssh tunnel through bastion host!"
+          exit 1
       fi
     fi
 

--- a/tests/e2e/config/scripts/setup_ssh_tunnel.sh
+++ b/tests/e2e/config/scripts/setup_ssh_tunnel.sh
@@ -34,6 +34,7 @@ fi
 VCN_CIDR=$(oci network vcn list \
   --compartment-id "${TF_VAR_compartment_id}" \
   --display-name "${TF_VAR_label_prefix}-oke-vcn" \
+  --lifecycle-state AVAILABLE \
   | jq -r '.data[0]."cidr-block"')
 
 if [ -z "VCN_CIDR" ]; then
@@ -45,6 +46,7 @@ fi
 BASTION_ID=$(oci compute instance list \
   --compartment-id "${TF_VAR_compartment_id}" \
   --display-name "${TF_VAR_label_prefix}-bastion" \
+  --lifecycle-state RUNNING \
   | jq -r '.data[0]."id"')
 
 if [ -z "$BASTION_ID" ]; then

--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -38,7 +38,8 @@ while true; do
       echo "Terraform apply tries exceeded.  Cluster creation has failed!"
       break
    fi
-   echo "Terraform apply failed, applying again"
+   echo "Deleting Cluster Terraform and applying again"
+   $SCRIPT_DIR/delete-cluster.sh
    sleep 30
 done
 

--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -38,8 +38,7 @@ while true; do
       echo "Terraform apply tries exceeded.  Cluster creation has failed!"
       break
    fi
-   echo "Deleting Cluster Terraform and applying again"
-   $SCRIPT_DIR/delete-cluster.sh
+   echo "Terraform apply failed, applying again"
    sleep 30
 done
 


### PR DESCRIPTION
# Description

A few small fixes to the OCI service integration pipeline:

1. The job name for this pipeline doesn't contain "-dns-" so just change the agentLabel to VM.Standard2.8
2. Fix incorrect check of exit code after creating the OKE cluster
3. Add lifecycle state filtering when setting up the bastion ssh session. This fixes the problem where the cluster creation is retried and there may be multiple resources that match the display name, we only want to consider active resources

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
