### PR TITLE
VZ-5744 Prometheus E2E upgrade tests

### DIFF
--- a/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_suite_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheus
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestVerifyPrometheusPostUpgrade(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Post Upgrade Verify Prometheus Suite")
+}

--- a/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_test.go
+++ b/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_test.go
@@ -23,28 +23,24 @@ const (
 
 var t = framework.NewTestFramework("prometheus")
 
+var _ = t.BeforeSuite(func() {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	supported := pkg.IsPrometheusEnabled(kubeconfigPath)
+	// Only run tests if Prometheus component is enabled in Verrazzano CR
+	if !supported {
+		Skip("Prometheus component is not enabled")
+	}
+})
 
 var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"), func() {
-	PrometheusSupportedIt := func(description string, f func()) {
-		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-		if err != nil {
-			t.It(description, func() {
-				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-			})
-		}
-		supported := pkg.IsPrometheusEnabled(kubeconfigPath)
-		// Only run tests if Prometheus component is enabled in Verrazzano CR
-		if supported {
-			t.It(description, f)
-		} else {
-			pkg.Log(pkg.Info, fmt.Sprintf("Skipping check '%v', Prometheus component is not enabled in current Verrazzano Installation", description))
-		}
-	}
 
 	// GIVEN a running Prometheus instance,
 	// WHEN a scrape config is created,
 	// THEN verify that the scrape config is created correctly
-	PrometheusSupportedIt("Old indices are deleted", func() {
+	It("Old indices are deleted", func() {
 		Eventually(func() bool {
 
 			return true
@@ -55,7 +51,7 @@ var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"
 	// GIVEN a running Prometheus instance,
 	// WHEN the data streams are retrieved
 	// THEN verify that they have data streams
-	PrometheusSupportedIt("Data streams are created", func() {
+	It("Data streams are created", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -65,7 +61,7 @@ var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"
 	// GIVEN a running Prometheus instance,
 	// WHEN
 	// THEN verify that the data can be retrieved successfully
-	PrometheusSupportedIt("OpenSearch get old data", func() {
+	It("OpenSearch get old data", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -76,7 +72,7 @@ var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"
 	// WHEN VZ custom resource is upgraded
 	// THEN only the system logs that are as old as the retention period
 	//      is migrated and older logs are purged
-	PrometheusSupportedIt("OpenSearch system logs older than retention period is not available post upgrade", func() {
+	It("OpenSearch system logs older than retention period is not available post upgrade", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -87,7 +83,7 @@ var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"
 	// WHEN VZ custom resource is upgraded
 	// THEN only the application logs that are as old as the retention period
 	//      is migrated and older logs are purged
-	PrometheusSupportedIt("OpenSearch application logs older than retention period is not available post upgrade", func () {
+	It("OpenSearch application logs older than retention period is not available post upgrade", func () {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),

--- a/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_test.go
+++ b/tests/e2e/upgrade/post-upgrade/prometheus/prometheus_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheus
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	threeMinutes    = 3 * time.Minute
+	pollingInterval = 10 * time.Second
+	documentFile    = "testdata/upgrade/opensearch/document1.json"
+	longTimeout     = 10 * time.Minute
+)
+
+var t = framework.NewTestFramework("prometheus")
+
+
+var _ = t.Describe("Post upgrade Prometheus", Label("f:observability.logging.es"), func() {
+	PrometheusSupportedIt := func(description string, f func()) {
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			t.It(description, func() {
+				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+			})
+		}
+		supported := pkg.IsPrometheusEnabled(kubeconfigPath)
+		// Only run tests if Prometheus component is enabled in Verrazzano CR
+		if supported {
+			t.It(description, f)
+		} else {
+			pkg.Log(pkg.Info, fmt.Sprintf("Skipping check '%v', Prometheus component is not enabled in current Verrazzano Installation", description))
+		}
+	}
+
+	// GIVEN a running Prometheus instance,
+	// WHEN a scrape config is created,
+	// THEN verify that the scrape config is created correctly
+	PrometheusSupportedIt("Old indices are deleted", func() {
+		Eventually(func() bool {
+
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected not to find any old indices")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN the data streams are retrieved
+	// THEN verify that they have data streams
+	PrometheusSupportedIt("Data streams are created", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected not to find any old indices")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN
+	// THEN verify that the data can be retrieved successfully
+	PrometheusSupportedIt("OpenSearch get old data", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN VZ custom resource is upgraded
+	// THEN only the system logs that are as old as the retention period
+	//      is migrated and older logs are purged
+	PrometheusSupportedIt("OpenSearch system logs older than retention period is not available post upgrade", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN VZ custom resource is upgraded
+	// THEN only the application logs that are as old as the retention period
+	//      is migrated and older logs are purged
+	PrometheusSupportedIt("OpenSearch application logs older than retention period is not available post upgrade", func () {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+})

--- a/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_suite_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheus
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestVerifyPrometheusPostUpgrade(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Post Upgrade Verify Prometheus Suite")
+}

--- a/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_test.go
@@ -23,28 +23,24 @@ const (
 
 var t = framework.NewTestFramework("prometheus")
 
+var _ = t.BeforeSuite(func() {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+	}
+	supported := pkg.IsPrometheusEnabled(kubeconfigPath)
+	// Only run tests if Prometheus component is enabled in Verrazzano CR
+	if !supported {
+		Skip("Prometheus component is not enabled")
+	}
+})
 
 var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es"), func() {
-	PrometheusSupportedIt := func(description string, f func()) {
-		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-		if err != nil {
-			t.It(description, func() {
-				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-			})
-		}
-		supported := pkg.IsPrometheusEnabled(kubeconfigPath)
-		// Only run tests if Prometheus component is enabled in Verrazzano CR
-		if supported {
-			t.It(description, f)
-		} else {
-			pkg.Log(pkg.Info, fmt.Sprintf("Skipping check '%v', Prometheus component is not enabled in current Verrazzano Installation", description))
-		}
-	}
 
 	// GIVEN a running Prometheus instance,
 	// WHEN a scrape config is created,
 	// THEN verify that the scrape config is created correctly
-	PrometheusSupportedIt("Scrape targets can be listed and there is atleast 1 scrape target", func() {
+	It("Scrape targets can be listed and there is atleast 1 scrape target", func() {
 		Eventually(func() bool {
 			scrapeTargets, err  := pkg.ScrapeTargets()
 			if err != nil {
@@ -59,7 +55,7 @@ var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es")
 	// GIVEN a running Prometheus instance,
 	// WHEN the data streams are retrieved
 	// THEN verify that they have data streams
-	PrometheusSupportedIt("Data streams are created", func() {
+	It("Data streams are created", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -69,7 +65,7 @@ var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es")
 	// GIVEN a running Prometheus instance,
 	// WHEN
 	// THEN verify that the data can be retrieved successfully
-	PrometheusSupportedIt("OpenSearch get old data", func() {
+	It("OpenSearch get old data", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -80,7 +76,7 @@ var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es")
 	// WHEN VZ custom resource is upgraded
 	// THEN only the system logs that are as old as the retention period
 	//      is migrated and older logs are purged
-	PrometheusSupportedIt("OpenSearch system logs older than retention period is not available post upgrade", func() {
+	It("OpenSearch system logs older than retention period is not available post upgrade", func() {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
@@ -91,7 +87,7 @@ var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es")
 	// WHEN VZ custom resource is upgraded
 	// THEN only the application logs that are as old as the retention period
 	//      is migrated and older logs are purged
-	PrometheusSupportedIt("OpenSearch application logs older than retention period is not available post upgrade", func () {
+	It("OpenSearch application logs older than retention period is not available post upgrade", func () {
 		Eventually(func() bool {
 			return true
 		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),

--- a/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/prometheus/prometheus_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package prometheus
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	threeMinutes    = 3 * time.Minute
+	pollingInterval = 10 * time.Second
+	documentFile    = "testdata/upgrade/opensearch/document1.json"
+	longTimeout     = 10 * time.Minute
+)
+
+var t = framework.NewTestFramework("prometheus")
+
+
+var _ = t.Describe("Pre upgrade Prometheus", Label("f:observability.logging.es"), func() {
+	PrometheusSupportedIt := func(description string, f func()) {
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+		if err != nil {
+			t.It(description, func() {
+				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+			})
+		}
+		supported := pkg.IsPrometheusEnabled(kubeconfigPath)
+		// Only run tests if Prometheus component is enabled in Verrazzano CR
+		if supported {
+			t.It(description, f)
+		} else {
+			pkg.Log(pkg.Info, fmt.Sprintf("Skipping check '%v', Prometheus component is not enabled in current Verrazzano Installation", description))
+		}
+	}
+
+	// GIVEN a running Prometheus instance,
+	// WHEN a scrape config is created,
+	// THEN verify that the scrape config is created correctly
+	PrometheusSupportedIt("Scrape targets can be listed and there is atleast 1 scrape target", func() {
+		Eventually(func() bool {
+			scrapeTargets, err  := pkg.ScrapeTargets()
+			if err != nil {
+				pkg.Log(pkg.Error, err.Error())
+				return false
+			}
+			return len(scrapeTargets) > 0
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected not to find any old indices")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN the data streams are retrieved
+	// THEN verify that they have data streams
+	PrometheusSupportedIt("Data streams are created", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected not to find any old indices")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN
+	// THEN verify that the data can be retrieved successfully
+	PrometheusSupportedIt("OpenSearch get old data", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN VZ custom resource is upgraded
+	// THEN only the system logs that are as old as the retention period
+	//      is migrated and older logs are purged
+	PrometheusSupportedIt("OpenSearch system logs older than retention period is not available post upgrade", func() {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+	// GIVEN a running Prometheus instance,
+	// WHEN VZ custom resource is upgraded
+	// THEN only the application logs that are as old as the retention period
+	//      is migrated and older logs are purged
+	PrometheusSupportedIt("OpenSearch application logs older than retention period is not available post upgrade", func () {
+		Eventually(func() bool {
+			return true
+		}).WithPolling(pollingInterval).WithTimeout(threeMinutes).Should(BeTrue(),
+			"Expected to find the old data")
+	})
+
+})


### PR DESCRIPTION
# Description

Contains E2E tests for prometheus pre and post upgrade. Tests validate if an app deployed with an ingress trait, sends metric pre and post upgrade. Also tests the system metrics are exported to prometheus pre and post upgrade.

Fixes VZ-5744

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
