### PR TITLE
VZ-5864: Modify Rancher upgrade check to detect any system chart not found

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -168,7 +168,7 @@ func checkRancherUpgradeFailure(c client.Client, log vzlog.VerrazzanoLogger) err
 		restartPod := false
 		scanner := bufio.NewScanner(logStream)
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), "Failed to find system chart rancher-webhook will try again in 5 seconds") {
+			if strings.Contains(scanner.Text(), "Failed to find system chart") {
 				restartPod = true
 				break
 			}


### PR DESCRIPTION
# Description

Modify Rancher upgrade check to detect any system chart not found.  The original problem was thought to just be with rancher-webhook charts.  But now seeing the same error for fleet charts not found.

Fixes VZ-5864

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
