### PR TITLE
VZ-5900: Managed cluster federation for Prometheus Operator Prometheus

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -181,3 +181,13 @@ const ConfigMapKind = "ConfigMap"
 
 // SecretKind is a label value for Secret Kind
 const SecretKind = "Secret"
+
+// PromAdditionalScrapeConfigsSecretName is the name of the secret that contains the additional scrape configurations loaded by Prometheus
+const PromAdditionalScrapeConfigsSecretName = "additional-scrape-configs"
+
+// PromAdditionalScrapeConfigsSecretKey is the name of the key in the additional scrape configurations secret that contains the scrape config YAML
+const PromAdditionalScrapeConfigsSecretKey = "jobs"
+
+// PromManagedClusterTlsCertsSecretName is the name of the secret that contains managed cluster TLS certificates. The secret is mounted
+// as a volume in the Prometheus pod.
+const PromManagedClusterTlsCertsSecretName = "managed-cluster-tls-certs"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -188,6 +188,6 @@ const PromAdditionalScrapeConfigsSecretName = "additional-scrape-configs"
 // PromAdditionalScrapeConfigsSecretKey is the name of the key in the additional scrape configurations secret that contains the scrape config YAML
 const PromAdditionalScrapeConfigsSecretKey = "jobs"
 
-// PromManagedClusterTlsCertsSecretName is the name of the secret that contains managed cluster TLS certificates. The secret is mounted
+// PromManagedClusterTLSCertsSecretName is the name of the secret that contains managed cluster TLS certificates. The secret is mounted
 // as a volume in the Prometheus pod.
-const PromManagedClusterTlsCertsSecretName = "managed-cluster-tls-certs"
+const PromManagedClusterTLSCertsSecretName = "managed-cluster-tls-certs"

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -12,9 +12,13 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
+	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/yaml"
 )
 
@@ -24,6 +28,7 @@ const (
 	scrapeConfigsKey         = "scrape_configs"
 	jobNameKey               = "job_name"
 	prometheusConfigBasePath = "/etc/prometheus/config/"
+	managedCertsBasePath     = "/etc/prometheus/managed-cluster-tls-certs/"
 	configMapKind            = "ConfigMap"
 	configMapVersion         = "v1"
 	scrapeConfigTemplate     = `job_name: ##JOB_NAME##
@@ -89,6 +94,18 @@ func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.C
 	if err != nil {
 		return err
 	}
+
+	// The additional scrape configs and managed cluster TLS secrets are needed by the Prometheus Operator Prometheus
+	// because the federated scrape config can't be represented in a PodMonitor, ServiceMonitor, etc.
+	err = r.mutateAdditionalScrapeConfigs(ctx, vmc, &secret)
+	if err != nil {
+		return err
+	}
+	err = r.mutateManagedClusterTLSSecret(ctx, vmc, &secret)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -208,6 +225,12 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterPrometheusConfiguratio
 	if err != nil {
 		return err
 	}
+
+	err = r.mutateAdditionalScrapeConfigs(ctx, vmc, nil)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -237,4 +260,106 @@ func parsePrometheusConfig(promConfigStr string) (*gabs.Container, error) {
 // getCAKey returns the key by which the CA cert will be retrieved by the scaper HTTP client
 func getCAKey(vmc *clustersv1alpha1.VerrazzanoManagedCluster) string {
 	return "ca-" + vmc.Name
+}
+
+// mutateAdditionalScrapeConfigs adds and removes scrape config for managed clusters to the additional scrape configurations secret. Prometheus appends the raw scrape config
+// in this secret to the scrape config it generates from PodMonitor and ServiceMonitor resources.
+func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *v1.Secret) error {
+	// get the existing additional scrape config, if the secret doesn't exist we will create it
+	secret, err := r.getSecret(vpoconst.VerrazzanoMonitoringNamespace, vpoconst.PromAdditionalScrapeConfigsSecretName, false)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	var jobs string
+	if secret.Data != nil {
+		jobs = string(secret.Data[vpoconst.PromAdditionalScrapeConfigsSecretKey])
+	}
+
+	// parse the scrape config so we can manipulate it
+	scrapeConfigs, err := parseScrapeConfig(jobs)
+	if err != nil {
+		return err
+	}
+
+	// create the scrape config for the new managed cluster
+	newScrapeConfig, err := r.newScrapeConfig(cacrtSecret, vmc)
+	if err != nil {
+		return err
+	}
+	if newScrapeConfig == nil {
+		// we are removing the scrape config, so remove the TLS cert for the managed cluster from the TLS certs secret
+		err = r.mutateManagedClusterTLSSecret(ctx, vmc, cacrtSecret)
+		if err != nil {
+			return err
+		}
+	}
+	// TODO: Set this in the newScrapeConfig function when we remove the "old" Prometheus code
+	newScrapeConfig.Set(managedCertsBasePath+getCAKey(vmc), "tls_config", "ca_file")
+
+	found := false
+	for index, scrapeConfig := range scrapeConfigs.Children() {
+		scrapeJobName := scrapeConfig.Search(jobNameKey).Data()
+		if vmc.Name == scrapeJobName {
+			// found an existing scrape config, either remove it or replace it
+			found = true
+			if newScrapeConfig == nil {
+				scrapeConfigs.ArrayRemove(index)
+			} else {
+				scrapeConfigs.SetIndex(newScrapeConfig.Data(), index)
+			}
+			break
+		}
+	}
+	if !found && newScrapeConfig != nil {
+		// if we didn't find an existing scrape config and we are not removing it, append it to the existing scrape config
+		scrapeConfigs.ArrayAppend(newScrapeConfig.Data())
+	}
+
+	bytes, err := yaml.JSONToYAML(scrapeConfigs.Bytes())
+	if err != nil {
+		return err
+	}
+
+	// update the secret with the updated scrape config
+	secret = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpoconst.PromAdditionalScrapeConfigsSecretName,
+			Namespace: vpoconst.VerrazzanoMonitoringNamespace,
+		},
+		Data: map[string][]byte{},
+	}
+	if _, err := controllerruntime.CreateOrUpdate(ctx, r.Client, &secret, func() error {
+		secret.Data[vpoconst.PromAdditionalScrapeConfigsSecretKey] = bytes
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mutateManagedClusterTLSSecret adds and removes managed cluster TLS certs to/from the managed cluster TLS certs secret
+func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterTLSSecret(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *v1.Secret) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpoconst.PromManagedClusterTlsCertsSecretName,
+			Namespace: vpoconst.VerrazzanoMonitoringNamespace,
+		},
+	}
+
+	if _, err := controllerruntime.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		if cacrtSecret != nil && cacrtSecret.Data != nil && len(cacrtSecret.Data["cacrt"]) > 0 {
+			secret.Data[getCAKey(vmc)] = cacrtSecret.Data["cacrt"]
+		} else {
+			delete(secret.Data, getCAKey(vmc))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -342,7 +342,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx c
 func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterTLSSecret(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *v1.Secret) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vpoconst.PromManagedClusterTlsCertsSecretName,
+			Name:      vpoconst.PromManagedClusterTLSCertsSecretName,
 			Namespace: vpoconst.VerrazzanoMonitoringNamespace,
 		},
 	}

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -86,12 +86,6 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(ctx context.Context, req 
 		return newRequeueWithDelay(), nil
 	}
 
-	// Never return an error since it has already been logged and we don't want the
-	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
-	if err != nil {
-		return newRequeueWithDelay(), nil
-	}
-
 	// The resource has been reconciled.
 	log.Oncef("Successfully reconciled VerrazzanoManagedCluster resource %v", req.NamespacedName)
 

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -281,7 +281,7 @@ func appendAdditionalVolumeOverrides(ctx spi.ComponentContext, volumeMountKey, v
 	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].readOnly", volumeMountKey), Value: "true"})
 
 	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].name", volumeKey), Value: "managed-cluster-tls-certs"})
-	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].secret.secretName", volumeKey), Value: constants.PromManagedClusterTlsCertsSecretName})
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].secret.secretName", volumeKey), Value: constants.PromManagedClusterTLSCertsSecretName})
 	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].secret.optional", volumeKey), Value: "true"})
 
 	return kvs, nil

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
@@ -55,6 +56,33 @@ func preInstall(ctx spi.ComponentContext) error {
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)
+	}
+
+	// Create an empty secret for the additional scrape configs - this secret gets populated with scrape jobs for managed clusters
+	return ensureAdditionalScrapeConfigsSecret(ctx)
+}
+
+// ensureAdditionalScrapeConfigsSecret creates an empty secret for additional scrape configurations loaded by Prometheus, if the secret
+// does not already exist. Initially this secret is empty but when managed clusters are created, the federated scrape configuration
+// is added to this secret.
+func ensureAdditionalScrapeConfigsSecret(ctx spi.ComponentContext) error {
+	ctx.Log().Debugf("Creating or updating secret %s for Prometheus additional scrape configs", constants.PromAdditionalScrapeConfigsSecretName)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.PromAdditionalScrapeConfigsSecretName,
+			Namespace: ComponentNamespace,
+		},
+	}
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), secret, func() error {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		if _, exists := secret.Data[constants.PromAdditionalScrapeConfigsSecretKey]; !exists {
+			secret.Data[constants.PromAdditionalScrapeConfigsSecretKey] = []byte{}
+		}
+		return nil
+	}); err != nil {
+		return ctx.Log().ErrorfNewErr("Failed to create or update the %s secret: %v", constants.PromAdditionalScrapeConfigsSecretName, err)
 	}
 	return nil
 }
@@ -115,6 +143,14 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		kvs)
 	if err != nil {
 		return kvs, ctx.Log().ErrorfNewErr("Failed applying the Istio Overrides for Prometheus")
+	}
+
+	kvs, err = appendAdditionalVolumeOverrides(ctx,
+		"prometheus.prometheusSpec.volumeMounts",
+		"prometheus.prometheusSpec.volumes",
+		kvs)
+	if err != nil {
+		return kvs, ctx.Log().ErrorfNewErr("Failed applying additional volume overrides for Prometheus")
 	}
 	return kvs, nil
 }
@@ -234,4 +270,19 @@ func GetOverrides(ctx spi.ComponentContext) []vzapi.Overrides {
 		return ctx.EffectiveCR().Spec.Components.PrometheusOperator.ValueOverrides
 	}
 	return []vzapi.Overrides{}
+}
+
+// appendAdditionalVolumeOverrides adds a volume and volume mount so we can mount managed cluster TLS certs from a secret in the Prometheus pod.
+// Initially the secret does not exist. When managed clusters are created, the secret is created and Prometheus TLS certs for the managed
+// clusters are added to the secret.
+func appendAdditionalVolumeOverrides(ctx spi.ComponentContext, volumeMountKey, volumeKey string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].name", volumeMountKey), Value: "managed-cluster-tls-certs"})
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].mountPath", volumeMountKey), Value: "/etc/prometheus/managed-cluster-tls-certs"})
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].readOnly", volumeMountKey), Value: "true"})
+
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].name", volumeKey), Value: "managed-cluster-tls-certs"})
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].secret.secretName", volumeKey), Value: constants.PromManagedClusterTlsCertsSecretName})
+	kvs = append(kvs, bom.KeyValue{Key: fmt.Sprintf("%s[1].secret.optional", volumeKey), Value: "true"})
+
+	return kvs, nil
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -133,7 +133,7 @@ func TestAppendOverrides(t *testing.T) {
 	var err error
 	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 16)
+	assert.Len(t, kvs, 22)
 
 	assert.Equal(t, "ghcr.io/verrazzano/prometheus-config-reloader", bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.repository"))
 	assert.NotEmpty(t, bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.tag"))
@@ -165,7 +165,7 @@ func TestAppendOverrides(t *testing.T) {
 
 	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 16)
+	assert.Len(t, kvs, 22)
 
 	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 }

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -9,6 +9,11 @@ kubeStateMetrics:
   enabled: false
 prometheus:
   enabled: true
+  prometheusSpec:
+    additionalScrapeConfigsSecret:
+      enabled: true
+      name: additional-scrape-configs
+      key: jobs
 alertmanager:
   enabled: false
 prometheusOperator:


### PR DESCRIPTION
# Description

This PR adds support for scraping managed cluster Prometheus instances in the new Prometheus Operator Prometheus. The Prometheus Operator ServiceMonitor, PodMonitor, and Probe resources are not capable of representing the scrape configuration needed for federation, so this implementation adds the raw scrape config using the additional scrape config secret feature in the Prometheus CR.

There are two secrets: one for the scrape config and another for the managed cluster CA TLS certs. When the VerrazzanoManagedCluster resource is created or updated, the scrape config secret and managed cluster TLS cert secret are updated appropriately.

I tested this locally using the big bang script to setup a multicluster environment and validated that the new Prometheus collects the managed cluster metrics correctly.

Implements VZ-5900

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
