### PR TITLE
VZ-6074 add unit test for --operator-file flag

### DIFF
--- a/tools/vz/test/testdata/operator-file-fake.yaml
+++ b/tools/vz/test/testdata/operator-file-fake.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# A real operator.yaml file would contain more information that this.  For testing purposes
+# we are making sure the file gets applied and any objects within it are added to the cluster.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verrazzano-install
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: verrazzano-platform-operator
+  namespace: verrazzano-install
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verrazzano-platform-operator
+  namespace: verrazzano-install
+  labels:
+    app: verrazzano-platform-operator
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: 9443
+  selector:
+    app: verrazzano-platform-operator
+


### PR DESCRIPTION
# Description

Add a unit test for --operator-file flag

Fixes VZ-6074

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
