### PR TITLE
VZ-6437: Velero namespace change

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -211,7 +211,7 @@ const PrometheusStorageLabelValue = "prometheus"
 const VMISystemPrometheusVolumeClaim = "vmi-system-prometheus"
 
 // VeleroNameSpace indicates the namespace to be used for velero installation
-const VeleroNameSpace = "velero"
+const VeleroNameSpace = "verrazzano-backup"
 
 // ResticDaemonSetName indicates name of the daemonset that is installed as part of component velero
 const ResticDaemonSetName = "restic"

--- a/platform-operator/internal/k8s/status/deployment_ready.go
+++ b/platform-operator/internal/k8s/status/deployment_ready.go
@@ -5,6 +5,7 @@ package status
 import (
 	"context"
 	"fmt"
+	pkgConstants "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,7 +20,7 @@ import (
 // DeploymentsAreReady check that the named deployments have the minimum number of specified replicas ready and available
 func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedNames []types.NamespacedName, expectedReplicas int32, prefix string) bool {
 	veleroPodLabel := map[string]string{
-		"name": constants.VeleroNameSpace,
+		"name": pkgConstants.Velero,
 	}
 	veleroPodSelector := &metav1.LabelSelector{
 		MatchLabels: veleroPodLabel,
@@ -49,7 +50,7 @@ func DeploymentsAreReady(log vzlog.VerrazzanoLogger, client clipkg.Client, names
 		// Velero install deploys a daemonset and deployment with common labels. The labels need to be adjusted so the pod fetch logic works
 		// as expected
 		podSelector := deployment.Spec.Selector
-		if namespacedName.Namespace == constants.VeleroNameSpace && namespacedName.Name == constants.VeleroNameSpace {
+		if namespacedName.Namespace == constants.VeleroNameSpace && namespacedName.Name == pkgConstants.Velero {
 			podSelector = veleroPodSelector
 		}
 

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -241,7 +241,7 @@
             },
             {
               "image": "opensearch",
-              "tag": "1.2.3-20220707191348-c1dbc115d8a",
+              "tag": "1.2.3-20220715164419-c1dbc115d8a",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {


### PR DESCRIPTION
Today velero install happens in a namespace called velero. This could collide with another install of velero if its been installed out of band. 

We will be installing velero in verrazzano-backup namespace. 