### PR TITLE
in tests inspect cluster for node count

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -322,6 +322,18 @@ func ListNodes() (*corev1.NodeList, error) {
 	return nodes, nil
 }
 
+// GetNodeCount returns the number of nodes for the cluster
+func GetNodeCount() (uint32, error) {
+	nodes, err := ListNodes()
+	if err != nil {
+		return 0, err
+	}
+	if len(nodes.Items) < 1 {
+		return 0, fmt.Errorf("can not find node in the cluster")
+	}
+	return uint32(len(nodes.Items)), nil
+}
+
 // GetPodsFromSelector returns a collection of pods for the given namespace and selector
 func GetPodsFromSelector(selector *metav1.LabelSelector, namespace string) ([]corev1.Pod, error) {
 	var pods *corev1.PodList

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -4,10 +4,10 @@
 package authproxy
 
 import (
-	"os"
-	"strconv"
+	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -81,23 +81,24 @@ func (u AuthProxyDefaultModifier) ModifyCR(cr *vzapi.Verrazzano) {
 
 var t = framework.NewTestFramework("update authproxy")
 
-var nodeCount uint32 = 1
+var nodeCount uint32
 
 var _ = t.BeforeSuite(func() {
-	kindNodeCount := os.Getenv("KIND_NODE_COUNT")
-	if len(kindNodeCount) > 0 {
-		u, err := strconv.ParseUint(kindNodeCount, 10, 32)
-		if err == nil {
-			nodeCount = uint32(u)
-		}
+	var err error
+	nodeCount, err = getNodeCount()
+	if err != nil {
+		Fail(err.Error())
 	}
 })
 
 var _ = t.AfterSuite(func() {
 	m := AuthProxyDefaultModifier{}
-	update.UpdateCR(m)
-	cr := update.GetCR()
+	err := update.UpdateCR(m)
+	if err != nil {
+		Fail(err.Error())
+	}
 
+	cr := update.GetCR()
 	expectedRunning := uint32(1)
 	if cr.Spec.Profile == "prod" || cr.Spec.Profile == "" {
 		expectedRunning = 2
@@ -121,7 +122,10 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 	t.Describe("verrazzano-authproxy update replicas", Label("f:platform-lcm.authproxy-update-replicas"), func() {
 		t.It("authproxy explicit replicas", func() {
 			m := AuthProxyReplicasModifier{replicas: nodeCount}
-			update.UpdateCR(m)
+			err := update.UpdateCR(m)
+			if err != nil {
+				Fail(err.Error())
+			}
 
 			expectedRunning := nodeCount
 			update.ValidatePods(authProxyLabelValue, authProxyLabelKey, constants.VerrazzanoSystemNamespace, expectedRunning, false)
@@ -131,7 +135,10 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 	t.Describe("verrazzano-authproxy update affinity", Label("f:platform-lcm.authproxy-update-affinity"), func() {
 		t.It("authproxy explicit affinity", func() {
 			m := AuthProxyPodPerNodeAffintyModifier{}
-			update.UpdateCR(m)
+			err := update.UpdateCR(m)
+			if err != nil {
+				Fail(err.Error())
+			}
 
 			expectedRunning := nodeCount - 1
 			expectedPending := true
@@ -143,3 +150,14 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 		})
 	})
 })
+
+func getNodeCount() (uint32, error) {
+	nodes, err := pkg.ListNodes()
+	if err != nil {
+		return 0, err
+	}
+	if len(nodes.Items) < 1 {
+		return 0, fmt.Errorf("can not find node in the cluster")
+	}
+	return uint32(len(nodes.Items)), nil
+}

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -4,8 +4,6 @@
 package authproxy
 
 import (
-	"fmt"
-
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 
@@ -85,7 +83,7 @@ var nodeCount uint32
 
 var _ = t.BeforeSuite(func() {
 	var err error
-	nodeCount, err = getNodeCount()
+	nodeCount, err = pkg.GetNodeCount()
 	if err != nil {
 		Fail(err.Error())
 	}
@@ -150,14 +148,3 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 		})
 	})
 })
-
-func getNodeCount() (uint32, error) {
-	nodes, err := pkg.ListNodes()
-	if err != nil {
-		return 0, err
-	}
-	if len(nodes.Items) < 1 {
-		return 0, fmt.Errorf("can not find node in the cluster")
-	}
-	return uint32(len(nodes.Items)), nil
-}

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -6,9 +6,7 @@ package nginxistio
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"reflect"
-	"strconv"
 	"text/template"
 	"time"
 
@@ -200,15 +198,13 @@ func (u NginxIstioServicePortsModifier) ModifyCR(cr *vzapi.Verrazzano) {
 
 var t = framework.NewTestFramework("update nginx-istio")
 
-var nodeCount uint32 = 1
+var nodeCount uint32
 
 var _ = t.BeforeSuite(func() {
-	kindNodeCount := os.Getenv("KIND_NODE_COUNT")
-	if len(kindNodeCount) > 0 {
-		u, err := strconv.ParseUint(kindNodeCount, 10, 32)
-		if err == nil {
-			nodeCount = uint32(u)
-		}
+	var err error
+	nodeCount, err = getNodeCount()
+	if err != nil {
+		Fail(err.Error())
 	}
 })
 
@@ -265,26 +261,15 @@ var _ = t.Describe("Update nginx-istio", Label("f:platform-lcm.update"), func() 
 				Fail(err.Error())
 			}
 
-			nodes, err := pkg.ListNodes()
+			systemServerList, applicationServerList, err := buildServerLists()
 			if err != nil {
 				Fail(err.Error())
 			}
-			if len(nodes.Items) < 1 {
-				Fail("can not find node in the cluster")
-			}
-			var nginxList, istioList string
-			for _, node := range nodes.Items {
-				if len(node.Status.Addresses) < 1 {
-					Fail("can not find address in the node")
-				}
-				nginxList = nginxList + fmt.Sprintf("           server %s:31443;\n", node.Status.Addresses[0].Address)
-				istioList = istioList + fmt.Sprintf("           server %s:32443;\n", node.Status.Addresses[0].Address)
-			}
 
-			applyResource("testdata/external-lb/system-external-lb-cm.yaml", &externalLBsTemplateData{ServerList: nginxList})
+			applyResource("testdata/external-lb/system-external-lb-cm.yaml", &externalLBsTemplateData{ServerList: systemServerList})
 			applyResource("testdata/external-lb/system-external-lb.yaml", &externalLBsTemplateData{})
 			applyResource("testdata/external-lb/system-external-lb-svc.yaml", &externalLBsTemplateData{})
-			applyResource("testdata/external-lb/application-external-lb-cm.yaml", &externalLBsTemplateData{ServerList: istioList})
+			applyResource("testdata/external-lb/application-external-lb-cm.yaml", &externalLBsTemplateData{ServerList: applicationServerList})
 			applyResource("testdata/external-lb/application-external-lb.yaml", &externalLBsTemplateData{})
 			applyResource("testdata/external-lb/application-external-lb-svc.yaml", &externalLBsTemplateData{})
 
@@ -310,6 +295,36 @@ var _ = t.Describe("Update nginx-istio", Label("f:platform-lcm.update"), func() 
 		})
 	})
 })
+
+func getNodeCount() (uint32, error) {
+	nodes, err := pkg.ListNodes()
+	if err != nil {
+		return 0, err
+	}
+	if len(nodes.Items) < 1 {
+		return 0, fmt.Errorf("can not find node in the cluster")
+	}
+	return uint32(len(nodes.Items)), nil
+}
+
+func buildServerLists() (string, string, error) {
+	nodes, err := pkg.ListNodes()
+	if err != nil {
+		return "", "", err
+	}
+	if len(nodes.Items) < 1 {
+		return "", "", fmt.Errorf("can not find node in the cluster")
+	}
+	var serverListNginx, serverListIstio string
+	for _, node := range nodes.Items {
+		if len(node.Status.Addresses) < 1 {
+			return "", "", fmt.Errorf("can not find address in the node")
+		}
+		serverListNginx = serverListNginx + fmt.Sprintf("           server %s:31443;\n", node.Status.Addresses[0].Address)
+		serverListIstio = serverListIstio + fmt.Sprintf("           server %s:32443;\n", node.Status.Addresses[0].Address)
+	}
+	return serverListNginx, serverListIstio, nil
+}
 
 func applyResource(resourceFile string, templateData *externalLBsTemplateData) {
 	file, err := pkg.FindTestDataFile(resourceFile)

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -202,7 +202,7 @@ var nodeCount uint32
 
 var _ = t.BeforeSuite(func() {
 	var err error
-	nodeCount, err = getNodeCount()
+	nodeCount, err = pkg.GetNodeCount()
 	if err != nil {
 		Fail(err.Error())
 	}
@@ -295,17 +295,6 @@ var _ = t.Describe("Update nginx-istio", Label("f:platform-lcm.update"), func() 
 		})
 	})
 })
-
-func getNodeCount() (uint32, error) {
-	nodes, err := pkg.ListNodes()
-	if err != nil {
-		return 0, err
-	}
-	if len(nodes.Items) < 1 {
-		return 0, fmt.Errorf("can not find node in the cluster")
-	}
-	return uint32(len(nodes.Items)), nil
-}
 
 func buildServerLists() (string, string, error) {
 	nodes, err := pkg.ListNodes()


### PR DESCRIPTION
# Description

So that it doesn't need env var KIND_NODE_COUNT and makes it possible to run dynamic-config-tests on OKE.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
