### PR TITLE
VZ-6232.  Move external-dns uninstall to VPO

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -917,27 +917,7 @@ func uninstallCertManager(compContext spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-
-	// Remove finalizers from the cert-manager namespace to avoid hanging namespace deletion
-	certNs := v1.Namespace{}
-	err = compContext.Client().Get(context.TODO(), types.NamespacedName{Name: ComponentNamespace}, &certNs)
-	if crtclient.IgnoreNotFound(err) != nil {
-		return compContext.Log().ErrorfNewErr("Failed to get the %s %s: %v", certNs.GetObjectKind(), ComponentNamespace, err)
-	} else if err == nil {
-		certNs.SetFinalizers([]string{})
-		err = compContext.Client().Update(context.TODO(), &certNs)
-		if err != nil {
-			return compContext.Log().ErrorfNewErr("Failed to update the %s %s: %v", certNs.GetObjectKind(), ComponentNamespace, err)
-		}
-	}
-
-	// Delete the cert-manager namespace now that the finalizers have been removed
-	return vzresource.Resource{
-		Name:   ComponentNamespace,
-		Client: compContext.Client(),
-		Object: &v1.Namespace{},
-		Log:    compContext.Log(),
-	}.Delete()
+	return nil
 }
 
 func deleteObject(client crtclient.Client, name string, namespace string, object crtclient.Object) error {

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_test.go
@@ -618,9 +618,6 @@ func TestUninstallCertManager(t *testing.T) {
 			err = c.Get(context.TODO(), types.NamespacedName{Name: caInjectorConfigMap, Namespace: constants.KubeSystem}, &v1.ConfigMap{})
 			assert.Error(t, err, "Expected the ConfigMap %s to be deleted", caInjectorConfigMap)
 			// expect the Namespace to get deleted
-			err = c.Get(context.TODO(), types.NamespacedName{Name: constants.CertManagerNamespace}, &v1.Namespace{})
-			assert.Error(t, err, "Expected the Namespace %s to be deleted", ComponentNamespace)
-			// expect the Namespace to get deleted
 			err = c.Get(context.TODO(), types.NamespacedName{Name: verrazzanoClusterIssuerName, Namespace: vzconst.DefaultNamespace}, &certv1.ClusterIssuer{})
 			assert.Error(t, err, "Expected the ClusterIssuer %s to be deleted", ComponentNamespace)
 			// expect the Namespace to get deleted

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -90,6 +90,7 @@ func preInstall(compContext spi.ComponentContext) error {
 	return nil
 }
 
+// postUninstall Clean up the cluster role/bindings
 func postUninstall(log vzlog.VerrazzanoLogger, cli client.Client) error {
 	log.Progressf("Deleting ClusterRoles and ClusterRoleBindings for external-dns")
 	err := resource.Resource{

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -32,6 +32,9 @@ const (
 	imagePullSecretHelmKey = "global.imagePullSecrets[0]"
 	ownerIDHelmKey         = "txtOwnerId"
 	prefixKey              = "txtPrefix"
+
+	clusterRoleName        = ComponentName
+	clusterRoleBindingName = ComponentName
 )
 
 func preInstall(compContext spi.ComponentContext) error {
@@ -90,7 +93,7 @@ func preInstall(compContext spi.ComponentContext) error {
 func postUninstall(log vzlog.VerrazzanoLogger, cli client.Client) error {
 	log.Progressf("Deleting ClusterRoles and ClusterRoleBindings for external-dns")
 	err := resource.Resource{
-		Name:   "external-dns",
+		Name:   clusterRoleName,
 		Client: cli,
 		Object: &rbacv1.ClusterRole{},
 		Log:    log,
@@ -99,7 +102,7 @@ func postUninstall(log vzlog.VerrazzanoLogger, cli client.Client) error {
 		return err
 	}
 	return resource.Resource{
-		Name:   "external-dns",
+		Name:   clusterRoleBindingName,
 		Client: cli,
 		Object: &rbacv1.ClusterRoleBinding{},
 		Log:    log,

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/helm"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"hash/fnv"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,6 +85,25 @@ func preInstall(compContext spi.ComponentContext) error {
 		return compContext.Log().ErrorfNewErr("Failed to create or update the external DNS secret: %v", err)
 	}
 	return nil
+}
+
+func postUninstall(log vzlog.VerrazzanoLogger, cli client.Client) error {
+	log.Progressf("Deleting ClusterRoles and ClusterRoleBindings for external-dns")
+	err := resource.Resource{
+		Name:   "external-dns",
+		Client: cli,
+		Object: &rbacv1.ClusterRole{},
+		Log:    log,
+	}.Delete()
+	if err != nil {
+		return err
+	}
+	return resource.Resource{
+		Name:   "external-dns",
+		Client: cli,
+		Object: &rbacv1.ClusterRoleBinding{},
+		Log:    log,
+	}.Delete()
 }
 
 func isExternalDNSReady(compContext spi.ComponentContext) bool {

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
@@ -5,9 +5,9 @@ package externaldns
 
 import (
 	"fmt"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"path/filepath"
 
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -30,17 +30,18 @@ var _ spi.Component = externalDNSComponent{}
 func NewComponent() spi.Component {
 	return externalDNSComponent{
 		helm.HelmComponent{
-			ReleaseName:             ComponentName,
-			ChartDir:                filepath.Join(config.GetThirdPartyDir(), ComponentName),
-			ChartNamespace:          ComponentNamespace,
-			IgnoreNamespaceOverride: true,
-			SupportsOperatorInstall: true,
-			ImagePullSecretKeyname:  imagePullSecretHelmKey,
-			ValuesFile:              filepath.Join(config.GetHelmOverridesDir(), "external-dns-values.yaml"),
-			AppendOverridesFunc:     AppendOverrides,
-			MinVerrazzanoVersion:    constants.VerrazzanoVersion1_0_0,
-			Dependencies:            []string{},
-			GetInstallOverridesFunc: GetOverrides,
+			ReleaseName:               ComponentName,
+			ChartDir:                  filepath.Join(config.GetThirdPartyDir(), ComponentName),
+			ChartNamespace:            ComponentNamespace,
+			IgnoreNamespaceOverride:   true,
+			SupportsOperatorInstall:   true,
+			SupportsOperatorUninstall: true,
+			ImagePullSecretKeyname:    imagePullSecretHelmKey,
+			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "external-dns-values.yaml"),
+			AppendOverridesFunc:       AppendOverrides,
+			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_0_0,
+			Dependencies:              []string{},
+			GetInstallOverridesFunc:   GetOverrides,
 		},
 	}
 }
@@ -62,6 +63,12 @@ func (e externalDNSComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 		return true
 	}
 	return false
+}
+
+func (e externalDNSComponent) PostUninstall(ctx spi.ComponentContext) error {
+	//   # delete all ExternalDNS ingresses before deleting ExternalDNS
+	//  delete_k8s_resources ingress ":metadata.name,:metadata.annotations" "Could not delete Ingresses managed by ExternalDNS" '/external-dns/ {print $1}' \
+	return postUninstall(ctx.Log(), ctx.Client())
 }
 
 // ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
@@ -65,9 +65,8 @@ func (e externalDNSComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
 	return false
 }
 
+// PostUninstall Clean up external-dns resources not removed by Uninstall()
 func (e externalDNSComponent) PostUninstall(ctx spi.ComponentContext) error {
-	//   # delete all ExternalDNS ingresses before deleting ExternalDNS
-	//  delete_k8s_resources ingress ":metadata.name,:metadata.annotations" "Could not delete Ingresses managed by ExternalDNS" '/external-dns/ {print $1}' \
 	return postUninstall(ctx.Log(), ctx.Client())
 }
 

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	helm2 "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	constants2 "github.com/verrazzano/verrazzano/pkg/mcconstants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -1575,6 +1576,11 @@ func expectSharedNamespaceDeletes(mock *mocks.MockClient) {
 		Get(gomock.Any(), types.NamespacedName{Name: constants.VerrazzanoMonitoringNamespace}, gomock.Not(gomock.Nil())).
 		Return(nil)
 	mock.EXPECT().Delete(gomock.Any(), nsMatcher{Name: constants.VerrazzanoMonitoringNamespace}, gomock.Any()).Return(nil)
+
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: vzconst.CertManagerNamespace}, gomock.Not(gomock.Nil())).
+		Return(nil)
+	mock.EXPECT().Delete(gomock.Any(), nsMatcher{Name: vzconst.CertManagerNamespace}, gomock.Any()).Return(nil)
 }
 
 // TestMergeMapsNilSourceMap tests mergeMaps function

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -5,10 +5,9 @@ package verrazzano
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-
 	vzappclusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
@@ -48,6 +47,12 @@ const (
 	// vzStateUninstallEnd is the terminal state
 	vzStateUninstallEnd uninstallState = "vzStateUninstallEnd"
 )
+
+// sharedNamespaces The set of namespaces shared by multiple components; managed separately apart from individual components
+var sharedNamespaces = []string{
+	vzconst.VerrazzanoMonitoringNamespace,
+	constants.CertManagerNamespace,
+}
 
 // uninstallState identifies the state of a Verrazzano uninstall operation
 type uninstallState string
@@ -240,10 +245,17 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 
 //deleteNamespaces Cleans up any namespaces shared by multiple components
 func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
-	return resource.Resource{
-		Name:   promoperator.ComponentNamespace,
-		Client: r.Client,
-		Object: &corev1.Namespace{},
-		Log:    log,
-	}.RemoveFinalizersAndDelete()
+	for _, ns := range sharedNamespaces {
+		log.Progressf("Deleting namespace %s", ns)
+		err := resource.Resource{
+			Name:   ns,
+			Client: r.Client,
+			Object: &corev1.Namespace{},
+			Log:    log,
+		}.RemoveFinalizersAndDelete()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Move external-dns uninstall from Job to Go code in VPO
- Also move the delete of the cert-manager namespace to the global cleanup in the controller