### PR TITLE
VZ-6111: added console overrides support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -527,7 +527,8 @@ type KialiComponent struct {
 // ConsoleComponent specifies the Console UI configuration
 type ConsoleComponent struct {
 	// +optional
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled          *bool `json:"enabled,omitempty"`
+	InstallOverrides `json:",inline"`
 }
 
 // DNSComponent specifies the DNS configuration

--- a/platform-operator/controllers/verrazzano/component/console/console_component.go
+++ b/platform-operator/controllers/verrazzano/component/console/console_component.go
@@ -42,6 +42,7 @@ func NewComponent() spi.Component {
 			Dependencies:            []string{authproxy.ComponentName},
 			AppendOverridesFunc:     AppendOverrides,
 			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
+			GetInstallOverridesFunc: GetOverrides,
 		},
 	}
 }
@@ -76,4 +77,23 @@ func (c consoleComponent) PreInstall(ctx spi.ComponentContext) error {
 // PreUpgrade performs any required pre upgrade operations
 func (c consoleComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	return preHook(ctx)
+}
+
+// GetOverrides gets the install overrides for the console
+func GetOverrides(effectiveCR *vzapi.Verrazzano) []vzapi.Overrides {
+	if effectiveCR.Spec.Components.Console != nil {
+		return effectiveCR.Spec.Components.Console.ValueOverrides
+	}
+	return []vzapi.Overrides{}
+}
+
+// MonitorOverrides checks whether monitoring of install overrides for the console is enabled or not
+func (c consoleComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
+	if ctx.EffectiveCR().Spec.Components.Console != nil {
+		if ctx.EffectiveCR().Spec.Components.Console.MonitorChanges != nil {
+			return *ctx.EffectiveCR().Spec.Components.Console.MonitorChanges
+		}
+		return true
+	}
+	return false
 }

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -1276,6 +1276,53 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      monitorChanges:
+                        type: boolean
+                      overrides:
+                        items:
+                          description: Overrides stores the specified overrides
+                          properties:
+                            configMapRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            secretRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            values:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        type: array
                     type: object
                   dns:
                     description: DNS contains the DNS component configuration


### PR DESCRIPTION
This change adds overrides support for the console component. This includes adding overrides to the console component api and adding the GetOverrides and MonitorOverrides SPI functions to the console component.

Fixes VZ-6111

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
