### PR TITLE
WIP: VZ-6278 Handle an initial upgrade (chaos) pipeline build in a newly created branch

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -131,7 +131,11 @@ pipeline {
                     EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
                     if (params.GIT_COMMIT_FOR_UPGRADE == "NONE") {
                         echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = checkout scm
+                        def scmInfo = = checkout([
+                                $class: 'GitSCM',
+                                branches: [[name: env.BRANCH_NAME]],
+                                extensions: [[$class: 'LocalBranch']],
+                                userRemoteConfigs: [[refspec: '+refs/heads/*:refs/remotes/origin/*', url: env.SCM_VERRAZZANO_GIT_URL]]])
                         env.GIT_COMMIT = scmInfo.GIT_COMMIT
                         env.GIT_BRANCH = scmInfo.GIT_BRANCH
                     } else {

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
                     BRANCH_ORIGIN = sh(returnStdout: true, script: "git log -- master..HEAD --oneline | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
                     if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
-                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 master^1").trim()
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 origin/master^1").trim()
                         BRANCH_TO_USE = "master"
                     } else {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
                     BRANCH_ORIGIN = sh(returnStdout: true, script: "git log -- master..HEAD --oneline | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
                     if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
-                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 origin/master^1").trim()
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin/master^1 -1 --pretty='%H'").trim()
                         BRANCH_TO_USE = "master"
                     } else {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -270,10 +270,10 @@ pipeline {
                 script {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // check if this commit is first in branch
-                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log origin master..HEAD --oneline --pretty='%h' | tail -1").trim()
+                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log master..HEAD --oneline --pretty='%h' | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
                     if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
-                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin master^1 -1 --pretty='%h'").trim()
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log master^1 -1 --pretty='%h' | tail -1").trim()
                         BRANCH_TO_USE = "master"
                     } else {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -270,10 +270,10 @@ pipeline {
                 script {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // check if this commit is first in branch
-                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log -- master..HEAD --oneline | tail -1").trim()
+                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log origin master..HEAD --oneline --pretty='%h' | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
                     if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
-                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin/master^1 -1 --pretty='%H'").trim()
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin master^1 -1 --pretty='%h'").trim()
                         BRANCH_TO_USE = "master"
                     } else {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
                     EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
                     if (params.GIT_COMMIT_FOR_UPGRADE == "NONE") {
                         echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = = checkout([
+                        def scmInfo = checkout([
                                 $class: 'GitSCM',
                                 branches: [[name: env.BRANCH_NAME]],
                                 extensions: [[$class: 'LocalBranch']],

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -269,8 +269,16 @@ pipeline {
             steps {
                 script {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
-                    INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()
-                    while (sh(returnStatus: true, script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/${INTERIM_UPGRADE_COMMIT}/operator.yaml --file ${WORKSPACE}/interim-operator.yaml") != 0) {
+                    // check if this commit is first in branch
+                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log -- master..HEAD --oneline | tail -1").trim()
+                    BRANCH_TO_USE = "${env.BRANCH_NAME}"
+                    if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 master^1").trim()
+                        BRANCH_TO_USE = "master"
+                    } else {
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()
+                    }
+                    while (sh(returnStatus: true, script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${BRANCH_TO_USE}/${INTERIM_UPGRADE_COMMIT}/operator.yaml --file ${WORKSPACE}/interim-operator.yaml") != 0) {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${INTERIM_UPGRADE_COMMIT}^1").trim()
                     }
                 }

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -304,7 +304,7 @@ pipeline {
                     then
                         echo "Upgrading VPO to earlier version from branch"
                         echo "commit: ${INTERIM_UPGRADE_COMMIT}"
-                        curl -o ${WORKSPACE}/interim-upgrade-bom.json https://objectstorage.us-phoenix-1.oraclecloud.com/n/${OCI_OS_NAMESPACE}/b/${OCI_OS_BUCKET}/o/${env.BRANCH_NAME}/${INTERIM_UPGRADE_COMMIT}/generated-verrazzano-bom.json
+                        curl -o ${WORKSPACE}/interim-upgrade-bom.json https://objectstorage.us-phoenix-1.oraclecloud.com/n/${OCI_OS_NAMESPACE}/b/${OCI_OS_BUCKET}/o/${BRANCH_TO_USE}/${INTERIM_UPGRADE_COMMIT}/generated-verrazzano-bom.json
                         kubectl apply -f ${WORKSPACE}/interim-operator.yaml
 
                     else

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -271,13 +271,16 @@ pipeline {
                 OCI_OS_BUCKET="verrazzano-builds"
             }
             steps {
+                sh """
+                    git fetch
+                """
                 script {
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // check if this commit is first in branch
-                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log master..HEAD --oneline --pretty='%h' | tail -1").trim()
+                    BRANCH_ORIGIN = sh(returnStdout: true, script: "git log origin/master..HEAD --oneline --pretty='%h' | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
                     if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
-                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log master^1 -1 --pretty='%h' | tail -1").trim()
+                        INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin/master^1 -1 --pretty='%h' | tail -1").trim()
                         BRANCH_TO_USE = "master"
                     } else {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git rev-parse --short=8 ${SHORT_COMMIT_HASH}^1").trim()

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                                 doGenerateSubmoduleConfigurations: false,
                                 extensions: [],
                                 submoduleCfg: [],
-                                userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
+                                userRemoteConfigs: [[refspec: '+refs/heads/*:refs/remotes/origin/*', url: env.SCM_VERRAZZANO_GIT_URL]]])
                         env.GIT_COMMIT = scmInfo.GIT_COMMIT
                         env.GIT_BRANCH = scmInfo.GIT_BRANCH
                         // If the commit we were handed is not what the SCM says we are using, fail

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
                     // check if this commit is first in branch
                     BRANCH_ORIGIN = sh(returnStdout: true, script: "git log origin/master..HEAD --oneline --pretty='%h' | tail -1").trim()
                     BRANCH_TO_USE = "${env.BRANCH_NAME}"
-                    if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.length() <= 0) {
+                    if (BRANCH_ORIGIN == null || BRANCH_ORIGIN.equals(SHORT_COMMIT_HASH)) {
                         INTERIM_UPGRADE_COMMIT = sh(returnStdout: true, script: "git log origin/master^1 -1 --pretty='%h' | tail -1").trim()
                         BRANCH_TO_USE = "master"
                     } else {


### PR DESCRIPTION
Some of the upgrade tests require an an initial, intermediate, and final VZ installation to perform the required testing. For a newly created branch with no additional commits, the search for a prior (initial) build would generally fail.  The situation would resolve after 2 new commits existed in the feature branch.

This PR addresses this issue by enabling the search for prior builds to continue into the parent (master) branch.

The PR is marked WIP while some testing is being completed.