### PR TITLE
VZ-6222 don't delete uninstall tracker until job done

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -325,7 +325,9 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client, vz *vzapi.V
 		return log.ErrorfThrottledNewErr("Failed setting Rancher access token: %s", err.Error())
 	}
 	if err := rest.DeleteLocalHost(); err != nil {
-		return log.ErrorfThrottledNewErr("Failed deleting Rancher local host: %s", err.Error())
+		// This is a warning
+		log.Oncef("Failed deleting Rancher local host: %s", err.Error())
+		return nil
 	}
 
 	log.Once("Successfully delete Rancher local cluster")

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -1072,6 +1072,10 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 			}
 
 			delete(initializedSet, vz.Name)
+
+			// Delete the uninstall tracker so the memory can be freed up
+			DeleteUninstallTracker(vz)
+
 			// Uninstall is done, all cleanup is finished, and finalizer removed.
 			return ctrl.Result{}, nil
 		}

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -96,6 +96,7 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			tracker.vzState = vzStateUninstallDone
 
 		case vzStateUninstallDone:
+			log.Once("Successfully uninstalled all Verrazzano components")
 			tracker.vzState = vzStateUninstallEnd
 
 		case vzStateUninstallEnd:
@@ -130,8 +131,4 @@ func DeleteUninstallTracker(cr *installv1alpha1.Verrazzano) {
 	if ok {
 		delete(UninstallTrackerMap, key)
 	}
-}
-
-func DeleteResource(name string, namespace string) {
-
 }

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -100,8 +100,6 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 
 		case vzStateUninstallEnd:
 			done = true
-			// Uninstall completely done
-			deleteUninstallTracker(cr)
 		}
 	}
 	// Uninstall done, no need to requeue
@@ -124,11 +122,16 @@ func getUninstallTracker(cr *installv1alpha1.Verrazzano) *UninstallTracker {
 	return vuc
 }
 
-// deleteUninstallTracker deletes the Uninstall tracker for the Verrazzano resource
-func deleteUninstallTracker(cr *installv1alpha1.Verrazzano) {
+// DeleteUninstallTracker deletes the Uninstall tracker for the Verrazzano resource
+// This needs to be called when uninstall is completely done
+func DeleteUninstallTracker(cr *installv1alpha1.Verrazzano) {
 	key := getNSNKey(cr)
 	_, ok := UninstallTrackerMap[key]
 	if ok {
 		delete(UninstallTrackerMap, key)
 	}
+}
+
+func DeleteResource(name string, namespace string) {
+
 }

--- a/platform-operator/controllers/verrazzano/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/uninstall_test.go
@@ -263,5 +263,5 @@ func TestReconcileUninstall(t *testing.T) {
 	asserts.NoError(err)
 	asserts.NotZero(len(vzcr.Status.Components), "Status.Components len should not be zero")
 	asserts.Equal("Uninstalled", string(vzcr.Status.Components["fake"].State), "Invalid component state")
-	asserts.Zero(len(UninstallTrackerMap), "UninstallTrackerMap should have no entries")
+	asserts.NotZero(len(UninstallTrackerMap), "UninstallTrackerMap should have no entries")
 }


### PR DESCRIPTION
The uninstall tracker has the in-memory state machine.  When the uninstallComponents completed, the tracker was also getting deleted, however the uninstall job was still running.  Don't delete the tracker until the job is done.  Also, treat delete rancher local cluster registration as a warning, it cannot cause uninstall to fail.
