### PR TITLE
VZ-6353: Update component condition timestamp in VZ status

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -711,6 +711,7 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 func appendConditionIfNecessary(log vzlog.VerrazzanoLogger, compStatus *installv1alpha1.ComponentStatusDetails, newCondition installv1alpha1.Condition) []installv1alpha1.Condition {
 	for _, existingCondition := range compStatus.Conditions {
 		if existingCondition.Type == newCondition.Type {
+			existingCondition.LastTransitionTime = newCondition.LastTransitionTime
 			return compStatus.Conditions
 		}
 	}

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -709,9 +709,9 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 }
 
 func appendConditionIfNecessary(log vzlog.VerrazzanoLogger, compStatus *installv1alpha1.ComponentStatusDetails, newCondition installv1alpha1.Condition) []installv1alpha1.Condition {
-	for _, existingCondition := range compStatus.Conditions {
+	for i, existingCondition := range compStatus.Conditions {
 		if existingCondition.Type == newCondition.Type {
-			existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+			compStatus.Conditions[i] = newCondition
 			return compStatus.Conditions
 		}
 	}


### PR DESCRIPTION
This change updates the timestamp in the component conditions in the VZ CR status if the condition already exists. It does not change the order of the status, just simply replaces the old condition data with the new condition data. Functionally speaking, all this does is update the lastTransitionTime field.