### PR TITLE
Update fluentd pattern to correctly parse severity value from WebLogic logs (port to 1.3)

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogic_logging.go
+++ b/application-operator/controllers/wlsworkload/weblogic_logging.go
@@ -38,7 +38,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 	format8 / <(?<info2>(.*?))>/
 	format9 / <(?<info3>(.*?))>/
 	format10 / <(?<sequenceNumber>(.*?))>/
-	format11 / <\[severity-value: (?P<severity>(\d+))\].*?>/
+	format11 / <\[severity-value: (?<severity>(\d+))\].*?>/
 	format12 / <(?<messageID>(.*?))>/
 	format13 / <(?<message>([\s\S]*?))>\s*$/
 	time_key timestamp
@@ -63,7 +63,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 	format8 / <(?<info2>(.*?))>/
 	format9 / <(?<info3>(.*?))>/
 	format10 / <(?<sequenceNumber>(.*?))>/
-	format11 / <\[severity-value: (?P<severity>(\d+))\].*?>/
+	format11 / <\[severity-value: (?<severity>(\d+))\].*?>/
 	format12 / <(?<messageID>(.*?))>/
 	format13 / <(?<message>([\s\S]*?))>\s*$/
 	time_key timestamp

--- a/application-operator/controllers/wlsworkload/weblogic_logging.go
+++ b/application-operator/controllers/wlsworkload/weblogic_logging.go
@@ -38,7 +38,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 	format8 / <(?<info2>(.*?))>/
 	format9 / <(?<info3>(.*?))>/
 	format10 / <(?<sequenceNumber>(.*?))>/
-	format11 / <(?<severity>(.*?))>/
+	format11 / <\[severity-value: (?P<severity>(\d+))\].*?>/
 	format12 / <(?<messageID>(.*?))>/
 	format13 / <(?<message>([\s\S]*?))>\s*$/
 	time_key timestamp
@@ -63,7 +63,7 @@ const WlsFluentdParsingRules = `<match fluent.**>
 	format8 / <(?<info2>(.*?))>/
 	format9 / <(?<info3>(.*?))>/
 	format10 / <(?<sequenceNumber>(.*?))>/
-	format11 / <(?<severity>(.*?))>/
+	format11 / <\[severity-value: (?P<severity>(\d+))\].*?>/
 	format12 / <(?<messageID>(.*?))>/
 	format13 / <(?<message>([\s\S]*?))>\s*$/
 	time_key timestamp

--- a/application-operator/controllers/wlsworkload/weblogic_logging_test.go
+++ b/application-operator/controllers/wlsworkload/weblogic_logging_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package wlsworkload

--- a/application-operator/controllers/wlsworkload/weblogic_logging_test.go
+++ b/application-operator/controllers/wlsworkload/weblogic_logging_test.go
@@ -91,14 +91,15 @@ func readFormat() string {
 
 func Test_parseFormat(t *testing.T) {
 	tests := []struct {
-		name     string
-		text     string
-		expected string //expected text in the last line of the message
+		name             string
+		text             string
+		expectedMessage  string //expected text in the last line of the message
+		expectedSeverity string //expected severity as severity-value attribute of the message
 	}{
-		{"log1", log1, "-Dweblogic.security.allowCryptoJDefaultJCEVerification=true."},
-		{"log2", log2, "registering MBean >"},
-		{"log3", log3, "Admin Traffic Enabled\t true ResolveDNSName Enabled\t false"},
-		{"log4", log4, "java.net.UnknownHostException: mysql.wrong.svc.cluster.local"},
+		{"log1", log1, "-Dweblogic.security.allowCryptoJDefaultJCEVerification=true.", "64"},
+		{"log2", log2, "registering MBean >", "256"},
+		{"log3", log3, "Admin Traffic Enabled\t true ResolveDNSName Enabled\t false", "64"},
+		{"log4", log4, "java.net.UnknownHostException: mysql.wrong.svc.cluster.local", "64"},
 	}
 	assert := asserts.New(t)
 	for _, tt := range tests {
@@ -108,7 +109,9 @@ func Test_parseFormat(t *testing.T) {
 			//Total number of matches should be 27 = 1 + 13*2
 			assert.Equal(27, len(matches))
 			//The last match should be the message
-			assert.Contains(matches[26], tt.expected)
+			assert.Contains(matches[26], tt.expectedMessage)
+			//The 22nd match should be the severity value
+			assert.Contains(matches[22], tt.expectedSeverity)
 		})
 	}
 }

--- a/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-application.yaml
+++ b/tests/testdata/loggingtrait/weblogicworkload/weblogic-logging-application.yaml
@@ -57,7 +57,7 @@ spec:
                     format8 / <(?<info2>(.*?))>/
                     format9 / <(?<info3>(.*?))>/
                     format10 / <(?<sequenceNumber>(.*?))>/
-                    format11 / <(?<severity>(.*?))>/
+                    format11 / <\[severity-value: (?<severity>(\d+))\].*?>/
                     format12 / <(?<messageID>(.*?))>/
                     format13 / <(?<message>[^>]*)>[\\s]*/
                     time_key timestamp


### PR DESCRIPTION
# Description

Correctly parses severity value from the WebLogic logs, omits deprecated partition related fields

Fixes VZ-5978

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
