### PR TITLE
No JIRA: Update Prometheus URL in Kiali Overrides to fix Kiali UI

### DIFF
--- a/platform-operator/helm_config/overrides/kiali-server-values.yaml
+++ b/platform-operator/helm_config/overrides/kiali-server-values.yaml
@@ -27,7 +27,7 @@ kubernetes_config:
 
 external_services:
   prometheus:
-    url: http://vmi-system-prometheus:9090
+    url: http://prometheus-operator-kube-p-prometheus.verrazzano-monitoring.svc.cluster.local:9090
   grafana:
     enabled: false
   tracing:


### PR DESCRIPTION
# Description

No JIRA

Update the Kiali URL for Prometheus to the new Prometheus service and worked on DNS resolution issues for the prometheus service.