### PR TITLE
VZ-6251: Check whether report file can be created before actually collecting the info from the cluster

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -4,13 +4,16 @@
 package bugreport
 
 import (
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	vzbugreport "github.com/verrazzano/verrazzano/tools/vz/pkg/bugreport"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -40,12 +43,6 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return fmt.Errorf("error fetching flag: %s", err.Error())
 	}
 
-	// Fail if the bugReportFile already exists
-	_, err = os.Stat(bugReportFile)
-	if !os.IsNotExist(err) {
-		return fmt.Errorf("file %s already exists", bugReportFile)
-	}
-
 	// Get the kubernetes clientset, which will validate that the kubeconfig and context are valid.
 	kubeClient, err := vzHelper.GetKubeClient(cmd)
 	if err != nil {
@@ -58,6 +55,52 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return err
 	}
 
+	// Check whether the file already exists
+	err = checkExistingFile(bugReportFile)
+	if err != nil {
+		return err
+	}
+
+	// Create the bug report file
+	bugRepFile, err := os.Create(bugReportFile)
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return fmt.Errorf("permission denied to create the bug report: %s", bugReportFile)
+		}
+		return fmt.Errorf("an error occurred while creating %s: %s", bugReportFile, err.Error())
+	}
+	defer bugRepFile.Close()
+
 	// Generate the bug report
-	return vzbugreport.GenerateBugReport(kubeClient, client, bugReportFile, vzHelper)
+	err = vzbugreport.GenerateBugReport(kubeClient, client, bugRepFile, vzHelper)
+	if err != nil {
+		os.Remove(bugReportFile)
+	}
+	return nil
+}
+
+// checkExistingFile determines whether a file / directory with the name bugReportFile already exists
+func checkExistingFile(bugReportFile string) error {
+	// Fail if the bugReportFile already exists or is a directory
+	fileInfo, err := os.Stat(bugReportFile)
+	if fileInfo != nil {
+		if fileInfo.IsDir() {
+			return fmt.Errorf("%s is an existing directory", bugReportFile)
+		}
+		return fmt.Errorf("file %s already exists", bugReportFile)
+	}
+
+	// check if the parent directory exists
+	if err != nil {
+		fi, fe := os.Stat(filepath.Dir(bugReportFile))
+		if fi != nil {
+			if !fi.IsDir() {
+				return fmt.Errorf("%s is not a directory", filepath.Dir(bugReportFile))
+			}
+		}
+		if fe != nil {
+			return fmt.Errorf("an error occurred while creating %s: %s", bugReportFile, fe.Error())
+		}
+	}
+	return nil
 }

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -73,3 +73,77 @@ func TestBugReportExistingReportFile(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("%s already exists", reportFile))
 }
+
+// TestBugReportExistingDir
+// GIVEN a CLI bug-report command with flag --report-file pointing to an existing directory
+//  WHEN I call cmd.Execute for bug-report
+//  THEN expect an error
+func TestBugReportExistingDir(t *testing.T) {
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	cmd := NewCmdBugReport(rc)
+	assert.NotNil(t, cmd)
+
+	tmpDir, _ := ioutil.TempDir("", "bug-report")
+	defer os.RemoveAll(tmpDir)
+
+	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
+	if err := os.Mkdir(reportDir, os.ModePerm); err != nil {
+		assert.Error(t, err)
+	}
+
+	cmd.PersistentFlags().Set(constants.BugReportFileFlagName, reportDir)
+	err := cmd.Execute()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "test-report is an existing directory")
+}
+
+// TestBugReportNonExistingFileDir
+// GIVEN a CLI bug-report command with flag --report-file pointing to a file, where the directory doesn't exist
+//  WHEN I call cmd.Execute for bug-report
+//  THEN expect an error
+func TestBugReportNonExistingFileDir(t *testing.T) {
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	cmd := NewCmdBugReport(rc)
+	assert.NotNil(t, cmd)
+
+	tmpDir, _ := ioutil.TempDir("", "bug-report")
+	defer os.RemoveAll(tmpDir)
+
+	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
+	reportFile := reportDir + string(os.PathSeparator) + string(os.PathSeparator) + "bug-report.tgz"
+
+	cmd.PersistentFlags().Set(constants.BugReportFileFlagName, reportFile)
+	err := cmd.Execute()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "test-report: no such file or directory")
+}
+
+// TestBugReportFileNoPermission
+// GIVEN a CLI bug-report command with flag --report-file pointing to a file, where there is no write permission
+//  WHEN I call cmd.Execute for bug-report
+//  THEN expect an error
+func TestBugReportFileNoPermission(t *testing.T) {
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	cmd := NewCmdBugReport(rc)
+	assert.NotNil(t, cmd)
+
+	tmpDir, _ := ioutil.TempDir("", "bug-report")
+	defer os.RemoveAll(tmpDir)
+
+	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
+	// Create a directory with only read permission
+	if err := os.Mkdir(reportDir, 0400); err != nil {
+		assert.Error(t, err)
+	}
+	reportFile := reportDir + string(os.PathSeparator) + "bug-report.tgz"
+	cmd.PersistentFlags().Set(constants.BugReportFileFlagName, reportFile)
+	err := cmd.Execute()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "permission denied to create the bug report")
+}

--- a/tools/vz/pkg/bugreport/genreport.go
+++ b/tools/vz/pkg/bugreport/genreport.go
@@ -28,7 +28,7 @@ type ErrorsChannel struct {
 // - Workloads (Deployment and ReplicaSet, StatefulSet, Daemonset), pods, events, ingress and services from verrazzano-system namespace.
 
 // GenerateBugReport creates a bug report by including the resources selectively from the cluster, useful to analyze the issue.
-func GenerateBugReport(kubeClient kubernetes.Interface, client clipkg.Client, bugReportFile string, vzHelper pkghelpers.VZHelper) error {
+func GenerateBugReport(kubeClient kubernetes.Interface, client clipkg.Client, bugReportFile *os.File, vzHelper pkghelpers.VZHelper) error {
 
 	// Create a temporary directory to place the cluster data
 	bugReportDir, err := ioutil.TempDir("", constants.BugReportDir)
@@ -54,7 +54,7 @@ func GenerateBugReport(kubeClient kubernetes.Interface, client clipkg.Client, bu
 		return fmt.Errorf("there is an error in creating the bug report, %s", err.Error())
 	}
 
-	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Successfully created the bug report: %s\n", bugReportFile))
+	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Successfully created the bug report: %s\n", bugReportFile.Name()))
 
 	// Display a warning message to review the contents of the report
 	fmt.Fprint(vzHelper.GetOutputStream(), "WARNING: Please examine the contents of the bug report for sensitive data.\n")

--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -30,17 +30,7 @@ var containerStartLog = "==== START logs for container %s of pod %s/%s ====\n"
 var containerEndLog = "==== END logs for container %s of pod %s/%s ====\n"
 
 // CreateReportArchive creates the .tar.gz file specified by bugReportFile, from the files in captureDir
-func CreateReportArchive(captureDir, bugReportFile string) error {
-
-	// Create the bug report file
-	bugRepFile, err := os.Create(bugReportFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("parent directory for the bug report file doesn't exit")
-		}
-		return fmt.Errorf(errBugReport, err.Error())
-	}
-	defer bugRepFile.Close()
+func CreateReportArchive(captureDir string, bugRepFile *os.File) error {
 
 	// Create new Writers for gzip and tar
 	gzipWriter := gzip.NewWriter(bugRepFile)


### PR DESCRIPTION
This PR adds validations to determine whether the bug report file can actually be created. If there is an existing file with the same name, or if the user doesn't have the permission to create the file, an appropriate error is returned with this change.