### PR TITLE
Fix for ignoring pods created by cronjobs in envoy pod monitor

### DIFF
--- a/platform-operator/thirdparty/manifests/prometheus-operator/envoy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/envoy_monitor.yaml
@@ -19,6 +19,11 @@ spec:
           - __meta_kubernetes_pod_container_port_name
         regex: .*-envoy-prom
         action: keep
+      # Ignore pods that are created by CronJobs and in Completed state
+      - sourceLabels:
+          - __meta_kubernetes_pod_phase
+        regex: Succeeded
+        action: drop
       - sourceLabels:
           - __address__
           - __meta_kubernetes_pod_annotation_prometheus_io_port


### PR DESCRIPTION
Signed-off-by: Anand Francis Joseph <anand.francis.joseph.augustin@oracle.com>

`jaeger-operator-jaeger-es-index-cleaner` is a CronJob that runs when Jaeger Operator component is enabled and runs within the mesh. This CronJob creates cleanup job at scheduled interval and goes to `Completed` state once its done. Pods spawned by such cron jobs should not be scraped for envoy metrics as all the containers are in completed state.

`jaeger-operator-jaeger-es-index-cleaner-27637915-7sqfl   0/2     Completed   0          3h33m`

![Screenshot 2022-07-20 at 8 55 47 AM](https://user-images.githubusercontent.com/28599136/179966446-ecd384fa-ed33-4823-b803-22a05b654f6e.png)

