### PR TITLE
VZ-6530: Uptake latest build of OS Dashboards image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -246,7 +246,7 @@
             },
             {
               "image": "opensearch-dashboards",
-              "tag": "1.2.0-20220301201035-be0efd47ab",
+              "tag": "1.2.0-20220721221818-c206c8b25f",
               "helmFullImageKey": "monitoringOperator.kibanaImage"
             },
             {


### PR DESCRIPTION
Cherry pick the commit from "VZ-6339: Uptake latest build of OS Dashboards image" to backport OSD image upgrade to release-1.3 branch.

