### PR TITLE
VZ-5809: Change upgrade path default profile to prod, enable persistence for dev profile

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     parameters {
         booleanParam (description: 'Whether to use External Elasticsearch', name: 'EXTERNAL_ELASTICSEARCH', defaultValue: false)
         choice (description: 'Number of Cluster', name: 'TOTAL_CLUSTERS', choices: ["2", "1", "3"])
-        choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
+        choice (description: 'Predefined config permutations for Verrazzano installation. Prod profile is the default profile for NONE', name: 'VZ_INSTALL_CONFIG',
                 choices: ["NONE", "dev-kind-persistence"])
         choice (description: 'Verrazzano Test Environment', name: 'TEST_ENV',
                 choices: ["KIND", "magicdns_oke", "ocidns_oke"])

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         booleanParam (description: 'Whether to use External Elasticsearch', name: 'EXTERNAL_ELASTICSEARCH', defaultValue: false)
         choice (description: 'Number of Cluster', name: 'TOTAL_CLUSTERS', choices: ["2", "1", "3"])
         choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
-                choices: ["NONE", "dev-kind-all-default"])
+                choices: ["NONE", "dev-kind-persistence"])
         choice (description: 'Verrazzano Test Environment', name: 'TEST_ENV',
                 choices: ["KIND", "magicdns_oke", "ocidns_oke"])
         choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',
@@ -1518,8 +1518,8 @@ def emitJobMetrics() {
 }
 
 def setVZConfigForInstallation(){
-    if(params.VZ_INSTALL_CONFIG == "dev-kind-all-default"){
-        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml"
+    if(params.VZ_INSTALL_CONFIG == "dev-kind-persistence"){
+        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         ADMIN_CLUSTER_PROFILE = "dev"
         MANAGED_CLUSTER_PROFILE = "managed-cluster"
     }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -42,7 +42,7 @@ pipeline {
                 defaultValue: '3',
                 description: 'This is to define total number of jobs executed in parallel per each batch',
                 trim: true)
-        choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
+        choice (description: 'Predefined config permutations for Verrazzano installation. Prod profile is the default profile for NONE', name: 'VZ_INSTALL_CONFIG',
                 choices: ["NONE", "dev-kind-persistence"])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4",

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -43,7 +43,7 @@ pipeline {
                 description: 'This is to define total number of jobs executed in parallel per each batch',
                 trim: true)
         choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
-                choices: ["dev-kind-all-default", "NONE"])
+                choices: ["NONE", "dev-kind-persistence"])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)

--- a/ci/upgrade-paths/JenkinsfileTestTriggerPatchRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerPatchRelease
@@ -42,7 +42,7 @@ pipeline {
                 defaultValue: '3',
                 description: 'This is to define total number of jobs executed in parallel per each batch',
                 trim: true)
-        choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
+        choice (description: 'Predefined config permutations for Verrazzano installation. Prod profile is the default profile for NONE', name: 'VZ_INSTALL_CONFIG',
                 choices: ["NONE", "dev-kind-persistence"])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4",

--- a/ci/upgrade-paths/JenkinsfileTestTriggerPatchRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerPatchRelease
@@ -43,7 +43,7 @@ pipeline {
                 description: 'This is to define total number of jobs executed in parallel per each batch',
                 trim: true)
         choice (description: 'Predefined config permutations for Verrazzano installation', name: 'VZ_INSTALL_CONFIG',
-                choices: ["dev-kind-all-default", "NONE"])
+                choices: ["NONE", "dev-kind-persistence"])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)


### PR DESCRIPTION
- Change the default profile to prod for both minor and patch release upgrade testing. 
- Enable persistence for dev profile. 

Fixes VZ-5809

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
