### PR TITLE
VZ-6230.  Enable component-level uninstall in VPO for Console

### DIFF
--- a/platform-operator/controllers/verrazzano/component/console/console_component.go
+++ b/platform-operator/controllers/verrazzano/component/console/console_component.go
@@ -33,16 +33,17 @@ var _ spi.Component = consoleComponent{}
 func NewComponent() spi.Component {
 	return consoleComponent{
 		helm.HelmComponent{
-			ReleaseName:             ComponentName,
-			JSONName:                ComponentJSONName,
-			ChartDir:                filepath.Join(config.GetHelmChartsDir(), ComponentName),
-			ChartNamespace:          ComponentNamespace,
-			IgnoreNamespaceOverride: true,
-			SupportsOperatorInstall: true,
-			Dependencies:            []string{authproxy.ComponentName},
-			AppendOverridesFunc:     AppendOverrides,
-			ImagePullSecretKeyname:  secret.DefaultImagePullSecretKeyName,
-			GetInstallOverridesFunc: GetOverrides,
+			ReleaseName:               ComponentName,
+			JSONName:                  ComponentJSONName,
+			ChartDir:                  filepath.Join(config.GetHelmChartsDir(), ComponentName),
+			ChartNamespace:            ComponentNamespace,
+			IgnoreNamespaceOverride:   true,
+			SupportsOperatorInstall:   true,
+			SupportsOperatorUninstall: true,
+			Dependencies:              []string{authproxy.ComponentName},
+			AppendOverridesFunc:       AppendOverrides,
+			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
+			GetInstallOverridesFunc:   GetOverrides,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -6,7 +6,9 @@ package oam
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
@@ -128,6 +130,22 @@ func ensureClusterRoles(ctx spi.ComponentContext) error {
 	})
 
 	return err
+}
+
+func deleteOAMClusterRoles(client client.Client, log vzlog.VerrazzanoLogger) error {
+	ctx := context.TODO()
+	clusterRoles := []*rbacv1.ClusterRole{
+		{ObjectMeta: metav1.ObjectMeta{Name: pvcClusterRoleName}},
+		{ObjectMeta: metav1.ObjectMeta{Name: istioClusterRoleName}},
+		{ObjectMeta: metav1.ObjectMeta{Name: certClusterRoleName}},
+	}
+	for _, role := range clusterRoles {
+		log.Progressf("Deleting OAM clusterrole %s", role.Name)
+		if err := client.Delete(ctx, role); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // GetOverrides gets the install overrides

--- a/platform-operator/controllers/verrazzano/component/oam/oam_component.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam_component.go
@@ -85,6 +85,10 @@ func (c oamComponent) PostInstall(ctx spi.ComponentContext) error {
 	return c.HelmComponent.PostInstall(ctx)
 }
 
+func (c oamComponent) PostUninstall(ctx spi.ComponentContext) error {
+	return deleteOAMClusterRoles(ctx.Client(), ctx.Log())
+}
+
 // PostUpgrade runs post-upgrade processing for the OAM component
 func (c oamComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	if err := ensureClusterRoles(ctx); err != nil {

--- a/platform-operator/controllers/verrazzano/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/uninstall_component.go
@@ -118,6 +118,11 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				compLog.Progressf("Waiting for the component to be uninstalled", compName)
 				return newRequeueWithDelay(), nil
 			}
+			if err := comp.PostUninstall(compContext); err != nil {
+				compLog.Errorf("PostUninstall for component %s failed, will retry: %v", compName, err)
+				// requeue for 30 to 60 seconds later
+				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
+			}
 			UninstallContext.state = compStateUninstalledone
 
 		case compStateUninstalledone:

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -219,7 +219,7 @@ function delete_fluentd {
 }
 
 action "Deleting Fluentd" delete_fluentd || exit 1
-action "Deleting Verrazzano Console" delete_verrazzano_console || exit 1
+#action "Deleting Verrazzano Console" delete_verrazzano_console || exit 1
 action "Deleting Prometheus Pushgateway " delete_prometheus_pushgateway || exit 1
 action "Deleting Jaeger operator " delete_jaeger_operator || exit 1
 action "Deleting Prometheus adapter " delete_prometheus_adapter || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -200,15 +200,6 @@ function delete_jaeger_operator {
   rm -f jaeger.yaml
 }
 
-function delete_verrazzano_console {
-  log "Uninstall the Verrazzano Console"
-  if helm status verrazzano-console --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
-    if ! helm uninstall verrazzano-console --namespace "${VERRAZZANO_NS}" ; then
-      error "Failed to uninstall the Verrazzano Console."
-    fi
-  fi
-}
-
 function delete_fluentd {
   log "Uninstall the Fluentd"
   if helm status fluentd --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
@@ -219,7 +210,6 @@ function delete_fluentd {
 }
 
 action "Deleting Fluentd" delete_fluentd || exit 1
-#action "Deleting Verrazzano Console" delete_verrazzano_console || exit 1
 action "Deleting Prometheus Pushgateway " delete_prometheus_pushgateway || exit 1
 action "Deleting Jaeger operator " delete_jaeger_operator || exit 1
 action "Deleting Prometheus adapter " delete_prometheus_adapter || exit 1

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const VerrazzanoInstall = "verrazzano-install"
 
 const VerrazzanoManagedCluster = "verrazzano-managed-cluster"
 
-const VerrazzanoPlatformOperatorWait = 5
+const VerrazzanoPlatformOperatorWait = 1
 
 // Analysis tool flags
 const (

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const VerrazzanoInstall = "verrazzano-install"
 
 const VerrazzanoManagedCluster = "verrazzano-managed-cluster"
 
-const VerrazzanoPlatformOperatorWait = 1
+const VerrazzanoPlatformOperatorWait = 5
 
 // Analysis tool flags
 const (


### PR DESCRIPTION
Enable component-level uninstall in the platform operator, and general support for `HelmComponent` uninstalls, and shift the VZ console uninstall to the VPO first.
- Add code to `HelmComponent` to do uninstalls
- Update OAM to delete the cluster roles; not used at present
- Update controller to call Component.PostUninstall
- Clean up 3-uninstall-verrazzano.sh script to remove Console delete from there

Related to VZ-6230.