### PR TITLE
VZ-6227 - Updated the console version to include Jaeger URL

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -191,7 +191,7 @@
             },
             {
               "image": "console",
-              "tag": "1.4.0-20220614120434-203cb7c",
+              "tag": "1.4.0-20220718130912-363a2cb",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
VZ-6227 - Verrazzano Console upgrade to include changes for displaying Jaeger UI URL in the main page of Verrazzano Console.
