### PR TITLE
Save generated files in post-success hook of Build Images stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,6 +224,8 @@ pipeline {
                             }
                         }
                         success {
+                            echo "Saving generated files"
+                            saveGeneratedFiles()
                             script {
                                 METRICS_PUSHED=metricTimerEnd("${VZ_BUILD_METRIC}", '1')
                                 archiveArtifacts artifacts: "generated-verrazzano-bom.json,verrazzano_images.txt", allowEmptyArchive: true
@@ -309,24 +311,6 @@ pipeline {
                 success {
                     script {
                         SCAN_IMAGE_PATCH_OPERATOR = true
-                    }
-                }
-            }
-        }
-
-        stage('Save Generated Files') {
-            when {
-                allOf {
-                    not { buildingTag() }
-                }
-            }
-            steps {
-                saveGeneratedFiles()
-            }
-            post {
-                failure {
-                    script {
-                        SKIP_TRIGGERED_TESTS = true
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ pipeline {
                     }
                 }
 
-                stage('Build Images') {
+                stage('Build Images and Save Generated Files') {
                     when { not { buildingTag() } }
                     steps {
                         script {


### PR DESCRIPTION
Move save-generated files step to success hook in `Build Images` stage, so that it is always created on a successful image build.  Right now if any of the parallel stages fails it won't push the operator manifests to ObjectStore.