### PR TITLE
Fix use of CreateOrUpdate for the verrazzano-monitoring namespace

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
@@ -37,7 +37,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Adapter", ComponentNamespace)
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), prometheus.GetVerrazzanoMonitoringNamespace(ctx), func() error {
+	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
+		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
@@ -39,7 +39,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for Kube State Metrics", ComponentNamespace)
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), prometheus.GetVerrazzanoMonitoringNamespace(ctx), func() error {
+	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
+		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
@@ -48,7 +48,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Node-Exporter", ComponentNamespace)
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), prometheus.GetVerrazzanoMonitoringNamespace(ctx), func() error {
+	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
+		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -68,7 +68,9 @@ func preInstallUpgrade(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating/updating namespace %s for the Prometheus Operator", ComponentNamespace)
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), prometheus.GetVerrazzanoMonitoringNamespace(ctx), func() error {
+	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
+		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/prometheus_utils.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/prometheus_utils.go
@@ -11,21 +11,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetVerrazzanoMonitoringNamespace provides the namespace for the Monitoring subcomponents in one location
-func GetVerrazzanoMonitoringNamespace(ctx spi.ComponentContext) *corev1.Namespace {
-	labels := map[string]string{
-		v8oconst.LabelVerrazzanoNamespace: vpoconst.VerrazzanoMonitoringNamespace,
+// MutateVerrazzanoMonitoringNamespace modifies the given namespace for the Monitoring subcomponents
+// with the appropriate labels, in one location. If the provided namespace is not the Verrazzano
+// monitoring namespace, it is ignored.
+func MutateVerrazzanoMonitoringNamespace(ctx spi.ComponentContext, namespace *corev1.Namespace) {
+	if namespace.Name != vpoconst.VerrazzanoMonitoringNamespace {
+		return
 	}
+	if namespace.Labels == nil {
+		namespace.Labels = map[string]string{}
+	}
+	namespace.Labels[v8oconst.LabelVerrazzanoNamespace] = vpoconst.VerrazzanoMonitoringNamespace
 
 	istio := ctx.EffectiveCR().Spec.Components.Istio
 	if istio != nil && istio.IsInjectionEnabled() {
-		labels[v8oconst.LabelIstioInjection] = "enabled"
+		namespace.Labels[v8oconst.LabelIstioInjection] = "enabled"
 	}
+}
 
+// GetVerrazzanoMonitoringNamespace creates and returns a namespace object for the Monitoring
+// subcomponents' namespace
+func GetVerrazzanoMonitoringNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   vpoconst.VerrazzanoMonitoringNamespace,
-			Labels: labels,
+			Name: vpoconst.VerrazzanoMonitoringNamespace,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/prometheus_utils_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/prometheus_utils_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
-// TestGetVerrazzanoMonitoringNamespace tests the GetVerrazzanoMonitoringNamespace function.
-func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
+// TestMutateVerrazzanoMonitoringNamespace tests the MutateVerrazzanoMonitoringNamespace function.
+func TestMutateVerrazzanoMonitoringNamespace(t *testing.T) {
 	// GIVEN a Verrazzano CR with Istio injection enabled
 	//  WHEN we call the function to create the Verrazzano monitoring namespace struct
 	//  THEN the struct has the expected labels, including the label with Istio injection enabled
@@ -30,7 +30,8 @@ func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
 	}
 	ctx := spi.NewFakeContext(nil, vz, false)
 
-	ns := GetVerrazzanoMonitoringNamespace(ctx)
+	ns := GetVerrazzanoMonitoringNamespace()
+	MutateVerrazzanoMonitoringNamespace(ctx, ns)
 	assert.Equal(t, "enabled", ns.Labels[v8oconst.LabelIstioInjection])
 	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
 	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
@@ -50,8 +51,16 @@ func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
 	}
 	ctx = spi.NewFakeContext(nil, vz, false)
 
-	ns = GetVerrazzanoMonitoringNamespace(ctx)
+	ns = GetVerrazzanoMonitoringNamespace()
+	MutateVerrazzanoMonitoringNamespace(ctx, ns)
 	assert.NotContains(t, ns.Labels, v8oconst.LabelIstioInjection)
 	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
 	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
+}
+
+// TestGetVerrazzanoMonitoringNamespace tests the GetVerrazzanoMonitoringNamespace function.
+func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
+	ns := GetVerrazzanoMonitoringNamespace()
+	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
+	assert.Nil(t, ns.Labels)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
@@ -39,7 +39,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Pushgateway Component", ComponentNamespace)
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), prometheus.GetVerrazzanoMonitoringNamespace(ctx), func() error {
+	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
+		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
