### PR TITLE
VZ-6074 vz install output mimics kubectl for apply for operator.yaml

### DIFF
--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -84,6 +84,12 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
+	// Validate the command options
+	err := validateCmd(cmd)
+	if err != nil {
+		return fmt.Errorf("Command validation failed: %s", err.Error())
+	}
+
 	// Get the verrazzano install resource to be created
 	vz, err := getVerrazzanoYAML(cmd)
 	if err != nil {
@@ -360,5 +366,13 @@ func waitForInstallToComplete(client clipkg.Client, kubeClient kubernetes.Interf
 		}
 	}
 
+	return nil
+}
+
+// validateCmd - validate the command line options
+func validateCmd(cmd *cobra.Command) error {
+	if cmd.PersistentFlags().Changed(constants.VersionFlag) && cmd.PersistentFlags().Changed(constants.OperatorFileFlag) {
+		return fmt.Errorf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.OperatorFileFlag)
+	}
 	return nil
 }

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -236,6 +236,11 @@ func applyPlatformOperatorYaml(cmd *cobra.Command, client client.Client, vzHelpe
 	if err != nil {
 		return fmt.Errorf("Failed to apply the file: %s", err.Error())
 	}
+
+	// Dump out the object result messages
+	for _, result := range yamlApplier.ObjectResultMsgs() {
+		fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("%s\n", strings.ToLower(result)))
+	}
 	return nil
 }
 

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -120,19 +120,22 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 		return err
 	}
 
-	// Get the version from the command line
-	version, err := cmd.PersistentFlags().GetString(constants.VersionFlag)
-	if err != nil {
-		return err
-	}
-	if version == constants.VersionFlagDefault {
-		// Find the latest release version of Verrazzano
-		version, err = helpers.GetLatestReleaseVersion(vzHelper.GetHTTPClient())
+	// When --operator-file is not used, get the version from the command line
+	var version string
+	if !cmd.PersistentFlags().Changed(constants.OperatorFileFlag) {
+		version, err = cmd.PersistentFlags().GetString(constants.VersionFlag)
 		if err != nil {
 			return err
 		}
+		if version == constants.VersionFlagDefault {
+			// Find the latest release version of Verrazzano
+			version, err = helpers.GetLatestReleaseVersion(vzHelper.GetHTTPClient())
+			if err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Installing Verrazzano version %s\n", version))
 	}
-	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Installing Verrazzano version %s\n", version))
 
 	// Apply the Verrazzano operator.yaml.
 	err = applyPlatformOperatorYaml(cmd, client, vzHelper, version)

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -6,6 +6,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -286,6 +287,23 @@ func TestInstallCmdOperatorFile(t *testing.T) {
 	svc := corev1.Service{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "verrazzano-install", Name: "verrazzano-platform-operator"}, &svc)
 	assert.NoError(t, err)
+}
+
+// TestInstallValidations
+// GIVEN an install command
+//  WHEN invalid command options exist
+//  THEN expect an error
+func TestInstallValidations(t *testing.T) {
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	cmd := NewCmdInstall(rc)
+	assert.NotNil(t, cmd)
+	cmd.PersistentFlags().Set(constants.OperatorFileFlag, "test")
+	cmd.PersistentFlags().Set(constants.VersionFlag, "test")
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.OperatorFileFlag))
 }
 
 // TestGetWaitTimeoutDefault

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -274,6 +274,7 @@ func TestInstallCmdOperatorFile(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
+	assert.Contains(t, buf.String(), "Applying the file ../../test/testdata/operator-file-fake.yaml\nnamespace/verrazzano-install created\nserviceaccount/verrazzano-platform-operator created\nservice/verrazzano-platform-operator created\n")
 
 	// Verify the objects in the operator-file got added
 	sa := corev1.ServiceAccount{}


### PR DESCRIPTION
# Description

The console output of "vz install" will now show each object applied within operator.yaml (using the same text formatting as kubectl)

Fixes VZ-6074

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
