### PR TITLE
VZ-6101: Do not install Prometheus when the component is disabled

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -194,6 +194,28 @@ func TestAppendOverrides(t *testing.T) {
 	assert.Len(t, kvs, 27)
 
 	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
+
+	// GIVEN a Verrazzano CR with Prometheus disabled
+	// WHEN the AppendOverrides function is called
+	// THEN the key/value slice contains the expected helm override keys and values
+	vz = &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Prometheus: &vzapi.PrometheusComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+
+	ctx = spi.NewFakeContext(client, vz, false)
+	kvs = make([]bom.KeyValue, 0)
+
+	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
+	assert.NoError(t, err)
+	assert.Len(t, kvs, 12)
+
+	assert.Equal(t, "false", bom.FindKV(kvs, "prometheus.enabled"))
 }
 
 // TestPreInstallUpgrade tests the preInstallUpgrade function.

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -8,7 +8,6 @@ nodeExporter:
 kubeStateMetrics:
   enabled: false
 prometheus:
-  enabled: true
   prometheusSpec:
     securityContext:
       fsGroup: 65534


### PR DESCRIPTION
This PR fixes a bug where Prometheus was still installed by the Prometheus Operator even if the Prometheus component in the Verrazzano CR was disabled.