### PR TITLE
VZ-6012 Update from NodePort to Loadbalancer in dynamic-config-update test

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -5,8 +5,9 @@ package authproxy
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"path/filepath"
+
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
@@ -48,6 +49,15 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
 			GetInstallOverridesFunc: GetOverrides,
 			Dependencies:            []string{nginx.ComponentName},
+			Certificates: []types.NamespacedName{
+				{Name: "verrazzano-tls", Namespace: ComponentNamespace},
+			},
+			IngressNames: []types.NamespacedName{
+				{
+					Namespace: ComponentNamespace,
+					Name:      constants.VzConsoleIngress,
+				},
+			},
 		},
 	}
 }
@@ -76,17 +86,6 @@ func (c authProxyComponent) IsReady(ctx spi.ComponentContext) bool {
 		return isAuthProxyReady(ctx)
 	}
 	return false
-}
-
-// GetIngressNames - gets the names of the ingresses associated with this component
-func (c authProxyComponent) GetIngressNames(ctx spi.ComponentContext) []types.NamespacedName {
-	ingressNames := []types.NamespacedName{
-		{
-			Namespace: constants.VerrazzanoSystemNamespace,
-			Name:      constants.VzConsoleIngress,
-		},
-	}
-	return ingressNames
 }
 
 // PreInstall - actions to perform prior to installing this component

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -5,6 +5,7 @@ package authproxy
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"path/filepath"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -46,6 +47,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
 			GetInstallOverridesFunc: GetOverrides,
+			Dependencies:            []string{nginx.ComponentName},
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -50,7 +50,7 @@ func NewComponent() spi.Component {
 			GetInstallOverridesFunc: GetOverrides,
 			Dependencies:            []string{nginx.ComponentName},
 			Certificates: []types.NamespacedName{
-				{Name: "verrazzano-tls", Namespace: ComponentNamespace},
+				{Name: constants.VerrazzanoIngressSecret, Namespace: ComponentNamespace},
 			},
 			IngressNames: []types.NamespacedName{
 				{

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -40,8 +40,6 @@ const (
 	vzImagePullSecretKeyName = "global.imagePullSecrets[0]"
 
 	// Certificate names
-	verrazzanoCertificateName = "verrazzano-tls"
-
 	prometheusCertificateName = "system-tls-prometheus"
 
 	// ES secret keys
@@ -257,11 +255,6 @@ func (c verrazzanoComponent) GetIngressNames(ctx spi.ComponentContext) []types.N
 // GetCertificateNames - gets the names of the ingresses associated with this component
 func (c verrazzanoComponent) GetCertificateNames(ctx spi.ComponentContext) []types.NamespacedName {
 	var certificateNames []types.NamespacedName
-
-	certificateNames = append(certificateNames, types.NamespacedName{
-		Namespace: ComponentNamespace,
-		Name:      verrazzanoCertificateName,
-	})
 
 	if vzconfig.IsPrometheusEnabled(ctx.EffectiveCR()) {
 		certificateNames = append(certificateNames, types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
@@ -157,13 +157,13 @@ func TestGetCertificateNames(t *testing.T) {
 	vzComp := NewComponent()
 
 	certNames := vzComp.GetCertificateNames(ctx)
-	assert.Len(t, certNames, 1, "Unexpected number of cert names")
+	assert.Len(t, certNames, 0, "Unexpected number of cert names")
 
 	vmiEnabled = true
 	vz.Spec.Components.Prometheus.Enabled = &vmiEnabled
 
 	certNames = vzComp.GetCertificateNames(ctx)
-	assert.Len(t, certNames, 2, "Unexpected number of cert names")
+	assert.Len(t, certNames, 1, "Unexpected number of cert names")
 }
 
 // TestUpgrade tests the Verrazzano Upgrade call; simple wrapper exercise, more detailed testing is done elsewhere

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -40,7 +40,7 @@ const (
 	istioIngressServiceName  = "istio-ingressgateway"
 	nginxExternalIPArg       = "controller.service.externalIPs"
 	istioExternalIPArg       = "gateways.istio-ingressgateway.externalIPs"
-	waitTimeout              = 10 * time.Minute
+	waitTimeout              = 5 * time.Minute
 	pollingInterval          = 5 * time.Second
 	ociLBShapeAnnotation     = "service.beta.kubernetes.io/oci-load-balancer-shape"
 	nginxLBShapeArg          = "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\""
@@ -518,13 +518,13 @@ func validateServiceNodePortAndExternalIP(expectedSystemExternalIP, expectedAppl
 			return fmt.Errorf("expect istio ingress with externalIPs %v, but got %v", expectedAppIPs, istioIngress.Spec.ExternalIPs)
 		}
 
-		// validate Verrazzano Ingress URL
-		err = validateVerrazzanoIngressHost(expectedSystemExternalIP)
+		// validate Ingress Host
+		err = validateKeycloakIngressHost(expectedSystemExternalIP)
 		if err != nil {
 			return err
 		}
 
-		// validate hello-helidon HOSTS
+		// validate application HOSTS
 		err = validateHelloHelidonHost(expectedApplicationExternalIP)
 		if err != nil {
 			return err
@@ -569,13 +569,13 @@ func validateServiceLoadBalancer() {
 			return fmt.Errorf("invalid loadBalancer IP %s for istio", istioLBIP)
 		}
 
-		// validate Verrazzano Ingress URL
-		err = validateVerrazzanoIngressHost(nginxLBIP)
+		// validate Ingress Host
+		err = validateKeycloakIngressHost(nginxLBIP)
 		if err != nil {
 			return err
 		}
 
-		// validate hello-helidon HOSTS
+		// validate application HOSTS
 		err = validateHelloHelidonHost(istioLBIP)
 		if err != nil {
 			return err
@@ -585,7 +585,7 @@ func validateServiceLoadBalancer() {
 	}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "expect to get LoadBalancer type and loadBalancer IP from nginx and istio services")
 }
 
-func validateVerrazzanoIngressHost(expectedIP string) error {
+func validateKeycloakIngressHost(expectedIP string) error {
 	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
 		return err
@@ -594,7 +594,7 @@ func validateVerrazzanoIngressHost(expectedIP string) error {
 	if err != nil {
 		return err
 	}
-	ingress, err := clientset.NetworkingV1().Ingresses("verrazzano-system").Get(context.TODO(), "verrazzano-ingress", v1.GetOptions{})
+	ingress, err := clientset.NetworkingV1().Ingresses("keycloak").Get(context.TODO(), "keycloak", v1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -40,7 +40,7 @@ const (
 	istioIngressServiceName  = "istio-ingressgateway"
 	nginxExternalIPArg       = "controller.service.externalIPs"
 	istioExternalIPArg       = "gateways.istio-ingressgateway.externalIPs"
-	waitTimeout              = 5 * time.Minute
+	waitTimeout              = 10 * time.Minute
 	pollingInterval          = 5 * time.Second
 	ociLBShapeAnnotation     = "service.beta.kubernetes.io/oci-load-balancer-shape"
 	nginxLBShapeArg          = "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\""

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -559,7 +559,7 @@ func validateServiceNodePortAndExternalIP(expectedSystemExternalIP, expectedAppl
 		}
 		expectedAppIPs := []string{expectedApplicationExternalIP}
 		if !reflect.DeepEqual(expectedAppIPs, istioIngress.Spec.ExternalIPs) {
-			return fmt.Errorf("expect nginx ingress with externalIPs %v, but got %v", expectedAppIPs, istioIngress.Spec.ExternalIPs)
+			return fmt.Errorf("expect istio ingress with externalIPs %v, but got %v", expectedAppIPs, istioIngress.Spec.ExternalIPs)
 		}
 
 		// validate Verrazzano Ingress URL

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -519,13 +519,13 @@ func validateServiceNodePortAndExternalIP(expectedSystemExternalIP, expectedAppl
 		}
 
 		// validate Ingress Host
-		err = validateKeycloakIngressHost(expectedSystemExternalIP)
+		err = validateIngressHost(expectedSystemExternalIP)
 		if err != nil {
 			return err
 		}
 
-		// validate application HOSTS
-		err = validateHelloHelidonHost(expectedApplicationExternalIP)
+		// validate application Host
+		err = validateApplicationHost(expectedApplicationExternalIP)
 		if err != nil {
 			return err
 		}
@@ -570,13 +570,13 @@ func validateServiceLoadBalancer() {
 		}
 
 		// validate Ingress Host
-		err = validateKeycloakIngressHost(nginxLBIP)
+		err = validateIngressHost(nginxLBIP)
 		if err != nil {
 			return err
 		}
 
-		// validate application HOSTS
-		err = validateHelloHelidonHost(istioLBIP)
+		// validate application Host
+		err = validateApplicationHost(istioLBIP)
 		if err != nil {
 			return err
 		}
@@ -585,7 +585,7 @@ func validateServiceLoadBalancer() {
 	}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "expect to get LoadBalancer type and loadBalancer IP from nginx and istio services")
 }
 
-func validateKeycloakIngressHost(expectedIP string) error {
+func validateIngressHost(expectedIP string) error {
 	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
 		return err
@@ -608,7 +608,7 @@ func validateKeycloakIngressHost(expectedIP string) error {
 	return nil
 }
 
-func validateHelloHelidonHost(expectedIP string) error {
+func validateApplicationHost(expectedIP string) error {
 	host, err := k8sutil.GetHostnameFromGateway("hello-helidon", "")
 	if err != nil {
 		return err

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -321,7 +321,7 @@ var _ = t.Describe("Update nginx-istio", Serial, Ordered, Label("f:platform-lcm.
 
 	t.Describe("verrazzano-nginx-istio update nodeport", Label("f:platform-lcm.nginx-istio-update-nodeport"), func() {
 		t.It("nginx-istio update ingress type to nodeport", func() {
-			t.Logs.Infof("Update nginx/istio ingresses to use NodePort with external load balancers: %s and %s", systemExternalIP, applicationExternalIP)
+			t.Logs.Infof("Update nginx/istio ingresses to use NodePort type with external load balancers: %s and %s", systemExternalIP, applicationExternalIP)
 			m := NginxIstioNodePortModifier{systemExternalLBIP: systemExternalIP, applicationExternalLBIP: applicationExternalIP}
 			err := update.UpdateCR(m)
 			if err != nil {
@@ -335,6 +335,7 @@ var _ = t.Describe("Update nginx-istio", Serial, Ordered, Label("f:platform-lcm.
 
 	t.Describe("verrazzano-nginx-istio update loadbalancer", Label("f:platform-lcm.nginx-istio-update-loadbalancer"), func() {
 		t.It("nginx-istio update ingress type to loadbalancer", func() {
+			t.Logs.Infof("Update nginx/istio ingresses to use LoadBalancer type")
 			m := NginxIstioLoadBalancerModifier{}
 			err := update.UpdateCR(m)
 			if err != nil {
@@ -348,7 +349,7 @@ var _ = t.Describe("Update nginx-istio", Serial, Ordered, Label("f:platform-lcm.
 
 	t.Describe("verrazzano-nginx-istio update nodeport 2", Label("f:platform-lcm.nginx-istio-update-nodeport-2"), func() {
 		t.It("nginx-istio update ingress type to nodeport 2", func() {
-			t.Logs.Infof("Update nginx/istio ingresses to use NodePort with external load balancers: %s and %s", systemExternalIP, applicationExternalIP)
+			t.Logs.Infof("Update nginx/istio ingresses to use NodePort type with external load balancers: %s and %s", systemExternalIP, applicationExternalIP)
 			m := NginxIstioNodePortModifier{systemExternalLBIP: systemExternalIP, applicationExternalLBIP: applicationExternalIP}
 			err := update.UpdateCR(m)
 			if err != nil {
@@ -502,7 +503,7 @@ func validateServiceNodePortAndExternalIP(expectedSystemExternalIP, expectedAppl
 			return fmt.Errorf("expect nginx ingress with externalIPs %v, but got %v", expectedSysIPs, nginxIngress.Spec.ExternalIPs)
 		}
 
-		// validate Istion Ingress Service
+		// validate Istio Ingress Service
 		istioIngress, err := pkg.GetService(constants.IstioSystemNamespace, istioIngressServiceName)
 		if err != nil {
 			return err
@@ -553,7 +554,7 @@ func validateServiceLoadBalancer() {
 			return fmt.Errorf("invalid loadBalancer IP %s for nginx", nginxLBIP)
 		}
 
-		// validate Istion Ingress Service
+		// validate Istio Ingress Service
 		istioIngress, err := pkg.GetService(constants.IstioSystemNamespace, istioIngressServiceName)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

- Add nginx as authproxy's dependence
- Move verrazzano-ingress and verrazzano-tls from verrazzano component to authproxy component
- Add test for updating Nginx/Istio from a NodePort configuration to a Loadbalancer configuration in dynamic-config-update test

Fixes VZ-6012

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
