### PR TITLE
VZ-5931: Use hashicorp/oci v4.76.0 in terraform scripts for release-1.3

### DIFF
--- a/tests/e2e/config/scripts/terraform/cluster/provider.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/provider.tf
@@ -8,6 +8,7 @@ variable "api_fingerprint" {}
 variable "api_private_key_path" {}
 
 provider "oci" {
+  version              = "4.75.0"
   tenancy_ocid         = var.tenancy_id
   user_ocid            = var.user_id
   fingerprint          = var.api_fingerprint

--- a/tests/e2e/config/scripts/terraform/cluster/provider.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/provider.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 variable "region" {}


### PR DESCRIPTION
# Description

Locks hashicorp/oci module to version 4.76.0 in the terraform scripts, used to create OKE clusters.

Contributes to VZ-5931

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
