### PR TITLE
VZ-6418.  Fix cp error in webhook-init mode

### DIFF
--- a/platform-operator/config/scripts/run.sh
+++ b/platform-operator/config/scripts/run.sh
@@ -21,8 +21,14 @@ function create-kubeconfig {
   export KUBECONFIG=$VERRAZZANO_KUBECONFIG
 }
 
-# Set up a valid Kubeconfig for tools that require them
-create-kubeconfig
+echo "*************************************************************"
+echo " Running in ${MODE} mode                                     "
+echo "*************************************************************"
+
+if [ -n "${VERRAZZANO_KUBECONFIG}" ]; then
+  # Set up a valid Kubeconfig for tools that require them
+  create-kubeconfig
+fi
 
 # Run the operator
 /usr/local/bin/verrazzano-platform-operator $*

--- a/platform-operator/config/scripts/run.sh
+++ b/platform-operator/config/scripts/run.sh
@@ -21,12 +21,8 @@ function create-kubeconfig {
   export KUBECONFIG=$VERRAZZANO_KUBECONFIG
 }
 
-echo "*************************************************************"
-echo " Running in ${MODE} mode                                     "
-echo "*************************************************************"
-
 if [ -n "${VERRAZZANO_KUBECONFIG}" ]; then
-  # Set up a valid Kubeconfig for tools that require them
+  # If VERRAZZANO_KUBECONFIG is set, set up a valid Kubeconfig for tools that require them at the requested location
   create-kubeconfig
 fi
 

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -29,9 +29,6 @@ spec:
           args:
             - --zap-log-level=info
             - --init-webhooks=true
-          env:
-            - name: MODE
-              value: WEBHOOK_INIT
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
@@ -61,8 +58,6 @@ spec:
             - --zap-log-level=info
             - --enable-webhook-validation=true
           env:
-            - name: MODE
-              value: RUN_OPERATOR
             - name: VERRAZZANO_KUBECONFIG
               value: /home/verrazzano/kubeconfig
             {{- if .Values.global.registry }}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - --init-webhooks=true
           env:
             - name: MODE
-              value: RUN_OPERATOR
+              value: WEBHOOK_INIT
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
@@ -65,8 +65,6 @@ spec:
               value: RUN_OPERATOR
             - name: VERRAZZANO_KUBECONFIG
               value: /home/verrazzano/kubeconfig
-            - name: VZ_INSTALL_IMAGE
-              value: {{ .Values.image }}
             {{- if .Values.global.registry }}
             - name: REGISTRY
               value: {{ .Values.global.registry }}


### PR DESCRIPTION
Follow-up for VZ-6418, fix an error trying to create the Kubeconfig when the VPO runs in webhook-init mode.
- Also removes the now obsolete `VZ_INSTALL_IMAGE` env var