### PR TITLE
VZ-6022: Fluentd Monitor Agent should not be logged (#3369)

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/verrazzano-logging.yaml
@@ -110,7 +110,6 @@ data:
       @id in_monitor_agent
       bind 0.0.0.0
       port 24220
-      tag fluentd.monitor.metrics
     </source>
 
   prometheus.conf: |
@@ -579,7 +578,7 @@ data:
 {{- if .Values.fluentd.oci }}
   oci-logging-system.conf: |
     # Match all "system" namespaces so system log records are sent to a separate OCI Log object
-    <match kubernetes.**kube-** kubernetes.**verrazzano-system** kubernetes.**verrazzano-install** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** systemd.** fluentd.monitor.metrics>
+    <match kubernetes.**kube-** kubernetes.**verrazzano-system** kubernetes.**verrazzano-install** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** systemd.**>
       @type oci_logging
       log_object_id {{ .Values.fluentd.oci.systemLogId }}
       <buffer>


### PR DESCRIPTION
# Description
Backport to 1.2

Fixes VZ-6022

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
