### PR TITLE
No Jira: Fix bug in helidon test

### DIFF
--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -211,7 +211,7 @@ func appEndpointAccessible(url string, hostname string) bool {
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		t.Logs.Errorf("Unexpected error while making http request=%v", err)
-		if resp.Body != nil {
+		if resp != nil && resp.Body != nil {
 			bodyRaw, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)

--- a/tests/e2e/pkg/hello_helidon.go
+++ b/tests/e2e/pkg/hello_helidon.go
@@ -16,8 +16,8 @@ const (
 	helidonPollingInterval = 10 * time.Second
 	helidonWaitTimeout     = 5 * time.Minute
 
-	helidonComponentYaml = "../../../examples/hello-helidon/hello-helidon-comp.yaml"
-	helidonAppYaml       = "../../../examples/hello-helidon/hello-helidon-app.yaml"
+	helidonComponentYaml = "examples/hello-helidon/hello-helidon-comp.yaml"
+	helidonAppYaml       = "examples/hello-helidon/hello-helidon-app.yaml"
 )
 
 var expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}


### PR DESCRIPTION
This change is to fix a bug in the helidon e2e test that manifests in a failure in the OCIDNS ACME job. After this line is run,
`resp, err := httpClient.Do(req)`
we do this check `if resp.Body != nil`.
However, if the host record is not created yet in the OCIDNS Zone after the `Do` function does 8 retries, the `Do` function will return a `resp` of nil. The if statement will then panic because of a nil pointer. The solution is to change the conditional to `if resp != nil && resp.Body != nil`. This is wrapped in an Eventually, so this will all retry and will eventually succeed.