### PR TITLE
Sdosapat/vz 6503 generate bug report

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -252,7 +252,6 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('pre-upgrade-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('pre-upgrade-tests-cluster-dump')
                         }
                     }
                 }
@@ -260,7 +259,6 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('install-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('install-success-cluster-dump')
                         }
                     }
                 }
@@ -332,7 +330,6 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('post-upgrade-vpo-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('post-upgrade-vpo-failure-cluster-dump')
                         }
                     }
                 }
@@ -559,7 +556,6 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('upgrade-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -600,7 +596,6 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('post-upgrade-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('post-upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -608,7 +603,6 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('post-upgrade-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('post-upgrade-success-cluster-dump')
                         }
                     }
                 }
@@ -709,14 +703,9 @@ def runGinkgoNamespace(testSuitePath, skipDeploy, skipUndeploy, namespace) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -76,6 +76,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         CLUSTER_NAME = 'verrazzano'
@@ -251,6 +252,7 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('pre-upgrade-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('pre-upgrade-tests-cluster-dump')
                         }
                     }
                 }
@@ -258,6 +260,7 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('install-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('install-success-cluster-dump')
                         }
                     }
                 }
@@ -329,6 +332,7 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('post-upgrade-vpo-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('post-upgrade-vpo-failure-cluster-dump')
                         }
                     }
                 }
@@ -555,6 +559,7 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('upgrade-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -595,6 +600,7 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('post-upgrade-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('post-upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -602,6 +608,7 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('post-upgrade-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('post-upgrade-success-cluster-dump')
                         }
                     }
                 }
@@ -628,7 +635,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/build/resources/**,**/*-cluster-dump/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/build/resources/**,**/*-cluster-dump/**,**/bug-report/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             script {
@@ -702,6 +709,14 @@ def runGinkgoNamespace(testSuitePath, skipDeploy, skipUndeploy, namespace) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -91,6 +91,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
@@ -234,6 +235,7 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                                     dumpK8sCluster('dynamic-update-post-install-cluster-dump')
+                                    dumpK8sClusterFromBugReport('dynamic-update-post-install-cluster-dump')
                                 }
                             }
                         }
@@ -543,6 +545,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('dynamic-update-failed-cluster-dump')
+                            dumpK8sClusterFromBugReport('dynamic-update-failed-cluster-dump')
                         }
                     }
                 }
@@ -551,6 +554,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('dynamic-update-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('dynamic-update-success-cluster-dump')
                         }
                     }
                 }
@@ -577,7 +581,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -739,6 +743,14 @@ def runGinkgoAppTest(testSuitePath, namespace, dumpDir = '', skipDeploy = 'false
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -235,7 +235,6 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                                     dumpK8sCluster('dynamic-update-post-install-cluster-dump')
-                                    dumpK8sClusterFromBugReport('dynamic-update-post-install-cluster-dump')
                                 }
                             }
                         }
@@ -545,7 +544,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('dynamic-update-failed-cluster-dump')
-                            dumpK8sClusterFromBugReport('dynamic-update-failed-cluster-dump')
                         }
                     }
                 }
@@ -554,7 +552,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('dynamic-update-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('dynamic-update-success-cluster-dump')
                         }
                     }
                 }
@@ -743,14 +740,9 @@ def runGinkgoAppTest(testSuitePath, namespace, dumpDir = '', skipDeploy = 'false
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -336,7 +336,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -345,7 +344,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -458,14 +456,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -93,6 +93,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
@@ -335,6 +336,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -343,6 +345,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -385,7 +388,7 @@ pipeline {
                  sort -u -o ${IMG_LIST_FILE} ${IMG_LIST_FILE}
                 fi
             """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/Screenshot*.png,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/Screenshot*.png,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -455,6 +458,14 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -102,6 +102,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         DUMP_ROOT_DIRECTORY="${WORKSPACE}/test-cluster-dumps"
         POST_INSTALL_DUMP="true"
 
@@ -169,6 +170,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -177,6 +179,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -185,7 +188,7 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/Screenshot*.png,**/ConsoleLog*.log,**/*${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/*${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             script {
@@ -525,4 +528,11 @@ def emitJobMetrics() {
     runTestTarget('jobmetrics')
 }
 
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+    """
+}
 

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -170,7 +170,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -179,7 +178,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -528,7 +526,7 @@ def emitJobMetrics() {
     runTestTarget('jobmetrics')
 }
 
-def dumpK8sClusterFromBugReport(dumpDirectory) {
+def dumpK8sCluster(dumpDirectory) {
     sh """
             go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
             mkdir bug-report

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -524,7 +524,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -533,7 +532,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -633,14 +631,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -164,6 +164,7 @@ pipeline {
         ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
 
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
@@ -435,6 +436,7 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-install-cluster-dump")
                     }
                 }
             }
@@ -452,6 +454,7 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
                     }
                 }
             }
@@ -546,6 +549,7 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
+                                dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
                             }
                         }
                     }
@@ -556,12 +560,14 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
@@ -569,6 +575,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
+                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                         }
                     }
                 }
@@ -587,6 +594,7 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
                     }
                 }
             }
@@ -609,12 +617,14 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                     }
                 }
                 success {
@@ -622,11 +632,12 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
+                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                         }
                     }
                 }
                 always {
-                    archiveArtifacts artifacts: "**/multicluster-uninstall-dump/**,**/*cluster-dump*/**,**/test-cluster-dumps/**", allowEmptyArchive: true
+                    archiveArtifacts artifacts: "**/multicluster-uninstall-dump/**,**/*cluster-dump*/**,**/bug-report/**,**/test-cluster-dumps/**", allowEmptyArchive: true
                 }
             }
         }
@@ -662,7 +673,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*cluster-dump*/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*cluster-dump*/**,**/bug-report/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             script {
@@ -1235,6 +1246,14 @@ def dumpK8sCluster(dumpDirectory) {
             }
         }
     }
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+    """
 }
 
 def dumpVerrazzanoSystemPods() {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -436,7 +436,6 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-install-cluster-dump")
                     }
                 }
             }
@@ -454,7 +453,6 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
                     }
                 }
             }
@@ -549,7 +547,6 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
-                                dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump-pre-uninstall")
                             }
                         }
                     }
@@ -560,14 +557,12 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
@@ -575,7 +570,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
-                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-acceptance-tests-cluster-dump")
                         }
                     }
                 }
@@ -594,7 +588,6 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
                     }
                 }
             }
@@ -617,14 +610,12 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                     }
                 }
                 success {
@@ -632,7 +623,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-uninstall-dump")
-                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-uninstall-dump")
                         }
                     }
                 }
@@ -1242,18 +1232,13 @@ def dumpK8sCluster(dumpDirectory) {
                 sh """
                 export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory}-${count} -r ${dumpDirectory}-${count}/cluster-dump/analysis.report
+                go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+                mkdir bug-report
+                tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
             """
             }
         }
     }
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
-    """
 }
 
 def dumpVerrazzanoSystemPods() {

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -68,6 +68,7 @@ pipeline {
         TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
         KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
@@ -409,6 +410,7 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -416,6 +418,7 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -436,7 +439,7 @@ pipeline {
                     dumpVerrazzanoApiLogs()
                 }
             }
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
 
             sh """
@@ -492,6 +495,14 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -410,7 +410,6 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -418,7 +417,6 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -495,14 +493,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
@@ -440,6 +441,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -448,6 +450,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -475,7 +478,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -556,6 +559,14 @@ def runGinkgoNoFlags(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -441,7 +441,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -450,7 +449,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -559,14 +557,9 @@ def runGinkgoNoFlags(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -131,6 +131,7 @@ pipeline {
         VZ_ENVIRONMENT_NAME = "default"
 
         DUMP_COMMAND="${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         // used for console artifact capture on failure and for downloading the operator.yaml file
@@ -415,6 +416,7 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                                     dumpK8sCluster('oci-integration-tests-oke-cluster-dump')
+                                    dumpK8sClusterFromBugReport('oci-integration-tests-oke-cluster-dump')
                                 }
                             }
 
@@ -630,6 +632,7 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                                     dumpK8sCluster('oci-integration-tests-kind-cluster-dump')
+                                    dumpK8sClusterFromBugReport('oci-integration-tests-kind-cluster-dump')
                                 }
                             }
 
@@ -645,7 +648,7 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -704,6 +707,14 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -416,7 +416,6 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                                     dumpK8sCluster('oci-integration-tests-oke-cluster-dump')
-                                    dumpK8sClusterFromBugReport('oci-integration-tests-oke-cluster-dump')
                                 }
                             }
 
@@ -632,7 +631,6 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                                     dumpK8sCluster('oci-integration-tests-kind-cluster-dump')
-                                    dumpK8sClusterFromBugReport('oci-integration-tests-kind-cluster-dump')
                                 }
                             }
 
@@ -707,14 +705,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -149,6 +149,7 @@ pipeline {
 
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         // used for console artifact capture on failure
@@ -536,6 +537,7 @@ pipeline {
             script {
                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                     dumpK8sCluster('oke-acceptance-tests-cluster-dump')
+                    dumpK8sClusterFromBugReport('oke-acceptance-tests-cluster-dump')
                 }
             }
 
@@ -544,7 +546,7 @@ pipeline {
             dumpNginxIngressControllerLogs()
             dumpVerrazzanoPlatformOperatorLogs()
 
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/*-cluster-dump/**,**/test-cluster-dumps/**/,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/*-cluster-dump/**,**/bug-report/**,**/test-cluster-dumps/**/,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -630,6 +632,14 @@ def runGinkgoFailFast(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -537,7 +537,6 @@ pipeline {
             script {
                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true || currentBuild.currentResult == 'FAILURE') {
                     dumpK8sCluster('oke-acceptance-tests-cluster-dump')
-                    dumpK8sClusterFromBugReport('oke-acceptance-tests-cluster-dump')
                 }
             }
 
@@ -632,14 +631,9 @@ def runGinkgoFailFast(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${WORKSPACE}/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
         // Used for dumping cluster from inside tests
         DUMP_KUBECONFIG="${KUBECONFIG}"
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dump"
 
         // Ideally use the TIBURON-DEV compartment, but we need permissions
@@ -288,6 +289,7 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                                     dumpK8sCluster('install-success-cluster-dump')
+                                    dumpK8sClusterFromBugReport('install-success-cluster-dump')
                                 }
                             }
                         }
@@ -462,6 +464,7 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('tests-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('tests-failure-cluster-dump')
                         }
                     }
                 }
@@ -469,6 +472,7 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('tests-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('tests-success-cluster-dump')
                         }
                     }
                 }
@@ -503,9 +507,11 @@ pipeline {
                 }
                 failure {
                     dumpK8sCluster('uninstall-failure-cluster-dump')
+                    dumpK8sClusterFromBugReport('uninstall-failure-cluster-dump')
                 }
                 aborted {
                     dumpK8sCluster('uninstall-aborted-cluster-dump')
+                    dumpK8sClusterFromBugReport('uninstall-aborted-cluster-dump')
                 }
             }
         }
@@ -523,11 +529,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('verify-uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-failed-cluster-dump')
+                    dumpK8sClusterFromBugReport('verify-uninstall-failed-cluster-dump')
                 }
             }
         }
@@ -559,7 +567,7 @@ pipeline {
                     dumpVerrazzanoApiLogs()
                 }
             }
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             sh """
@@ -613,6 +621,14 @@ def runGinkgo(testSuitePath, String... extraArgs) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${DUMP_COMMAND} -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -289,7 +289,6 @@ pipeline {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                                     dumpK8sCluster('install-success-cluster-dump')
-                                    dumpK8sClusterFromBugReport('install-success-cluster-dump')
                                 }
                             }
                         }
@@ -464,7 +463,6 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('tests-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('tests-failure-cluster-dump')
                         }
                     }
                 }
@@ -472,7 +470,6 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('tests-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('tests-success-cluster-dump')
                         }
                     }
                 }
@@ -507,11 +504,9 @@ pipeline {
                 }
                 failure {
                     dumpK8sCluster('uninstall-failure-cluster-dump')
-                    dumpK8sClusterFromBugReport('uninstall-failure-cluster-dump')
                 }
                 aborted {
                     dumpK8sCluster('uninstall-aborted-cluster-dump')
-                    dumpK8sClusterFromBugReport('uninstall-aborted-cluster-dump')
                 }
             }
         }
@@ -529,13 +524,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('verify-uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-failed-cluster-dump')
-                    dumpK8sClusterFromBugReport('verify-uninstall-failed-cluster-dump')
                 }
             }
         }
@@ -621,14 +614,9 @@ def runGinkgo(testSuitePath, String... extraArgs) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${DUMP_COMMAND} -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
         TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
         KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         VERRAZZANO_OPERATOR_IMAGE="${params.VERRAZZANO_OPERATOR_IMAGE}"
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
@@ -358,6 +359,7 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -365,6 +367,7 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
+                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -385,7 +388,7 @@ pipeline {
                     dumpVerrazzanoApiLogs()
                 }
             }
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**', allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
 
             sh """
@@ -432,6 +435,14 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -359,7 +359,6 @@ pipeline {
                     script {
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -367,7 +366,6 @@ pipeline {
                     script {
                         if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                             dumpK8sCluster('new-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-acceptance-tests-cluster-dump')
                         }
                     }
                 }
@@ -435,14 +433,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -296,14 +296,12 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-install-cluster-dump')
-                            dumpK8sClusterFromBugReport('verrazzano-install-cluster-dump')
                         }
                     }
                 }
                 failure {
                     script {
                         dumpK8sCluster('verrazzano-install-failure-cluster-dump')
-                        dumpK8sClusterFromBugReport('verrazzano-install-failure-cluster-dump')
                         sh """
                             mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs
                             ${LOOPING_TEST_SCRIPTS_DIR}/dump_resources.sh > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/resources.log
@@ -331,13 +329,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-testrun-after-install-cluster-dump')
-                            dumpK8sClusterFromBugReport('verrazzano-testrun-after-install-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-test-failure-cluster-dump')
-                    dumpK8sClusterFromBugReport('verrazzano-test-failure-cluster-dump')
 
                 }
             }
@@ -365,13 +361,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-uninstall-cluster-dump')
-                            dumpK8sClusterFromBugReport('verrazzano-uninstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-uninstall-failure-cluster-dump')
-                    dumpK8sClusterFromBugReport('verrazzano-uninstall-failure-cluster-dump')
                 }
             }
         }
@@ -390,13 +384,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-cluster-dump')
-                            dumpK8sClusterFromBugReport('verify-uninstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-cluster-dump')
-                    dumpK8sClusterFromBugReport('verify-uninstall-cluster-dump')
                 }
             }
         }
@@ -433,13 +425,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-reinstall-cluster-dump')
-                            dumpK8sClusterFromBugReport('verrazzano-reinstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-reinstall-failure-cluster-dump')
-                    dumpK8sClusterFromBugReport('verrazzano-reinstall-failure-cluster-dump')
                     sh """
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs
                         ${LOOPING_TEST_SCRIPTS_DIR}/dump_resources.sh > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/resources.log
@@ -466,13 +456,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-testrun-after-reinstall-cluster-dump')
-                            dumpK8sClusterFromBugReport('verrazzano-testrun-after-reinstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-test-failure-after-reinstall-cluster-dump')
-                    dumpK8sClusterFromBugReport('verrazzano-test-failure-after-reinstall-cluster-dump')
                 }
             }
         }
@@ -534,14 +522,9 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
         POST_DUMP_FAILED_FILE = "${WORKSPACE}/post_dump_failed_file.tmp"
         KUBECONFIG = "${WORKSPACE}/oke_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
@@ -295,12 +296,14 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-install-cluster-dump')
+                            dumpK8sClusterFromBugReport('verrazzano-install-cluster-dump')
                         }
                     }
                 }
                 failure {
                     script {
                         dumpK8sCluster('verrazzano-install-failure-cluster-dump')
+                        dumpK8sClusterFromBugReport('verrazzano-install-failure-cluster-dump')
                         sh """
                             mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs
                             ${LOOPING_TEST_SCRIPTS_DIR}/dump_resources.sh > ${WORKSPACE}/verrazzano-platform-operator/scripts/install/build/logs/resources.log
@@ -328,11 +331,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-testrun-after-install-cluster-dump')
+                            dumpK8sClusterFromBugReport('verrazzano-testrun-after-install-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-test-failure-cluster-dump')
+                    dumpK8sClusterFromBugReport('verrazzano-test-failure-cluster-dump')
 
                 }
             }
@@ -360,11 +365,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-uninstall-cluster-dump')
+                            dumpK8sClusterFromBugReport('verrazzano-uninstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-uninstall-failure-cluster-dump')
+                    dumpK8sClusterFromBugReport('verrazzano-uninstall-failure-cluster-dump')
                 }
             }
         }
@@ -383,11 +390,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-cluster-dump')
+                            dumpK8sClusterFromBugReport('verify-uninstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-cluster-dump')
+                    dumpK8sClusterFromBugReport('verify-uninstall-cluster-dump')
                 }
             }
         }
@@ -424,11 +433,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-reinstall-cluster-dump')
+                            dumpK8sClusterFromBugReport('verrazzano-reinstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-reinstall-failure-cluster-dump')
+                    dumpK8sClusterFromBugReport('verrazzano-reinstall-failure-cluster-dump')
                     sh """
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs
                         ${LOOPING_TEST_SCRIPTS_DIR}/dump_resources.sh > ${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/resources.log
@@ -455,11 +466,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verrazzano-testrun-after-reinstall-cluster-dump')
+                            dumpK8sClusterFromBugReport('verrazzano-testrun-after-reinstall-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verrazzano-test-failure-after-reinstall-cluster-dump')
+                    dumpK8sClusterFromBugReport('verrazzano-test-failure-after-reinstall-cluster-dump')
                 }
             }
         }
@@ -472,7 +485,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
             script {
                 if (params.EMIT_METRICS) {
@@ -487,7 +500,7 @@ pipeline {
         failure {
             script {
                 METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
-                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump/**', allowEmptyArchive: true
+                archiveArtifacts artifacts: '**/oke_kubeconfig,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump/**,**/bug-report/**', allowEmptyArchive: true
                 script {
                     if (env.JOB_NAME == "verrazzano-uninstall-test/master" || env.JOB_NAME ==~ "verrazzano-uninstall-test/release-*") {
                         slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
@@ -521,6 +534,14 @@ def runGinkgo(testSuitePath) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -325,7 +325,6 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/install-failure-cluster-dump")
-                                dumpK8sClusterFromBugReport("${WORKSPACE}/install-failure-cluster-dump")
                                 INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
                             }
                         }
@@ -424,7 +423,6 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-install-cluster-dump")
                     }
                 }
             }
@@ -455,7 +453,6 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
                     }
                 }
             }
@@ -583,7 +580,6 @@ pipeline {
                                 failure {
                                     script {
                                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
-                                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
                                     }
                                 }
                             }
@@ -611,14 +607,12 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
@@ -626,7 +620,6 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
-                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                         }
                     }
                 }
@@ -646,7 +639,6 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
-                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
                     }
                 }
             }
@@ -1453,14 +1445,12 @@ def dumpK8sCluster(dumpDirectory) {
             parallel verrazzanoDumpK8sClusterStages
         }
     }
-}
 
-def dumpK8sClusterFromBugReport(dumpDirectory) {
     sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
-    """
+                go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+                mkdir bug-report
+                tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        """
 }
 
 def dumpK8sSpecificCluster(count, dumpDirectory) {

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -171,6 +171,7 @@ pipeline {
         ADMIN_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
 
         DUMP_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-dumps"
 
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
@@ -324,6 +325,7 @@ pipeline {
                         failure {
                             script {
                                 dumpK8sCluster("${WORKSPACE}/install-failure-cluster-dump")
+                                dumpK8sClusterFromBugReport("${WORKSPACE}/install-failure-cluster-dump")
                                 INSTALL_METRICS_PUSHED=metricTimerEnd("${VZ_INSTALL_METRIC}", '0')
                             }
                         }
@@ -422,6 +424,7 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-install-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-install-cluster-dump")
                     }
                 }
             }
@@ -452,6 +455,7 @@ pipeline {
                 failure {
                     script {
                         dumpK8sCluster("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-verify-upgrade-cluster-dump")
                     }
                 }
             }
@@ -579,6 +583,7 @@ pipeline {
                                 failure {
                                     script {
                                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
+                                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump-pre-uninstall")
                                     }
                                 }
                             }
@@ -606,12 +611,14 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                     }
                 }
                 aborted {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                     }
                 }
                 success {
@@ -619,6 +626,7 @@ pipeline {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
+                            dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-post-upgrade-acceptance-tests-cluster-dump")
                         }
                     }
                 }
@@ -638,6 +646,7 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         dumpK8sCluster("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
+                        dumpK8sClusterFromBugReport("${WORKSPACE}/multicluster-cleanup-tests-cluster-dump")
                     }
                 }
             }
@@ -654,7 +663,7 @@ pipeline {
                 }
             }
             copyGeneratedTestReports()
-            archiveArtifacts artifacts: "**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/*-operator.yaml,**/install-verrazzano.yaml,**/kube_config,**/coverage.html,**/logs/**,**/build/resources/**,**/verrazzano_images.txt,**/*-cluster-dump*/**,**/bug-report/**,**/test-cluster-dumps/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             script {
@@ -1444,6 +1453,14 @@ def dumpK8sCluster(dumpDirectory) {
             parallel verrazzanoDumpK8sClusterStages
         }
     }
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+    """
 }
 
 def dumpK8sSpecificCluster(count, dumpDirectory) {

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
         TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
         KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
         VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        VZ_COMMAND="${GO_REPO_PATH}/verrazzano/tools/scripts/test-call-vz.sh"
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
@@ -277,6 +278,7 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('pre-upgrade-tests-cluster-dump')
+                                    dumpK8sClusterFromBugReport('pre-upgrade-tests-cluster-dump')
                                 }
                             }
                         }
@@ -284,6 +286,7 @@ pipeline {
                             script {
                                 if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('install-success-cluster-dump')
+                                    dumpK8sClusterFromBugReport('install-success-cluster-dump')
                                 }
                             }
                         }
@@ -326,6 +329,7 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('post-upgrade-vpo-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('post-upgrade-vpo-failure-cluster-dump')
                         }
                     }
                 }
@@ -401,6 +405,7 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('upgrade-failure-cluster-dump')
+                            dumpK8sClusterFromBugReport('upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -422,6 +427,7 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-install-cluster-dump')
+                                    dumpK8sClusterFromBugReport('post-upgrade-install-cluster-dump')
                                 }
                             }
                         }
@@ -500,6 +506,7 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-failure-cluster-dump')
+                                    dumpK8sClusterFromBugReport('post-upgrade-failure-cluster-dump')
                                 }
                             }
                         }
@@ -507,6 +514,7 @@ pipeline {
                             script {
                                 if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-success-cluster-dump')
+                                    dumpK8sClusterFromBugReport('post-upgrade-success-cluster-dump')
                                 }
                             }
                         }
@@ -547,14 +555,17 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('uninstall-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('uninstall-failure-cluster-dump')
+                    dumpK8sClusterFromBugReport('uninstall-failure-cluster-dump')
                 }
                 aborted {
                     dumpK8sCluster('uninstall-aborted-cluster-dump')
+                    dumpK8sClusterFromBugReport('uninstall-aborted-cluster-dump')
                 }
             }
         }
@@ -572,11 +583,13 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-success-cluster-dump')
+                            dumpK8sClusterFromBugReport('verify-uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-failed-cluster-dump')
+                    dumpK8sClusterFromBugReport('verify-uninstall-failed-cluster-dump')
                 }
             }
         }
@@ -601,7 +614,7 @@ pipeline {
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
                 find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
             """
-            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/build/resources/**,**/*-cluster-dump/**,**/${TEST_REPORT}", allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/build/resources/**,**/*-cluster-dump/**,**/bug-report/**,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
 
             script {
@@ -684,6 +697,14 @@ def runGinkgoNamespace(testSuitePath, skipDeploy, skipUndeploy, namespace) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
+    """
+}
+
+def dumpK8sClusterFromBugReport(dumpDirectory) {
+    sh """
+            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+            mkdir bug-report
+            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -278,7 +278,6 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('pre-upgrade-tests-cluster-dump')
-                                    dumpK8sClusterFromBugReport('pre-upgrade-tests-cluster-dump')
                                 }
                             }
                         }
@@ -286,7 +285,6 @@ pipeline {
                             script {
                                 if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('install-success-cluster-dump')
-                                    dumpK8sClusterFromBugReport('install-success-cluster-dump')
                                 }
                             }
                         }
@@ -329,7 +327,6 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('post-upgrade-vpo-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('post-upgrade-vpo-failure-cluster-dump')
                         }
                     }
                 }
@@ -405,7 +402,6 @@ pipeline {
                     script {
                         if (fileExists(env.TESTS_EXECUTED_FILE)) {
                             dumpK8sCluster('upgrade-failure-cluster-dump')
-                            dumpK8sClusterFromBugReport('upgrade-failure-cluster-dump')
                         }
                     }
                 }
@@ -427,7 +423,6 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-install-cluster-dump')
-                                    dumpK8sClusterFromBugReport('post-upgrade-install-cluster-dump')
                                 }
                             }
                         }
@@ -506,7 +501,6 @@ pipeline {
                             script {
                                 if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-failure-cluster-dump')
-                                    dumpK8sClusterFromBugReport('post-upgrade-failure-cluster-dump')
                                 }
                             }
                         }
@@ -514,7 +508,6 @@ pipeline {
                             script {
                                 if (params.DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
                                     dumpK8sCluster('post-upgrade-success-cluster-dump')
-                                    dumpK8sClusterFromBugReport('post-upgrade-success-cluster-dump')
                                 }
                             }
                         }
@@ -555,17 +548,14 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('uninstall-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('uninstall-failure-cluster-dump')
-                    dumpK8sClusterFromBugReport('uninstall-failure-cluster-dump')
                 }
                 aborted {
                     dumpK8sCluster('uninstall-aborted-cluster-dump')
-                    dumpK8sClusterFromBugReport('uninstall-aborted-cluster-dump')
                 }
             }
         }
@@ -583,13 +573,11 @@ pipeline {
                     script {
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                             dumpK8sCluster('verify-uninstall-success-cluster-dump')
-                            dumpK8sClusterFromBugReport('verify-uninstall-success-cluster-dump')
                         }
                     }
                 }
                 failure {
                     dumpK8sCluster('verify-uninstall-failed-cluster-dump')
-                    dumpK8sClusterFromBugReport('verify-uninstall-failed-cluster-dump')
                 }
             }
         }
@@ -697,14 +685,9 @@ def runGinkgoNamespace(testSuitePath, skipDeploy, skipUndeploy, namespace) {
 def dumpK8sCluster(dumpDirectory) {
     sh """
         ${GO_REPO_PATH}/verrazzano/tools/scripts/k8s-dump-cluster.sh -d ${dumpDirectory} -r ${dumpDirectory}/cluster-dump/analysis.report
-    """
-}
-
-def dumpK8sClusterFromBugReport(dumpDirectory) {
-    sh """
-            go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
-            mkdir bug-report
-            tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
+        go run ${GO_REPO_PATH}/verrazzano/tools/vz/main.go bug-report --report-file ${dumpDirectory}/bug-report.tar.gz
+        mkdir bug-report
+        tar -xvf ${dumpDirectory}/bug-report.tar.gz -C bug-report
     """
 }
 


### PR DESCRIPTION
This PR adds the support to generate the bug-report for JenkinsFiles when the tests failed or the flag to dump cluster is enabled. This will fix: VZ-6503.

If there are any dependencies, for example on a PR in another repository, list those.

Summary of changes:
- Changes in JenkinsFile 
- to capture bug-report along with the cluster dump
- to archive the **/bug-report/** artifacts
