### PR TITLE
VZ-4969: Add end-to-end test for OAM workloads

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -416,6 +416,14 @@ pipeline {
                                 runGinkgo('workloads/coherence')
                             }
                         }
+                        stage('OAM workloads') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/oam-workloads"
+                            }
+                            steps {
+                                runGinkgo('workloads/oam')
+                            }
+                        }
                         stage('examples helidon-metrics') {
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/helidonmetrics"

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -1225,7 +1225,7 @@ func GetServiceAccount(namespace, name string) (*corev1.ServiceAccount, error) {
 	return sa, nil
 }
 
-func GetPersistentVolumes(namespace string) (map[string]*corev1.PersistentVolumeClaim, error) {
+func GetPersistentVolumeClaims(namespace string) (map[string]*corev1.PersistentVolumeClaim, error) {
 	clientset, err := k8sutil.GetKubernetesClientset()
 	if err != nil {
 		return nil, err

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -106,7 +106,7 @@ var _ = t.BeforeSuite(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(BeEmpty())
 
 	Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
-		volumeClaims, err = pkg.GetPersistentVolumes(verrazzanoNamespace)
+		volumeClaims, err = pkg.GetPersistentVolumeClaims(verrazzanoNamespace)
 		return volumeClaims, err
 	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -6,8 +6,6 @@ package keycloak
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"os/exec"
 	"path"
 	"strings"
@@ -15,6 +13,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -103,7 +103,7 @@ var t = framework.NewTestFramework("keycloak")
 var _ = t.BeforeSuite(func() {
 	Eventually(func() (map[string]*corev1.PersistentVolumeClaim, error) {
 		var err error
-		volumeClaims, err = pkg.GetPersistentVolumes(keycloakNamespace)
+		volumeClaims, err = pkg.GetPersistentVolumeClaims(keycloakNamespace)
 		return volumeClaims, err
 	}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 })

--- a/tests/e2e/workloads/oam/oam_workload_suite_test.go
+++ b/tests/e2e/workloads/oam/oam_workload_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oam
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var skipDeploy bool
+var skipUndeploy bool
+var namespace string
+
+// init initializes variables from command line arguments
+func init() {
+	flag.BoolVar(&skipDeploy, "skipDeploy", false, "skipDeploy skips the call to install the application")
+	flag.BoolVar(&skipUndeploy, "skipUndeploy", false, "skipUndeploy skips the call to uninstall the application")
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+}
+
+// TestOAMWorkloads runs the OAM workload test suite that tests various OAM workload types
+func TestOAMWorkloads(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Test Suite to validate the support for OAM workloads")
+}

--- a/tests/e2e/workloads/oam/oam_workload_test.go
+++ b/tests/e2e/workloads/oam/oam_workload_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oam
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	shortWaitTimeout     = 2 * time.Minute
+	shortPollingInterval = 10 * time.Second
+
+	appConfiguration  = "tests/testdata/test-applications/oam/oam-app.yaml"
+	compConfiguration = "tests/testdata/test-applications/oam/oam-comp.yaml"
+
+	pvcName = "test-pvc"
+)
+
+var (
+	t                  = framework.NewTestFramework("oam_workloads")
+	generatedNamespace = pkg.GenerateNamespace("oam-workloads")
+)
+
+var _ = BeforeSuite(func() {
+	if !skipDeploy {
+		start := time.Now()
+		deployOAMApp()
+		metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
+	}
+	beforeSuitePassed = true
+})
+
+var failed = false
+var beforeSuitePassed = false
+var _ = t.AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = t.AfterSuite(func() {
+	if failed || !beforeSuitePassed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
+	if !skipUndeploy {
+		undeployOAMApp()
+	}
+})
+
+var _ = t.Describe("An OAM application is deployed", Label("f:app-lcm.oam"), func() {
+	t.Context("Check for created resources", func() {
+		// GIVEN the test application is deployed
+		// AND the application includes a component that wraps a persistent volume claim
+		// WHEN a call is made to fetch the persistent volume claim
+		// THEN the persistent volume claim is found to exist
+		t.It("The persistent volume claim exists", func() {
+			Eventually(func() (bool, error) {
+				return volumeClaimExists(pvcName)
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+		})
+	})
+})
+
+// volumeClaimExists checks if the persistent volume claim with the specified name exists
+// in the test namespace
+func volumeClaimExists(volumeClaimName string) (bool, error) {
+	volumeClaims, err := pkg.GetPersistentVolumeClaims(namespace)
+	if err != nil {
+		return false, err
+	}
+	_, ok := volumeClaims[volumeClaimName]
+	return ok, nil
+}
+
+// deployOAMApp deploys the test components and application configuration
+func deployOAMApp() {
+	t.Logs.Info("Deploy OAM application")
+
+	t.Logs.Info("Create namespace")
+	Eventually(func() (*v1.Namespace, error) {
+		nsLabels := map[string]string{
+			"verrazzano-managed": "true"}
+		return pkg.CreateNamespace(namespace, nsLabels)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(BeNil())
+
+	t.Logs.Info("Create component resources")
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(compConfiguration, namespace)
+	}, shortWaitTimeout, shortPollingInterval, "Failed to create component resources for Coherence application").ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Create application resources")
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(appConfiguration, namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+}
+
+// undeployOAMApp removes the test components and application configuration
+func undeployOAMApp() {
+	t.Logs.Info("Undeploy OAM application")
+	start := time.Now()
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(appConfiguration, namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Delete components")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(compConfiguration, namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for persistent volume claim to terminate")
+	Eventually(func() (bool, error) {
+		return volumeClaimExists(pvcName)
+	}, shortWaitTimeout, shortPollingInterval).Should(BeFalse())
+
+	t.Logs.Info("Delete namespace")
+	Eventually(func() error {
+		return pkg.DeleteNamespace(namespace)
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for namespace finalizer to be removed")
+	Eventually(func() bool {
+		return pkg.CheckNamespaceFinalizerRemoved(namespace)
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+
+	t.Logs.Info("Wait for namespace deletion")
+	Eventually(func() bool {
+		_, err := pkg.GetNamespace(namespace)
+		return err != nil && errors.IsNotFound(err)
+	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
+
+	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
+}

--- a/tests/testdata/test-applications/oam/oam-app.yaml
+++ b/tests/testdata/test-applications/oam/oam-app.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: test-pvc-appconf
+spec:
+  components:
+    - componentName: test-pvc-component

--- a/tests/testdata/test-applications/oam/oam-comp.yaml
+++ b/tests/testdata/test-applications/oam/oam-comp.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
+metadata:
+  name: test-pvc-component
+spec:
+  workload:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: test-pvc
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
# Description

This PR adds the start of an end-to-end test suite for OAM workloads. The first test introduced here verifies that the OAM operator is able to create a persistent volume claim workload from a component. This test suite runs as part of the KinD acceptance test pipeline.

The plan is to add more OAM tests in the future.

Fixes VZ-4969

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
