### PR TITLE
VZ-5928.  Fix an NPE in the prometheus operator component

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -86,6 +86,9 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 
 // GetHelmOverrides appends Helm value overrides for the Prometheus Operator Helm chart
 func GetHelmOverrides(ctx spi.ComponentContext) []vzapi.Overrides {
+	if ctx.EffectiveCR() == nil || ctx.EffectiveCR().Spec.Components.PrometheusOperator == nil {
+		return []vzapi.Overrides{}
+	}
 	return ctx.EffectiveCR().Spec.Components.PrometheusOperator.ValueOverrides
 }
 


### PR DESCRIPTION
# Description

Fixes an NPE in the `GetHelmOverrides` func of the `PrometheusOperator` component.  It was detected during an upgrade of a very stale 1.3 deployment in master that had the Prometheus operator deployed by default.  It has since been disabled by default, but because the install had an instance running the upgrade code detected the helm install and tried to upgrade it.

Fixes VZ-5928.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
