### PR TITLE
VZ-6052: Update network policies to use new Prometheus

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
@@ -6,16 +6,25 @@ package nodeexporter
 import (
 	"context"
 	"fmt"
+
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const daemonsetName = "prometheus-node-exporter" // Should match fullName override in prometheus-node-exporter-values.yaml
+const (
+	daemonsetName     = "prometheus-node-exporter" // Should match fullName override in prometheus-node-exporter-values.yaml
+	networkPolicyName = "node-exporter"
+)
 
 // isPrometheusNodeExporterReady checks if the Prometheus Node-Exporter daemonset is ready
 func isPrometheusNodeExporterReady(ctx spi.ComponentContext) bool {
@@ -53,4 +62,53 @@ func GetOverrides(effectiveCR *vzapi.Verrazzano) []vzapi.Overrides {
 		return effectiveCR.Spec.Components.PrometheusNodeExporter.ValueOverrides
 	}
 	return []vzapi.Overrides{}
+}
+
+// createOrUpdateNetworkPolicies creates or updates network policies for this component
+func createOrUpdateNetworkPolicies(ctx spi.ComponentContext) error {
+	netPolicy := &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyName, Namespace: ComponentNamespace}}
+
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), ctx.Client(), netPolicy, func() error {
+		netPolicy.Spec = newNetworkPolicySpec()
+		return nil
+	})
+
+	return err
+}
+
+// newNetworkPolicy returns a populated NetworkPolicySpec with ingress rules for Prometheus node exporter
+func newNetworkPolicySpec() netv1.NetworkPolicySpec {
+	tcpProtocol := corev1.ProtocolTCP
+	port := intstr.FromInt(9100)
+
+	return netv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "prometheus-node-exporter",
+			},
+		},
+		PolicyTypes: []netv1.PolicyType{
+			netv1.PolicyTypeIngress,
+		},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				// allow ingress to port 9100 from Prometheus
+				From: []netv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/name": "prometheus",
+							},
+						},
+					},
+				},
+				Ports: []netv1.NetworkPolicyPort{
+					{
+						Protocol: &tcpProtocol,
+						Port:     &port,
+					},
+				},
+			},
+		},
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -97,3 +97,13 @@ func (c prometheusNodeExporterComponent) MonitorOverrides(ctx spi.ComponentConte
 	}
 	return false
 }
+
+// PostInstall creates/updates associated resources after this component is installed
+func (c prometheusNodeExporterComponent) PostInstall(ctx spi.ComponentContext) error {
+	return createOrUpdateNetworkPolicies(ctx)
+}
+
+// PostUpgrade creates/updates associated resources after this component is installed
+func (c prometheusNodeExporterComponent) PostUpgrade(ctx spi.ComponentContext) error {
+	return createOrUpdateNetworkPolicies(ctx)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const profilesRelativePath = "../../../../../manifests/profiles"
@@ -133,4 +134,26 @@ func TestAppendOverrides(t *testing.T) {
 			assert.Equal(t, tt.expectedOverrides, kvs)
 		})
 	}
+}
+
+// TestPostInstall tests the PostInstall component function
+func TestPostInstall(t *testing.T) {
+	// GIVEN the Prometheus Node Exporter is being installed
+	// WHEN we call the PostInstall function
+	// THEN no error is returned
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false, profilesRelativePath)
+	err := NewComponent().PostInstall(ctx)
+	assert.NoError(t, err)
+}
+
+// TestPostUpgrade tests the PostUpgrade component function
+func TestPostUpgrade(t *testing.T) {
+	// GIVEN the Prometheus Node Exporter is being upgraded
+	// WHEN we call the PostUpgrade function
+	// THEN no error is returned
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false, profilesRelativePath)
+	err := NewComponent().PostUpgrade(ctx)
+	assert.NoError(t, err)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_test.go
@@ -4,14 +4,17 @@
 package nodeexporter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	appsv1 "k8s.io/api/apps/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -82,4 +85,22 @@ func TestIsPrometheusNodeExporterReady(t *testing.T) {
 			assert.Equal(t, tt.expectTrue, isPrometheusNodeExporterReady(ctx))
 		})
 	}
+}
+
+// TestCreateOrUpdateNetworkPolicies tests the createOrUpdateNetworkPolicies function
+func TestCreateOrUpdateNetworkPolicies(t *testing.T) {
+	// GIVEN a Prometheus Node Exporter component
+	// WHEN  the createOrUpdateNetworkPolicies function is called
+	// THEN  no error is returned and the expected network policies have been created
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := createOrUpdateNetworkPolicies(ctx)
+	assert.NoError(t, err)
+
+	netPolicy := &netv1.NetworkPolicy{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: networkPolicyName, Namespace: ComponentNamespace}, netPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, []netv1.PolicyType{netv1.PolicyTypeIngress}, netPolicy.Spec.PolicyTypes)
+	assert.Equal(t, int32(9100), netPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -83,7 +83,7 @@ func (c prometheusComponent) PreInstall(ctx spi.ComponentContext) error {
 	return preInstall(ctx)
 }
 
-// PostInstall applies monitor resources for Verrazzano system components
+// PostInstall creates/updates associated resources after this component is installed
 func (c prometheusComponent) PostInstall(ctx spi.ComponentContext) error {
 	if err := applySystemMonitors(ctx); err != nil {
 		return err
@@ -91,15 +91,21 @@ func (c prometheusComponent) PostInstall(ctx spi.ComponentContext) error {
 	if err := updateApplicationAuthorizationPolicies(ctx); err != nil {
 		return err
 	}
+	if err := createOrUpdateNetworkPolicies(ctx); err != nil {
+		return err
+	}
 	return c.HelmComponent.PostInstall(ctx)
 }
 
-// PostUpgrade applies monitor resources for Verrazzano system components
+// PostInstall creates/updates associated resources after this component is upgraded
 func (c prometheusComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	if err := applySystemMonitors(ctx); err != nil {
 		return err
 	}
 	if err := updateApplicationAuthorizationPolicies(ctx); err != nil {
+		return err
+	}
+	if err := createOrUpdateNetworkPolicies(ctx); err != nil {
 		return err
 	}
 	return c.HelmComponent.PostUpgrade(ctx)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -22,6 +22,7 @@ import (
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -643,4 +644,22 @@ func TestUpdateApplicationAuthorizationPolicies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateOrUpdateNetworkPolicies tests the createOrUpdateNetworkPolicies function
+func TestCreateOrUpdateNetworkPolicies(t *testing.T) {
+	// GIVEN a Prometheus Operator component
+	// WHEN  the createOrUpdateNetworkPolicies function is called
+	// THEN  no error is returned and the expected network policies have been created
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
+
+	err := createOrUpdateNetworkPolicies(ctx)
+	assert.NoError(t, err)
+
+	netPolicy := &netv1.NetworkPolicy{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: networkPolicyName, Namespace: ComponentNamespace}, netPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, []netv1.PolicyType{netv1.PolicyTypeIngress}, netPolicy.Spec.PolicyTypes)
+	assert.Equal(t, int32(9090), netPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
 }

--- a/platform-operator/helm_config/charts/verrazzano-monitoring-operator/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-monitoring-operator/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Network policy for Verrazzano monitoring operator
-# Ingress: deny all
+# Ingress: allow Prometheus to scrape Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -15,3 +15,14 @@ spec:
       k8s-app: {{ .Values.monitoringOperator.name }}
   policyTypes:
     - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 15090
+          protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -40,10 +40,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP
@@ -78,10 +78,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -24,10 +24,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP
@@ -83,55 +83,12 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
-          protocol: TCP
-{{- end }}
-{{- if .Values.prometheus.enabled}}
----
-# Network policy for VMI System Prometheus
-# Ingress: allow connect from the ingress controller to oidc port 8775
-#          allow connect from Grafana to port 9090
-# Egress: allow all
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: vmi-system-prometheus
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app: system-prometheus
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              verrazzano.io/namespace: verrazzano-system
-          podSelector:
-            matchLabels:
-              app: verrazzano-authproxy
-      ports:
-        - port: 9090
-          protocol: TCP
-    - from:
-        - podSelector:
-            matchLabels:
-              app: system-grafana
-      ports:
-        - port: 9090
-          protocol: TCP
-    - from:
-        - podSelector:
-            matchLabels:
-              app: kiali
-      ports:
-        - port: 9090
           protocol: TCP
 {{- end }}
 ---
@@ -154,10 +111,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: {{ .Release.Namespace }}
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 9402
           protocol: TCP
@@ -177,34 +134,6 @@ spec:
       app.kubernetes.io/instance: external-dns
   policyTypes:
     - Ingress
-{{- end }}
-{{- if .Values.nodeExporter.enabled }}
----
-# Network policy for Node Exporter
-# Ingress: allow connect from Prometheus to scrape metrics
-# Egress: allow all
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: node-exporter
-  namespace: monitoring
-spec:
-  podSelector:
-    matchLabels:
-      app: node-exporter
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              verrazzano.io/namespace: verrazzano-system
-          podSelector:
-            matchLabels:
-              app: system-prometheus
-      ports:
-        - port: 9100
-          protocol: TCP
 {{- end }}
 {{- if .Values.keycloak.enabled }}
 ---
@@ -244,10 +173,10 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            verrazzano.io/namespace: verrazzano-system
+            verrazzano.io/namespace: verrazzano-monitoring
         podSelector:
           matchLabels:
-            app: system-prometheus
+            app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP
@@ -278,10 +207,10 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            verrazzano.io/namespace: verrazzano-system
+            verrazzano.io/namespace: verrazzano-monitoring
         podSelector:
           matchLabels:
-            app: system-prometheus
+            app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP
@@ -379,8 +308,8 @@ spec:
         - namespaceSelector:
             matchLabels:
               verrazzano.io/namespace: verrazzano-system
-    # Allow ingress to port 10254 from system-prometheus to scrape metrics
-    # Allow ingress to port 15090 from system-prometheus to scrape Envoy stats
+    # Allow ingress to port 10254 from Prometheus to scrape metrics
+    # Allow ingress to port 15090 from Prometheus to scrape Envoy stats
     - ports:
         - port: 10254
           protocol: TCP
@@ -389,10 +318,10 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
 ---
 # Network policy for NGINX Ingress default-backend
 # Egress: allow all
@@ -422,10 +351,10 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
 ---
 # Network policy for istio-system pod communication
 # Ingress: allow all pod-to-pod communication within the namespace
@@ -468,10 +397,10 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
 ---
 # Network policy for Istio egress gateway
 # Ingress: allow ingress to port 8443 from anywhere
@@ -497,10 +426,10 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
 ---
 # Network policy for Istio coredns
 # Ingress: allow ingress to port 53 from kube-system DNS
@@ -534,7 +463,7 @@ spec:
 # Ingress: allow ingress to port 15012 from verrazzano-system prometheus and keycloak (for Istio proxy sidecar)
 #          allow ingress to port 15012 for application namespaces
 #          allow port 15017 for webhooks
-#          allow port 15014 from system-prometheus to scrape metrics
+#          allow port 15014 from Prometheus to scrape metrics
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -575,7 +504,7 @@ spec:
               verrazzano.io/namespace: {{ .Release.Namespace }}
           podSelector:
             matchExpressions:
-              - {key: app, operator: In, values: [system-prometheus, fluentd, verrazzano-authproxy, verrazzano-console, system-es-master, system-es-ingest, system-es-data, system-grafana, system-kibana, weblogic-operator, kiali]}
+              - {key: app, operator: In, values: [fluentd, verrazzano-authproxy, verrazzano-console, system-es-master, system-es-ingest, system-es-data, system-grafana, system-kibana, weblogic-operator, kiali]}
         - namespaceSelector:
             matchLabels:
               verrazzano.io/namespace: keycloak
@@ -609,10 +538,10 @@ spec:
       from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
 ---
 # Network policy for Kiali
 # Ingress: allow connect from istio-system
@@ -644,10 +573,10 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 9090
           protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano/templates/vmi-es-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/vmi-es-networkpolicy.yaml
@@ -44,14 +44,17 @@ spec:
       ports:
         - protocol: TCP
           port: 9300
+    # Allow ingress from Prometheus to collect metrics from the app and the Istio sidecar
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
+        - port: 9200
+          protocol: TCP
         - port: 15090
           protocol: TCP
 ---
@@ -60,7 +63,7 @@ spec:
 #          allow from ES data to port 9300
 #          allow from ES ingest to port 9200 and 9300
 #          allow from Kibana to port 9200
-#          allow from Prometheus to scrape Envoy stats on port 15090
+#          allow from Prometheus to scrape port 9200 and Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -108,14 +111,17 @@ spec:
       ports:
         - protocol: TCP
           port: 9200
+    # Allow ingress from Prometheus
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
+        - port: 9200
+          protocol: TCP
         - port: 15090
           protocol: TCP
 ---
@@ -123,7 +129,7 @@ spec:
 # Ingress: allow from auth proxy to port 9200
 #          allow from ES master and ES data to port 9300
 #          allow from Kibana to port 9200
-#          allow from Prometheus to scrape Envoy stats on port 15090
+#          allow from Prometheus to scrape port 9200 and Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -166,14 +172,17 @@ spec:
       ports:
         - protocol: TCP
           port: 9200
+    # Allow ingress from Prometheus
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
+        - port: 9200
+          protocol: TCP
         - port: 15090
           protocol: TCP
   {{- else }}
@@ -182,7 +191,7 @@ spec:
 #          allow from Verrazzano Monitoring Operator to port 9200
 #          allow from auth proxy to port 9200
 #          allow from Kibana to port 9200
-#          allow from Prometheus to scrape Envoy stats on port 15090
+#          allow from Prometheus to scrape port 9200 and Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -230,15 +239,17 @@ spec:
     - ports:
         - protocol: TCP
           port: 9200
-    # Allow ingress from Prometheus to scrape Envoy stats
+    # Allow ingress from Prometheus
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
+        - port: 9200
+          protocol: TCP
         - port: 15090
           protocol: TCP
   # end else
@@ -279,13 +290,14 @@ spec:
       ports:
         - protocol: TCP
           port: 5601
+    # Allow ingress from Prometheus
     - from:
         - namespaceSelector:
             matchLabels:
-              verrazzano.io/namespace: verrazzano-system
+              verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
             matchLabels:
-              app: system-prometheus
+              app.kubernetes.io/name: prometheus
       ports:
         - port: 15090
           protocol: TCP

--- a/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
@@ -9,3 +9,8 @@ service:
 # The way the daemonset name is defined results in a very long name with duplication (using the Chart name +
 # release name). Instead override the full name of the daemonset to what we want.
 fullName: prometheus-node-exporter
+
+# Enable Prometheus ServiceMonitor
+prometheus:
+  monitor:
+    enabled: true

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -14,6 +14,13 @@ prometheus:
       enabled: true
       name: additional-scrape-configs
       key: jobs
+    serviceMonitorSelector:
+      matchExpressions:
+      - key: release
+        operator: In
+        values:
+        - prometheus-operator
+        - prometheus-node-exporter
 alertmanager:
   enabled: false
 prometheusOperator:


### PR DESCRIPTION
# Description

PR to switch the network policies to use the new Prometheus Operator-managed Prometheus. Two policies were removed from the Verrazzano helm chart. One is now created programmatically in the Prometheus Operator component and the other is created in the Prometheus Node Exporter component.

I also fixed the node exporter helm overrides to enable the ServiceMonitor, and fixed a bug in the VMO network policy that prevented scraping of the VMO envoy sidecar.

DO NOT merge until we swap the ingress to the new Prometheus.

Implements VZ-6052

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
