### PR TITLE
Tvlatas/stable commit

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -58,6 +58,7 @@ pipeline {
                 defaultValue: '',
                 description: 'The branch to check out after cloning the console repository.',
                 trim: true)
+        booleanParam (description: 'This will FORCE a stable commit update without running any tests. This is normally ONLY used for debugging, it can be used to force a manual value into object storage', name: 'FORCE_STABLE_COMMIT_UPDATE', defaultValue: false)
     }
 
     environment {
@@ -131,6 +132,12 @@ pipeline {
         }
 
         stage ('Kick off parallel tests') {
+            when {
+                allOf {
+                    not { buildingTag() }
+                    expression {params.FORCE_STABLE_COMMIT_UPDATE == false}
+                }
+            }
             parallel {
                 stage('Multi Cluster Tests') {
                     steps {
@@ -349,6 +356,9 @@ def storePipelineArtifacts() {
         // as well
         sh """
             echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-stable-commit.txt
+            if [ "true" == "${params.FORCE_STABLE_COMMIT_UPDATE}" ]; then
+                echo "forced-by-job=${env.BUILD_URL}" >> $WORKSPACE/last-stable-commit.txt
+            fi
             cat $WORKSPACE/last-stable-commit.txt
             oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-stable-commit.txt --file $WORKSPACE/last-stable-commit.txt
         """

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -349,6 +349,7 @@ def storePipelineArtifacts() {
         // as well
         sh """
             echo "git-commit=${env.GIT_COMMIT}" > $WORKSPACE/last-stable-commit.txt
+            cat $WORKSPACE/last-stable-commit.txt
             oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}/last-stable-commit.txt --file $WORKSPACE/last-stable-commit.txt
         """
     }


### PR DESCRIPTION
This adds the ability to force the stable commit for a branch to be set to the commit specified without running any tests.

This is very useful for folks who need to do periodic testing on a branch for some reason, which relies on the stable commit being set. 

It also can be used in situations where a master/release branch needs to have the stable commit manually updated for some reason, however that is an exceptional situation and not the norm.

When the parameter is specified to force a commit level, it will also record the job run which forced it. That way we can tell if a master/release commit was forced and when.
