### PR TITLE
VZ-5744 Alternative testing approach for prometheus E2E tests

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
+                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
                             }
                         }
                     }
@@ -565,7 +565,7 @@ pipeline {
                         }
                         stage('Prometheus post-upgrade') {
                             steps {
-                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
+                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
                             }
                         }
                         stage ("Verify install scripts") {

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade", "false", "false", "true", "deploymetrics")
+                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade", "false", "true", "false", "deploymetrics")
                             }
                         }
                     }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
+                                runGinkgoVerifyParallel('Prometheus pre-upgrade', 'metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "true", "deploymetrics")
                             }
                         }
                     }
@@ -565,7 +565,7 @@ pipeline {
                         }
                         stage('Prometheus post-upgrade') {
                             steps {
-                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
+                                runGinkgoVerifyParallel('Prometheus post-upgrade', 'metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
                             }
                         }
                         stage ("Verify install scripts") {
@@ -1329,7 +1329,7 @@ def runGinkgoVerify(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeplo
     }
 }
 
-def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
+def runGinkgoVerifyParallel(testSuitePrefix, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
     script {
         def runGinkgoVerifyStages = createClusterExecutionsMap()
         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
@@ -1342,7 +1342,7 @@ def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, ski
             } else {
                 clusterName="managed${count-1}"
             }
-            runGinkgoVerifyStages["${clusterName} - ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
+            runGinkgoVerifyStages["${testSuitePrefix} - ${clusterName}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
         }
         parallel runGinkgoVerifyStages
     }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,8 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerify('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade-admin", "false", "false", "true")
-                                runGinkgoVerifyManaged('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade-managed", "false", "false", "true")
+                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade", "false", "false", "true", "deploymetrics")
                             }
                         }
                     }
@@ -588,8 +587,7 @@ pipeline {
                         }
                         stage('Prometheus post-upgrade') {
                             steps {
-                                runGinkgoVerify('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-admin", "true", "false", "false")
-                                runGinkgoVerifyManaged('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-managed", "true", "false", "false")
+                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-admin", "true", "false", "false", "deploymetrics")
                             }
                         }
                     }
@@ -1328,6 +1326,44 @@ def runGinkgoVerify(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeplo
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
         """
+    }
+}
+
+def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
+ catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            def runGinkgoVerifyStages = createClusterExecutionsMap()
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            def clusterName = ""
+            for(int count=1; count<=clusterCount; count++) {
+                // The first cluster created by this script is named as admin, and the subsequent clusters are named as
+                // managed1, managed2, etc.
+                if (count == 1) {
+                    clusterName="admin"
+                } else {
+                    clusterName="managed${count-1}"
+                }
+                runGinkgoVerifyStages["${count} - Executing ginkgo test suite ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
+            }
+            parallel runGinkgoVerifyStages
+        }
+    }
+}
+
+def runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
+    // For parallel execution, wrap this in a Groovy enclosure {}
+    return {
+        script {
+            sh """
+                export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                export CLUSTER_NAME=${clusterName}
+                export ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+                export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                export DUMP_DIRECTORY="${clusterDumpDirectory}-${count}"
+                cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
+            """
+        }
     }
 }
 

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -563,6 +563,11 @@ pipeline {
                                 runGinkgoRandomizeSerialAdmin('upgrade/post-upgrade/grafana', "${TEST_DUMP_ROOT}/grafana")
                             }
                         }
+                        stage('Prometheus post-upgrade') {
+                            steps {
+                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
+                            }
+                        }
                         stage ("Verify install scripts") {
                             steps {
                                 runGinkgoRandomizeAdmin("scripts/install", "${TEST_DUMP_ROOT}/install-scripts")
@@ -583,11 +588,6 @@ pipeline {
                                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
                                     }
                                 }
-                            }
-                        }
-                        stage('Prometheus post-upgrade') {
-                            steps {
-                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
                             }
                         }
                     }
@@ -1330,23 +1330,21 @@ def runGinkgoVerify(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeplo
 }
 
 def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            def runGinkgoVerifyStages = createClusterExecutionsMap()
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            def clusterName = ""
-            for(int count=1; count<=clusterCount; count++) {
-                // The first cluster created by this script is named as admin, and the subsequent clusters are named as
-                // managed1, managed2, etc.
-                if (count == 1) {
-                    clusterName="admin"
-                } else {
-                    clusterName="managed${count-1}"
-                }
-                runGinkgoVerifyStages["${clusterName} - ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
+    script {
+        def runGinkgoVerifyStages = createClusterExecutionsMap()
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        def clusterName = ""
+        for(int count=1; count<=clusterCount; count++) {
+            // The first cluster created by this script is named as admin, and the subsequent clusters are named as
+            // managed1, managed2, etc.
+            if (count == 1) {
+                clusterName="admin"
+            } else {
+                clusterName="managed${count-1}"
             }
-            parallel runGinkgoVerifyStages
+            runGinkgoVerifyStages["${clusterName} - ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
         }
+        parallel runGinkgoVerifyStages
     }
 }
 

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade", "false", "true", "false", "deploymetrics")
+                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
                             }
                         }
                     }
@@ -587,7 +587,7 @@ pipeline {
                         }
                         stage('Prometheus post-upgrade') {
                             steps {
-                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-admin", "true", "false", "false", "deploymetrics")
+                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
                             }
                         }
                     }
@@ -1330,7 +1330,7 @@ def runGinkgoVerify(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeplo
 }
 
 def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
- catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         script {
             def runGinkgoVerifyStages = createClusterExecutionsMap()
             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
@@ -1343,7 +1343,7 @@ def runGinkgoVerifyParallel(testSuitePath, clusterDumpDirectory, skipDeploy, ski
                 } else {
                     clusterName="managed${count-1}"
                 }
-                runGinkgoVerifyStages["${count} - Executing ginkgo test suite ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
+                runGinkgoVerifyStages["${clusterName} - ${testSuitePath}"] = runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace)
             }
             parallel runGinkgoVerifyStages
         }
@@ -1359,10 +1359,37 @@ def runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirec
                 export CLUSTER_NAME=${clusterName}
                 export ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
                 export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                export DUMP_DIRECTORY="${clusterDumpDirectory}-${count}"
+                export DUMP_DIRECTORY="${clusterDumpDirectory}${clusterName}"
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
             """
+        }
+    }
+}
+
+def runGinkgoVerifySerial(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        script {
+            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+            def clusterName = ""
+            for(int count=1; count<=clusterCount; count++) {
+                // The first cluster created by this script is named as admin, and the subsequent clusters are named as
+                // managed1, managed2, etc.
+                if (count == 1) {
+                    clusterName="admin"
+                } else {
+                    clusterName="managed${count-1}"
+                }
+                sh """
+                    export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    export CLUSTER_NAME=${clusterName}
+                    export ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+                    export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    export DUMP_DIRECTORY="${clusterDumpDirectory}${clusterName}"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
+                """
+            }
         }
     }
 }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1365,33 +1365,6 @@ def runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirec
     }
 }
 
-def runGinkgoVerifySerial(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeploy, skipVerify, namespace) {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        script {
-            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-            def clusterName = ""
-            for(int count=1; count<=clusterCount; count++) {
-                // The first cluster created by this script is named as admin, and the subsequent clusters are named as
-                // managed1, managed2, etc.
-                if (count == 1) {
-                    clusterName="admin"
-                } else {
-                    clusterName="managed${count-1}"
-                }
-                sh """
-                    export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                    export CLUSTER_NAME=${clusterName}
-                    export ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
-                    export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
-                    export DUMP_DIRECTORY="${clusterDumpDirectory}${clusterName}"
-                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
-                """
-            }
-        }
-    }
-}
-
 // Configure the Admin and Managed cluster installer custom resources
 def configureVerrazzanoInstallers(installResourceTemplate, configProcessorScript, String... extraArgs) {
     script {

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -396,6 +396,12 @@ pipeline {
                                 runGinkgoVerifyManaged("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/mccoherence-workload", "false", "false", "false")
                             }
                         }
+                        stage('Prometheus pre-upgrade') {
+                            steps {
+                                runGinkgoVerify('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade-admin", "false", "false", "true")
+                                runGinkgoVerifyManaged('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-preupgrade-managed", "false", "false", "true")
+                            }
+                        }
                     }
                 }
                 stage("upgrade-platform-operator") {
@@ -578,6 +584,12 @@ pipeline {
                                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
                                     }
                                 }
+                            }
+                        }
+                        stage('Prometheus post-upgrade') {
+                            steps {
+                                runGinkgoVerify('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-admin", "true", "false", "false")
+                                runGinkgoVerifyManaged('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prom-postupgrade-managed", "true", "false", "false")
                             }
                         }
                     }
@@ -1207,6 +1219,8 @@ def runGinkgoVerifyManaged(testSuitePath, clusterDumpDirectory, skipDeploy, skip
             export MANAGED_CLUSTER_NAME="managed1"
             export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
             export CLUSTER_COUNT=$clusterCount
+            export ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
+            export CLUSTER_NAME="managed1"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/2/kube_config"
             export DUMP_DIRECTORY="${clusterDumpDirectory}"

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
                         }
                         stage('Prometheus pre-upgrade') {
                             steps {
-                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
+                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompreupgrade", "false", "true", "false", "deploymetrics")
                             }
                         }
                     }
@@ -565,7 +565,7 @@ pipeline {
                         }
                         stage('Prometheus post-upgrade') {
                             steps {
-                                runGinkgoVerifyParallel('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
+                                runGinkgoVerifySerial('metrics/deploymetrics', "${TEST_DUMP_ROOT}/prompostupgrade", "true", "false", "false", "deploymetrics")
                             }
                         }
                         stage ("Verify install scripts") {

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
@@ -11,9 +11,17 @@ import (
 	"github.com/onsi/gomega"
 )
 
+var skipDeploy bool
+var skipUndeploy bool
+var namespace string
+var skipVerify bool
 var istioInjection string
 
 func init() {
+	flag.BoolVar(&skipDeploy, "skipDeploy", false, "skipDeploy skips the call to install the application")
+	flag.BoolVar(&skipUndeploy, "skipUndeploy", false, "skipUndeploy skips the call to install the application")
+	flag.StringVar(&namespace, "namespace", "deploymetrics", "namespace is the app namespace")
+	flag.BoolVar(&skipVerify, "skipVerify", false, "skipVerify skips the post deployment app validations")
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
@@ -20,7 +20,7 @@ var istioInjection string
 func init() {
 	flag.BoolVar(&skipDeploy, "skipDeploy", false, "skipDeploy skips the call to install the application")
 	flag.BoolVar(&skipUndeploy, "skipUndeploy", false, "skipUndeploy skips the call to install the application")
-	flag.StringVar(&namespace, "namespace", "deploymetrics", "namespace is the app namespace")
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
 	flag.BoolVar(&skipVerify, "skipVerify", false, "skipVerify skips the post deployment app validations")
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -20,23 +20,30 @@ import (
 )
 
 const (
-	promConfigJobName = "deploymetrics-appconf_default_deploymetrics_deploymetrics-deployment"
-	skipVerifications = "Skip Verifications"
+	deploymetricsCompYaml = "testdata/deploymetrics/deploymetrics-comp.yaml"
+	deploymetricsAppYaml  = "testdata/deploymetrics/deploymetrics-app.yaml"
+	promConfigJobName     = "deploymetrics-appconf_default_deploymetrics_deploymetrics-deployment"
+	skipVerifications     = "Skip Verifications"
 )
 
-var expectedPodsDeploymetricsApp = []string{"deploymetrics-workload"}
-var waitTimeout = 10 * time.Minute
-var pollingInterval = 30 * time.Second
-var shortPollingInterval = 10 * time.Second
-var shortWaitTimeout = 5 * time.Minute
-var longWaitTimeout = 15 * time.Minute
-var longPollingInterval = 30 * time.Second
-var imagePullWaitTimeout = 40 * time.Minute
-var imagePullPollingInterval = 30 * time.Second
+var (
+	expectedPodsDeploymetricsApp = []string{"deploymetrics-workload"}
+	generatedNamespace           = pkg.GenerateNamespace("deploymetrics")
 
-var adminKubeConfig string
-var label string
-var t = framework.NewTestFramework("deploymetrics")
+	waitTimeout              = 10 * time.Minute
+	pollingInterval          = 30 * time.Second
+	shortPollingInterval     = 10 * time.Second
+	shortWaitTimeout         = 5 * time.Minute
+	longWaitTimeout          = 15 * time.Minute
+	longPollingInterval      = 30 * time.Second
+	imagePullWaitTimeout     = 40 * time.Minute
+	imagePullPollingInterval = 30 * time.Second
+
+	adminKubeConfig string
+	label           string
+
+	t = framework.NewTestFramework("deploymetrics")
+)
 
 var clusterDump = pkg.NewClusterDumpWrapper()
 var _ = clusterDump.BeforeSuite(func() {
@@ -72,12 +79,12 @@ func deployMetricsApplication() {
 
 	t.Logs.Info("Create component resource")
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("testdata/deploymetrics/deploymetrics-comp.yaml")
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(deploymetricsCompYaml, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	t.Logs.Info("Create application resource")
 	Eventually(func() error {
-		return pkg.CreateOrUpdateResourceFromFile("testdata/deploymetrics/deploymetrics-app.yaml")
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(deploymetricsAppYaml, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred(), "Failed to create DeployMetrics application resource")
 
 	Eventually(func() bool {
@@ -101,12 +108,12 @@ func undeployMetricsApplication() {
 	t.Logs.Info("Delete application")
 	start := time.Now()
 	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("testdata/deploymetrics/deploymetrics-app.yaml")
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(deploymetricsCompYaml, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	t.Logs.Info("Delete components")
 	Eventually(func() error {
-		return pkg.DeleteResourceFromFile("testdata/deploymetrics/deploymetrics-comp.yaml")
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(deploymetricsAppYaml, namespace)
 	}, shortWaitTimeout, shortPollingInterval).ShouldNot(HaveOccurred())
 
 	t.Logs.Info("Wait for pods to terminate")

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -21,14 +21,16 @@ import (
 
 const (
 	deploymetricsCompYaml = "testdata/deploymetrics/deploymetrics-comp.yaml"
+	deploymetricsCompName = "deploymetrics-deployment"
 	deploymetricsAppYaml  = "testdata/deploymetrics/deploymetrics-app.yaml"
-	promConfigJobName     = "deploymetrics-appconf_default_deploymetrics_deploymetrics-deployment"
+	deployMetricsAppName  = "deploymetrics-appconf"
 	skipVerifications     = "Skip Verifications"
 )
 
 var (
 	expectedPodsDeploymetricsApp = []string{"deploymetrics-workload"}
 	generatedNamespace           = pkg.GenerateNamespace("deploymetrics")
+	promConfigJobName            = fmt.Sprintf("%s_default_%s_%s", deployMetricsAppName, generatedNamespace, deploymetricsCompName)
 
 	waitTimeout              = 10 * time.Minute
 	pollingInterval          = 30 * time.Second

--- a/tests/testdata/deploymetrics/deploymetrics-app.yaml
+++ b/tests/testdata/deploymetrics/deploymetrics-app.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration

--- a/tests/testdata/deploymetrics/deploymetrics-app.yaml
+++ b/tests/testdata/deploymetrics/deploymetrics-app.yaml
@@ -4,7 +4,6 @@ apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: deploymetrics-appconf
-  namespace: deploymetrics
   annotations:
     version: v1.0.0
     description: "Test that Prometheus can scrape metrics from a Deployment Component"

--- a/tests/testdata/deploymetrics/deploymetrics-comp.yaml
+++ b/tests/testdata/deploymetrics/deploymetrics-comp.yaml
@@ -4,7 +4,6 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: deploymetrics-deployment
-  namespace: deploymetrics
 spec:
   workload:
     apiVersion: apps/v1


### PR DESCRIPTION
# Description

Contains E2E tests for prometheus pre and post upgrade. Tests validate if an app deployed with an ingress trait, sends metric pre and post upgrade. Also tests the system metrics are exported to prometheus pre and post upgrade.

Fixes VZ-5744

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
