### PR TITLE
VZ-6067.   Backport Periodics labels to release-1.2

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -108,6 +108,17 @@ pipeline {
                     echo "Force run: ${params.FORCE}"
                     echo "Execute tests: " + runTests()
 
+                    // Indicate in title if run is up-to-date or dry-run
+                    if (params.DRY_RUN) {
+                        currentBuild.displayName = "${currentBuild.displayName} : DRY-RUN"
+                    }
+                    if (periodicsUpToDate) {
+                        currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE"
+                    }
+                    if (params.FORCE) {
+                        currentBuild.displayName = "${currentBuild.displayName} : FORCE"
+                    }
+
                     if (runTests()) {
                         echo "Executing periodic tests for commit ${GIT_COMMIT_TO_USE}"
                     }


### PR DESCRIPTION

# Description

Backport to 1.2, indicate in Periodics display-name if the run was skipped due to up-to-date or dry-run settings.

Fixes VZ-6067.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
