### PR TITLE
NO JIRA: Bump upgrade wait timeout from 30m to 45m

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -383,7 +383,7 @@ pipeline {
                         kubectl apply -f ${WORKSPACE}/verrazzano-upgrade-cr.yaml
 
                         # A successful completion of the upgrade means the Keycloak configuration was successfully rebuilt
-                        kubectl wait --timeout=30m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                        kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                         # Kill MySQL and wait for Keycloak to be healthy again
                         ${GO_REPO_PATH}/verrazzano/ci/scripts/chaos_test_ephemeral_storage.sh
@@ -527,7 +527,7 @@ pipeline {
                     if [[ "uninstall.failed.upgrade" != ${params.CHAOS_TEST_TYPE} ]]
                     then
                         # wait for the upgrade to complete
-                        kubectl wait --timeout=30m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                        kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                         # Dump the resource to debug
                         kubectl get -o yaml verrazzano/my-verrazzano || true

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -920,7 +920,7 @@ def upgradeVerrazzano() {
                 cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
                 # wait for the upgrade to complete
-                kubectl wait --timeout=30m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                 # Get the install job(s) and mke sure the it matches pre-install.  If there is more than 1 job or the job changed, then it won't match
                 kubectl -n verrazzano-install get job -o yaml --selector=job-name=verrazzano-install-my-verrazzano > ${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-post-upgrade-job.out

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -374,7 +374,7 @@ pipeline {
                     kubectl apply -f ${UPGRADE_CR}
 
                     # wait for the upgrade to complete
-                    kubectl wait --timeout=30m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                    kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
 
                     # Dump the resource to debug
                     kubectl get -o yaml verrazzano/my-verrazzano || true


### PR DESCRIPTION
In the MC test pipelines, the Verrazzano upgrade is taking a few minutes longer and sometimes goes over the configured 30m wait timeout, which causes the test pipeline to fail. This PR bumps the upgrade wait timeout to 45m.