### PR TITLE
VZ-6076 Add retry for finding VPO pod

### DIFF
--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -194,7 +194,7 @@ func waitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper) (s
 	for {
 		retryCount++
 		if retryCount > 60 {
-			return "", fmt.Errorf("Failed to find a Verrazzano platform-operator pod running")
+			return "", fmt.Errorf("%s pod not found in namespace %s", verrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
 		}
 		time.Sleep(verrazzanoPlatformOperatorWait * time.Second)
 		seconds += verrazzanoPlatformOperatorWait
@@ -207,10 +207,10 @@ func waitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper) (s
 				LabelSelector: labelSelector,
 			})
 		if err != nil {
-			continue
+			return "", fmt.Errorf("Failed to list pods %v", err)
 		}
 		if len(podList.Items) == 0 {
-			return "", fmt.Errorf("%s pod not found in namespace %s", verrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
+			continue
 		}
 		if len(podList.Items) > 1 {
 			return "", fmt.Errorf("More than one %s pod was found in namespace %s", verrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)


### PR DESCRIPTION
# Description

Add retry logic for finding the VPO pod.  The install command would sometimes fail because it didn't find the vpo pod on the first try.

Fixes VZ-6076

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
