### PR TITLE
Optimize dependency check to check component Ready status

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/appoper"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
@@ -149,11 +150,23 @@ func checkDependencies(c spi.Component, context spi.ComponentContext, visited ma
 			return trace, err
 		}
 		// Only check if dependency is ready when the dependency is enabled
-		if dependency.IsEnabled(context.EffectiveCR()) && !dependency.IsReady(context) {
+		if dependency.IsEnabled(context.EffectiveCR()) && // Is enabled
+			!isInReadyState(context, dependency) && // CR status does not already indicate ready status
+			!dependency.IsReady(context) {
 			stateMap[dependencyName] = false // dependency is not ready
 			continue
 		}
 		stateMap[dependencyName] = true // dependency is ready
 	}
 	return stateMap, nil
+}
+
+func isInReadyState(context spi.ComponentContext, comp spi.Component) bool {
+	if dependencyStatus, ok := context.ActualCR().Status.Components[comp.Name()]; ok {
+		// We've already reported Ready status for this component
+		if dependencyStatus.State == vzapi.CompStateReady {
+			return true
+		}
+	}
+	return false
 }

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -494,6 +494,73 @@ func TestNoComponentDependencies(t *testing.T) {
 	assert.True(t, ready)
 }
 
+// TestComponentDependenciesMetStateCheckReady tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN returns true if a dependency's component status is already in Ready state
+func TestComponentDependenciesMetStateCheckReady(t *testing.T) {
+	runDepenencyStateCheckTest(t, v1alpha1.CompStateReady, true)
+}
+
+// TestComponentDependenciesMetStateCheckNotReady tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN returns false if a dependency's component status is not Ready state and the deployments are not ready
+func TestComponentDependenciesMetStateCheckNotReady(t *testing.T) {
+	runDepenencyStateCheckTest(t, v1alpha1.CompStatePreInstalling, true)
+}
+
+// TestComponentDependenciesMetStateCheckCompDisabled tests ComponentDependenciesMet
+// GIVEN a component
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN returns false if a dependency is disabled and the component status is disabled
+func TestComponentDependenciesMetStateCheckCompDisabled(t *testing.T) {
+	runDepenencyStateCheckTest(t, v1alpha1.CompStateDisabled, false)
+}
+
+func runDepenencyStateCheckTest(t *testing.T, state v1alpha1.CompStateType, enabled bool) {
+	const compName = coherence.ComponentName
+	comp := fakeComponent{name: "foo", enabled: true, dependencies: []string{compName}}
+
+	dependency := fakeComponent{name: compName, enabled: true, ready: false}
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			dependency,
+		}
+	})
+	defer ResetGetComponentsFn()
+
+	expectedResult := true
+	if state != v1alpha1.CompStateReady {
+		expectedResult = false
+	}
+
+	cr := &v1alpha1.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				CoherenceOperator: &v1alpha1.CoherenceOperatorComponent{
+					Enabled: &enabled,
+				},
+			},
+		},
+		Status: v1alpha1.VerrazzanoStatus{
+			Components: v1alpha1.ComponentStatusMap{
+				compName: &v1alpha1.ComponentStatusDetails{
+					Name:  compName,
+					State: state,
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
+	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, cr, true))
+	assert.Equal(t, expectedResult, ready)
+}
+
 // Create a new deployment object for testing
 func newReadyDeployment(name string, namespace string, labels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -545,6 +612,7 @@ type fakeComponent struct {
 	name         string
 	dependencies []string
 	enabled      bool
+	ready        bool
 }
 
 var _ spi.Component = fakeComponent{}
@@ -570,7 +638,7 @@ func (f fakeComponent) GetDependencies() []string {
 }
 
 func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
-	return true
+	return f.ready
 }
 
 func (f fakeComponent) IsEnabled(effectiveCR *v1alpha1.Verrazzano) bool {


### PR DESCRIPTION
- Add a short-circuit check of the current component state for `Ready` in its' status field in the dependency check to avoid unnecessary calls to `IsReady`

