### PR TITLE
VZ-6051: Update Istio authz policies to reference new Prometheus

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -31,11 +31,11 @@ spec:
       to:
         - operation:
             ports: ["{{ .Values.api.port }}"]
-    # verrazzano-authproxy:15090 <- vmi-system-prometheus (uses VMO SA)
+    # verrazzano-authproxy:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090"]
@@ -72,11 +72,11 @@ spec:
       to:
         - operation:
             ports: ["9200","9300"]
-    # vmi-system-es-master:15090 <- vmi-system-prometheus (uses VMO SA)
+    # vmi-system-es-master:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090"]
@@ -111,11 +111,11 @@ spec:
       to:
         - operation:
             ports: ["9200","9300"]
-    # vmi-system-es-ingest:15090 <- vmi-system-prometheus (uses VMO SA)
+    # vmi-system-es-ingest:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090"]
@@ -145,11 +145,11 @@ spec:
       to:
         - operation:
             ports: ["3000"]
-    # vmi-system-grafana:15090 <- vmi-system-prometheus
+    # vmi-system-grafana:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090"]
@@ -179,53 +179,14 @@ spec:
       to:
         - operation:
             ports: ["5601"]
-    # vmi-system-kibana:15090 <- vmi-system-prometheus (uses VMO SA)
+    # vmi-system-kibana:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090", "5601"]
-{{- end }}
-
----
-{{- if .Values.prometheus.enabled }}
-#
-# Istio AuthorizationPolicy for vmi-system-prometheus
-#
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: vmi-system-prometheus-authzpol
-  namespace: {{ .Release.Namespace }}
-spec:
-  selector:
-    matchLabels:
-      app: system-prometheus
-  action: ALLOW
-  rules:
-    # vmi-system-prometheus:9090 <- verrazzano-authproxy
-    # vmi-system-prometheus:9090 <- vmi-system-grafana (uses VMO SA)
-    # vmi-system-prometheus:9090 <- kiali (uses Kiali SA)
-    - from:
-        - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.api.name }}",
-                         "cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}",
-                         "cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.kiali.name }}"]
-      to:
-        - operation:
-            ports: ["9090"]
-
-    # vmi-system-prometheus:15090 <- vmi-system-prometheus (uses VMO SA)
-    - from:
-        - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
-      to:
-        - operation:
-            ports: ["15090"]
 {{- end }}
 
 ---
@@ -252,11 +213,11 @@ spec:
       to:
         - operation:
             ports: ["8000"]
-    # verrazzano-console:15090 <- vmi-system-prometheus (uses VMO SA)
+    # verrazzano-console:15090 <- prometheus
     - from:
         - source:
-            namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.monitoringOperator.name }}"]
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
             ports: ["15090"]

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -21,6 +21,8 @@ prometheus:
   requests:
     memory: 128Mi
     storage: 50Gi
+  namespace: verrazzano-monitoring
+  serviceAccount: prometheus-operator-kube-p-operator
 
 grafana:
   enabled: true


### PR DESCRIPTION
# Description

Update the Istio authorization policies to reference the Prometheus Operator-managed Prometheus.

Note that the `vmi-system-prometheus` policy goes away because its replacement will be created by the Prometheus Operator install/upgrade component.

DO NOT merge until the ingress is switched to the new Prometheus.

Implements VZ-6051

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
