### PR TITLE
VZ-6259: Secrets controller outputs frequent error messages during uninstall

### DIFF
--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -67,12 +67,16 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	if vzList != nil && len(vzList.Items) > 0 {
 		vz := &vzList.Items[0]
-		res, err := r.reconcileInstallOverrideSecret(ctx, req, vz)
-		if err != nil {
-			zap.S().Errorf("Failed to reconcile Secret: %v", err)
-			return newRequeueWithDelay(), err
+		if vz.DeletionTimestamp != nil {
+			return ctrl.Result{}, nil
+		} else {
+			res, err := r.reconcileInstallOverrideSecret(ctx, req, vz)
+			if err != nil {
+				zap.S().Errorf("Failed to reconcile Secret: %v", err)
+				return newRequeueWithDelay(), err
+			}
+			return res, nil
 		}
-		return res, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -49,13 +49,6 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		ctx = context.TODO()
 	}
 
-	// We care about the CA secret for the cluster - this can come from the verrazzano ingress
-	// tls secret (verrazzano-tls in verrazzano-system NS), OR from the tls-additional-ca in the
-	// cattle-system NS (used in the Let's Encrypt staging cert case)
-	if isVerrazzanoIngressSecretName(req.NamespacedName) || isAdditionalTLSSecretName(req.NamespacedName) {
-		return r.reconcileVerrazzanoTLS(ctx, req)
-	}
-
 	vzList := &installv1alpha1.VerrazzanoList{}
 	err := r.List(ctx, vzList)
 	if err != nil {
@@ -70,6 +63,13 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if vz.DeletionTimestamp != nil {
 			return ctrl.Result{}, nil
 		} else {
+			// We care about the CA secret for the cluster - this can come from the verrazzano ingress
+			// tls secret (verrazzano-tls in verrazzano-system NS), OR from the tls-additional-ca in the
+			// cattle-system NS (used in the Let's Encrypt staging cert case)
+			if isVerrazzanoIngressSecretName(req.NamespacedName) || isAdditionalTLSSecretName(req.NamespacedName) {
+				return r.reconcileVerrazzanoTLS(ctx, req)
+			}
+
 			res, err := r.reconcileInstallOverrideSecret(ctx, req, vz)
 			if err != nil {
 				zap.S().Errorf("Failed to reconcile Secret: %v", err)

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -60,6 +60,7 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	if vzList != nil && len(vzList.Items) > 0 {
 		vz := &vzList.Items[0]
+		// Nothing to do if the vz resource is being deleted
 		if vz.DeletionTimestamp != nil {
 			return ctrl.Result{}, nil
 		} else {

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -63,25 +63,24 @@ func (r *VerrazzanoSecretsReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// Nothing to do if the vz resource is being deleted
 		if vz.DeletionTimestamp != nil {
 			return ctrl.Result{}, nil
-		} else {
-			// We care about the CA secret for the cluster - this can come from the verrazzano ingress
-			// tls secret (verrazzano-tls in verrazzano-system NS), OR from the tls-additional-ca in the
-			// cattle-system NS (used in the Let's Encrypt staging cert case)
-			if isVerrazzanoIngressSecretName(req.NamespacedName) || isAdditionalTLSSecretName(req.NamespacedName) {
-				return r.reconcileVerrazzanoTLS(ctx, req)
-			}
-
-			res, err := r.reconcileInstallOverrideSecret(ctx, req, vz)
-			if err != nil {
-				zap.S().Errorf("Failed to reconcile Secret: %v", err)
-				return newRequeueWithDelay(), err
-			}
-			return res, nil
 		}
+
+		// We care about the CA secret for the cluster - this can come from the verrazzano ingress
+		// tls secret (verrazzano-tls in verrazzano-system NS), OR from the tls-additional-ca in the
+		// cattle-system NS (used in the Let's Encrypt staging cert case)
+		if isVerrazzanoIngressSecretName(req.NamespacedName) || isAdditionalTLSSecretName(req.NamespacedName) {
+			return r.reconcileVerrazzanoTLS(ctx, req)
+		}
+
+		res, err := r.reconcileInstallOverrideSecret(ctx, req, vz)
+		if err != nil {
+			zap.S().Errorf("Failed to reconcile Secret: %v", err)
+			return newRequeueWithDelay(), err
+		}
+		return res, nil
 	}
 
 	return ctrl.Result{}, nil
-
 }
 
 // initialize secret logger


### PR DESCRIPTION
The pull request fixes the secrets controller to not log frequent secret not found messages during an uninstall of Verrazzano.