### PR TITLE
NO JIRA: Uptake Rancher 2.6.6

### DIFF
--- a/platform-operator/thirdparty/charts/rancher/Chart.yaml
+++ b/platform-operator/thirdparty/charts/rancher/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
-version: 2.6.5
-appVersion: v2.6.5
+version: 2.6.6
+appVersion: v2.6.6
 kubeVersion: < 1.24.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.5-20220714005945-ef6dc5264",
+              "tag": "v2.6.6-20220720145845-9376298c4",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.5-20220714005945-ef6dc5264"
+              "tag": "v2.6.6-20220720145845-9376298c4"
             }
           ]
         },


### PR DESCRIPTION
This was already reviewed and merged, but reverted due to test failures. Now that the timeout for the Verrazzano upgrade has been increased, resubmitting this change.