### PR TITLE
NO JIRA: Do not attempt to create Prometheus auth policy if istio is disabled

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -519,6 +519,12 @@ func updateApplicationAuthorizationPolicies(ctx spi.ComponentContext) error {
 
 // createOrUpdatePrometheusAuthPolicy creates the Istio authorization policy for Prometheus
 func createOrUpdatePrometheusAuthPolicy(ctx spi.ComponentContext) error {
+	// if Istio is explicitly disabled, do not attempt to create the auth policy
+	istio := ctx.EffectiveCR().Spec.Components.Istio
+	if istio != nil && istio.Enabled != nil && !*istio.Enabled {
+		return nil
+	}
+
 	authPol := istioclisec.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ComponentNamespace, Name: prometheusAuthPolicyName},
 	}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -725,6 +725,29 @@ func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
 	assert.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assert.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/vmi-system-kiali")
 	assert.Contains(authPolicy.Spec.Rules[1].From[0].Source.Principals, serviceAccount)
+
+	// GIVEN Prometheus Operator is being installed or upgraded
+	// AND   Istio is disabled
+	// WHEN  we call the createOrUpdatePrometheusAuthPolicy function
+	// THEN  no Istio authorization policy is created
+	client = fake.NewClientBuilder().WithScheme(testScheme).Build()
+	vz := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Istio: &vzapi.IstioComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+	ctx = spi.NewFakeContext(client, vz, false)
+
+	err = createOrUpdatePrometheusAuthPolicy(ctx)
+	assert.NoError(err)
+
+	authPolicy = &istioclisec.AuthorizationPolicy{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: prometheusAuthPolicyName}, authPolicy)
+	assert.ErrorContains(err, "not found")
 }
 
 // TestCreateOrUpdateNetworkPolicies tests the createOrUpdateNetworkPolicies function


### PR DESCRIPTION
If Istio is disabled, the Prometheus Operator install fails because it attempts to create an Istio AuthorizationPolicy and that resource type does not exist in the cluster. This PR fixes that by skipping creation of the auth policy if Istio is disabled.