### PR TITLE
Fix logic in CheckAllImagesPulled for pods having containers with same image

### DIFF
--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	v12 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"io/ioutil"
 	"net/http"
 	neturl "net/url"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	v12 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -503,7 +504,8 @@ func ContainerImagePullWaitInCluster(namespace string, namePrefixes []string, ku
 // in case of unrecoverable failures.
 func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes []string) bool {
 
-	allContainers := make(map[string][]interface{})
+	allContainers := make(map[string][]*v1.Container)
+	allImages := make(map[string]map[string]bool)
 	imagesYetToBePulled := 0
 	scheduledPods := make(map[string]bool)
 
@@ -511,12 +513,17 @@ func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes [
 	for _, pod := range pods.Items {
 		for _, namePrefix := range namePrefixes {
 			if strings.HasPrefix(pod.Name, namePrefix) {
+				if _, ok := allImages[pod.Name]; !ok {
+					allImages[pod.Name] = make(map[string]bool)
+				}
 				for _, initContainer := range pod.Spec.InitContainers {
-					allContainers[pod.Name] = append(allContainers[pod.Name], initContainer.Name)
+					allContainers[pod.Name] = append(allContainers[pod.Name], &initContainer)
+					allImages[pod.Name][initContainer.Image] = true
 					imagesYetToBePulled++
 				}
 				for _, container := range pod.Spec.Containers {
-					allContainers[pod.Name] = append(allContainers[pod.Name], container.Name)
+					allContainers[pod.Name] = append(allContainers[pod.Name], &container)
+					allImages[pod.Name][container.Image] = true
 					imagesYetToBePulled++
 				}
 				scheduledPods[namePrefix] = true
@@ -540,20 +547,28 @@ func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes [
 			for i := len(events.Items) - 1; i >= 0; i-- {
 				event := events.Items[i]
 				// used to match exact container name in event data
-				containerRegex := "{" + container.(string) + "}"
+				containerRegex := "{" + container.Name + "}"
 
 				if event.InvolvedObject.Kind == "Pod" && event.InvolvedObject.Name == podName && len(event.InvolvedObject.FieldPath) > 0 && strings.Contains(event.InvolvedObject.FieldPath, containerRegex) {
 
 					// Stop waiting in case of ImagePullBackoff and CrashLoopBackOff
 					if event.Reason == "Failed" {
-						Log(Info, fmt.Sprintf("Pod: %v container: %v status: %v ", podName, container, event.Reason))
+						Log(Info, fmt.Sprintf("Pod: %v container: %v image: %v status: %v ", podName, container.Name, container.Image, event.Reason))
 						if strings.Contains(event.Message, ImagePullBackOff) || strings.Contains(event.Message, CrashLoopBackOff) {
 							return true
 						}
 					}
 					if event.Reason == "Pulled" {
 						imagesYetToBePulled--
-						Log(Info, fmt.Sprintf("Pod: %v container: %v status: %v ", podName, container, event.Reason))
+						Log(Info, fmt.Sprintf("Pod: %v container: %v image: %v status: %v ", podName, container.Name, container.Image, event.Reason))
+						if imagesYetToBePulledForPod, ok := allImages[podName]; ok {
+							if _, ok := imagesYetToBePulledForPod[container.Image]; ok {
+								delete(imagesYetToBePulledForPod, container.Image)
+								if len(imagesYetToBePulledForPod) == 0 {
+									delete(allImages, podName)
+								}
+							}
+						}
 						break
 					}
 
@@ -562,10 +577,10 @@ func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes [
 		}
 	}
 
-	if imagesYetToBePulled != 0 {
+	if imagesYetToBePulled != 0 && len(allImages) != 0 {
 		Log(Info, fmt.Sprintf("%d images yet to be pulled", imagesYetToBePulled))
 	}
-	return imagesYetToBePulled == 0
+	return imagesYetToBePulled == 0 || len(allImages) == 0
 }
 
 // CheckNamespaceFinalizerRemoved checks whether namespace finalizers are removed

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -504,7 +504,7 @@ func ContainerImagePullWaitInCluster(namespace string, namePrefixes []string, ku
 // in case of unrecoverable failures.
 func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes []string) bool {
 
-	allContainers := make(map[string][]*v1.Container)
+	allContainers := make(map[string][]v1.Container)
 	allImages := make(map[string]map[string]bool)
 	imagesYetToBePulled := 0
 	scheduledPods := make(map[string]bool)
@@ -517,12 +517,12 @@ func CheckAllImagesPulled(pods *v1.PodList, events *v1.EventList, namePrefixes [
 					allImages[pod.Name] = make(map[string]bool)
 				}
 				for _, initContainer := range pod.Spec.InitContainers {
-					allContainers[pod.Name] = append(allContainers[pod.Name], &initContainer)
+					allContainers[pod.Name] = append(allContainers[pod.Name], initContainer)
 					allImages[pod.Name][initContainer.Image] = true
 					imagesYetToBePulled++
 				}
 				for _, container := range pod.Spec.Containers {
-					allContainers[pod.Name] = append(allContainers[pod.Name], &container)
+					allContainers[pod.Name] = append(allContainers[pod.Name], container)
 					allImages[pod.Name][container.Image] = true
 					imagesYetToBePulled++
 				}


### PR DESCRIPTION
# Description

The [CheckAllImagesPulled](https://github.com/verrazzano/verrazzano/blob/6a5a1f0f6fedc0ab7a71d3a77f72e9e924888cb2/tests/e2e/pkg/common.go#L504) function in test checks for all pod events and based on all the `Pull`  events decides whether all the containers for all the pods in a test are  scheduled or not. A failure was encountered in a pipeline where the image for both the `istio-init` and `istio-proxy` pods was same , the `Pull` event was received for one of them but not the other and the test kept waiting. Since they use same image, even if `Pull` event is not received, the pod was still up and running. This fix adds a check to see if all the images for containers in a pod are pulled and then even if a `Pull` event is not received for any of the containers, still allow the test to proceed.

Fixes VZ-5894

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
