### PR TITLE
VZ-6006 monitorChanges scoped to all components

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -164,7 +164,8 @@ pipeline {
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
                                         booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
+                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
+                                        string(name: 'VERSION_FOR_INSTALL', value: 'v1.2.0'),
                                     ], wait: true
                             }
                         }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -443,6 +443,9 @@ pipeline {
             post {
                 failure {
                     script {
+                        sh """
+                            kubectl get vz -o yaml
+                        """
                         dumpK8sCluster("${WORKSPACE}/multicluster-upgrade-cluster-dump")
                     }
                 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -917,7 +917,7 @@ def upgradeVerrazzano() {
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
                 # wait for the upgrade to complete
-                kubectl wait --timeout=25m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                kubectl wait --timeout=40m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                 # Get the install job(s) and mke sure the it matches pre-install.  If there is more than 1 job or the job changed, then it won't match
                 kubectl -n verrazzano-install get job -o yaml --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-post-upgrade-job.out

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -416,6 +416,19 @@ pipeline {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
+            }
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
+                    }
+                }
+            }
+        }
+
+        stage('Upgrade Verrazzano') {
+            // Upgrade Verrazzano
+            stages {
                 stage("upgrade-platform-operator") {
                     steps {
                         upgradePlatformOperator()
@@ -426,18 +439,11 @@ pipeline {
                         upgradeVerrazzano()
                     }
                 }
-                post {
-                    failure {
-                        script {
-                            dumpK8sCluster("${WORKSPACE}/multicluster-upgrade-cluster-dump")
-                        }
-                    }
-                }
             }
             post {
                 failure {
                     script {
-                        dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
+                        dumpK8sCluster("${WORKSPACE}/multicluster-upgrade-cluster-dump")
                     }
                 }
             }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -932,6 +932,8 @@ def upgradeVerrazzano() {
                 echo "Following is the verrazzano CR file with the new version:"
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
+                sleep 30
+                kubectl get vz -o yaml
                 # wait for the upgrade to complete
                 kubectl wait --timeout=25m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -930,7 +930,7 @@ def upgradeVerrazzano() {
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
                 # wait for the upgrade to complete
-                kubectl wait --timeout=40m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                kubectl wait --timeout=25m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                 # Get the install job(s) and mke sure the it matches pre-install.  If there is more than 1 job or the job changed, then it won't match
                 kubectl -n verrazzano-install get job -o yaml --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-post-upgrade-job.out

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -426,6 +426,13 @@ pipeline {
                         upgradeVerrazzano()
                     }
                 }
+                post {
+                    failure {
+                        script {
+                            dumpK8sCluster("${WORKSPACE}/multicluster-upgrade-cluster-dump")
+                        }
+                    }
+                }
             }
             post {
                 failure {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -416,19 +416,6 @@ pipeline {
                         runGinkgoRandomize('metrics/syscomponents')
                     }
                 }
-            }
-            post {
-                failure {
-                    script {
-                        dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
-                    }
-                }
-            }
-        }
-
-        stage('Upgrade Verrazzano') {
-            // Upgrade Verrazzano
-            stages {
                 stage("upgrade-platform-operator") {
                     steps {
                         upgradePlatformOperator()
@@ -443,10 +430,7 @@ pipeline {
             post {
                 failure {
                     script {
-                        sh """
-                            kubectl get vz -o yaml
-                        """
-                        dumpK8sCluster("${WORKSPACE}/multicluster-upgrade-cluster-dump")
+                        dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
                     }
                 }
             }
@@ -802,15 +786,9 @@ def getVerrazzanoOperatorYaml() {
         echo "Platform Operator Configuration"
         cd ${GO_REPO_PATH}/verrazzano
         if [ "NONE" == "${params.VERRAZZANO_OPERATOR_IMAGE}" ]; then
-            if [ "true" == "${params.EXTERNAL_ELASTICSEARCH}" ]; then
-                echo "Using the latest branch operator.yaml from object storage because external ES is not supported in versions prior to v1.1"
-                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-                cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-            else
-                echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
-                wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
-                cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-            fi
+            echo "Downloading operator.yaml for release ${params.VERSION_FOR_INSTALL}"
+            wget "https://github.com/verrazzano/verrazzano/releases/download/${params.VERSION_FOR_INSTALL}/operator.yaml" -O ${WORKSPACE}/downloaded-release-operator.yaml
+            cp ${WORKSPACE}/downloaded-release-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
         else
             echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
             env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
@@ -932,8 +910,6 @@ def upgradeVerrazzano() {
                 echo "Following is the verrazzano CR file with the new version:"
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
-                sleep 30
-                kubectl get vz -o yaml
                 # wait for the upgrade to complete
                 kubectl wait --timeout=25m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package semver

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package semver

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -100,14 +100,12 @@ func TestCompareVersion(t *testing.T) {
 func TestCompareTo(t *testing.T) {
 
 	v010, _ := NewSemVersion("v0.1.0")
-	vn010, _ := NewSemVersion("0.1.0")
 	v010_2, _ := NewSemVersion("v0.1.0")
 	v011, _ := NewSemVersion("v0.1.1")
 
 	v020, _ := NewSemVersion("v0.2.0")
 	v100, _ := NewSemVersion("v1.0.0")
 
-	assert.Equal(t, 0, v010.CompareTo(vn010))
 	assert.Equal(t, 0, v010.CompareTo(v010_2))
 	assert.Equal(t, -1, v010.CompareTo(v011))
 	assert.Equal(t, -1, v010.CompareTo(v020))

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -100,12 +100,14 @@ func TestCompareVersion(t *testing.T) {
 func TestCompareTo(t *testing.T) {
 
 	v010, _ := NewSemVersion("v0.1.0")
+	vn010, _ := NewSemVersion("0.1.0")
 	v010_2, _ := NewSemVersion("v0.1.0")
 	v011, _ := NewSemVersion("v0.1.1")
 
 	v020, _ := NewSemVersion("v0.2.0")
 	v100, _ := NewSemVersion("v1.0.0")
 
+	assert.Equal(t, 0, v010.CompareTo(vn010))
 	assert.Equal(t, 0, v010.CompareTo(v010_2))
 	assert.Equal(t, -1, v010.CompareTo(v011))
 	assert.Equal(t, -1, v010.CompareTo(v020))

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -196,11 +196,23 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(actualCR.Status) {
-		if len(actualCR.Spec.Version) > 0 && actualCR.Spec.Version != actualCR.Status.Version {
-			// Transition to upgrade state
-			r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
-			return newRequeueWithDelay(), err
+		if len(actualCR.Spec.Version) > 0 {
+			specVersion, err := semver.NewSemVersion(actualCR.Spec.Version)
+			if err != nil {
+				return newRequeueWithDelay(), err
+			}
+			statusVersion, err := semver.NewSemVersion(actualCR.Status.Version)
+			if err != nil {
+				return newRequeueWithDelay(), err
+			}
+			// if the spec version field is set and the SemVer spec field doesn't equal the SemVer status field
+			if specVersion.CompareTo(statusVersion) != 0 {
+				// Transition to upgrade state
+				r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
+				return newRequeueWithDelay(), err
+			}
 		}
+
 		// Keep retrying to reconcile components until it completes
 		if result, err := r.reconcileComponents(vzctx); err != nil {
 			return newRequeueWithDelay(), err

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -196,23 +196,11 @@ func (r *Reconciler) ProcReadyState(vzctx vzcontext.VerrazzanoContext) (ctrl.Res
 
 	// If Verrazzano is installed see if upgrade is needed
 	if isInstalled(actualCR.Status) {
-		if len(actualCR.Spec.Version) > 0 {
-			specVersion, err := semver.NewSemVersion(actualCR.Spec.Version)
-			if err != nil {
-				return newRequeueWithDelay(), err
-			}
-			statusVersion, err := semver.NewSemVersion(actualCR.Status.Version)
-			if err != nil {
-				return newRequeueWithDelay(), err
-			}
-			// if the spec version field is set and the SemVer spec field doesn't equal the SemVer status field
-			if specVersion.CompareTo(statusVersion) != 0 {
-				// Transition to upgrade state
-				r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
-				return newRequeueWithDelay(), err
-			}
+		if len(actualCR.Spec.Version) > 0 && actualCR.Spec.Version != actualCR.Status.Version {
+			// Transition to upgrade state
+			r.updateVzState(log, actualCR, installv1alpha1.VzStateUpgrading)
+			return newRequeueWithDelay(), err
 		}
-
 		// Keep retrying to reconcile components until it completes
 		if result, err := r.reconcileComponents(vzctx); err != nil {
 			return newRequeueWithDelay(), err

--- a/platform-operator/controllers/verrazzano/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/fake_component_test.go
@@ -31,6 +31,7 @@ type fakeComponent struct {
 	installed       string `default:"true"`
 	ready           string `default:"true"`
 	enabled         string `default:"true"`
+	monitorChanges  string `default:"true"`
 	minVersion      string
 }
 
@@ -109,6 +110,10 @@ func (f fakeComponent) GetMinVerrazzanoVersion() string {
 		return f.minVersion
 	}
 	return constants.VerrazzanoVersion1_0_0
+}
+
+func (f fakeComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
+	return getBool(f.monitorChanges, "monitorChanges")
 }
 
 // getBool implements defaults for boolean fields

--- a/platform-operator/controllers/verrazzano/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/fake_component_test.go
@@ -31,7 +31,6 @@ type fakeComponent struct {
 	installed       string `default:"true"`
 	ready           string `default:"true"`
 	enabled         string `default:"true"`
-	monitorChanges  string `default:"true"`
 	minVersion      string
 }
 
@@ -110,10 +109,6 @@ func (f fakeComponent) GetMinVerrazzanoVersion() string {
 		return f.minVersion
 	}
 	return constants.VerrazzanoVersion1_0_0
-}
-
-func (f fakeComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
-	return getBool(f.monitorChanges, "monitorChanges")
 }
 
 // getBool implements defaults for boolean fields

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -51,24 +51,20 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			continue
 		}
 		if checkConfigUpdated(spiCtx, componentStatus, compName) && comp.IsEnabled(compContext.EffectiveCR()) {
-			if !comp.MonitorOverrides(compContext) && comp.IsEnabled(spiCtx.EffectiveCR()) {
-				compLog.Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
-			} else {
-				oldState := componentStatus.State
-				oldGen := componentStatus.ReconcilingGeneration
-				componentStatus.ReconcilingGeneration = 0
-				if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
-					return ctrl.Result{Requeue: true}, err
-				}
-				compLog.Oncef("CR.generation: %v reset component %s state: %v generation: %v to state: %v generation: %v ",
-					spiCtx.ActualCR().Generation, compName, oldState, oldGen, componentStatus.State, componentStatus.ReconcilingGeneration)
-				if spiCtx.ActualCR().Status.State == vzapi.VzStateReady {
-					err = r.setInstallingState(vzctx.Log, spiCtx.ActualCR())
-					compLog.Oncef("Reset Verrazzano state to %v for generation %v", spiCtx.ActualCR().Status.State, spiCtx.ActualCR().Generation)
-					if err != nil {
-						spiCtx.Log().Errorf("Failed to reset state: %v", err)
-						return newRequeueWithDelay(), err
-					}
+			oldState := componentStatus.State
+			oldGen := componentStatus.ReconcilingGeneration
+			componentStatus.ReconcilingGeneration = 0
+			if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
+				return ctrl.Result{Requeue: true}, err
+			}
+			compLog.Oncef("CR.generation: %v reset component %s state: %v generation: %v to state: %v generation: %v ",
+				spiCtx.ActualCR().Generation, compName, oldState, oldGen, componentStatus.State, componentStatus.ReconcilingGeneration)
+			if spiCtx.ActualCR().Status.State == vzapi.VzStateReady {
+				err = r.setInstallingState(vzctx.Log, spiCtx.ActualCR())
+				compLog.Oncef("Reset Verrazzano state to %v for generation %v", spiCtx.ActualCR().Status.State, spiCtx.ActualCR().Generation)
+				if err != nil {
+					spiCtx.Log().Errorf("Failed to reset state: %v", err)
+					return newRequeueWithDelay(), err
 				}
 			}
 		}

--- a/platform-operator/controllers/verrazzano/install_test.go
+++ b/platform-operator/controllers/verrazzano/install_test.go
@@ -36,7 +36,7 @@ func TestUpdate(t *testing.T) {
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
 		lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.0", "1.3.0", namespace, name)
+		"1.3.0", "1.3.0", namespace, name, "true")
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateInstalling, vz.Status.State)
@@ -55,7 +55,7 @@ func TestNoUpdateSameGeneration(t *testing.T) {
 	lastReconciledGeneration := int64(2)
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration, reconcilingGen, lastReconciledGeneration,
-		"1.3.1", "1.3.1", namespace, name)
+		"1.3.1", "1.3.1", namespace, name, "true")
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
@@ -74,7 +74,7 @@ func TestUpdateWithUpgrade(t *testing.T) {
 	lastReconciledGeneration := int64(2)
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.0", "1.2.0", namespace, name)
+		"1.3.0", "1.2.0", namespace, name, "true")
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateUpgrading, vz.Status.State)
@@ -94,12 +94,32 @@ func TestUpdateOnUpdate(t *testing.T) {
 	reconcilingGen := int64(3)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
 		reconcilingGen+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.3", "1.3.3", namespace, name)
+		"1.3.3", "1.3.3", namespace, name, "true")
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateInstalling, vz.Status.State)
 	asserts.True(*fakeCompUpdated)
 	asserts.True(result.Requeue)
+}
+
+// TestUpdateFalseMonitorChanges tests the reconcile func with updated generation
+// GIVEN a request to reconcile an verrazzano resource after install is completed
+// WHEN all components have the smaller LastReconciledGeneration but MonitorOverrides returns false
+// THEN ensure a condition with type InstallStarted is not added
+func TestUpdateFalseMonitorChanges(t *testing.T) {
+	initUnitTesing()
+	namespace := "verrazzano"
+	name := "TestUpdate"
+	lastReconciledGeneration := int64(2)
+	reconcilingGen := int64(0)
+	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
+		lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
+		"1.3.0", "1.3.0", namespace, name, "false")
+	defer reset()
+	asserts.NoError(err)
+	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
+	asserts.Nil(fakeCompUpdated)
+	asserts.False(result.Requeue)
 }
 
 func reset() {
@@ -115,7 +135,7 @@ func testUpdate(t *testing.T,
 	//mocker *gomock.Controller, mock *mocks.MockClient,
 	vzCrGen, reconcilingGen, lastReconciledGeneration int64,
 	//mockStatus *mocks.MockStatusWriter,
-	specVer, statusVer, namespace, name string) (*assert.Assertions, *vzapi.Verrazzano, ctrl.Result, *bool, error) {
+	specVer, statusVer, namespace, name, monitorChanges string) (*assert.Assertions, *vzapi.Verrazzano, ctrl.Result, *bool, error) {
 	asserts := assert.New(t)
 
 	config.SetDefaultBomFilePath(testBomFile)
@@ -127,6 +147,7 @@ func testUpdate(t *testing.T,
 	fakeComp := fakeComponent{}
 	fakeComp.ReleaseName = "verrazzano-authproxy"
 	fakeComp.SupportsOperatorInstall = true
+	fakeComp.monitorChanges = monitorChanges
 	var fakeCompUpdated *bool
 	fakeComp.installFunc = func(ctx spi.ComponentContext) error {
 		update := true

--- a/platform-operator/controllers/verrazzano/install_test.go
+++ b/platform-operator/controllers/verrazzano/install_test.go
@@ -36,7 +36,7 @@ func TestUpdate(t *testing.T) {
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
 		lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.0", "1.3.0", namespace, name, "true")
+		"1.3.0", "1.3.0", namespace, name)
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateInstalling, vz.Status.State)
@@ -55,7 +55,7 @@ func TestNoUpdateSameGeneration(t *testing.T) {
 	lastReconciledGeneration := int64(2)
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration, reconcilingGen, lastReconciledGeneration,
-		"1.3.1", "1.3.1", namespace, name, "true")
+		"1.3.1", "1.3.1", namespace, name)
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
@@ -74,7 +74,7 @@ func TestUpdateWithUpgrade(t *testing.T) {
 	lastReconciledGeneration := int64(2)
 	reconcilingGen := int64(0)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t, lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.0", "1.2.0", namespace, name, "true")
+		"1.3.0", "1.2.0", namespace, name)
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateUpgrading, vz.Status.State)
@@ -94,32 +94,12 @@ func TestUpdateOnUpdate(t *testing.T) {
 	reconcilingGen := int64(3)
 	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
 		reconcilingGen+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.3", "1.3.3", namespace, name, "true")
+		"1.3.3", "1.3.3", namespace, name)
 	defer reset()
 	asserts.NoError(err)
 	asserts.Equal(vzapi.VzStateInstalling, vz.Status.State)
 	asserts.True(*fakeCompUpdated)
 	asserts.True(result.Requeue)
-}
-
-// TestUpdateFalseMonitorChanges tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
-// WHEN all components have the smaller LastReconciledGeneration but MonitorOverrides returns false
-// THEN ensure a condition with type InstallStarted is not added
-func TestUpdateFalseMonitorChanges(t *testing.T) {
-	initUnitTesing()
-	namespace := "verrazzano"
-	name := "TestUpdate"
-	lastReconciledGeneration := int64(2)
-	reconcilingGen := int64(0)
-	asserts, vz, result, fakeCompUpdated, err := testUpdate(t,
-		lastReconciledGeneration+1, reconcilingGen, lastReconciledGeneration,
-		"1.3.0", "1.3.0", namespace, name, "false")
-	defer reset()
-	asserts.NoError(err)
-	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
-	asserts.Nil(fakeCompUpdated)
-	asserts.False(result.Requeue)
 }
 
 func reset() {
@@ -135,7 +115,7 @@ func testUpdate(t *testing.T,
 	//mocker *gomock.Controller, mock *mocks.MockClient,
 	vzCrGen, reconcilingGen, lastReconciledGeneration int64,
 	//mockStatus *mocks.MockStatusWriter,
-	specVer, statusVer, namespace, name, monitorChanges string) (*assert.Assertions, *vzapi.Verrazzano, ctrl.Result, *bool, error) {
+	specVer, statusVer, namespace, name string) (*assert.Assertions, *vzapi.Verrazzano, ctrl.Result, *bool, error) {
 	asserts := assert.New(t)
 
 	config.SetDefaultBomFilePath(testBomFile)
@@ -147,7 +127,6 @@ func testUpdate(t *testing.T,
 	fakeComp := fakeComponent{}
 	fakeComp.ReleaseName = "verrazzano-authproxy"
 	fakeComp.SupportsOperatorInstall = true
-	fakeComp.monitorChanges = monitorChanges
 	var fakeCompUpdated *bool
 	fakeComp.installFunc = func(ctx spi.ComponentContext) error {
 		update := true

--- a/tests/e2e/update/overrides/overrides_test.go
+++ b/tests/e2e/update/overrides/overrides_test.go
@@ -41,6 +41,7 @@ var (
 )
 
 var inlineData string
+var monitorChanges bool
 
 var failed = false
 var _ = t.AfterEach(func() {
@@ -95,7 +96,7 @@ func (o PrometheusOperatorOverridesModifier) ModifyCR(cr *vzapi.Verrazzano) {
 		},
 	}
 	cr.Spec.Components.PrometheusOperator.Enabled = &trueVal
-	cr.Spec.Components.PrometheusOperator.MonitorChanges = &trueVal
+	cr.Spec.Components.PrometheusOperator.MonitorChanges = &monitorChanges
 	cr.Spec.Components.PrometheusOperator.ValueOverrides = overrides
 }
 
@@ -121,12 +122,15 @@ func (o PrometheusOperatorValuesModifier) ModifyCR(cr *vzapi.Verrazzano) {
 			},
 		},
 	}
+	cr.Spec.Components.PrometheusOperator.Enabled = &trueVal
+	cr.Spec.Components.PrometheusOperator.MonitorChanges = &monitorChanges
 	cr.Spec.Components.PrometheusOperator.ValueOverrides = overrides
 }
 
 var _ = t.BeforeSuite(func() {
 	m := PrometheusOperatorOverridesModifier{}
 	inlineData = oldInlineData
+	monitorChanges = true
 	update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 	_ = update.GetCR()
 })
@@ -175,12 +179,13 @@ var _ = t.Describe("Post Install Overrides", func() {
 		})
 	})
 
-	t.Context("Test overrides update", func() {
-		// Update the overrides resources listed in Verrazzano and verify
-		// that the new values have been applied to promtheus-operator
+	t.Context("Test no update with monitorChanges false", func() {
+		// Update the overrides resources listed in Verrazzano and set monitorChanges to false and verify
+		// that the new values have not been applied to Prometheus Operator
 		t.Context("Update Overrides", func() {
 			t.It("Update Inline Data", func() {
 				inlineData = newInlineData
+				monitorChanges = false
 				m := PrometheusOperatorOverridesModifier{}
 				update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 				_ = update.GetCR()
@@ -198,6 +203,33 @@ var _ = t.Describe("Post Install Overrides", func() {
 				gomega.Eventually(func() error {
 					return pkg.UpdateSecret(&testSecret)
 				}, waitTimeout, pollingInterval).Should(gomega.BeNil())
+			})
+		})
+
+		t.It("Verify override values are applied", func() {
+			gomega.Eventually(func() bool {
+				return checkValues(overrideOldValue)
+			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+		})
+
+		// Verify that re-install succeeds
+		t.It("Verify Verrazzano re-install is successful", func() {
+			gomega.Eventually(func() error {
+				return vzReady()
+			}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "Expected to get Verrazzano CR with Ready state")
+		})
+	})
+
+	t.Context("Test overrides update", func() {
+		// Change monitorChanges to true in Verrazzano and verify
+		// that the new values have been applied to promtheus-operator
+		t.Context("Update Overrides", func() {
+			t.It("Update Inline Data", func() {
+				inlineData = newInlineData
+				monitorChanges = true
+				m := PrometheusOperatorOverridesModifier{}
+				update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
+				_ = update.GetCR()
 			})
 		})
 

--- a/tests/e2e/update/overrides/overrides_test.go
+++ b/tests/e2e/update/overrides/overrides_test.go
@@ -41,7 +41,6 @@ var (
 )
 
 var inlineData string
-var monitorChanges bool
 
 var failed = false
 var _ = t.AfterEach(func() {
@@ -96,7 +95,7 @@ func (o PrometheusOperatorOverridesModifier) ModifyCR(cr *vzapi.Verrazzano) {
 		},
 	}
 	cr.Spec.Components.PrometheusOperator.Enabled = &trueVal
-	cr.Spec.Components.PrometheusOperator.MonitorChanges = &monitorChanges
+	cr.Spec.Components.PrometheusOperator.MonitorChanges = &trueVal
 	cr.Spec.Components.PrometheusOperator.ValueOverrides = overrides
 }
 
@@ -122,15 +121,12 @@ func (o PrometheusOperatorValuesModifier) ModifyCR(cr *vzapi.Verrazzano) {
 			},
 		},
 	}
-	cr.Spec.Components.PrometheusOperator.Enabled = &trueVal
-	cr.Spec.Components.PrometheusOperator.MonitorChanges = &monitorChanges
 	cr.Spec.Components.PrometheusOperator.ValueOverrides = overrides
 }
 
 var _ = t.BeforeSuite(func() {
 	m := PrometheusOperatorOverridesModifier{}
 	inlineData = oldInlineData
-	monitorChanges = true
 	update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 	_ = update.GetCR()
 })
@@ -179,13 +175,12 @@ var _ = t.Describe("Post Install Overrides", func() {
 		})
 	})
 
-	t.Context("Test no update with monitorChanges false", func() {
-		// Update the overrides resources listed in Verrazzano and set monitorChanges to false and verify
-		// that the new values have not been applied to Prometheus Operator
+	t.Context("Test overrides update", func() {
+		// Update the overrides resources listed in Verrazzano and verify
+		// that the new values have been applied to promtheus-operator
 		t.Context("Update Overrides", func() {
 			t.It("Update Inline Data", func() {
 				inlineData = newInlineData
-				monitorChanges = false
 				m := PrometheusOperatorOverridesModifier{}
 				update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 				_ = update.GetCR()
@@ -203,33 +198,6 @@ var _ = t.Describe("Post Install Overrides", func() {
 				gomega.Eventually(func() error {
 					return pkg.UpdateSecret(&testSecret)
 				}, waitTimeout, pollingInterval).Should(gomega.BeNil())
-			})
-		})
-
-		t.It("Verify override values are applied", func() {
-			gomega.Eventually(func() bool {
-				return checkValues(overrideOldValue)
-			}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
-		})
-
-		// Verify that re-install succeeds
-		t.It("Verify Verrazzano re-install is successful", func() {
-			gomega.Eventually(func() error {
-				return vzReady()
-			}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "Expected to get Verrazzano CR with Ready state")
-		})
-	})
-
-	t.Context("Test overrides update", func() {
-		// Change monitorChanges to true in Verrazzano and verify
-		// that the new values have been applied to promtheus-operator
-		t.Context("Update Overrides", func() {
-			t.It("Update Inline Data", func() {
-				inlineData = newInlineData
-				monitorChanges = true
-				m := PrometheusOperatorOverridesModifier{}
-				update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
-				_ = update.GetCR()
 			})
 		})
 


### PR DESCRIPTION
This change is a backport of a commit that doesn't run install on  a component during update if the monitorChanges is set to false.

Fixes VZ-6006

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
