### PR TITLE
VZ-6049 Refactor Prometheus job_name constant to one place and use that everywhere. Do likewise for verrazzano-monitoring NS constant in platform-operator

### DIFF
--- a/application-operator/controllers/metricsbinding/metricsbinding_controller.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_controller.go
@@ -202,7 +202,7 @@ func (r *Reconciler) deleteScrapeConfig(metricsBinding *vzapi.MetricsBinding, co
 	// Delete scrape config with job name matching resource
 	scrapeConfigs := promConfig.Search(prometheusScrapeConfigsLabel).Children()
 	for index, scrapeConfig := range scrapeConfigs {
-		existingJobName := scrapeConfig.Search(prometheusJobNameLabel).Data()
+		existingJobName := scrapeConfig.Search(constants.PrometheusJobNameKey).Data()
 		createdJobName := createJobName(metricsBinding)
 		if existingJobName == createdJobName {
 			err = promConfig.ArrayRemoveP(index, prometheusScrapeConfigsLabel)
@@ -288,7 +288,7 @@ func (r *Reconciler) createOrUpdateScrapeConfig(metricsBinding *vzapi.MetricsBin
 	existingUpdated := false
 	scrapeConfigs := promConfig.Search(prometheusScrapeConfigsLabel).Children()
 	for index, scrapeConfig := range scrapeConfigs {
-		existingJobName := scrapeConfig.Search(prometheusJobNameLabel).Data()
+		existingJobName := scrapeConfig.Search(constants.PrometheusJobNameKey).Data()
 		if existingJobName == createdJobName {
 			// Remove and recreate scrape config
 			err = promConfig.ArrayRemoveP(index, prometheusScrapeConfigsLabel)

--- a/application-operator/controllers/metricsbinding/metricsbinding_utils.go
+++ b/application-operator/controllers/metricsbinding/metricsbinding_utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Jeffail/gabs/v2"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,7 +19,6 @@ import (
 const (
 	prometheusConfigKey          = "prometheus.yml"
 	prometheusScrapeConfigsLabel = "scrape_configs"
-	prometheusJobNameLabel       = "job_name"
 
 	configMapKind       = "ConfigMap"
 	configMapAPIVersion = "v1"
@@ -57,5 +57,5 @@ func getConfigData(configMap *v1.ConfigMap) (*gabs.Container, error) {
 
 // Formats job name as specified by the Prometheus config
 func formatJobName(jobName string) string {
-	return "job_name: " + jobName + "\n"
+	return fmt.Sprintf("%s: %s\n", constants.PrometheusJobNameKey, jobName)
 }

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -59,7 +59,6 @@ const (
 	// Markers used during the processing of Prometheus scrape configurations
 	prometheusConfigKey          = "prometheus.yml"
 	prometheusScrapeConfigsLabel = "scrape_configs"
-	prometheusJobNameLabel       = "job_name"
 	prometheusClusterNameLabel   = "verrazzano_cluster"
 
 	// Annotation names for metrics read by the controller
@@ -109,7 +108,7 @@ tls_config:
 
 // prometheusScrapeConfigTemplate configuration for general Prometheus scrape target template
 // Used to add new scrape config to a Prometheus configmap
-const prometheusScrapeConfigTemplate = `job_name: ##JOB_NAME##
+const prometheusScrapeConfigTemplate = vzconst.PrometheusJobNameKey + `: ##JOB_NAME##
 ##SSL_PROTOCOL##
 kubernetes_sd_configs:
 - role: pod
@@ -154,7 +153,7 @@ relabel_configs:
 
 // prometheusWLSScrapeConfigTemplate configuration for WebLogic Prometheus scrape target template
 // Used to add new WebLogic scrape config to a Prometheus configmap
-const prometheusWLSScrapeConfigTemplate = `job_name: ##JOB_NAME##
+const prometheusWLSScrapeConfigTemplate = vzconst.PrometheusJobNameKey + `: ##JOB_NAME##
 ##SSL_PROTOCOL##
 kubernetes_sd_configs:
 - role: pod
@@ -652,7 +651,7 @@ func mutatePrometheusScrapeConfig(ctx context.Context, trait *vzapi.MetricsTrait
 		}
 		existingReplaced := false
 		for _, oldScrapeConfig := range oldScrapeConfigs {
-			oldScrapeJob := oldScrapeConfig.Search(prometheusJobNameLabel).Data()
+			oldScrapeJob := oldScrapeConfig.Search(vzconst.PrometheusJobNameKey).Data()
 			if newScrapeJob == oldScrapeJob {
 				// If the scrape config should be removed then skip adding it to the result slice.
 				// This will occur in three situations.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,6 +68,10 @@ const IstioSystemNamespace = "istio-system"
 // IngressNamespace - the NGINX ingress namespace
 const IngressNamespace = "ingress-nginx"
 
+// PrometheusOperatorNamespace - the namespace where Verrazzano installs Prometheus Operator
+// and its related components.
+const PrometheusOperatorNamespace = "verrazzano-monitoring"
+
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
 
@@ -107,6 +111,8 @@ const DefaultVerrazzanoCASecretName = "verrazzano-ca-certificate-secret"
 
 // VmiPromConfigName - The name of the prometheus config map
 const VmiPromConfigName string = "vmi-system-prometheus-config"
+
+const PrometheusJobNameKey = "job_name"
 
 // TestPrometheusJobScrapeInterval - The string 0s representing a test only prometheus config scrape interval
 const TestPrometheusJobScrapeInterval = "0s"

--- a/pkg/scrapeconfigutils/edit_scrapeconfig.go
+++ b/pkg/scrapeconfigutils/edit_scrapeconfig.go
@@ -5,12 +5,11 @@ package scrapeconfigutils
 
 import (
 	"github.com/Jeffail/gabs/v2"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"sigs.k8s.io/yaml"
 )
 
-const jobNameKey = "job_name"
-
-// EditScrapeJob edits a scrape config that and adds or replaces the specified job with the new scrape
+// EditScrapeJob edits a scrape config and adds or replaces the specified job with the new scrape
 // config for that job.
 func EditScrapeJob(scrapeConfigs *gabs.Container, editScrapeJobName string, newScrapeConfig *gabs.Container) (*gabs.Container, error) {
 	scrapeJobIndex := findScrapeJob(scrapeConfigs, editScrapeJobName)
@@ -35,7 +34,7 @@ func EditScrapeJob(scrapeConfigs *gabs.Container, editScrapeJobName string, newS
 // findScrapeJob returns the index of the given job name in the scrapeConfigs list, -1 if not found.
 func findScrapeJob(scrapeConfigs *gabs.Container, jobNameToFind string) int {
 	for index, scrapeConfig := range scrapeConfigs.Children() {
-		scrapeJobName := scrapeConfig.Search(jobNameKey).Data()
+		scrapeJobName := scrapeConfig.Search(constants.PrometheusJobNameKey).Data()
 		if jobNameToFind == scrapeJobName {
 			return index
 		}

--- a/pkg/scrapeconfigutils/edit_scrapeconfig_test.go
+++ b/pkg/scrapeconfigutils/edit_scrapeconfig_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 )
 
 const newJobName = "newjob"
 const existingJobName = "prometheus"
-const newScrapeJob = `
-job_name: ` + newJobName + `
+const newScrapeJob = constants.PrometheusJobNameKey + `: ` + newJobName + `
 kubernetes_sd_configs:
 - role: endpoints
 relabel_configs:
@@ -25,8 +25,7 @@ scrape_interval: 20s
 scrape_timeout: 15s
 `
 
-const replaceExistingScrapeJob = `
-job_name: ` + existingJobName + `
+const replaceExistingScrapeJob = constants.PrometheusJobNameKey + `: ` + existingJobName + `
 scrape_interval: 20s
 scrape_timeout: 15s
 static_configs:

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -27,12 +27,11 @@ const (
 	prometheusConfigMapName  = "vmi-system-prometheus-config"
 	prometheusYamlKey        = "prometheus.yml"
 	scrapeConfigsKey         = "scrape_configs"
-	jobNameKey               = "job_name"
 	prometheusConfigBasePath = "/etc/prometheus/config/"
 	managedCertsBasePath     = "/etc/prometheus/managed-cluster-ca-certs/"
 	configMapKind            = "ConfigMap"
 	configMapVersion         = "v1"
-	scrapeConfigTemplate     = `job_name: ##JOB_NAME##
+	scrapeConfigTemplate     = constants.PrometheusJobNameKey + `: ##JOB_NAME##
 scrape_interval: 20s
 scrape_timeout: 15s
 scheme: https
@@ -141,7 +140,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutatePrometheusConfigMap(vmc *clus
 	}
 	existingReplaced := false
 	for _, oldScrapeConfig := range oldScrapeConfigs {
-		oldScrapeJob := oldScrapeConfig.Search(jobNameKey).Data()
+		oldScrapeJob := oldScrapeConfig.Search(constants.PrometheusJobNameKey).Data()
 		if vmc.Name == oldScrapeJob {
 			if vmc.DeletionTimestamp == nil || vmc.DeletionTimestamp.IsZero() {
 				// need to replace existing entry for this vmc

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -351,7 +351,7 @@ func TestCreateVMCNoCACert(t *testing.T) {
 // THEN ensure all the objects are created
 func TestCreateVMCWithExistingScrapeConfiguration(t *testing.T) {
 	namespace := "verrazzano-mc"
-	jobs := `  - job_name: cluster1
+	jobs := `  - ` + constants.PrometheusJobNameKey + `: cluster1
     scrape_interval: 20s
     scrape_timeout: 15s
     scheme: http`
@@ -432,7 +432,7 @@ scrape_configs:
 // THEN ensure all the objects are created (existing configuration is replaced)
 func TestReplaceExistingScrapeConfiguration(t *testing.T) {
 	namespace := "verrazzano-mc"
-	jobs := `  - job_name: test
+	jobs := `  - ` + constants.PrometheusJobNameKey + `: test
     scrape_interval: 20s
     scrape_timeout: 15s
     scheme: http`
@@ -678,11 +678,11 @@ func TestDeleteVMC(t *testing.T) {
 			return nil
 		})
 
-	jobs := `  - job_name: test
+	jobs := `  - ` + constants.PrometheusJobNameKey + `: test
     scrape_interval: 20s
     scrape_timeout: 15s
     scheme: http
-  - job_name: test2
+  - ` + constants.PrometheusJobNameKey + `: test2
     scrape_interval: 20s
     scrape_timeout: 15s
     scheme: http`
@@ -727,7 +727,7 @@ scrape_configs:
 
 			asserts.NotNil(prometheusYaml, "No prometheus config yaml found")
 			asserts.NotNil(scrapeConfig, "No scrape configs found")
-			asserts.Equal("test2", scrapeConfig.Path("job_name").Data(), "Expected scrape config not found")
+			asserts.Equal("test2", scrapeConfig.Path(constants.PrometheusJobNameKey).Data(), "Expected scrape config not found")
 
 			return nil
 		})
@@ -762,7 +762,7 @@ scrape_configs:
 				return err
 			}
 			asserts.Len(scrapeConfigs.Children(), 1, "Expected only one scrape config")
-			scrapeJobName := scrapeConfigs.Children()[0].Search(jobNameKey).Data()
+			scrapeJobName := scrapeConfigs.Children()[0].Search(constants.PrometheusJobNameKey).Data()
 			asserts.Equal("test2", scrapeJobName)
 			return nil
 		})
@@ -1954,7 +1954,7 @@ func getScrapeConfig(prometheusYaml string, name string) (*gabs.Container, error
 func getJob(scrapeConfigs []*gabs.Container, name string) *gabs.Container {
 	var job *gabs.Container
 	for _, scrapeConfig := range scrapeConfigs {
-		jobName := scrapeConfig.Search(jobNameKey).Data()
+		jobName := scrapeConfig.Search(constants.PrometheusJobNameKey).Data()
 		if jobName == name {
 			job = scrapeConfig
 			break

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -6,10 +6,12 @@ package authz
 import (
 	"bufio"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,7 +32,6 @@ const prometheusConfigMapName string = "prometheus.yml"
 const prometheusFooScrapeName string = "authpolicy-appconf_default_foo_springboot-frontend"
 const prometheusBarScrapeName string = "authpolicy-appconf_default_bar_springboot-frontend"
 const prometheusNoIstioScrapeName string = "authpolicy-appconf_default_noistio_springboot-frontend"
-const prometheusJobName string = "job_name"
 const prometheusHTTPSScheme string = "scheme: https"
 
 var expectedPodsFoo = []string{"sleep-workload", "springboot-frontend-workload", "springboot-backend-workload"}
@@ -510,7 +511,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				if strings.Contains(currentString, prometheusFooScrapeName) {
 					for scanner.Scan() {
 						innerString := scanner.Text()
-						if strings.Contains(innerString, prometheusJobName) {
+						if strings.Contains(innerString, constants.PrometheusJobNameKey) {
 							break
 						}
 						if strings.Contains(innerString, prometheusHTTPSScheme) {
@@ -548,7 +549,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				if strings.Contains(currentString, prometheusBarScrapeName) {
 					for scanner.Scan() {
 						innerString := scanner.Text()
-						if strings.Contains(innerString, prometheusJobName) {
+						if strings.Contains(innerString, constants.PrometheusJobNameKey) {
 							break
 						}
 						if strings.Contains(innerString, prometheusHTTPSScheme) {
@@ -586,7 +587,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 				if strings.Contains(currentString, prometheusNoIstioScrapeName) {
 					for scanner.Scan() {
 						innerString := scanner.Text()
-						if strings.Contains(innerString, prometheusJobName) {
+						if strings.Contains(innerString, constants.PrometheusJobNameKey) {
 							break
 						}
 						if strings.Contains(innerString, prometheusHTTPSScheme) {

--- a/tests/e2e/registry/registry_test.go
+++ b/tests/e2e/registry/registry_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,8 +45,8 @@ var listOfNamespaces = []string{
 	"monitoring",
 	"verrazzano-install",
 	"verrazzano-mc",
-	"verrazzano-system",
-	"verrazzano-monitoring",
+	constants.VerrazzanoSystemNamespace,
+	constants.VerrazzanoMonitoringNamespace,
 }
 
 var t = framework.NewTestFramework("registry")

--- a/tests/e2e/update/overrides/overrides_test.go
+++ b/tests/e2e/update/overrides/overrides_test.go
@@ -5,11 +5,12 @@ package overrides
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/verrazzano/verrazzano/tests/e2e/update"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -24,16 +25,15 @@ import (
 )
 
 const (
-	waitTimeout                          = 5 * time.Minute
-	pollingInterval                      = 5 * time.Second
-	overrideConfigMapSecretName   string = "test-overrides-1"
-	verrazzanoMonitoringNamespace string = "verrazzano-monitoring"
-	dataKey                       string = "values.yaml"
-	overrideKey                   string = "override"
-	inlineOverrideKey             string = "inlineOverride"
-	overrideOldValue              string = "true"
-	overrideNewValue              string = "false"
-	deploymentName                string = "prometheus-operator-kube-p-operator"
+	waitTimeout                        = 5 * time.Minute
+	pollingInterval                    = 5 * time.Second
+	overrideConfigMapSecretName string = "test-overrides-1"
+	dataKey                     string = "values.yaml"
+	overrideKey                 string = "override"
+	inlineOverrideKey           string = "inlineOverride"
+	overrideOldValue            string = "true"
+	overrideNewValue            string = "false"
+	deploymentName              string = "prometheus-operator-kube-p-operator"
 )
 
 var (
@@ -313,9 +313,9 @@ func checkValues(overrideValue string) bool {
 	labelMatch := map[string]string{overrideKey: overrideValue}
 	pods, err := pkg.GetPodsFromSelector(&metav1.LabelSelector{
 		MatchLabels: labelMatch,
-	}, verrazzanoMonitoringNamespace)
+	}, constants.VerrazzanoMonitoringNamespace)
 	if err != nil {
-		ginkgo.AbortSuite(fmt.Sprintf("Label override not found for the Prometheus Operator pod in namespace %s: %v", verrazzanoMonitoringNamespace, err))
+		ginkgo.AbortSuite(fmt.Sprintf("Label override not found for the Prometheus Operator pod in namespace %s: %v", constants.VerrazzanoMonitoringNamespace, err))
 	}
 	foundAnnotation := false
 	for _, pod := range pods {

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -310,12 +310,12 @@ var _ = t.Describe("Verify prometheus configmap reconciliation,", Label("f:platf
 			for _, nsc := range scrapeConfigs {
 				scrapeConfig := nsc.(map[interface{}]interface{})
 				// Check that interval is updated
-				if scrapeConfig["job_name"] == "prometheus" {
+				if scrapeConfig[vzconst.PrometheusJobNameKey] == "prometheus" {
 					intervalUpdated = (scrapeConfig["scrape_interval"].(string) != vzconst.TestPrometheusJobScrapeInterval)
 				}
 
 				// Check that test scrape config is not removed
-				if scrapeConfig["job_name"] == vzconst.TestPrometheusScrapeJob {
+				if scrapeConfig[vzconst.PrometheusJobNameKey] == vzconst.TestPrometheusScrapeJob {
 					testJobFound = true
 				}
 			}

--- a/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_test.go
@@ -58,13 +58,13 @@ func updateConfigMap() {
 		for _, nsc := range scrapeConfigs {
 			scrapeConfig := nsc.(map[interface{}]interface{})
 			// Change the default value of an existing default job
-			if scrapeConfig["job_name"] == "prometheus" && scrapeConfig["scrape_interval"].(string) != vzconst.TestPrometheusJobScrapeInterval {
+			if scrapeConfig[vzconst.PrometheusJobNameKey] == "prometheus" && scrapeConfig["scrape_interval"].(string) != vzconst.TestPrometheusJobScrapeInterval {
 				scrapeConfig["scrape_interval"] = vzconst.TestPrometheusJobScrapeInterval
 				updateMap = true
 			}
 
 			// Create test job only once
-			if scrapeConfig["job_name"] == vzconst.TestPrometheusScrapeJob {
+			if scrapeConfig[vzconst.PrometheusJobNameKey] == vzconst.TestPrometheusScrapeJob {
 				testJobFound = true
 			}
 		}
@@ -72,7 +72,7 @@ func updateConfigMap() {
 		if !testJobFound {
 			// Add a test scrape config
 			dummyScrapConfig := make(map[interface{}]interface{})
-			dummyScrapConfig["job_name"] = vzconst.TestPrometheusScrapeJob
+			dummyScrapConfig[vzconst.PrometheusJobNameKey] = vzconst.TestPrometheusScrapeJob
 			scrapeConfigs = append(scrapeConfigs, dummyScrapConfig)
 			updateMap = true
 		}
@@ -116,12 +116,12 @@ var _ = t.Describe("Update prometheus configmap", Label("f:platform-lcm.upgrade"
 				for _, nsc := range scrapeConfigs {
 					scrapeConfig := nsc.(map[interface{}]interface{})
 					// Check that interval is updated
-					if scrapeConfig["job_name"] == "prometheus" {
+					if scrapeConfig[vzconst.PrometheusJobNameKey] == "prometheus" {
 						intervalUpdated = (scrapeConfig["scrape_interval"].(string) == vzconst.TestPrometheusJobScrapeInterval)
 					}
 
 					// Check that test scrape config is created
-					if scrapeConfig["job_name"] == vzconst.TestPrometheusScrapeJob {
+					if scrapeConfig[vzconst.PrometheusJobNameKey] == vzconst.TestPrometheusScrapeJob {
 						testJobFound = true
 					}
 				}

--- a/tests/e2e/verify-install/jaeger-operator/jaeger_operator_test.go
+++ b/tests/e2e/verify-install/jaeger-operator/jaeger_operator_test.go
@@ -12,15 +12,15 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
 const (
-	verrazzanoMonitoringNamespace = "verrazzano-monitoring"
-	waitTimeout                   = 3 * time.Minute
-	pollingInterval               = 10 * time.Second
-	jaegerOperatorName            = "jaeger-operator"
-	operatorImage                 = "ghcr.io/verrazzano/jaeger-operator"
+	waitTimeout        = 3 * time.Minute
+	pollingInterval    = 10 * time.Second
+	jaegerOperatorName = "jaeger-operator"
+	operatorImage      = "ghcr.io/verrazzano/jaeger-operator"
 )
 
 var (
@@ -76,7 +76,7 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 				if !isJaegerOperatorEnabled() {
 					return true, nil
 				}
-				return pkg.DoesNamespaceExist(verrazzanoMonitoringNamespace)
+				return pkg.DoesNamespaceExist(constants.VerrazzanoMonitoringNamespace)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
@@ -88,9 +88,9 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 				if !isJaegerOperatorEnabled() {
 					return true
 				}
-				result, err := pkg.PodsRunning(verrazzanoMonitoringNamespace, []string{jaegerOperatorName})
+				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, []string{jaegerOperatorName})
 				if err != nil {
-					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", jaegerOperatorName, verrazzanoMonitoringNamespace, err))
+					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", jaegerOperatorName, constants.VerrazzanoMonitoringNamespace, err))
 				}
 				return result
 			}
@@ -104,17 +104,17 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 			verifyImages := func() bool {
 				if isJaegerOperatorEnabled() {
 					// Check if Jaeger operator is running with the expected Verrazzano Jaeger Operator image
-					image, err := pkg.GetContainerImage(verrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
+					image, err := pkg.GetContainerImage(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
 					if err != nil {
-						pkg.Log(pkg.Error, fmt.Sprintf("Container %s is not running in the namespace: %s, error: %v", jaegerOperatorName, verrazzanoMonitoringNamespace, err))
+						pkg.Log(pkg.Error, fmt.Sprintf("Container %s is not running in the namespace: %s, error: %v", jaegerOperatorName, constants.VerrazzanoMonitoringNamespace, err))
 						return false
 					}
 					if !strings.HasPrefix(image, operatorImage) {
-						pkg.Log(pkg.Error, fmt.Sprintf("Container %s image %s is not running with the expected image %s in the namespace: %s", jaegerOperatorName, image, operatorImage, verrazzanoMonitoringNamespace))
+						pkg.Log(pkg.Error, fmt.Sprintf("Container %s image %s is not running with the expected image %s in the namespace: %s", jaegerOperatorName, image, operatorImage, constants.VerrazzanoMonitoringNamespace))
 						return false
 					}
 					// Check if Jaeger operator env has been set to use Verrazzano Jaeger images
-					containerEnv, err := pkg.GetContainerEnv(verrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
+					containerEnv, err := pkg.GetContainerEnv(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf("Not able to get the environment variables in the container %s, error: %v", jaegerOperatorName, err))
 						return false

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	verrazzanoMonitoringNamespace   = "verrazzano-monitoring"
 	waitTimeout                     = 3 * time.Minute
 	pollingInterval                 = 10 * time.Second
 	prometheusTLSSecret             = "prometheus-operator-kube-p-admission"
@@ -131,7 +130,7 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 				if len(listEnabledComponents()) == 0 {
 					return true, nil
 				}
-				return pkg.DoesNamespaceExist(verrazzanoMonitoringNamespace)
+				return pkg.DoesNamespaceExist(constants.VerrazzanoMonitoringNamespace)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
@@ -141,9 +140,9 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 		WhenPromStackInstalledIt("should have running pods", func() {
 			promStackPodsRunning := func() bool {
 				enabledPods := listEnabledComponents()
-				result, err := pkg.PodsRunning(verrazzanoMonitoringNamespace, enabledPods)
+				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, enabledPods)
 				if err != nil {
-					AbortSuite(fmt.Sprintf("Pods %v is not running in the namespace: %v, error: %v", enabledPods, verrazzanoMonitoringNamespace, err))
+					AbortSuite(fmt.Sprintf("Pods %v is not running in the namespace: %v, error: %v", enabledPods, constants.VerrazzanoMonitoringNamespace, err))
 				}
 				return result
 			}
@@ -160,9 +159,9 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 					if err == nil {
 						pods, err := pkg.GetPodsFromSelector(&metav1.LabelSelector{
 							MatchLabels: labelMatch,
-						}, verrazzanoMonitoringNamespace)
+						}, constants.VerrazzanoMonitoringNamespace)
 						if err != nil {
-							AbortSuite(fmt.Sprintf("Label override not found for the Prometheus Operator pod in namespace %s: %v", verrazzanoMonitoringNamespace, err))
+							AbortSuite(fmt.Sprintf("Label override not found for the Prometheus Operator pod in namespace %s: %v", constants.VerrazzanoMonitoringNamespace, err))
 						}
 						foundAnnotation := false
 						for _, pod := range pods {
@@ -186,7 +185,7 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 		WhenPromStackInstalledIt(fmt.Sprintf("should have the correct default image arguments: %s, %s", expectedPromOperatorArgs[0], expectedPromOperatorArgs[1]), func() {
 			promStackPodsRunning := func() (bool, error) {
 				if isPrometheusOperatorEnabled() {
-					return pkg.ContainerHasExpectedArgs(verrazzanoMonitoringNamespace, prometheusOperatorDeployment, prometheusOperatorContainerName, expectedPromOperatorArgs)
+					return pkg.ContainerHasExpectedArgs(constants.VerrazzanoMonitoringNamespace, prometheusOperatorDeployment, prometheusOperatorContainerName, expectedPromOperatorArgs)
 				}
 				return true, nil
 			}
@@ -212,7 +211,7 @@ var _ = t.Describe("Prometheus Stack", Label("f:platform-lcm.install"), func() {
 		WhenPromStackInstalledIt("should have the TLS secret", func() {
 			Eventually(func() bool {
 				if isPrometheusOperatorEnabled() {
-					return pkg.SecretsCreated(verrazzanoMonitoringNamespace, prometheusTLSSecret)
+					return pkg.SecretsCreated(constants.VerrazzanoMonitoringNamespace, prometheusTLSSecret)
 				}
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())


### PR DESCRIPTION


# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
