### PR TITLE
VZ-5891 Add Verrazzano CLI for ARM to existing release distribution

### DIFF
--- a/ci/scripts/save_tooling.sh
+++ b/ci/scripts/save_tooling.sh
@@ -27,6 +27,7 @@ tar -czf ${WORKSPACE}/verrazzano-analysis-linux-amd64.tar.gz -C linux_amd64 .
 tar -czf ${WORKSPACE}/verrazzano-analysis-darwin-amd64.tar.gz -C darwin_amd64 .
 tar -czf ${WORKSPACE}/vz-linux-amd64.tar.gz -C linux_amd64 .
 tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
+tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
 
 cd ${WORKSPACE}
 sha256sum k8s-dump-cluster.sh > k8s-dump-cluster.sh.sha256
@@ -34,6 +35,7 @@ sha256sum verrazzano-analysis-linux-amd64.tar.gz > verrazzano-analysis-linux-amd
 sha256sum verrazzano-analysis-darwin-amd64.tar.gz > verrazzano-analysis-darwin-amd64.tar.gz.sha256
 sha256sum vz-linux-amd64.tar.gz > vz-linux-amd64.tar.gz.sha256
 sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
+sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/k8s-dump-cluster.sh --file k8s-dump-cluster.sh
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/k8s-dump-cluster.sh.sha256 --file k8s-dump-cluster.sh.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/verrazzano-analysis-linux-amd64.tar.gz --file verrazzano-analysis-linux-amd64.tar.gz
@@ -44,6 +46,8 @@ oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} 
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/verrazzano-analysis-darwin-amd64.tar.gz.sha256 --file verrazzano-analysis-darwin-amd64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/k8s-dump-cluster.sh --file k8s-dump-cluster.sh
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/k8s-dump-cluster.sh.sha256 --file k8s-dump-cluster.sh.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/verrazzano-analysis-linux-amd64.tar.gz --file verrazzano-analysis-linux-amd64.tar.gz
@@ -54,3 +58,5 @@ oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} 
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/verrazzano-analysis-darwin-amd64.tar.gz.sha256 --file verrazzano-analysis-darwin-amd64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256

--- a/ci/scripts/update_periodic_on_success.sh
+++ b/ci/scripts/update_periodic_on_success.sh
@@ -46,6 +46,8 @@ oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OC
 oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/verrazzano-analysis-darwin-amd64.tar.gz.sha256 --file verrazzano-analysis-darwin-amd64.tar.gz.sha256
 oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
 oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/k8s-dump-cluster.sh --file k8s-dump-cluster.sh
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/k8s-dump-cluster.sh.sha256 --file k8s-dump-cluster.sh.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/verrazzano-analysis-linux-amd64.tar.gz --file verrazzano-analysis-linux-amd64.tar.gz
@@ -56,6 +58,8 @@ oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} 
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/verrazzano-analysis-darwin-amd64.tar.gz.sha256 --file verrazzano-analysis-darwin-amd64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-periodic-test/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
 
 # Generate a Verrazzano full Zip for private registry testing
 

--- a/release/scripts/common.sh
+++ b/release/scripts/common.sh
@@ -17,6 +17,8 @@ declare -a releaseArtifacts=("operator.yaml"
                              "verrazzano-analysis-linux-amd64.tar.gz.sha256"
                              "vz-darwin-amd64.tar.gz"
                              "vz-darwin-amd64.tar.gz.sha256"
+                             "vz-darwin-arm64.tar.gz"
+                             "vz-darwin-arm64.tar.gz.sha256"
                              "vz-linux-amd64.tar.gz"
                              "vz-linux-amd64.tar.gz.sha256")
 

--- a/release/scripts/verify_github_release.sh
+++ b/release/scripts/verify_github_release.sh
@@ -52,6 +52,7 @@ function verify_released_artifacts() {
   ${SHA_CMD} verrazzano-analysis-darwin-amd64.tar.gz.sha256
   ${SHA_CMD} verrazzano-analysis-linux-amd64.tar.gz.sha256
   ${SHA_CMD} vz-darwin-amd64.tar.gz.sha256
+  ${SHA_CMD} vz-darwin-arm64.tar.gz.sha256
   ${SHA_CMD} vz-linux-amd64.tar.gz.sha256
 
   # Latest tag is automatic, do we really need to check ? If required, better compare the files from the two directories
@@ -70,6 +71,7 @@ function verify_released_artifacts() {
   ${SHA_CMD} verrazzano-analysis-darwin-amd64.tar.gz.sha256
   ${SHA_CMD} verrazzano-analysis-linux-amd64.tar.gz.sha256
   ${SHA_CMD} vz-darwin-amd64.tar.gz.sha256
+  ${SHA_CMD} vz-darwin-arm64.tar.gz.sha256
   ${SHA_CMD} vz-linux-amd64.tar.gz.sha256
 }
 

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -38,6 +38,10 @@ go-build:
 		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
 		-o out/darwin_amd64/vz \
 		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
+	GOOS=darwin GOARCH=arm64 $(GO) build \
+		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
+		-o out/darwin_arm64/vz \
+		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
 	GOOS=linux GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
 		-o out/linux_amd64/vz \


### PR DESCRIPTION
This change adds the CLI for Darwin ARM64 as an artifact to get released alongside existing distributions

Fixes VZ-5897

# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
