### PR TITLE
VZ-6158 Pick up new Keycloak image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -408,8 +408,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "15.0.2-20220714111758-1da41d36bf",
+              "image": "keycloak",
+              "tag": "15.0.2-20220715095148-3c526fbe0f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -408,8 +408,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "15.0.2-20220613060015-16e593e4ac",
+              "image": "keycloak-jenkins",
+              "tag": "15.0.2-20220714111758-1da41d36bf",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Pick up new Keycloak image, which reverts back to version 4.3.5 of protostream.
