### PR TITLE
JIRA: VZ-5944 Allow for multiple authorization rule conditions (fix to make attribute an array)

### DIFF
--- a/application-operator/apis/oam/v1alpha1/ingresstrait_authorization.go
+++ b/application-operator/apis/oam/v1alpha1/ingresstrait_authorization.go
@@ -17,7 +17,7 @@ type AuthorizationRuleCondition struct {
 // AuthorizationRule matches requests from a list of request principals that access a specific path subject to a
 // list of conditions.
 type AuthorizationRule struct {
-	From *AuthorizationRuleFrom      `json:"from,omitempty"`
+	From *AuthorizationRuleFrom        `json:"from,omitempty"`
 	When []*AuthorizationRuleCondition `json:"when,omitempty"`
 }
 

--- a/application-operator/apis/oam/v1alpha1/ingresstrait_authorization.go
+++ b/application-operator/apis/oam/v1alpha1/ingresstrait_authorization.go
@@ -18,7 +18,7 @@ type AuthorizationRuleCondition struct {
 // list of conditions.
 type AuthorizationRule struct {
 	From *AuthorizationRuleFrom      `json:"from,omitempty"`
-	When *AuthorizationRuleCondition `json:"when,omitempty"`
+	When []*AuthorizationRuleCondition `json:"when,omitempty"`
 }
 
 // AuthorizationPolicy defines the set of rules for authorizing a request.

--- a/application-operator/apis/oam/v1alpha1/zz_generated.deepcopy.go
+++ b/application-operator/apis/oam/v1alpha1/zz_generated.deepcopy.go
@@ -49,8 +49,14 @@ func (in *AuthorizationRule) DeepCopyInto(out *AuthorizationRule) {
 	}
 	if in.When != nil {
 		in, out := &in.When, &out.When
-		*out = new(AuthorizationRuleCondition)
-		(*in).DeepCopyInto(*out)
+		*out = make([]*AuthorizationRuleCondition, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(AuthorizationRuleCondition)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 }
 

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -837,11 +837,15 @@ func createAuthorizationPolicyRule(rule *vzapi.AuthorizationRule, path string) (
 		},
 	}
 	if rule.When != nil {
-		condition := &v1beta1.Condition{
-			Key:    rule.When.Key,
-			Values: rule.When.Values,
+		conditions := []*v1beta1.Condition{}
+		for _, vzCondition := range rule.When {
+			condition := &v1beta1.Condition{
+				Key:    vzCondition.Key,
+				Values: vzCondition.Values,
+			}
+			conditions = append(conditions, condition)
 		}
-		authzRule.When = []*v1beta1.Condition{condition}
+		authzRule.When = conditions
 	}
 
 	return &authzRule, nil

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_ingresstraits.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/oam.verrazzano.io_ingresstraits.yaml
@@ -79,11 +79,21 @@ spec:
                           for an ingress trait.
                         properties:
                           authorizationPolicy:
+                            description: AuthorizationPolicy defines the set of rules
+                              for authorizing a request.
                             properties:
                               rules:
+                                description: A list of rules to match the request.
+                                  A match occurs when at least one rule matches the
+                                  request.
                                 items:
+                                  description: AuthorizationRule matches requests
+                                    from a list of request principals that access
+                                    a specific path subject to a list of conditions.
                                   properties:
                                     from:
+                                      description: AuthorizationRuleFrom includes
+                                        a list of request principals.
                                       properties:
                                         requestPrincipals:
                                           items:
@@ -91,14 +101,18 @@ spec:
                                           type: array
                                       type: object
                                     when:
-                                      properties:
-                                        key:
-                                          type: string
-                                        values:
-                                          items:
+                                      items:
+                                        description: AuthorizationRuleCondition specifies
+                                          additional required attributes.
+                                        properties:
+                                          key:
                                             type: string
-                                          type: array
-                                      type: object
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
                                   type: object
                                 type: array
                             type: object

--- a/tests/testdata/jwt/helidon/hello-helidon-app.yaml
+++ b/tests/testdata/jwt/helidon/hello-helidon-app.yaml
@@ -32,7 +32,7 @@ spec:
                           - from:
                               requestPrincipals:
                                 - "*"
-                              when:
-                                - key: request.auth.claims[realm_access][roles]
-                                  values:
-                                    - "customer"
+                            when:
+                              - key: request.auth.claims[realm_access][roles]
+                                values:
+                                  - "customer"


### PR DESCRIPTION
# Description

Fixed the authorization rule conditions to be an array, allowing for multiple keys and associated values.

Fixes VZ-5944

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
