### PR TITLE
VZ-6073 remove dependency on kubectl

### DIFF
--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -5,15 +5,17 @@ package install
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
+	"io/ioutil"
+	"net/http"
+	"os"
 	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
@@ -24,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -89,6 +92,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			return err
 		}
 	}
+	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Installing Verrazzano version %s\n", version))
 
 	// Get the timeout value for the install command
 	timeout, err := cmdhelpers.GetWaitTimeout(cmd)
@@ -108,14 +112,14 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 		return err
 	}
 
-	// Apply the Verrazzano operator.yaml.
-	err = applyPlatformOperatorYaml(vzHelper, version)
+	// Get the controller runtime client
+	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
 		return err
 	}
 
-	// Get the controller runtime client
-	client, err := vzHelper.GetClient(cmd)
+	// Apply the Verrazzano operator.yaml.
+	err = applyPlatformOperatorYaml(client, vzHelper, fmt.Sprintf(constants.VerrazzanoOperatorURL, version))
 	if err != nil {
 		return err
 	}
@@ -147,19 +151,31 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 }
 
 // applyPlatformOperatorYaml applies a given version of the platform operator yaml file
-func applyPlatformOperatorYaml(vzHelper helpers.VZHelper, version string) error {
-	// Apply the Verrazzano operator.yaml. A valid version must be specified for this to succeed.
-	kubectl := exec.Command("kubectl", "apply", "-f", fmt.Sprintf("https://github.com/verrazzano/verrazzano/releases/download/%s/operator.yaml", version)) //nolint:gosec //#nosec G204
-	var stdout bytes.Buffer
-	kubectl.Stdout = &stdout
-	var stderr bytes.Buffer
-	kubectl.Stderr = &stderr
-	cmdErr := kubectl.Run()
-	if cmdErr != nil {
-		return fmt.Errorf("Failed to download operator.yaml: %s", stderr.String())
+func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, url string) error {
+	// Get the Verrazzano operator.yaml
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("Failed to access the Verrazzano operator.yaml file: %s", err.Error())
 	}
-	fmt.Fprintf(vzHelper.GetOutputStream(), stdout.String())
 
+	// Store response in a temporary file
+	tmpFile, err := ioutil.TempFile("", "vz")
+	if err != nil {
+		return fmt.Errorf("Failed to install the Verrazzano operator.yaml file: %s", err.Error())
+	}
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.ReadFrom(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to install the Verrazzano operator.yaml file: %s", err.Error())
+	}
+
+	// Apply the Verrazzano operator.yaml. A valid version must be specified for this to succeed.
+	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", url))
+	yamlApplier := k8sutil.NewYAMLApplier(client, "")
+	err = yamlApplier.ApplyF(tmpFile.Name())
+	if err != nil {
+		return fmt.Errorf("Failed to apply the Verrazzano operator.yaml file: %s", err.Error())
+	}
 	return nil
 }
 
@@ -191,6 +207,10 @@ func waitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper) (s
 	pod := &corev1.Pod{}
 	seconds := 0
 	for {
+		time.Sleep(verrazzanoPlatformOperatorWait * time.Second)
+		seconds += verrazzanoPlatformOperatorWait
+		fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("\rWaiting for verrazzano-platform-operator to be ready before starting install - %d seconds", seconds))
+
 		err := client.Get(context.TODO(), types.NamespacedName{Namespace: podList.Items[0].Namespace, Name: podList.Items[0].Name}, pod)
 		if err != nil {
 			return "", err
@@ -214,10 +234,6 @@ func waitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper) (s
 			fmt.Fprintf(vzHelper.GetOutputStream(), "\n")
 			break
 		}
-
-		time.Sleep(verrazzanoPlatformOperatorWait * time.Second)
-		seconds += verrazzanoPlatformOperatorWait
-		fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("\rWaiting for verrazzano-platform-operator to be ready before starting install - %d seconds", seconds))
 	}
 	return pod.Name, nil
 }

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -152,8 +152,8 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 
 // applyPlatformOperatorYaml applies a given version of the platform operator yaml file
 func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, version string) error {
-	// Get the Verrazzano operator.yaml
-	resp, err := http.Get(fmt.Sprintf("https://github.com/verrazzano/verrazzano/releases/download/%s/operator.yaml", version))
+	// Get the Verrazzano operator.yaml - use a string constant for the URL to avoid security warnings
+	resp, err := http.Get(fmt.Sprintf(constants.VerrazzanoOperatorURL, version))
 	if err != nil {
 		return fmt.Errorf("Failed to access the Verrazzano operator.yaml file: %s", err.Error())
 	}
@@ -170,7 +170,8 @@ func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, 
 	}
 
 	// Apply the Verrazzano operator.yaml. A valid version must be specified for this to succeed.
-	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", resp.Request.URL.String()))
+	url := fmt.Sprintf(constants.VerrazzanoOperatorURL, version)
+	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", url))
 	yamlApplier := k8sutil.NewYAMLApplier(client, "")
 	err = yamlApplier.ApplyF(tmpFile.Name())
 	if err != nil {

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -119,7 +119,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	}
 
 	// Apply the Verrazzano operator.yaml.
-	err = applyPlatformOperatorYaml(client, vzHelper, fmt.Sprintf(constants.VerrazzanoOperatorURL, version))
+	err = applyPlatformOperatorYaml(client, vzHelper, version)
 	if err != nil {
 		return err
 	}
@@ -151,9 +151,9 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 }
 
 // applyPlatformOperatorYaml applies a given version of the platform operator yaml file
-func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, url string) error {
+func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, version string) error {
 	// Get the Verrazzano operator.yaml
-	resp, err := http.Get(url)
+	resp, err := http.Get(fmt.Sprintf("https://github.com/verrazzano/verrazzano/releases/download/%s/operator.yaml", version))
 	if err != nil {
 		return fmt.Errorf("Failed to access the Verrazzano operator.yaml file: %s", err.Error())
 	}
@@ -170,7 +170,7 @@ func applyPlatformOperatorYaml(client client.Client, vzHelper helpers.VZHelper, 
 	}
 
 	// Apply the Verrazzano operator.yaml. A valid version must be specified for this to succeed.
-	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", url))
+	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", resp.Request.URL.String()))
 	yamlApplier := k8sutil.NewYAMLApplier(client, "")
 	err = yamlApplier.ApplyF(tmpFile.Name())
 	if err != nil {

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -46,3 +46,6 @@ const (
 
 // VerrazzanoReleaseList - API for getting the list of Verrazzano releases
 const VerrazzanoReleaseList = "https://api.github.com/repos/verrazzano/verrazzano/releases"
+
+// VerrazzanoOperatorURL - URL for downloading Verrazzano releases
+const VerrazzanoOperatorURL = "https://github.com/verrazzano/verrazzano/releases/download/%s/operator.yaml"


### PR DESCRIPTION
# Description

Remove dependency on kubectl from the vz command-line utility

Fixes VZ-6073

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
