### PR TITLE
VZ-5937.  Remove additional-rancher from bom-validator ignore-subComponents

### DIFF
--- a/tools/bom-validator/bom-validator.go
+++ b/tools/bom-validator/bom-validator.go
@@ -53,9 +53,9 @@ type imageError struct {
 	clusterImageTags [tagLen]string
 }
 
-var ignoreSubComponents = []string{
-	"additional-rancher",
-}
+var (
+	ignoreSubComponents []string
+)
 
 // Hack to work around an issue with the 1.2 upgrade; Rancher does not always update the webhook image
 type knownIssues struct {


### PR DESCRIPTION

# Description

Remove additional-rancher from bom-validator ignore-subComponents, which was merged back in from an earlier commit by accident.

Related to VZ-5937.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
