### PR TITLE
VZ-5012: Replicate logic of oci/oke driver activation in Rancher PostUpgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -237,43 +238,35 @@ func (r rancherComponent) IsReady(ctx spi.ComponentContext) bool {
 - Retrieve the Rancher admin password
 - Retrieve the Rancher hostname
 - Set the Rancher server URL using the admin password and the hostname
+- Activate the oci and oke drivers
 */
 func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 	c := ctx.Client()
-	vz := ctx.EffectiveCR()
 	log := ctx.Log()
 
 	if err := createAdminSecretIfNotExists(log, c); err != nil {
 		return log.ErrorfThrottledNewErr("Failed creating Rancher admin secret: %s", err.Error())
 	}
-	password, err := common.GetAdminSecret(c)
+
+	vz := ctx.EffectiveCR()
+	rest, err := configureRancherRestClient(log, c, vz)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher admin secret: %s", err.Error())
-	}
-	rancherHostName, err := getRancherHostname(c, vz)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher hostname: %s", err.Error())
+		return err
 	}
 
-	rest, err := common.NewClient(c, rancherHostName, password)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher client: %s", err.Error())
-	}
-	if err := rest.SetAccessToken(); err != nil {
-		return log.ErrorfThrottledNewErr("Failed setting Rancher access token: %s", err.Error())
-	}
 	if err := rest.PutServerURL(); err != nil {
 		return log.ErrorfThrottledNewErr("Failed setting Rancher server URL: %s", err.Error())
 	}
+
+	err = activateDrivers(log, rest)
+	if err != nil {
+		return err
+	}
+
 	if err := removeBootstrapSecretIfExists(log, c); err != nil {
 		return log.ErrorfThrottledNewErr("Failed removing Rancher bootstrap secret: %s", err.Error())
 	}
-	if err := rest.ActivateOCIDriver(); err != nil {
-		return log.ErrorfThrottledNewErr("Failed activating OCI Driver: %s", err.Error())
-	}
-	if err := rest.ActivateOKEDriver(); err != nil {
-		return log.ErrorfThrottledNewErr("Failed activating OKE Driver: %s", err.Error())
-	}
+
 	if err := r.HelmComponent.PostInstall(ctx); err != nil {
 		return log.ErrorfThrottledNewErr("Failed helm component post install: %s", err.Error())
 	}
@@ -300,40 +293,60 @@ func (r rancherComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
 	return false
 }
 
-// PostUpgrade activates OCI and OKE drivers in Rancher
+// PostUpgrade configures the Rancher rest client and activates OCI and OKE drivers in Rancher
 func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	c := ctx.Client()
 	log := ctx.Log()
 	vz := ctx.EffectiveCR()
+	rest, err := configureRancherRestClient(log, c, vz)
+	if err != nil {
+		return err
+	}
+
+	err = activateDrivers(log, rest)
+	if err != nil {
+		return err
+	}
+
+	if err := r.HelmComponent.PostUpgrade(ctx); err != nil {
+		return log.ErrorfThrottledNewErr("Failed helm component post upgrade: %s", err.Error())
+	}
+
+	return nil
+}
+
+// configureRancherRestClient configures the REST rancher client and sets the access token.
+func configureRancherRestClient(log vzlog.VerrazzanoLogger, c client.Client, vz *vzapi.Verrazzano) (*common.RESTClient, error) {
 	password, err := common.GetAdminSecret(c)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher admin secret: %s", err.Error())
+		return nil, log.ErrorfThrottledNewErr("Failed getting Rancher admin secret: %s", err.Error())
 	}
 
 	rancherHostName, err := getRancherHostname(c, vz)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher hostname: %s", err.Error())
+		return nil, log.ErrorfThrottledNewErr("Failed getting Rancher hostname: %s", err.Error())
 	}
 
 	rest, err := common.NewClient(c, rancherHostName, password)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher client: %s", err.Error())
+		return nil, log.ErrorfThrottledNewErr("Failed getting Rancher client: %s", err.Error())
 	}
 
 	if err := rest.SetAccessToken(); err != nil {
-		return log.ErrorfThrottledNewErr("Failed setting Rancher access token: %s", err.Error())
+		return nil, log.ErrorfThrottledNewErr("Failed setting Rancher access token: %s", err.Error())
 	}
 
+	return rest, nil
+}
+
+// activateDrivers activates the oci nodeDriver and oraclecontainerengine kontainerDriver
+func activateDrivers(log vzlog.VerrazzanoLogger, rest *common.RESTClient) error {
 	if err := rest.ActivateOCIDriver(); err != nil {
 		return log.ErrorfThrottledNewErr("Failed activating OCI Driver: %s", err.Error())
 	}
 
 	if err := rest.ActivateOKEDriver(); err != nil {
 		return log.ErrorfThrottledNewErr("Failed activating OKE Driver: %s", err.Error())
-	}
-
-	if err := r.HelmComponent.PostUpgrade(ctx); err != nil {
-		return log.ErrorfThrottledNewErr("Failed helm component post upgrade: %s", err.Error())
 	}
 
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -320,6 +320,10 @@ func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("Failed getting Rancher client: %s", err.Error())
 	}
 
+	if err := rest.SetAccessToken(); err != nil {
+		return log.ErrorfThrottledNewErr("Failed setting Rancher access token: %s", err.Error())
+	}
+
 	if err := rest.ActivateOCIDriver(); err != nil {
 		return log.ErrorfThrottledNewErr("Failed activating OCI Driver: %s", err.Error())
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -244,59 +244,21 @@ func TestIsReady(t *testing.T) {
 //  WHEN PostInstall is called
 //  THEN PostInstall should return nil
 func TestPostInstall(t *testing.T) {
-	// mock the k8s resources used in post install
-	caSecret := createCASecret()
-	rootCASecret := createRootCASecret()
-	adminSecret := createAdminSecret()
-	rancherPodList := createRancherPodListWithAllRunning()
-	ingress := v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: common.CattleSystem,
-			Name:      constants.RancherIngress,
-		},
-	}
-	time := metav1.Now()
-	cert := certapiv1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{Name: certificates[0].Name, Namespace: certificates[0].Namespace},
-		Status: certapiv1.CertificateStatus{
-			Conditions: []certapiv1.CertificateCondition{
-				{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
-			},
-		},
-	}
-
-	clientWithoutIngress := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret, &rootCASecret, &adminSecret, &rancherPodList.Items[0]).Build()
-	ctxWithoutIngress := spi.NewFakeContext(clientWithoutIngress, &vzDefaultCA, false)
-
-	clientWithIngress := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret, &rootCASecret, &adminSecret, &rancherPodList.Items[0], &ingress, &cert).Build()
-	ctxWithIngress := spi.NewFakeContext(clientWithIngress, &vzDefaultCA, false)
-
-	// mock the pod executor when resetting the Rancher admin password
-	k8sutil.NewPodExecutor = k8sutilfake.NewPodExecutor
-	k8sutilfake.PodSTDOUT = "password"
-	k8sutil.ClientConfig = func() (*rest.Config, kubernetes.Interface, error) {
-		config, k := k8sutilfake.NewClientsetConfig()
-		return config, k, nil
-	}
-
-	// mock the HTTP responses for the Rancher API
-	common.HTTPDo = func(hc *http.Client, req *http.Request) (*http.Response, error) {
-		url := req.URL.String()
-		if strings.Contains(url, common.RancherServerURLPath) {
-			return &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader("blahblah")),
-			}, nil
-		}
-		return &http.Response{
-			StatusCode: 200,
-			Body:       io.NopCloser(strings.NewReader(`{"token":"token"}`)),
-		}, nil
-	}
-
 	component := NewComponent()
+	ctxWithoutIngress, ctxWithIngress := prepareContexts()
 	assert.IsType(t, fmt.Errorf(""), component.PostInstall(ctxWithoutIngress))
 	assert.Nil(t, component.PostInstall(ctxWithIngress))
+}
+
+// TestPostUpgrade tests a happy path post upgrade run
+// GIVEN a Rancher install state where all components are ready
+//  WHEN PostUpgrade is called
+//  THEN PostUpgrade should return nil
+func TestPostUpgrade(t *testing.T) {
+	component := NewComponent()
+	ctxWithoutIngress, ctxWithIngress := prepareContexts()
+	assert.IsType(t, fmt.Errorf(""), component.PostUpgrade(ctxWithoutIngress))
+	assert.Nil(t, component.PostUpgrade(ctxWithIngress))
 }
 
 func Test_rancherComponent_ValidateUpdate(t *testing.T) {
@@ -350,6 +312,61 @@ func Test_rancherComponent_ValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func prepareContexts() (spi.ComponentContext, spi.ComponentContext) {
+	// mock the k8s resources used in post install
+	caSecret := createCASecret()
+	rootCASecret := createRootCASecret()
+	adminSecret := createAdminSecret()
+	rancherPodList := createRancherPodListWithAllRunning()
+	ingress := v1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      constants.RancherIngress,
+		},
+	}
+	time := metav1.Now()
+	cert := certapiv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: certificates[0].Name, Namespace: certificates[0].Namespace},
+		Status: certapiv1.CertificateStatus{
+			Conditions: []certapiv1.CertificateCondition{
+				{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+			},
+		},
+	}
+
+	clientWithoutIngress := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret, &rootCASecret, &adminSecret, &rancherPodList.Items[0]).Build()
+	ctxWithoutIngress := spi.NewFakeContext(clientWithoutIngress, &vzDefaultCA, false)
+
+	clientWithIngress := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret, &rootCASecret, &adminSecret, &rancherPodList.Items[0], &ingress, &cert).Build()
+	ctxWithIngress := spi.NewFakeContext(clientWithIngress, &vzDefaultCA, false)
+
+	// mock the pod executor when resetting the Rancher admin password
+	k8sutil.NewPodExecutor = k8sutilfake.NewPodExecutor
+	k8sutilfake.PodSTDOUT = "password"
+	k8sutil.ClientConfig = func() (*rest.Config, kubernetes.Interface, error) {
+		config, k := k8sutilfake.NewClientsetConfig()
+		return config, k, nil
+	}
+
+	// mock the HTTP responses for the Rancher API
+	common.HTTPDo = func(hc *http.Client, req *http.Request) (*http.Response, error) {
+		url := req.URL.String()
+		if strings.Contains(url, common.RancherServerURLPath) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("blahblah")),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"token":"token"}`)),
+		}, nil
+	}
+
+	return ctxWithoutIngress, ctxWithIngress
+
 }
 
 func newReadyDeployment(namespace string, name string) *appsv1.Deployment {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -257,7 +257,7 @@ func TestPostInstall(t *testing.T) {
 func TestPostUpgrade(t *testing.T) {
 	component := NewComponent()
 	ctxWithoutIngress, ctxWithIngress := prepareContexts()
-	assert.IsType(t, fmt.Errorf(""), component.PostUpgrade(ctxWithoutIngress))
+	assert.Nil(t, component.PostUpgrade(ctxWithoutIngress))
 	assert.Nil(t, component.PostUpgrade(ctxWithIngress))
 }
 


### PR DESCRIPTION
In https://github.com/verrazzano/verrazzano/pull/3543, some code was added to [rancher_component.PostInstall](https://github.com/verrazzano/verrazzano/blob/master/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go#L271) to activate the drivers using. Rancher API. 
Now when VZ is upgraded from a lower version to 1.4, this code is being called while doing reconciliation at a later time, after the upgrade has finished. A [test](https://github.com/verrazzano/verrazzano/blob/master/tests/e2e/verify-infra/restapi/rancher_url_test.go#L130) was also added to verify the effect of these changes.
However, this test fails in upgrade pipeline when the reconciliation logic kicks off after the test has timeout, passes otherwise.

This PR to implement activation of drivers in PostUpgrade stage also
