### PR TITLE
VZ-6354 uninstall wait until all namespaces are deleted

### DIFF
--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -41,6 +41,11 @@ func (g grafanaComponent) Name() string {
 	return ComponentName
 }
 
+// Namespace returns the component namespace
+func (g grafanaComponent) Namespace() string {
+	return ComponentNamespace
+}
+
 // GetDependencies returns the dependencies of the Grafana component
 func (g grafanaComponent) GetDependencies() []string {
 	return []string{vmo.ComponentName}

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -142,6 +142,11 @@ func (h HelmComponent) Name() string {
 	return h.ReleaseName
 }
 
+// Namespace returns the component namespace
+func (h HelmComponent) Namespace() string {
+	return h.ChartNamespace
+}
+
 // GetJsonName returns the josn name of the verrazzano component in CRD
 func (h HelmComponent) GetJSONName() string {
 	return h.JSONName

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -79,6 +79,11 @@ type istioComponent struct {
 	monitor installMonitor
 }
 
+// Namespace returns the component namespace
+func (i istioComponent) Namespace() string {
+	return IstioNamespace
+}
+
 // GetJSONName returns the json name of the verrazzano component in CRD
 func (i istioComponent) GetJSONName() string {
 	return ComponentJSONName

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
@@ -31,6 +31,11 @@ const ComponentJSONName = "opensearch"
 
 type opensearchComponent struct{}
 
+// Namespace returns the component namespace
+func (o opensearchComponent) Namespace() string {
+	return ComponentNamespace
+}
+
 // GetDependencies returns the dependencies of the OpenSearch component
 func (o opensearchComponent) GetDependencies() []string {
 	return []string{vmo.ComponentName}

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
@@ -31,6 +31,11 @@ const ComponentJSONName = "opensearch-dashboards"
 
 type opensearchDashboardsComponent struct{}
 
+// Namespace returns the component namespace
+func (d opensearchDashboardsComponent) Namespace() string {
+	return ComponentNamespace
+}
+
 // GetDependencies returns the dependencies of the OpenSearch-Dashbaords component
 func (d opensearchDashboardsComponent) GetDependencies() []string {
 	return []string{vmo.ComponentName}

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -4,8 +4,9 @@
 package registry
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/velero"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/velero"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/helm"
@@ -543,6 +544,7 @@ func newReplicaSet(name string, namespace string) *appsv1.ReplicaSet {
 
 type fakeComponent struct {
 	name         string
+	namespace    string
 	dependencies []string
 	enabled      bool
 }
@@ -551,6 +553,10 @@ var _ spi.Component = fakeComponent{}
 
 func (f fakeComponent) Name() string {
 	return f.name
+}
+
+func (f fakeComponent) Namespace() string {
+	return f.namespace
 }
 
 func (f fakeComponent) GetJSONName() string {

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -38,6 +38,8 @@ type ComponentContext interface {
 type ComponentInfo interface {
 	// Name returns the name of the Verrazzano component
 	Name() string
+	// Namespace returns the namespace of the Verrazzano component
+	Namespace() string
 	// GetDependencies returns the dependencies of this component
 	GetDependencies() []string
 	// IsReady Indicates whether or not a component is available and ready

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -665,7 +665,8 @@ func setFakeComponentsDisabled() {
 		return []spi.Component{
 			fakeComponent{
 				HelmComponent: helm2.HelmComponent{
-					ReleaseName: "fake",
+					ReleaseName:    "fake",
+					ChartNamespace: "fake",
 				},
 				isInstalledFunc: func(ctx spi.ComponentContext) (bool, error) {
 					return false, nil
@@ -1130,6 +1131,7 @@ func expectDeleteClusterRoleBinding(mock *mocks.MockClient, namespace string, na
 }
 
 func expectSharedNamespaceDeletes(mock *mocks.MockClient) {
+	const fakeNS = "fake"
 	for _, ns := range sharedNamespaces {
 		mock.EXPECT().
 			Get(gomock.Any(), types.NamespacedName{Name: ns}, gomock.Not(gomock.Nil())).
@@ -1139,6 +1141,15 @@ func expectSharedNamespaceDeletes(mock *mocks.MockClient) {
 			Get(gomock.Any(), types.NamespacedName{Name: ns}, gomock.Not(gomock.Nil())).
 			Return(errors.NewNotFound(schema.ParseGroupResource("Namespace"), ns))
 	}
+	// Expect delete for component namesapces
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: fakeNS}, gomock.Not(gomock.Nil())).
+		Return(nil)
+	mock.EXPECT().Delete(gomock.Any(), nsMatcher{Name: fakeNS}, gomock.Any()).Return(nil)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: fakeNS}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.ParseGroupResource("Namespace"), fakeNS))
+
 }
 
 // expectRancherPostUninstall creates the expects for the Rancher post-install client calls

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -302,10 +302,20 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 	return nil
 }
 
-//deleteNamespaces Cleans up any namespaces shared by multiple components
+//deleteNamespaces deletes up all component namespaces plus any namespaces shared by multiple components
 // - returns an error or a requeue with delay result
 func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, error) {
-	for _, ns := range sharedNamespaces {
+	// Load a set of all component namespaces plus shared namespaces
+	nsSet := make(map[string]bool)
+	for _, comp := range registry.GetComponents() {
+		nsSet[comp.Namespace()] = true
+	}
+	for i := range sharedNamespaces {
+		nsSet[sharedNamespaces[i]] = true
+	}
+
+	// Delete all the namespaces
+	for ns := range nsSet {
 		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
 			Name:   ns,
@@ -317,8 +327,10 @@ func (r *Reconciler) deleteNamespaces(log vzlog.VerrazzanoLogger) (ctrl.Result, 
 			return ctrl.Result{}, err
 		}
 	}
+
+	// Wait for all the namespaces to be deleted
 	waiting := false
-	for _, ns := range sharedNamespaces {
+	for ns := range nsSet {
 		err := r.Get(context.TODO(), types.NamespacedName{Name: ns}, &corev1.Namespace{})
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/platform-operator/mocks/component_mock.go
+++ b/platform-operator/mocks/component_mock.go
@@ -724,6 +724,20 @@ func (mr *MockComponentMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockComponent)(nil).Name))
 }
 
+// Namespace mocks base method.
+func (m *MockComponent) Namespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Namespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Namespace indicates an expected call of Namespace.
+func (mr *MockComponentMockRecorder) Namespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockComponent)(nil).Namespace))
+}
+
 // PostInstall mocks base method.
 func (m *MockComponent) PostInstall(arg0 spi.ComponentContext) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Make sure all namespaces created by a Verrazzano installation are deleted, also wait until they are gone.
