### PR TITLE
VZ 6411: HA Monitors Setup

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -269,17 +269,27 @@ pipeline {
                     }
                 }
 
-                stage('Rolling Update') {
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/rollingupdate"
-                    }
-                    steps {
-                        runGinkgoRandomize('ha/rollingupdate')
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-dumps/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                stage('Parallel HA Tests and Rolling Update') {
+                    parallel {
+                        stage('Rolling Update') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/rollingupdate"
+                            }
+                            steps {
+                                runGinkgoRandomize('ha/rollingupdate')
+                            }
+                            post {
+                                always {
+                                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-dumps/**', allowEmptyArchive: true
+                                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                                }
+                            }
+                        }
+
+                        stage('HA Tests') {
+                            steps {
+                                runGinkgoRandomize('ha/monitor')
+                            }
                         }
                     }
                 }

--- a/tests/e2e/ha/monitor/authproxy_ha_test.go
+++ b/tests/e2e/ha/monitor/authproxy_ha_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package monitor
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"time"
+)
+
+var _ = t.Describe("AuthProxy HA Monitoring", Label("f:platform-lcm:ha"), func() {
+	RunningUntilShutdownIt("verifies AuthProxy is ready and running", func() {
+		t.Logs.Info("running authproxy tests!")
+		time.Sleep(5 * time.Second)
+	})
+})

--- a/tests/e2e/ha/monitor/monitor_suite_test.go
+++ b/tests/e2e/ha/monitor/monitor_suite_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package monitor
+
+import (
+	"flag"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/ha"
+	"testing"
+)
+
+var runContinuous bool
+var clientset = k8sutil.GetKubernetesClientsetOrDie()
+var t = framework.NewTestFramework("monitor")
+
+func init() {
+	flag.BoolVar(&runContinuous, "runContinuous", true, "run monitors continuously if set")
+}
+
+func TestHAMonitor(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "HA Monitoring Suite")
+}
+
+func RunningUntilShutdownIt(description string, test func()) {
+	t.It(description, func() {
+		for {
+			test()
+			// break out of the loop if we are not running the suite continuously,
+			// or the shutdown signal is set
+			if !runContinuous || ha.IsShutdownSignalSet(clientset) {
+				t.Logs.Info("Shutting down...")
+				break
+			}
+		}
+	})
+}

--- a/tests/e2e/ha/monitor/prometheus_ha_test.go
+++ b/tests/e2e/ha/monitor/prometheus_ha_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package monitor
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"time"
+)
+
+var _ = t.Describe("Prometheus HA Monitoring", Label("f:platform-lcm:ha"), func() {
+	RunningUntilShutdownIt("verifies Prometheus is ready and running", func() {
+		t.Logs.Info("running prometheus tests!")
+		time.Sleep(5 * time.Second)
+	})
+})

--- a/tests/e2e/ha/rollingupdate/rolling_update_test.go
+++ b/tests/e2e/ha/rollingupdate/rolling_update_test.go
@@ -36,6 +36,8 @@ var _ = t.Describe("Rolling Update", Label("f:platform-lcm:ha"), func() {
 			eventuallyPodsReady(clientset)
 			t.Logs.Infof("Finished rolling update from node[%s] to node[%s]", node.Name, unschedulableNode.Name)
 		}
+		// Create shutdown signal once rolling update is done
+		ha.EventuallyCreateShutdownSignal(clientset, t.Logs)
 	})
 })
 

--- a/tests/e2e/ha/signal.go
+++ b/tests/e2e/ha/signal.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ha
+
+import (
+	"context"
+	"github.com/onsi/gomega"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	shutdownSignalName      = "ha-shutdown-signal"
+	shutdownSignalNamespace = "default"
+)
+
+func EventuallyCreateShutdownSignal(cs *kubernetes.Clientset, log *zap.SugaredLogger) {
+	gomega.Eventually(func() bool {
+		shutdownSignal := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: shutdownSignalNamespace,
+				Name:      shutdownSignalName,
+			},
+		}
+		if _, err := cs.CoreV1().Secrets(shutdownSignalNamespace).Create(context.TODO(), shutdownSignal, metav1.CreateOptions{}); err != nil {
+			log.Errorf("Failed to create shutdown signal: %v", err)
+			return false
+		}
+		return true
+	}).Should(gomega.BeTrue())
+	log.Infof("Created shutdown signal %s", shutdownSignalName)
+}
+
+func IsShutdownSignalSet(cs *kubernetes.Clientset) bool {
+	_, err := cs.CoreV1().Secrets(shutdownSignalNamespace).Get(context.TODO(), shutdownSignalName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	return true
+
+}


### PR DESCRIPTION
Setup pipeline to concurrently run HA monitor tests while rolling upgrade is occurring.
HA component tests will continuously run while the rolling upgrade occurs. Once the rolling upgrade is done, it broadcasts a signal to the component tests, which finish on the next test cycle.