### PR TITLE
Don't set finalizer if VZ CR is being deleted

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -123,15 +123,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // doReconcile the Verrazzano CR
 func (r *Reconciler) doReconcile(ctx context.Context, log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) (ctrl.Result, error) {
 
-	// Initialize once for this Verrazzano resource when the operator starts
-	result, err := r.initForVzResource(vz, log)
-	if err != nil {
-		return result, err
-	}
-	if vzctrl.ShouldRequeue(result) {
-		return result, nil
-	}
-
 	// Ensure the required resources needed for both install and uninstall exist
 	// This needs to be done for every state since the initForVzResource might have deleted
 	// role binding during old resource cleanup.
@@ -140,6 +131,20 @@ func (r *Reconciler) doReconcile(ctx context.Context, log vzlog.VerrazzanoLogger
 	}
 	if err := r.createClusterRoleBinding(ctx, log, vz); err != nil {
 		return newRequeueWithDelay(), err
+	}
+
+	// Check if uninstalling
+	if !vz.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.procDelete(ctx, log, vz)
+	}
+
+	// Initialize once for this Verrazzano resource when the operator starts
+	result, err := r.initForVzResource(vz, log)
+	if err != nil {
+		return result, err
+	}
+	if vzctrl.ShouldRequeue(result) {
+		return result, nil
 	}
 
 	// Init the state to Ready if this CR has never been processed
@@ -153,11 +158,6 @@ func (r *Reconciler) doReconcile(ctx context.Context, log vzlog.VerrazzanoLogger
 	if err != nil {
 		log.Errorf("Failed to create component context: %v", err)
 		return newRequeueWithDelay(), err
-	}
-
-	// Check if uninstalling
-	if !vz.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.procDelete(ctx, log, vz)
 	}
 
 	// Process CR based on state
@@ -1196,7 +1196,6 @@ func createPredicate(f func(e event.CreateEvent) bool) predicate.Funcs {
 // Clean up old resources from a 1.0 release where jobs, etc were in the default namespace
 // Add a watch for each Verrazzano resource
 func (r *Reconciler) initForVzResource(vz *installv1alpha1.Verrazzano, log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
-
 	// Add our finalizer if not already added
 	if !vzstring.SliceContainsString(vz.ObjectMeta.Finalizers, finalizerName) {
 		log.Debugf("Adding finalizer %s", finalizerName)

--- a/platform-operator/controllers/verrazzano/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/uninstall_component.go
@@ -86,18 +86,18 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				return ctrl.Result{}, err
 			}
 			if !installed {
-				compLog.Oncef("Component %s is not installed, nothing to do for uninstall", compName)
+				compLog.Oncef("Component %s is not installed", compName)
 				UninstallContext.state = compStateUninstallEnd
 				continue
 			}
 			if err := r.updateComponentStatus(compContext, "Uninstall started", vzapi.CondUninstallStarted); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
-			compLog.Oncef("Component %s is starting to uninstall", compName)
+			compLog.Oncef("Component %s starting to uninstall", compName)
 			UninstallContext.state = compStatePreUninstall
 
 		case compStatePreUninstall:
-			compLog.Oncef("Component %s is calling pre-uninstall", compName)
+			compLog.Oncef("Component %s pre-uninstall running", compName)
 			if err := comp.PreUninstall(compContext); err != nil {
 				compLog.Errorf("Failed pre-uninstalling component %s: %v", compName, err)
 				return ctrl.Result{}, err
@@ -105,7 +105,7 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 			UninstallContext.state = compStateUninstall
 
 		case compStateUninstall:
-			compLog.Progressf("Component %s is calling uninstall", compName)
+			compLog.Progressf("Component %s uninstall running", compName)
 			if err := comp.Uninstall(compContext); err != nil {
 				compLog.Errorf("Failed uninstalling component %s, will retry: %v", compName, err)
 				// requeue for 30 to 60 seconds later
@@ -114,20 +114,14 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 			UninstallContext.state = compStateWaitUninstalled
 
 		case compStateWaitUninstalled:
-			installed, err := comp.IsInstalled(compContext)
-			if err != nil {
-				compLog.Errorf("Failed checking if component %s is installed: %v", compName, err)
-				return controller.NewRequeueWithDelay(10, 15, time.Second), nil
-			}
-			if installed {
-				compLog.Progressf("Waiting for component %s to be uninstalled", compName)
+			if installed, err := comp.IsInstalled(compContext); err != nil || installed {
+				compLog.Progressf("Waiting for the component to be uninstalled", compName)
 				return newRequeueWithDelay(), nil
 			}
-			compLog.Progressf("Component %s has been uninstalled, running post-uninstall", compName)
 			if err := comp.PostUninstall(compContext); err != nil {
-				compLog.Errorf("PostUninstall for component %s failed: %v", compName, err)
-				// requeue for 10 to 15 seconds later
-				return controller.NewRequeueWithDelay(10, 15, time.Second), nil
+				compLog.Errorf("PostUninstall for component %s failed, will retry: %v", compName, err)
+				// requeue for 30 to 60 seconds later
+				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
 			}
 			UninstallContext.state = compStateUninstalledone
 

--- a/platform-operator/controllers/verrazzano/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/uninstall_component.go
@@ -86,18 +86,18 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				return ctrl.Result{}, err
 			}
 			if !installed {
-				compLog.Oncef("Component %s is not installed", compName)
+				compLog.Oncef("Component %s is not installed, nothing to do for uninstall", compName)
 				UninstallContext.state = compStateUninstallEnd
 				continue
 			}
 			if err := r.updateComponentStatus(compContext, "Uninstall started", vzapi.CondUninstallStarted); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
-			compLog.Oncef("Component %s starting to uninstall", compName)
+			compLog.Oncef("Component %s is starting to uninstall", compName)
 			UninstallContext.state = compStatePreUninstall
 
 		case compStatePreUninstall:
-			compLog.Oncef("Component %s pre-uninstall running", compName)
+			compLog.Oncef("Component %s is calling pre-uninstall", compName)
 			if err := comp.PreUninstall(compContext); err != nil {
 				compLog.Errorf("Failed pre-uninstalling component %s: %v", compName, err)
 				return ctrl.Result{}, err
@@ -105,7 +105,7 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 			UninstallContext.state = compStateUninstall
 
 		case compStateUninstall:
-			compLog.Progressf("Component %s uninstall running", compName)
+			compLog.Progressf("Component %s is calling uninstall", compName)
 			if err := comp.Uninstall(compContext); err != nil {
 				compLog.Errorf("Failed uninstalling component %s, will retry: %v", compName, err)
 				// requeue for 30 to 60 seconds later
@@ -114,14 +114,20 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 			UninstallContext.state = compStateWaitUninstalled
 
 		case compStateWaitUninstalled:
-			if installed, err := comp.IsInstalled(compContext); err != nil || installed {
-				compLog.Progressf("Waiting for the component to be uninstalled", compName)
+			installed, err := comp.IsInstalled(compContext)
+			if err != nil {
+				compLog.Errorf("Failed checking if component %s is installed: %v", compName, err)
+				return controller.NewRequeueWithDelay(10, 15, time.Second), nil
+			}
+			if installed {
+				compLog.Progressf("Waiting for component %s to be uninstalled", compName)
 				return newRequeueWithDelay(), nil
 			}
+			compLog.Progressf("Component %s has been uninstalled, running post-uninstall", compName)
 			if err := comp.PostUninstall(compContext); err != nil {
-				compLog.Errorf("PostUninstall for component %s failed, will retry: %v", compName, err)
-				// requeue for 30 to 60 seconds later
-				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
+				compLog.Errorf("PostUninstall for component %s failed: %v", compName, err)
+				// requeue for 10 to 15 seconds later
+				return controller.NewRequeueWithDelay(10, 15, time.Second), nil
 			}
 			UninstallContext.state = compStateUninstalledone
 


### PR DESCRIPTION
I am seeing cases where finalizer is being set after it is deleted.  This can happen if the controller runtime cache has stale CRs.  Always process deletion before setting finalizer.
