### PR TITLE
VZ-5000: Add validations to the scripts to create an Oracle Cloud Infrastructure secret in release-1.1

### DIFF
--- a/platform-operator/scripts/install/create_oci_config_secret.sh
+++ b/platform-operator/scripts/install/create_oci_config_secret.sh
@@ -3,6 +3,10 @@
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
+# Creates a Kubernetes secret based on an OCI CLI configuration for consumption by External-DNS and/or Cert-Manager
+#
+
+# WARNING: This script can be downloaded and run standalone. All required functions must exist within this script
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 if [ -z "${KUBECONFIG:-}" ] ; then
@@ -32,7 +36,8 @@ function read_config() {
   local key
   [ $# -eq 3 ] && key=$3
 
- local lines=$(awk '/\[/{prefix=$0; next} $1{print prefix $0}' $ocifile)
+ # Read the lines from the OCI CLI configuration file, by ignoring the comments and prefix each line with the given section.
+ local lines=$(awk '!/^#/{gsub(/^[[:space:]]*#.*/,"",$0);print}' $ocifile | awk '/\[/{prefix=$0; next} $1{print prefix $0}')
   for line in $lines; do
     if [[ "$line" = \[$SECTION\]* ]]; then
       local keyval=$(echo $line | sed -e "s/^\[$SECTION\]//")
@@ -50,9 +55,9 @@ function read_config() {
 function usage {
     echo
     echo "usage: $0 [-o oci_config_file] [-s config_file_section]"
-    echo "  -o oci_config_file         The full path to the OCI configuration file (default ~/.oci/config)"
-    echo "  -s config_file_section     The properties section within the OCI configuration file.  Default is DEFAULT"
-    echo "  -k secret_name             The secret name containing the OCI configuration.  Default is oci"
+    echo "  -o oci_config_file         The full path to the OCI configuration file. Default is ~/.oci/config"
+    echo "  -s config_file_section     The properties section within the OCI configuration file. Default is DEFAULT"
+    echo "  -k secret_name             The secret name containing the OCI configuration. Default is oci"
     echo "  -c context_name            The kubectl context to use"
     echo "  -a auth_type               The auth_type to be used to access OCI. Valid values are user_principal/instance_principal. Default is user_principal."
     echo "  -h                         Help"
@@ -88,13 +93,29 @@ if [ "${OCI_AUTH_TYPE_INPUT:-}" ] ; then
   fi
 fi
 
-#create the yaml file
-SECTION_PROPS=$(read_config $OCI_CONFIG_FILE $SECTION *)
-eval $SECTION_PROPS
 if [ ${OCI_AUTH_TYPE} == "instance_principal" ] ; then
   echo "auth:" > $OUTPUT_FILE
   echo "  authtype: instance_principal" >> $OUTPUT_FILE
-else
+fi
+
+if [ ${OCI_AUTH_TYPE} == "user_principal" ] ; then
+  if [[ ! -f ${OCI_CONFIG_FILE} ]]; then
+    echo "OCI CLI configuration ${OCI_CONFIG_FILE} does not exist."
+    usage
+    exit 1
+  fi
+
+  SECTION_PROPS=$(read_config $OCI_CONFIG_FILE $SECTION *)
+  eval $SECTION_PROPS
+
+  # The entries user, fingerprint, key_file, tenancy and region are mandatory in the OCI CLI configuration file.
+  # An empty/null value for any of the values in $OUTPUT_FILE indicates an issue with the configuration file.
+  if [ -z "$region" ] || [ -z "$tenancy" ] || [ -z "$user" ] || [ -z "$key_file" ] || [ -z "$fingerprint" ]; then
+    echo "One or more required entries are missing from section $SECTION in OCI CLI configuration."
+    exit 1
+  fi
+
+  #create the yaml file
   echo "auth:" > $OUTPUT_FILE
   echo "  region: $region" >> $OUTPUT_FILE
   echo "  tenancy: $tenancy" >> $OUTPUT_FILE
@@ -109,7 +130,6 @@ else
 fi
 
 # create the secret in verrazzano-install namespace
-create_secret=true
 kubectl ${K8SCONTEXT} get secret $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   # secret exists
@@ -117,8 +137,3 @@ if [ $? -eq 0 ]; then
   exit 1
 fi
 kubectl ${K8SCONTEXT} create secret -n $VERRAZZANO_INSTALL_NS  generic $OCI_CONFIG_SECRET_NAME --from-file=$OUTPUT_FILE
-
-
-
-
-

--- a/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+++ b/tests/e2e/config/scripts/create-test-oci-config-secret.sh
@@ -9,56 +9,59 @@ set -e
 TMP_DIR=$(mktemp -d)
 trap 'rc=$?; rm -rf ${TMP_DIR} || true' EXIT
 
-OCI_CONFIG_SECRET_NAME=oci
-VERRAZZANO_INSTALL_NS=verrazzano-install
-
 if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
   # perform these validations when instance principal is not used
   # Validate expected environment variables exist
   if [ -z "${OCI_CLI_REGION}" ]; then
-    echo "OCI_REGION environment variable must be set"
+    echo "OCI_CLI_REGION environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_TENANCY}" ]; then
-    echo "OCI_TENANCY_OCID environment variable must be set"
+    echo "OCI_CLI_TENANCY environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_USER}" ]; then
-    echo "OCI_USER_OCID environment variable must be set"
+    echo "OCI_CLI_USER environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_FINGERPRINT}" ]; then
-    echo "OCI_FINGERPRINT environment variable must be set"
+    echo "OCI_CLI_FINGERPRINT environment variable must be set"
     exit 1
   fi
   if [ -z "${OCI_CLI_KEY_FILE}" ]; then
-    echo "OCI_PRIVATE_KEY_FILE environment variable must be set"
+    echo "OCI_CLI_KEY_FILE environment variable must be set"
     exit 1
   fi
 fi
 
+if [ -z "$WORKSPACE" ] ; then
+  echo "This script must only be called from Jenkins and requires environment variable WORKSPACE is set"
+  exit 1
+fi
 
-OUTPUT_FILE=$TMP_DIR/oci-config.yaml
-echo "OCI_DNS_AUTH value = " ${OCI_DNS_AUTH}
-# Generate the yaml file
-if [ "${OCI_DNS_AUTH}" == "instance_principal" ]; then
-  echo "auth:" > $OUTPUT_FILE
-  echo "  authtype: instance_principal" >> $OUTPUT_FILE
-else
-  echo "auth:" > $OUTPUT_FILE
-  echo "  region: ${OCI_CLI_REGION}" >> $OUTPUT_FILE
-  echo "  tenancy: ${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
-  echo "  user: ${OCI_CLI_USER}" >> $OUTPUT_FILE
-  echo "  key: |" >> $OUTPUT_FILE
-  cat ${OCI_CLI_KEY_FILE} | sed 's/^/    /' >> $OUTPUT_FILE
-  echo "  fingerprint: ${OCI_CLI_FINGERPRINT}" >> $OUTPUT_FILE
+# Copy/download the create_oci_config_secret.sh to WORKSPACE and run it as a standalone script
+cp ${WORKSPACE}/platform-operator/scripts/install/create_oci_config_secret.sh ${WORKSPACE}/create_oci_config_secret.sh
+chmod +x ${WORKSPACE}/create_oci_config_secret.sh
+
+if [ "${OCI_DNS_AUTH}" != "instance_principal" ]; then
+  OUTPUT_FILE="$TMP_DIR/oci_config"
+  KEY_FILE="$TMP_DIR/oci_key"
+  echo "[DEFAULT]" > $OUTPUT_FILE
+  echo "#region=someregion.region.com" >> $OUTPUT_FILE
+  echo "#tenancy=OCID of the tenancy" >> $OUTPUT_FILE
+  echo "#user=" >> $OUTPUT_FILE
+  echo "region=${OCI_CLI_REGION}" >> $OUTPUT_FILE
+  echo "tenancy=${OCI_CLI_TENANCY}" >> $OUTPUT_FILE
+  echo "user=${OCI_CLI_USER}" >> $OUTPUT_FILE
+  echo "fingerprint=${OCI_CLI_FINGERPRINT}" >> $OUTPUT_FILE
   if [[ ! -z "${OCI_PRIVATE_KEY_PASSPHRASE}" ]]; then
     echo "  passphrase: ${OCI_PRIVATE_KEY_PASSPHRASE}" >> $OUTPUT_FILE
   fi
+  echo "key_file=$KEY_FILE" >> $OUTPUT_FILE
+  cat ${OCI_CLI_KEY_FILE} > $KEY_FILE
+  echo "Creating the secret with auth_type user_principal"
+  ${WORKSPACE}/create_oci_config_secret.sh -o ${OUTPUT_FILE}
+else
+  echo "Creating the secret with auth_type instance_principal"
+  ${WORKSPACE}/create_oci_config_secret.sh -a instance_principal
 fi
-# create the secret in verrazzano-install namespace
-if ! kubectl get namespace ${VERRAZZANO_INSTALL_NS} ; then
-  echo "The namespace ${VERRAZZANO_INSTALL_NS} doesn't exit. Please install the Verrazzano platform operator and try again."
-  exit 1
-fi
-kubectl create secret generic $OCI_CONFIG_SECRET_NAME -n $VERRAZZANO_INSTALL_NS --from-file=$OUTPUT_FILE


### PR DESCRIPTION
# Description

Updates helper script - platform-operator/scripts/install/create_oci_config_secret.sh to handle comments, space and tab characters for the keys in OCI CLI configuration. The script is used to create an Oracle Cloud Infrastructure (OCI) secret.

Additional validations are included as appropriate. The test specific script creating the OCI secret is modified to call the helper script.

Contributes to VZ-5000

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
