### PR TITLE
VZ-6017 Correct multiple port labeling string

### DIFF
--- a/application-operator/internal/metrics/service_monitor.go
+++ b/application-operator/internal/metrics/service_monitor.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"fmt"
+	"strconv"
 
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -111,7 +112,7 @@ func createServiceMonitorEndpoint(info ScrapeInfo, portIncrement int) (promopera
 	if info.VZPrometheusLabels != nil && *info.VZPrometheusLabels {
 		var portString string
 		if portIncrement > 0 {
-			portString = fmt.Sprintf("_%d", portIncrement)
+			portString = strconv.Itoa(portIncrement)
 		}
 		enabledLabel = fmt.Sprintf("__meta_kubernetes_pod_annotation_verrazzano_io_metricsEnabled%s", portString)
 		portLabel = fmt.Sprintf("__meta_kubernetes_pod_annotation_verrazzano_io_metricsPort%s", portString)

--- a/application-operator/internal/metrics/service_monitor_test.go
+++ b/application-operator/internal/metrics/service_monitor_test.go
@@ -83,7 +83,7 @@ func TestPopulateServiceMonitor(t *testing.T) {
 						promoperapi.LabelName("__meta_kubernetes_pod_annotation_verrazzano_io_metricsEnabled"))
 					if len(serviceMonitor.Spec.Endpoints) >= 1 {
 						asserts.Contains(t, serviceMonitor.Spec.Endpoints[1].RelabelConfigs[1].SourceLabels,
-							promoperapi.LabelName("__meta_kubernetes_pod_annotation_verrazzano_io_metricsEnabled_1"))
+							promoperapi.LabelName("__meta_kubernetes_pod_annotation_verrazzano_io_metricsEnabled1"))
 					}
 					asserts.Contains(t, serviceMonitor.Spec.Endpoints[0].RelabelConfigs[1].SourceLabels,
 						promoperapi.LabelName("test"))


### PR DESCRIPTION
# Description

The port naming for multiple ports was causing coherence workloads to lose some metrics. This should fix that issue

Fixes VZ-6017

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
