### PR TITLE
VZ-5000: Update test script to create OCI CLI configuration with comments inside default section

### DIFF
--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -13,23 +13,23 @@ if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   # perform these validations when instance principal is not used
   # Validate expected environment variables exist
   if [ -z "${OCI_CLI_REGION}" ]; then
-    echo "OCI_REGION environment variable must be set"
+    echo "OCI_CLI_REGION environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_TENANCY}" ]; then
-    echo "OCI_TENANCY_OCID environment variable must be set"
+    echo "OCI_CLI_TENANCY environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_USER}" ]; then
-    echo "OCI_USER_OCID environment variable must be set"
+    echo "OCI_CLI_USER environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_FINGERPRINT}" ]; then
-    echo "OCI_FINGERPRINT environment variable must be set"
+    echo "OCI_CLI_FINGERPRINT environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_KEY_FILE}" ]; then
-    echo "OCI_PRIVATE_KEY_FILE environment variable must be set"
+    echo "OCI_CLI_KEY_FILE environment variable must be set"
     exit 1
   fi
 fi
@@ -47,9 +47,9 @@ if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   OUTPUT_FILE="$TMP_DIR/oci_config"
   KEY_FILE="$TMP_DIR/oci_key"
   echo "[DEFAULT]" > $OUTPUT_FILE
-  echo "#region=someregion.region.com" > $OUTPUT_FILE
-  echo "#tenancy=OCID of the tenancy" > $OUTPUT_FILE
-  echo "#user=" > $OUTPUT_FILE
+  echo "#region=someregion.region.com" >> $OUTPUT_FILE
+  echo "#tenancy=OCID of the tenancy" >> $OUTPUT_FILE
+  echo "#user=" >> $OUTPUT_FILE
   echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE
   echo "tenancy=${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
   echo "user=${OCI_CLI_USER}" >> $OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -47,9 +47,9 @@ if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   OUTPUT_FILE="$TMP_DIR/oci_config"
   KEY_FILE="$TMP_DIR/oci_key"
   echo "[DEFAULT]" > $OUTPUT_FILE
-  echo "#region=someregion.region.com"
-  echo "#tenancy=OCID of the tenancy"
-  echo "#user="
+  echo "#region=someregion.region.com" > $OUTPUT_FILE
+  echo "#tenancy=OCID of the tenancy" > $OUTPUT_FILE
+  echo "#user=" > $OUTPUT_FILE
   echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE
   echo "tenancy=${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
   echo "user=${OCI_CLI_USER}" >> $OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -47,7 +47,7 @@ if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   OUTPUT_FILE="$TMP_DIR/oci_config"
   KEY_FILE="$TMP_DIR/oci_key"
   echo "[DEFAULT]" > $OUTPUT_FILE
-  echo "#region=someregion.region.com
+  echo "#region=someregion.region.com"
   echo "#tenancy=OCID of the tenancy"
   echo "#user="
   echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -47,6 +47,9 @@ if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   OUTPUT_FILE="$TMP_DIR/oci_config"
   KEY_FILE="$TMP_DIR/oci_key"
   echo "[DEFAULT]" > $OUTPUT_FILE
+  echo "#region=someregion.region.com
+  echo "#tenancy=OCID of the tenancy"
+  echo "#user="
   echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE
   echo "tenancy=${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
   echo "user=${OCI_CLI_USER}" >> $OUTPUT_FILE


### PR DESCRIPTION
# Description

Updates test script to create OCI CLI configuration with comments inside default section, there by provides basic test coverage for the earlier fix made to scripts provided to create Oracle Cloud Infrastructure secrets

Contributes to VZ-5000

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
