### PR TITLE
VZ-6017: Only update Prometheus scrape config when user overrides the default scraper

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -117,3 +117,7 @@ const VerrazzanoIngressTLSSecret = "verrazzano-tls" //nolint:gosec //#gosec G101
 
 // VerrazzanoLocalCABundleSecret is the name of the secret in the verrazzano-mc namespace on an admin cluster that contains the cluster's ca bundle
 const VerrazzanoLocalCABundleSecret = "verrazzano-local-ca-bundle" //nolint:gosec //#gosec G101
+
+// DefaultScraperName is the default Prometheus deployment name used to scrape metrics. If a metrics trait does not specify a scraper, this
+// is the scraper that will be used.
+const DefaultScraperName = "verrazzano-system/vmi-system-prometheus-0"

--- a/application-operator/controllers/metricstrait/metricstrait_controller.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller.go
@@ -14,6 +14,7 @@ import (
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/reconcileresults"
@@ -321,6 +322,12 @@ func (r *Reconciler) reconcileTraitCreateOrUpdate(ctx context.Context, trait *vz
 		return reconcile.Result{Requeue: false}, supported, nil
 	}
 
+	// If the legacy Prometheus instance is the scraper, do not attempt to update scrape config, a ServiceMonitor will be
+	// created instead.
+	if r.isLegacyPrometheusScraper(trait, traitDefaults) {
+		return reconcile.Result{}, true, nil
+	}
+
 	var scraper *k8sapps.Deployment
 	if scraper, err = r.fetchPrometheusDeploymentFromTrait(ctx, trait, traitDefaults, log); err != nil {
 		return reconcile.Result{}, true, err
@@ -536,6 +543,15 @@ func (r *Reconciler) updatePrometheusScraperConfigMap(ctx context.Context, trait
 		return rel, controllerutil.OperationResultNone, err
 	}
 	return rel, controllerutil.OperationResultUpdated, nil
+}
+
+// isLegacyPrometheusScraper returns true if the scraper is the legacy VMO-managed Prometheus.
+func (r *Reconciler) isLegacyPrometheusScraper(trait *vzapi.MetricsTrait, traitDefaults *vzapi.MetricsTraitSpec) bool {
+	scraperRef := trait.Spec.Scraper
+	if scraperRef == nil {
+		scraperRef = traitDefaults.Scraper
+	}
+	return *scraperRef == constants.DefaultScraperName
 }
 
 // fetchPrometheusDeploymentFromTrait fetches the Prometheus deployment from information in the trait.

--- a/application-operator/controllers/metricstrait/operator.go
+++ b/application-operator/controllers/metricstrait/operator.go
@@ -49,6 +49,12 @@ func (r *Reconciler) reconcileOperatorTraitCreateOrUpdate(ctx context.Context, t
 		return reconcile.Result{Requeue: false}, nil
 	}
 
+	// If the user has specified a non-default (i.e. not the legacy Prometheus) scraper, then we have already updated the scrape config,
+	// so do not attempt to create/update a ServiceMonitor.
+	if !r.isLegacyPrometheusScraper(trait, traitDefaults) {
+		return reconcile.Result{}, nil
+	}
+
 	// Find the child resources of the workload based on the childResourceKinds from the
 	// workload definition, workload uid and the ownerReferences of the children.
 	var children []*unstructured.Unstructured

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -74,8 +74,6 @@ func init() {
 	_ = promoperapi.AddToScheme(scheme)
 }
 
-const defaultScraperName = "verrazzano-system/vmi-system-prometheus-0"
-
 var (
 	metricsAddr           string
 	defaultMetricsScraper string
@@ -86,7 +84,7 @@ var (
 
 func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&defaultMetricsScraper, "default-metrics-scraper", defaultScraperName,
+	flag.StringVar(&defaultMetricsScraper, "default-metrics-scraper", constants.DefaultScraperName,
 		"The namespace/deploymentName of the prometheus deployment to be used as the default metrics scraper")
 	flag.StringVar(&certDir, "cert-dir", "/etc/certs/", "The directory containing tls.crt and tls.key.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,


### PR DESCRIPTION
# Description

The metrics trait controller currently updates the old Prometheus scrape config and also creates a ServiceMonitor for the new Prometheus. This PR changes that so that the scrape config is only updated if the user has provided their own scraper (i.e. the external Prometheus case). Additionally, if the user provides a scraper we won't create a ServiceMonitor.

Implements VZ-6017

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
