### PR TITLE
VZ-6325.  Fix ns deletion wait handling and logging

### DIFF
--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -1024,7 +1024,7 @@ func (r *Reconciler) procDelete(ctx context.Context, log vzlog.VerrazzanoLogger,
 	for _, condition := range vz.Status.Conditions {
 		if condition.Type == installv1alpha1.CondUninstallComplete || condition.Type == installv1alpha1.CondUninstallFailed {
 			if condition.Type == installv1alpha1.CondUninstallComplete {
-				log.Once("Successfully uninstalled Verrrazzano")
+				log.Once("Successfully uninstalled Verrazzano")
 			} else {
 				log.Once("Failed uninstalling Verraazzano")
 			}

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -125,9 +125,9 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			err = r.uninstallCleanup(spiCtx)
-			if err != nil {
-				return ctrl.Result{}, err
+			result, err := r.uninstallCleanup(spiCtx)
+			if err != nil || !result.IsZero() {
+				return result, err
 			}
 			tracker.vzState = vzStateUninstallDone
 		case vzStateUninstallDone:
@@ -230,9 +230,9 @@ func (r *Reconciler) isMC(log vzlog.VerrazzanoLogger) (bool, error) {
 }
 
 // uninstallCleanup Perform the final cleanup of shared resources, etc not tracked by individual component uninstalls
-func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) error {
+func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, error) {
 	if err := rancher.PostUninstall(ctx); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 	return r.deleteNamespaces(ctx.Log())
 }
@@ -252,7 +252,8 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 }
 
 //deleteNamespaces Cleans up any namespaces shared by multiple components
-func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
+// - returns an error or a requeue with delay result
+func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
 	for _, ns := range sharedNamespaces {
 		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
@@ -262,7 +263,7 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			Log:    log,
 		}.RemoveFinalizersAndDelete()
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 	waiting := false
@@ -272,13 +273,14 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return err
+			return ctrl.Result{}, err
 		}
 		waiting = true
 		log.Progressf("Waiting for namespace %s to terminate", ns)
 	}
 	if waiting {
-		return log.ErrorfThrottledNewErr("Namespace terminations still in progress")
+		log.Progressf("Namespace terminations still in progress")
+		return newRequeueWithDelay(), nil
 	}
-	return nil
+	return ctrl.Result{}, nil
 }

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -282,5 +282,6 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, 
 		log.Progressf("Namespace terminations still in progress")
 		return newRequeueWithDelay(), nil
 	}
+	log.Once("Namespaces terminated successfully")
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Fix up the reporting/logging around waiting for namespace deletion.
- Return a requeue with delay instead of error waiting for ns deletion from the cleanup methods
- Clean up and enhance the logging in a couple of spots

