### PR TITLE
WIP: VZ-6150 VMO expects a default storage class even when emptyDir is configured

### DIFF
--- a/pkg/bom/testdata/verrazzano-bom.json
+++ b/pkg/bom/testdata/verrazzano-bom.json
@@ -226,8 +226,8 @@
               "helmTagKey": "nodeExporter.imageVersion"
             },
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "1.1.0-20210816150650-1ff4223",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "1.4.0-20220616115606-59c3c86",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -219,8 +219,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "1.4.0-20220525201121-c0046fa",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "1.4.0-20220616115606-59c3c86",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
# Description

- Fixes VZ-6150
- VMO expects a default storage class even when emptyDir is configured
- Added logic to ignore PVC creation if defaultVolumeSource is not configured or is set to emptyDir

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
