### PR TITLE
VZ-6245: use helm package for vz CLI --set argument

### DIFF
--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -222,7 +222,15 @@ func createSetFlagsYAMl(pvs map[string]string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(yamlFile), nil
+
+	yamlString := string(yamlFile)
+
+	// Replace any double-quoted strings that are surrounded by single quotes.
+	// These type of strings are problematic for helm.
+	yamlString = strings.ReplaceAll(yamlString, "'\"", "\"")
+	yamlString = strings.ReplaceAll(yamlString, "\"'", "\"")
+
+	return yamlString, nil
 }
 
 // getSetArguments gets all the set arguments and returns a map of property/value

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -10,15 +10,16 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/verrazzano/verrazzano/pkg/yaml"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	"helm.sh/helm/v3/pkg/strvals"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -157,8 +158,8 @@ func getVerrazzanoYAML(cmd *cobra.Command, vzHelper helpers.VZHelper) (vz *vzapi
 		return nil, err
 	}
 
-	// Get the set arguments - list of paths and value
-	pv, err := getSetArguments(cmd, vzHelper)
+	// Get the set arguments - returning a list of properties and value
+	pvs, err := getSetArguments(cmd, vzHelper)
 	if err != nil {
 		return nil, err
 	}
@@ -182,21 +183,46 @@ func getVerrazzanoYAML(cmd *cobra.Command, vzHelper helpers.VZHelper) (vz *vzapi
 		}
 	}
 
+	// Generate yaml for the set flags passed on the command line
+	outYAML, err := createSetFlagsYAMl(pvs)
+	if err != nil {
+		return nil, err
+	}
+
 	// Merge the set flags passed on the command line. The set flags take precedence over
 	// the yaml files passed on the command line.
-	for path, value := range pv {
-		outYaml, err := yaml.Expand(0, false, path, value)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to generate yaml from specified set flags: %s", err.Error())
-		}
-		vz, err = cmdhelpers.MergeSetFlags(vz, outYaml)
-		if err != nil {
-			return nil, err
-		}
+	vz, err = cmdhelpers.MergeSetFlags(vz, outYAML)
+	if err != nil {
+		return nil, err
 	}
 
 	// Return the merged verrazzano install resource to be created
 	return vz, nil
+}
+
+// createSetFlagsYAMl creates a YAML string from a map of property value pairs representing --set flags
+// specified in the install command
+func createSetFlagsYAMl(pvs map[string]string) (string, error) {
+	yamlObject := map[string]interface{}{}
+	for path, value := range pvs {
+		// replace unwanted characters in the value to avoid splitting
+		ignoreChars := ",[.{}"
+		for _, char := range ignoreChars {
+			value = strings.Replace(value, string(char), "\\"+string(char), -1)
+		}
+
+		composedStr := fmt.Sprintf("%s=%s", path, value)
+		err := strvals.ParseInto(composedStr, yamlObject)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	yamlFile, err := yaml.Marshal(yamlObject)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlFile), nil
 }
 
 // getSetArguments gets all the set arguments and returns a map of property/value

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -184,7 +184,7 @@ func getVerrazzanoYAML(cmd *cobra.Command, vzHelper helpers.VZHelper) (vz *vzapi
 	}
 
 	// Generate yaml for the set flags passed on the command line
-	outYAML, err := createSetFlagsYAMl(pvs)
+	outYAML, err := generateYAMLForSetFlags(pvs)
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +200,9 @@ func getVerrazzanoYAML(cmd *cobra.Command, vzHelper helpers.VZHelper) (vz *vzapi
 	return vz, nil
 }
 
-// createSetFlagsYAMl creates a YAML string from a map of property value pairs representing --set flags
-// specified in the install command
-func createSetFlagsYAMl(pvs map[string]string) (string, error) {
+// generateYAMLForSetFlags creates a YAML string from a map of property value pairs representing --set flags
+// specified on the install command
+func generateYAMLForSetFlags(pvs map[string]string) (string, error) {
 	yamlObject := map[string]interface{}{}
 	for path, value := range pvs {
 		// replace unwanted characters in the value to avoid splitting

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sigs.k8s.io/yaml"
 	"testing"
 	"time"
 
@@ -479,10 +480,12 @@ func TestInstallCmdFilenamesAndSets(t *testing.T) {
 	assert.Equal(t, true, *vz.Spec.Components.Ingress.Enabled)
 	json, err := vz.Spec.Components.Ingress.InstallOverrides.ValueOverrides[0].Values.MarshalJSON()
 	assert.NoError(t, err)
-	assert.Equal(t, "{\"controller\":{\"podLabels\":{\"override\":\"true\"}}}", string(json))
+	outyaml, err := yaml.JSONToYAML(json)
+	assert.Equal(t, "controller:\n  podLabels:\n    override: \"true\"\n", string(outyaml))
 	json, err = vz.Spec.Components.Ingress.InstallOverrides.ValueOverrides[1].Values.MarshalJSON()
 	assert.NoError(t, err)
-	assert.Equal(t, "{\"controller\":{\"service\":{\"annotations\":{\"service.beta.kubernetes.io/oci-load-balancer-shape\":\"10Mbps\"}}}}", string(json))
+	outyaml, err = yaml.JSONToYAML(json)
+	assert.Equal(t, "controller:\n  service:\n    annotations:\n      service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps\n", string(outyaml))
 }
 
 // TestInstallCmdOperatorFile

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -481,10 +481,12 @@ func TestInstallCmdFilenamesAndSets(t *testing.T) {
 	json, err := vz.Spec.Components.Ingress.InstallOverrides.ValueOverrides[0].Values.MarshalJSON()
 	assert.NoError(t, err)
 	outyaml, err := yaml.JSONToYAML(json)
+	assert.NoError(t, err)
 	assert.Equal(t, "controller:\n  podLabels:\n    override: \"true\"\n", string(outyaml))
 	json, err = vz.Spec.Components.Ingress.InstallOverrides.ValueOverrides[1].Values.MarshalJSON()
 	assert.NoError(t, err)
 	outyaml, err = yaml.JSONToYAML(json)
+	assert.NoError(t, err)
 	assert.Equal(t, "controller:\n  service:\n    annotations:\n      service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps\n", string(outyaml))
 }
 

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -470,7 +470,7 @@ func TestInstallCmdFilenamesAndSets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
 
-	// Verify the vz resource is as expected.
+	// Verify the vz resource is as expected
 	vz := vzapi.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "my-verrazzano"}, &vz)
 	assert.NoError(t, err)


### PR DESCRIPTION
# Description

This pull request changes the parsing of vz CLI --set argument to use a helm package.

# Checklist 

As the author of this PR, I have:

- [ ] Checked that I included or updated copyright and license notices in all files that I altered
- [ ] Added or updated unit tests for any new functions I added
- [ ] Added or updated integration tests if appropriate
- [ ] Added or updated acceptance tests if appropriate

Code reviewer, please confirm this PR:

- [ ] Addressed the requirement and meets the acceptance criteria
- [ ] Does not introduce unrelated or spurious changes
- [ ] Does not introduce any unapproved dependency
- [ ] Makes sense and it easy to understand, and/or difficult areas of code are clearly documented so that they can be understood
