### PR TITLE
VZ-6504/VZ-6506 Uptake new version of Rancher v2.6.6 with updates

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -125,13 +125,13 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.6-20220720145845-9376298c4",
+              "tag": "v2.6.6-20220722140326-0029c0a73",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.6-20220720145845-9376298c4"
+              "tag": "v2.6.6-20220722140326-0029c0a73"
             }
           ]
         },


### PR DESCRIPTION
For VZ-6504 and VZ-6506, updates to Rancher 2.6.6