### PR TITLE
VZ-6098 Revert "revert making nginx a dependency of authproxy"

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
+
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -46,6 +48,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
 			GetInstallOverridesFunc: GetOverrides,
+			Dependencies:            []string{nginx.ComponentName},
 			Certificates: []types.NamespacedName{
 				{Name: constants.VerrazzanoIngressSecret, Namespace: ComponentNamespace},
 			},

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -524,11 +524,10 @@ func validateServiceNodePortAndExternalIP(expectedSystemExternalIP, expectedAppl
 		if err != nil {
 			return err
 		}
-		// uncomment this once nginx is a dependence of authproxy
-		//err = validateIngressHost(expectedSystemExternalIP, "verrazzano-ingress", "verrazzano-system")
-		//if err != nil {
-		//	return err
-		//}
+		err = validateIngressHost(expectedSystemExternalIP, "verrazzano-ingress", "verrazzano-system")
+		if err != nil {
+			return err
+		}
 
 		// validate application Host
 		err = validateApplicationHost(expectedApplicationExternalIP)
@@ -580,11 +579,10 @@ func validateServiceLoadBalancer() {
 		if err != nil {
 			return err
 		}
-		// uncomment this once nginx is a dependence of authproxy
-		//err = validateIngressHost(nginxLBIP, "verrazzano-ingress", "verrazzano-system")
-		//if err != nil {
-		//	return err
-		//}
+		err = validateIngressHost(nginxLBIP, "verrazzano-ingress", "verrazzano-system")
+		if err != nil {
+			return err
+		}
 
 		// validate application Host
 		err = validateApplicationHost(istioLBIP)


### PR DESCRIPTION
This reverts commit 65ef6976d561257e16a7842a867948e15c72371a.

# Description

Make authproxy depend on nginx.
Enable dynamic-config-updates test for verrazzano-ingress.

Fixes VZ-6098

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
