### PR TITLE
VZ-5000: Add validations to the scripts to create an Oracle Cloud Infrastructure secret in release-1.3

### DIFF
--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -9,56 +9,59 @@ set -e
 TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
-OCI_CONFIG_SECRET_NAME=oci
-VERRAZZANO_INSTALL_NS=verrazzano-install
-
 if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   # perform these validations when instance principal is not used
   # Validate expected environment variables exist
   if [ -z "${OCI_CLI_REGION}" ]; then
-    echo "OCI_REGION environment variable must be set"
+    echo "OCI_CLI_REGION environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_TENANCY}" ]; then
-    echo "OCI_TENANCY_OCID environment variable must be set"
+    echo "OCI_CLI_TENANCY environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_USER}" ]; then
-    echo "OCI_USER_OCID environment variable must be set"
+    echo "OCI_CLI_USER environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_FINGERPRINT}" ]; then
-    echo "OCI_FINGERPRINT environment variable must be set"
+    echo "OCI_CLI_FINGERPRINT environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_KEY_FILE}" ]; then
-    echo "OCI_PRIVATE_KEY_FILE environment variable must be set"
+    echo "OCI_CLI_KEY_FILE environment variable must be set"
     exit 1
   fi
 fi
 
+if [ -z "$WORKSPACE" ] ; then
+  echo "This script must only be called from Jenkins and requires environment variable WORKSPACE is set"
+  exit 1
+fi
 
-OUTPUT_FILE=$TMP_DIR/oci-config.yaml
-echo "OCI_DNS_AUTH value = " ${OCI_DNS_AUTH}
-# Generate the yaml file
-if [ "${OCI_DNS_AUTH}" == "instance_principal" ]; then
-  echo "auth:" > $OUTPUT_FILE
-  echo "  authtype: instance_principal" >> $OUTPUT_FILE
-else
-  echo "auth:" > $OUTPUT_FILE
-  echo "  region: ${OCI_CLI_REGION}" >> $OUTPUT_FILE
-  echo "  tenancy: ${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
-  echo "  user: ${OCI_CLI_USER}" >> $OUTPUT_FILE
-  echo "  key: |" >> $OUTPUT_FILE
-  cat ${OCI_CLI_KEY_FILE} | sed 's/^/    /' >> $OUTPUT_FILE
-  echo "  fingerprint: ${OCI_CLI_FINGERPRINT}" >> $OUTPUT_FILE
+# Copy/download the create_oci_config_secret.sh to WORKSPACE and run it as a standalone script
+cp ${WORKSPACE}/platform-operator/scripts/install/create_oci_config_secret.sh ${WORKSPACE}/create_oci_config_secret.sh
+chmod +x ${WORKSPACE}/create_oci_config_secret.sh
+
+if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
+  OUTPUT_FILE="$TMP_DIR/oci_config"
+  KEY_FILE="$TMP_DIR/oci_key"
+  echo "[DEFAULT]" > $OUTPUT_FILE
+  echo "#region=someregion.region.com" >> $OUTPUT_FILE
+  echo "#tenancy=OCID of the tenancy" >> $OUTPUT_FILE
+  echo "#user=" >> $OUTPUT_FILE
+  echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE
+  echo "tenancy=${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
+  echo "user=${OCI_CLI_USER}" >> $OUTPUT_FILE
+  echo "fingerprint=${OCI_CLI_FINGERPRINT}" >> $OUTPUT_FILE
   if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
     echo "  passphrase: ${OCI_PRIVATE_KEY_PASSPHRASE}" >> $OUTPUT_FILE
   fi
+  echo "key_file=$KEY_FILE" >> $OUTPUT_FILE
+  cat ${OCI_CLI_KEY_FILE} > $KEY_FILE
+  echo "Creating the secret with auth_type user_principal"
+  ${WORKSPACE}/create_oci_config_secret.sh -o ${OUTPUT_FILE}
+else
+  echo "Creating the secret with auth_type instance_principal"
+  ${WORKSPACE}/create_oci_config_secret.sh -a instance_principal
 fi
-# create the secret in verrazzano-install namespace
-if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
-  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and try again."
-  exit 1
-fi
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE


### PR DESCRIPTION
# Description

Updates helper script - platform-operator/scripts/install/create_oci_config_secret.sh to handle comments, space and tab characters for the keys in OCI CLI configuration. The script is used to create an Oracle Cloud Infrastructure (OCI) secret.

Additional validations are included as appropriate. The test specific script creating the OCI secret is modified to call the helper script.

Contributes to VZ-5000

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
