### PR TITLE
VZ-6480 fix uninstall after re-install

### DIFF
--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -158,7 +158,7 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 
 // getUninstallTracker gets the Uninstall tracker for Verrazzano
 func getUninstallTracker(cr *installv1alpha1.Verrazzano) *UninstallTracker {
-	key := getNSNKey(cr)
+	key := getTrackerKey(cr)
 	vuc, ok := UninstallTrackerMap[key]
 	// If the entry is missing or the generation is different create a new entry
 	if !ok || vuc.gen != cr.Generation {
@@ -175,7 +175,7 @@ func getUninstallTracker(cr *installv1alpha1.Verrazzano) *UninstallTracker {
 // DeleteUninstallTracker deletes the Uninstall tracker for the Verrazzano resource
 // This needs to be called when uninstall is completely done
 func DeleteUninstallTracker(cr *installv1alpha1.Verrazzano) {
-	key := getNSNKey(cr)
+	key := getTrackerKey(cr)
 	_, ok := UninstallTrackerMap[key]
 	if ok {
 		delete(UninstallTrackerMap, key)

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -6,6 +6,7 @@ package verrazzano
 import (
 	"context"
 	"fmt"
+
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
@@ -227,14 +228,14 @@ func postVerrazzanoUpgrade(log vzlog.VerrazzanoLogger, client clipkg.Client, cr 
 	return istio.RestartComponents(log, config.GetInjectedSystemNamespaces(), cr.Generation, istio.DoesPodContainOldIstioSidecar)
 }
 
-// getNSNKey gets the key for the verrazzano resource
-func getNSNKey(cr *installv1alpha1.Verrazzano) string {
-	return fmt.Sprintf("%s-%s", cr.Namespace, cr.Name)
+// getTrackerKey gets the tracker key for the Verrazzano resource
+func getTrackerKey(cr *installv1alpha1.Verrazzano) string {
+	return fmt.Sprintf("%s-%s-%s", cr.Namespace, cr.Name, string(cr.UID))
 }
 
 // getUpgradeTracker gets the upgrade tracker for Verrazzano
 func getUpgradeTracker(cr *installv1alpha1.Verrazzano) *upgradeTracker {
-	key := getNSNKey(cr)
+	key := getTrackerKey(cr)
 	vuc, ok := upgradeTrackerMap[key]
 	// If the entry is missing or the generation is different create a new entry
 	if !ok || vuc.gen != cr.Generation {
@@ -250,7 +251,7 @@ func getUpgradeTracker(cr *installv1alpha1.Verrazzano) *upgradeTracker {
 
 // deleteUpgradeTracker deletes the upgrade tracker for the Verrazzano resource
 func deleteUpgradeTracker(cr *installv1alpha1.Verrazzano) {
-	key := getNSNKey(cr)
+	key := getTrackerKey(cr)
 	_, ok := upgradeTrackerMap[key]
 	if ok {
 		delete(upgradeTrackerMap, key)


### PR DESCRIPTION
Delete is broken you install, un-install, install, then un-install.  The last uninstall deletes the VZ CR but none of the components were uninstalled.  The problem is that the in-memory state machine tracker was using NSN as a key and old states were being used.  Fixed to use NSN+UID as the key.
