### PR TITLE
VZ-6239.  Revert component level uninstall for Grafana (#3499)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -19,6 +19,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/namespace"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -108,24 +109,6 @@ func CreateOrUpdateVMI(ctx spi.ComponentContext, updateFunc VMIMutateFunc) error
 	return nil
 }
 
-// UpdateVMI Updates the system VMI instance IFF the VMO is enabled and it already exists
-func UpdateVMI(ctx spi.ComponentContext, updateFunc VMIMutateFunc) error {
-	if !vzconfig.IsVMOEnabled(ctx.EffectiveCR()) {
-		return nil
-	}
-	if err := ctx.Client().Get(context.TODO(), GetSystemVMIName(), &vmov1.VerrazzanoMonitoringInstance{}); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return CreateOrUpdateVMI(ctx, updateFunc)
-}
-
-func GetSystemVMIName() types.NamespacedName {
-	return types.NamespacedName{Name: system, Namespace: globalconst.VerrazzanoSystemNamespace}
-}
-
 // EnsureVMISecret creates or updates the VMI secret
 func EnsureVMISecret(cli client.Client) error {
 	secret := &corev1.Secret{
@@ -172,21 +155,6 @@ func EnsureGrafanaAdminSecret(cli client.Client) error {
 		return nil
 	}); err != nil {
 		return err
-	}
-	return nil
-}
-
-func DeleteGrafanaAdminSecret(cli client.Client) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.GrafanaSecret,
-			Namespace: globalconst.VerrazzanoSystemNamespace,
-		},
-	}
-	if err := cli.Delete(context.TODO(), secret); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/dashboard.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/dashboard.go
@@ -11,9 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
@@ -60,21 +58,6 @@ func createGrafanaConfigMaps(ctx spi.ComponentContext) error {
 		return nil
 	})
 	return err
-}
-
-func deleteGrafanaConfigMaps(ctx spi.ComponentContext) error {
-	// Create the ConfigMap for Grafana Dashboards
-	dashboards := systemDashboardsCM()
-	if err := ctx.Client().Get(context.TODO(), types.NamespacedName{Name: dashboards.Name, Namespace: dashboards.Namespace}, dashboards); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if err := ctx.Client().Delete(context.TODO(), dashboards); err != nil {
-		return err
-	}
-	return nil
 }
 
 //dashboardName individual dashboards live in the configmap as files of the format:

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -6,7 +6,6 @@ package grafana
 import (
 	"fmt"
 
-	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -150,7 +149,7 @@ func (g grafanaComponent) PostInstall(ctx spi.ComponentContext) error {
 }
 
 func (g grafanaComponent) IsOperatorUninstallSupported() bool {
-	return true
+	return false
 }
 
 func (g grafanaComponent) PreUninstall(context spi.ComponentContext) error {
@@ -158,17 +157,11 @@ func (g grafanaComponent) PreUninstall(context spi.ComponentContext) error {
 }
 
 func (g grafanaComponent) Uninstall(context spi.ComponentContext) error {
-	return common.UpdateVMI(context, func(ctx spi.ComponentContext, storage *common.ResourceRequestValues, vmi *vmov1.VerrazzanoMonitoringInstance, existingVMI *vmov1.VerrazzanoMonitoringInstance) error {
-		vmi.Spec.Grafana.Enabled = false
-		return nil
-	})
+	return nil
 }
 
 func (g grafanaComponent) PostUninstall(context spi.ComponentContext) error {
-	if err := deleteGrafanaConfigMaps(context); err != nil {
-		return err
-	}
-	return common.DeleteGrafanaAdminSecret(context.Client())
+	return nil
 }
 
 // PreUpgrade ensures that preconditions are met before upgrading the Grafana component

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component_test.go
@@ -12,11 +12,8 @@ import (
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -328,95 +325,4 @@ func TestValidateUpdate(t *testing.T) {
 	// THEN the function does not return an error
 	newVz.Spec.Components.Grafana.Enabled = &trueValue
 	assert.NoError(t, NewComponent().ValidateUpdate(oldVz, newVz))
-}
-
-// TestUninstall tests the Uninstall method such that
-// GIVEN a call to Uninstall
-//  WHEN the Grafana component is disabled in the system VMI
-func TestUninstall(t *testing.T) {
-
-	client := fake.NewClientBuilder().WithScheme(testScheme).
-		WithObjects(
-			&vmov1.VerrazzanoMonitoringInstance{
-				ObjectMeta: metav1.ObjectMeta{Name: "system", Namespace: ComponentNamespace},
-				Spec: vmov1.VerrazzanoMonitoringInstanceSpec{
-					Grafana: vmov1.Grafana{
-						Enabled: true,
-					},
-				},
-			}).
-		Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{
-		Spec: vzapi.VerrazzanoSpec{
-			Components: vzapi.ComponentSpec{
-				Ingress: &vzapi.IngressNginxComponent{
-					Enabled: &falseValue, // Skip the call to get the DNS suffix, not required for this test
-				},
-			},
-		},
-	},
-		false)
-	comp := NewComponent()
-	assert.NoError(t, comp.Uninstall(ctx))
-
-	updatedVMI := &vmov1.VerrazzanoMonitoringInstance{}
-	client.Get(context.TODO(), common.GetSystemVMIName(), updatedVMI)
-	assert.False(t, updatedVMI.Spec.Grafana.Enabled)
-}
-
-// TestUninstallNoSystemVMI tests the Uninstall method such that
-// GIVEN a call to Uninstall
-// WHEN the system VMI is not present
-// THEN no error is returned
-func TestUninstallNoSystemVMI(t *testing.T) {
-	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
-	comp := NewComponent()
-	err := comp.Uninstall(ctx)
-	assert.NoError(t, err)
-}
-
-// TestPostUninstall tests the PostUninstall method such that
-// GIVEN a call to PostUninstall
-// WHEN the dashboards and Grafana secret still exist
-// THEN No error is returned and the dashboards and Grafana secret are deleted
-func TestPostUninstall(t *testing.T) {
-
-	dashboards := systemDashboardsCM()
-
-	client := fake.NewClientBuilder().WithScheme(testScheme).
-		WithObjects(
-			dashboards,
-			&v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      constants.GrafanaSecret,
-					Namespace: globalconst.VerrazzanoSystemNamespace,
-				},
-			}).
-		Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
-
-	comp := NewComponent()
-	err := comp.PostUninstall(ctx)
-	assert.NoError(t, err)
-
-	err = client.Get(context.TODO(), types.NamespacedName{Name: dashboards.Name, Namespace: dashboards.Namespace}, &v1.ConfigMap{})
-	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err))
-
-	err = client.Get(context.TODO(), types.NamespacedName{Name: constants.GrafanaSecret, Namespace: globalconst.VerrazzanoSystemNamespace}, &v1.Secret{})
-	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err))
-}
-
-// TestPostUninstallObjectsNotFound tests the PostUninstall method such that
-// GIVEN a call to PostUninstall
-// WHEN the dashboards and Grafana secret do not exist
-// THEN No error is returned
-func TestPostUninstallObjectsNotFound(t *testing.T) {
-	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
-	comp := NewComponent()
-	err := comp.PostUninstall(ctx)
-	assert.NoError(t, err)
 }


### PR DESCRIPTION
This reverts commit 8005633b260aaafe4d36244acb55a8ef3daad73e.

