### PR TITLE
Set default OKE version to v1.21.5 in release-1.2 build pipeline

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.20.8", "v1.18.10", "v1.19.7", "v1.19.12" ])
+                choices: [ "v1.21.5", "v1.20.8", "v1.18.10", "v1.19.7", "v1.19.12" ])
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             choices: [ "VM.Standard2.4-2", "VM.Standard.E3.Flex-8-2", "VM.Standard.E2.2" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
             // 1st choice is the default value
-            choices: [ "v1.20.8", "1.18.10", "v1.19.7", "v1.19.12" ])
+            choices: [ "v1.21.5", "v1.20.8", "v1.19.7", "v1.19.12" ])
         choice (description: 'Kubernetes Version for KinD Cluster',
             name: 'KIND_CLUSTER_VERSION',
             // 1st choice is the default value

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
             choices: [ "GLOBAL","PRIVATE" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.20.8", "1.18.10", "v1.19.7", "v1.19.12" ])
+                choices: [ "v1.21.5", "v1.20.8", "v1.19.7", "v1.19.12" ])
         choice (description: 'Certificate Issuer', name: 'CERT_ISSUER',
                 choices: certIssuers)
         choice (description: 'ACME Certificate Environment (Staging or Production)', name: 'ACME_ENVIRONMENT',

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.20.8", "v1.18.10", "v1.19.7", "v1.19.12" ])
+                choices: [ "v1.21.5", "v1.20.8", "v1.19.7", "v1.19.12" ])
         booleanParam (name: 'DUMP_K8S_CLUSTER_ON_SUCCESS',
                       defaultValue: false,
                       description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)')


### PR DESCRIPTION
Sets default OKE version to v1.21.5 in release-1.2 build pipeline
