### PR TITLE
VZ-6087 shorten hello helidon app name

### DIFF
--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-oam-appconfig-existing.yaml
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-oam-appconfig-existing.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration

--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-oam-appconfig-existing.yaml
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/testdata/hello-oam-appconfig-existing.yaml
@@ -3,7 +3,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   namespace: hello-helidon
   annotations:
     version: v1.0.0

--- a/application-operator/controllers/clusters/multiclustercomponent/testdata/hello-oam-comp-existing.yaml
+++ b/application-operator/controllers/clusters/multiclustercomponent/testdata/hello-oam-comp-existing.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component

--- a/application-operator/test/templates/containerized_workload_deployment.yaml
+++ b/application-operator/test/templates/containerized_workload_deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     deployment.kubernetes.io/revision: "2"
     description: Hello Helidon application
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"core.oam.dev/v1alpha2","kind":"ApplicationConfiguration","metadata":{"annotations":{"description":"Hello Helidon application","version":"v1.0.0"},"name":"hello-helidon-appconf","namespace":"hello-helidon"},"spec":{"components":[{"componentName":"hello-helidon-component","traits":[{"trait":{"apiVersion":"oam.verrazzano.io/v1alpha1","kind":"MetricsTrait","spec":{"scraper":"verrazzano-system/vmi-system-prometheus-0"}}},{"trait":{"apiVersion":"oam.verrazzano.io/v1alpha1","kind":"IngressTrait"}}]}]}}
+      {"apiVersion":"core.oam.dev/v1alpha2","kind":"ApplicationConfiguration","metadata":{"annotations":{"description":"Hello Helidon application","version":"v1.0.0"},"name":"hello-helidon","namespace":"hello-helidon"},"spec":{"components":[{"componentName":"hello-helidon-component","traits":[{"trait":{"apiVersion":"oam.verrazzano.io/v1alpha1","kind":"MetricsTrait","spec":{"scraper":"verrazzano-system/vmi-system-prometheus-0"}}},{"trait":{"apiVersion":"oam.verrazzano.io/v1alpha1","kind":"IngressTrait"}}]}]}}
     version: v1.0.0
   creationTimestamp: "2020-12-10T02:07:45Z"
   generation: 3

--- a/application-operator/test/templates/prometheus_config_job_to_be_removed.yaml
+++ b/application-operator/test/templates/prometheus_config_job_to_be_removed.yaml
@@ -231,7 +231,7 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_verrazzano_io_metricsEnabled,
                         __meta_kubernetes_pod_label_app_oam_dev_name, __meta_kubernetes_pod_label_app_oam_dev_component]
         separator: ;
-        regex: true;hello-helidon-appconf;hello-helidon-component
+        regex: true;hello-helidon;hello-helidon-component
         replacement: $1
         action: keep
       - source_labels: [__meta_kubernetes_pod_annotation_verrazzano_io_metricsPath]

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
         SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
 
         // sample app deployed before upgrade and UI console tests
-        SAMPLE_APP_NAME="hello-helidon-appconf"
+        SAMPLE_APP_NAME="hello-helidon"
         SAMPLE_APP_NAMESPACE="hello-helidon-sample"
         SAMPLE_APP_PROJECT="hello-helidon-sample-proj"
         SAMPLE_APP_COMPONENT="hello-helidon-component"

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -195,7 +195,7 @@ pipeline {
         SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
 
         // sample app deployed before upgrade and UI console tests
-        SAMPLE_APP_NAME="hello-helidon-appconf"
+        SAMPLE_APP_NAME="hello-helidon"
         SAMPLE_APP_NAMESPACE="hello-helidon"
         SAMPLE_APP_PROJECT="hello-helidon-sample-proj"
         SAMPLE_APP_COMPONENT="hello-helidon-component"

--- a/examples/hello-helidon/hello-helidon-app.yaml
+++ b/examples/hello-helidon/hello-helidon-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"

--- a/examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml
+++ b/examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterApplicationConfiguration

--- a/examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml
+++ b/examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   namespace: hello-helidon
 spec:
   template:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -197,7 +197,7 @@
             },
             {
               "image": "console",
-              "tag": "1.3.0-20220413232225-9d9bb79",
+              "tag": "1.4.0-20220614120434-203cb7c",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -247,11 +247,11 @@ func appEndpointAccessible(url string, hostname string) bool {
 }
 
 func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "hello-helidon")
+	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", helloHelidon)
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon")
+	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", helloHelidon)
 }
 
 func appConfigMetricsExists() bool {

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -162,14 +162,14 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon-appconf",
+					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
 					"kubernetes.container_name":            "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"kubernetes.labels.app_oam_dev\\/component": "hello-helidon-component",
-					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon-appconf",
+					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon",
 					"kubernetes.container_name":                 "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
@@ -250,7 +250,7 @@ func appMetricsExists() bool {
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon-appconf")
+	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon")
 }
 
 func appConfigMetricsExists() bool {

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -29,11 +29,12 @@ const (
 	imagePullWaitTimeout     = 40 * time.Minute
 	imagePullPollingInterval = 30 * time.Second
 	skipVerifications        = "Skip Verifications"
+	helloHelidon             = "hello-helidon"
 )
 
 var (
 	t                  = framework.NewTestFramework("helidon")
-	generatedNamespace = pkg.GenerateNamespace("hello-helidon")
+	generatedNamespace = pkg.GenerateNamespace(helloHelidon)
 	//yamlApplier              = k8sutil.YAMLApplier{}
 	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
 )
@@ -162,14 +163,14 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
+					"kubernetes.labels.app_oam_dev\\/name": helloHelidon,
 					"kubernetes.container_name":            "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"kubernetes.labels.app_oam_dev\\/component": "hello-helidon-component",
-					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon",
+					"kubernetes.labels.app_oam_dev\\/name":      helloHelidon,
 					"kubernetes.container_name":                 "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")

--- a/tests/e2e/examples/helidonmetrics/testdata/hello-helidon-app-metrics-disabled.yaml
+++ b/tests/e2e/examples/helidonmetrics/testdata/hello-helidon-app-metrics-disabled.yaml
@@ -3,7 +3,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -5,12 +5,13 @@ package helidon
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
@@ -187,14 +188,14 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon-appconf",
+					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
 					"kubernetes.container_name":            "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"kubernetes.labels.app_oam_dev\\/component": "hello-helidon-component",
-					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon-appconf",
+					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon",
 					"kubernetes.container_name":                 "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
@@ -307,7 +308,7 @@ func appMetricsExists() bool {
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon-appconf")
+	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon")
 }
 
 func appConfigMetricsExists() bool {

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -30,6 +30,7 @@ const (
 	imagePullWaitTimeout     = 40 * time.Minute
 	imagePullPollingInterval = 30 * time.Second
 	skipVerifications        = "Skip Verifications"
+	helloHelidon             = "hello-helidon"
 )
 
 const (
@@ -39,7 +40,7 @@ const (
 
 var (
 	t                  = framework.NewTestFramework("helidon")
-	generatedNamespace = pkg.GenerateNamespace("hello-helidon")
+	generatedNamespace = pkg.GenerateNamespace(helloHelidon)
 	//yamlApplier              = k8sutil.YAMLApplier{}
 	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
 )
@@ -188,14 +189,14 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-					"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
+					"kubernetes.labels.app_oam_dev\\/name": helloHelidon,
 					"kubernetes.container_name":            "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 			Eventually(func() bool {
 				return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"kubernetes.labels.app_oam_dev\\/component": "hello-helidon-component",
-					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon",
+					"kubernetes.labels.app_oam_dev\\/name":      helloHelidon,
 					"kubernetes.container_name":                 "hello-helidon-container",
 				})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
@@ -304,11 +305,11 @@ func appEndpointAccess(url string, hostname string, token string, requestShouldS
 }
 
 func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "hello-helidon")
+	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", helloHelidon)
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon")
+	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", helloHelidon)
 }
 
 func appConfigMetricsExists() bool {

--- a/tests/e2e/logging/helidon/helidon_logging_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_test.go
@@ -5,10 +5,11 @@ package helidon
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -162,7 +163,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 				t.It("Verify recent Elasticsearch log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.app_oam_dev\\/name": "hello-helidon-appconf",
+							"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
 							"kubernetes.container_name":            "hello-helidon-container"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record for container hello-helidon-container")
 				})
@@ -174,7 +175,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 				t.It("Verify recent Elasticsearch log record of other-container exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.app_oam_dev\\/name": "hello-helidon-appconf",
+							"kubernetes.labels.app_oam_dev\\/name": "hello-helidon",
 							"kubernetes.container_name":            "other-container"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record for other-container")
 				})

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
+	helloHelidon          = "hello-helidon"
 	TestNamespace         = "hello-helidon" // currently only used for placement tests
 	multiclusterNamespace = "verrazzano-mc"
-	projectName           = "hello-helidon"
-	appConfigName         = "hello-helidon"
+	projectName           = helloHelidon
+	appConfigName         = helloHelidon
 	componentName         = "hello-helidon-component"
 	workloadName          = "hello-helidon-workload"
 )

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -21,7 +21,7 @@ const (
 	TestNamespace         = "hello-helidon" // currently only used for placement tests
 	multiclusterNamespace = "verrazzano-mc"
 	projectName           = "hello-helidon"
-	appConfigName         = "hello-helidon-appconf"
+	appConfigName         = "hello-helidon"
 	componentName         = "hello-helidon-component"
 	workloadName          = "hello-helidon-workload"
 )

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -5,10 +5,11 @@ package mchelidon
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
@@ -178,7 +179,7 @@ var _ = t.Describe("Multi-cluster verify hello-helidon", func() {
 			Eventually(func() bool {
 				return pkg.LogRecordFoundInCluster(indexName, time.Now().Add(-24*time.Hour), map[string]string{
 					"kubernetes.labels.app_oam_dev\\/component": "hello-helidon-component",
-					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon-appconf",
+					"kubernetes.labels.app_oam_dev\\/name":      "hello-helidon",
 					"kubernetes.container_name":                 "hello-helidon-container",
 				}, adminKubeconfig)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")

--- a/tests/e2e/multicluster/examples/helidon-deprecated/testdata/mc-hello-helidon-app.yaml
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/testdata/mc-hello-helidon-app.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterApplicationConfiguration

--- a/tests/e2e/multicluster/examples/helidon-deprecated/testdata/mc-hello-helidon-app.yaml
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/testdata/mc-hello-helidon-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   namespace: hello-helidon-dep
 spec:
   template:

--- a/tests/testdata/jwt/helidon/hello-helidon-app.yaml
+++ b/tests/testdata/jwt/helidon/hello-helidon-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   namespace: hello-helidon
   annotations:
     version: v1.0.0

--- a/tests/testdata/logging/helidon/helidon-logging-app.yaml
+++ b/tests/testdata/logging/helidon/helidon-logging-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"

--- a/tests/testdata/loggingtrait/helidonworkload/helidon-logging-application.yaml
+++ b/tests/testdata/loggingtrait/helidonworkload/helidon-logging-application.yaml
@@ -4,7 +4,7 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: hello-helidon-appconf
+  name: hello-helidon
   annotations:
     version: v1.0.0
     description: "Hello Helidon application"


### PR DESCRIPTION
# Description
Shorten hello helidon app name to prevent Let's Encrypt certificate error because the host name is > 64 characters.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
