### PR TITLE
VZ-5899: Add ServiceMonitor and PodMonitor resources for Verrazzano system components

### DIFF
--- a/pkg/k8sutil/apply_yaml.go
+++ b/pkg/k8sutil/apply_yaml.go
@@ -9,15 +9,16 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"path"
+	"strings"
+	"text/template"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	crtpkg "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
-	"strings"
-	"text/template"
 )
 
 const (
@@ -61,6 +62,26 @@ func (y *YAMLApplier) ApplyD(directory string) error {
 	for _, file := range filteredFiles {
 		filePath := path.Join(directory, file.Name())
 		if err = y.ApplyF(filePath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+//ApplyDT applies a directory of file templates to Kubernetes
+func (y *YAMLApplier) ApplyDT(directory string, args map[string]interface{}) error {
+	files, err := os.ReadDir(directory)
+	if err != nil {
+		return err
+	}
+	filteredFiles := filterYamlExt(files)
+	if len(filteredFiles) < 1 {
+		return fmt.Errorf("no files passed to apply: %s", directory)
+	}
+	for _, file := range filteredFiles {
+		filePath := path.Join(directory, file.Name())
+		if err = y.ApplyFT(filePath, args); err != nil {
 			return err
 		}
 	}

--- a/pkg/k8sutil/apply_yaml_test.go
+++ b/pkg/k8sutil/apply_yaml_test.go
@@ -4,11 +4,12 @@
 package k8sutil_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const (
@@ -129,6 +130,45 @@ func TestApplyFT(t *testing.T) {
 			c := fake.NewFakeClientWithScheme(k8scheme.Scheme)
 			y := k8sutil.NewYAMLApplier(c, "")
 			err := y.ApplyFT(tt.file, tt.args)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.count, len(y.Objects()))
+		})
+	}
+}
+
+func TestApplyDT(t *testing.T) {
+	var tests = []struct {
+		name    string
+		dir     string
+		args    map[string]interface{}
+		count   int
+		isError bool
+	}{
+		{
+			"should apply all template files in directory",
+			testdata,
+			map[string]interface{}{"namespace": "default"},
+			3,
+			false,
+		},
+		{
+			"should fail to apply when one or more templates are incomplete",
+			testdata,
+			map[string]interface{}{},
+			0,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewFakeClientWithScheme(k8scheme.Scheme)
+			y := k8sutil.NewYAMLApplier(c, "")
+			err := y.ApplyDT(tt.dir, tt.args)
 			if tt.isError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/k8sutil/apply_yaml_test.go
+++ b/pkg/k8sutil/apply_yaml_test.go
@@ -140,6 +140,7 @@ func TestApplyFT(t *testing.T) {
 	}
 }
 
+// TestApplyDT tests the ApplyDT function.
 func TestApplyDT(t *testing.T) {
 	var tests = []struct {
 		name    string
@@ -148,6 +149,9 @@ func TestApplyDT(t *testing.T) {
 		count   int
 		isError bool
 	}{
+		// GIVEN a directory of template YAML files
+		// WHEN the ApplyDT function is called with substitution key/value pairs
+		// THEN the call succeeds and the resources are applied to the cluster
 		{
 			"should apply all template files in directory",
 			testdata,
@@ -155,6 +159,9 @@ func TestApplyDT(t *testing.T) {
 			3,
 			false,
 		},
+		// GIVEN a directory of template YAML files
+		// WHEN the ApplyDT function is called with no substitution key/value pairs
+		// THEN the call fails
 		{
 			"should fail to apply when one or more templates are incomplete",
 			testdata,

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -6,10 +6,12 @@ package operator
 import (
 	"context"
 	"fmt"
+	"path"
 	"strconv"
 
 	vmoconst "github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -234,4 +236,20 @@ func GetOverrides(ctx spi.ComponentContext) []vzapi.Overrides {
 		return ctx.EffectiveCR().Spec.Components.PrometheusOperator.ValueOverrides
 	}
 	return []vzapi.Overrides{}
+}
+
+// applySystemMonitors applies templatized PodMonitor and ServiceMonitor custom resources for Verrazzano system
+// components to the cluster
+func applySystemMonitors(ctx spi.ComponentContext) error {
+	// create template key/value map
+	args := make(map[string]interface{})
+	args["systemNamespace"] = constants.VerrazzanoSystemNamespace
+	args["monitoringNamespace"] = constants.VerrazzanoMonitoringNamespace
+	args["nginxNamespace"] = constants.IngressNginxNamespace
+	args["istioNamespace"] = constants.IstioSystemNamespace
+
+	// substitute template values to all files in the directory and apply the resulting YAML
+	dir := path.Join(config.GetThirdPartyManifestsDir(), "prometheus-operator")
+	yamlApplier := k8sutil.NewYAMLApplier(ctx.Client(), "")
+	return yamlApplier.ApplyDT(dir, args)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -82,6 +82,22 @@ func (c prometheusComponent) PreInstall(ctx spi.ComponentContext) error {
 	return preInstall(ctx)
 }
 
+// PostInstall applies monitor resources for Verrazzano system components
+func (c prometheusComponent) PostInstall(ctx spi.ComponentContext) error {
+	if err := applySystemMonitors(ctx); err != nil {
+		return err
+	}
+	return c.HelmComponent.PostInstall(ctx)
+}
+
+// PostUpgrade applies monitor resources for Verrazzano system components
+func (c prometheusComponent) PostUpgrade(ctx spi.ComponentContext) error {
+	if err := applySystemMonitors(ctx); err != nil {
+		return err
+	}
+	return c.HelmComponent.PostUpgrade(ctx)
+}
+
 // ValidateInstall verifies the installation of the Verrazzano object
 func (c prometheusComponent) ValidateInstall(effectiveCR *vzapi.Verrazzano) error {
 	return c.validatePrometheusOperator(effectiveCR)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const profilesRelativePath = "../../../../../manifests/profiles"
@@ -70,4 +72,38 @@ func TestIsEnabled(t *testing.T) {
 			assert.Equal(t, tt.expectTrue, NewComponent().IsEnabled(ctx.EffectiveCR()))
 		})
 	}
+}
+
+// TestPostInstall tests the component PostInstall function
+func TestPostInstall(t *testing.T) {
+	// GIVEN the Prometheus Operator is being installed
+	// WHEN we call the PostInstall function
+	// THEN no error is returned
+	oldConfig := config.Get()
+	defer config.Set(oldConfig)
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../../..",
+	})
+
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false, profilesRelativePath)
+	err := NewComponent().PostInstall(ctx)
+	assert.NoError(t, err)
+}
+
+// TestPostUpgrade tests the component PostUpgrade function
+func TestPostUpgrade(t *testing.T) {
+	// GIVEN the Prometheus Operator is being upgraded
+	// WHEN we call the PostUpgrade function
+	// THEN no error is returned
+	oldConfig := config.Get()
+	defer config.Set(oldConfig)
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../../..",
+	})
+
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false, profilesRelativePath)
+	err := NewComponent().PostUpgrade(ctx)
+	assert.NoError(t, err)
 }

--- a/platform-operator/thirdparty/manifests/README.md
+++ b/platform-operator/thirdparty/manifests/README.md
@@ -16,3 +16,5 @@ curl -L -o "cert-manager.crds.yaml" \
 
 The `prometheus-operator` folder contains template Prometheus ServiceMonitor and PodMonitor resources that are applied during install and upgrade. The monitors
 will cause Prometheus to collect metrics from Verrazzano system components.
+
+The `prometheus-operator` folder and all of the files contained in the folder were created by the Verrazzano development team.

--- a/platform-operator/thirdparty/manifests/README.md
+++ b/platform-operator/thirdparty/manifests/README.md
@@ -12,4 +12,7 @@ curl -L -o "cert-manager.crds.yaml" \
     "https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_RELEASE}/cert-manager.crds.yaml"
 ```
 
+## Prometheus Operator
 
+The `prometheus-operator` folder contains template Prometheus ServiceMonitor and PodMonitor resources that are applied during install and upgrade. The monitors
+will cause Prometheus to collect metrics from Verrazzano system components.

--- a/platform-operator/thirdparty/manifests/prometheus-operator/envoy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/envoy_monitor.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-stats
+  namespace: {{ .monitoringNamespace }}
+  labels:
+    release: prometheus-operator
+spec:
+  selector: {}
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_container_port_name
+        regex: .*-envoy-prom
+        action: keep
+      - sourceLabels:
+          - __address__
+          - __meta_kubernetes_pod_annotation_prometheus_io_port
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        action: replace
+        replacement: $1:15090
+        targetLabel: __address__
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_(.+) 
+      - sourceLabels:
+          - __meta_kubernetes_namespace
+        action: replace
+        targetLabel: namespace
+      - sourceLabels:
+          - __meta_kubernetes_pod_name
+        action: replace
+        targetLabel: pod_name

--- a/platform-operator/thirdparty/manifests/prometheus-operator/nginx_ingress_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/nginx_ingress_monitor.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: nginx-ingress-controller
+  namespace: {{ .monitoringNamespace }}
+  labels:
+    release: prometheus-operator
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .nginxNamespace }}
+  selector: {}
+  podMetricsEndpoints:
+  - port: metrics
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_name
+        action: replace
+        targetLabel: kubernetes_pod_name
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - sourceLabels:
+          - __meta_kubernetes_namespace
+        action: replace
+        targetLabel: kubernetes_namespace
+      - sourceLabels:
+          - __meta_kubernetes_pod_annotation_system_io_scrape
+        action: keep
+        regex: "true"
+      - sourceLabels: 
+          - __address__
+          - __meta_kubernetes_pod_annotation_prometheus_io_port
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:10254
+        targetLabel: __address__

--- a/platform-operator/thirdparty/manifests/prometheus-operator/opensearch_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/opensearch_monitor.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: opensearch
+  namespace: {{ .monitoringNamespace }}
+  labels:
+    release: prometheus-operator
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .systemNamespace }}
+  selector: {}
+  podMetricsEndpoints:
+  - port: http
+    path: /_prometheus/metrics
+    scheme: http
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_name
+        regex: vmi-system-es-.*
+        action: keep
+      - sourceLabels:
+          - __meta_kubernetes_pod_container_port_number
+        regex: "9200"
+        action: keep
+      - sourceLabels:
+          - __meta_kubernetes_namespace
+        action: replace
+        targetLabel: namespace
+      - sourceLabels:
+          - __meta_kubernetes_pod_name
+        action: replace
+        targetLabel: kubernetes_pod_name

--- a/platform-operator/thirdparty/manifests/prometheus-operator/pilot_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/pilot_monitor.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pilot
+  namespace: {{ .monitoringNamespace }}
+  labels:
+    release: prometheus-operator
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .istioNamespace }}
+  selector: {}
+  endpoints:
+  - relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_service_name
+          - __meta_kubernetes_endpoint_port_name
+        regex: istiod;http-monitoring
+        action: keep
+      - sourceLabels:
+          - __meta_kubernetes_service_label_app
+        targetLabel: app


### PR DESCRIPTION
# Description

During install of the Prometheus Operator, we now create ServiceMonitor and PodMonitor resources for Verrazzano system components. This is equivalent to the out-of-the-box scrape configuration that the VMO applies to the "old" Prometheus instance.

I added a new "apply" utility function similar to the existing functions. I don't like how the functions are named in that file but named the new function consistently. At some point those functions should be renamed to be more descriptive but I did not want to include that in this PR.

Implements VZ-5899

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
