### PR TITLE
VZ-6444: uninstall CLI must stream uninstall job log for pre v1.4.0

### DIFF
--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -159,7 +159,7 @@ func WaitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper, co
 // WaitForOperationToComplete waits for the Verrazzano install/upgrade to complete and
 // shows the logs of the ongoing Verrazzano install/upgrade.
 func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Interface, vzHelper helpers.VZHelper, vpoPodName string, namespacedName types.NamespacedName, timeout time.Duration, logFormat LogFormat, condType vzapi.ConditionType) error {
-	rc, err := GetLogStream(kubeClient, vpoPodName)
+	rc, err := GetVpoLogStream(kubeClient, vpoPodName)
 	if err != nil {
 		return err
 	}
@@ -249,8 +249,8 @@ func GetVerrazzanoPlatformOperatorPodName(client clipkg.Client) (string, error) 
 	return podList.Items[0].Name, nil
 }
 
-// GetLogStream returns the stream to the verrazzano-platform-operator log file
-func GetLogStream(kubeClient kubernetes.Interface, vpoPodName string) (io.ReadCloser, error) {
+// GetVpoLogStream returns the stream to the verrazzano-platform-operator log file
+func GetVpoLogStream(kubeClient kubernetes.Interface, vpoPodName string) (io.ReadCloser, error) {
 	// Tail the log messages from the verrazzano-platform-operator starting at the current time.
 	//
 	// The stream is intentionally not closed due to not being able to cancel a blocking read.  The calls to

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -8,10 +8,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
+	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/semver"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
@@ -20,6 +24,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +45,16 @@ vz uninstall
 # Uninstall Verrazzano and wait for the command to complete. Timeout the command after 30 minutes.
 vz uninstall --timeout 30m`
 )
+
+// Number of retries after waiting a second for uninstall job pod to be ready
+const uninstallDefaultWaitRetries = 300
+const verrazzanoUninstallJobDetectWait = 1
+
+var uninstallWaitRetries = uninstallDefaultWaitRetries
+
+// Used with unit testing
+func setWaitRetries(retries int) { uninstallWaitRetries = retries }
+func resetWaitRetries()          { uninstallWaitRetries = uninstallDefaultWaitRetries }
 
 var propagationPolicy = metav1.DeletePropagationBackground
 var deleteOptions = &clipkg.DeleteOptions{PropagationPolicy: &propagationPolicy}
@@ -81,6 +97,22 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return fmt.Errorf("Verrazzano is not installed: %s", err.Error())
 	}
 
+	// Get the installed Verrazzano version and decide whether to stream the old uninstall
+	// job log or the VPO log.  With Verrazzano 1.4.0, the uninstall job has been removed and
+	// the VPO does the uninstall.
+	if reflect.DeepEqual(vz.Status, vzapi.VerrazzanoStatus{}) {
+		return fmt.Errorf("Verrazzano version not found in verrazzano resource")
+	}
+	useUninstallJob := false
+	minVersion := semver.SemVersion{Major: 1, Minor: 4, Patch: 0}
+	vzVersion, err := semver.NewSemVersion(vz.Status.Version)
+	if err != nil {
+		return err
+	}
+	if vzVersion.IsLessThan(&minVersion) {
+		useUninstallJob = true
+	}
+
 	// Get the kubernetes clientset.  This will validate that the kubeconfig and context are valid.
 	kubeClient, err := vzHelper.GetKubeClient(cmd)
 	if err != nil {
@@ -106,14 +138,21 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	}
 	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Uninstalling Verrazzano\n")
 
-	// Get the VPO pod to stream the logs from.
-	vpoPodName, err := cmdhelpers.GetVerrazzanoPlatformOperatorPodName(client)
+	var podName string
+	if useUninstallJob {
+		// Get the uninstall job for streaming the logs
+		jobName := constants.VerrazzanoUninstall + "-" + vz.Name
+		podName, err = getUninstallJobPodName(client, vzHelper, jobName)
+	} else {
+		// Get the VPO pod for streaming the logs
+		podName, err = cmdhelpers.GetVerrazzanoPlatformOperatorPodName(client)
+	}
 	if err != nil {
 		return err
 	}
 
 	// Wait for the Verrazzano uninstall to complete.
-	err = waitForUninstallToComplete(client, kubeClient, vzHelper, vpoPodName, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, logFormat)
+	err = waitForUninstallToComplete(client, kubeClient, vzHelper, podName, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, logFormat, useUninstallJob)
 	if err != nil {
 		return fmt.Errorf("Failed to uninstall Verrazzano: %s", err.Error())
 	}
@@ -149,9 +188,100 @@ func cleanupResources(client clipkg.Client, vzHelper helpers.VZHelper) error {
 	return nil
 }
 
+// getUninstallJobPodName returns the name of the pod for the verrazzano-uninstall job
+// The uninstall job is triggered by deleting the Verrazzano custom resource
+func getUninstallJobPodName(c client.Client, vzHelper helpers.VZHelper, jobName string) (string, error) {
+	// Find the verrazzano-uninstall pod using the job-name label selector
+	jobNameLabel, _ := labels.NewRequirement("job-name", selection.Equals, []string{jobName})
+	labelSelector := labels.NewSelector()
+	labelSelector = labelSelector.Add(*jobNameLabel)
+	podList := corev1.PodList{}
+
+	// Provide the user with feedback while waiting for the verrazzano-uninstall pod to be ready
+	feedbackChan := make(chan bool)
+	defer close(feedbackChan)
+	go func(outputStream io.Writer) {
+		seconds := 0
+		for {
+			select {
+			case <-feedbackChan:
+				return
+			default:
+				time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+				seconds += verrazzanoUninstallJobDetectWait
+				fmt.Fprintf(outputStream, fmt.Sprintf("\rWaiting for %s pod to be ready before starting uninstall - %d seconds", jobName, seconds))
+			}
+		}
+	}(vzHelper.GetOutputStream())
+
+	// Wait for the verrazzano-uninstall pod to be found
+	seconds := 0
+	retryCount := 0
+	for {
+		retryCount++
+		if retryCount > uninstallWaitRetries {
+			return "", fmt.Errorf("Waiting for %s, %s pod not found in namespace %s", jobName, jobName, vzconstants.VerrazzanoInstallNamespace)
+		}
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
+
+		err := c.List(
+			context.TODO(),
+			&podList,
+			&client.ListOptions{
+				Namespace:     vzconstants.VerrazzanoInstallNamespace,
+				LabelSelector: labelSelector,
+			})
+		if err != nil {
+			return "", fmt.Errorf("Waiting for %s, failed to list pods: %s", jobName, err.Error())
+		}
+		if len(podList.Items) == 0 {
+			continue
+		}
+		if len(podList.Items) > 1 {
+			return "", fmt.Errorf("Waiting for %s, more than one %s pod was found in namespace %s", jobName, jobName, vzconstants.VerrazzanoInstallNamespace)
+		}
+		feedbackChan <- true
+		break
+	}
+
+	// We found the verrazzano-uninstall pod. Wait until it's containers are ready.
+	pod := &corev1.Pod{}
+	seconds = 0
+	for {
+		time.Sleep(verrazzanoUninstallJobDetectWait * time.Second)
+		seconds += verrazzanoUninstallJobDetectWait
+
+		err := c.Get(context.TODO(), types.NamespacedName{Namespace: podList.Items[0].Namespace, Name: podList.Items[0].Name}, pod)
+		if err != nil {
+			return "", err
+		}
+
+		ready := true
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready {
+				ready = false
+				break
+			}
+		}
+
+		if ready {
+			_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "\n")
+			break
+		}
+	}
+	return pod.Name, nil
+}
+
 // waitForUninstallToComplete waits for the Verrazzano resource to no longer exist
-func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Interface, vzHelper helpers.VZHelper, vpoPodName string, namespacedName types.NamespacedName, timeout time.Duration, logFormat cmdhelpers.LogFormat) error {
-	rc, err := cmdhelpers.GetLogStream(kubeClient, vpoPodName)
+func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Interface, vzHelper helpers.VZHelper, podName string, namespacedName types.NamespacedName, timeout time.Duration, logFormat cmdhelpers.LogFormat, uninstallJobLog bool) error {
+	var err error
+	var rc io.ReadCloser
+	if uninstallJobLog {
+		rc, err = getUninstallJobLogStream(kubeClient, podName)
+	} else {
+		rc, err = cmdhelpers.GetVpoLogStream(kubeClient, podName)
+	}
 	if err != nil {
 		return err
 	}
@@ -167,9 +297,9 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 		sc := bufio.NewScanner(rc)
 		sc.Split(bufio.ScanLines)
 		for sc.Scan() {
-			if logFormat == cmdhelpers.LogFormatSimple {
+			if !uninstallJobLog && logFormat == cmdhelpers.LogFormatSimple {
 				cmdhelpers.PrintSimpleLogFormat(sc, outputStream, re)
-			} else if logFormat == cmdhelpers.LogFormatJSON {
+			} else {
 				_, _ = fmt.Fprintf(outputStream, fmt.Sprintf("%s\n", sc.Text()))
 			}
 		}
@@ -211,6 +341,21 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 	// Delete remaining Verrazzano resources, excluding CRDs
 	_ = cleanupResources(client, vzHelper)
 	return nil
+}
+
+// getUninstallJobLogStream returns the stream to the uninstall job log file
+func getUninstallJobLogStream(kubeClient kubernetes.Interface, uninstallPodName string) (io.ReadCloser, error) {
+	// Tail the log messages from the uninstall job log starting at the current time.
+	sinceTime := metav1.Now()
+	rc, err := kubeClient.CoreV1().Pods(vzconstants.VerrazzanoInstallNamespace).GetLogs(uninstallPodName, &corev1.PodLogOptions{
+		Container: "uninstall",
+		Follow:    true,
+		SinceTime: &sinceTime,
+	}).Stream(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read the %s log file: %s", uninstallPodName, err.Error())
+	}
+	return rc, nil
 }
 
 // deleteNamespace deletes a given Namespace

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -110,6 +110,10 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return err
 	}
 	if vzVersion.IsLessThan(&minVersion) {
+		// log-format argument ignored with pre 1.4.0 uninstalls if specified
+		if cmd.PersistentFlags().Changed(constants.LogFormatFlag) {
+			fmt.Fprintf(vzHelper.GetOutputStream(), "Warning: --log-format argument is ignored with uninstalls prior to v1.4.0\n")
+		}
 		useUninstallJob = true
 	}
 

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -24,7 +24,10 @@ import (
 	"testing"
 )
 
-// TestUninstallCmd - check that the uninstall command removes the Verrazzano resource
+// TestUninstallCmd
+// GIVEN a CLI uninstall command with all defaults and --wait==false
+//  WHEN I call cmd.Execute for uninstall
+//  THEN the CLI uninstall command is successful
 func TestUninstallCmd(t *testing.T) {
 	vpo := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -65,8 +68,105 @@ func TestUninstallCmd(t *testing.T) {
 			Namespace: "default",
 			Name:      "verrazzano",
 		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.4.0"},
 	}
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vpo, vz, namespace, validatingWebhookConfig, clusterRoleBinding, clusterRole).Build()
+
+	// Send stdout stderr to a byte buffer
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	cmd := NewCmdUninstall(rc)
+	assert.NotNil(t, cmd)
+
+	// Run uninstall command, check for the expected status results to be displayed
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, "", errBuf.String())
+	assert.Contains(t, buf.String(), "Uninstalling Verrazzano\n")
+	assert.Contains(t, buf.String(), "Successfully uninstalled Verrazzano\n")
+
+	// Expect the Verrazzano resource to be deleted
+	v := vzapi.Verrazzano{}
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &v)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Expect the install namespace to be deleted
+	ns := corev1.Namespace{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: vzconstants.VerrazzanoInstallNamespace}, &ns)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Expect the Validating Webhook Configuration to be deleted
+	vwc := adminv1.ValidatingWebhookConfiguration{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: constants.VerrazzanoPlatformOperator}, &vwc)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Expect the Cluster Role Binding to be deleted
+	crb := rbacv1.ClusterRoleBinding{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: constants.VerrazzanoPlatformOperator}, &crb)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Expect the Cluster Role to be deleted
+	cr := rbacv1.ClusterRole{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: constants.VerrazzanoManagedCluster}, &cr)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+// TestUninstallCmdUninstallJob
+// GIVEN a CLI uninstall command with all defaults and --wait==false and a 1.3.1 version install
+//  WHEN I call cmd.Execute for uninstall
+//  THEN the CLI uninstall command is successful
+func TestUninstallCmdUninstallJob(t *testing.T) {
+	job := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: vzconstants.VerrazzanoInstallNamespace,
+			Name:      constants.VerrazzanoUninstall,
+			Labels: map[string]string{
+				"job-name": constants.VerrazzanoUninstall + "-verrazzano",
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+		},
+	}
+	namespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vzconstants.VerrazzanoInstallNamespace,
+		},
+	}
+	validatingWebhookConfig := &adminv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.VerrazzanoPlatformOperator,
+		},
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.VerrazzanoPlatformOperator,
+		},
+	}
+	clusterRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.VerrazzanoManagedCluster,
+		},
+	}
+	vz := &vzapi.Verrazzano{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "verrazzano",
+		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.3.1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(job, vz, namespace, validatingWebhookConfig, clusterRoleBinding, clusterRole).Build()
 
 	// Send stdout stderr to a byte buffer
 	buf := new(bytes.Buffer)
@@ -135,6 +235,7 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 			Namespace: "default",
 			Name:      "verrazzano",
 		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.4.0"},
 	}
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vpo, vz, namespace).Build()
 
@@ -167,6 +268,7 @@ func TestUninstallCmdDefaultNoWait(t *testing.T) {
 			Namespace: "default",
 			Name:      "verrazzano",
 		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.4.0"},
 	}
 	vpo := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,6 +307,7 @@ func TestUninstallCmdJsonLogFormat(t *testing.T) {
 			Namespace: "default",
 			Name:      "verrazzano",
 		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.4.0"},
 	}
 	vpo := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -244,6 +347,7 @@ func TestUninstallCmdDefaultNoVPO(t *testing.T) {
 			Namespace: "default",
 			Name:      "verrazzano",
 		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.4.0"},
 	}
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vz).Build()
 
@@ -260,6 +364,39 @@ func TestUninstallCmdDefaultNoVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Failed to find the Verrazzano platform operator in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Failed to find the Verrazzano platform operator in namespace verrazzano-install")
+}
+
+// TestUninstallCmdDefaultNoUninstallJob
+// GIVEN a CLI uninstall command with all defaults and no uninstall job pod
+//  WHEN I call cmd.Execute for uninstall
+//  THEN the CLI uninstall command fails
+func TestUninstallCmdDefaultNoUninstallJob(t *testing.T) {
+	vz := &vzapi.Verrazzano{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "verrazzano",
+		},
+		Status: vzapi.VerrazzanoStatus{Version: "1.3.1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vz).Build()
+
+	// Send stdout stderr to a byte buffer
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	cmd := NewCmdUninstall(rc)
+	assert.NotNil(t, cmd)
+
+	setWaitRetries(1)
+	defer resetWaitRetries()
+
+	// Run uninstall command
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "Waiting for verrazzano-uninstall-verrazzano, verrazzano-uninstall-verrazzano pod not found in namespace verrazzano-install")
+	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-uninstall-verrazzano, verrazzano-uninstall-verrazzano pod not found in namespace verrazzano-install")
 }
 
 // TestUninstallCmdDefaultNoVzResource
@@ -282,4 +419,36 @@ func TestUninstallCmdDefaultNoVzResource(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Verrazzano is not installed: Failed to find any Verrazzano resources")
 	assert.Contains(t, errBuf.String(), "Error: Verrazzano is not installed: Failed to find any Verrazzano resources")
+}
+
+// TestUninstallNoVzStatus
+// GIVEN a CLI uninstall command with all defaults and no vz resource status found
+//  WHEN I call cmd.Execute for uninstall
+//  THEN the CLI uninstall command fails
+func TestUninstallNoVzStatus(t *testing.T) {
+	vz := &vzapi.Verrazzano{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "verrazzano",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vz).Build()
+
+	// Send stdout stderr to a byte buffer
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	cmd := NewCmdUninstall(rc)
+	assert.NotNil(t, cmd)
+
+	setWaitRetries(1)
+	defer resetWaitRetries()
+
+	// Run uninstall command
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "Verrazzano version not found in verrazzano resource")
+	assert.Contains(t, errBuf.String(), "Error: Verrazzano version not found in verrazzano resource")
 }


### PR DESCRIPTION
This pull request adds back the ability to stream the uninstall job log.  For pre v1.4.0 installs the uninstall job log is streamed otherwise the VPO log is streamed.