### PR TITLE
VZ-6112 Network policy to allow jaeger pods to connect to istiod

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/thirdparty-networkpolicy.yaml
@@ -530,6 +530,12 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchLabels:
+              app: jaeger
     - ports:
         - port: 15017
           protocol: TCP


### PR DESCRIPTION
VZ-6112 Allow Jaeger component pods to communicate to Istiod. `istio-proxy` container running inside the jaeger containers need to communicate with the `istiod` service and fetch the mesh configuration. Due to missing network policy, this was not happening causing the pods to crash.