### PR TITLE
Fixed the Jaeger index prefix used in OpenSearch

### DIFF
--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
@@ -110,7 +110,7 @@ const jaegerValueTemplate = `jaeger:
       options:
         es:
           server-urls: {{.OpenSearchURL}}
-          index-prefix: verrazzano-jaeger
+          index-prefix: verrazzano
       secretName: {{.SecretName}}
 `
 

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideValues.yaml
@@ -37,5 +37,5 @@ jaeger:
       options:
         es:
           server-urls: "http://verrazzano-authproxy-elasticsearch.verrazzano-system.svc.cluster.local:8775"
-          index-prefix: verrazzano-jaeger
+          index-prefix: verrazzano
       secretName: "verrazzano-jaeger-secret"


### PR DESCRIPTION
Demo commands to avoid duplicated jaeger name in the index name.
