### PR TITLE
VZ-6101: Test that Prometheus spec can be overridden in Verrazzano CR

### DIFF
--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -17,6 +17,10 @@ spec:
         - secretRef:
             name: test-overrides
             key: test-overrides-secret.yaml
+        - values:
+            prometheus:
+              prometheusSpec:
+                replicas: 2
     prometheusAdapter:
       enabled: true
     kubeStateMetrics:


### PR DESCRIPTION
Extend the e2e `verify-infra/vmi_test` to validate that Prometheus can be configured using overrides in the Verrazzano CR. This test is called in several pipelines under several different configurations, so I added a bit of code to fetch the Prometheus replica count from the Verrazzano CR Prometheus Operator overrides, instead of hardcoding an expected value.