### PR TITLE
Discover external os LB IP

### DIFF
--- a/tests/e2e/config/scripts/create-external-os.sh
+++ b/tests/e2e/config/scripts/create-external-os.sh
@@ -20,6 +20,22 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 # This corresponds to OpenSearch 1.2.3
 OPENSEARCH_CHART_VERSION="1.5.7"
 
+# Install OpenSearch
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+helm upgrade --install opensearch opensearch/opensearch --version "$OPENSEARCH_CHART_VERSION" \
+  -f "$SCRIPT_DIR"/opensearch.yaml
+
+# Discover the LoadBalancer IP
+until [ -n "$(kubectl get svc opensearch-cluster-master -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
+    sleep 3
+done
+
+EXTERNAL_IP="$(kubectl get svc opensearch-cluster-master -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+
+echo "bootstrapping certificates for LoadBalancer @ $EXTERNAL_IP"
+
+sed -i "s/subjectAltName = critical,IP:.*/subjectAltName = critical,IP:$EXTERNAL_IP/" "$SCRIPT_DIR"/cert.conf
 # create root ca key
 echo -n '' > index.txt
 echo -n '00' > serial.txt
@@ -34,19 +50,19 @@ openssl pkcs8 -topk8 -inform PEM -in server_key.pem -out key.pem -nocrypt
 certdata=$(cat cert.pem)
 echo "-----${certdata#*-----}" > cert.pem
 
+# this secret is used by OpenSearch for loading certificates
 kubectl create secret generic opensearch-certificates \
   --from-file=cert.pem \
   --from-file=key.pem \
   --from-file=root-ca.pem
 
-# Install OpenSearch
-helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm repo update
 helm upgrade --install opensearch opensearch/opensearch --version "$OPENSEARCH_CHART_VERSION" \
-  -f "$SCRIPT_DIR"/opensearch.yaml
+  -f "$SCRIPT_DIR"/opensearch.yaml \
+  --set service.loadBalancerIP="$EXTERNAL_IP"
 
 kubectl create ns verrazzano-install
 cp root-ca.pem "$SCRIPT_DIR"/ca-bundle
 cat cert.pem >> "$SCRIPT_DIR"/ca-bundle
 
+# this secret is used by Verrazzano for loading certificates and credentials
 kubectl -n verrazzano-install create secret generic external-es-secret --from-literal=username=admin --from-literal=password=admin --from-file="${SCRIPT_DIR}"/ca-bundle

--- a/tests/e2e/config/scripts/opensearch.yaml
+++ b/tests/e2e/config/scripts/opensearch.yaml
@@ -3,7 +3,6 @@
 replicas: 1
 service:
   type: LoadBalancer
-  loadBalancerIP: 172.18.0.238
 
 extraEnvs:
   - name: DISABLE_INSTALL_DEMO_CONFIG


### PR DESCRIPTION
This fixes the create-external-os.sh script to work in environments where the LoadBalancer IP is not known ahead of time.