### PR TITLE
VZ-5889 Initial framework for the minimal CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,3 @@ check-eventually-test: ## run tests for Gomega Eventually checker
 
 cli-poc: ## build the CLI POC
 	(cd tools/cli-poc/vz; go install)
-
-
-#
-# CLI
-#
-
-##@ CLI
-
-cli: ## build the CLI
-	(cd tools/vz; go install)

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,20 @@ check-eventually-test: ## run tests for Gomega Eventually checker
 	(cd tools/eventually-checker; go test .)
 
 #
+# CLI-POC
+#
+
+##@ CLI-POC
+
+cli-poc: ## build the CLI POC
+	(cd tools/cli-poc/vz; go install)
+
+
+#
 # CLI
 #
 
 ##@ CLI
 
-cli-poc: ## build the CLI POC
-	(cd tools/cli-poc/vz; go install)
+cli: ## build the CLI
+	(cd tools/vz; go install)

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -1,0 +1,21 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+GO ?= GO111MODULE=on GOPRIVATE=github.com/verrazzano go
+
+#
+# CLI
+#
+
+##@ CLI
+
+.PHONY: cli
+cli: ## build the CLI
+	$(GO) install
+
+
+.PHONY: unit-test
+unit-test: cli
+	$(GO) test -v  ./cmd/...
+
+

--- a/tools/vz/README.md
+++ b/tools/vz/README.md
@@ -1,0 +1,15 @@
+# Verrazzano CLI
+
+The Verrazzano Command Line Interface (CLI) is a tool which can be used to interact with the Verrazzano resources.
+
+## Building the CLI
+
+The binary will be located in `/bin`.
+
+Run `make cli`
+
+## Usage
+
+Run `vz --help` for a list of available commands.
+
+

--- a/tools/vz/README.md
+++ b/tools/vz/README.md
@@ -4,7 +4,7 @@ The Verrazzano Command Line Interface (CLI) is a tool which can be used to inter
 
 ## Building the CLI
 
-The binary will be located in `/bin`.
+The binary will be located in `$GOPATH/bin`.
 
 Run `make cli`
 

--- a/tools/vz/cmd/root.go
+++ b/tools/vz/cmd/root.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/status"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
+)
+
+var kubeconfig string
+var context string
+
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vz",
+		Short: "Verrazzano CLI",
+		Long:  "Verrazzano CLI",
+	}
+
+	// Add global flags
+	cmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "c", "", "Kubernetes configuration file")
+	cmd.PersistentFlags().StringVar(&context, "context", "", "The name of the kubeconfig context to use")
+
+	cmd.AddCommand(status.NewCmdStatus())
+	cmd.AddCommand(version.NewCmdVersion())
+
+	return cmd
+}

--- a/tools/vz/cmd/root.go
+++ b/tools/vz/cmd/root.go
@@ -12,6 +12,11 @@ import (
 var kubeconfig string
 var context string
 
+const (
+	GlobalFlagKubeconfig = "kubeconfig"
+	GlobalFlagContext    = "context"
+)
+
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vz",
@@ -20,9 +25,10 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	// Add global flags
-	cmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "c", "", "Kubernetes configuration file")
-	cmd.PersistentFlags().StringVar(&context, "context", "", "The name of the kubeconfig context to use")
+	cmd.PersistentFlags().StringVarP(&kubeconfig, GlobalFlagKubeconfig, "c", "", "Kubernetes configuration file")
+	cmd.PersistentFlags().StringVar(&context, GlobalFlagContext, "", "The name of the kubeconfig context to use")
 
+	// Add commands
 	cmd.AddCommand(status.NewCmdStatus())
 	cmd.AddCommand(version.NewCmdVersion())
 

--- a/tools/vz/cmd/root_test.go
+++ b/tools/vz/cmd/root_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/status"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
+)
+
+func TestNewRootCmd(t *testing.T) {
+
+	rootCmd := NewRootCmd()
+	assert.NotNil(t, rootCmd)
+
+	// Verify the expected commands are defined
+	assert.Len(t, rootCmd.Commands(), 2)
+	foundCount := 0
+	for _, cmd := range rootCmd.Commands() {
+		switch cmd.Name() {
+		case status.CommandName:
+			foundCount++
+		case version.CommandName:
+			foundCount++
+		}
+	}
+	assert.Equal(t, 2, foundCount)
+
+	// Verify the expected global flags are defined
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup(GlobalFlagKubeconfig))
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup(GlobalFlagContext))
+}

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -23,5 +23,4 @@ func NewCmdStatus() *cobra.Command {
 
 func runCmdStatus(cmd *cobra.Command, args []string) {
 	fmt.Println("Not implemented yet")
-	return
 }

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package status
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdStatus() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Status of the Verrazzano install and access endpoints",
+		Long:  "Status of the Verrazzano install and access endpoints",
+		Run:   runCmdStatus,
+	}
+	return cmd
+}
+
+func runCmdStatus(cmd *cobra.Command, args []string) {
+	fmt.Println("Not implemented yet")
+	return
+}

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -9,9 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const CommandName = "status"
+
 func NewCmdStatus() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status",
+		Use:   CommandName,
 		Short: "Status of the Verrazzano install and access endpoints",
 		Long:  "Status of the Verrazzano install and access endpoints",
 		Run:   runCmdStatus,

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -23,5 +23,4 @@ func NewCmdVersion() *cobra.Command {
 
 func runCmdVersion(cmd *cobra.Command, args []string) {
 	fmt.Println("Not implemented yet")
-	return
 }

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -9,9 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const CommandName = "version"
+
 func NewCmdVersion() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
+		Use:   CommandName,
 		Short: "Verrazzano version information",
 		Long:  "Verrazzano version information",
 		Run:   runCmdVersion,

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Verrazzano version information",
+		Long:  "Verrazzano version information",
+		Run:   runCmdVersion,
+	}
+	return cmd
+}
+
+func runCmdVersion(cmd *cobra.Command, args []string) {
+	fmt.Println("Not implemented yet")
+	return
+}

--- a/tools/vz/main.go
+++ b/tools/vz/main.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("vz", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	rootCmd := cmd.NewRootCmd()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
# Description

Sample output of commands:

```
> vz
Verrazzano CLI

Usage:
  vz [command]

Available Commands:
  help        Help about any command
  status      Status of the Verrazzano install and access endpoints
  version     Verrazzano version information

Flags:
      --context string      The name of the kubeconfig context to use
  -h, --help                help for vz
  -c, --kubeconfig string   Kubernetes configuration file

Use "vz [command] --help" for more information about a command.
```

```
> vz status -h
Status of the Verrazzano install and access endpoints

Usage:
  vz status [flags]

Flags:
  -h, --help   help for status

Global Flags:
      --context string      The name of the kubeconfig context to use
  -c, --kubeconfig string   Kubernetes configuration file
```

```
> vz version -h
Verrazzano version information

Usage:
  vz version [flags]

Flags:
  -h, --help   help for version

Global Flags:
      --context string      The name of the kubeconfig context to use
  -c, --kubeconfig string   Kubernetes configuration file
```

```
> vz status
Not implemented yet
```

```
> vz version
Not implemented yet
```

Fixes VZ-5889

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
