### PR TITLE
VZ-6384 enable  uninstall.failed.upgrade chaos test

### DIFF
--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -179,7 +179,6 @@ pipeline {
                         }
                     }
                 }
-                /*
                 stage('Uninstall failed upgrade') {
                     steps {
                         script {
@@ -197,7 +196,6 @@ pipeline {
                         }
                     }
                 }
-                */
                 stage('Upgrade a failed 1.2.0 upgrade') {
                     steps {
                         script {


### PR DESCRIPTION
Re-enable uninstall.failed.upgrade chaos test.  This is a revert of a revert commit 0cbcba98bf609cfe5f8f765f1803f610525d6ba6

Revert "temporarily disable upgrade-uninstall chaos test (#3530)"
