### PR TITLE
Remove the IsVerrazzanoBelowVersion utility function which is the exact opposite of (and mostly duplicates) IsVerrazzanoMinVersion

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -138,7 +138,7 @@ func ListDeployments(namespace string) (*appsv1.DeploymentList, error) {
 	return deployments, nil
 }
 
-//GetReplicaCounts Builds a map of pod counts for a list of deployments
+// GetReplicaCounts Builds a map of pod counts for a list of deployments
 // expectedDeployments - a list of namespaced names for deployments to look for
 // optsBuilder - a callback func to build the right set of options to select pods for the deployment
 func GetReplicaCounts(expectedDeployments []types.NamespacedName, optsBuilder func(name types.NamespacedName) (metav1.ListOptions, error)) (map[string]uint32, error) {
@@ -536,26 +536,6 @@ func IsVerrazzanoMinVersion(minVersion string, kubeconfigPath string) (bool, err
 		return false, err
 	}
 	return !vzSemver.IsLessThan(minSemver), nil
-}
-
-// IsVerrazzanoBelowVersion returns true if the Verrazzano version < belowVersion
-func IsVerrazzanoBelowVersion(belowVersion string, kubeconfigpath string) (bool, error) {
-	vzVersion, err := GetVerrazzanoVersion(kubeconfigpath)
-	if err != nil {
-		return false, err
-	}
-	if len(vzVersion) == 0 {
-		return false, nil
-	}
-	vzSemver, err := semver.NewSemVersion(vzVersion)
-	if err != nil {
-		return false, err
-	}
-	maxSemver, err := semver.NewSemVersion(belowVersion)
-	if err != nil {
-		return false, err
-	}
-	return vzSemver.IsLessThan(maxSemver), nil
 }
 
 // IsProdProfile returns true if the deployed resource is a 'prod' profile

--- a/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_test.go
@@ -5,6 +5,7 @@ package metricsbinding
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
@@ -52,19 +53,20 @@ func WhenMetricsBindingInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	below, err := pkg.IsVerrazzanoBelowVersion("1.4.0", kubeconfigPath)
+	vz14OrLater, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version less than 1.4.0: %s", err.Error()))
 		})
 	}
-	above, err := pkg.IsVerrazzanoMinVersion("1.2.0", kubeconfigPath)
+	below14 := !vz14OrLater
+	above12, err := pkg.IsVerrazzanoMinVersion("1.2.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version at or above 1.2.0: %s", err.Error()))
 		})
 	}
-	if below && above {
+	if below14 && above12 {
 		t.It(description, f)
 	} else {
 		t.Logs.Infof("Skipping check '%v', the Metrics Binding is not supported", description)


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
