### PR TITLE
VZ-6375 - uninstall deletes project NS rolebindings for managed clusters, and VMC ServiceAccount

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -180,7 +180,7 @@ func deleteMatchingResources(ctx spi.ComponentContext) error {
 		return ctx.Log().ErrorfNewErr("Failed to list the RoleBindings: %v", err)
 	}
 	for i := range rblist.Items {
-		err = deleteMatchingObject(ctx, []string{"rb"}, &rblist.Items[i])
+		err = deleteMatchingObject(ctx, []string{"^rb-"}, &rblist.Items[i])
 		if err != nil {
 			return err
 		}

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -135,9 +135,9 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			result, err := r.uninstallCleanup(spiCtx)
-			if err != nil || !result.IsZero() {
-				return result, err
+			err = r.uninstallCleanup(spiCtx)
+			if err != nil {
+				return ctrl.Result{}, err
 			}
 			tracker.vzState = vzStateUninstallDone
 		case vzStateUninstallDone:
@@ -186,6 +186,17 @@ func (r *Reconciler) deleteMCResources(log vzlog.VerrazzanoLogger) error {
 		return err
 	}
 
+	projects := vzappclusters.VerrazzanoProjectList{}
+	if err := r.List(context.TODO(), &projects, &client.ListOptions{Namespace: vzconst.VerrazzanoMultiClusterNamespace}); err != nil {
+		return log.ErrorfNewErr("Failed listing MC projects: %v", err)
+	}
+	// Delete MC rolebindings for each project
+	for _, p := range projects.Items {
+		if err := r.deleteManagedClusterRoleBindings(p, log); err != nil {
+			return err
+		}
+	}
+
 	log.Oncef("Deleting all VMC resources")
 	vmcList := clustersapi.VerrazzanoManagedClusterList{}
 	if err := r.List(context.TODO(), &vmcList, &client.ListOptions{}); err != nil {
@@ -193,16 +204,19 @@ func (r *Reconciler) deleteMCResources(log vzlog.VerrazzanoLogger) error {
 	}
 
 	for i, vmc := range vmcList.Items {
+		// Delete the VMC ServiceAccount (since managed cluster role bindings associated to it should now be deleted)
+		vmcSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Namespace: vmc.Namespace, Name: vmc.Spec.ServiceAccount},
+		}
+		if err := r.Delete(context.TODO(), &vmcSA); err != nil {
+			return log.ErrorfNewErr("Failed to delete VMC service account %s/%s, %v", vmc.Namespace, vmc.Spec.ServiceAccount, err)
+		}
 		if err := r.Delete(context.TODO(), &vmcList.Items[i]); err != nil {
 			return log.ErrorfNewErr("Failed to delete VMC %s/%s, %v", vmc.Namespace, vmc.Name, err)
 		}
 	}
 
 	// Delete VMC namespace only if there are no projects
-	projects := vzappclusters.VerrazzanoProjectList{}
-	if err := r.List(context.TODO(), &projects, &client.ListOptions{Namespace: vzconst.VerrazzanoMultiClusterNamespace}); err != nil {
-		return log.ErrorfNewErr("Failed listing MC projects: %v", err)
-	}
 	if len(projects.Items) == 0 {
 		log.Oncef("Deleting %s namespace", vzconst.VerrazzanoMultiClusterNamespace)
 		if err := r.deleteNamespace(context.TODO(), log, vzconst.VerrazzanoMultiClusterNamespace); err != nil {
@@ -220,6 +234,25 @@ func (r *Reconciler) deleteMCResources(log vzlog.VerrazzanoLogger) error {
 		}
 		if err := r.deleteSecret(log, vzconst.VerrazzanoSystemNamespace, vzconst.MCAgentSecret); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// deleteManagedClusterRoleBindings deletes the managed cluster rolebindings from each namespace
+// governed by the given project
+func (r *Reconciler) deleteManagedClusterRoleBindings(project vzappclusters.VerrazzanoProject, log vzlog.VerrazzanoLogger) error {
+	for _, projectNSTemplate := range project.Spec.Template.Namespaces {
+		rbList := rbacv1.RoleBindingList{}
+		if err := r.List(context.TODO(), &rbList, &client.ListOptions{Namespace: projectNSTemplate.Metadata.Name}); err != nil {
+			return err
+		}
+		for i, rb := range rbList.Items {
+			if rb.RoleRef.Name == "verrazzano-managed-cluster" {
+				if err := r.Delete(context.TODO(), &rbList.Items[i]); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -246,17 +279,17 @@ func (r *Reconciler) isManagedCluster(log vzlog.VerrazzanoLogger) (bool, error) 
 }
 
 // uninstallCleanup Perform the final cleanup of shared resources, etc not tracked by individual component uninstalls
-func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, error) {
+func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) error {
 	if err := rancher.PostUninstall(ctx); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	if err := r.deleteIstioCARootCert(ctx); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	if err := r.nodeExporterCleanup(ctx.Log()); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	return r.deleteNamespaces(ctx.Log())
@@ -302,9 +335,8 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 	return nil
 }
 
-//deleteNamespaces Cleans up any namespaces shared by multiple components
-// - returns an error or a requeue with delay result
-func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
+// deleteNamespaces Cleans up any namespaces shared by multiple components
+func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 	for _, ns := range sharedNamespaces {
 		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
@@ -314,7 +346,7 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, 
 			Log:    log,
 		}.RemoveFinalizersAndDelete()
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 	waiting := false
@@ -324,17 +356,15 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, 
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return ctrl.Result{}, err
+			return err
 		}
 		waiting = true
 		log.Progressf("Waiting for namespace %s to terminate", ns)
 	}
 	if waiting {
-		log.Progressf("Namespace terminations still in progress")
-		return newRequeueWithDelay(), nil
+		return log.ErrorfThrottledNewErr("Namespace terminations still in progress")
 	}
-	log.Once("Namespaces terminated successfully")
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // deleteIstioCARootCert deletes the Istio root cert ConfigMap that gets distributed across the cluster

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -135,9 +135,9 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			err = r.uninstallCleanup(spiCtx)
-			if err != nil {
-				return ctrl.Result{}, err
+			result, err := r.uninstallCleanup(spiCtx)
+			if err != nil || !result.IsZero() {
+				return result, err
 			}
 			tracker.vzState = vzStateUninstallDone
 		case vzStateUninstallDone:
@@ -279,17 +279,17 @@ func (r *Reconciler) isManagedCluster(log vzlog.VerrazzanoLogger) (bool, error) 
 }
 
 // uninstallCleanup Perform the final cleanup of shared resources, etc not tracked by individual component uninstalls
-func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) error {
+func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, error) {
 	if err := rancher.PostUninstall(ctx); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.deleteIstioCARootCert(ctx); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.nodeExporterCleanup(ctx.Log()); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	return r.deleteNamespaces(ctx.Log())
@@ -336,7 +336,7 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 }
 
 // deleteNamespaces Cleans up any namespaces shared by multiple components
-func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
+func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
 	for _, ns := range sharedNamespaces {
 		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
@@ -346,7 +346,7 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			Log:    log,
 		}.RemoveFinalizersAndDelete()
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 	waiting := false
@@ -356,15 +356,17 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) error {
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return err
+			return ctrl.Result{}, err
 		}
 		waiting = true
 		log.Progressf("Waiting for namespace %s to terminate", ns)
 	}
 	if waiting {
-		return log.ErrorfThrottledNewErr("Namespace terminations still in progress")
+		log.Progressf("Namespace terminations still in progress")
+		return newRequeueWithDelay(), nil
 	}
-	return nil
+	log.Once("Namespaces terminated successfully")
+	return ctrl.Result{}, nil
 }
 
 // deleteIstioCARootCert deletes the Istio root cert ConfigMap that gets distributed across the cluster

--- a/platform-operator/controllers/verrazzano/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/uninstall_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -292,6 +294,16 @@ func TestUninstallVariations(t *testing.T) {
 			defer config.Set(config.Get())
 			config.Set(config.OperatorConfig{VersionCheckEnabled: false})
 
+			_ = vzapi.AddToScheme(k8scheme.Scheme)
+			_ = clustersv1alpha1.AddToScheme(k8scheme.Scheme)
+			_ = vzappclusters.AddToScheme(k8scheme.Scheme)
+
+			c, vzcr := buildFakeClientAndObjects(test.createMCNamespace, test.createProject, test.secrets)
+
+			// Delete tracker so each test has a fresh state machine
+			DeleteUninstallTracker(vzcr)
+
+			// reconcile a first time with isInstalled returning true
 			registry.OverrideGetComponentsFn(func() []spi.Component {
 				return []spi.Component{
 					fakeComponent{
@@ -303,21 +315,13 @@ func TestUninstallVariations(t *testing.T) {
 				}
 			})
 			defer registry.ResetGetComponentsFn()
-
-			_ = vzapi.AddToScheme(k8scheme.Scheme)
-			_ = clustersv1alpha1.AddToScheme(k8scheme.Scheme)
-			_ = vzappclusters.AddToScheme(k8scheme.Scheme)
-
-			c, vzcr := buildFakeClientAndObjects(test.createMCNamespace, test.createProject, test.secrets)
-
-			// call reconcile once with installed true, then again with installed false
 			reconciler := newVerrazzanoReconciler(c)
-			DeleteUninstallTracker(vzcr)
 			result, err := reconciler.reconcileUninstall(vzlog.DefaultLogger(), vzcr)
 			asserts.NoError(err)
 			asserts.Equal(true, result.Requeue)
 			asserts.NotEqual(time.Duration(0), result.RequeueAfter)
 
+			// reconcile a second time with isInstalled returning false
 			registry.OverrideGetComponentsFn(func() []spi.Component {
 				return []spi.Component{
 					fakeComponent{
@@ -331,7 +335,6 @@ func TestUninstallVariations(t *testing.T) {
 					},
 				}
 			})
-			// reconcile a second time
 			result, err = reconciler.reconcileUninstall(vzlog.DefaultLogger(), vzcr)
 			asserts.NoError(err)
 			asserts.Equal(false, result.Requeue)
@@ -357,6 +360,8 @@ func TestUninstallVariations(t *testing.T) {
 			err = c.Get(context.TODO(), types.NamespacedName{Name: vzconst.VerrazzanoMultiClusterNamespace}, &ns)
 			if test.createProject {
 				asserts.NoError(err, fmt.Sprintf("Namespace %s should exist since it has projects", ns.Name))
+				assertProjectNamespaces(c, asserts)
+				assertProjectRoleBindings(c, asserts)
 			} else {
 				asserts.True(errors.IsNotFound(err), fmt.Sprintf("Namespace %s should not exist since there are no projects", ns.Name))
 			}
@@ -418,10 +423,85 @@ func buildFakeClientAndObjects(createMCNamespace bool, createProject bool, secre
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: vzconst.VerrazzanoMultiClusterNamespace}})
 	}
 	if createProject {
-		objects = append(objects,
-			&vzappclusters.VerrazzanoProject{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: vzconst.VerrazzanoMultiClusterNamespace}})
+		proj := vzappclusters.VerrazzanoProject{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: vzconst.VerrazzanoMultiClusterNamespace},
+			Spec: vzappclusters.VerrazzanoProjectSpec{
+				Template: vzappclusters.ProjectTemplate{
+					Namespaces: []vzappclusters.NamespaceTemplate{
+						{Metadata: metav1.ObjectMeta{Name: "projns1"}},
+						{Metadata: metav1.ObjectMeta{Name: "projns2"}},
+					},
+				},
+			},
+		}
+		projns1 := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "projns1"}}
+		projns2 := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "projns2"}}
+		objects = append(objects, &proj, &projns1, &projns2)
+		objects = addFakeProjectRoleBindings(objects)
 	}
 	cb.WithObjects(objects...)
 
 	return cb.Build(), vzcr
+}
+
+func addFakeProjectRoleBindings(objects []client.Object) []client.Object {
+	mcClusterRoleRef := rbacv1.RoleRef{
+		Name:     "verrazzano-managed-cluster",
+		Kind:     "ClusterRole",
+		APIGroup: rbacv1.GroupName,
+	}
+	otherClusterRoleRef := rbacv1.RoleRef{
+		Name:     "somerole",
+		Kind:     "ClusterRole",
+		APIGroup: rbacv1.GroupName,
+	}
+	mcRolebinding1 := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "projns1"},
+		RoleRef:    mcClusterRoleRef,
+	}
+	mcRolebinding2 := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster2", Namespace: "projns1"},
+		RoleRef:    mcClusterRoleRef,
+	}
+	mcRolebinding3 := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "projns2"},
+		RoleRef:    mcClusterRoleRef,
+	}
+	otherRolebinding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "somerb", Namespace: "projns2"},
+		RoleRef:    otherClusterRoleRef,
+	}
+	clusterRoleManaged := rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "verrazzano-managed-cluster"}}
+	clusterRoleOther := rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "somerole"}}
+	return append(objects, &clusterRoleManaged, &clusterRoleOther, &mcRolebinding1, &mcRolebinding2, &mcRolebinding3, &otherRolebinding)
+}
+
+func assertProjectNamespaces(c client.Client, asserts *assert.Assertions) {
+	ns := corev1.Namespace{}
+	for _, nsName := range []string{"projns1", "projns2"} {
+		err := c.Get(context.TODO(), types.NamespacedName{Name: nsName}, &ns)
+		asserts.NoError(err, "Project namespace %s should exist", nsName)
+	}
+}
+
+func assertProjectRoleBindings(c client.Client, asserts *assert.Assertions) {
+	rblist := rbacv1.RoleBindingList{}
+	c.List(context.TODO(), &rblist)
+	rb := rbacv1.RoleBinding{}
+	roleBindingsDeleted := []types.NamespacedName{
+		{Name: "cluster1", Namespace: "projns1"},
+		{Name: "cluster2", Namespace: "projns1"},
+		{Name: "cluster1", Namespace: "projns2"},
+	}
+	roleBindingsExist := []types.NamespacedName{
+		{Name: "somerb", Namespace: "projns2"},
+	}
+	for _, rbDeleted := range roleBindingsDeleted {
+		err := c.Get(context.TODO(), rbDeleted, &rb)
+		asserts.Error(err, "Role cluster1 should have been deleted")
+	}
+	for _, rbExists := range roleBindingsExist {
+		err := c.Get(context.TODO(), rbExists, &rb)
+		asserts.NoError(err, "RoleBinding %s/%s should still exist", rbExists.Namespace, rbExists.Name)
+	}
 }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
