### PR TITLE
VZ-6386: update build of external-dns in the bom

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -84,7 +84,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.10.2-20220225144626-7bae1b96",
+              "tag": "v0.10.2-20220714144740-7bae1b96",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
Pick up a more recent build of external-dns, which resolves a number of vulnerabilites by picking up a newer version of the base image (oraclelinux:7-slim).