### PR TITLE
NO JIRA: Temporarily disable upgrade-uninstall chaos test

### DIFF
--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -179,6 +179,7 @@ pipeline {
                         }
                     }
                 }
+                /*
                 stage('Uninstall failed upgrade') {
                     steps {
                         script {
@@ -196,6 +197,7 @@ pipeline {
                         }
                     }
                 }
+                */
                 stage('Upgrade a failed 1.2.0 upgrade') {
                     steps {
                         script {


### PR DESCRIPTION
This pull request temporarily disables the upgrade-uninstall chaos test during the ongoing changes to uninstall.