### PR TITLE
Adding 'always' key rotation policy to root CA Cert

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -720,6 +720,9 @@ func createOrUpdateCAResources(compContext spi.ComponentContext) (controllerutil
 					Name: issuer.Name,
 					Kind: issuer.Kind,
 				},
+				PrivateKey: &certv1.CertificatePrivateKey{
+					RotationPolicy: certv1.RotationPolicyAlways,
+				},
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
Signed-off-by: stshapir <steven.shapiro@oracle.com>

# Description

This PR adds the RotationPolicy annotation to the root CA cert "verrazzano-root-ca" as "Always"

Fixes VZ-5777

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
