### PR TITLE
VZ-5049 throttled unsteady rancher logs during oci dns host unavailability 

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -259,7 +259,10 @@ func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 	if err := removeBootstrapSecretIfExists(log, c); err != nil {
 		return log.ErrorfThrottledNewErr("Failed removing Rancher bootstrap secret: %s", err.Error())
 	}
-	return r.HelmComponent.PostInstall(ctx)
+	if err := r.HelmComponent.PostInstall(ctx); err != nil {
+		return log.ErrorfThrottledNewErr("Failed helm component post install: %s", err.Error())
+	}
+	return nil
 }
 
 // MonitorOverrides checks whether monitoring of install overrides is enabled or not

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -338,7 +338,7 @@ func TestPostInstall(t *testing.T) {
 	}
 
 	component := NewComponent()
-	assert.IsType(t, spi2.RetryableError{}, component.PostInstall(ctxWithoutIngress))
+	assert.IsType(t, fmt.Errorf(""), component.PostInstall(ctxWithoutIngress))
 	assert.Nil(t, component.PostInstall(ctxWithIngress))
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -15,7 +15,6 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	spi2 "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	k8sutilfake "github.com/verrazzano/verrazzano/pkg/k8sutil/fake"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"


### PR DESCRIPTION
# Description

This PR throttles the unsteady rancher logs during oci dns host unavailability. 

Fixes [VZ-5049](https://jira.oraclecorp.com/jira/browse/VZ-5049)
# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
