### PR TITLE
VZ-5890 Minor changes to VZ status command

### DIFF
--- a/tools/vz/cmd/helpers/cmd_context.go
+++ b/tools/vz/cmd/helpers/cmd_context.go
@@ -33,6 +33,11 @@ func (rc *RootCmdContext) GetErrorStream() io.Writer {
 	return rc.IOStreams.ErrOut
 }
 
+// GetInputStream - return the input stream
+func (rc *RootCmdContext) GetInputStream() io.Reader {
+	return rc.IOStreams.In
+}
+
 // GetClient - return a kubernetes client that supports the schemes used by the CLI
 func (rc *RootCmdContext) GetClient(cmd *cobra.Command) (client.Client, error) {
 	// Get command line value of kubeConfig location

--- a/tools/vz/cmd/helpers/command.go
+++ b/tools/vz/cmd/helpers/command.go
@@ -15,8 +15,13 @@ func NewCommand(vzHelper helpers.VZHelper, use string, short string, long string
 		Short: short,
 		Long:  long,
 	}
+
+	// Configure the IO streams
 	cmd.SetOut(vzHelper.GetOutputStream())
 	cmd.SetErr(vzHelper.GetErrorStream())
 	cmd.SetIn(vzHelper.GetInputStream())
+
+	// Disable usage output on errors
+	cmd.SilenceUsage = true
 	return cmd
 }

--- a/tools/vz/cmd/helpers/command.go
+++ b/tools/vz/cmd/helpers/command.go
@@ -17,5 +17,6 @@ func NewCommand(vzHelper helpers.VZHelper, use string, short string, long string
 	}
 	cmd.SetOut(vzHelper.GetOutputStream())
 	cmd.SetErr(vzHelper.GetErrorStream())
+	cmd.SetIn(vzHelper.GetInputStream())
 	return cmd
 }

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -170,7 +170,7 @@ func runCmdStatus(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) 
 	vz := vzapi.Verrazzano{}
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
 	if err != nil {
-		return fmt.Errorf("Failed to find Verrazzano with name %s in namespace %s: %v", name, namespace, err.Error())
+		return fmt.Errorf("Failed to find Verrazzano with name %q in namespace %s: %v", name, namespace, err.Error())
 	}
 
 	// Report the status information

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -170,7 +170,7 @@ func runCmdStatus(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) 
 	vz := vzapi.Verrazzano{}
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
 	if err != nil {
-		return fmt.Errorf("Failed to find Verrazzano with name %q in namespace %s: %v", name, namespace, err.Error())
+		return fmt.Errorf("Failed to find Verrazzano with name %q in namespace %q: %v", name, namespace, err.Error())
 	}
 
 	// Report the status information

--- a/tools/vz/cmd/status/status_test.go
+++ b/tools/vz/cmd/status/status_test.go
@@ -105,7 +105,7 @@ func TestStatusCmd(t *testing.T) {
 	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), name, fmt.Sprintf("--%s", namespaceFlag), "default"})
 	err = statusCmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name verrazzano in namespace default"))
+	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"verrazzano\" in namespace default"))
 
 	// Run the status command with the incorrect name, expect that the Verrazzano resource is not found
 	errBuf.Reset()
@@ -113,7 +113,7 @@ func TestStatusCmd(t *testing.T) {
 	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), "bad", fmt.Sprintf("--%s", namespaceFlag), namespace})
 	err = statusCmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name bad in namespace test"))
+	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"bad\" in namespace test"))
 }
 
 func makeVerrazzanoComponentStatusMap() vzapi.ComponentStatusMap {

--- a/tools/vz/cmd/status/status_test.go
+++ b/tools/vz/cmd/status/status_test.go
@@ -105,7 +105,7 @@ func TestStatusCmd(t *testing.T) {
 	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), name, fmt.Sprintf("--%s", namespaceFlag), "default"})
 	err = statusCmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"verrazzano\" in namespace default"))
+	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"verrazzano\" in namespace \"default\""))
 
 	// Run the status command with the incorrect name, expect that the Verrazzano resource is not found
 	errBuf.Reset()
@@ -113,7 +113,7 @@ func TestStatusCmd(t *testing.T) {
 	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), "bad", fmt.Sprintf("--%s", namespaceFlag), namespace})
 	err = statusCmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"bad\" in namespace test"))
+	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"bad\" in namespace \"test\""))
 }
 
 func makeVerrazzanoComponentStatusMap() vzapi.ComponentStatusMap {

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -13,5 +13,6 @@ import (
 type VZHelper interface {
 	GetOutputStream() io.Writer
 	GetErrorStream() io.Writer
+	GetInputStream() io.Reader
 	GetClient(cmd *cobra.Command) (client.Client, error)
 }

--- a/tools/vz/test/helpers/fake_cmd_context.go
+++ b/tools/vz/test/helpers/fake_cmd_context.go
@@ -26,6 +26,11 @@ func (rc *FakeRootCmdContext) GetErrorStream() io.Writer {
 	return rc.IOStreams.ErrOut
 }
 
+// GetInputStream - return the input stream
+func (rc *FakeRootCmdContext) GetInputStream() io.Reader {
+	return rc.IOStreams.In
+}
+
 // GetClient - return a kubernetes client that supports the schemes used by the CLI
 func (rc *FakeRootCmdContext) GetClient(cmd *cobra.Command) (client.Client, error) {
 	return rc.client, nil


### PR DESCRIPTION
# Description

- Configure the stdin setting for a cmd
- Change error message for VZ not found to quote the name of the object to handle case of no name passed.
- Disable printing the help text any time a command fails

Fixes VZ-5890

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
