### PR TITLE
NOJIRA: Changes for getting the correct coverage metrics

### DIFF
--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -4,11 +4,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Code coverage generation
-# Excludes test utility packages and the test directory
-go test -coverpkg=./... -coverprofile ./coverage.raw.cov $(go list ./... | \
+TEST_PKGS=$(go list ./... | \
   grep -Ev github.com/verrazzano/verrazzano/application-operator/test/integ | \
   grep -Ev github.com/verrazzano/verrazzano/application-operator/mocks | \
   grep -Ev github.com/verrazzano/verrazzano/application-operator/clients | \
+  grep -Ev github.com/verrazzano/verrazzano/image-patch-operator/clients | \
   grep -Ev github.com/verrazzano/verrazzano/platform-operator/mocks | \
   grep -Ev github.com/verrazzano/verrazzano/platform-operator/test/integ | \
   grep -Ev github.com/verrazzano/verrazzano/platform-operator/clients | \
@@ -18,6 +18,8 @@ go test -coverpkg=./... -coverprofile ./coverage.raw.cov $(go list ./... | \
   grep -Ev github.com/verrazzano/verrazzano/tools/fix-copyright | \
   grep -Ev github.com/verrazzano/verrazzano/tests | \
   grep -Ev github.com/verrazzano/verrazzano/pkg/test/framework)
+# Excludes test utility packages and the test directory
+go test -coverpkg=$(echo ${TEST_PKGS}|tr ' ' ',') -coverprofile ./coverage.raw.cov ${TEST_PKGS}
 
 TEST_STATUS=$?
 


### PR DESCRIPTION
# Description

When running coverage using  make target, `make -B coverage`, the `-covpkg` argument is set to `./...`. This includes all packages under verrazzano. However, only the required packages which are covered as part of the tests needs to be included. This change is for addressing this issue and .

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
