### PR TITLE
NO JIRA: Fix bugs in authproxy ServiceMonitor

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/monitors.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/monitors.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-  {{- if .Values.prometheusOperatorEnabled }}
+  {{- if .Values.config.prometheusOperatorEnabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -14,8 +14,7 @@ spec:
       - {{ .Release.Namespace }}
   selector: {}
   endpoints:
-    - port: https
-      path: /metrics
+    - path: /metrics
       scheme: https
       tlsConfig:
         caFile: /etc/istio-certs/root-cert.pem
@@ -51,5 +50,5 @@ spec:
         replacement: $1
         sourceLabels:
         - name
-        targetLabel:
+        targetLabel: app
   {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -47,6 +47,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
         traffic.sidecar.istio.io/excludeOutboundPorts: 443,6443
+        verrazzano.io/metricsEnabled: "true"
       labels:
         app: {{ .Values.name }}
     spec:


### PR DESCRIPTION
There were two bugs that prevented the authproxy ServiceMonitor from being created during install/upgrade:

1. The helm key that enables the monitor was wrong
2. A previous commit introduced a syntax error (empty `targetLabel` value)

There were also two bugs that prevented Prometheus from properly discovering the authproxy target:

1. The monitor specified `port: https` which needed to be removed so the actual metrics port would be used
2. The authproxy pod was missing an annotation to allow discovery

I tested the changes against a local cluster and the authproxy target is correctly discovered. In the master branch the monitor is down because the Istio auth policy hasn't been switched to allow the new Prometheus to access the metrics port. That will be fixed when the other Prometheus PRs are merged.
