### PR TITLE
Extend periodic/push timeout to 6 hours

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -18,7 +18,7 @@ def verrazzanoImagesBuildNumber = 0 // will be set to actual build number when t
 
 pipeline {
     options {
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
         skipDefaultCheckout true
         disableConcurrentBuilds()
         timestamps ()

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -5,7 +5,7 @@ def agentLabel = env.JOB_NAME.contains('master') ? "phxsmall" : "VM.Standard2.2"
 
 pipeline {
     options {
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
         skipDefaultCheckout true
     }
 

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -5,7 +5,7 @@ def agentLabel = env.JOB_NAME.contains('master') ? "phxsmall" : "VM.Standard2.2"
 
 pipeline {
     options {
-        timeout(time: 6, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
         skipDefaultCheckout true
     }
 


### PR DESCRIPTION
…ggered

# Description

Bumping timeout for periodic and push triggered, based on reviewing some jobs with retry now have passed with longer times taken

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
