### PR TITLE
Ignore new advice doc that is not in all lines, until we make them be…

### DIFF
--- a/tools/url_linter/ignore_urls.txt
+++ b/tools/url_linter/ignore_urls.txt
@@ -70,3 +70,6 @@ http://mozilla.org/MPL/2.0/
 http://www.iana.org/assignments/service-names
 
 https://oracle.github.io/coherence-operator/charts
+
+# Until we have the advice versioned, ignore new advice not in all releases
+https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape

--- a/tools/url_linter/ignore_urls.txt
+++ b/tools/url_linter/ignore_urls.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2021, Oracle and/or its affiliates.
+# Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Test, example, in-cluster URLs, etc...


### PR DESCRIPTION
… versioned

The advice documentation links are not versioned and point at latest. Saidu will be updating these in his work in VZ-6280 that he is just starting on. 

But the master build just hit a failure where an advice page was not seen in the "latest" docs which highlighted that a new page which is not in a release yet needs to be ignored until we get to that work. This is ignoring seeing this as a dead url, when we have a release which includes it we can remove this.

I don't know why this was not failing all of the time, the only place I think the new advice is at currently is in docs-stage, v1.3 and earlier did not have it (ie: current releases don't have it yet)
