### PR TITLE
VZ-6244 Handle managed cluster name changed for ServiceMonitors and PodMonitors

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -96,8 +96,10 @@ func (s *Syncer) ProcessAgentThread() error {
 	if managedClusterName != s.ManagedClusterName {
 		s.Log.Debugf("Found secret named %s in namespace %s, cluster name changed from %q to %q", secret.Name, secret.Namespace, s.ManagedClusterName, managedClusterName)
 		s.ManagedClusterName = managedClusterName
-
 	}
+
+	// Update all Prometheus monitors relabel configs in all namespaces with new cluster name if needed
+	s.updatePrometheusMonitorsClusterName()
 
 	// Create the client for accessing the admin cluster when there is a change in the secret
 	if secret.ResourceVersion != s.SecretResourceVersion {

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -99,13 +99,15 @@ func (s *Syncer) ProcessAgentThread() error {
 	}
 
 	// Update all Prometheus monitors relabel configs in all namespaces with new cluster name if needed
-	s.updatePrometheusMonitorsClusterName()
-
+	err = s.updatePrometheusMonitorsClusterName()
+	if err != nil {
+		return fmt.Errorf("failed to update the cluster name to %s on Prometheus monitor resources with error %v", s.ManagedClusterName, err)
+	}
 	// Create the client for accessing the admin cluster when there is a change in the secret
 	if secret.ResourceVersion != s.SecretResourceVersion {
 		adminClient, err := getAdminClient(&secret)
 		if err != nil {
-			return fmt.Errorf("Failed to get the client for cluster %q with error %v", managedClusterName, err)
+			return fmt.Errorf("failed to get the client for cluster %q with error %v", managedClusterName, err)
 		}
 		s.AdminClient = adminClient
 		s.SecretResourceVersion = secret.ResourceVersion

--- a/application-operator/mcagent/mcagent_metrics.go
+++ b/application-operator/mcagent/mcagent_metrics.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mcagent
+
+import (
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (s *Syncer) updatePrometheusMonitorsClusterName() error {
+	err := s.updateServiceMonitorsClusterName()
+	if err != nil {
+		return err
+	}
+	err = s.updatePodMonitorsClusterName()
+	return err
+}
+
+// updateServiceMonitorsClusterName - updates the cluster name in all ServiceMonitors in the managed
+// cluster
+func (s *Syncer) updateServiceMonitorsClusterName() error {
+	serviceMonitors, err := s.listManagedClusterServiceMonitors()
+	if err != nil {
+		return err
+	}
+	for _, svcMonitor := range serviceMonitors.Items {
+		_, err = controllerutil.CreateOrUpdate(s.Context, s.LocalClient, svcMonitor, func() error {
+			for _, endpoint := range svcMonitor.Spec.Endpoints {
+				updated := updateClusterNameRelabelConfigs(endpoint.RelabelConfigs, s.ManagedClusterName)
+				if updated {
+					s.Log.Infof("Updating managed cluster name to %s for service monitor %s", s.ManagedClusterName, svcMonitor.Name)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			s.Log.Errorf("Error updating managed cluster name in metrics for service monitor %s: %v", svcMonitor.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// updatePodMonitorsClusterName - updates the cluster name in all PodMonitors in the managed
+// cluster
+func (s *Syncer) updatePodMonitorsClusterName() error {
+	podMonitors, err := s.listManagedClusterPodMonitors()
+	if err != nil {
+		return err
+	}
+	for _, podMonitor := range podMonitors.Items {
+		_, err = controllerutil.CreateOrUpdate(s.Context, s.LocalClient, podMonitor, func() error {
+			for _, endpoint := range podMonitor.Spec.PodMetricsEndpoints {
+				updated := updateClusterNameRelabelConfigs(endpoint.RelabelConfigs, s.ManagedClusterName)
+				if updated {
+					s.Log.Infof("Updating managed cluster name to %s for pod monitor %s", s.ManagedClusterName, podMonitor.Name)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			s.Log.Errorf("Error updating managed cluster name in metrics for pod monitor %s: %v", podMonitor.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// updateClusterNameRelabelConfigs - given a list of relabel configs, finds the one for the
+// verrazzano_cluster name target label, and updates the cluster name replacement value
+func updateClusterNameRelabelConfigs(configs []*v1.RelabelConfig, clusterName string) bool {
+	updated := false
+	for _, relabelCfg := range configs {
+		if relabelCfg.TargetLabel == constants.PrometheusClusterNameLabel {
+			if relabelCfg.Replacement != clusterName {
+				updated = true
+			}
+			relabelCfg.Replacement = clusterName
+		}
+	}
+	return updated
+}
+
+func (s *Syncer) listManagedClusterServiceMonitors() (*v1.ServiceMonitorList, error) {
+	listOptions := &client.ListOptions{Namespace: ""}
+	serviceMonitorsList := v1.ServiceMonitorList{}
+	err := s.LocalClient.List(s.Context, &serviceMonitorsList, listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &serviceMonitorsList, nil
+}
+
+func (s *Syncer) listManagedClusterPodMonitors() (*v1.PodMonitorList, error) {
+	listOptions := &client.ListOptions{Namespace: ""}
+	podMonitorsList := v1.PodMonitorList{}
+	err := s.LocalClient.List(s.Context, &podMonitorsList, listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &podMonitorsList, nil
+}

--- a/application-operator/mcagent/mcagent_metrics_test.go
+++ b/application-operator/mcagent/mcagent_metrics_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mcagent
+
+import (
+	"context"
+	"testing"
+
+	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"go.uber.org/zap"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSyncer_updatePrometheusMonitorsClusterName(t *testing.T) {
+	type fields struct {
+		OldManagedClusterName string
+		NewManagedClusterName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{"managed cluster name changed", fields{OldManagedClusterName: "local", NewManagedClusterName: "mgdcluster1"}},
+		{"managed cluster name unchanged", fields{OldManagedClusterName: "mgcluster", NewManagedClusterName: "mgcluster"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns1 := "ns1"
+			ns2 := "ns2"
+			ns3 := "ns3"
+			smWithOldClusterName := createTestServiceMonitor(true, tt.fields.OldManagedClusterName, "smold", ns1)
+			smWithNewClusterName := createTestServiceMonitor(true, tt.fields.NewManagedClusterName, "smnew", ns2)
+			smNoClusterName := createTestServiceMonitor(false, "", "smnone", ns3)
+			pmWithOldClusterName := createTestPodMonitor(true, tt.fields.OldManagedClusterName, "pmold", ns1)
+			pmWithNewClusterName := createTestPodMonitor(true, tt.fields.NewManagedClusterName, "pmnew", ns3)
+			pmNoClusterName := createTestPodMonitor(false, "", "pmnone", ns2)
+
+			scheme := runtime.NewScheme()
+			_ = promoperapi.AddToScheme(scheme)
+			mgdClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				smWithOldClusterName, smWithNewClusterName, smNoClusterName,
+				pmWithOldClusterName, pmWithNewClusterName, pmNoClusterName).Build()
+			adminClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+
+			s := &Syncer{
+				AdminClient:        adminClient,
+				LocalClient:        mgdClient,
+				Log:                zap.S().With(tt.name),
+				ManagedClusterName: tt.fields.NewManagedClusterName,
+				Context:            context.TODO(),
+			}
+			err := s.updatePrometheusMonitorsClusterName()
+			assert.NoError(t, err)
+			assertServiceMonitorLabel(t, mgdClient, smWithOldClusterName, tt.fields.NewManagedClusterName)
+			assertServiceMonitorLabel(t, mgdClient, smWithNewClusterName, tt.fields.NewManagedClusterName)
+			assertPodMonitorLabel(t, mgdClient, pmWithOldClusterName, tt.fields.NewManagedClusterName)
+			assertPodMonitorLabel(t, mgdClient, pmWithNewClusterName, tt.fields.NewManagedClusterName)
+		})
+	}
+}
+
+func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *v1.ServiceMonitor, newClusterName string) {
+	retrievedSM := v1.ServiceMonitor{}
+	err := client.Get(context.TODO(), types.NamespacedName{Namespace: sm.Namespace, Name: sm.Name}, &retrievedSM)
+	assert.NoError(t, err)
+	for i, ep := range retrievedSM.Spec.Endpoints {
+		assertRCLabels(t, sm.Spec.Endpoints[i].RelabelConfigs, ep.RelabelConfigs, newClusterName)
+	}
+}
+
+func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *v1.PodMonitor, newClusterName string) {
+	retrievedPM := v1.PodMonitor{}
+	err := client.Get(context.TODO(), types.NamespacedName{Namespace: pm.Namespace, Name: pm.Name}, &retrievedPM)
+	assert.NoError(t, err)
+	assert.Equal(t, len(pm.Spec.PodMetricsEndpoints), len(retrievedPM.Spec.PodMetricsEndpoints))
+	for i, ep := range retrievedPM.Spec.PodMetricsEndpoints {
+		assertRCLabels(t, pm.Spec.PodMetricsEndpoints[i].RelabelConfigs, ep.RelabelConfigs, newClusterName)
+	}
+}
+
+func assertRCLabels(t *testing.T, oldRCs []*v1.RelabelConfig, newRCs []*v1.RelabelConfig, clusterName string) {
+	assert.Equal(t, len(oldRCs), len(newRCs))
+	for _, rc := range newRCs {
+		if rc.TargetLabel == constants.PrometheusClusterNameLabel {
+			assert.Equal(t, clusterName, rc.Replacement)
+		}
+	}
+}
+
+func createTestServiceMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.ServiceMonitor {
+	relabelConfigs := []*v1.RelabelConfig{}
+	if hasClusterNameRelabelConfig {
+		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: constants.PrometheusClusterNameLabel, Replacement: clusterName})
+	}
+	return &v1.ServiceMonitor{
+		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
+		Spec: v1.ServiceMonitorSpec{
+			Endpoints: []v1.Endpoint{
+				{RelabelConfigs: relabelConfigs},
+			},
+		}}
+}
+
+func createTestPodMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.PodMonitor {
+	relabelConfigs := []*v1.RelabelConfig{}
+	if hasClusterNameRelabelConfig {
+		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: constants.PrometheusClusterNameLabel, Replacement: clusterName})
+	}
+	return &v1.PodMonitor{
+		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
+		Spec: v1.PodMonitorSpec{
+			PodMetricsEndpoints: []v1.PodMetricsEndpoint{
+				{RelabelConfigs: relabelConfigs},
+			},
+		}}
+}

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
@@ -82,6 +83,8 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 			return nil
 		})
 
+	expectServiceAndPodMonitorsList(mcMock, assert)
+
 	// Managed Cluster - expect call to list VerrazzanoProject objects - return an empty list
 	mcMock.EXPECT().
 		List(gomock.Any(), &clustersv1alpha1.VerrazzanoProjectList{}, gomock.Any()).
@@ -113,6 +116,22 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 	mcMocker.Finish()
 	assert.NoError(err)
 	assert.Equal(validSecret.ResourceVersion, s.SecretResourceVersion)
+}
+
+func expectServiceAndPodMonitorsList(mock *mocks.MockClient, assert *asserts.Assertions) {
+	// Managed Cluster, expect call to list service monitors, return an empty list
+	mock.EXPECT().
+		List(gomock.Any(), &v1.ServiceMonitorList{}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *v1.ServiceMonitorList, opts ...client.ListOption) error {
+			return nil
+		})
+	// Managed Cluster, expect call to list pod monitors, return an empty list
+	mock.EXPECT().
+		List(gomock.Any(), &v1.PodMonitorList{}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, list *v1.PodMonitorList, opts ...client.ListOption) error {
+			return nil
+		})
+
 }
 
 // TestProcessAgentThreadSecretDeleted tests agent thread when the registration secret is deleted

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -277,6 +277,7 @@ rules:
       - monitoring.coreos.com
     resources:
       - servicemonitors
+      - podmonitors
     verbs:
       - create
       - delete


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
