### PR TITLE
VZ-6223.  Add call to reconcileUninstall to VZ controller

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -604,8 +604,7 @@ func (r *Reconciler) createUninstallJob(log vzlog.VerrazzanoLogger, vz *installv
 
 	log.Progressf("Uninstall job %s is running", buildUninstallJobName(vz.Name))
 
-	err = r.setUninstallCondition(log, jobFound, vz)
-	if err != nil {
+	if err := r.setUninstallCondition(log, jobFound, vz); err != nil {
 		return err
 	}
 
@@ -883,7 +882,7 @@ func (r *Reconciler) initializeComponentStatus(log vzlog.VerrazzanoLogger, cr *i
 // setUninstallCondition sets the Verrazzano resource condition in status for uninstall
 func (r *Reconciler) setUninstallCondition(log vzlog.VerrazzanoLogger, job *batchv1.Job, vz *installv1alpha1.Verrazzano) (err error) {
 	// If the job has succeeded or failed add the appropriate condition
-	if job.Status.Succeeded != 0 || job.Status.Failed != 0 {
+	if job != nil && (job.Status.Succeeded != 0 || job.Status.Failed != 0) {
 		for _, condition := range vz.Status.Conditions {
 			if condition.Type == installv1alpha1.CondUninstallComplete || condition.Type == installv1alpha1.CondUninstallFailed {
 				return nil
@@ -1031,7 +1030,13 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 	}
 	log.Once("Deleting Verrazzano installation")
 
-	// Create the uninstall job if it doesn't exist
+	// Uninstall all components
+	log.Oncef("Uninstalling components")
+	if err := r.uninstallComponents(ctx, log, vz); err != nil {
+		return newRequeueWithDelay(), err
+	}
+
+	// Run the uninstall and check for completion
 	if err := r.createUninstallJob(log, vz); err != nil {
 		if errors.IsConflict(err) {
 			log.Debug("Resource conflict creating the uninstall job, requeuing")
@@ -1312,4 +1317,12 @@ func (r *Reconciler) IsWatchedComponent(compName string) bool {
 	r.WatchMutex.RLock()
 	defer r.WatchMutex.RUnlock()
 	return r.WatchedComponents[compName]
+}
+
+//uninstallComponents Loops through all components calling uninstall on each; returns nil when all have completed successfully
+func (r *Reconciler) uninstallComponents(_ context.Context, log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) error {
+	if err := r.setUninstallCondition(log, nil, vz); err != nil {
+		return err
+	}
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -741,7 +741,7 @@ func TestUninstallFailed(t *testing.T) {
 		})
 
 	// Expect a status update on the job
-	mockStatus.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+	mockStatus.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Expect a call to update the finalizers - return success
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
@@ -754,7 +754,7 @@ func TestUninstallFailed(t *testing.T) {
 		Update(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
 			return nil
-		})
+		}).AnyTimes()
 
 	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
 	expectDeleteServiceAccount(mock, getInstallNamespace(), name)
@@ -842,7 +842,7 @@ func TestUninstallSucceeded(t *testing.T) {
 		})
 
 	// Expect a status update on the job
-	mockStatus.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+	mockStatus.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Expect a call to update the finalizers - return success
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
@@ -855,7 +855,7 @@ func TestUninstallSucceeded(t *testing.T) {
 		Update(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, verrazzano *vzapi.Verrazzano, opts ...client.UpdateOption) error {
 			return nil
-		})
+		}).AnyTimes()
 
 	expectDeleteClusterRoleBinding(mock, getInstallNamespace(), name)
 	expectDeleteServiceAccount(mock, getInstallNamespace(), name)

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -46,7 +46,7 @@ var UninstallTrackerMap = make(map[string]*UninstallTracker)
 
 // reconcileUninstall will Uninstall a Verrazzano installation
 func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano) (ctrl.Result, error) {
-	log.Oncef("Upgrading Verrazzano to version %s", cr.Spec.Version)
+	log.Oncef("Uninstalling Verrazzano %s/%s", cr.Namespace, cr.Name)
 
 	tracker := getUninstallTracker(cr)
 	done := false


### PR DESCRIPTION
# Description

Adds a call in the main VZ controller loop to the stubbed call for component uninstalls, implemented in VZ-6222.

Fixes VZ-6223.

# Checklist 

As the author of this PR, I have:

- [x] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
