### PR TITLE
VZ-5892 Implement the "vz version" command

### DIFF
--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -7,9 +7,9 @@ VERSION_DIR:=${VZ_DIR}/cmd/version
 
 NAME:=vz
 
-GIT_COMMIT:=$(shell git rev-parse --short HEAD)
+GIT_COMMIT:=$(shell git rev-parse HEAD)
 CLI_VERSION:=$(shell grep verrazzano-development-version ${MAKEFILE_DIR}/../../.verrazzano-development-version | cut -d= -f 2)
-BUILD_DATE:=$(shell date '+%Y-%m-%d')
+BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -2,16 +2,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-TOOLS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
 
 NAME:=vz
 
-LOCAL_VERSION ?= local-$(shell git rev-parse --short HEAD)
+GIT_COMMIT = $(shell git rev-parse --short HEAD)
+CLI_VERSION = $(shell grep verrazzano-development-version ${MAKEFILE_DIR}/../../.verrazzano-development-version | cut -d= -f 2)
+BUILD_DATE = $(shell date '+%Y-%m-%d')
 
-OPERATOR_VERSION = ${LOCAL_VERSION}
-CLI_VERSION = ${LOCAL_VERSION}
 ifdef RELEASE_VERSION
-	OPERATOR_VERSION = ${RELEASE_VERSION}
 	CLI_VERSION = ${RELEASE_VERSION}
 endif
 ifndef RELEASE_BRANCH
@@ -21,7 +19,7 @@ endif
 DIST_DIR:=dist
 ENV_NAME=vz
 GO = GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go
-CLI_GO_LDFLAGS ?= -X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}
+CLI_GO_LDFLAGS = -X '${MAKEFILE_DIR}/cmd/version.gitCommit=${GIT_COMMIT}' -X '${MAKEFILE_DIR}/cmd/version.buildDate=${BUILD_DATE}' -X '${MAKEFILE_DIR}/cmd/version.cliVersion=${CLI_VERSION}'
 
 #
 # CLI
@@ -35,21 +33,21 @@ run:
 .PHONY: go-build
 go-build:
 	GOOS=darwin GOARCH=amd64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
+		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_amd64/vz \
 		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
 	GOOS=darwin GOARCH=arm64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
+		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_arm64/vz \
 		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
 	GOOS=linux GOARCH=amd64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" \
+		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/linux_amd64/vz \
 		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
 
 .PHONY: cli
 cli: ## build the CLI
-	$(GO) install -ldflags "${CLI_GO_LDFLAGS} -X main.cliVersion=${CLI_VERSION}" ./...
+	$(GO) install -ldflags "${CLI_GO_LDFLAGS}" ./...
 
 .PHONY: unit-test
 unit-test: cli

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -2,15 +2,17 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+VZ_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')
+VERSION_DIR:=${VZ_DIR}/cmd/version
 
 NAME:=vz
 
-GIT_COMMIT = $(shell git rev-parse --short HEAD)
-CLI_VERSION = $(shell grep verrazzano-development-version ${MAKEFILE_DIR}/../../.verrazzano-development-version | cut -d= -f 2)
-BUILD_DATE = $(shell date '+%Y-%m-%d')
+GIT_COMMIT:=$(shell git rev-parse --short HEAD)
+CLI_VERSION:=$(shell grep verrazzano-development-version ${MAKEFILE_DIR}/../../.verrazzano-development-version | cut -d= -f 2)
+BUILD_DATE:=$(shell date '+%Y-%m-%d')
 
 ifdef RELEASE_VERSION
-	CLI_VERSION = ${RELEASE_VERSION}
+	CLI_VERSION=${RELEASE_VERSION}
 endif
 ifndef RELEASE_BRANCH
 	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
@@ -18,15 +20,15 @@ endif
 
 DIST_DIR:=dist
 ENV_NAME=vz
-GO = GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go
-CLI_GO_LDFLAGS = -X '${MAKEFILE_DIR}/cmd/version.gitCommit=${GIT_COMMIT}' -X '${MAKEFILE_DIR}/cmd/version.buildDate=${BUILD_DATE}' -X '${MAKEFILE_DIR}/cmd/version.cliVersion=${CLI_VERSION}'
+GO=GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go
+CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.cliVersion=${CLI_VERSION}'
 
 #
 # CLI
 #
 .PHONY: run
 run:
-	$(GO) run ${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
+	$(GO) run ${GOPATH}/src/${VZ_DIR}/main.go
 #
 # Go build related tasks
 #
@@ -35,15 +37,15 @@ go-build:
 	GOOS=darwin GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_amd64/vz \
-		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
+		${GOPATH}/src/${VZ_DIR}/main.go
 	GOOS=darwin GOARCH=arm64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_arm64/vz \
-		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
+		${GOPATH}/src/${VZ_DIR}/main.go
 	GOOS=linux GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/linux_amd64/vz \
-		${GOPATH}/src/github.com/verrazzano/verrazzano/tools/vz/main.go
+		${GOPATH}/src/${VZ_DIR}/main.go
 
 .PHONY: cli
 cli: ## build the CLI

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -11,9 +11,9 @@ import (
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
 )
 
-var cliVersion = "1.2.3"
-var buildDate = "2022-06-10T13:57:03Z"
-var gitCommit = "9dbc916b58ab9781f7b4c25e51748fb31ec940f8"
+var cliVersion string
+var buildDate string
+var gitCommit string
 
 const (
 	CommandName = "version"

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -11,8 +11,8 @@ import (
 )
 
 var gitCommit = "abcde1234"
-var buildDate = "YYYY-MM-DD"
-var cliVersion = "vMajor.Minor.Patch"
+var buildDate = "2022-01-01"
+var cliVersion = "1.2.3"
 
 const (
 	CommandName = "version"

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -8,11 +8,12 @@ import (
 	"github.com/spf13/cobra"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
 )
 
-var gitCommit = "abcde1234"
-var buildDate = "2022-01-01"
 var cliVersion = "1.2.3"
+var buildDate = "2022-06-10T13:57:03Z"
+var gitCommit = "9dbc916b58ab9781f7b4c25e51748fb31ec940f8"
 
 const (
 	CommandName = "version"
@@ -20,6 +21,13 @@ const (
 	helpLong    = `The command 'version' reports information about the version of the vz tool being run`
 	helpExample = `vz version`
 )
+
+// statusOutputTemplate - template for output of status command
+const versionOutputTemplate = `
+Version: v{{.cli_version}}
+BuildDate: {{.build_date}}
+GitCommit: {{.git_commit}}
+`
 
 func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd := cmdhelpers.NewCommand(vzHelper, CommandName, helpShort, helpLong)
@@ -32,8 +40,17 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdVersion(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
-	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Version: v%s\n", cliVersion)
-	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "BuildDate: %s\n", buildDate)
-	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "GitCommit: %s\n", gitCommit)
+
+	templateValues := map[string]string{
+		"cli_version": cliVersion,
+		"build_date":  buildDate,
+		"git_commit":  gitCommit,
+	}
+
+	result, err := templates.ApplyTemplate(versionOutputTemplate, templateValues)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), result)
 	return nil
 }

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -5,18 +5,18 @@ package version
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 )
 
+var gitCommit = "MOOSE"
+
 const (
 	CommandName = "version"
 	helpShort   = "Verrazzano version information"
 	helpLong    = `The command 'version' reports information about the version of the vz tool being run`
-	helpExample = `
-vz version`
+	helpExample = `vz version`
 )
 
 func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
@@ -31,5 +31,6 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 
 func runCmdVersion(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
 	fmt.Fprintf(vzHelper.GetOutputStream(), "Not implemented yet\n")
+	fmt.Fprintf(vzHelper.GetOutputStream(), "testing %s value \n", gitCommit)
 	return nil
 }

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -10,7 +10,9 @@ import (
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 )
 
-var gitCommit = "MOOSE"
+var gitCommit = "abcde1234"
+var buildDate = "YYYY-MM-DD"
+var cliVersion = "vMajor.Minor.Patch"
 
 const (
 	CommandName = "version"
@@ -30,7 +32,8 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdVersion(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), "Not implemented yet\n")
-	fmt.Fprintf(vzHelper.GetOutputStream(), "testing %s value \n", gitCommit)
+	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Version: v%s\n", cliVersion)
+	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "BuildDate: %s\n", buildDate)
+	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "GitCommit: %s\n", gitCommit)
 	return nil
 }

--- a/tools/vz/cmd/version/version_test.go
+++ b/tools/vz/cmd/version/version_test.go
@@ -29,8 +29,8 @@ func TestVersionCmd(t *testing.T) {
 	assert.NoError(t, err)
 	result := buf.String()
 	results := strings.Split(result, "\n")
-	version, build, commit := results[0], results[1], results[2]
+	version, build, commit := results[1], results[2], results[3]
 	assert.Regexp(t, `^(Version: )?(v)?(\d+\.)?(\d+\.)?(\d+)$`, version)
-	assert.Regexp(t, `^(BuildDate: )?(\d+\-)?(\d+\-)?(\d+)$`, build)
-	assert.Regexp(t, `^(GitCommit: )?(\w{9})$`, commit)
+	assert.Regexp(t, `^(BuildDate: )?(\d+\-)?(\d+\-)?(\d+T)?(\d+\:)?(\d+\:)?(\d+Z)$`, build)
+	assert.Regexp(t, `^(GitCommit: )?(\w{40})$`, commit)
 }

--- a/tools/vz/cmd/version/version_test.go
+++ b/tools/vz/cmd/version/version_test.go
@@ -17,6 +17,10 @@ import (
 // TestVersionCmd - check that command reports not implemented yet
 func TestVersionCmd(t *testing.T) {
 
+	cliVersion = "1.2.3"
+	buildDate = "2022-06-10T13:57:03Z"
+	gitCommit = "9dbc916b58ab9781f7b4c25e51748fb31ec940f8"
+
 	// Send the command output to a byte buffer
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)

--- a/tools/vz/cmd/version/version_test.go
+++ b/tools/vz/cmd/version/version_test.go
@@ -6,6 +6,7 @@ package version
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,5 +28,9 @@ func TestVersionCmd(t *testing.T) {
 	err := versionCmd.Execute()
 	assert.NoError(t, err)
 	result := buf.String()
-	assert.Equal(t, "Not implemented yet\n", result)
+	results := strings.Split(result, "\n")
+	version, build, commit := results[0], results[1], results[2]
+	assert.Regexp(t, `^(Version: )?(v)?(\d+\.)?(\d+\.)?(\d+)$`, version)
+	assert.Regexp(t, `^(BuildDate: )?(\d+\-)?(\d+\-)?(\d+)$`, build)
+	assert.Regexp(t, `^(GitCommit: )?(\w{9})$`, commit)
 }


### PR DESCRIPTION
# Description

Implements functionality for the "vz version" command for the Verrazzano CLI

Fixes VZ-5892

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [x] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
