### PR TITLE
VZ-6325.  Fix up logging/error reporting around namespace logging deletion

### DIFF
--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -256,7 +256,7 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 	}
 
 	if err := r.nodeExporterCleanup(ctx.Log()); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	return r.deleteNamespaces(ctx.Log())

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -252,7 +252,7 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 	}
 
 	if err := r.deleteIstioCARootCert(ctx); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.nodeExporterCleanup(ctx.Log()); err != nil {

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -135,9 +135,9 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			err = r.uninstallCleanup(spiCtx)
-			if err != nil {
-				return ctrl.Result{}, err
+			result, err := r.uninstallCleanup(spiCtx)
+			if err != nil || !result.IsZero() {
+				return result, err
 			}
 			tracker.vzState = vzStateUninstallDone
 		case vzStateUninstallDone:
@@ -246,9 +246,9 @@ func (r *Reconciler) isManagedCluster(log vzlog.VerrazzanoLogger) (bool, error) 
 }
 
 // uninstallCleanup Perform the final cleanup of shared resources, etc not tracked by individual component uninstalls
-func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) error {
+func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, error) {
 	if err := rancher.PostUninstall(ctx); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.deleteIstioCARootCert(ctx); err != nil {
@@ -303,7 +303,8 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 }
 
 //deleteNamespaces Cleans up any namespaces shared by multiple components
-func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
+// - returns an error or a requeue with delay result
+func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
 	for _, ns := range sharedNamespaces {
 		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
@@ -313,7 +314,7 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			Log:    log,
 		}.RemoveFinalizersAndDelete()
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 	waiting := false
@@ -323,15 +324,17 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return err
+			return ctrl.Result{}, err
 		}
 		waiting = true
 		log.Progressf("Waiting for namespace %s to terminate", ns)
 	}
 	if waiting {
-		return log.ErrorfThrottledNewErr("Namespace terminations still in progress")
+		log.Progressf("Namespace terminations still in progress")
+		return newRequeueWithDelay(), nil
 	}
-	return nil
+	log.Once("Namespaces terminated successfully")
+	return ctrl.Result{}, nil
 }
 
 // deleteIstioCARootCert deletes the Istio root cert ConfigMap that gets distributed across the cluster


### PR DESCRIPTION
Reverts the revert of 8195186fc08ab52f0177740fbbf43734d56c86d1, and fixes up a merge conflict.