### PR TITLE
Changes to enable custom rancher dashboard

### DIFF
--- a/platform-operator/thirdparty/charts/rancher/values.yaml
+++ b/platform-operator/thirdparty/charts/rancher/values.yaml
@@ -38,9 +38,9 @@ debug: false
 restrictedAdmin: false
 
 # Extra environment variables passed to the rancher pods.
-# extraEnv:
-# - name: CATTLE_TLS_MIN_VERSION
-#   value: "1.0"
+extraEnv:
+- name: CATTLE_UI_OFFLINE_PREFERRED
+  value: "true"
 
 # Fully qualified name to reach your Rancher server
 # hostname: rancher.my.org

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20220628131948-d06f15118",
+              "tag": "v2.6.4-20220504205847-7131173f2",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20220628131948-d06f15118"
+              "tag": "v2.6.4-20220504205847-7131173f2"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20220628104150-d06f15118",
+              "tag": "20220628131948-d06f15118",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20220628104150-d06f15118"
+              "tag": "20220628131948-d06f15118"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.4-20220504205847-7131173f2",
+              "tag": "20220628104150-d06f15118",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.4-20220504205847-7131173f2"
+              "tag": "20220628104150-d06f15118"
             }
           ]
         },


### PR DESCRIPTION
- Env variable `CATTLE_UI_OFFLINE_PREFERRED` needs to be set to `true` for rancher to source all assets from the embedded dashoard and not  navigate to https://releases.rancher.com
- rancher versions will be changed in this PR once the BFS pipeline related [PRs](https://github.com/verrazzano/rancher/pull/36) are approved and merged