### PR TITLE
VZ-6162 - Fix for AuthProxy installation failure when prometheus operator is not enabled

### DIFF
--- a/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
@@ -6,13 +6,13 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: authproxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .monitoringNamespace }}
   labels:
     release: prometheus-operator
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ .systemNamespace }}
   selector: {}
   endpoints:
     - port: https

--- a/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-{{ if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -53,4 +52,3 @@ spec:
         sourceLabels:
         - name
         targetLabel: app
-  {{ end -}}

--- a/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/authproxy_monitor.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+{{ if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -52,3 +53,4 @@ spec:
         sourceLabels:
         - name
         targetLabel: app
+  {{ end -}}


### PR DESCRIPTION

# Description

When PrometheusOperator is disabled explicitly (enabled by default) in the Verrazzano CR, then the installation of Verrazzano fails as the AuthProxy component does not complete its installation. The root cause of the error is due to the `ServiceMonitor` CR added to the AuthProxy Helm chart. The fix is to move it from the Authproxy helm chart to PromOperator, so that the ServiceMonitor gets created only if the PrometheusOperator component is enabled.

Fixes VZ-6162

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
