### PR TITLE
VZ-6117 - Auth and Network Policy changes for allowing prometheus to reach Jaeger Components

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -263,5 +263,54 @@ spec:
       to:
         - operation:
             ports: ["9411", "14250"]
+
+#
+# Istio AuthorizationPolicy for Jaeger Collector deployed by Verrazzano
+#
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: jaeger-collector-prometheus-authzpol
+  namespace: {{ .Values.jaegerOperator.namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/component: collector
+      app.kubernetes.io/managed-by: jaeger-operator
+  action: ALLOW
+  rules:
+    # jaeger-collector-service:9411, 14269 <- prometheus
+    - from:
+        - source:
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
+      to:
+        - operation:
+            ports: ["14269"]
+#
+# Istio AuthorizationPolicy for Jaeger Query deployed by Verrazzano
+#
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: jaeger-query-prometheus-authzpol
+  namespace: {{ .Values.jaegerOperator.namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/component: query
+      app.kubernetes.io/managed-by: jaeger-operator
+  action: ALLOW
+  rules:
+    # jaeger-query-service: 14271 <- prometheus
+    - from:
+        - source:
+            namespaces: ["{{ .Values.prometheus.namespace }}"]
+            principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
+      to:
+        - operation:
+            ports: ["14271", "16687"]
 {{- end }}
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -248,7 +248,7 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: jaeger-authzpol
+  name: jaeger-collector-authzpol
   namespace: {{ .Values.jaegerOperator.namespace }}
 spec:
   selector:
@@ -263,38 +263,22 @@ spec:
       to:
         - operation:
             ports: ["9411", "14250"]
-
-#
-# Istio AuthorizationPolicy for Jaeger Collector deployed by Verrazzano
-#
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: jaeger-collector-prometheus-authzpol
-  namespace: {{ .Values.jaegerOperator.namespace }}
-spec:
-  selector:
-    matchLabels:
-      app: jaeger
-      app.kubernetes.io/component: collector
-      app.kubernetes.io/managed-by: jaeger-operator
-  action: ALLOW
-  rules:
-    # jaeger-collector-service:9411, 14269 <- prometheus
+    # jaeger-collector-service:15090, 14269 <- prometheus
     - from:
         - source:
             namespaces: ["{{ .Values.prometheus.namespace }}"]
             principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
-            ports: ["14269"]
+            ports: ["15090", "14269"]
+
 #
 # Istio AuthorizationPolicy for Jaeger Query deployed by Verrazzano
 #
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: jaeger-query-prometheus-authzpol
+  name: jaeger-query-authzpol
   namespace: {{ .Values.jaegerOperator.namespace }}
 spec:
   selector:
@@ -304,13 +288,21 @@ spec:
       app.kubernetes.io/managed-by: jaeger-operator
   action: ALLOW
   rules:
-    # jaeger-query-service: 14271 <- prometheus
+    # jaeger-collector-service:16686 <- verrazzano-authproxy
+    - from:
+        - source:
+            namespaces: ["{{ .Release.Namespace }}"]
+            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.api.name }}"]
+      to:
+        - operation:
+            ports: ["16686"]
+    # jaeger-query-service:15090, 14271, 16687 <- prometheus
     - from:
         - source:
             namespaces: ["{{ .Values.prometheus.namespace }}"]
             principals: ["cluster.local/ns/{{ .Values.prometheus.namespace }}/sa/{{ .Values.prometheus.serviceAccount }}"]
       to:
         - operation:
-            ports: ["14271", "16687"]
+            ports: ["15090", "14271", "16687"]
 {{- end }}
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -204,8 +204,8 @@ spec:
           protocol: TCP
         - port: 14271
           protocol: TCP
-        - protocol: TCP
-          port: 15090
+        - port: 15090
+          protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
@@ -214,6 +214,6 @@ spec:
             matchLabels:
               app: verrazzano-authproxy
       ports:
-        - protocol: TCP
-          port: 16686
+        - port: 16686
+          protocol: TCP
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -138,7 +138,8 @@ spec:
 ---
 # Network policy for Jaeger Collector
 # Ingress: allow access to connect to Jaeger Collector ports 9411 and 14250
-# Ingress: allow access from Prometheus to scrape Jaeger Collector metrics on port ports 14269
+#          allow access from Prometheus to scrape Jaeger Collector metrics on port ports 14269
+#          allow access from Prometheus to scrape Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -169,10 +170,13 @@ spec:
       ports:
         - port: 14269
           protocol: TCP
+        - port: 15090
+          protocol: TCP
 ---
 # Network policy for Jaeger Query
 # Ingress: allow access from Prometheus to scrape Jaeger Query metrics on port ports 14271 and 16687
-# Ingress: allow access from verrazzano-authproxy to Jaeger UI on port 16686
+#          allow access from verrazzano-authproxy to Jaeger UI on port 16686
+#          allow access from Prometheus to scrape Envoy stats on port 15090
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -210,4 +214,6 @@ spec:
       ports:
         - protocol: TCP
           port: 16686
+        - protocol: TCP
+          port: 15090
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -144,7 +144,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: jaeger
+  name: jaeger-collector
   namespace: {{ .Values.jaegerOperator.namespace }}
 spec:
   podSelector:

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -136,8 +136,9 @@ spec:
     - Ingress
 {{- if .Values.jaegerOperator.enabled }}
 ---
-# Network policy for Jaeger
+# Network policy for Jaeger Collector
 # Ingress: allow access to connect to Jaeger Collector ports 9411 and 14250
+# Ingress: allow access from Prometheus to scrape Jaeger Collector metrics on port ports 14269
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -158,4 +159,55 @@ spec:
           protocol: TCP
         - port: 14250
           protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 14269
+          protocol: TCP
+---
+# Network policy for Jaeger Query
+# Ingress: allow access from Prometheus to scrape Jaeger Query metrics on port ports 14271 and 16687
+# Ingress: allow access from verrazzano-authproxy to Jaeger UI on port 16686
+# Egress: allow all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: jaeger-query
+  namespace: {{ .Values.jaegerOperator.namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/component: query
+      app.kubernetes.io/managed-by: jaeger-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            verrazzano.io/namespace: verrazzano-monitoring
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus
+      ports:
+        - port: 16687
+          protocol: TCP
+        - port: 14271
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-system
+          podSelector:
+            matchLabels:
+              app: verrazzano-authproxy
+      ports:
+        - protocol: TCP
+          port: 16686
 {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/networkpolicy.yaml
@@ -175,8 +175,8 @@ spec:
 ---
 # Network policy for Jaeger Query
 # Ingress: allow access from Prometheus to scrape Jaeger Query metrics on port ports 14271 and 16687
-#          allow access from verrazzano-authproxy to Jaeger UI on port 16686
 #          allow access from Prometheus to scrape Envoy stats on port 15090
+#          allow access from verrazzano-authproxy to Jaeger UI on port 16686
 # Egress: allow all
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -204,6 +204,8 @@ spec:
           protocol: TCP
         - port: 14271
           protocol: TCP
+        - protocol: TCP
+          port: 15090
     - from:
         - namespaceSelector:
             matchLabels:
@@ -214,6 +216,4 @@ spec:
       ports:
         - protocol: TCP
           port: 16686
-        - protocol: TCP
-          port: 15090
 {{- end }}


### PR DESCRIPTION
Auth and Network policy changes to allow Prometheus to scrape metrics from Jaeger components (`jaeger-query`, `jaeger-agent` and `jaeger-collector`)
