### PR TITLE
Make the releasable Verrazzano images list contain the dev version, so that we don't overwrite the file after a release has happened and dev version updated

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -3,7 +3,7 @@
 
 def GIT_COMMIT_TO_USE
 def VERRAZZANO_DEV_VERSION
-
+def RELEASABLE_IMAGES_OBJECT_STORE
 def agentLabel = env.JOB_NAME.contains('master') ? "phxsmall" : "VM.Standard2.2"
 def TESTS_FAILED = false
 def tarfilePrefix="verrazzano_periodic"
@@ -70,7 +70,6 @@ pipeline {
         OCI_OS_BUCKET="verrazzano-builds"
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
-        RELEASABLE_IMAGES_OBJECT_STORE = "releasable-verrazzano-images.txt"
 
         STABLE_COMMIT_OS_LOCATION = "${CLEAN_BRANCH_NAME}/last-stable-commit.txt"
         CLEAN_PERIODIC_OS_LOCATION = "${CLEAN_BRANCH_NAME}-last-clean-periodic-test/verrazzano_periodic-commit.txt"
@@ -168,6 +167,7 @@ pipeline {
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
                     storeLocation="${CLEAN_BRANCH_NAME}-last-clean-periodic-test/${tarfilePrefix}.zip"
+                    RELEASABLE_IMAGES_OBJECT_STORE = "verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt"
                 }
             }
         }

--- a/release/builds/JenkinsfileReleaseExistingCandidate
+++ b/release/builds/JenkinsfileReleaseExistingCandidate
@@ -42,7 +42,6 @@ pipeline {
         OCI_CLI_REGION = "us-phoenix-1"
         OCI_REGION = "${env.OCI_CLI_REGION}"
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
-        RELEASABLE_IMAGES_OBJECT_STORE = "releasable-verrazzano-images.txt"
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
     }
 
@@ -67,7 +66,7 @@ pipeline {
                             println("ERROR: No releasable commit found for dev version ${VERRAZZANO_DEV_VERSION}")
                             sh "exit 1"
                         }
-                        IMAGES_TO_PUBLISH_OBJECT_STORE_FILE="${env.CLEAN_BRANCH_NAME}/${env.RELEASABLE_IMAGES_OBJECT_STORE}"
+                        IMAGES_TO_PUBLISH_OBJECT_STORE_FILE="${env.CLEAN_BRANCH_NAME}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt"
                     }
                 }
             }


### PR DESCRIPTION


# Description

Please include a summary of the change and which issue is fixed.  If there are any dependencies, for example on a PR in another repository, please list those.

Fixes VZ-9999

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
