### PR TITLE
VZ-5953 CLI Uninstall Command error handling

### DIFF
--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -198,6 +198,9 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 	resChan := make(chan error, 1)
 	defer close(resChan)
 
+	feedbackChan := make(chan bool)
+	defer close(feedbackChan)
+
 	// goroutine to stream log file output - this goroutine will be left running when this
 	// function is exited because there is no way to cancel the blocking read to the input stream.
 	re := regexp.MustCompile(`"level":"(.*?)","@timestamp":"(.*?)",(.*?)"message":"(.*?)",`)
@@ -223,26 +226,30 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 	}(vzHelper.GetOutputStream())
 
 	// goroutine to wait for the completion of the operation
-	go func() {
+	go func(outputStream io.Writer) {
 		for {
-			// Return when the Verrazzano operation has completed
-			vz, err := helpers.GetVerrazzanoResource(client, namespacedName)
-			if err != nil {
-				resChan <- err
+			// Pause before each status check
+			time.Sleep(1 * time.Second)
+			select {
+			case <-feedbackChan:
 				return
-			}
-			for _, condition := range vz.Status.Conditions {
-				// Operation condition met for install/upgrade
-				if condition.Type == condType {
-					resChan <- nil
+			default:
+				// Return when the Verrazzano operation has completed
+				vz, err := helpers.GetVerrazzanoResource(client, namespacedName)
+				if err != nil {
+					resChan <- err
 					return
 				}
+				for _, condition := range vz.Status.Conditions {
+					// Operation condition met for install/upgrade
+					if condition.Type == condType {
+						resChan <- nil
+						return
+					}
+				}
 			}
-
-			// Pause before next status check
-			time.Sleep(1 * time.Second)
 		}
-	}()
+	}(vzHelper.GetOutputStream())
 
 	select {
 	case result := <-resChan:

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -226,7 +226,7 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 	}(vzHelper.GetOutputStream())
 
 	// goroutine to wait for the completion of the operation
-	go func(outputStream io.Writer) {
+	go func() {
 		for {
 			// Pause before each status check
 			time.Sleep(1 * time.Second)
@@ -249,7 +249,7 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 				}
 			}
 		}
-	}(vzHelper.GetOutputStream())
+	}()
 
 	select {
 	case result := <-resChan:

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -257,7 +257,7 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 		sc := bufio.NewScanner(rc)
 		sc.Split(bufio.ScanLines)
 		for sc.Scan() {
-			_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("%s\n", sc.Text()))
+			_, _ = fmt.Fprintf(outputStream, fmt.Sprintf("%s\n", sc.Text()))
 		}
 	}(vzHelper.GetOutputStream())
 

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -261,7 +261,7 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 		}
 	}(vzHelper.GetOutputStream())
 
-	go func(outputStream io.Writer) {
+	go func() {
 		for {
 			// Pause before each check
 			time.Sleep(1 * time.Second)
@@ -281,7 +281,7 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 				}
 			}
 		}
-	}(vzHelper.GetOutputStream())
+	}()
 
 	select {
 	case result := <-resChan:

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -82,7 +82,9 @@ func TestUninstallCmd(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
-	assert.Equal(t, "Uninstalling Verrazzano\n\nfake logs\nSuccessfully uninstalled Verrazzano\n", buf.String())
+	assert.Contains(t, buf.String(), "Uninstalling Verrazzano\n")
+	assert.Contains(t, buf.String(), "Waiting for verrazzano-uninstall-verrazzano to be ready before starting uninstall")
+	assert.Contains(t, buf.String(), "Successfully uninstalled Verrazzano\n")
 
 	// Expect the Verrazzano resource to be deleted
 	v := vzapi.Verrazzano{}

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -155,9 +155,8 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
-	// This timeout is so short because the vz resource gets deleted from cache almost instantaneously.
-	// If this causes intermittent failures, the timeout duration will have to be decreased
-	// or a sleep will need to be forced in the uninstall function.
+	// This must be less than the 1 second polling delay to pass
+	// since the Verrazzano resource gets deleted almost instantaneously
 	assert.Contains(t, buf.String(), "Timeout 2ms exceeded waiting for uninstall to complete")
 }
 

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -149,13 +149,16 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	rc.SetClient(c)
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
-	_ = cmd.PersistentFlags().Set(constants.TimeoutFlag, "2ns")
+	_ = cmd.PersistentFlags().Set(constants.TimeoutFlag, "2ms")
 
 	// Run upgrade command
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
-	assert.Contains(t, buf.String(), "Timeout 2ns exceeded waiting for uninstall to complete")
+	// This timeout is so short because the vz resource gets deleted from cache almost instantaneously.
+	// If this causes intermittent failures, the timeout duration will have to be decreased
+	// or a sleep will need to be forced in the uninstall function.
+	assert.Contains(t, buf.String(), "Timeout 2ms exceeded waiting for uninstall to complete")
 }
 
 // TestUninstallCmdDefaultNoWait


### PR DESCRIPTION
Fixes VZ-5953

Adds error handling to prevent uninstall logs from writing to a closed channel.
