### PR TITLE
sdosapat/vz-6338: Adding support to collect logs for the verrazzano-uninstall-<vz-name>

### DIFF
--- a/tools/vz/pkg/bugreport/genreport.go
+++ b/tools/vz/pkg/bugreport/genreport.go
@@ -105,12 +105,12 @@ func capturePodLogs(client clipkg.Client, kubeClient kubernetes.Interface, bugRe
 
 	// Fixed list of pods for which, capture the log
 	vpoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
-	vuoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoUninstall, vzconstants.VerrazzanoInstallNamespace)
+	vuoPod, _ := pkghelpers.GetPodList(client, constants.JobNameLabel, constants.VerrazzanoUninstallExampleVerrazzano, vzconstants.VerrazzanoInstallNamespace)
 	vaoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoApplicationOperator, vzconstants.VerrazzanoSystemNamespace)
 	vmoPod, _ := pkghelpers.GetPodList(client, constants.K8SAppLabel, constants.VerrazzanoMonitoringOperator, vzconstants.VerrazzanoSystemNamespace)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(4)
 	ec := make(chan ErrorsChannel, 1)
 
 	go captureLogsInParallel(wg, ec, kubeClient, vpoPod, vzconstants.VerrazzanoInstallNamespace, bugReportDir, vzHelper)

--- a/tools/vz/pkg/bugreport/genreport.go
+++ b/tools/vz/pkg/bugreport/genreport.go
@@ -105,6 +105,7 @@ func capturePodLogs(client clipkg.Client, kubeClient kubernetes.Interface, bugRe
 
 	// Fixed list of pods for which, capture the log
 	vpoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
+	vuoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoUninstall, vzconstants.VerrazzanoInstallNamespace)
 	vaoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoApplicationOperator, vzconstants.VerrazzanoSystemNamespace)
 	vmoPod, _ := pkghelpers.GetPodList(client, constants.K8SAppLabel, constants.VerrazzanoMonitoringOperator, vzconstants.VerrazzanoSystemNamespace)
 
@@ -113,6 +114,7 @@ func capturePodLogs(client clipkg.Client, kubeClient kubernetes.Interface, bugRe
 	ec := make(chan ErrorsChannel, 1)
 
 	go captureLogsInParallel(wg, ec, kubeClient, vpoPod, vzconstants.VerrazzanoInstallNamespace, bugReportDir, vzHelper)
+	go captureLogsInParallel(wg, ec, kubeClient, vuoPod, vzconstants.VerrazzanoInstallNamespace, bugReportDir, vzHelper)
 	go captureLogsInParallel(wg, ec, kubeClient, vaoPod, vzconstants.VerrazzanoSystemNamespace, bugReportDir, vzHelper)
 	go captureLogsInParallel(wg, ec, kubeClient, vmoPod, vzconstants.VerrazzanoSystemNamespace, bugReportDir, vzHelper)
 

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -59,6 +59,8 @@ const VerrazzanoMonitoringOperator = "verrazzano-monitoring-operator"
 
 const VerrazzanoUninstall = "verrazzano-uninstall"
 
+const VerrazzanoUninstallExampleVerrazzano = "verrazzano-uninstall-example-verrazzano"
+
 const VerrazzanoInstall = "verrazzano-install"
 
 const VerrazzanoManagedCluster = "verrazzano-managed-cluster"
@@ -113,6 +115,7 @@ const (
 	BugReportRoot = "cluster-dump"
 
 	// Label for application
-	AppLabel    = "app"
-	K8SAppLabel = "k8s-app"
+	AppLabel     = "app"
+	K8SAppLabel  = "k8s-app"
+	JobNameLabel = "job-name"
 )


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

Summary:
> Code addition to include support to collect pods from verrazzano-uninstall

Validation:
With my changes, I validated in my local machine against an OKE live cluster and could able to see the uninstall logs are being collected successfully
```
[20:54:49 bash verrazzano-uninstall-example-verrazzano--1-rprdl]$pwd
~/Downloads/bug-report-delete/cluster-dump/verrazzano-install/verrazzano-uninstall-example-verrazzano--1-rprdl
[20:54:49 bash verrazzano-uninstall-example-verrazzano--1-rprdl]$ls
logs.txt
```