### PR TITLE
VZ-5937.  Add known-issues checks/warnings hooks to BOM validator

### DIFF
--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -249,7 +249,7 @@ func ignoreSubComponent(name string) bool {
 // Report out the findings
 // ImagesNotFound is informational
 // imageTagErrors is a failure condition
-func reportResults(imagesNotFound map[string]string, imageTagErrors map[string]imageError, warnings map[string]string, errorsFound bool) {
+func reportResults(imagesNotFound map[string]string, imageTagErrors map[string]imageError, warnings map[string]string, passedValidation bool) {
 	// Dump Images Not Found to Console, Informational
 	const textDivider = "----------------------------------------"
 
@@ -269,7 +269,7 @@ func reportResults(imagesNotFound map[string]string, imageTagErrors map[string]i
 	}
 	fmt.Println()
 	// Dump Images that don't match BOM, Failure
-	if !errorsFound {
+	if !passedValidation {
 		fmt.Println("Image Errors: BOM Images that don't match Cluster Images")
 		fmt.Println(textDivider)
 		for name, tags := range imageTagErrors {

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -15,8 +15,12 @@ import (
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 )
 
-const tagLen = 10                                                          // The number of unique tags for a specific image
-const platformOperatorPodNameSearchString = "verrazzano-platform-operator" // Pod Substring for finding the platform operator pod
+const (
+	tagLen                              = 10                             // The number of unique tags for a specific image
+	platformOperatorPodNameSearchString = "verrazzano-platform-operator" // Pod Substring for finding the platform operator pod
+
+	rancherWarningMessage = "See VZ-5937, Rancher upgrade issue, all VZ versions" // For known Rancher issues with VZ upgrade
+)
 
 // Verrazzano BOM types
 
@@ -56,10 +60,6 @@ type knownIssues struct {
 	alternateTags []string
 	message       string
 }
-
-const (
-	rancherWarningMessage = "See VZ-5937, Rancher upgrade issue, all VZ versions"
-)
 
 // Mainly a workaround for Rancher additional images; Rancher does not always update to the latest version
 // in the BOM file, possible Rancher bug that we are pursuing with the Rancher team

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -57,13 +57,17 @@ type knownIssues struct {
 	message       string
 }
 
+const (
+	rancherWarningMessage = "See VZ-5937, Rancher upgrade issue, all VZ versions"
+)
+
 // Mainly a workaround for Rancher additional images; Rancher does not always update to the latest version
-// in the BOM file, if their minimum-version requirements are met by what's deployed at upgrade time
+// in the BOM file, possible Rancher bug that we are pursuing with the Rancher team
 var knownImageIssues = map[string]knownIssues{
-	"rancher-webhook": {alternateTags: []string{"v0.1.1", "v0.1.2", "v0.1.4"}, message: "VZ-5937"},
-	"fleet-agent":     {alternateTags: []string{"v0.3.5"}, message: "See VZ-5937"},
-	"fleet":           {alternateTags: []string{"v0.3.5"}, message: "See VZ-5937"},
-	"gitjob":          {alternateTags: []string{"v0.1.15"}, message: "See VZ-5937"},
+	"rancher-webhook": {alternateTags: []string{"v0.1.1", "v0.1.2", "v0.1.4"}, message: rancherWarningMessage},
+	"fleet-agent":     {alternateTags: []string{"v0.3.5"}, message: rancherWarningMessage},
+	"fleet":           {alternateTags: []string{"v0.3.5"}, message: rancherWarningMessage},
+	"gitjob":          {alternateTags: []string{"v0.1.15"}, message: rancherWarningMessage},
 }
 
 func main() {

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -93,13 +93,13 @@ func main() {
 	populateMapWithInitContainerImages(imagesInstalled)
 
 	//  Loop through BOM and check against cluster images
-	errorsFound := validateBOM(&vBom, imagesInstalled, imagesNotFound, imageTagErrors, imageWarnings)
+	passedValidation := validateBOM(&vBom, imagesInstalled, imagesNotFound, imageTagErrors, imageWarnings)
 
 	// Write to stdout
-	reportResults(imagesNotFound, imageTagErrors, imageWarnings, errorsFound)
+	reportResults(imagesNotFound, imageTagErrors, imageWarnings, passedValidation)
 
 	// Failure
-	if !errorsFound {
+	if !passedValidation {
 		os.Exit(1)
 	}
 }

--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -53,17 +53,17 @@ var ignoreSubComponents = []string{}
 
 // Hack to work around an issue with the 1.2 upgrade; Rancher does not always update the webhook image
 type knownIssues struct {
-	alternateTags  []string
-	warningMessage string
+	alternateTags []string
+	message       string
 }
 
 // Mainly a workaround for Rancher additional images; Rancher does not always update to the latest version
 // in the BOM file, if their minimum-version requirements are met by what's deployed at upgrade time
 var knownImageIssues = map[string]knownIssues{
-	"rancher-webhook": {alternateTags: []string{"v0.1.1", "v0.1.2", "v0.1.4"}, warningMessage: "VZ-5937 - Known issue, Rancher image rancher-webhook not at expected version"},
-	"fleet-agent":     {alternateTags: []string{"v0.3.5"}, warningMessage: "VZ-5937 - Known issue, Rancher image fleet-agent not at expected version"},
-	"fleet":           {alternateTags: []string{"v0.3.5"}, warningMessage: "VZ-5937 - Known issue, Rancher image fleet not at expected version"},
-	"gitjob":          {alternateTags: []string{"v0.1.15"}, warningMessage: "VZ-5937 - Known issue, Rancher image gitjob not at expected version"},
+	"rancher-webhook": {alternateTags: []string{"v0.1.1", "v0.1.2", "v0.1.4"}, message: "VZ-5937"},
+	"fleet-agent":     {alternateTags: []string{"v0.3.5"}, message: "See VZ-5937"},
+	"fleet":           {alternateTags: []string{"v0.3.5"}, message: "See VZ-5937"},
+	"gitjob":          {alternateTags: []string{"v0.1.15"}, message: "See VZ-5937"},
 }
 
 func main() {
@@ -216,8 +216,8 @@ func checkImageTags(clusterImageMap map[string][10]string, image imageDetails, i
 			// Check if the image/tag in the cluster is known to have issues
 			imageWarning, hasKnownIssues := knownImageIssues[image.Image]
 			if hasKnownIssues && vzstring.SliceContainsString(imageWarning.alternateTags, tag) {
-				imageWarnings[image.Image] = fmt.Sprintf("Known issue for image %s, tag: %s, message: %s",
-					image.Image, tag, imageWarning.warningMessage)
+				imageWarnings[image.Image] = fmt.Sprintf("Known issue for image %s, found tag %s, expected tag %s message: %s",
+					image.Image, tag, image.Tag, imageWarning.message)
 				tagFound = true
 				break
 			}


### PR DESCRIPTION
# Description

Add known-issues checks/warnings hooks to BOM validator
- Allows workaround for known issues to be tracked as warnings in the output
- Use for Rancher upgrade scenario where rancher-webhook image does not always update to what's in the BOM
- Add alternate tags list for rancher-webhook, warning message

Example output:

```
[c:kind-kind:bom-validator]$ bom-validator 
USING KUBECONFIG:  /home/mcico/.kube/config
The platform operator pod name is pod/verrazzano-platform-operator-57cf88464d-knscg

Images From BOM not installed in cluster
----------------------------------------
Image not installed: cert-manager-acmesolver:1.2.0-20220225033913-4f1415cb5
Image not installed: external-dns:v0.10.2-20220225102356-7bae1b96
Image not installed: rancher-agent:v2.5.9-20220506124723-e049e83ce
Image not installed: kubectl:v1.20.2
Image not installed: weblogic-monitoring-exporter:2.0.4

Image Warnings - Tags not at expected BOM level due to known issues
 ----------------------------------------
Warning: Image Name = fleet: Known issue for image fleet, found tag v0.3.5, expected tag v0.3.9 message: See VZ-5937
Warning: Image Name = gitjob: Known issue for image gitjob, found tag v0.1.15, expected tag v0.1.26 message: See VZ-5937
Warning: Image Name = rancher-webhook: Known issue for image rancher-webhook, found tag v0.1.2, expected tag v0.1.4 message: VZ-5937
Warning: Image Name = fleet-agent: Known issue for image fleet-agent, found tag v0.3.5, expected tag v0.3.9 message: See VZ-5937
```

Related to VZ-5937.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
