### PR TITLE
VZ-6067.  Handle boundary condition where last clean periodics file doesn't exist yet

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -91,35 +91,16 @@ pipeline {
                 """
 
                 script {
-                    // attempt to get the last clean periodic commit ID; if not found continue the run
-                    cmdResult="${WORKSPACE}/last-periodics-result.txt"
-                    lastPeriodicCommitCommand = sh (
-                        label: "Get last clean periodic commit ID",
-                        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 > ${cmdResult}",
-                        returnStatus: true
-                        )
-                    if (lastPeriodicCommitCommand != 0) {
-                        // If the error code from OCI was anything other than a 404, fail the run otherwise continue
-                        echo "Error occurred getting last periodic commit from ObjectStore"
-                        lastPeriodicCommitCommandOutput = sh (
-                                script: "cat ${cmdResult}",
-                                returnStdout: true
-                                ).trim()
-                        echo "Error: $lastPeriodicCommitCommandOutput"
-                        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore"
-                    }
 
                     // Get the last stable commit ID to pass the triggered tests
                     def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
                     GIT_COMMIT_TO_USE = stableCommitProps['git-commit']
                     echo "Last stable commit: ${GIT_COMMIT_TO_USE}"
 
-                    // Get the commit ID for the last known clean pass of the Periodic tests
-                    def cleanPeriodicsCommitProps = readProperties file: "${CLEAN_PERIODIC_LOCATION}"
-                    LAST_CLEAN_PERIODIC_COMMIT = cleanPeriodicsCommitProps['git-commit']
-                    echo "Last clean periodics commit: ${LAST_CLEAN_PERIODIC_COMMIT}"
+                    lastCleanPeriodicCommit=getLastCleanPeriodicCommit()
+                    echo "Last clean periodics commit: ${lastCleanPeriodicCommit}"
 
-                    if (LAST_CLEAN_PERIODIC_COMMIT == GIT_COMMIT_TO_USE) {
+                    if (lastCleanPeriodicCommit == GIT_COMMIT_TO_USE) {
                         periodicsUpToDate = true
                     }
 
@@ -619,6 +600,30 @@ pipeline {
             deleteDir()
         }
     }
+}
+
+// Gets the most recent clean commit for the periodic tests
+def getLastCleanPeriodicCommit() {
+    // attempt to get the last clean periodic commit ID; if not found continue the run
+    cmdResult="${WORKSPACE}/last-periodics-result.txt"
+    lastPeriodicCommitCommand = sh (
+        label: "Get last clean periodic commit ID",
+        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 > ${cmdResult}",
+        returnStatus: true
+        )
+    if (lastPeriodicCommitCommand != 0) {
+        // If the error code from OCI was anything other than a 404, fail the run otherwise continue
+        echo "Error occurred getting last periodic commit from ObjectStore"
+        lastPeriodicCommitCommandOutput = sh (
+                script: "cat ${cmdResult}",
+                returnStdout: true
+                ).trim()
+        echo "Error: $lastPeriodicCommitCommandOutput"
+        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore"
+    }
+    // Get the commit ID for the last known clean pass of the Periodic tests
+    def cleanPeriodicsCommitProps = readProperties file: "${CLEAN_PERIODIC_LOCATION}"
+    return cleanPeriodicsCommitProps['git-commit']
 }
 
 // Checks all the conditions gating test execution and coallates the result

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -602,6 +602,8 @@ pipeline {
     }
 }
 
+// Returns the last clean commit for the periodics, or null if the commit file does not exist yet.
+// - fails the pipeline if any error other than 404 is returned by the OCI CLI
 def getLastCleanPeriodicCommit() {
     lastPeriodicCommitCommandOutput = sh (
         label: "Get last clean periodic commit ID",
@@ -609,7 +611,9 @@ def getLastCleanPeriodicCommit() {
         returnStdout: true
         ).trim()
     echo "command out: ${lastPeriodicCommitCommandOutput}"
-    assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+    if (lastPeriodicCommitCommandOutput.length() > 0) {
+        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+    }
     // Get the commit ID for the last known clean pass of the Periodic tests
     def cleanPeriodicsCommitProps = readProperties file: "${CLEAN_PERIODIC_LOCATION}"
     return cleanPeriodicsCommitProps['git-commit']

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -97,7 +97,7 @@ pipeline {
                         label: "Get last clean periodic commit ID",
                         script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 > ${cmdResult}",
                         returnStatus: true
-                        ).trim()
+                        )
                     if (lastPeriodicCommitCommand != 0) {
                         // If the error code from OCI was anything other than a 404, fail the run otherwise continue
                         echo "Error occurred getting last periodic commit from ObjectStore"

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -88,10 +88,27 @@ pipeline {
             steps {
                 sh """
                     oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${STABLE_COMMIT_OS_LOCATION} --file ${STABLE_COMMIT_LOCATION}
-                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION}
                 """
 
                 script {
+                    // attempt to get the last clean periodic commit ID; if not found continue the run
+                    cmdResult="${WORKSPACE}/last-periodics-result.txt"
+                    lastPeriodicCommitCommand = sh (
+                        label: "Get last clean periodic commit ID",
+                        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 > ${cmdResult}",
+                        returnStatus: true
+                        ).trim()
+                    if (lastPeriodicCommitCommand != 0) {
+                        // If the error code from OCI was anything other than a 404, fail the run otherwise continue
+                        echo "Error occurred getting last periodic commit from ObjectStore"
+                        lastPeriodicCommitCommandOutput = sh (
+                                script: "cat ${cmdResult}",
+                                returnStdout: true
+                                ).trim()
+                        echo "Error: $lastPeriodicCommitCommandOutput"
+                        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore"
+                    }
+
                     // Get the last stable commit ID to pass the triggered tests
                     def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
                     GIT_COMMIT_TO_USE = stableCommitProps['git-commit']

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -602,25 +602,14 @@ pipeline {
     }
 }
 
-// Gets the most recent clean commit for the periodic tests
 def getLastCleanPeriodicCommit() {
-    // attempt to get the last clean periodic commit ID; if not found continue the run
-    cmdResult="${WORKSPACE}/last-periodics-result.txt"
-    lastPeriodicCommitCommand = sh (
+    lastPeriodicCommitCommandOutput = sh (
         label: "Get last clean periodic commit ID",
-        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 > ${cmdResult}",
-        returnStatus: true
-        )
-    if (lastPeriodicCommitCommand != 0) {
-        // If the error code from OCI was anything other than a 404, fail the run otherwise continue
-        echo "Error occurred getting last periodic commit from ObjectStore"
-        lastPeriodicCommitCommandOutput = sh (
-                script: "cat ${cmdResult}",
-                returnStdout: true
-                ).trim()
-        echo "Error: $lastPeriodicCommitCommandOutput"
-        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore"
-    }
+        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_PERIODIC_OS_LOCATION} --file ${CLEAN_PERIODIC_LOCATION} 2>&1 || true",
+        returnStdout: true
+        ).trim()
+    echo "command out: ${lastPeriodicCommitCommandOutput}"
+    assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
     // Get the commit ID for the last known clean pass of the Periodic tests
     def cleanPeriodicsCommitProps = readProperties file: "${CLEAN_PERIODIC_LOCATION}"
     return cleanPeriodicsCommitProps['git-commit']


### PR DESCRIPTION
# Description

Handle boundary condition where last clean periodics file doesn't exist yet.  Abort run if `oci os object get` returns any error other than a 404.

Fixes VZ-6067.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [x] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
