### PR TITLE
VZ 5882: Fix per-component watches

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -1349,11 +1349,10 @@ func (r *Reconciler) AddWatch(name string) {
 	r.WatchedComponents[name] = true
 }
 
-//ClearWatches removes all component watches
-func (r *Reconciler) ClearWatches() {
+func (r *Reconciler) ClearWatch(name string) {
 	r.WatchMutex.Lock()
 	defer r.WatchMutex.Unlock()
-	r.WatchedComponents = map[string]bool{}
+	delete(r.WatchedComponents, name)
 }
 
 //IsWatchedComponent checks if a component is watched or not

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -6,8 +6,11 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/keycloak"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
@@ -46,9 +49,11 @@ import (
 // Reconciler reconciles a Verrazzano object
 type Reconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Controller controller.Controller
-	DryRun     bool
+	Scheme            *runtime.Scheme
+	Controller        controller.Controller
+	DryRun            bool
+	WatchedComponents map[string]bool
+	WatchMutex        *sync.RWMutex
 }
 
 // Name of finalizer
@@ -1211,6 +1216,7 @@ func (r *Reconciler) watchPods(namespace string, name string, log vzlog.Verrazza
 				return false
 			}
 			log.Debugf("Pod %s in namespace %s created", pod.Name, pod.Namespace)
+			r.AddWatch(keycloak.ComponentJSONName)
 			return true
 		}))
 }
@@ -1226,6 +1232,7 @@ func (r *Reconciler) watchJaegerService(namespace string, name string, log vzlog
 			service := e.Object.(*corev1.Service)
 			if service.Labels[vzconst.KubernetesAppLabel] == vzconst.JaegerCollectorService {
 				log.Debugf("Jaeger service %s/%s created", service.Namespace, service.Name)
+				r.AddWatch(istio.ComponentJSONName)
 				return true
 			}
 			return false
@@ -1333,4 +1340,25 @@ func (r *Reconciler) updateVerrazzanoStatus(log vzlog.VerrazzanoLogger, vz *inst
 	}
 	// Return error so that reconcile gets called again
 	return err
+}
+
+//AddWatch adds a component to the watched set
+func (r *Reconciler) AddWatch(name string) {
+	r.WatchMutex.Lock()
+	defer r.WatchMutex.Unlock()
+	r.WatchedComponents[name] = true
+}
+
+//ClearWatches removes all component watches
+func (r *Reconciler) ClearWatches() {
+	r.WatchMutex.Lock()
+	defer r.WatchMutex.Unlock()
+	r.WatchedComponents = map[string]bool{}
+}
+
+//IsWatchedComponent checks if a component is watched or not
+func (r *Reconciler) IsWatchedComponent(compName string) bool {
+	r.WatchMutex.RLock()
+	defer r.WatchMutex.RUnlock()
+	return r.WatchedComponents[compName]
 }

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -6,6 +6,7 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1351,8 +1352,11 @@ func newRequest(namespace string, name string) ctrl.Request {
 func newVerrazzanoReconciler(c client.Client) Reconciler {
 	scheme := newScheme()
 	reconciler := Reconciler{
-		Client: c,
-		Scheme: scheme}
+		Client:            c,
+		Scheme:            scheme,
+		WatchedComponents: map[string]bool{},
+		WatchMutex:        &sync.RWMutex{},
+	}
 	return reconciler
 }
 

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -51,7 +51,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			compLog.Debugf("Did not find status details in map for component %s", comp.Name())
 			continue
 		}
-		if r.checkConfigUpdated(spiCtx, componentStatus, compName) && comp.IsEnabled(compContext.EffectiveCR()) {
+		if checkConfigUpdated(spiCtx, componentStatus, compName) && comp.IsEnabled(compContext.EffectiveCR()) {
 			oldState := componentStatus.State
 			oldGen := componentStatus.ReconcilingGeneration
 			componentStatus.ReconcilingGeneration = 0
@@ -76,7 +76,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 				continue
 			}
 			// If the component config is updated, or the component is watched, it should be reconciled
-			if !r.checkConfigUpdated(spiCtx, componentStatus, compName) && !r.IsWatchedComponent(comp.GetJSONName()) {
+			if !checkConfigUpdated(spiCtx, componentStatus, compName) && !r.IsWatchedComponent(comp.GetJSONName()) {
 				continue
 			}
 
@@ -160,7 +160,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 
 // checkConfigUpdated checks if the component confg in the VZ CR has been updated and the component needs to
 // reset the state back to pre-install to re-enter install flow
-func (r *Reconciler) checkConfigUpdated(ctx spi.ComponentContext, componentStatus *vzapi.ComponentStatusDetails, name string) bool {
+func checkConfigUpdated(ctx spi.ComponentContext, componentStatus *vzapi.ComponentStatusDetails, name string) bool {
 	vzState := ctx.ActualCR().Status.State
 	// Do not interrupt upgrade flow
 	if vzState == vzapi.VzStateUpgrading || vzState == vzapi.VzStatePaused {

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -169,14 +169,14 @@ func (r *Reconciler) checkConfigUpdated(ctx spi.ComponentContext, componentStatu
 	if name == mysql.ComponentName {
 		return false
 	}
+	// The component should be reconciled if it is watched
+	if r.IsWatchedComponent(name) {
+		return true
+	}
 	// The component is being reconciled/installed with ReconcilingGeneration of the CR
 	// if CR.Generation > ReconcilingGeneration then re-enter install flow
 	if componentStatus.ReconcilingGeneration > 0 {
 		return ctx.ActualCR().Generation > componentStatus.ReconcilingGeneration
-	}
-	// The component should be reconciled if it is watched
-	if r.IsWatchedComponent(name) {
-		return true
 	}
 	// The component has been reconciled/installed with LastReconciledGeneration of the CR
 	// if CR.Generation > LastReconciledGeneration then re-enter install flow

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -150,10 +150,10 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			requeue = true
 		}
 	}
+	r.ClearWatches()
 	if requeue {
 		return newRequeueWithDelay(), nil
 	}
-	r.ClearWatches()
 	return ctrl.Result{}, nil
 }
 

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -149,8 +149,8 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			compLog.Progressf("Component %s waiting to finish installing", compName)
 			requeue = true
 		}
+		r.ClearWatch(compName)
 	}
-	r.ClearWatches()
 	if requeue {
 		return newRequeueWithDelay(), nil
 	}

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -149,7 +149,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			compLog.Progressf("Component %s waiting to finish installing", compName)
 			requeue = true
 		}
-		r.ClearWatch(compName)
+		r.ClearWatch(comp.GetJSONName())
 	}
 	if requeue {
 		return newRequeueWithDelay(), nil

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -75,7 +75,8 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			if !isInstalled(cr.Status) {
 				continue
 			}
-			if !r.checkConfigUpdated(spiCtx, componentStatus, compName) {
+			// If the component config is updated, or the component is watched, it should be reconciled
+			if !r.checkConfigUpdated(spiCtx, componentStatus, compName) && !r.IsWatchedComponent(comp.GetJSONName()) {
 				continue
 			}
 
@@ -168,10 +169,6 @@ func (r *Reconciler) checkConfigUpdated(ctx spi.ComponentContext, componentStatu
 	// Current VerrazzanoSpec or CRD does not define VerrazzanoSpec.components.mysql. MySQL Config update is not allowed yet.
 	if name == mysql.ComponentName {
 		return false
-	}
-	// The component should be reconciled if it is watched
-	if r.IsWatchedComponent(name) {
-		return true
 	}
 	// The component is being reconciled/installed with ReconcilingGeneration of the CR
 	// if CR.Generation > ReconcilingGeneration then re-enter install flow

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -128,7 +128,6 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 			compLog.Oncef("Component %s has successfully upgraded", compName)
 			upgradeContext.state = compStateEnd
 		}
-		r.ClearWatch(comp.GetJSONName())
 	}
 	// Component has been upgraded
 	return ctrl.Result{}, nil

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -128,6 +128,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 			compLog.Oncef("Component %s has successfully upgraded", compName)
 			upgradeContext.state = compStateEnd
 		}
+		r.ClearWatch(comp.GetJSONName())
 	}
 	// Component has been upgraded
 	return ctrl.Result{}, nil

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"sync"
 
 	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/validator"
@@ -162,9 +163,11 @@ func main() {
 
 	// Setup the reconciler
 	reconciler := vzcontroller.Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		DryRun: config.DryRun,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		DryRun:            config.DryRun,
+		WatchedComponents: map[string]bool{},
+		WatchMutex:        &sync.RWMutex{},
 	}
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "Failed to setup controller", vzlog.FieldController, "Verrazzano")


### PR DESCRIPTION
Take 2 on VZ 5882. I found putting the watch check in `checkConfigUpdated()` was causing unintended issues during the upgrade flow. The watch check needs to be in the ready state only.