### PR TITLE
VZ-5666: Verrazzano clusterrole changes to allow hook role permissions.

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-monitoring-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-monitoring-operator/templates/clusterrole.yaml
@@ -64,6 +64,7 @@ rules:
       - list
       - update
       - watch
+      - patch
   - apiGroups:
       - batch
     resources:
@@ -146,6 +147,22 @@ rules:
       - get
       - list
       - update
+      - watch
+  - apiGroups:
+      - velero.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - v1
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
       - watch
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
