### PR TITLE
VZ-6230.  Enable VPO uninstall of App operator

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -595,41 +595,12 @@ pipeline {
             stages {
                 stage('Uninstall') {
                     steps {
-                        script {
-                             // Create a dictionary of Verrazzano uninstall steps to be executed in parallel
-                             // - the first one will always be the Admin cluster
-                             // - clusters 2-max are managed clusters
-                             def verrazzanoUninstallStages = [:]
-                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                             for (int count = 1; count <= clusterCount; count++) {
-                                 def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                                 def key = "vz-mgd-${count - 1}"
-                                 if (count == 1) {
-                                     key = "vz-admin"
-                                 }
-                                 verrazzanoUninstallStages["${key}"] = uninstallVerrazzano(count, installerPath)
-                             }
-                             parallel verrazzanoUninstallStages
-                        }
+                        uninstallVerrazzano()
                     }
                 }
                 stage('Verify Uninstall') {
                     steps {
-                        script {
-                            // Create a dictionary of Verrazzano verify uninstall steps to be executed in parallel
-                            // - the first one will always be the Admin cluster
-                            // - clusters 2-max are managed clusters
-                            def verifyUninstallStages = [:]
-                            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                            for (int count = 1; count <= clusterCount; count++) {
-                                def key = "vz-mgd-${count - 1}"
-                                if (count == 1) {
-                                    key = "vz-admin"
-                                }
-                                verifyUninstallStages["${key}"] = verifyUninstall(count)
-                            }
-                            parallel verifyUninstallStages
-                        }
+                        verifyUninstall()
                     }
                 }
             }
@@ -954,10 +925,29 @@ def upgradeVerrazzano() {
     }
 }
 
+def uninstallVerrazzano() {
+    script {
+         // Create a dictionary of Verrazzano uninstall steps to be executed in parallel
+         // - the first one will always be the Admin cluster
+         // - clusters 2-max are managed clusters
+         def verrazzanoUninstallStages = [:]
+         int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+         for (int count = 1; count <= clusterCount; count++) {
+             def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
+             def key = "vz-mgd-${count - 1}"
+             if (count == 1) {
+                 key = "vz-admin"
+             }
+             verrazzanoUninstallStages["${key}"] = uninstallVerrazzanoOnCluster(count, installerPath)
+         }
+         parallel verrazzanoUninstallStages
+    }
+}
+
 // Uninstall Verrazzano
 // - count is the cluster index into the $KUBECONFIG_DIR
 // - verrazzanoConfig is the Verrazzano CR to use to install VZ on the cluster
-def uninstallVerrazzano(count, verrazzanoConfig) {
+def uninstallVerrazzanoOnCluster(count, verrazzanoConfig) {
     // For parallel execution, wrap this in a Groovy enclosure {}
     return {
         script {
@@ -970,9 +960,28 @@ def uninstallVerrazzano(count, verrazzanoConfig) {
     }
 }
 
-// Verify uninstall Verrazzano
+// Verify uninstall on all clusters
+def verifyUninstall() {
+    script {
+        // Create a dictionary of Verrazzano verify uninstall steps to be executed in parallel
+        // - the first one will always be the Admin cluster
+        // - clusters 2-max are managed clusters
+        def verifyUninstallStages = [:]
+        int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+        for (int count = 1; count <= clusterCount; count++) {
+            def key = "vz-mgd-${count - 1}"
+            if (count == 1) {
+                key = "vz-admin"
+            }
+            verifyUninstallStages["${key}"] = verifyUninstallOnCluster(count)
+        }
+        parallel verifyUninstallStages
+    }
+}
+
+// Verify uninstall Verrazzano on a single cluster
 // - count is the cluster index into the $KUBECONFIG_DIR
-def verifyUninstall(count) {
+def verifyUninstallOnCluster(count) {
     // For parallel execution, wrap this in a Groovy enclosure {}
     return {
         script {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -591,6 +591,74 @@ pipeline {
                 }
             }
         }
+        stage('Uninstall Verrazzano') {
+            stages {
+                stage('Uninstall') {
+                    steps {
+                        script {
+                             // Create a dictionary of Verrazzano uninstall steps to be executed in parallel
+                             // - the first one will always be the Admin cluster
+                             // - clusters 2-max are managed clusters
+                             def verrazzanoUninstallStages = [:]
+                             int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                             for (int count = 1; count <= clusterCount; count++) {
+                                 def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
+                                 def key = "vz-mgd-${count - 1}"
+                                 if (count == 1) {
+                                     key = "vz-admin"
+                                 }
+                                 verrazzanoUninstallStages["${key}"] = uninstallVerrazzano(count, installerPath)
+                             }
+                             parallel verrazzanoUninstallStages
+                        }
+                    }
+                }
+                stage('Verify Uninstall') {
+                    steps {
+                        script {
+                            // Create a dictionary of Verrazzano verify uninstall steps to be executed in parallel
+                            // - the first one will always be the Admin cluster
+                            // - clusters 2-max are managed clusters
+                            def verifyUninstallStages = [:]
+                            int clusterCount = params.TOTAL_CLUSTERS.toInteger()
+                            for (int count = 1; count <= clusterCount; count++) {
+                                def key = "vz-mgd-${count - 1}"
+                                if (count == 1) {
+                                    key = "vz-admin"
+                                }
+                                verifyUninstallStages["${key}"] = verifyUninstall(count)
+                            }
+                            parallel verifyUninstallStages
+                        }
+                    }
+                }
+            }
+            post {
+                failure {
+                    script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
+                        dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                    }
+                }
+                aborted {
+                    script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
+                        dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                    }
+                }
+                success {
+                    script {
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
+                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                        }
+                    }
+                }
+                always {
+                    archiveArtifacts artifacts: "**/*-cluster-dump*/**,**/test-cluster-dumps/**", allowEmptyArchive: true
+                }
+            }
+        }
     }
     post {
         failure {
@@ -626,39 +694,6 @@ pipeline {
             """
             archiveArtifacts artifacts: "**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
-
-            script {
-                 // Create a dictionary of Verrazzano uninstall steps to be executed in parallel
-                 // - the first one will always be the Admin cluster
-                 // - clusters 2-max are managed clusters
-                 def verrazzanoUninstallStages = [:]
-                 int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                 for (int count = 1; count <= clusterCount; count++) {
-                     def installerPath = "${KUBECONFIG_DIR}/${count}/${installerFileName}"
-                     def key = "vz-mgd-${count - 1}"
-                     if (count == 1) {
-                         key = "vz-admin"
-                     }
-                     verrazzanoUninstallStages["${key}"] = uninstallVerrazzano(count, installerPath)
-                 }
-                 parallel verrazzanoUninstallStages
-            }
-
-            script {
-                // Create a dictionary of Verrazzano verify uninstall steps to be executed in parallel
-                // - the first one will always be the Admin cluster
-                // - clusters 2-max are managed clusters
-                def verifyUninstallStages = [:]
-                int clusterCount = params.TOTAL_CLUSTERS.toInteger()
-                for (int count = 1; count <= clusterCount; count++) {
-                    def key = "vz-mgd-${count - 1}"
-                    if (count == 1) {
-                        key = "vz-admin"
-                    }
-                    verifyUninstallStages["${key}"] = verifyUninstall(count)
-                }
-                parallel verifyUninstallStages
-            }
 
             script {
                 if (params.EMIT_METRICS) {

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -38,16 +38,17 @@ type applicationOperatorComponent struct {
 func NewComponent() spi.Component {
 	return applicationOperatorComponent{
 		helm.HelmComponent{
-			ReleaseName:             ComponentName,
-			JSONName:                ComponentJSONName,
-			ChartDir:                filepath.Join(config.GetHelmChartsDir(), ComponentName),
-			ChartNamespace:          ComponentNamespace,
-			IgnoreNamespaceOverride: true,
-			SupportsOperatorInstall: true,
-			AppendOverridesFunc:     AppendApplicationOperatorOverrides,
-			ImagePullSecretKeyname:  "global.imagePullSecrets[0]",
-			Dependencies:            []string{oam.ComponentName, istio.ComponentName},
-			GetInstallOverridesFunc: GetOverrides,
+			ReleaseName:               ComponentName,
+			JSONName:                  ComponentJSONName,
+			ChartDir:                  filepath.Join(config.GetHelmChartsDir(), ComponentName),
+			ChartNamespace:            ComponentNamespace,
+			IgnoreNamespaceOverride:   true,
+			SupportsOperatorInstall:   true,
+			SupportsOperatorUninstall: true,
+			AppendOverridesFunc:       AppendApplicationOperatorOverrides,
+			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
+			Dependencies:              []string{oam.ComponentName, istio.ComponentName},
+			GetInstallOverridesFunc:   GetOverrides,
 		},
 	}
 }

--- a/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/0-uninstall-applications.sh
@@ -30,18 +30,6 @@ function delete_multicluster_resources {
     fi
     log "Deleting VMCs"
     delete_k8s_resources verrazzanomanagedcluster ":metadata.name" "Could not delete VerrazzanoManagedClusters from Verrazzano" "" "verrazzano-mc"
-    log "Deleting VerrazzanoProjects"
-    delete_k8s_resources verrazzanoproject ":metadata.name" "Could not delete VerrazzanoProjects from Verrazzano" "" "verrazzano-mc"
-    log "Deleting MultiClusterApplicationConfigurations"
-    delete_k8s_resource_from_all_namespaces multiclusterapplicationconfigurations.clusters.verrazzano.io no
-    log "Deleting MultiClusterComponents"
-    delete_k8s_resource_from_all_namespaces multiclustercomponents.clusters.verrazzano.io no
-    log "Deleting MultiClusterConfigMaps"
-    delete_k8s_resource_from_all_namespaces multiclusterconfigmaps.clusters.verrazzano.io no
-    log "Deleting MultiClusterLoggingScopes"
-    delete_k8s_resource_from_all_namespaces multiclusterloggingscopes.clusters.verrazzano.io no
-    log "Deleting MultiClusterSecrets"
-    delete_k8s_resource_from_all_namespaces multiclustersecrets.clusters.verrazzano.io no
 }
 
 action "Deleting Multicluster resources" delete_multicluster_resources || exit 1

--- a/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
+++ b/platform-operator/scripts/uninstall/uninstall-steps/3-uninstall-verrazzano.sh
@@ -48,7 +48,7 @@ function delete_verrazzano() {
     || return $? # return on pipefail
 
   log "Deleting Verrazzano namespaces"
-  delete_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not delete Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano.io\/namespace:monitoring|verrazzano-system|verrazzano-mc/ {print $1}' \
+  delete_k8s_resources namespace ":metadata.name,:metadata.labels" "Could not delete Verrazzano namespaces" '/k8s-app:verrazzano.io|verrazzano.io\/namespace:monitoring|verrazzano-system/ {print $1}' \
     || return $? # return on pipefail
 
   # Delete CR'S from all Verrazzano managed namespaces
@@ -72,15 +72,6 @@ function delete_oam_operator {
   kubectl delete clusterrole oam-kubernetes-runtime-pvc --ignore-not-found
   kubectl delete clusterrole oam-kubernetes-runtime-istio --ignore-not-found
   kubectl delete clusterrole oam-kubernetes-runtime-certificate --ignore-not-found
-}
-
-function delete_application_operator {
-  log "Uninstall the Verrazzano Kubernetes application operator"
-  if helm status verrazzano-application-operator --namespace "${VERRAZZANO_NS}" > /dev/null 2>&1 ; then
-    if ! helm uninstall verrazzano-application-operator --namespace "${VERRAZZANO_NS}" ; then
-      error "Failed to uninstall the Verrazzano Kubernetes application operator."
-    fi
-  fi
 }
 
 function delete_vmo {
@@ -233,7 +224,6 @@ action "Deleting Prometheus adapter " delete_prometheus_adapter || exit 1
 action "Deleting kube-state-metrics " delete_kube_state_metrics || exit 1
 action "Deleting Prometheus node-exporter " delete_prometheus_node_exporter || exit 1
 action "Deleting Prometheus operator " delete_prometheus_operator || exit 1
-action "Deleting Verrazzano Application Kubernetes operator" delete_application_operator || exit 1
 action "Deleting OAM Kubernetes operator" delete_oam_operator || exit 1
 action "Deleting Coherence Kubernetes operator" delete_coherence_operator || exit 1
 action "Deleting WebLogic Kubernetes operator" delete_weblogic_operator || exit 1


### PR DESCRIPTION
Enable VPO-uninstall for App operator
- don't delete MC app resources
- Update MC pipeline to move uninstall/verify to its own stage for debugging
- do not delete verrazzano-mc namespace as there may be user-installed resources there for applications

Of note
- we are not deleting any user created MC-app resources, as we intend to no longer uninstall user applications are part of uninstall
- Because of the above, we aren’t deleting the verrazzano-mc namespace in the scripts; that will be managed by the code to clean up VMCs in another PR, if no VerrazzanoProject resources exist
- I updated the MC pipeline Jenkinsfile to do uninstall/verify in a stage and not during cleanup, so we can grab cluster dumps on failure