### PR TITLE
NO JIRA: Change Prometheus scrape interval to 20s (from default of 30s)

### DIFF
--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -27,6 +27,7 @@ prometheus:
         - prometheus-node-exporter
         - kube-state-metrics
         - prometheus-pushgateway
+    scrapeInterval: 20s
   serviceMonitor:
     relabelings:
       - action: replace


### PR DESCRIPTION
Change the default Prometheus scrape interval from 30 seconds to 20 seconds so it matches the previous configuration we had in the VMO-managed Prometheus.