### PR TITLE
NO JIRA: Fix OpenSearch monitor so it works when Istio is disabled

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -300,6 +300,10 @@ func applySystemMonitors(ctx spi.ComponentContext) error {
 	args["istioNamespace"] = constants.IstioSystemNamespace
 	args["installNamespace"] = constants.VerrazzanoInstallNamespace
 
+	istio := ctx.EffectiveCR().Spec.Components.Istio
+	enabled := istio != nil && istio.IsInjectionEnabled()
+	args["isIstioEnabled"] = enabled
+
 	// substitute template values to all files in the directory and apply the resulting YAML
 	dir := path.Join(config.GetThirdPartyManifestsDir(), "prometheus-operator")
 	yamlApplier := k8sutil.NewYAMLApplier(ctx.Client(), "")

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -359,16 +359,16 @@ func TestApplySystemMonitors(t *testing.T) {
 	monitors.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "PodMonitor"})
 	err = client.List(context.TODO(), monitors)
 	assert.NoError(t, err)
-	assert.Len(t, monitors.Items, 3)
+	assert.Len(t, monitors.Items, 2)
 
 	monitors = &unstructured.UnstructuredList{}
 	monitors.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"})
 	err = client.List(context.TODO(), monitors)
 	assert.NoError(t, err)
 
-	// expect that 3 ServiceMonitors are created
+	// expect that 4 ServiceMonitors are created
 
-	assert.Len(t, monitors.Items, 3)
+	assert.Len(t, monitors.Items, 4)
 
 }
 

--- a/platform-operator/thirdparty/manifests/prometheus-operator/opensearch_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/opensearch_monitor.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
   name: opensearch
   namespace: {{ .monitoringNamespace }}
@@ -13,10 +13,13 @@ spec:
     matchNames:
       - {{ .systemNamespace }}
   selector: {}
-  podMetricsEndpoints:
-  - port: http
-    path: /_prometheus/metrics
+  endpoints:
+  - path: /_prometheus/metrics
+{{ if .isIstioEnabled }}
+    scheme: https
+{{ else }}
     scheme: http
+{{ end }}
     relabelings:
       - sourceLabels:
           - __meta_kubernetes_pod_name
@@ -34,3 +37,13 @@ spec:
           - __meta_kubernetes_pod_name
         action: replace
         targetLabel: kubernetes_pod_name
+      - action: replace
+        targetLabel: verrazzano_cluster
+        replacement: local
+{{ if .isIstioEnabled }}
+    tlsConfig:
+      caFile: /etc/istio-certs/root-cert.pem
+      certFile: /etc/istio-certs/cert-chain.pem
+      keyFile: /etc/istio-certs/key.pem
+      insecureSkipVerify: true
+{{ end }}


### PR DESCRIPTION
The OpenSearch Prometheus monitor was configured assuming OpenSearch was in the Istio service mesh. This PR fixes the monitor so that it also works when Istio injection is disabled.