### PR TITLE
NO JIRA: Fix wrong image specified in jaeger-operator yaml

### DIFF
--- a/platform-operator/thirdparty/manifests/jaeger/jaeger-operator.yaml
+++ b/platform-operator/thirdparty/manifests/jaeger/jaeger-operator.yaml
@@ -13228,7 +13228,6 @@ spec:
         - name: JAEGER-COLLECTOR-IMAGE
           value: {{.jaegercollector}}
         image: {{.jaegeroperator}}
-        image: quay.io/jaegertracing/jaeger-operator:1.32.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
# Description

As there were two entries specified for jaeger-operator image in jaeger-operator.yaml,  jaeger-operator image was picked up from quay.io than verrazzano registry. Removed the wrong image entry.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
