### PR TITLE
NO JIRA: Fix node-exporter job name

### DIFF
--- a/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
@@ -12,3 +12,9 @@ prometheus:
       - action: replace
         targetLabel: verrazzano_cluster
         replacement: local
+      # preserve job name compatibility with the old node-exporter
+      - action: replace
+        sourceLabels:
+        - job
+        targetLabel: job
+        replacement: node-exporter

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -30,6 +30,7 @@ const (
 	imagePullPollingInterval = 30 * time.Second
 	skipVerifications        = "Skip Verifications"
 	helloHelidon             = "hello-helidon"
+	nodeExporterJobName      = "node-exporter"
 )
 
 var (
@@ -261,35 +262,9 @@ func appConfigMetricsExists() bool {
 }
 
 func nodeExporterProcsRunning() bool {
-	nodeExporterJob, err := getNodeExporterJobName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJob)
+	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
 }
 
 func nodeExporterDiskIoNow() bool {
-	nodeExporterJob, err := getNodeExporterJobName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJob)
-}
-
-// getNodeExporterJobName returns the name of the Node Exporter job name depending on the Verrazzano version
-func getNodeExporterJobName() (string, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-		return "", err
-	}
-	minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
-	if err != nil {
-		pkg.Log(pkg.Error, fmt.Sprintf("Failed to verify the Verrazzano version was min 1.4.0: %v", err))
-		return "", err
-	}
-	if minVer14 {
-		return "prometheus-node-exporter", nil
-	}
-	return "node-exporter", nil
+	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -5,13 +5,14 @@ package helidonsvc
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
@@ -30,6 +31,7 @@ const (
 	imagePullWaitTimeout     = 40 * time.Minute
 	imagePullPollingInterval = 30 * time.Second
 	skipVerifications        = "Skip Verifications"
+	nodeExporterJobName      = "node-exporter"
 )
 
 const (
@@ -354,35 +356,9 @@ func appConfigMetricsExists() bool {
 }
 
 func nodeExporterProcsRunning() bool {
-	nodeExporterName, err := determineNodeExporterName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterName)
+	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
 }
 
 func nodeExporterDiskIoNow() bool {
-	nodeExporterName, err := determineNodeExporterName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterName)
-}
-
-func determineNodeExporterName() (string, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		t.Logs.Errorf("Failed to get the kubeconfig location: %v", err)
-		return "", err
-	}
-	nodeExporterJobName := "node-exporter"
-	isMin, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
-	if err != nil {
-		t.Logs.Errorf("Failed to determine Verrazzano version: %v", err)
-		return "", err
-	}
-	if isMin {
-		nodeExporterJobName = "prometheus-node-exporter"
-	}
-	return nodeExporterJobName, nil
+	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -31,6 +31,7 @@ const (
 	imagePullPollingInterval = 30 * time.Second
 	skipVerifications        = "Skip Verifications"
 	helloHelidon             = "hello-helidon"
+	nodeExporterJobName      = "node-exporter"
 )
 
 const (
@@ -317,35 +318,9 @@ func appConfigMetricsExists() bool {
 }
 
 func nodeExporterProcsRunning() bool {
-	nodeExporterName, err := determineNodeExporterName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterName)
+	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
 }
 
 func nodeExporterDiskIoNow() bool {
-	nodeExporterName, err := determineNodeExporterName()
-	if err != nil {
-		return false
-	}
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterName)
-}
-
-func determineNodeExporterName() (string, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		t.Logs.Errorf("Failed to get the kubeconfig location: %v", err)
-		return "", err
-	}
-	nodeExporterJobName := "node-exporter"
-	isMin, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
-	if err != nil {
-		t.Logs.Errorf("Failed to determine Verrazzano version: %v", err)
-		return "", err
-	}
-	if isMin {
-		nodeExporterJobName = "prometheus-node-exporter"
-	}
-	return nodeExporterJobName, nil
+	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -37,8 +37,7 @@ const (
 	keycloakNamespace         = "keycloak"
 
 	// Constants for various metric labels, used in the validation
-	nodeExporter        = "prometheus-node-exporter"
-	oldNodeExporter     = "node-exporter"
+	nodeExporter        = "node-exporter"
 	istiod              = "istiod"
 	pilot               = "pilot"
 	prometheus          = "prometheus-operator-kube-p-prometheus"
@@ -138,20 +137,8 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 		t.It("Verify sample Node Exporter metrics can be queried from Prometheus", func() {
 			Eventually(func() bool {
 				kv := map[string]string{
-					job: oldNodeExporter,
+					job: nodeExporter,
 				}
-
-				minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", adminKubeConfig)
-				if err != nil {
-					pkg.Log(pkg.Error, fmt.Sprintf(failedVerifyVersionMsg, err))
-					return false
-				}
-				if minVer14 {
-					kv = map[string]string{
-						job: nodeExporter,
-					}
-				}
-
 				return metricsContainLabels(cpuSecondsTotal, kv)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})


### PR DESCRIPTION
While we were doing the Prometheus Operator migration, we updated tests to that were checking the node-exporter job name to use the new node-exporter job name: `prometheus-node-exporter`. The old node-exporter's job name was `node-exporter`.

Instead of updating tests to check for the new job name, this PR relabels the job name to `node-exporter` so that it matches the previous job name. The tests are updated to not vary the job name based on version now.