### PR TITLE
VZ-6099 Resolve uninstall issue of a namespace not owned by Verrazzano being deleted

### DIFF
--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -160,7 +160,7 @@ function delete_rancher() {
 
   log "Removing Rancher namespace finalizers"
   # delete namespace finalizers
-  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespaces in Rancher" '/cattle-|local|p-|user-|fleet|rancher/ {print $1}' '{"metadata":{"finalizers":null}}' \
+  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespaces in Rancher" '/^cattle-|^local|^p-|^user-|^fleet|^rancher/ {print $1}' '{"metadata":{"finalizers":null}}' \
     || return $? # return on pipefail
 
   log "Delete the Rancher service accounts"

--- a/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/2-uninstall-system-components.sh
@@ -159,9 +159,10 @@ function delete_rancher() {
   kubectl delete configmap rancher-controller-lock -n kube-system --ignore-not-found=true || err_return $? "Could not delete ConfigMap rancher-controller-lock in namespace kube-system" || return $?
 
   log "Removing Rancher namespace finalizers"
-  # delete namespace finalizers
-  patch_k8s_resources namespaces ":metadata.name" "Could not remove finalizers from namespaces in Rancher" '/cattle-|local|p-|user-|fleet|rancher/ {print $1}' '{"metadata":{"finalizers":null}}' \
-    || return $? # return on pipefail
+  kubectl get namespaces --no-headers -o custom-columns=":metadata.name,:metadata.finalizers" \
+    | awk '/controller.cattle.io/ {print $1}' \
+    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
+    || err_return $? "Could not remove Rancher finalizers from all namespaces" || return $? # return on pipefail
 
   log "Delete the Rancher service accounts"
   if kubectl get serviceaccount -n cattle-system rancher > /dev/null 2>&1 ; then
@@ -183,9 +184,14 @@ function delete_rancher() {
   fi
 
   # delete cattle namespaces
-  log "Delete rancher namespace"
-  delete_k8s_resources namespaces ":metadata.name" "Could not delete namespaces from Rancher" '/cattle-|p-|user-|fleet|rancher/ {print $1}' \
-    || return $? # return on pipefail
+  log "Delete rancher namespaces"
+  local rancher_namespaces=("cattle-fleet-clusters-system" "cattle-fleet-local-system" "cattle-fleet-system" "cattle-global-data" "cattle-global-nt" "cattle-impersonation-system" "fleet-default" "fleet-local")
+  for namespace in "${rancher_namespaces[@]}"
+  do
+    if ! kubectl delete namespace ${namespace} --ignore-not-found=true ; then
+      error "Failed to delete the namespace ${namespace}"
+    fi
+  done
 
   # delete annotations left in kube-system secrets
   log "Delete Rancher Secret Annotations"
@@ -196,14 +202,6 @@ function delete_rancher() {
       | xargsr -I resource kubectl annotate secret resource -n "${namespace}" field.cattle.io/projectId- \
       || err_return $? "Could not delete Annotations from Rancher" || return $? # return on pipefail
   done
-
-  # Remove the Rancher namespace finalizers; do it here since Rancher is not guaranteed to have been installed by VZ
-  # (it can now be opted-out by the user)
-  log "Removing Rancher Namespace Finalizers"
-  kubectl get namespaces --no-headers -o custom-columns=":metadata.name,:metadata.finalizers" \
-    | awk '/controller.cattle.io/ {print $1}' \
-    | xargsr kubectl patch namespace -p '{"metadata":{"finalizers":null}}' --type=merge \
-    || err_return $? "Could not remove Rancher finalizers from all namespaces" || return $? # return on pipefail
 
 }
 


### PR DESCRIPTION
# Description

Change the uninstall of Rancher to delete an explicit set of namespaces.

Fixes VZ-6099

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
