### PR TITLE
VZ-5661: Make fluentd check for verrazzano-es-internal secret in preinstall and preupgrade to avoid fluentd pod CrashLoopBackoff and retries of the secret

### DIFF
--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -29,6 +30,28 @@ const (
 	fluentdConfig   = "fluentd-config"
 	fluentdEsConfig = "fluentd-es-config"
 )
+
+//checkSecretExists whether verrazzano-es-internal secret exists. Return error if secret does not exist.
+func checkSecretExists(ctx spi.ComponentContext) error {
+	// Check verrazzano-es-internal Secret. return error which will cause requeue
+	secret := &corev1.Secret{}
+	err := ctx.Client().Get(context.TODO(), clipkg.ObjectKey{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      globalconst.VerrazzanoESInternal,
+	}, secret)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			ctx.Log().Progressf("Component Fluentd waiting for the secret %s/%s to exist",
+				constants.VerrazzanoSystemNamespace, globalconst.VerrazzanoESInternal)
+			return ctrlerrors.RetryableError{Source: ComponentName}
+		}
+		ctx.Log().Errorf("Component Fluentd failed to get the secret %s/%s: %v",
+			constants.VerrazzanoSystemNamespace, globalconst.VerrazzanoESInternal, err)
+		return err
+	}
+	return nil
+}
 
 // loggingPreInstall copies logging secrets from the verrazzano-install namespace to the verrazzano-system namespace
 func loggingPreInstall(ctx spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component.go
@@ -116,6 +116,9 @@ func (f fluentdComponent) PreInstall(ctx spi.ComponentContext) error {
 	if err := loggingPreInstall(ctx); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed copying logging secrets for Verrazzano: %v", err)
 	}
+	if err := checkSecretExists(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -130,6 +133,9 @@ func (f fluentdComponent) Install(ctx spi.ComponentContext) error {
 // PreUpgrade Fluentd component pre-upgrade processing
 func (f fluentdComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	if err := fluentdPreUpgrade(ctx, ComponentNamespace); err != nil {
+		return err
+	}
+	if err := checkSecretExists(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
@@ -5,13 +5,16 @@ package fluentd
 
 import (
 	"github.com/stretchr/testify/assert"
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +40,13 @@ var fluentdEnabledCR = &vzapi.Verrazzano{
 				Enabled: &enabled,
 			},
 		},
+	},
+}
+
+var vzEsInternalSecret = &v1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      globalconst.VerrazzanoESInternal,
+		Namespace: constants.VerrazzanoSystemNamespace,
 	},
 }
 
@@ -252,17 +262,41 @@ func TestPostUpgrade(t *testing.T) {
 }
 
 // TestPreInstall tests the Fluentd PreInstall call
-// GIVEN a Verrazzano component
+// GIVEN a Fluentd component
 //  WHEN I call PreInstall when dependencies are met
-//  THEN no error is returned
+//  THEN no error is returned. Otherwise, return error.
 func TestPreInstall(t *testing.T) {
-	c := createPreInstallTestClient()
-	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, false)
-	err := NewComponent().PreInstall(ctx)
-	assert.NoError(t, err)
+	var tests = []struct {
+		name   string
+		client client.Client
+		isErr  bool
+	}{
+		{
+			"should fail when verrazzano-es-internal secret does not exist",
+			createFakeClient(),
+			true,
+		},
+		{
+			"should pass when verrazzano-es-internal secret does exist",
+			createFakeClient(vzEsInternalSecret),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := spi.NewFakeContext(tt.client, &vzapi.Verrazzano{}, false)
+			err := NewComponent().PreInstall(ctx)
+			if tt.isErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-func createPreInstallTestClient(extraObjs ...client.Object) client.Client {
+func createFakeClient(extraObjs ...client.Object) client.Client {
 	objs := []client.Object{}
 	objs = append(objs, extraObjs...)
 	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objs...).Build()
@@ -274,7 +308,7 @@ func createPreInstallTestClient(extraObjs ...client.Object) client.Client {
 //  WHEN I call Install when dependencies are met
 //  THEN no error is returned
 func TestInstall(t *testing.T) {
-	c := createPreInstallTestClient()
+	c := createFakeClient()
 	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
 			Components: vzapi.ComponentSpec{
@@ -301,13 +335,40 @@ func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string,
 // TestPreUpgrade tests the Verrazzano PreUpgrade call
 // GIVEN a Verrazzano component
 //  WHEN I call PreUpgrade with defaults
-//  THEN no error is returned
+//  THEN no error is returned. Otherwise, return error.
 func TestPreUpgrade(t *testing.T) {
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../helm_config"
-	err := NewComponent().PreUpgrade(spi.NewFakeContext(fake.NewClientBuilder().WithScheme(testScheme).Build(), &vzapi.Verrazzano{}, false))
-	assert.NoError(t, err)
+
+	var tests = []struct {
+		name   string
+		client client.Client
+		isErr  bool
+	}{
+		{
+			"should fail when verrazzano-es-internal secret does not exist",
+			createFakeClient(),
+			true,
+		},
+		{
+			"should pass when verrazzano-es-internal secret does exist",
+			createFakeClient(vzEsInternalSecret),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := spi.NewFakeContext(tt.client, &vzapi.Verrazzano{}, false)
+			err := NewComponent().PreUpgrade(ctx)
+			if tt.isErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 // TestUpgrade tests the Fluentd Upgrade call; simple wrapper exercise, more detailed testing is done elsewhere

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -66,7 +67,6 @@ func TestIsFluentdReady(t *testing.T) {
 		}, getFakeClient(0), false},
 	}
 	for _, test := range tests {
-		//client := createPreInstallTestClient()
 		ctx := spi.NewFakeContext(test.client, &test.spec, false)
 		if actual := isFluentdReady(ctx); actual != test.expected {
 			t.Errorf("test name %s: got fluent ready = %v, want %v", test.testName, actual, test.expected)
@@ -299,6 +299,42 @@ func TestLoggingPreInstallFluentdNotEnabled(t *testing.T) {
 		false)
 	err := loggingPreInstall(ctx)
 	assert.NoError(t, err)
+}
+
+// TestCheckSecretExists tests the verrazzano-es-internal secret exists.
+func TestCheckSecretExists(t *testing.T) {
+	var tests = []struct {
+		name   string
+		client clipkg.Client
+		isErr  bool
+		err    error
+	}{
+		{
+			"should fail when verrazzano-es-internal secret does not exist",
+			createFakeClient(),
+			false,
+			ctrlerrors.RetryableError{Source: ComponentName},
+		},
+		{
+			"should pass when verrazzano-es-internal secret does exist",
+			createFakeClient(vzEsInternalSecret),
+			false,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := spi.NewFakeContext(tt.client, &vzapi.Verrazzano{}, false)
+			err := checkSecretExists(ctx)
+			if tt.err != nil {
+				assert.Error(t, err)
+				assert.IsTypef(t, tt.err, err, "")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func getFakeClient(scheduled int32) clipkg.Client {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -103,7 +103,7 @@ func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 			constants.VerrazzanoSystemNamespace, constants.Verrazzano, err)
 		return err
 	}
-	// Check MySQL Secret. return error which will cause reque
+	// Check MySQL Secret. return error which will cause requeue
 	secret = &corev1.Secret{}
 	err = ctx.Client().Get(context.TODO(), client.ObjectKey{
 		Namespace: ComponentNamespace,


### PR DESCRIPTION
# Description

Make fluentd check for verrazzano-es-internal secret in preinstall and preupgrade to avoid fluentd pod CrashLoopBackoff and retries of the secret

Fixes VZ-5661

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [x] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
