### PR TITLE
NO JIRA: Reduce sleep interval when waiting during CLI uninstall

### DIFF
--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -36,6 +36,13 @@ func TestUninstallCmd(t *testing.T) {
 				"job-name": constants.VerrazzanoUninstall + "-verrazzano",
 			},
 		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+		},
 	}
 	namespace := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{},
@@ -126,6 +133,13 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 				"job-name": constants.VerrazzanoUninstall + "-verrazzano",
 			},
 		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+		},
 	}
 	namespace := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{},
@@ -179,6 +193,13 @@ func TestUninstallCmdDefaultNoWait(t *testing.T) {
 			Name:      constants.VerrazzanoUninstall,
 			Labels: map[string]string{
 				"job-name": constants.VerrazzanoUninstall + "-verrazzano",
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This pull request changes sleep intervals to be 1 second instead of 5 seconds.  When the sleep intervals were 5 seconds the unit tests were taking 15+ seconds to complete.  Also, moved a couple of sleeps to end of loops instead of start of loops.