### PR TITLE
VZ-6224: Add retry for failed create/update vz resource during vz install/upgrade

### DIFF
--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -127,9 +127,18 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	}
 
 	// Create the Verrazzano install resource.
-	err = client.Create(context.TODO(), vz)
-	if err != nil {
-		return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
+	retry := 0
+	for {
+		err = client.Create(context.TODO(), vz)
+		if err != nil {
+			if retry == 5 {
+				return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
+			}
+			retry += 1
+			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to create the verrazzano install resource: %s\n", err.Error()))
+			continue
+		}
+		break
 	}
 
 	// Wait for the Verrazzano install to complete

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -127,6 +127,8 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	}
 
 	// Create the Verrazzano install resource.
+	// We will retry up to 5 times if there is an error.
+	// Sometimes we see intermittent webhook errors due to timeouts.
 	retry := 0
 	for {
 		err = client.Create(context.TODO(), vz)
@@ -134,6 +136,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			if retry == 5 {
 				return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
 			}
+			time.Sleep(time.Second)
 			retry++
 			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to create the verrazzano install resource: %s\n", err.Error()))
 			continue

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -134,7 +134,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			if retry == 5 {
 				return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
 			}
-			retry += 1
+			retry++
 			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to create the verrazzano install resource: %s\n", err.Error()))
 			continue
 		}

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -121,11 +121,26 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		return err
 	}
 
-	// Update the version in the verrazzano install resource
+	// Update the version in the verrazzano install resource.  This will initiate the Verrazzano upgrade.
+	// We will retry up to 5 times if there is an error.
+	// Sometimes we see intermittent webhook errors due to timeouts.
 	vz.Spec.Version = version
-	err = client.Update(context.TODO(), vz)
+	retry := 0
+	for {
+		err = client.Update(context.TODO(), vz)
+		if err != nil {
+			if retry == 5 {
+				return fmt.Errorf("Failed to set the upgrade version in the verrazzano install resource: %s", err.Error())
+			}
+			time.Sleep(time.Second)
+			retry++
+			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to set the upgrade version in the verrazzano install resource: %s\n", err.Error()))
+			continue
+		}
+		break
+	}
+
 	if err != nil {
-		return fmt.Errorf("Failed to set upgrade version in the verrazzano install resource: %s", err.Error())
 	}
 
 	// Wait for the Verrazzano upgrade to complete

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -140,9 +140,6 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		break
 	}
 
-	if err != nil {
-	}
-
 	// Wait for the Verrazzano upgrade to complete
 	return waitForUpgradeToComplete(client, kubeClient, vzHelper, vpoPodName, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, logFormat)
 }


### PR DESCRIPTION
# Description

This pull request adds retry logic for a failed create vz resource during vz install and does the same for a failed update vz resource during vz upgrade.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
