### PR TITLE
[Security Advisory] CVE-2021-25742: Ingress-nginx custom snippets allows retrieval of ingress-nginx serviceaccount token and secrets across all namespaces

### DIFF
--- a/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
+++ b/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
@@ -61,6 +61,11 @@ controller:
   # Overrides value for --watch-ingress-without-class flag of the controller binary
   # Defaults to false
   watchIngressWithoutClass: true
+  # -- This configuration defines if Ingress Controller should allow users to set
+  # their own *-snippet annotations, otherwise this is forbidden / dropped
+  # when users add those annotations.
+  # Global snippets in ConfigMap are still respected
+  allowSnippetAnnotations: false
 defaultBackend:
   # NOTE: The image you're looking for isn't here. The nginx-ingress-default-backend image now comes from
   # the bill of materials file (verrazzano-bom.json).

--- a/platform-operator/thirdparty/charts/ingress-nginx/values.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/values.yaml
@@ -72,7 +72,7 @@ controller:
   # their own *-snippet annotations, otherwise this is forbidden / dropped
   # when users add those annotations.
   # Global snippets in ConfigMap are still respected
-  allowSnippetAnnotations: true
+  allowSnippetAnnotations: false
 
   # -- Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920


### PR DESCRIPTION
# Description

[Security Advisory] CVE-2021-25742: Ingress-nginx custom snippets allows retrieval of ingress-nginx serviceaccount token and secrets across all namespaces. Set allowSnippetAnnotations to false.

Fixes VZ-3924

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
