### PR TITLE
Bump CLI uninstall job wait timeout to 3 mins

### DIFF
--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -45,6 +45,8 @@ vz uninstall --timeout 30m`
 // Number of retries after waiting a second for uninstall pod to be ready
 const uninstallDefaultWaitRetries = 60
 
+const verrazzanoUninstallJobDetectWait = 5
+
 var uninstallWaitRetries = uninstallDefaultWaitRetries
 
 var propagationPolicy = metav1.DeletePropagationBackground
@@ -168,8 +170,8 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 				fmt.Fprint(outputStream, "\n")
 				return
 			default:
-				time.Sleep(constants.VerrazzanoPlatformOperatorWait * time.Second)
-				seconds += constants.VerrazzanoPlatformOperatorWait
+				time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+				seconds += verrazzanoUninstallJobDetectWait
 				fmt.Fprintf(outputStream, fmt.Sprintf("\rWaiting for %s to be ready before starting uninstall - %d seconds", jobName, seconds))
 			}
 		}
@@ -183,8 +185,8 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 		if retryCount > uninstallWaitRetries {
 			return "", fmt.Errorf("%s pod not found in namespace %s", constants.VerrazzanoUninstall, vzconstants.VerrazzanoInstallNamespace)
 		}
-		time.Sleep(constants.VerrazzanoPlatformOperatorWait * time.Second)
-		seconds += constants.VerrazzanoPlatformOperatorWait
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
 
 		err := c.List(
 			context.TODO(),
@@ -210,8 +212,8 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 	pod := &corev1.Pod{}
 	seconds = 0
 	for {
-		time.Sleep(constants.VerrazzanoPlatformOperatorWait * time.Second)
-		seconds += constants.VerrazzanoPlatformOperatorWait
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
 
 		err := c.Get(context.TODO(), types.NamespacedName{Namespace: podList.Items[0].Namespace, Name: podList.Items[0].Name}, pod)
 		if err != nil {

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -43,7 +43,7 @@ vz uninstall --timeout 30m`
 )
 
 // Number of retries after waiting a second for uninstall pod to be ready
-const uninstallDefaultWaitRetries = 20
+const uninstallDefaultWaitRetries = 60
 
 var uninstallWaitRetries = uninstallDefaultWaitRetries
 

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const VerrazzanoInstall = "verrazzano-install"
 
 const VerrazzanoManagedCluster = "verrazzano-managed-cluster"
 
-const VerrazzanoPlatformOperatorWait = 5
+const VerrazzanoPlatformOperatorWait = 1
 
 // Analysis tool flags
 const (

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const VerrazzanoInstall = "verrazzano-install"
 
 const VerrazzanoManagedCluster = "verrazzano-managed-cluster"
 
-const VerrazzanoPlatformOperatorWait = 1
+const VerrazzanoPlatformOperatorWait = 5
 
 // Analysis tool flags
 const (


### PR DESCRIPTION

Bump up the CLI wait for the uninstall job to start to 5 mins (5 sec wait intervals).  

This is to account for the working going on to shift the uninstall from the job scripts to the VPO.  The VPO component. uninstalls go first for now, then the uninstall job so they don't trample each other.  This can take about 30-60 seconds at present.

