### PR TITLE
NOJIRA: Disable tracing and Grafana by default in Kiali UI

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr.go
@@ -6,9 +6,10 @@ package istio
 import (
 	"bytes"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"strings"
 	"text/template"
+
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 
 	"sigs.k8s.io/yaml"
 
@@ -20,9 +21,6 @@ const (
 	//ExternalIPArg is used in a special case where Istio helm chart no longer supports ExternalIPs.
 	// Put external IPs into the IstioOperator YAML, which does support it
 	ExternalIPArg = "gateways.istio-ingressgateway.externalIPs"
-
-	//meshConfigEnableTracingValue is a boolean flag to enable/disable tracing in the istio mesh
-	meshConfigEnableTracingValue = "meshConfig.enableTracing"
 
 	//meshConfigTracingAddress is the Jaeger collector address
 	meshConfigTracingAddress = "meshConfig.defaultConfig.tracing.zipkin.address"
@@ -98,8 +96,6 @@ type ReplicaData struct {
 func BuildIstioOperatorYaml(ctx spi.ComponentContext, comp *vzapi.IstioComponent) (string, error) {
 
 	var externalIPYAMLTemplateValue = ""
-	// Tracing is disabled by default
-	installArgs := append([]vzapi.InstallArgs{{Name: meshConfigEnableTracingValue, Value: "false"}}, comp.IstioInstallArgs...)
 
 	// Build a list of YAML strings from the istioComponent initargs, one for each arg.
 	expandedYamls := []string{}
@@ -110,7 +106,7 @@ func BuildIstioOperatorYaml(ctx spi.ComponentContext, comp *vzapi.IstioComponent
 		return "", err
 	}
 
-	for _, arg := range append(jaegerArgs, installArgs...) {
+	for _, arg := range append(jaegerArgs, comp.IstioInstallArgs...) {
 		values := arg.ValueList
 		if len(values) == 0 {
 			values = []string{arg.Value}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_cr_test.go
@@ -5,12 +5,13 @@ package istio
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -207,8 +208,6 @@ spec:
     global:
       defaultPodDisruptionBudget:
         enabled: false
-    meshConfig:
-        enableTracing: false
     pilot:
       resources:
         requests:
@@ -357,8 +356,6 @@ spec:
     global:
       defaultPodDisruptionBudget:
         enabled: false
-    meshConfig:
-        enableTracing: false
     pilot:
       resources:
         requests:
@@ -506,9 +503,6 @@ spec:
         service:
           type: LoadBalancer
       name: istio-ingressgateway
-  values:
-    meshConfig:
-      enableTracing: false
 `
 
 var cr4 = &vzapi.IstioComponent{

--- a/platform-operator/helm_config/overrides/kiali-server-values.yaml
+++ b/platform-operator/helm_config/overrides/kiali-server-values.yaml
@@ -28,6 +28,10 @@ kubernetes_config:
 external_services:
   prometheus:
     url: http://vmi-system-prometheus:9090
+  grafana:
+    enabled: false
+  tracing:
+    enabled: false
 
 server:
   web_root: ""


### PR DESCRIPTION
# Description

Please see #3223 for details of same change done in 1.3. In nutshell
- we do not need to set `enableTracing` in `meshConfig` for the `IstioOperator` CR because tracing is by default not enabled
- In order for Kiali UI to not try to fetch tracing spans and Grafana, it needs to explicitly disabled in kiali config

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
