### PR TITLE
VZ-6488 - Rancher post uninstall removes CRD finalizers for deleted CRDs - these CRD deletions hang in K8S 1.21 on Kind; More leftover Rancher namespaces deleted.

### DIFF
--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -37,15 +37,15 @@ func (r Resource) Delete() error {
 
 // RemoveFinializersAndDelete removes all finalizers from a resource and deletes the resource
 func (r Resource) RemoveFinalizersAndDelete() error {
-	err := r.removeFinalizers()
+	err := r.RemoveFinalizers()
 	if err != nil {
 		return err
 	}
 	return r.Delete()
 }
 
-// removeFinalizers removes all finalizers from a resource
-func (r Resource) removeFinalizers() error {
+// RemoveFinalizers removes all finalizers from a resource
+func (r Resource) RemoveFinalizers() error {
 	val := reflect.ValueOf(r.Object)
 	kind := val.Elem().Type().Name()
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Namespace, Name: r.Name}, r.Object)

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -147,7 +147,7 @@ func TestDeleteNotExists(t *testing.T) {
 
 // TestRemoveFinalizers tests the removing a finalizers from a resource
 // GIVEN a Kubernetes resource
-// WHEN removeFinalizers is called
+// WHEN RemoveFinalizers is called
 // THEN the resource will have finalizers removed
 func TestRemoveFinalizers(t *testing.T) {
 	asserts := assert.New(t)
@@ -176,7 +176,7 @@ func TestRemoveFinalizers(t *testing.T) {
 		Client: c,
 		Object: &corev1.Namespace{},
 		Log:    vzlog.DefaultLogger(),
-	}.removeFinalizers()
+	}.RemoveFinalizers()
 
 	// Validate that resource is updated with no finalizer
 	asserts.NoError(err)
@@ -187,8 +187,8 @@ func TestRemoveFinalizers(t *testing.T) {
 
 // TestRemoveFinalizersNotExists tests the removal of finalizer from a resource
 // GIVEN a resource that doesn't exist
-// WHEN removeFinalizers is called
-// THEN the removeFinalizers function should not return an error
+// WHEN RemoveFinalizers is called
+// THEN the RemoveFinalizers function should not return an error
 func TestRemoveFinalizersNotExists(t *testing.T) {
 	asserts := assert.New(t)
 
@@ -208,7 +208,7 @@ func TestRemoveFinalizersNotExists(t *testing.T) {
 		Client: c,
 		Object: &corev1.Pod{},
 		Log:    vzlog.DefaultLogger(),
-	}.removeFinalizers()
+	}.RemoveFinalizers()
 	asserts.NoError(err)
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	v12 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -66,6 +67,7 @@ func getScheme() *runtime.Scheme {
 	_ = certv1.AddToScheme(scheme)
 	_ = admv1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
+	_ = v12.AddToScheme(scheme)
 	return scheme
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -41,12 +41,15 @@ var rancherSystemNS = []string{
 	"cattle-istio",
 	"cattle-global-nt",
 	"security-scan",
+	"cattle-fleet-clusters-system",
 	"cattle-fleet-system",
 	"cattle-fleet-local-system",
 	"tigera-operator",
 	"cattle-impersonation-system",
 	"rancher-operator-system",
 	"cattle-csp-adapter-system",
+	"fleet-default",
+	"fleet-local",
 	"local",
 }
 

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	vzappclusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
-
 	clustersapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 
 	"sync"

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -14,6 +14,7 @@ import (
 	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	vzappclusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
@@ -63,6 +64,8 @@ func init() {
 	// Add the Prometheus Operator resources to the scheme
 	_ = promoperapi.AddToScheme(scheme)
 
+	// Add K8S api-extensions so that we can list CustomResourceDefinitions during uninstall of VZ
+	_ = v1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
