### PR TITLE
Sdosapat/vz 6255

### DIFF
--- a/tools/vz/pkg/analysis/test/files/sanity_test.txt
+++ b/tools/vz/pkg/analysis/test/files/sanity_test.txt
@@ -1,0 +1,6 @@
+Copyright (C) 2022, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+1.1.1.1.
+182.234.234.12
+132.23.234.24

--- a/tools/vz/pkg/analysis/test/files/sanity_test_no_match.txt
+++ b/tools/vz/pkg/analysis/test/files/sanity_test_no_match.txt
@@ -1,0 +1,9 @@
+Copyright (C) 2022, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+test-no-match
+1234
+abcd
+123456.21345
+245346.324
+2134.46.75689.235464356768

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -90,8 +90,8 @@ func SanitizeFile(path string, replaceFile bool) error {
 	//fmt.Println("Modified file is: \n", string(modifiedFile))
 
 	if replaceFile == true {
-		printError(os.Remove(path))
-		printError(os.Rename(path+"_tmpfoo", path))
+		check(os.Remove(path))
+		check(os.Rename(path+"_tmpfoo", path))
 	}
 
 	return nil
@@ -106,13 +106,8 @@ func sanitizeEachLine(l string) string {
 
 func check(e error) error {
 	if e != nil {
+		fmt.Errorf(e.Error())
 		return e
 	}
 	return nil
-}
-
-func printError(err error) {
-	if err != nil {
-		fmt.Println(err.Error())
-	}
 }

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -18,6 +18,8 @@ var regexToReplacementMap = make(map[string]string)
 const redactIpAddress = "REDACTED-IP4-ADDRESS"
 const ipv4Regex = "[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}"
 
+// Initialize the regex string to replacement string map
+// Append to this map for any future additions
 func initRegexToReplacementMap() {
 	regexToReplacementMap[ipv4Regex] = redactIpAddress
 }
@@ -49,6 +51,8 @@ func GetMatchingFiles(rootDirectory string, fileMatchRe *regexp.Regexp) (fileMat
 	return fileMatches, err
 }
 
+// This will iterate over the given root directory to sanitize each file
+// replaceFile is to whether replace the file with sanitized content or create a new file with _tmpfoo suffix
 func SanitizeDirectory(rootDirectory string, replaceFile bool) {
 	initRegexToReplacementMap()
 	fileMatches, err := GetMatchingFiles(rootDirectory, regexp.MustCompile(".*"))
@@ -58,6 +62,7 @@ func SanitizeDirectory(rootDirectory string, replaceFile bool) {
 	}
 }
 
+//Sanitize the given file, replaceFile boolean is to whether inplace replacement or to a new file
 func SanitizeFile(path string, replaceFile bool) error {
 	fmt.Println("path provided is: ", path)
 	input, err := os.Open(path)
@@ -97,6 +102,8 @@ func SanitizeFile(path string, replaceFile bool) error {
 	return nil
 }
 
+// Sanitize each line in a given file,
+// Sanitizes based on the regex map initialized above
 func sanitizeEachLine(l string) string {
 	for k, v := range regexToReplacementMap {
 		l = regexp.MustCompile(k).ReplaceAllString(l, v)

--- a/tools/vz/pkg/helpers/vzsanitize_test.go
+++ b/tools/vz/pkg/helpers/vzsanitize_test.go
@@ -1,0 +1,44 @@
+package helpers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"regexp"
+	"testing"
+)
+
+var testDir = "../../pkg/analysis/test/files"
+
+func TestSanitizeDirectoryMatch(t *testing.T) {
+	SanitizeDirectory(testDir, false)
+	testFile := testDir + "/sanity_test.txt"
+	testFiletmp := testFile + "_tmpfoo"
+	file, err := os.ReadFile(testFiletmp)
+	assert.Nil(t, err)
+	assert.Contains(t, string(file), "REDACT")
+	assert.NotContains(t, string(file), "132.23.234.24")
+	testCleanup(testDir)
+}
+
+func TestSanitizeDirectoryNoMatch(t *testing.T) {
+	SanitizeDirectory(testDir, false)
+	testFile := testDir + "/sanity_test_no_match.txt"
+	testFiletmp := testFile + "_tmpfoo"
+	file, err := os.ReadFile(testFiletmp)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(file), "REDACT")
+	assert.Contains(t, string(file), "2134.46.75689.235464356768")
+	testCleanup(testDir)
+}
+
+func testCleanup(path string) error {
+	files, err := GetMatchingFiles(path, regexp.MustCompile(".*_tmpfoo"))
+	if err != nil {
+		return err
+	}
+	for _, eachFile := range files {
+		println("deleting temp file: ", eachFile)
+		os.Remove(eachFile)
+	}
+	return nil
+}


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

Validation:
```
[19:41:37 bash vz]$make cli
GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go install -ldflags "-X 'github.com/verrazzano/verrazzano/tools/vz/cmd/version.gitCommit=8eb4a519f422bb27e2e6f5f7987f2251785a0a37' -X 'github.com/verrazzano/verrazzano/tools/vz/cmd/version.buildDate=2022-07-05T19:41:44Z' -X 'github.com/verrazzano/verrazzano/tools/vz/cmd/version.cliVersion=1.4.0'" ./...
[19:42:02 bash vz]$vz
The vz tool is a command-line utility that allows Verrazzano operators to query and manage a Verrazzano environment

Usage:
  vz [command]

Available Commands:
  analyze     Analyze cluster
  help        Help about any command
  install     Install Verrazzano
  status      Status of the Verrazzano installation and access endpoints
  uninstall   Uninstall Verrazzano
  upgrade     Upgrade Verrazzano
  version     Verrazzano version information

Flags:
      --context string      The name of the kubeconfig context to use
  -h, --help                help for vz
      --kubeconfig string   Path to the kubeconfig file to use

Use "vz [command] --help" for more information about a command.
[19:42:10 bash vz]$

```