### PR TITLE
VZ-6098.  Backport to release-1.3

### DIFF
--- a/pkg/istio/istioctl.go
+++ b/pkg/istio/istioctl.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	vzos "github.com/verrazzano/verrazzano/pkg/os"
@@ -76,7 +77,6 @@ func Install(log vzlog.VerrazzanoLogger, overrideStrings string, overridesFiles 
 
 // IsInstalled returns true if Istio is installed
 func IsInstalled(log vzlog.VerrazzanoLogger) (bool, error) {
-
 	// Perform istioctl call of type upgrade
 	stdout, _, err := VerifyInstall(log)
 	if err != nil {
@@ -89,14 +89,13 @@ func IsInstalled(log vzlog.VerrazzanoLogger) (bool, error) {
 }
 
 // VerifyInstall verifies the Istio installation
-
 func VerifyInstall(log vzlog.VerrazzanoLogger) (stdout []byte, stderr []byte, err error) {
 	args := []string{"verify-install"}
 
 	// Perform istioctl call of type upgrade
 	stdout, stderr, err = runIstioctl(log, args, "verify-install")
 	if err != nil {
-		return stdout, stderr, err
+		return stdout, stderr, errors.Wrapf(err, "verify-install failed, stderr: %s", stderr)
 	}
 
 	return stdout, stderr, nil
@@ -107,11 +106,10 @@ func VerifyInstall(log vzlog.VerrazzanoLogger) (stdout []byte, stderr []byte, er
 // The operationName field is just used for visibility of operation in logging at the moment
 func runIstioctl(log vzlog.VerrazzanoLogger, cmdArgs []string, operationName string) (stdout []byte, stderr []byte, err error) {
 	cmd := exec.Command("istioctl", cmdArgs...)
-	log.Infof("Running istioctl command: %s", cmd.String())
-
+	log.Progressf("Running istioctl command: %s", cmd.String())
 	stdout, stderr, err = runner.Run(cmd)
 	if err != nil {
-		log.Errorf("Failed running istioctl command %s: %s", cmd.String(), stderr)
+		log.Progressf("Failed running istioctl command %s: %s", cmd.String(), stderr)
 		return stdout, stderr, err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -58,6 +58,9 @@ const subcompIstiod = "istiod"
 // This IstioOperator YAML uses this imagePullSecret key
 const imagePullSecretHelmKey = "values.global.imagePullSecrets[0]"
 
+// istioManfiestNotInstalledError - Expected error during install when running verify-install before Istio CR is applied
+const istioManfiestNotInstalledError = "Istio present but verify-install needs an IstioOperator or manifest for comparison"
+
 // istioComponent represents an Istio component
 type istioComponent struct {
 	// ValuesFile contains the path to the IstioOperator CR values file
@@ -240,14 +243,20 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 		return false
 	}
 
-	// Make sure istioctl successfully completed.  We have seen cases during install where the Istio
-	// deployments are ready but istioctl fails.
-	if context.ActualCR().Status.State == vzapi.VzStateInstalling && !i.monitor.isIstioctlSuccess() {
-		context.Log().Infof("%s is waiting for istioctl install to successfully complete", prefix)
+	verified, err := isInstalledFunc(context.Log())
+	if err != nil && !isIstioManifestNotInstalledError(err) {
+		context.Log().ErrorfThrottled("Unexpected error checking Istio status: %s", err)
 		return false
 	}
-
+	if !verified {
+		context.Log().Progressf("%s is waiting for istioctl verify-install to successfully complete", prefix)
+		return false
+	}
 	return true
+}
+
+func isIstioManifestNotInstalledError(err error) bool {
+	return strings.Contains(err.Error(), istioManfiestNotInstalledError)
 }
 
 // GetDependencies returns the dependencies of this component

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -6,6 +6,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/istio"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/types"
 	"os/exec"
@@ -368,10 +369,13 @@ func TestIsReady(t *testing.T) {
 			},
 		},
 	).Build()
-	var iComp istioComponent
-	iComp.monitor = &fakeMonitor{
-		istioctlSuccess: true,
+
+	isInstalledFunc = func(log vzlog.VerrazzanoLogger) (bool, error) {
+		return true, nil
 	}
+	defer func() { isInstalledFunc = istio.IsInstalled }()
+
+	var iComp istioComponent
 	compContext := spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)
 	assert.True(t, iComp.IsReady(compContext))
 }


### PR DESCRIPTION

# Description

Backport to release-1.3.

Use Istioctl verify-install to check Istio install readiness. (#3373)
- Remove success boolean/accessor from installMonitor
- Clean up istio.VerifyInstall error reporting
- Squelch runIstioctl verbose output for VerifyInstall calls
- Ignore expected verify-install error during initial install of Istio

Fixes VZ-6098.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
