### PR TITLE
Backport the test fix to obtain the OAM application config scheme to release-1.2

### DIFF
--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -31,7 +31,7 @@ const (
 	waitTimeout          = 10 * time.Minute
 	longWaitTimeout      = 20 * time.Minute
 	pollingInterval      = 30 * time.Second
-	sockshopAppName      = "sockshop-appconfig"
+	sockshopAppName      = "sockshop-appconf"
 )
 
 var sockShop SockShop
@@ -107,6 +107,16 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 	})
 
 	sockShop.SetHostHeader(hostname)
+
+	t.It("SockShop application configuration exists", func() {
+		Eventually(func() bool {
+			appConfig, err := pkg.GetAppConfig(namespace, sockshopAppName)
+			if err != nil {
+				return false
+			}
+			return appConfig != nil
+		}, waitTimeout, pollingInterval).Should(BeTrue(), "Failed to get the application configuration for Sockshop")
+	})
 
 	t.It("SockShop can be accessed and user can be registered", func() {
 		Eventually(func() (bool, error) {
@@ -341,7 +351,7 @@ func appMetricsExists() bool {
 
 // appComponentMetricsExists checks whether component related metrics are available
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "sockshop-appconf")
+	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", sockshopAppName)
 }
 
 // appConfigMetricsExists checks whether config metrics are available

--- a/tests/e2e/pkg/oam.go
+++ b/tests/e2e/pkg/oam.go
@@ -5,6 +5,7 @@ package pkg
 
 import (
 	"context"
+	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,8 +28,8 @@ func GetAppConfig(namespace string, name string) (*unstructured.Unstructured, er
 // getOamAppConfigScheme returns the appconfig scheme needed to get unstructured data
 func getOamAppConfigScheme() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
-		Group:    "core.oam.dev",
-		Version:  "v1alpha2",
-		Resource: "ApplicationConfiguration",
+		Group:    oamcore.Group,
+		Version:  oamcore.Version,
+		Resource: "applicationconfigurations",
 	}
 }


### PR DESCRIPTION
This PR backports the fix to the function to get the OAM application config scheme, which is used by the test suite for Sockshop.
