### PR TITLE
VZ-5781 - Sync registration info from admin to managed cluster so that DNS updates are picked up. Also make sure update to Let's Encrypt Staging admin cluster updates the local ca bundle synced to managed.

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -57,7 +57,7 @@ func StartAgent(client client.Client, statusUpdateChannel chan clusters.StatusUp
 			s.Log.Errorf("Failed processing multi-cluster resources: %v", err)
 		}
 		s.updateDeployment("verrazzano-monitoring-operator")
-		s.configureLogging()
+		s.configureLogging(false)
 		if !s.AgentReadyToSync() {
 			// there is no admin cluster we are connected to, so nowhere to send any status updates
 			// received - discard them
@@ -120,12 +120,18 @@ func (s *Syncer) ProcessAgentThread() error {
 	s.SyncMultiClusterResources()
 
 	// Check whether the admin or local clusters' CA certs have rolled, and sync as necessary
-	err = s.syncClusterCAs()
+	managedClusterResult, err := s.syncClusterCAs()
 	if err != nil {
 		// we couldn't sync the cluster CAs - but we should keep going with the rest of the work
 		s.Log.Errorf("Failed to synchronize cluster CA certificates: %v", err)
 	}
 
+	// if managed cluster information resulted in a change, the fluentd daemonset needs to be restarted
+	if managedClusterResult != controllerutil.OperationResultNone {
+		// configure logging and force a restart of the fluentd daemonset since CA or registration
+		// were updated
+		s.configureLogging(true)
+	}
 	return nil
 }
 
@@ -281,7 +287,7 @@ func (s *Syncer) updateDeployment(name string) {
 }
 
 // reconfigure Fluentd by restarting Fluentd DaemonSet if ManagedClusterName has been changed
-func (s *Syncer) configureLogging() {
+func (s *Syncer) configureLogging(forceRestart bool) {
 	loggingName := types.NamespacedName{Name: vzconstants.FluentdDaemonSetName, Namespace: constants.VerrazzanoSystemNamespace}
 	daemonSet := appsv1.DaemonSet{}
 	err := s.LocalClient.Get(context.TODO(), loggingName, &daemonSet)
@@ -296,6 +302,13 @@ func (s *Syncer) configureLogging() {
 		if client.IgnoreNotFound(regErr) != nil {
 			return
 		}
+	}
+
+	if forceRestart {
+		if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
+			daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		daemonSet.Spec.Template.ObjectMeta.Annotations[vzconstants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
 	}
 
 	// CreateOrUpdate updates the fluentd daemonset - if no changes to the daemonset after we mutate it in memory,

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -304,16 +304,15 @@ func (s *Syncer) configureLogging(forceRestart bool) {
 		}
 	}
 
-	if forceRestart {
-		if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
-			daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
-		}
-		daemonSet.Spec.Template.ObjectMeta.Annotations[vzconstants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
-	}
-
 	// CreateOrUpdate updates the fluentd daemonset - if no changes to the daemonset after we mutate it in memory,
 	// controllerutil will not update it
 	controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &daemonSet, func() error {
+		if forceRestart {
+			if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
+				daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			}
+			daemonSet.Spec.Template.ObjectMeta.Annotations[vzconstants.VerrazzanoRestartAnnotation] = time.Now().Format(time.RFC3339)
+		}
 		s.updateLoggingDaemonSet(regSecret, &daemonSet)
 		return nil
 	})

--- a/application-operator/mcagent/mcagent_clusterca.go
+++ b/application-operator/mcagent/mcagent_clusterca.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,13 +18,11 @@ import (
 
 const (
 	keyCaCrtNoDot = "cacrt"
-	keyCaCrt      = "ca.crt"
-	keyCaBundle   = "ca-bundle"
 )
 
 // Synchronize Secret objects to the local cluster
 func (s *Syncer) syncClusterCAs() error {
-	err := s.syncAdminClusterCA()
+	err := s.syncRegistrationFromAdminCluster()
 	if err != nil {
 		s.Log.Errorf("Error syncing Admin Cluster CA: %v", err)
 	}
@@ -34,15 +33,28 @@ func (s *Syncer) syncClusterCAs() error {
 	return nil
 }
 
-// syncAdminClusterCA - synchronize the admin cluster CA cert -- update local copy if admin CA changes
-func (s *Syncer) syncAdminClusterCA() error {
+// syncRegistrationFromAdminCluster - synchronize the admin cluster registration info including
+// CA cert, URLs and credentials -- update local registration if any of those change
+func (s *Syncer) syncRegistrationFromAdminCluster() error {
 
-	// Get the cluster CA secret from the admin cluster
+	// Get the cluster CA secret from the admin cluster - for the CA secret, this is considered
+	// the source of truth
 	adminCASecret := corev1.Secret{}
 	err := s.AdminClient.Get(s.Context, client.ObjectKey{
 		Namespace: constants.VerrazzanoMultiClusterNamespace,
 		Name:      constants.VerrazzanoLocalCABundleSecret,
 	}, &adminCASecret)
+	if err != nil {
+		return err
+	}
+
+	// Get the managed cluster registration secret for THIS managed cluster, from the admin cluster.
+	// This will be used to sync registration information here on the managed cluster.
+	adminRegistrationSecret := corev1.Secret{}
+	err = s.AdminClient.Get(s.Context, client.ObjectKey{
+		Namespace: constants.VerrazzanoMultiClusterNamespace,
+		Name:      getRegistrationSecretName(s.ManagedClusterName),
+	}, &adminRegistrationSecret)
 	if err != nil {
 		return err
 	}
@@ -57,10 +69,19 @@ func (s *Syncer) syncAdminClusterCA() error {
 		return err
 	}
 
-	// Update the local cluster registration secret if the admin CA certs are different
-	if !secretsEqualTrimmedWhitespace(registrationSecret.Data[keyCaBundle], adminCASecret.Data[keyCaBundle]) {
+	// Update the local cluster registration secret if the admin CA certs are different, or if
+	// any of the registration info on admin cluster is different
+	if !byteSlicesEqualTrimmedWhitespace(registrationSecret.Data[mcconstants.AdminCaBundleKey], adminCASecret.Data[mcconstants.AdminCaBundleKey]) ||
+		!registrationInfoEqual(registrationSecret, adminRegistrationSecret) {
 		result, err := controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &registrationSecret, func() error {
-			registrationSecret.Data[keyCaBundle] = adminCASecret.Data[keyCaBundle]
+			// Get CA info from admin CA secret
+			registrationSecret.Data[mcconstants.AdminCaBundleKey] = adminCASecret.Data[mcconstants.AdminCaBundleKey]
+
+			// Get other registration info from admin registration secret for this managed cluster
+			registrationSecret.Data[mcconstants.ESURLKey] = adminRegistrationSecret.Data[mcconstants.ESURLKey]
+			registrationSecret.Data[mcconstants.RegistrationUsernameKey] = adminRegistrationSecret.Data[mcconstants.RegistrationUsernameKey]
+			registrationSecret.Data[mcconstants.RegistrationPasswordKey] = adminRegistrationSecret.Data[mcconstants.RegistrationPasswordKey]
+			registrationSecret.Data[mcconstants.KeycloakURLKey] = adminRegistrationSecret.Data[mcconstants.KeycloakURLKey]
 			return nil
 		})
 		if err != nil {
@@ -72,6 +93,17 @@ func (s *Syncer) syncAdminClusterCA() error {
 	}
 
 	return nil
+}
+
+func registrationInfoEqual(regSecret1 corev1.Secret, regSecret2 corev1.Secret) bool {
+	return byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.ESURLKey],
+		regSecret2.Data[mcconstants.ESURLKey]) &&
+		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.KeycloakURLKey],
+			regSecret2.Data[mcconstants.KeycloakURLKey]) &&
+		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.RegistrationUsernameKey],
+			regSecret2.Data[mcconstants.RegistrationUsernameKey]) &&
+		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.RegistrationPasswordKey],
+			regSecret2.Data[mcconstants.RegistrationPasswordKey])
 }
 
 // syncLocalClusterCA - synchronize the local cluster CA cert -- update admin copy if local CA changes
@@ -101,7 +133,7 @@ func (s *Syncer) syncLocalClusterCA() error {
 	}
 
 	// Update the VMC cluster CA secret if the local CA is different
-	if !secretsEqualTrimmedWhitespace(vmcCASecret.Data[keyCaCrtNoDot], localCASecretData) {
+	if !byteSlicesEqualTrimmedWhitespace(vmcCASecret.Data[keyCaCrtNoDot], localCASecretData) {
 		result, err := controllerutil.CreateOrUpdate(s.Context, s.AdminClient, &vmcCASecret, func() error {
 			vmcCASecret.Data[keyCaCrtNoDot] = localCASecretData
 			return nil
@@ -141,11 +173,23 @@ func (s *Syncer) getLocalClusterCASecretData() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return localCASecret.Data[keyCaCrt], nil
+	return localCASecret.Data[mcconstants.CaCrtKey], nil
 }
 
-func secretsEqualTrimmedWhitespace(secret1, secret2 []byte) bool {
-	a := bytes.Trim(secret1, " \t\n\r")
-	b := bytes.Trim(secret2, " \t\n\r")
+func byteSlicesEqualTrimmedWhitespace(byteSlice1, byteSlice2 []byte) bool {
+	a := bytes.Trim(byteSlice1, " \t\n\r")
+	b := bytes.Trim(byteSlice2, " \t\n\r")
 	return bytes.Equal(a, b)
+}
+
+// Generate the common name used by all resources specific to a given managed cluster
+func generateManagedResourceName(clusterName string) string {
+	return fmt.Sprintf("verrazzano-cluster-%s", clusterName)
+}
+
+// getRegistrationSecretName returns the registration secret name for a managed cluster on the admin
+// cluster
+func getRegistrationSecretName(clusterName string) string {
+	const registrationSecretSuffix = "-registration"
+	return generateManagedResourceName(clusterName) + registrationSecretSuffix
 }

--- a/application-operator/mcagent/mcagent_clusterca.go
+++ b/application-operator/mcagent/mcagent_clusterca.go
@@ -16,10 +16,9 @@ import (
 )
 
 const (
-	keyCaCrtNoDot   = "cacrt"
-	keyCaCrt        = "ca.crt"
-	keyCaBundle     = "ca-bundle"
-	keyAdditionalCa = "ca-additional.pem"
+	keyCaCrtNoDot = "cacrt"
+	keyCaCrt      = "ca.crt"
+	keyCaBundle   = "ca-bundle"
 )
 
 // Synchronize Secret objects to the local cluster
@@ -132,7 +131,7 @@ func (s *Syncer) getLocalClusterCASecretData() ([]byte, error) {
 	}
 
 	if errAddlTLS == nil {
-		return localCASecret.Data[keyAdditionalCa], nil
+		return localCASecret.Data[globalconst.AdditionalTLSCAKey], nil
 	}
 	// additional TLS secret not found, check for Verrazzano TLS secret
 	err := s.LocalClient.Get(s.Context, client.ObjectKey{

--- a/application-operator/mcagent/mcagent_clusterca.go
+++ b/application-operator/mcagent/mcagent_clusterca.go
@@ -83,6 +83,7 @@ func (s *Syncer) syncRegistrationFromAdminCluster() (controllerutil.OperationRes
 			registrationSecret.Data[mcconstants.RegistrationUsernameKey] = adminRegistrationSecret.Data[mcconstants.RegistrationUsernameKey]
 			registrationSecret.Data[mcconstants.RegistrationPasswordKey] = adminRegistrationSecret.Data[mcconstants.RegistrationPasswordKey]
 			registrationSecret.Data[mcconstants.KeycloakURLKey] = adminRegistrationSecret.Data[mcconstants.KeycloakURLKey]
+			registrationSecret.Data[mcconstants.ESCaBundleKey] = adminRegistrationSecret.Data[mcconstants.ESCaBundleKey]
 			return nil
 		})
 		if err != nil {
@@ -104,7 +105,9 @@ func registrationInfoEqual(regSecret1 corev1.Secret, regSecret2 corev1.Secret) b
 		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.RegistrationUsernameKey],
 			regSecret2.Data[mcconstants.RegistrationUsernameKey]) &&
 		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.RegistrationPasswordKey],
-			regSecret2.Data[mcconstants.RegistrationPasswordKey])
+			regSecret2.Data[mcconstants.RegistrationPasswordKey]) &&
+		byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.ESCaBundleKey],
+			regSecret2.Data[mcconstants.ESCaBundleKey])
 }
 
 // syncLocalClusterCA - synchronize the local cluster CA cert -- update admin copy if local CA changes

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	asserts "github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
@@ -175,7 +176,7 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 
 	newRegCA := testAdminCASecret.Data["ca-bundle"]
 	// Managed cluster additional TLS secret is the one to sync to admin cluster
-	newMCCA := testMCAdditionalTLSSecret.Data["ca-additional.pem"]
+	newMCCA := testMCAdditionalTLSSecret.Data[constants.AdditionalTLSCAKey]
 
 	adminClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testAdminCASecret, &testMCCASecret, &testVMC)
 

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -365,4 +365,5 @@ func assertRegistrationInfoEqual(t *testing.T, regSecret1 *corev1.Secret, regSec
 	asserts.Equal(t, regSecret1.Data[mcconstants.KeycloakURLKey], regSecret2.Data[mcconstants.KeycloakURLKey], "Keycloak URL is different")
 	asserts.Equal(t, regSecret1.Data[mcconstants.RegistrationUsernameKey], regSecret2.Data[mcconstants.RegistrationUsernameKey], "Registration Username is different")
 	asserts.Equal(t, regSecret1.Data[mcconstants.RegistrationPasswordKey], regSecret2.Data[mcconstants.RegistrationPasswordKey], "Registration Password is different")
+	asserts.Equal(t, regSecret1.Data[mcconstants.ESCaBundleKey], regSecret2.Data[mcconstants.ESCaBundleKey], "Registration Password is different")
 }

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -11,6 +11,7 @@ import (
 
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	corev1 "k8s.io/api/core/v1"
 
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
@@ -23,11 +24,15 @@ import (
 
 const (
 	clusterRegSecretPath       = "testdata/clusterca-clusterregsecret.yaml"
+	adminRegSecretPath         = "testdata/clusterca-adminregsecret.yaml"
+	adminRegNewSecretPath      = "testdata/clusterca-adminregsecret-new.yaml"
 	mcCASecretPath             = "testdata/clusterca-mccasecret.yaml"
-	vzTLSSecretPath            = "testdata/clusterca-mctlssecret-new.yaml"
+	vzTLSSecretPathNew         = "testdata/clusterca-mctlssecret-new.yaml"
+	vzTLSSecretPath            = "testdata/clusterca-mctlssecret.yaml"
 	vmcPath                    = "testdata/clusterca-vmc.yaml"
 	sampleAdminCAReadErrMsg    = "failed to read sample Admin CA Secret"
-	sampleClusterRegReadErrMsg = "failed to read sample Cluster Registration Secret"
+	sampleClusterRegReadErrMsg = "failed to read sample Managed Cluster Registration Secret"
+	sampleAdminRegReadErrMsg   = "failed to read sample Admin Cluster Registration Secret for the managed cluster"
 	sampleMCTLSReadErrMsg      = "failed to read sample MC TLS Secret"
 	sampleMCCAReadErrMsg       = "failed to read sample MC CA Secret"
 	sampleVMCReadErrMsg        = "failed to read sample VMC"
@@ -36,35 +41,44 @@ const (
 )
 
 // TestSyncAdminCANoDifference tests the synchronization method for the following use case.
-// GIVEN a request to sync Admin CA certs
-// WHEN the CAs are the same
+// GIVEN a request to sync Admin registration info
+// WHEN the CAs are the same and registration info is the same
 // THEN ensure that no secret is updated.
 func TestSyncCACertsNoDifference(t *testing.T) {
 	assert := asserts.New(t)
 	log := zap.S().With("test")
 
 	// Test data
-	testAdminCASecret, err := getSampleClusterCASecret("testdata/clusterca-admincasecret.yaml")
+	testAdminCASecret, err := getSampleSecret("testdata/clusterca-admincasecret.yaml")
 	assert.NoError(err, sampleAdminCAReadErrMsg)
 
-	testClusterRegSecret, err := getSampleClusterCASecret(clusterRegSecretPath)
+	testAdminRegSecret, err := getSampleSecret(adminRegSecretPath)
+	assert.NoError(err, sampleAdminRegReadErrMsg)
+
+	testClusterRegSecret, err := getSampleSecret(clusterRegSecretPath)
 	assert.NoError(err, sampleClusterRegReadErrMsg)
 
-	testMCTLSSecret, err := getSampleClusterCASecret("testdata/clusterca-mctlssecret.yaml")
+	testMCTLSSecret, err := getSampleSecret(vzTLSSecretPath)
 	assert.NoError(err, sampleMCTLSReadErrMsg)
 
-	testMCCASecret, err := getSampleClusterCASecret(mcCASecretPath)
+	testMCCASecret, err := getSampleSecret(mcCASecretPath)
 	assert.NoError(err, sampleMCCAReadErrMsg)
 
 	testVMC, err := getSampleClusterCAVMC(vmcPath)
 	assert.NoError(err, sampleVMCReadErrMsg)
 
-	origRegCA := testClusterRegSecret.Data["ca-bundle"]
-	origMCCA := testMCCASecret.Data["cacrt"]
+	origRegCA := testClusterRegSecret.Data[mcconstants.AdminCaBundleKey]
+	origMCCA := testMCCASecret.Data[keyCaCrtNoDot]
 
-	adminClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testAdminCASecret, &testMCCASecret, &testVMC)
+	adminClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testAdminCASecret, &testMCCASecret, &testVMC, &testAdminRegSecret).
+		Build()
 
-	localClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testClusterRegSecret, &testMCTLSSecret)
+	localClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testClusterRegSecret, &testMCTLSSecret).
+		Build()
 
 	// Make the request
 	s := &Syncer{
@@ -83,44 +97,57 @@ func TestSyncCACertsNoDifference(t *testing.T) {
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(origRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
+	assert.Equal(origRegCA, localSecret.Data[mcconstants.AdminCaBundleKey], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
 	assert.NoError(err)
-	assert.Equal(origMCCA, adminSecret.Data["cacrt"], mcCASecChangedErrMsg)
+	assert.Equal(origMCCA, adminSecret.Data[keyCaCrtNoDot], mcCASecChangedErrMsg)
+
+	// The registration info should not have been changed since the admin secret had the same info
+	// as the existing managed cluster registration secret
+	assertRegistrationInfoEqual(t, localSecret, testClusterRegSecret)
 }
 
 // TestSyncCACertsAreDifferent tests the synchronization method for the following use case.
 // GIVEN a request to sync Admin CA certs
-// WHEN the CAs are different
-// THEN ensure that the secrets are updated.
+// WHEN the CAs are different but registration info is same,
+// THEN ensure that the secrets are updated, but nothing else is
 func TestSyncCACertsAreDifferent(t *testing.T) {
 	assert := asserts.New(t)
 	log := zap.S().With("test")
 
 	// Test data
-	testAdminCASecret, err := getSampleClusterCASecret("testdata/clusterca-admincasecret-new.yaml")
+	testAdminCASecret, err := getSampleSecret("testdata/clusterca-admincasecret-new.yaml")
 	assert.NoError(err, sampleAdminCAReadErrMsg)
 
-	testClusterRegSecret, err := getSampleClusterCASecret(clusterRegSecretPath)
+	testAdminRegSecret, err := getSampleSecret(adminRegSecretPath)
+	assert.NoError(err, sampleAdminRegReadErrMsg)
+
+	testClusterRegSecret, err := getSampleSecret(clusterRegSecretPath)
 	assert.NoError(err, sampleClusterRegReadErrMsg)
 
-	testMCTLSSecret, err := getSampleClusterCASecret(vzTLSSecretPath)
+	testMCTLSSecret, err := getSampleSecret(vzTLSSecretPathNew)
 	assert.NoError(err, sampleMCTLSReadErrMsg)
 
-	testMCCASecret, err := getSampleClusterCASecret(mcCASecretPath)
+	testMCCASecret, err := getSampleSecret(mcCASecretPath)
 	assert.NoError(err, sampleMCCAReadErrMsg)
 
 	testVMC, err := getSampleClusterCAVMC(vmcPath)
 	assert.NoError(err, sampleVMCReadErrMsg)
 
-	newRegCA := testAdminCASecret.Data["ca-bundle"]
-	newMCCA := testMCTLSSecret.Data["ca.crt"]
+	newRegCA := testAdminCASecret.Data[mcconstants.AdminCaBundleKey]
+	newMCCA := testMCTLSSecret.Data[mcconstants.CaCrtKey]
 
-	adminClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testAdminCASecret, &testMCCASecret, &testVMC)
+	adminClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testAdminCASecret, &testMCCASecret, &testVMC, &testAdminRegSecret).
+		Build()
 
-	localClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testClusterRegSecret, &testMCTLSSecret)
+	localClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testClusterRegSecret, &testMCTLSSecret).
+		Build()
 
 	// Make the request
 	s := &Syncer{
@@ -135,16 +162,20 @@ func TestSyncCACertsAreDifferent(t *testing.T) {
 	// Validate the results
 	assert.NoError(err)
 
-	// Verify the CA secrets were not updated
+	// Verify the CA secrets were updated
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
+	assert.Equal(newRegCA, localSecret.Data[mcconstants.AdminCaBundleKey], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
 	assert.NoError(err)
-	assert.Equal(newMCCA, adminSecret.Data["cacrt"], mcCASecChangedErrMsg)
+	assert.Equal(newMCCA, adminSecret.Data[keyCaCrtNoDot], mcCASecChangedErrMsg)
+
+	// The registration info should not have been changed since the admin secret had the same info
+	// as the existing managed cluster registration secret
+	assertRegistrationInfoEqual(t, localSecret, testClusterRegSecret)
 }
 
 // Test the case when managed cluster uses Let's Encrypt staging (i.e. tls-ca-additional secret
@@ -154,33 +185,42 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 	log := zap.S().With("test")
 
 	// Test data
-	testAdminCASecret, err := getSampleClusterCASecret("testdata/clusterca-admincasecret-new.yaml")
+	testAdminCASecret, err := getSampleSecret("testdata/clusterca-admincasecret-new.yaml")
 	assert.NoError(err, sampleAdminCAReadErrMsg)
 
-	testClusterRegSecret, err := getSampleClusterCASecret(clusterRegSecretPath)
+	testAdminRegSecret, err := getSampleSecret(adminRegSecretPath)
+	assert.NoError(err, sampleAdminRegReadErrMsg)
+
+	testClusterRegSecret, err := getSampleSecret(clusterRegSecretPath)
 	assert.NoError(err, sampleClusterRegReadErrMsg)
 
 	// Managed cluster "normal" VZ ingress TLS secret (verrazzano-tls)
-	testMCTLSSecret, err := getSampleClusterCASecret(vzTLSSecretPath)
+	testMCTLSSecret, err := getSampleSecret(vzTLSSecretPathNew)
 	assert.NoError(err, sampleMCTLSReadErrMsg)
 
 	// Managed cluster additional TLS secret is also present
-	testMCAdditionalTLSSecret, err := getSampleClusterCASecret("testdata/clusterca-mc-additionaltls-secret.yaml")
+	testMCAdditionalTLSSecret, err := getSampleSecret("testdata/clusterca-mc-additionaltls-secret.yaml")
 	assert.NoError(err, "failed to read sample MC additional TLS CA Secret")
 
-	testMCCASecret, err := getSampleClusterCASecret(mcCASecretPath)
+	testMCCASecret, err := getSampleSecret(mcCASecretPath)
 	assert.NoError(err, sampleMCCAReadErrMsg)
 
 	testVMC, err := getSampleClusterCAVMC(vmcPath)
 	assert.NoError(err, sampleVMCReadErrMsg)
 
-	newRegCA := testAdminCASecret.Data["ca-bundle"]
+	newRegCA := testAdminCASecret.Data[mcconstants.AdminCaBundleKey]
 	// Managed cluster additional TLS secret is the one to sync to admin cluster
 	newMCCA := testMCAdditionalTLSSecret.Data[constants.AdditionalTLSCAKey]
 
-	adminClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testAdminCASecret, &testMCCASecret, &testVMC)
+	adminClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testAdminCASecret, &testMCCASecret, &testVMC, &testAdminRegSecret).
+		Build()
 
-	localClient := fake.NewFakeClientWithScheme(newClusterCAScheme(), &testClusterRegSecret, &testMCTLSSecret, &testMCAdditionalTLSSecret)
+	localClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testClusterRegSecret, &testMCTLSSecret, &testMCAdditionalTLSSecret).
+		Build()
 
 	// Make the request
 	s := &Syncer{
@@ -195,33 +235,92 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 	// Validate the results
 	assert.NoError(err)
 
-	// Verify the CA secrets were not updated
+	// Verify the CA secrets were updated
 	localSecret := &corev1.Secret{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
 	assert.NoError(err)
-	assert.Equal(newRegCA, localSecret.Data["ca-bundle"], regSecChangedErrMsg)
+	assert.Equal(newRegCA, localSecret.Data[mcconstants.AdminCaBundleKey], regSecChangedErrMsg)
 
 	adminSecret := &corev1.Secret{}
 	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
 	assert.NoError(err)
-	assert.Equal(newMCCA, adminSecret.Data["cacrt"], "MC CA secret on admin cluster did not match the additional TLS CA secret on managed cluster.")
+	assert.Equal(newMCCA, adminSecret.Data[keyCaCrtNoDot], "MC CA secret on admin cluster did not match the additional TLS CA secret on managed cluster.")
+
+	// Registration info should not have changed
+	assertRegistrationInfoEqual(t, localSecret, testClusterRegSecret)
 }
 
-// getSampleClusterCASecret creates and returns a sample Secret used in tests
-func getSampleClusterCASecret(filePath string) (corev1.Secret, error) {
-	secret := corev1.Secret{}
-	sampleSecretFile, err := filepath.Abs(filePath)
-	if err != nil {
-		return secret, err
-	}
+// TestSyncRegistrationInfoDifferent tests the synchronization method for the following use case.
+// GIVEN a request to sync Admin registration info
+// WHEN the registration info is different but CAs are the same,
+// THEN ensure that the reg info is updated, but nothing else is
+func TestSyncRegistrationInfoDifferent(t *testing.T) {
+	assert := asserts.New(t)
+	log := zap.S().With("test")
 
-	rawResource, err := clusterstest.ReadYaml2Json(sampleSecretFile)
-	if err != nil {
-		return secret, err
-	}
+	// Test data
 
-	err = json.Unmarshal(rawResource, &secret)
-	return secret, err
+	// Admin CA secret is the unchanged one
+	testAdminCASecret, err := getSampleSecret("testdata/clusterca-admincasecret.yaml")
+	assert.NoError(err, sampleAdminCAReadErrMsg)
+
+	// Use the "updated" admin registration data to simulate admin cluster reg secret changed
+	testAdminRegSecret, err := getSampleSecret(adminRegNewSecretPath)
+	assert.NoError(err, sampleAdminRegReadErrMsg)
+
+	testClusterRegSecret, err := getSampleSecret(clusterRegSecretPath)
+	assert.NoError(err, sampleClusterRegReadErrMsg)
+
+	testMCCASecret, err := getSampleSecret(mcCASecretPath)
+	assert.NoError(err, sampleMCCAReadErrMsg)
+
+	testMCTLSSecret, err := getSampleSecret(vzTLSSecretPath)
+	assert.NoError(err, sampleMCTLSReadErrMsg)
+
+	testVMC, err := getSampleClusterCAVMC(vmcPath)
+	assert.NoError(err, sampleVMCReadErrMsg)
+
+	origRegCA := testClusterRegSecret.Data[mcconstants.AdminCaBundleKey]
+	origMCCA := testMCCASecret.Data[keyCaCrtNoDot]
+	newRegSecret := testAdminRegSecret
+
+	adminClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testAdminCASecret, &testMCCASecret, &testVMC, &testAdminRegSecret).
+		Build()
+
+	localClient := fake.NewClientBuilder().
+		WithScheme(newClusterCAScheme()).
+		WithRuntimeObjects(&testClusterRegSecret, &testMCTLSSecret).
+		Build()
+
+	// Make the request
+	s := &Syncer{
+		AdminClient:        adminClient,
+		LocalClient:        localClient,
+		Log:                log,
+		ManagedClusterName: testClusterName,
+		Context:            context.TODO(),
+	}
+	err = s.syncClusterCAs()
+
+	// Validate the results
+	assert.NoError(err)
+
+	// Verify the CA secrets were NOT updated
+	localSecret := &corev1.Secret{}
+	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testClusterRegSecret.Name, Namespace: testClusterRegSecret.Namespace}, localSecret)
+	assert.NoError(err)
+	assert.Equal(origRegCA, localSecret.Data[mcconstants.AdminCaBundleKey], regSecChangedErrMsg)
+
+	adminSecret := &corev1.Secret{}
+	err = s.AdminClient.Get(s.Context, types.NamespacedName{Name: testMCCASecret.Name, Namespace: testMCCASecret.Namespace}, adminSecret)
+	assert.NoError(err)
+	assert.Equal(origMCCA, adminSecret.Data[keyCaCrtNoDot], mcCASecChangedErrMsg)
+
+	// The registration info SHOULD have been changed since the admin secret had different info
+	// from the existing managed cluster registration secret
+	assertRegistrationInfoEqual(t, localSecret, newRegSecret)
 }
 
 // getSampleClusterCAVMC creates and returns a sample VMC
@@ -246,4 +345,11 @@ func newClusterCAScheme() *runtime.Scheme {
 	corev1.SchemeBuilder.AddToScheme(scheme)
 	platformopclusters.AddToScheme(scheme)
 	return scheme
+}
+
+func assertRegistrationInfoEqual(t *testing.T, regSecret1 *corev1.Secret, regSecret2 corev1.Secret) {
+	asserts.Equal(t, regSecret1.Data[mcconstants.ESURLKey], regSecret2.Data[mcconstants.ESURLKey], "ES URL is different")
+	asserts.Equal(t, regSecret1.Data[mcconstants.KeycloakURLKey], regSecret2.Data[mcconstants.KeycloakURLKey], "Keycloak URL is different")
+	asserts.Equal(t, regSecret1.Data[mcconstants.RegistrationUsernameKey], regSecret2.Data[mcconstants.RegistrationUsernameKey], "Registration Username is different")
+	asserts.Equal(t, regSecret1.Data[mcconstants.RegistrationPasswordKey], regSecret2.Data[mcconstants.RegistrationPasswordKey], "Registration Password is different")
 }

--- a/application-operator/mcagent/mcagent_clusterca_test.go
+++ b/application-operator/mcagent/mcagent_clusterca_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
@@ -88,10 +89,13 @@ func TestSyncCACertsNoDifference(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncClusterCAs()
+	localClusterResult, err := s.syncClusterCAs()
 
 	// Validate the results
 	assert.NoError(err)
+
+	// assert no update on local cluster
+	assert.Equal(controllerutil.OperationResultNone, localClusterResult)
 
 	// Verify the CA secrets were not updated
 	localSecret := &corev1.Secret{}
@@ -157,10 +161,13 @@ func TestSyncCACertsAreDifferent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncClusterCAs()
+	localClusterResult, err := s.syncClusterCAs()
 
 	// Validate the results
 	assert.NoError(err)
+
+	// assert there was a change on local cluster
+	assert.NotEqual(controllerutil.OperationResultNone, localClusterResult)
 
 	// Verify the CA secrets were updated
 	localSecret := &corev1.Secret{}
@@ -230,10 +237,13 @@ func TestSyncCACertsAdditionalTLSPresent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncClusterCAs()
+	localClusterResult, err := s.syncClusterCAs()
 
 	// Validate the results
 	assert.NoError(err)
+
+	// assert there was a change on local cluster
+	assert.NotEqual(controllerutil.OperationResultNone, localClusterResult)
 
 	// Verify the CA secrets were updated
 	localSecret := &corev1.Secret{}
@@ -302,10 +312,13 @@ func TestSyncRegistrationInfoDifferent(t *testing.T) {
 		ManagedClusterName: testClusterName,
 		Context:            context.TODO(),
 	}
-	err = s.syncClusterCAs()
+	localClusterResult, err := s.syncClusterCAs()
 
 	// Validate the results
 	assert.NoError(err)
+
+	// assert there was a change on local cluster
+	assert.NotEqual(controllerutil.OperationResultNone, localClusterResult)
 
 	// Verify the CA secrets were NOT updated
 	localSecret := &corev1.Secret{}

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -558,6 +558,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 		dsClusterName  string
 		dsEsURL        string
 		dsSecretName   string
+		forceDSRestart bool
 		expectUpdateDS bool
 	}
 	const externalEsURL = "externalEsURL"
@@ -575,6 +576,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  "",
 				dsEsURL:        "",
 				dsSecretName:   "",
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -585,6 +587,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  regSecretClusterName,
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -595,6 +598,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  "differentClusterName",
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -605,6 +609,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  regSecretClusterName,
 				dsEsURL:        "differentEsURL",
 				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -615,6 +620,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  regSecretClusterName,
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   "differentSecret",
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -625,6 +631,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  defaultClusterName,
 				dsEsURL:        vzconstants.DefaultOpensearchURL,
 				dsSecretName:   defaultSecretName,
+				forceDSRestart: false,
 				expectUpdateDS: false,
 			},
 		},
@@ -635,6 +642,18 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  regSecretClusterName,
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: false,
+				expectUpdateDS: false,
+			},
+		},
+		{
+			name: "same registration force DS restart",
+			fields: fields{
+				secretExists:   true,
+				dsClusterName:  regSecretClusterName,
+				dsEsURL:        regSecretEsURL,
+				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: true,
 				expectUpdateDS: false,
 			},
 		},
@@ -646,6 +665,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  "",
 				dsEsURL:        "",
 				dsSecretName:   "",
+				forceDSRestart: false,
 				expectUpdateDS: true,
 			},
 		},
@@ -657,6 +677,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  defaultClusterName,
 				dsEsURL:        externalEsURL,
 				dsSecretName:   externalEsSecret,
+				forceDSRestart: false,
 				expectUpdateDS: false,
 			},
 		},
@@ -668,6 +689,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsClusterName:  regSecretClusterName,
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   constants.MCRegistrationSecret,
+				forceDSRestart: false,
 				expectUpdateDS: false,
 			},
 		},
@@ -748,7 +770,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				Log:         zap.S().With("test"),
 				Context:     context.TODO(),
 			}
-			s.configureLogging()
+			s.configureLogging(tt.fields.forceDSRestart)
 
 			// Validate the results
 			mcMocker.Finish()

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -654,7 +654,7 @@ func TestSyncer_configureLogging(t *testing.T) {
 				dsEsURL:        regSecretEsURL,
 				dsSecretName:   constants.MCRegistrationSecret,
 				forceDSRestart: true,
-				expectUpdateDS: false,
+				expectUpdateDS: true,
 			},
 		},
 		{

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -422,12 +422,20 @@ func expectAdminVMCStatusUpdateSuccess(adminMock *mocks.MockClient, vmcName type
 func expectCASyncSuccess(localMock, adminMock *mocks.MockClient, assert *asserts.Assertions, testClusterName string) {
 	localRegistrationSecret := types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.MCRegistrationSecret}
 	adminCASecret := types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: constants.VerrazzanoLocalCABundleSecret}
+	adminRegSecret := types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: getRegistrationSecretName(testClusterName)}
 	localIngressTLSSecret := types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoIngressTLSSecret}
 	adminMock.EXPECT().
 		Get(gomock.Any(), adminCASecret, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Name = adminCASecret.Name
 			secret.Namespace = adminCASecret.Namespace
+			return nil
+		})
+	adminMock.EXPECT().
+		Get(gomock.Any(), adminRegSecret, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.Name = adminRegSecret.Name
+			secret.Namespace = adminRegSecret.Namespace
 			return nil
 		})
 	localMock.EXPECT().

--- a/application-operator/mcagent/testdata/clusterca-adminregsecret-new.yaml
+++ b/application-operator/mcagent/testdata/clusterca-adminregsecret-new.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verrazzano-cluster-managed1-registration
+  namespace: verrazzano-mc
+data:
+  # cleartext: https://elasticsearchupdated.vmi.system.vzenv.example.com
+  es-url: aHR0cHM6Ly9lc3VwZGF0ZWQudm1pLnN5c3RlbS52emVudi5leGFtcGxlLmNvbQo=
+  # cleartext: https://kcupdated.vzenv.example.com
+  keycloak-url: aHR0cHM6Ly9rY3VwZGF0ZWQudnplbnYuZXhhbXBsZS5jb20K
+  managed-cluster-name: bWFuYWdlZDE= # managed1
+  password: Wmh4VnhnaFVHUGx0d1Vn
+  username: dnp1c2VyCg== # vzuser

--- a/application-operator/mcagent/testdata/clusterca-adminregsecret-new.yaml
+++ b/application-operator/mcagent/testdata/clusterca-adminregsecret-new.yaml
@@ -6,6 +6,7 @@ metadata:
   name: verrazzano-cluster-managed1-registration
   namespace: verrazzano-mc
 data:
+  es-ca-bundle: bmV3IEVTIENBIGJ1bmRsZQo= #cleartext: new ES CA bundle
   # cleartext: https://elasticsearchupdated.vmi.system.vzenv.example.com
   es-url: aHR0cHM6Ly9lc3VwZGF0ZWQudm1pLnN5c3RlbS52emVudi5leGFtcGxlLmNvbQo=
   # cleartext: https://kcupdated.vzenv.example.com

--- a/application-operator/mcagent/testdata/clusterca-adminregsecret.yaml
+++ b/application-operator/mcagent/testdata/clusterca-adminregsecret.yaml
@@ -6,6 +6,7 @@ metadata:
   name: verrazzano-cluster-managed1-registration
   namespace: verrazzano-mc
 data:
+  es-ca-bundle: VGhpc0lzVGhlT3JpZ2luYWxBZG1pbkNBCg== # cleartext: ThisIsTheOriginalAdminCA
   # cleartext: https://elasticsearch.vmi.system.vzenv.example.com
   es-url: aHR0cHM6Ly9lbGFzdGljc2VhcmNoLnZtaS5zeXN0ZW0udnplbnYuZXhhbXBsZS5jb20K
   # cleartext: https://keycloak.vzenv.example.com

--- a/application-operator/mcagent/testdata/clusterca-adminregsecret.yaml
+++ b/application-operator/mcagent/testdata/clusterca-adminregsecret.yaml
@@ -3,12 +3,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: verrazzano-cluster-registration
-  namespace: verrazzano-system
+  name: verrazzano-cluster-managed1-registration
+  namespace: verrazzano-mc
 data:
-  # cleartext: ThisIsTheOriginalAdminCA
-  ca-bundle: VGhpc0lzVGhlT3JpZ2luYWxBZG1pbkNBCg==
-  # below fields same as clusterca-adminsecret.yaml
   # cleartext: https://elasticsearch.vmi.system.vzenv.example.com
   es-url: aHR0cHM6Ly9lbGFzdGljc2VhcmNoLnZtaS5zeXN0ZW0udnplbnYuZXhhbXBsZS5jb20K
   # cleartext: https://keycloak.vzenv.example.com

--- a/application-operator/mcagent/testdata/clusterca-clusterregsecret.yaml
+++ b/application-operator/mcagent/testdata/clusterca-clusterregsecret.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   # cleartext: ThisIsTheOriginalAdminCA
   ca-bundle: VGhpc0lzVGhlT3JpZ2luYWxBZG1pbkNBCg==
+  es-ca-bundle: VGhpc0lzVGhlT3JpZ2luYWxBZG1pbkNBCg==
   # below fields same as clusterca-adminsecret.yaml
   # cleartext: https://elasticsearch.vmi.system.vzenv.example.com
   es-url: aHR0cHM6Ly9lbGFzdGljc2VhcmNoLnZtaS5zeXN0ZW0udnplbnYuZXhhbXBsZS5jb20K

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -83,6 +83,9 @@ const VerrazzanoPromInternal = "verrazzano-prom-internal"
 // AdditionalTLS is an optional tls secret that contains additional CA
 const AdditionalTLS = "tls-ca-additional"
 
+// AdditionalTLSCAKey is the key containing the CA in the secret specified by the AdditionalTLS constant
+const AdditionalTLSCAKey = "ca-additional.pem"
+
 // VMCAgentPollingTimeInterval - The time interval at which mcagent polls Verrazzano Managed CLuster resource on the admin cluster.
 const VMCAgentPollingTimeInterval = 60 * time.Second
 
@@ -95,8 +98,8 @@ const FluentdDaemonSetName = "fluentd"
 // KubeSystem - The name of the kube-system namespace
 const KubeSystem = "kube-system"
 
-//DefaultVerrazzanoCASecretName Default self-signed CA secret name
-//#nosec
+// DefaultVerrazzanoCASecretName Default self-signed CA secret name
+// #nosec
 const DefaultVerrazzanoCASecretName = "verrazzano-ca-certificate-secret"
 
 // VmiPromConfigName - The name of the prometheus config map

--- a/pkg/mcconstants/secret_keys.go
+++ b/pkg/mcconstants/secret_keys.go
@@ -1,7 +1,8 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package clusters
+// Package mcconstants - Constants in this file are keys in MultiCluster related secrets
+package mcconstants
 
 // CaCrtKey is the CA cert key in the tls secret
 const CaCrtKey = "ca.crt"

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clusterapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzk8s "github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
 
@@ -83,7 +84,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	}
 
 	// Load the kubeconfig struct
-	token := secret.Data[TokenKey]
+	token := secret.Data[mcconstants.TokenKey]
 	b64Cert, err := getB64CAData(config)
 	if err != nil {
 		return err
@@ -134,8 +135,8 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateAgentSecret(vmc *clus
 func (r *VerrazzanoManagedClusterReconciler) mutateAgentSecret(secret *corev1.Secret, kubeconfig string, manageClusterName string) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		KubeconfigKey:         []byte(kubeconfig),
-		ManagedClusterNameKey: []byte(manageClusterName),
+		mcconstants.KubeconfigKey:         []byte(kubeconfig),
+		mcconstants.ManagedClusterNameKey: []byte(manageClusterName),
 	}
 	return nil
 }

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	constants2 "github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clusterapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +111,7 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateManifestSecret(vmc *c
 func (r *VerrazzanoManagedClusterReconciler) mutateManifestSecret(secret *corev1.Secret, yamlData string) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		YamlKey: []byte(yamlData),
+		constants2.YamlKey: []byte(yamlData),
 	}
 	return nil
 }

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Jeffail/gabs/v2"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -117,7 +118,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutatePrometheusConfigMap(vmc *clus
 		return err
 	}
 	if newScrapeConfig == nil {
-		//deletion
+		// deletion
 		delete(configMap.Data, getCAKey(vmc))
 	}
 	existingReplaced := false
@@ -170,7 +171,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(cacrtSecret *v1.Sec
 	newScrapeConfigMappings := map[string]string{
 		"##JOB_NAME##":     vmc.Name,
 		"##HOST##":         vmc.Status.PrometheusHost,
-		"##PASSWORD##":     string(vzPromSecret.Data[VerrazzanoPasswordKey]),
+		"##PASSWORD##":     string(vzPromSecret.Data[mcconstants.VerrazzanoPasswordKey]),
 		"##CLUSTER_NAME##": vmc.Name}
 	configTemplate := scrapeConfigTemplate
 	for key, value := range newScrapeConfigMappings {

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clusterapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -101,17 +102,17 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 		if err != nil {
 			return err
 		}
-		esCaBundle = esSecret.Data[FluentdESCaBundleKey]
-		esUsername = esSecret.Data[VerrazzanoUsernameKey]
-		esPassword = esSecret.Data[VerrazzanoPasswordKey]
+		esCaBundle = esSecret.Data[mcconstants.FluentdESCaBundleKey]
+		esUsername = esSecret.Data[mcconstants.VerrazzanoUsernameKey]
+		esPassword = esSecret.Data[mcconstants.VerrazzanoPasswordKey]
 	} else {
 		esSecret, err := r.getSecret(constants.VerrazzanoSystemNamespace, constants.VerrazzanoESInternal, true)
 		if err != nil {
 			return err
 		}
 		esCaBundle = adminCaBundle
-		esUsername = esSecret.Data[VerrazzanoUsernameKey]
-		esPassword = esSecret.Data[VerrazzanoPasswordKey]
+		esUsername = esSecret.Data[mcconstants.VerrazzanoUsernameKey]
+		esPassword = esSecret.Data[mcconstants.VerrazzanoPasswordKey]
 	}
 
 	// Get the keycloak URL
@@ -122,13 +123,13 @@ func (r *VerrazzanoManagedClusterReconciler) mutateRegistrationSecret(secret *co
 
 	// Build the secret data
 	secret.Data = map[string][]byte{
-		ManagedClusterNameKey:   []byte(manageClusterName),
-		ESURLKey:                []byte(esURL),
-		ESCaBundleKey:           esCaBundle,
-		RegistrationUsernameKey: esUsername,
-		RegistrationPasswordKey: esPassword,
-		KeycloakURLKey:          []byte(keycloakURL),
-		AdminCaBundleKey:        adminCaBundle,
+		mcconstants.ManagedClusterNameKey:   []byte(manageClusterName),
+		mcconstants.ESURLKey:                []byte(esURL),
+		mcconstants.ESCaBundleKey:           esCaBundle,
+		mcconstants.RegistrationUsernameKey: esUsername,
+		mcconstants.RegistrationPasswordKey: esPassword,
+		mcconstants.KeycloakURLKey:          []byte(keycloakURL),
+		mcconstants.AdminCaBundleKey:        adminCaBundle,
 	}
 	return nil
 }
@@ -201,7 +202,7 @@ func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	caBundle = secret.Data[CaCrtKey]
+	caBundle = secret.Data[mcconstants.CaCrtKey]
 
 	// Append CA from additional-ca secret if it exists
 	optSecret, err := r.getSecret(constants.RancherSystemNamespace, constants.AdditionalTLS, false)
@@ -210,8 +211,8 @@ func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) 
 	}
 	if err == nil {
 		// Combine the two CA bundles
-		caBundle = make([]byte, len(secret.Data[CaCrtKey]))
-		copy(caBundle, secret.Data[CaCrtKey])
+		caBundle = make([]byte, len(secret.Data[mcconstants.CaCrtKey]))
+		copy(caBundle, secret.Data[mcconstants.CaCrtKey])
 		caBundle = append(caBundle, optSecret.Data[constants.AdditionalTLSCAKey]...)
 	}
 

--- a/platform-operator/controllers/clusters/sync_registration_secret.go
+++ b/platform-operator/controllers/clusters/sync_registration_secret.go
@@ -21,7 +21,6 @@ import (
 
 const vmiIngest = "vmi-system-es-ingest"
 const defaultSecretName = "verrazzano"
-const rancherCAAdditionalPem = "ca-additional.pem"
 
 // Create a registration secret with the managed cluster information.  This secret will
 // be used on the managed cluster to get information about itself, like the cluster name
@@ -213,7 +212,7 @@ func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) 
 		// Combine the two CA bundles
 		caBundle = make([]byte, len(secret.Data[CaCrtKey]))
 		copy(caBundle, secret.Data[CaCrtKey])
-		caBundle = append(caBundle, optSecret.Data[rancherCAAdditionalPem]...)
+		caBundle = append(caBundle, optSecret.Data[constants.AdditionalTLSCAKey]...)
 	}
 
 	return caBundle, nil

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -729,7 +730,7 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetAgentSecretName(clusterName)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				KubeconfigKey: []byte(kubeconfigData),
+				mcconstants.KubeconfigKey: []byte(kubeconfigData),
 			}
 			return nil
 		})
@@ -739,11 +740,11 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetRegistrationSecretName(clusterName)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				ManagedClusterNameKey:   []byte(clusterName),
-				CaCrtKey:                []byte(caData),
-				RegistrationUsernameKey: []byte(userData),
-				RegistrationPasswordKey: []byte(passwordData),
-				ESURLKey:                []byte(urlData),
+				mcconstants.ManagedClusterNameKey:   []byte(clusterName),
+				mcconstants.CaCrtKey:                []byte(caData),
+				mcconstants.RegistrationUsernameKey: []byte(userData),
+				mcconstants.RegistrationPasswordKey: []byte(passwordData),
+				mcconstants.ESURLKey:                []byte(urlData),
 			}
 			return nil
 		})
@@ -773,7 +774,7 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			data := secret.Data[YamlKey]
+			data := secret.Data[mcconstants.YamlKey]
 			asserts.NotZero(len(data), "Expected yaml data in manifest secret")
 			return nil
 		})
@@ -1300,7 +1301,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: saSecretName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				TokenKey: []byte(token),
+				mcconstants.TokenKey: []byte(token),
 			}
 			return nil
 		})
@@ -1398,14 +1399,14 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			if externalES {
 				secret.Data = map[string][]byte{
-					VerrazzanoUsernameKey: []byte(externalUserData),
-					VerrazzanoPasswordKey: []byte(externalPasswordData),
-					FluentdESCaBundleKey:  []byte(externalCaData),
+					mcconstants.VerrazzanoUsernameKey: []byte(externalUserData),
+					mcconstants.VerrazzanoPasswordKey: []byte(externalPasswordData),
+					mcconstants.FluentdESCaBundleKey:  []byte(externalCaData),
 				}
 			} else {
 				secret.Data = map[string][]byte{
-					VerrazzanoUsernameKey: []byte(vzUserData),
-					VerrazzanoPasswordKey: []byte(vzPasswordData),
+					mcconstants.VerrazzanoUsernameKey: []byte(vzUserData),
+					mcconstants.VerrazzanoPasswordKey: []byte(vzPasswordData),
 				}
 			}
 			return nil
@@ -1416,7 +1417,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: "verrazzano-tls"}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				CaCrtKey: []byte(vzCaData),
+				mcconstants.CaCrtKey: []byte(vzCaData),
 			}
 			return nil
 		})
@@ -1446,19 +1447,19 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			asserts.Equalf(testManagedCluster, string(secret.Data[ManagedClusterNameKey]), "Incorrect cluster testManagedCluster in Registration secret ")
-			asserts.Equalf("https://keycloak", string(secret.Data[KeycloakURLKey]), "Incorrect admin ca bundle in Registration secret ")
-			asserts.Equalf(vzCaData, string(secret.Data[AdminCaBundleKey]), "Incorrect admin ca bundle in Registration secret ")
+			asserts.Equalf(testManagedCluster, string(secret.Data[mcconstants.ManagedClusterNameKey]), "Incorrect cluster testManagedCluster in Registration secret ")
+			asserts.Equalf("https://keycloak", string(secret.Data[mcconstants.KeycloakURLKey]), "Incorrect admin ca bundle in Registration secret ")
+			asserts.Equalf(vzCaData, string(secret.Data[mcconstants.AdminCaBundleKey]), "Incorrect admin ca bundle in Registration secret ")
 			if externalES {
-				asserts.Equalf(externalEsURLData, string(secret.Data[ESURLKey]), "Incorrect ES URL in Registration secret ")
-				asserts.Equalf(externalCaData, string(secret.Data[ESCaBundleKey]), "Incorrect ES ca bundle in Registration secret ")
-				asserts.Equalf(externalUserData, string(secret.Data[RegistrationUsernameKey]), "Incorrect ES user in Registration secret ")
-				asserts.Equalf(externalPasswordData, string(secret.Data[RegistrationPasswordKey]), "Incorrect ES password in Registration secret ")
+				asserts.Equalf(externalEsURLData, string(secret.Data[mcconstants.ESURLKey]), "Incorrect ES URL in Registration secret ")
+				asserts.Equalf(externalCaData, string(secret.Data[mcconstants.ESCaBundleKey]), "Incorrect ES ca bundle in Registration secret ")
+				asserts.Equalf(externalUserData, string(secret.Data[mcconstants.RegistrationUsernameKey]), "Incorrect ES user in Registration secret ")
+				asserts.Equalf(externalPasswordData, string(secret.Data[mcconstants.RegistrationPasswordKey]), "Incorrect ES password in Registration secret ")
 			} else {
-				asserts.Equalf(vzEsURLData, string(secret.Data[ESURLKey]), "Incorrect ES URL in Registration secret ")
-				asserts.Equalf(vzCaData, string(secret.Data[ESCaBundleKey]), "Incorrect ES ca bundle in Registration secret ")
-				asserts.Equalf(vzUserData, string(secret.Data[RegistrationUsernameKey]), "Incorrect ES user in Registration secret ")
-				asserts.Equalf(vzPasswordData, string(secret.Data[RegistrationPasswordKey]), "Incorrect ES password in Registration secret ")
+				asserts.Equalf(vzEsURLData, string(secret.Data[mcconstants.ESURLKey]), "Incorrect ES URL in Registration secret ")
+				asserts.Equalf(vzCaData, string(secret.Data[mcconstants.ESCaBundleKey]), "Incorrect ES ca bundle in Registration secret ")
+				asserts.Equalf(vzUserData, string(secret.Data[mcconstants.RegistrationUsernameKey]), "Incorrect ES user in Registration secret ")
+				asserts.Equalf(vzPasswordData, string(secret.Data[mcconstants.RegistrationPasswordKey]), "Incorrect ES password in Registration secret ")
 			}
 			return nil
 		})
@@ -1481,7 +1482,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockStatus *mocks.
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetAgentSecretName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				KubeconfigKey: []byte(kubeconfigData),
+				mcconstants.KubeconfigKey: []byte(kubeconfigData),
 			}
 			return nil
 		})
@@ -1491,11 +1492,11 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockStatus *mocks.
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: GetRegistrationSecretName(name)}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				ManagedClusterNameKey:   []byte(clusterName),
-				CaCrtKey:                []byte(caData),
-				RegistrationUsernameKey: []byte(userData),
-				RegistrationPasswordKey: []byte(passwordData),
-				ESURLKey:                []byte(urlData),
+				mcconstants.ManagedClusterNameKey:   []byte(clusterName),
+				mcconstants.CaCrtKey:                []byte(caData),
+				mcconstants.RegistrationUsernameKey: []byte(userData),
+				mcconstants.RegistrationPasswordKey: []byte(passwordData),
+				mcconstants.ESURLKey:                []byte(urlData),
 			}
 			return nil
 		})
@@ -1521,7 +1522,7 @@ func expectSyncManifest(t *testing.T, mock *mocks.MockClient, mockStatus *mocks.
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			data := secret.Data[YamlKey]
+			data := secret.Data[mcconstants.YamlKey]
 			asserts.NotZero(len(data), "Expected yaml data in manifest secret")
 
 			// YAML should contain the Rancher manifest things
@@ -1596,7 +1597,7 @@ func expectSyncPrometheusScraper(mock *mocks.MockClient, vmcName string, prometh
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VerrazzanoPromInternal}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
-				VerrazzanoPasswordKey: []byte("nRXlxXgMwN"),
+				mcconstants.VerrazzanoPasswordKey: []byte("nRXlxXgMwN"),
 			}
 			return nil
 		})

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -70,7 +70,7 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			req.Namespace, req.Name, err)
 		return newRequeueWithDelay(), nil
 	}
-	zap.S().Infof("DEVA Fetched secret %s/%s ", req.NamespacedName.Namespace, req.NamespacedName.Name)
+	zap.S().Debugf("Fetched secret %s/%s ", req.NamespacedName.Namespace, req.NamespacedName.Name)
 
 	// Get the resource logger needed to log message using 'progress' and 'once' methods
 	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
@@ -113,7 +113,7 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if mcCASecret.Data == nil {
 			mcCASecret.Data = make(map[string][]byte)
 		}
-		zap.S().Infof("DEVA Updating MC CA secret with data from %s key of %s/%s secret ", caKey, caSecret.Namespace, caSecret.Name)
+		zap.S().Debugf("Updating MC CA secret with data from %s key of %s/%s secret ", caKey, caSecret.Namespace, caSecret.Name)
 		mcCASecret.Data["ca-bundle"] = caSecret.Data[caKey]
 		return nil
 	})

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -64,6 +64,7 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			req.Namespace, req.Name, err)
 		return newRequeueWithDelay(), nil
 	}
+	zap.S().Infof("DEVA Fetched secret %s/%s ", req.NamespacedName.Namespace, req.NamespacedName.Name)
 
 	// Get the resource logger needed to log message using 'progress' and 'once' methods
 	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
@@ -106,6 +107,7 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if mcCASecret.Data == nil {
 			mcCASecret.Data = make(map[string][]byte)
 		}
+		zap.S().Infof("DEVA Updating MC CA secret with data from %s key of %s/%s secret ", caKey, caSecret.Namespace, caSecret.Name)
 		mcCASecret.Data["ca-bundle"] = caSecret.Data[caKey]
 		return nil
 	})

--- a/platform-operator/controllers/secrets/secrets_controller_test.go
+++ b/platform-operator/controllers/secrets/secrets_controller_test.go
@@ -180,6 +180,12 @@ func runNamespaceErrorTest(t *testing.T, expectedErr error) {
 			return nil
 		}).AnyTimes()
 
+	// Expect a call to get the verrazzano-tls secret
+	mock.EXPECT().
+		Get(gomock.Any(), additionalTLSSecret, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: constants2.RancherSystemNamespace, Resource: "Secret"}, additionalTLSSecret.Name)).
+		MinTimes(1)
+
 	// Create and make the request
 	request := newRequest(vzTLSSecret.Namespace, vzTLSSecret.Name)
 	reconciler := newSecretsReconciler(mock)

--- a/platform-operator/controllers/secrets/secrets_controller_test.go
+++ b/platform-operator/controllers/secrets/secrets_controller_test.go
@@ -30,7 +30,7 @@ var additionalTLSSecret = types.NamespacedName{Name: constants2.AdditionalTLS, N
 var vzLocalCaBundleSecret = types.NamespacedName{Name: "verrazzano-local-ca-bundle", Namespace: constants.VerrazzanoMultiClusterNamespace}
 var unwatchedSecret = types.NamespacedName{Name: "any-secret", Namespace: "any-namespace"}
 
-const addnlTLSSecretData = "YWRkaXRpb25hbCB0bHMgc2VjcmV0" // "additional tls secret"
+const addnlTLSData = "YWRkaXRpb25hbCB0bHMgc2VjcmV0" // "additional tls secret"
 
 // TestCreateLocalCABundle tests the Reconcile method for the following use cases
 // GIVEN a request to reconcile the verrazzano-tls secret OR the tls-additional-ca secret
@@ -62,7 +62,7 @@ func TestCreateLocalCABundle(t *testing.T) {
 			secretName:     additionalTLSSecret.Name,
 			secretNS:       additionalTLSSecret.Namespace,
 			secretKey:      constants2.AdditionalTLSCAKey,
-			secretData:     addnlTLSSecretData,
+			secretData:     addnlTLSData,
 			addnlTLSExists: true,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/common/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher.go
@@ -24,14 +24,13 @@ const (
 	// RancherName is the name of the component
 	RancherName = "rancher"
 	// CattleSystem is the namespace of the component
-	CattleSystem           = "cattle-system"
-	RancherIngressCAName   = "tls-rancher-ingress"
-	RancherAdminSecret     = "rancher-admin-secret"
-	RancherCACert          = "ca.crt"
-	RancherCAAdditionalPem = "ca-additional.pem"
-	contentTypeHeader      = "Content-Type"
-	authorizationHeader    = "Authorization"
-	applicationJSON        = "application/json"
+	CattleSystem         = "cattle-system"
+	RancherIngressCAName = "tls-rancher-ingress"
+	RancherAdminSecret   = "rancher-admin-secret"
+	RancherCACert        = "ca.crt"
+	contentTypeHeader    = "Content-Type"
+	authorizationHeader  = "Authorization"
+	applicationJSON      = "application/json"
 	// Path to get a login token
 	loginActionPath = "/v3-public/localProviders/local?action=login"
 	// Template body to POST for a login token
@@ -88,7 +87,7 @@ func NewClient(c client.Reader, hostname, password string) (*RESTClient, error) 
 	}, nil
 }
 
-//GetAdminSecret fetches the Rancher admin secret
+// GetAdminSecret fetches the Rancher admin secret
 func GetAdminSecret(c client.Reader) (string, error) {
 	secret := &corev1.Secret{}
 	nsName := types.NamespacedName{
@@ -127,7 +126,7 @@ func GetAdditionalCA(c client.Reader) []byte {
 		return []byte{}
 	}
 
-	return secret.Data[RancherCAAdditionalPem]
+	return secret.Data[constants.AdditionalTLSCAKey]
 }
 
 func CertPool(certs ...[]byte) *x509.CertPool {

--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
@@ -53,7 +53,7 @@ func (c *certBuilder) appendCertWithHTTP(uri string) error {
 	return nil
 }
 
-//buildLetsEncryptStagingChain builds the LetsEncrypt Staging certificate chain
+// buildLetsEncryptStagingChain builds the LetsEncrypt Staging certificate chain
 // LetsEncrypt staging provides a certificate chain for staging environments, mimicking production.
 // Verrazzano uses the LetsEncrypt staging certificate chain for Rancher ingress on ACME staging environments.
 // See https://letsencrypt.org/docs/staging-environment/ for more information.
@@ -113,7 +113,7 @@ func createAdditionalCertificates(log vzlog.VerrazzanoLogger, cli client.Client,
 			return err
 		}
 		secret.Data = map[string][]byte{
-			RancherCAAdditionalPem: builder.cert,
+			constants.AdditionalTLSCAKey: builder.cert,
 		}
 		return nil
 	})

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/helm"
+	constants2 "github.com/verrazzano/verrazzano/pkg/mcconstants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/rbac"
@@ -277,7 +277,7 @@ func TestCreateLocalRegistrationSecret(t *testing.T) {
 		Create(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
 			secret.Data = map[string][]byte{
-				clusters.ManagedClusterNameKey: []byte("cluster1"),
+				constants2.ManagedClusterNameKey: []byte("cluster1"),
 			}
 			return nil
 		})
@@ -1330,8 +1330,8 @@ func TestGetOCIConfigSecretError(t *testing.T) {
 // newScheme creates a new scheme that includes this package's object to use for testing
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	//_ = clientgoscheme.AddToScheme(scheme)
-	//_ = core.AddToScheme(scheme)
+	// _ = clientgoscheme.AddToScheme(scheme)
+	// _ = core.AddToScheme(scheme)
 	_ = vzapi.AddToScheme(scheme)
 	return scheme
 }

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -6,8 +6,9 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+
+	constants2 "github.com/verrazzano/verrazzano/pkg/mcconstants"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/clusters"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +67,7 @@ func (r *Reconciler) createOrUpdateLocalRegistrationSecret(name string, namespac
 func (r *Reconciler) mutateLocalRegistrationSecret(secret *corev1.Secret) error {
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		clusters.ManagedClusterNameKey: []byte(constants.MCLocalCluster),
+		constants2.ManagedClusterNameKey: []byte(constants.MCLocalCluster),
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
+++ b/platform-operator/controllers/verrazzano/sync_local_registration_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verrazzano


### PR DESCRIPTION
# Description

When admin cluster DNS and certs are updated, the managed cluster fluentd log pushes should continue to work (they don't always, right now).  The following changes were made:

1. Sync the registration secret entries for ES URL and creds to the managed cluster when they change. That way when there are DNS updates on admin cluster, the new ES URL automatically syncs to managed cluster
2. In secret_controller, make sure that the admin cluster local ca bundle is also updated for the LE staging case (i.e. based on additional TLS secret present in cattle-system). Otherwise updating admin cluster to LE staging certs will not sync the certs to managed cluster.
3. Just added - force a fluentd restart (using an annotation on daemonset) when managed cluster CAs or registration is updated. This restart is not guaranteed to happen when only certs are updated.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
