### PR TITLE
VZ-6063: Prometheus Operator-managed Prometheus persistent storage

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -191,3 +191,12 @@ const PromAdditionalScrapeConfigsSecretKey = "jobs"
 // PromManagedClusterCACertsSecretName is the name of the secret that contains managed cluster CA certificates. The secret is mounted
 // as a volume in the Prometheus pod.
 const PromManagedClusterCACertsSecretName = "managed-cluster-ca-certs"
+
+// OldReclaimPolicyLabel is the name of the label used to store the old reclaim policy of a persistent volume before it is migrated
+const OldReclaimPolicyLabel = "verrazzano.io/old-reclaim-policy"
+
+// StorageForLabel is the name of the label applied to a persistent volume so storage can be selected by a pod
+const StorageForLabel = "verrazzano.io/storage-for"
+
+// PrometheusStorageLabelValue is the label value for Prometheus storage
+const PrometheusStorageLabelValue = "prometheus"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -200,3 +200,6 @@ const StorageForLabel = "verrazzano.io/storage-for"
 
 // PrometheusStorageLabelValue is the label value for Prometheus storage
 const PrometheusStorageLabelValue = "prometheus"
+
+// VMISystemPrometheusVolumeClaim is the name of the VMO-managed Prometheus persistent volume claim
+const VMISystemPrometheusVolumeClaim = "vmi-system-prometheus"

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -122,7 +122,7 @@ func removeOldClaimFromPrometheusVolume(ctx spi.ComponentContext) error {
 		if pv.Status.Phase != corev1.VolumeReleased {
 			continue
 		}
-		if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Namespace == constants.VerrazzanoSystemNamespace && pv.Spec.ClaimRef.Name == "vmi-system-prometheus" {
+		if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Namespace == constants.VerrazzanoSystemNamespace && pv.Spec.ClaimRef.Name == constants.VMISystemPrometheusVolumeClaim {
 			ctx.Log().Infof("Found volume, removing old claim from Prometheus persistent volume %s", pv.Name)
 			pv.Spec.ClaimRef = nil
 			if err := ctx.Client().Update(context.TODO(), &pv); err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -79,7 +79,22 @@ func (c prometheusComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
 
 // PreInstall updates resources necessary for the Prometheus Operator Component installation
 func (c prometheusComponent) PreInstall(ctx spi.ComponentContext) error {
-	return preInstall(ctx)
+	return preInstallUpgrade(ctx)
+}
+
+// PreUpgrade updates resources necessary for the Prometheus Operator Component installation
+func (c prometheusComponent) PreUpgrade(ctx spi.ComponentContext) error {
+	return preInstallUpgrade(ctx)
+}
+
+// PostInstall does post-install processing for the Prometheus Operator Component
+func (c prometheusComponent) PostInstall(ctx spi.ComponentContext) error {
+	return postInstallUpgrade(ctx)
+}
+
+// PostUpgrade does post-upgrade processing for the Prometheus Operator Component
+func (c prometheusComponent) PostUpgrade(ctx spi.ComponentContext) error {
+	return postInstallUpgrade(ctx)
 }
 
 // ValidateInstall verifies the installation of the Verrazzano object

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -377,7 +377,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				ClaimRef: &corev1.ObjectReference{
-					Name:      "vmi-system-prometheus",
+					Name:      constants.VMISystemPrometheusVolumeClaim,
 					Namespace: constants.VerrazzanoSystemNamespace,
 				},
 			},
@@ -423,7 +423,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				ClaimRef: &corev1.ObjectReference{
-					Name:      "vmi-system-prometheus",
+					Name:      constants.VMISystemPrometheusVolumeClaim,
 					Namespace: constants.VerrazzanoSystemNamespace,
 				},
 			},
@@ -455,7 +455,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				ClaimRef: &corev1.ObjectReference{
-					Name:      "vmi-system-prometheus",
+					Name:      constants.VMISystemPrometheusVolumeClaim,
 					Namespace: constants.VerrazzanoSystemNamespace,
 				},
 			},

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -15,12 +15,17 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -170,19 +175,31 @@ func TestAppendOverrides(t *testing.T) {
 	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 }
 
-// TestPreInstall tests the preInstall function.
-func TestPreInstall(t *testing.T) {
-	// GIVEN the Prometheus Operator is being installed
-	// WHEN the preInstall function is called
+// TestPreInstallUpgrade tests the preInstallUpgrade function.
+func TestPreInstallUpgrade(t *testing.T) {
+	// GIVEN the Prometheus Operator is being installed or upgraded
+	// WHEN the preInstallUpgrade function is called
 	// THEN the component namespace is created in the cluster
 	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
 
-	err := preInstall(ctx)
+	err := preInstallUpgrade(ctx)
 	assert.NoError(t, err)
 
 	ns := v1.Namespace{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: ComponentNamespace}, &ns)
+	assert.NoError(t, err)
+}
+
+// TestPreUpgrade tests the preUpgrade function.
+func TestPostInstallUpgrade(t *testing.T) {
+	// GIVEN the Prometheus Operator is being installed or upgraded
+	// WHEN the postInstallUpgrade function is called
+	// THEN the function does not return an error
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := postInstallUpgrade(ctx)
 	assert.NoError(t, err)
 }
 
@@ -329,6 +346,392 @@ func TestValidatePrometheusOperator(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// erroringFakeClient wraps a k8s client and returns an error when Update is called
+type erroringFakeClient struct {
+	client.Client
+}
+
+// Update always returns an error - used to simulate an error updating a resource
+func (e *erroringFakeClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return errors.NewConflict(schema.GroupResource{}, "", nil)
+}
+
+// TestRemoveOldClaimFromPrometheusVolume tests the removeOldClaimFromPrometheusVolume function
+func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
+	const volumeName = "pvc-5ab58a05-71f9-4f09-8911-a5c029f6305f"
+
+	// GIVEN a persistent volume that has a released status and a claim that references vmi-system-prometheus
+	// WHEN the removeOldClaimFromPrometheusVolume function is called
+	// THEN the persistent volume is updated and the claim is removed
+	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for": "prometheus",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{
+					Name:      "vmi-system-prometheus",
+					Namespace: constants.VerrazzanoSystemNamespace,
+				},
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeReleased,
+			},
+		}).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := removeOldClaimFromPrometheusVolume(ctx)
+	assert.NoError(t, err)
+
+	// validate that the ClaimRef is now nil
+	pv := &corev1.PersistentVolume{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
+	assert.NoError(t, err)
+	assert.Nil(t, pv.Spec.ClaimRef)
+
+	// GIVEN no persistent volumes
+	// WHEN the removeOldClaimFromPrometheusVolume function is called
+	// THEN no error is returned
+	client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+			},
+		}).Build()
+	ctx = spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err = removeOldClaimFromPrometheusVolume(ctx)
+	assert.NoError(t, err)
+
+	// GIVEN a persistent volume that is bound and has a claim that references vmi-system-prometheus
+	// WHEN the removeOldClaimFromPrometheusVolume function is called
+	// THEN the persistent volume is not updated
+	client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for": "prometheus",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{
+					Name:      "vmi-system-prometheus",
+					Namespace: constants.VerrazzanoSystemNamespace,
+				},
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeBound,
+			},
+		}).Build()
+	ctx = spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err = removeOldClaimFromPrometheusVolume(ctx)
+	assert.NoError(t, err)
+
+	// validate that the ClaimRef is not nil
+	pv = &corev1.PersistentVolume{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
+	assert.NoError(t, err)
+	assert.NotNil(t, pv.Spec.ClaimRef)
+
+	// GIVEN a persistent volume that has a released status and a claim that references vmi-system-prometheus
+	// WHEN the removeOldClaimFromPrometheusVolume function is called and the call to update the volume fails
+	// THEN an error is returned
+	client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for": "prometheus",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{
+					Name:      "vmi-system-prometheus",
+					Namespace: constants.VerrazzanoSystemNamespace,
+				},
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeReleased,
+			},
+		}).Build()
+	erroringClient := &erroringFakeClient{Client: client}
+	ctx = spi.NewFakeContext(erroringClient, &vzapi.Verrazzano{}, false)
+
+	// validate that the expected error is returned
+	err = removeOldClaimFromPrometheusVolume(ctx)
+	assert.ErrorContains(t, err, "Failed removing claim")
+}
+
+// TestResetVolumeReclaimPolicy tests the resetVolumeReclaimPolicy function
+func TestResetVolumeReclaimPolicy(t *testing.T) {
+	const volumeName = "pvc-5ab58a05-71f9-4f09-8911-a5c029f6305f"
+
+	// GIVEN a persistent volume that has a bound status
+	// WHEN the resetVolumeReclaimPolicy function is called
+	// THEN the persistent volume reclaim policy is reset to the original value
+	// AND the old-reclaim-policy label is removed
+	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for":        "prometheus",
+					"verrazzano.io/old-reclaim-policy": "Delete",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeBound,
+			},
+		}).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := resetVolumeReclaimPolicy(ctx)
+	assert.NoError(t, err)
+
+	// validate that the reclaim policy is now "Delete" and the label has been removed
+	pv := &corev1.PersistentVolume{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
+	assert.NoError(t, err)
+	assert.Equal(t, corev1.PersistentVolumeReclaimDelete, pv.Spec.PersistentVolumeReclaimPolicy)
+	assert.NotContains(t, pv.Labels, "verrazzano.io/old-reclaim-policy")
+
+	// GIVEN a persistent volume that has an available status
+	// WHEN the resetVolumeReclaimPolicy function is called
+	// THEN the persistent volume is not updated
+	client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for":        "prometheus",
+					"verrazzano.io/old-reclaim-policy": "Delete",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeAvailable,
+			},
+		}).Build()
+	ctx = spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err = resetVolumeReclaimPolicy(ctx)
+	assert.NoError(t, err)
+
+	// validate that the reclaim policy has not changed and that the label still exists
+	pv = &corev1.PersistentVolume{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
+	assert.NoError(t, err)
+	assert.Equal(t, corev1.PersistentVolumeReclaimRetain, pv.Spec.PersistentVolumeReclaimPolicy)
+	assert.Contains(t, pv.Labels, "verrazzano.io/old-reclaim-policy")
+
+	// GIVEN a persistent volume that has a bound status
+	// WHEN the resetVolumeReclaimPolicy function is called and the call to update the volume fails
+	// THEN an error is returned
+	client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeName,
+				Labels: map[string]string{
+					"verrazzano.io/storage-for":        "prometheus",
+					"verrazzano.io/old-reclaim-policy": "Delete",
+				},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeBound,
+			},
+		}).Build()
+	erroringClient := &erroringFakeClient{Client: client}
+	ctx = spi.NewFakeContext(erroringClient, &vzapi.Verrazzano{}, false)
+
+	// validate that the expected error is returned
+	err = resetVolumeReclaimPolicy(ctx)
+	assert.ErrorContains(t, err, "Failed resetting reclaim policy")
+}
+
+// TestAppendResourceRequestOverrides tests the appendResourceRequestOverrides function
+func TestAppendResourceRequestOverrides(t *testing.T) {
+	const (
+		storageSize = "1Gi"
+		memorySize  = "128Mi"
+	)
+	clientNoPV := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	clientWithPV := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pvc-5ab58a05-71f9-4f09-8911-a5c029f6305f",
+				Labels: map[string]string{
+					"verrazzano.io/storage-for": "prometheus",
+				},
+			},
+		}).Build()
+
+	tests := []struct {
+		name            string
+		client          client.Client
+		request         common.ResourceRequestValues
+		expectOverrides []bom.KeyValue
+		expectError     bool
+	}{
+		{
+			// GIVEN a resource request with both storage and memory set and there are no existing Prometheus persistent volumes
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and the expected key/value overrides are returned
+			name:   "both storage and memory set, no existing Prometheus persistent volume",
+			client: clientNoPV,
+			request: common.ResourceRequestValues{
+				Storage: storageSize,
+				Memory:  memorySize,
+			},
+			expectOverrides: []bom.KeyValue{
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.disableMountSubPath",
+					Value: "true",
+				},
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage",
+					Value: storageSize,
+				},
+				{
+					Key:   "prometheus.prometheusSpec.resources.requests.memory",
+					Value: memorySize,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// GIVEN a resource request with both storage and memory set and there is an existing Prometheus persistent volume
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and the expected key/value overrides are returned
+			name:   "both storage and memory set, and existing Prometheus persistent volume",
+			client: clientWithPV,
+			request: common.ResourceRequestValues{
+				Storage: storageSize,
+				Memory:  memorySize,
+			},
+			expectOverrides: []bom.KeyValue{
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.disableMountSubPath",
+					Value: "true",
+				},
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage",
+					Value: storageSize,
+				},
+				{
+					Key:   `prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.selector.matchLabels.verrazzano\.io/storage-for`,
+					Value: "prometheus",
+				},
+				{
+					Key:   "prometheus.prometheusSpec.resources.requests.memory",
+					Value: memorySize,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// GIVEN a resource request with no storage or memory requests
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and no key/value overrides are returned
+			name:            "neither storage nor memory set",
+			client:          clientNoPV,
+			request:         common.ResourceRequestValues{},
+			expectOverrides: []bom.KeyValue{},
+			expectError:     false,
+		},
+		{
+			// GIVEN a resource request with only storage set and there are no existing Prometheus persistent volumes
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and the expected key/value overrides are returned
+			name:   "only storage set, no persistent volumes",
+			client: clientNoPV,
+			request: common.ResourceRequestValues{
+				Storage: storageSize,
+			},
+			expectOverrides: []bom.KeyValue{
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.disableMountSubPath",
+					Value: "true",
+				},
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage",
+					Value: storageSize,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// GIVEN a resource request with only storage set and there are is an existing Prometheus persistent volume
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and the expected key/value overrides are returned
+			name:   "only storage set, and persistent volume exists",
+			client: clientWithPV,
+			request: common.ResourceRequestValues{
+				Storage: storageSize,
+			},
+			expectOverrides: []bom.KeyValue{
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.disableMountSubPath",
+					Value: "true",
+				},
+				{
+					Key:   "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage",
+					Value: storageSize,
+				},
+				{
+					Key:   `prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.selector.matchLabels.verrazzano\.io/storage-for`,
+					Value: "prometheus",
+				},
+			},
+			expectError: false,
+		},
+		{
+			// GIVEN a resource request with only memory set
+			// WHEN the appendResourceRequestOverrides function is called
+			// THEN no error is returned and the expected key/value overrides are returned
+			name:   "only memory set",
+			client: clientNoPV,
+			request: common.ResourceRequestValues{
+				Memory: memorySize,
+			},
+			expectOverrides: []bom.KeyValue{
+				{
+					Key:   "prometheus.prometheusSpec.resources.requests.memory",
+					Value: memorySize,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := spi.NewFakeContext(tt.client, &vzapi.Verrazzano{}, false)
+
+			kvs, err := appendResourceRequestOverrides(ctx, &tt.request, []bom.KeyValue{})
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectOverrides, kvs)
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -372,7 +372,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for": "prometheus",
+					constants.StorageForLabel: constants.PrometheusStorageLabelValue,
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -418,7 +418,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for": "prometheus",
+					constants.StorageForLabel: constants.PrometheusStorageLabelValue,
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -450,7 +450,7 @@ func TestRemoveOldClaimFromPrometheusVolume(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for": "prometheus",
+					constants.StorageForLabel: constants.PrometheusStorageLabelValue,
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -484,8 +484,8 @@ func TestResetVolumeReclaimPolicy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for":        "prometheus",
-					"verrazzano.io/old-reclaim-policy": "Delete",
+					constants.StorageForLabel:       constants.PrometheusStorageLabelValue,
+					constants.OldReclaimPolicyLabel: string(corev1.PersistentVolumeReclaimDelete),
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -505,7 +505,7 @@ func TestResetVolumeReclaimPolicy(t *testing.T) {
 	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
 	assert.NoError(t, err)
 	assert.Equal(t, corev1.PersistentVolumeReclaimDelete, pv.Spec.PersistentVolumeReclaimPolicy)
-	assert.NotContains(t, pv.Labels, "verrazzano.io/old-reclaim-policy")
+	assert.NotContains(t, pv.Labels, constants.OldReclaimPolicyLabel)
 
 	// GIVEN a persistent volume that has an available status
 	// WHEN the resetVolumeReclaimPolicy function is called
@@ -515,8 +515,8 @@ func TestResetVolumeReclaimPolicy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for":        "prometheus",
-					"verrazzano.io/old-reclaim-policy": "Delete",
+					constants.StorageForLabel:       constants.PrometheusStorageLabelValue,
+					constants.OldReclaimPolicyLabel: string(corev1.PersistentVolumeReclaimDelete),
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -536,7 +536,7 @@ func TestResetVolumeReclaimPolicy(t *testing.T) {
 	err = client.Get(context.TODO(), types.NamespacedName{Name: volumeName}, pv)
 	assert.NoError(t, err)
 	assert.Equal(t, corev1.PersistentVolumeReclaimRetain, pv.Spec.PersistentVolumeReclaimPolicy)
-	assert.Contains(t, pv.Labels, "verrazzano.io/old-reclaim-policy")
+	assert.Contains(t, pv.Labels, constants.OldReclaimPolicyLabel)
 
 	// GIVEN a persistent volume that has a bound status
 	// WHEN the resetVolumeReclaimPolicy function is called and the call to update the volume fails
@@ -546,8 +546,8 @@ func TestResetVolumeReclaimPolicy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeName,
 				Labels: map[string]string{
-					"verrazzano.io/storage-for":        "prometheus",
-					"verrazzano.io/old-reclaim-policy": "Delete",
+					constants.StorageForLabel:       constants.PrometheusStorageLabelValue,
+					constants.OldReclaimPolicyLabel: string(corev1.PersistentVolumeReclaimDelete),
 				},
 			},
 			Spec: corev1.PersistentVolumeSpec{
@@ -577,7 +577,7 @@ func TestAppendResourceRequestOverrides(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pvc-5ab58a05-71f9-4f09-8911-a5c029f6305f",
 				Labels: map[string]string{
-					"verrazzano.io/storage-for": "prometheus",
+					constants.StorageForLabel: constants.PrometheusStorageLabelValue,
 				},
 			},
 		}).Build()

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -44,7 +44,6 @@ const (
 	fluentDaemonset       = "fluentd"
 	nodeExporterDaemonset = "node-exporter"
 
-	prometheusDeployment        = "vmi-system-prometheus-0"
 	verrazzanoConsoleDeployment = "verrazzano-console"
 )
 
@@ -79,14 +78,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 			})
 	}
 
-	if vzconfig.IsPrometheusEnabled(ctx.EffectiveCR()) {
-		deployments = append(deployments,
-			types.NamespacedName{
-				Name:      prometheusDeployment,
-				Namespace: ComponentNamespace,
-			})
-	}
-
 	if !status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix) {
 		return false
 	}
@@ -111,16 +102,6 @@ func isVerrazzanoReady(ctx spi.ComponentContext) bool {
 		return false
 	}
 	return common.IsVMISecretReady(ctx)
-}
-
-// doesPromExist is the verrazzano IsInstalled check
-func doesPromExist(ctx spi.ComponentContext) bool {
-	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	deploy := []types.NamespacedName{{
-		Name:      prometheusDeployment,
-		Namespace: ComponentNamespace,
-	}}
-	return status.DoDeploymentsExist(ctx.Log(), ctx.Client(), deploy, 1, prefix)
 }
 
 // VerrazzanoPreUpgrade contains code that is run prior to helm upgrade for the Verrazzano helm chart

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -143,11 +143,7 @@ func (c verrazzanoComponent) IsReady(ctx spi.ComponentContext) bool {
 
 // IsInstalled component check
 func (c verrazzanoComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
-	installed, _ := c.HelmComponent.IsInstalled(ctx)
-	if installed {
-		return doesPromExist(ctx), nil
-	}
-	return false, nil
+	return c.HelmComponent.IsInstalled(ctx)
 }
 
 // PostInstall - post-install, clean up temp files

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_test.go
@@ -984,18 +984,6 @@ func TestIsReadySecretNotReady(t *testing.T) {
 				UpdatedReplicas:   1,
 			},
 		},
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      prometheusDeployment,
-				Labels:    map[string]string{"app": "system-prometheus"},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				Replicas:          1,
-				UpdatedReplicas:   1,
-			},
-		},
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: globalconst.VerrazzanoSystemNamespace,
@@ -1049,18 +1037,6 @@ func TestIsReady(t *testing.T) {
 				UpdatedReplicas:   1,
 			},
 		},
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      prometheusDeployment,
-				Labels:    map[string]string{"app": "system-prometheus"},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				Replicas:          1,
-				UpdatedReplicas:   1,
-			},
-		},
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: globalconst.VerrazzanoSystemNamespace,
@@ -1107,18 +1083,6 @@ func TestIsReadyDeploymentNotAvailable(t *testing.T) {
 				AvailableReplicas: 1,
 				Replicas:          1,
 				UpdatedReplicas:   0,
-			},
-		},
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      prometheusDeployment,
-				Labels:    map[string]string{"app": "system-prometheus"},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				Replicas:          1,
-				UpdatedReplicas:   1,
 			},
 		},
 		&appsv1.DaemonSet{
@@ -1193,27 +1157,4 @@ func TestConfigHashSum(t *testing.T) {
 	assert.NotEqual(t, HashSum(f1), HashSum(f2))
 	f2.Enabled = &b
 	assert.Equal(t, HashSum(f1), HashSum(f2))
-}
-
-// TestIsinstalled tests the Verrazzano doesPromExist call
-// GIVEN a Verrazzano component
-//  WHEN I call doesPromExist
-//  THEN true is returned
-func TestIsinstalled(t *testing.T) {
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
-	})
-	defer helm.SetDefaultChartStatusFunction()
-	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      prometheusDeployment,
-				Labels:    map[string]string{"app": "system-prometheus"},
-			},
-		},
-	).Build()
-	vz := &vzapi.Verrazzano{}
-	ctx := spi.NewFakeContext(c, vz, false)
-	assert.True(t, doesPromExist(ctx))
 }

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo.go
@@ -86,18 +86,18 @@ func appendInitImageOverrides(kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 // to retain the volume so it can be migrated.
 func retainPrometheusPersistentVolume(ctx spi.ComponentContext) error {
 	pvc := &corev1.PersistentVolumeClaim{}
-	if err := ctx.Client().Get(context.TODO(), types.NamespacedName{Name: "vmi-system-prometheus", Namespace: ComponentNamespace}, pvc); err != nil {
+	if err := ctx.Client().Get(context.TODO(), types.NamespacedName{Name: constants.VMISystemPrometheusVolumeClaim, Namespace: ComponentNamespace}, pvc); err != nil {
 		// no pvc so just log it and there's nothing left to do
-		ctx.Log().Debugf("Did not find pvc vmi-system-prometheus, skipping volume migration: %v", err)
+		ctx.Log().Debugf("Did not find pvc %s, skipping volume migration: %v", constants.VMISystemPrometheusVolumeClaim, err)
 		return nil
 	}
 
-	ctx.Log().Info("Updating persistent volume associated with pvc vmi-system-prometheus so that the volume can be migrated")
+	ctx.Log().Infof("Updating persistent volume associated with pvc %s so that the volume can be migrated", constants.VMISystemPrometheusVolumeClaim)
 
 	pvName := pvc.Spec.VolumeName
 	pv := &corev1.PersistentVolume{}
 	if err := ctx.Client().Get(context.TODO(), types.NamespacedName{Name: pvName}, pv); err != nil {
-		return ctx.Log().ErrorfNewErr("Failed fetching persistent volume associated with pvc vmi-system-prometheus: %v", err)
+		return ctx.Log().ErrorfNewErr("Failed fetching persistent volume associated with pvc %s: %v", constants.VMISystemPrometheusVolumeClaim, err)
 	}
 
 	// set the reclaim policy on the pv to retain so that it does not get deleted when the VMO-managed Prometheus is removed
@@ -113,7 +113,7 @@ func retainPrometheusPersistentVolume(ctx spi.ComponentContext) error {
 	pv.Labels[constants.OldReclaimPolicyLabel] = string(oldReclaimPolicy)
 
 	if err := ctx.Client().Update(context.TODO(), pv); err != nil {
-		return ctx.Log().ErrorfNewErr("Failed updating persistent volume associated with pvc vmi-system-prometheus: %v", err)
+		return ctx.Log().ErrorfNewErr("Failed updating persistent volume associated with pvc %s: %v", constants.VMISystemPrometheusVolumeClaim, err)
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
@@ -108,8 +109,8 @@ func retainPrometheusPersistentVolume(ctx spi.ComponentContext) error {
 	if pv.Labels == nil {
 		pv.Labels = make(map[string]string)
 	}
-	pv.Labels["verrazzano.io/storage-for"] = "prometheus"
-	pv.Labels["verrazzano.io/old-reclaim-policy"] = string(oldReclaimPolicy)
+	pv.Labels[constants.StorageForLabel] = constants.PrometheusStorageLabelValue
+	pv.Labels[constants.OldReclaimPolicyLabel] = string(oldReclaimPolicy)
 
 	if err := ctx.Client().Update(context.TODO(), pv); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed updating persistent volume associated with pvc vmi-system-prometheus: %v", err)

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo_component.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo_component.go
@@ -5,6 +5,8 @@ package vmo
 
 import (
 	"context"
+	"path/filepath"
+
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -16,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"path/filepath"
 )
 
 // ComponentName is the name of the component
@@ -82,7 +83,13 @@ func (c vmoComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 
 // PreUpgrade VMO pre-upgrade processing
 func (c vmoComponent) PreUpgrade(context spi.ComponentContext) error {
-	return common.ApplyCRDYaml(context, config.GetHelmVMOChartsDir())
+	if err := common.ApplyCRDYaml(context, config.GetHelmVMOChartsDir()); err != nil {
+		return err
+	}
+	if err := retainPrometheusPersistentVolume(context); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Upgrade VMO processing

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo_test.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo_test.go
@@ -219,7 +219,7 @@ func TestRetainPrometheusPersistentVolume(t *testing.T) {
 		&corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ComponentNamespace,
-				Name:      "vmi-system-prometheus",
+				Name:      constants.VMISystemPrometheusVolumeClaim,
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				VolumeName: volumeName,
@@ -260,7 +260,7 @@ func TestRetainPrometheusPersistentVolume(t *testing.T) {
 		&corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ComponentNamespace,
-				Name:      "vmi-system-prometheus",
+				Name:      constants.VMISystemPrometheusVolumeClaim,
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				VolumeName: volumeName,
@@ -277,7 +277,7 @@ func TestRetainPrometheusPersistentVolume(t *testing.T) {
 		&corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ComponentNamespace,
-				Name:      "vmi-system-prometheus",
+				Name:      constants.VMISystemPrometheusVolumeClaim,
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				VolumeName: volumeName,

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo_test.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
@@ -241,8 +242,8 @@ func TestRetainPrometheusPersistentVolume(t *testing.T) {
 	a.NoError(err)
 
 	// validate that the expected labels are set and the reclaim policy is set to "retain"
-	a.Equal("prometheus", pv.Labels["verrazzano.io/storage-for"])
-	a.Equal(string(reclaimPolicy), pv.Labels["verrazzano.io/old-reclaim-policy"])
+	a.Equal(constants.PrometheusStorageLabelValue, pv.Labels[constants.StorageForLabel])
+	a.Equal(string(reclaimPolicy), pv.Labels[constants.OldReclaimPolicyLabel])
 	a.Equal(corev1.PersistentVolumeReclaimRetain, pv.Spec.PersistentVolumeReclaimPolicy)
 
 	// GIVEN no vmi-system-prometheus pvc

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -14,6 +14,11 @@ prometheus:
       enabled: true
       name: additional-scrape-configs
       key: jobs
+    securityContext:
+      fsGroup: 65534
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
 alertmanager:
   enabled: false
 prometheusOperator:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -215,12 +215,13 @@
       "name": "verrazzano-monitoring-operator",
       "subcomponents": [
         {
-          "repository": "verrazzano",
+          "registry": "phx.ocir.io",
+          "repository": "odsbuilddev/sandboxes/fred.tibbitts/dev",
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "1.4.0-20220525201121-c0046fa",
+              "image": "verrazzano-monitoring-operator-dev",
+              "tag": "local-c0046fa",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -215,13 +215,12 @@
       "name": "verrazzano-monitoring-operator",
       "subcomponents": [
         {
-          "registry": "phx.ocir.io",
-          "repository": "odsbuilddev/sandboxes/fred.tibbitts/dev",
+          "repository": "verrazzano",
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator-dev",
-              "tag": "local-c0046fa",
+              "image": "verrazzano-monitoring-operator",
+              "tag": "1.4.0-20220525201121-c0046fa",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
# Description

This PR fixes the persistence settings for the Prometheus Operator-managed Prometheus and also adds support to migrate the existing Prometheus storage volume from the VMI-managed Prometheus to the new Prometheus.

The steps to migrate the storage volume include:

1. Prior to upgrading the VMO component, find the PVC for the VMO-managed Prometheus storage volume, locate the associated persistent volume, and set the reclaim policy to "retain". This ensures that the volume will not be deleted when the VMO-managed Prometheus claim is deleted. We also add a label to the persistent volume so the storage can be selected by the new Prometheus instance, and a second label to capture the old reclaim policy value so it can be reset once the migration is complete.
2. During VMO upgrade, Prometheus and the persistent volume claim are deleted.
3. Prior to installing or upgrading the Prometheus Operator, the old Prometheus claim is removed from the persistent volume. This makes it available to be bound by the new Prometheus instance.
4. Helm settings for storage on the Prometheus CR are configured to select the persistent volume during Prometheus Operator install and upgrade.
5. During Prometheus Operator post install and upgrade, once the persistent volume is bound to the new Prometheus instance, the reclaim policy on the storage volume is reset to what it was before the migration.

Notes:

1. This PR can't be merged until other Prometheus work is completed, including uptaking the new VMO that removes the VMO-managed Prometheus resources. This branch will need to be rebased with master.
2. This branch is branched off of VZ-6016. That branch depends on the new VMO that removes Prometheus, and has changes to not check for running VMO-managed Prometheus pods during installation.

Implements VZ-6063

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
