### PR TITLE
VZ-6385: VZ-6378: update keycloak-oracle-theme image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -416,7 +416,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "1.3.0-20220510114742-dc513a7"
+              "tag": "1.4.0-20220721182006-bd71eb4"
             }
           ]
         }


### PR DESCRIPTION
Update keycloak-oracle-theme image built against updated Oracle linux base image.