### PR TITLE
VZ-5949 syntax updates for vz install/upgrade/uninstall

### DIFF
--- a/tools/vz/cmd/helpers/logsflag.go
+++ b/tools/vz/cmd/helpers/logsflag.go
@@ -20,7 +20,7 @@ func (lf *LogsFormat) String() string {
 
 // Type is only used in help text
 func (lf *LogsFormat) Type() string {
-	return "logFormat"
+	return "format"
 }
 
 // Set must have pointer receiver so it doesn't change the value of a copy

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -19,16 +19,16 @@ const (
 	helpLong    = `Install the Verrazzano Platform Operator and install the Verrazzano components specified by the Verrazzano CR provided on the command line.`
 	helpExample = `
 # Install the latest version of Verrazzano using the prod profile. Stream the logs to the console until the install completes.
-vz install --logs
+vz install
 
 # Install version 1.3.0 using a dev profile, timeout the command after 20 minutes.
-vz install --version v1.3.0 --set profile=dev --wait --timeout 20m
+vz install --version v1.3.0 --set profile=dev --timeout 20m
 
 # Install version 1.3.0 using a dev profile with elasticsearch disabled and wait for the install to complete.
-vz install --version v1.3.0 --set profile=dev --set components.elasticsearch.enabled=false --wait
+vz install --version v1.3.0 --set profile=dev --set components.elasticsearch.enabled=false
 
 # Install the latest version of Verrazzano using CR overlays and explicit value sets.  Output the logs in json format.
-vz install -f base.yaml -f custom.yaml --set profile=prod --logs json`
+vz install -f base.yaml -f custom.yaml --set profile=prod --log-format json`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -40,11 +40,11 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 	}
 	cmd.Example = helpExample
 
-	cmd.PersistentFlags().Bool(constants.WaitFlag, false, constants.WaitFlagHelp)
+	cmd.PersistentFlags().Bool(constants.WaitFlag, constants.WaitFlagDefault, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, "latest", constants.VersionFlagHelp)
 	cmd.PersistentFlags().StringSliceP(constants.FilenameFlag, constants.FilenameFlagShorthand, []string{}, constants.FilenameFlagHelp)
-	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
+	cmd.PersistentFlags().Var(&logsEnum, constants.LogFormatFlag, constants.LogFormatHelp)
 	cmd.PersistentFlags().StringArrayP(constants.SetFlag, constants.SetFlagShorthand, []string{}, constants.SetFlagHelp)
 
 	// Initially the operator-file flag may be for internal use, hide from help until

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -28,10 +28,7 @@ vz install --version v1.3.0 --set profile=dev --wait --timeout 20m
 vz install --version v1.3.0 --set profile=dev --set components.elasticsearch.enabled=false --wait
 
 # Install the latest version of Verrazzano using CR overlays and explicit value sets.  Output the logs in json format.
-vz install -f base.yaml -f custom.yaml --set profile=prod --logs json
-
-# Do a dry run of installing version 1.3.0 and see a summary of what the install would have done.
-vz install --version v1.3.0 --dry-run`
+vz install -f base.yaml -f custom.yaml --set profile=prod --logs json`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple
@@ -47,7 +44,6 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, "latest", constants.VersionFlagHelp)
 	cmd.PersistentFlags().StringSliceP(constants.FilenameFlag, constants.FilenameFlagShorthand, []string{}, constants.FilenameFlagHelp)
-	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an install.")
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
 	cmd.PersistentFlags().StringArrayP(constants.SetFlag, constants.SetFlagShorthand, []string{}, constants.SetFlagHelp)
 
@@ -55,6 +51,10 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 	// a decision is made on supporting this option.
 	cmd.PersistentFlags().String(constants.OperatorFileFlag, "", constants.OperatorFileFlagHelp)
 	cmd.PersistentFlags().MarkHidden(constants.OperatorFileFlag)
+
+	// Dry run flag is still being discussed - keep hidden for now
+	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an install.")
+	cmd.PersistentFlags().MarkHidden(constants.DryRunFlag)
 
 	return cmd
 }

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -36,9 +36,9 @@ func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 	}
 	cmd.Example = helpExample
 
-	cmd.PersistentFlags().Bool(constants.WaitFlag, false, constants.WaitFlagHelp)
+	cmd.PersistentFlags().Bool(constants.WaitFlag, constants.WaitFlagDefault, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
-	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
+	cmd.PersistentFlags().Var(&logsEnum, constants.LogFormatFlag, constants.LogFormatHelp)
 	cmd.PersistentFlags().Bool(crdsFlag, false, crdsFlagHelp)
 
 	// Dry run flag is still being discussed - keep hidden for now

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -20,11 +20,11 @@ const (
 	helpShort    = "Uninstall Verrazzano"
 	helpLong     = `Uninstall the Verrazzano Platform Operator and all of the currently installed components.`
 	helpExample  = `
-# Uninstall Verrazzano except for CRDs and stream the logs to the console.
-vz uninstall --logs
+# Uninstall Verrazzano except for CRDs and stream the logs to the console.  Stream the logs to the console until the uninstall completes.
+vz uninstall
 
 # Uninstall Verrazzano including the CRDs and wait for the command to complete.
-vz uninstall --crds --wait`
+vz uninstall --crds`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -24,10 +24,7 @@ const (
 vz uninstall --logs
 
 # Uninstall Verrazzano including the CRDs and wait for the command to complete.
-vz uninstall --crds --wait
-
-# Do a dry run of uninstalling Verrazzano.
-vz uninstall --dry-run`
+vz uninstall --crds --wait`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple
@@ -41,9 +38,12 @@ func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 
 	cmd.PersistentFlags().Bool(constants.WaitFlag, false, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
-	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an uninstall.")
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
 	cmd.PersistentFlags().Bool(crdsFlag, false, crdsFlagHelp)
+
+	// Dry run flag is still being discussed - keep hidden for now
+	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an uninstall.")
+	cmd.PersistentFlags().MarkHidden(constants.DryRunFlag)
 
 	return cmd
 }

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -22,10 +22,7 @@ const (
 vz upgrade --wait
 
 # Upgrade to Verrazzano v1.3.0 and stream the logs to the console.
-vz upgrade --version v1.3.0 --logs
-
-# Upgrade to Verrazzano 1.3.0 and update some configuration settings.
-vz upgrade --version v1.3.0 -f update.yaml --wait`
+vz upgrade --version v1.3.0 --logs`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple
@@ -40,9 +37,7 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().Bool(constants.WaitFlag, false, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, "latest", constants.VersionFlagHelp)
-	cmd.PersistentFlags().StringSliceP(constants.FilenameFlag, constants.FilenameFlagShorthand, []string{}, constants.FilenameFlagHelp)
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
-	cmd.PersistentFlags().StringArrayP(constants.SetFlag, constants.SetFlagShorthand, []string{}, constants.SetFlagHelp)
 
 	// Initially the operator-file flag may be for internal use, hide from help until
 	// a decision is made on supporting this option.

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -18,11 +18,11 @@ const (
 	helpShort   = "Upgrade Verrazzano"
 	helpLong    = `Upgrade the Verrazzano Platform Operator to the specified version and update all of the currently installed components.`
 	helpExample = `
-# Upgrade to the latest version of Verrazzano and wait for the command to complete.
-vz upgrade --wait
+# Upgrade to the latest version of Verrazzano and wait for the command to complete.  Stream the logs to the console until the upgrade completes.
+vz upgrade
 
-# Upgrade to Verrazzano v1.3.0 and stream the logs to the console.
-vz upgrade --version v1.3.0 --logs`
+# Upgrade to Verrazzano v1.3.0, stream the logs to the console and timeout after 20m.
+vz upgrade --version v1.3.0 --timeout 20m`
 )
 
 var logsEnum = cmdhelpers.LogsFormatSimple

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -34,10 +34,10 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	}
 	cmd.Example = helpExample
 
-	cmd.PersistentFlags().Bool(constants.WaitFlag, false, constants.WaitFlagHelp)
+	cmd.PersistentFlags().Bool(constants.WaitFlag, constants.WaitFlagDefault, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, "latest", constants.VersionFlagHelp)
-	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
+	cmd.PersistentFlags().Var(&logsEnum, constants.LogFormatFlag, constants.LogFormatHelp)
 
 	// Initially the operator-file flag may be for internal use, hide from help until
 	// a decision is made on supporting this option.

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -41,7 +41,6 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, "latest", constants.VersionFlagHelp)
 	cmd.PersistentFlags().StringSliceP(constants.FilenameFlag, constants.FilenameFlagShorthand, []string{}, constants.FilenameFlagHelp)
-	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an upgrade.")
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogsFlag, constants.LogsFlagHelp)
 	cmd.PersistentFlags().StringArrayP(constants.SetFlag, constants.SetFlagShorthand, []string{}, constants.SetFlagHelp)
 
@@ -49,6 +48,10 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	// a decision is made on supporting this option.
 	cmd.PersistentFlags().String(constants.OperatorFileFlag, "", constants.OperatorFileFlagHelp)
 	cmd.PersistentFlags().MarkHidden(constants.OperatorFileFlag)
+
+	// Dry run flag is still being discussed - keep hidden for now
+	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an upgrade.")
+	cmd.PersistentFlags().MarkHidden(constants.DryRunFlag)
 
 	return cmd
 }

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -16,8 +16,9 @@ const GlobalFlagHelp = "help"
 
 // Flags that are common to more than one command
 const (
-	WaitFlag     = "wait"
-	WaitFlagHelp = "Wait for the command to complete. The wait period is controlled by --timeout."
+	WaitFlag        = "wait"
+	WaitFlagHelp    = "Wait for the command to complete and stream the logs to the console. The wait period is controlled by --timeout."
+	WaitFlagDefault = true
 
 	TimeoutFlag     = "timeout"
 	TimeoutFlagHelp = "Limits the amount of time a command will wait to complete."
@@ -34,8 +35,8 @@ const (
 	OperatorFileFlag     = "operator-file"
 	OperatorFileFlagHelp = "The path to the file for installing the Verrazzano platform operator. The default is derived from the version string."
 
-	LogsFlag     = "logs"
-	LogsFlagHelp = "Print the logs until the command completes. Valid output formats are \"simple\" and \"json\"."
+	LogFormatFlag = "log-format"
+	LogFormatHelp = "The format of the log output. Valid output formats are \"simple\" and \"json\"."
 
 	FilenameFlag          = "filename"
 	FilenameFlagShorthand = "f"


### PR DESCRIPTION
# Description

Updates to the CLI syntax after a review

- Hide dry run command
- Remove configuration overrides from the upgrade command
- Change wait to be true by default.  Logs are always output when waiting.  Renamed --logs to be --log-format.

Fixes VZ-5949

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
