### PR TITLE
NO JIRA: revert move of sleep timers during CLI uninstall

### DIFF
--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -181,6 +181,13 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 	seconds := 0
 	retryCount := 0
 	for {
+		retryCount++
+		if retryCount > uninstallWaitRetries {
+			return "", fmt.Errorf("Waiting for %s, %s pod not found in namespace %s", jobName, jobName, vzconstants.VerrazzanoInstallNamespace)
+		}
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
+
 		err := c.List(
 			context.TODO(),
 			&podList,
@@ -192,13 +199,6 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 			return "", fmt.Errorf("Waiting for %s, failed to list pods: %s", jobName, err.Error())
 		}
 		if len(podList.Items) == 0 {
-			retryCount++
-			if retryCount > uninstallWaitRetries {
-				return "", fmt.Errorf("Waiting for %s, %s pod not found in namespace %s", jobName, jobName, vzconstants.VerrazzanoInstallNamespace)
-			}
-			time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
-			seconds += verrazzanoUninstallJobDetectWait
-
 			continue
 		}
 		if len(podList.Items) > 1 {
@@ -212,20 +212,19 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 	pod := &corev1.Pod{}
 	seconds = 0
 	for {
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
+
 		err := c.Get(context.TODO(), types.NamespacedName{Namespace: podList.Items[0].Namespace, Name: podList.Items[0].Name}, pod)
 		if err != nil {
 			return "", err
 		}
 
 		ready := true
-		if pod.Status.ContainerStatuses == nil || len(pod.Status.ContainerStatuses) == 0 {
-			ready = false
-		} else {
-			for _, container := range pod.Status.ContainerStatuses {
-				if !container.Ready {
-					ready = false
-					break
-				}
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready {
+				ready = false
+				break
 			}
 		}
 
@@ -233,9 +232,6 @@ func getUninstallPodName(c client.Client, vzHelper helpers.VZHelper, jobName str
 			_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "\n")
 			break
 		}
-
-		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
-		seconds += verrazzanoUninstallJobDetectWait
 	}
 	return pod.Name, nil
 }


### PR DESCRIPTION
The pull request reverts the move of sleep timers during CLI install.  Unit tests can intermittently fail.