### PR TITLE
VZ-5890 Remove name and namespace options from vz status command

### DIFF
--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -4,7 +4,6 @@
 package status
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -156,21 +155,11 @@ func runCmdStatus(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) 
 		return err
 	}
 
-	// Find the VZ resource
-	vzList := vzapi.VerrazzanoList{}
-	err = client.List(context.TODO(), &vzList)
+	// Get the VZ resource
+	vz, err := helpers.FindVerrazzanoResource(client)
 	if err != nil {
 		return err
 	}
-	if len(vzList.Items) == 0 {
-		return fmt.Errorf("Failed to find any Verrazzano resources")
-	}
-	if len(vzList.Items) != 1 {
-		return fmt.Errorf("Expected to only find one Verrazzano resource, but found %d", len(vzList.Items))
-	}
-
-	// Get the VZ resource
-	vz := vzList.Items[0]
 
 	// Report the status information
 	templateValues := map[string]string{

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -13,23 +13,17 @@ import (
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
-	CommandName   = "status"
-	namespaceFlag = "namespace"
-	nameFlag      = "name"
-	helpShort     = "Status of the Verrazzano install and access endpoints"
-	helpLong      = `The command 'status' returns summary information about a Verrazzano installation.`
-	helpExample   = `
+	CommandName = "status"
+	helpShort   = "Status of the Verrazzano install and access endpoints"
+	helpLong    = `The command 'status' returns summary information about a Verrazzano installation.`
+	helpExample = `
 vz status --name my-verrazzano
 vz status --name my-verrazzano --context minikube
 vz status --name my-verrazzano --kubeconfig ~/.kube/config --context minikube`
 )
-
-var namespace string
-var name string
 
 // The component output is disabled pending the resolution some issues with
 // the content of the Verrazzano status block
@@ -37,7 +31,9 @@ var componentOutputEnabled = false
 
 // statusOutputTemplate - template for output of status command
 const statusOutputTemplate = `
-Status of Verrazzano {{.verrazzano_name}}
+Verrazzano Status
+  Name: {{.verrazzano_name}}
+  Namespace: {{.verrazzano_namespace}}
   Version: {{.verrazzano_version}}
   State: {{.verrazzano_state}}
   Profile: {{.install_profile}}
@@ -150,10 +146,6 @@ func NewCmdStatus(vzHelper helpers.VZHelper) *cobra.Command {
 	}
 	cmd.Example = helpExample
 
-	// Add flags specific to this command and its sub-commands
-	cmd.PersistentFlags().StringVarP(&namespace, namespaceFlag, "n", "default", "The namespace of the Verrazzano resource")
-	cmd.PersistentFlags().StringVar(&name, nameFlag, "", "The name of the Verrazzano resource")
-
 	return cmd
 }
 
@@ -164,19 +156,29 @@ func runCmdStatus(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) 
 		return err
 	}
 
-	// Get the VZ resource
-	vz := vzapi.Verrazzano{}
-	err = client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
+	// Find the VZ resource
+	vzList := vzapi.VerrazzanoList{}
+	err = client.List(context.TODO(), &vzList)
 	if err != nil {
-		return fmt.Errorf("Failed to find Verrazzano with name %q in namespace %q: %v", name, namespace, err.Error())
+		return err
 	}
+	if len(vzList.Items) == 0 {
+		return fmt.Errorf("Failed to find any Verrazzano resources")
+	}
+	if len(vzList.Items) != 1 {
+		return fmt.Errorf("Expected to only find one Verrazzano resource, but found %d", len(vzList.Items))
+	}
+
+	// Get the VZ resource
+	vz := vzList.Items[0]
 
 	// Report the status information
 	templateValues := map[string]string{
-		"verrazzano_name":    vz.Name,
-		"verrazzano_version": vz.Status.Version,
-		"verrazzano_state":   string(vz.Status.State),
-		"install_profile":    string(vz.Spec.Profile),
+		"verrazzano_name":      vz.Name,
+		"verrazzano_namespace": vz.Namespace,
+		"verrazzano_version":   vz.Status.Version,
+		"verrazzano_state":     string(vz.Status.State),
+		"install_profile":      string(vz.Spec.Profile),
 	}
 	addAccessEndpoints(vz.Status.VerrazzanoInstance, templateValues)
 	addComponents(vz.Status.Components, templateValues)

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -20,9 +20,9 @@ const (
 	helpShort   = "Status of the Verrazzano install and access endpoints"
 	helpLong    = `The command 'status' returns summary information about a Verrazzano installation.`
 	helpExample = `
-vz status --name my-verrazzano
-vz status --name my-verrazzano --context minikube
-vz status --name my-verrazzano --kubeconfig ~/.kube/config --context minikube`
+vz status
+vz status --context minikube
+vz status --kubeconfig ~/.kube/config --context minikube`
 )
 
 // The component output is disabled pending the resolution some issues with

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -21,14 +21,11 @@ const (
 	namespaceFlag = "namespace"
 	nameFlag      = "name"
 	helpShort     = "Status of the Verrazzano install and access endpoints"
-	helpLong      = `The command 'status' returns summary information about a Verrazzano installation.
-
-For example:
-
+	helpLong      = `The command 'status' returns summary information about a Verrazzano installation.`
+	helpExample   = `
 vz status --name my-verrazzano
 vz status --name my-verrazzano --context minikube
-vz status --name my-verrazzano --kubeconfig ~/.kube/config --context minikube
-`
+vz status --name my-verrazzano --kubeconfig ~/.kube/config --context minikube`
 )
 
 var namespace string
@@ -151,6 +148,7 @@ func NewCmdStatus(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runCmdStatus(cmd, args, vzHelper)
 	}
+	cmd.Example = helpExample
 
 	// Add flags specific to this command and its sub-commands
 	cmd.PersistentFlags().StringVarP(&namespace, namespaceFlag, "n", "default", "The namespace of the Verrazzano resource")

--- a/tools/vz/cmd/status/status_test.go
+++ b/tools/vz/cmd/status/status_test.go
@@ -5,25 +5,25 @@ package status
 
 import (
 	"bytes"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
-
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
 	"github.com/verrazzano/verrazzano/tools/vz/test/helpers"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// TestStatusCmd tests the status command
+// GIVEN an environment with a single VZ resource
+//  WHEN I run the command vz status
+//  THEN expect a successful status report
 func TestStatusCmd(t *testing.T) {
 	name := "verrazzano"
 	namespace := "test"
@@ -65,18 +65,19 @@ func TestStatusCmd(t *testing.T) {
 
 	// Template map for status command output
 	templateMap := map[string]string{
-		"verrazzano_name":    name,
-		"verrazzano_version": version,
-		"verrazzano_state":   string(vzapi.VzStateInstalling),
-		"console_url":        consoleURL,
-		"keycloak_url":       keycloakURL,
-		"rancher_url":        rancherURL,
-		"os_url":             osURL,
-		"kibana_url":         kibanaURL,
-		"grafana_url":        grafanaURL,
-		"prometheus_url":     prometheusURL,
-		"kiali_url":          kialiURL,
-		"install_profile":    string(vzapi.Dev),
+		"verrazzano_name":      name,
+		"verrazzano_namespace": namespace,
+		"verrazzano_version":   version,
+		"verrazzano_state":     string(vzapi.VzStateInstalling),
+		"console_url":          consoleURL,
+		"keycloak_url":         keycloakURL,
+		"rancher_url":          rancherURL,
+		"os_url":               osURL,
+		"kibana_url":           kibanaURL,
+		"grafana_url":          grafanaURL,
+		"prometheus_url":       prometheusURL,
+		"kiali_url":            kialiURL,
+		"install_profile":      string(vzapi.Dev),
 	}
 
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
@@ -91,29 +92,74 @@ func TestStatusCmd(t *testing.T) {
 	assert.NotNil(t, statusCmd)
 
 	// Run the status command, check for the expected status results to be displayed
-	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), name, fmt.Sprintf("--%s", namespaceFlag), namespace})
 	err := statusCmd.Execute()
 	assert.NoError(t, err)
 	result := buf.String()
 	expectedResult, err := templates.ApplyTemplate(statusOutputTemplate, templateMap)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
+}
 
-	// Run the status command with the incorrect namespace, expect that the Verrazzano resource is not found
-	errBuf.Reset()
-	buf.Reset()
-	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), name, fmt.Sprintf("--%s", namespaceFlag), "default"})
-	err = statusCmd.Execute()
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"verrazzano\" in namespace \"default\""))
+// TestVZNotFound tests the status command
+// GIVEN an environment with a no VZ resources exist
+//  WHEN I run the command vz status
+//  THEN expect an error of no VZ resources found
+func TestVZNotFound(t *testing.T) {
 
-	// Run the status command with the incorrect name, expect that the Verrazzano resource is not found
-	errBuf.Reset()
-	buf.Reset()
-	statusCmd.SetArgs([]string{fmt.Sprintf("--%s", nameFlag), "bad", fmt.Sprintf("--%s", namespaceFlag), namespace})
-	err = statusCmd.Execute()
+	_ = vzapi.AddToScheme(k8scheme.Scheme)
+	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
+
+	// Send the command output to a byte buffer
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	statusCmd := NewCmdStatus(rc)
+	assert.NotNil(t, statusCmd)
+
+	// Run the status command, check for the expected status results to be displayed
+	err := statusCmd.Execute()
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(errBuf.String(), "Failed to find Verrazzano with name \"bad\" in namespace \"test\""))
+	assert.Equal(t, "Failed to find any Verrazzano resources", err.Error())
+}
+
+// TestStatusMultipleVZ tests the status command
+// GIVEN an environment with a two VZ resources
+//  WHEN I run the command vz status
+//  THEN expect an error of only expecting one VZ
+func TestStatusMultipleVZ(t *testing.T) {
+	name := "verrazzano"
+	namespace1 := "test1"
+	namespace2 := "test2"
+
+	vz1 := vzapi.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace1,
+			Name:      name,
+		},
+	}
+	vz2 := vzapi.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace2,
+			Name:      name,
+		},
+	}
+
+	_ = vzapi.AddToScheme(k8scheme.Scheme)
+	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(&vz1, &vz2).Build()
+
+	// Send the command output to a byte buffer
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	statusCmd := NewCmdStatus(rc)
+	assert.NotNil(t, statusCmd)
+
+	// Run the status command, check for the expected status results to be displayed
+	err := statusCmd.Execute()
+	assert.Error(t, err)
+	assert.Equal(t, "Expected to only find one Verrazzano resource, but found 2", err.Error())
 }
 
 func makeVerrazzanoComponentStatusMap() vzapi.ComponentStatusMap {

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -14,17 +14,15 @@ import (
 const (
 	CommandName = "version"
 	helpShort   = "Verrazzano version information"
-	helpLong    = `The command 'version' reports information about the version of the vz tool being run.
-
-For example:
-
-vz version
-`
+	helpLong    = `The command 'version' reports information about the version of the vz tool being run.`
+	helpExample = `
+vz version`
 )
 
 func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd := cmdhelpers.NewCommand(vzHelper, CommandName, helpShort, helpLong)
 	cmd.Run = runCmdVersion
+	cmd.Example = helpExample
 
 	return cmd
 }

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -4,9 +4,12 @@
 package helpers
 
 import (
+	"context"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,4 +18,21 @@ type VZHelper interface {
 	GetErrorStream() io.Writer
 	GetInputStream() io.Reader
 	GetClient(cmd *cobra.Command) (client.Client, error)
+}
+
+// FindVerrazzanoResource - find the single Verrazzano resource
+func FindVerrazzanoResource(client client.Client) (*vzapi.Verrazzano, error) {
+
+	vzList := vzapi.VerrazzanoList{}
+	err := client.List(context.TODO(), &vzList)
+	if err != nil {
+		return nil, err
+	}
+	if len(vzList.Items) == 0 {
+		return nil, fmt.Errorf("Failed to find any Verrazzano resources")
+	}
+	if len(vzList.Items) != 1 {
+		return nil, fmt.Errorf("Expected to only find one Verrazzano resource, but found %d", len(vzList.Items))
+	}
+	return &vzList.Items[0], nil
 }


### PR DESCRIPTION
# Description

Remove the name and namespace options, and instead find the VZ resource automatically.

Fixes VZ-5890

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
