### PR TITLE
Fix apply yaml issue when updating an existing ClusterRole

### DIFF
--- a/pkg/k8sutil/apply_yaml.go
+++ b/pkg/k8sutil/apply_yaml.go
@@ -186,13 +186,16 @@ func (y *YAMLApplier) applyAction(obj *unstructured.Unstructured) error {
 			}
 
 			// See if merge needed on objects of type map[string]interface {}
-			//
-			// For objects of type []interface{}, e.g. secrets or imagePullSecrets, a replace will be
-			// done.  This appears to be consistent with the behavior of kubectl.
 			if clientField.typeOf == "map[string]interface {}" {
 				if serverField != nil {
 					merge(serverField.(map[string]interface{}), clientField.nestedCopy.(map[string]interface{}))
 				}
+			}
+
+			// For objects of type []interface{}, e.g. secrets or imagePullSecrets, a replace will be
+			// done.  This appears to be consistent with the behavior of kubectl.
+			if clientField.typeOf == "[]interface {}" {
+				serverField = clientField.nestedCopy
 			}
 
 			// If serverSpec is nil, then the clientSpec field is being added

--- a/pkg/k8sutil/apply_yaml_test.go
+++ b/pkg/k8sutil/apply_yaml_test.go
@@ -291,7 +291,7 @@ func TestApplyDT(t *testing.T) {
 			"should apply all template files in directory",
 			testdata,
 			map[string]interface{}{"namespace": "default"},
-			5,
+			7,
 			false,
 		},
 		// GIVEN a directory of template YAML files
@@ -301,7 +301,7 @@ func TestApplyDT(t *testing.T) {
 			"should fail to apply when one or more templates are incomplete",
 			testdata,
 			map[string]interface{}{},
-			2,
+			4,
 			true,
 		},
 	}

--- a/pkg/k8sutil/testdata/clusterrole_create.yaml
+++ b/pkg/k8sutil/testdata/clusterrole_create.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-managed-cluster
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/k8sutil/testdata/clusterrole_update.yaml
+++ b/pkg/k8sutil/testdata/clusterrole_update.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-managed-cluster
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update

--- a/pkg/k8sutil/testdata/deployment_merge.yaml
+++ b/pkg/k8sutil/testdata/deployment_merge.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: apps/v1

--- a/pkg/k8sutil/testdata/sa_add_imagepullsecrets.yaml
+++ b/pkg/k8sutil/testdata/sa_add_imagepullsecrets.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: v1


### PR DESCRIPTION
The yaml apply code was loosing updates on some fields that had changed in the yaml being applied, but already existed on the server side.

Added a unit test for applying a ClusterRole and updating the verbs allowed.

Fix some copyright dates that should not have had 2021.
