### PR TITLE
VZ-6351.  Fixes for uninstall resiliency pipelines

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -133,7 +133,7 @@ pipeline {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
-                                    string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
                                     string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
@@ -150,7 +150,7 @@ pipeline {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
-                                    string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'INSTALL_LOOP_COUNT', value: "1"),
                                     string(name: 'INSTALL_PROFILE', value: "prod"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
@@ -169,7 +169,7 @@ pipeline {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
-                                    string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'INSTALL_LOOP_COUNT', value: "3"),
                                     string(name: 'INSTALL_PROFILE', value: "dev"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
@@ -188,7 +188,7 @@ pipeline {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
-                                    string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     string(name: 'INSTALL_LOOP_COUNT', value: "3"),
                                     string(name: 'INSTALL_PROFILE', value: "managed-cluster"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -23,7 +23,7 @@ pipeline {
     }
 
     parameters {
-        choice (name: 'UNINSTALL_CHAOS_TEST_TYPE',
+        choice (name: 'CHAOS_TEST_TYPE',
                 description: 'Type of chaos to inflict',
                 // 1st choice is the default value
                 choices: [ "uninstall.interrupt.uninstall", "uninstall.reinstall.loop" ])
@@ -100,12 +100,10 @@ pipeline {
         INSTALL_CONFIG_FILE_KIND_PERSISTENCE = "./tests/e2e/config/scripts/install-verrazzano-kind-with-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND_EPHEMERAL = "./tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml"
         INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-verrazzano-kind-no-persistence.yaml"
-        INSTALL_PROFILE = "dev"
+
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
         LOOPING_TEST_SCRIPTS_DIR = "${TEST_SCRIPTS_DIR}/looping-test"
-        // needed for prepare at shell script
-        //VERRAZZANO_OPERATOR_IMAGE="NONE"
 
         // Location to store Platform Operator manifest
         TARGET_OPERATOR_FILE="${WORKSPACE}/acceptance-test-operator.yaml"
@@ -121,19 +119,19 @@ pipeline {
         APP_NAMEPACES="'todo-list bobs-books hello-helidon springboot sockshop'"
 
         // used to emit metrics
-         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
-         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
-         TEST_ENV_LABEL = "kind"
-         K8S_VERSION_LABEL = "${params.KUBERNETES_CLUSTER_VERSION}"
-         TEST_ENV = "KIND"
-         SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
-         SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
-         SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
+        PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
+        PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
+        TEST_ENV_LABEL = "kind"
+        K8S_VERSION_LABEL = "${params.KUBERNETES_CLUSTER_VERSION}"
+        TEST_ENV = "KIND"
+        SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
+        SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
+        SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
 
-         // used to generate Ginkgo test reports
-         TEST_REPORT = "test-report.xml"
-         GINKGO_REPORT_ARGS = "--junit-report=${TEST_REPORT} --keep-separate-reports=true"
-         TEST_REPORT_DIR = "${WORKSPACE}/tests/e2e"
+        // used to generate Ginkgo test reports
+        TEST_REPORT = "test-report.xml"
+        GINKGO_REPORT_ARGS = "--junit-report=${TEST_REPORT} --keep-separate-reports=true"
+        TEST_REPORT_DIR = "${WORKSPACE}/tests/e2e"
     }
 
     stages {
@@ -234,8 +232,10 @@ pipeline {
                         runInstallStage(count)
                         runTestStage("Run Test", count)
                         runUninstall(count)
-                        //runReInstall(count)
-                        //runTestStage("Rerun Test", count)
+                        if (params.CHAOS_TEST_TYPE == "uninstall.interrupt.uninstall") {
+                            runReInstall(count)
+                            runTestStage("Rerun Test", count)
+                        }
                     }
 		        }
 		    }
@@ -364,9 +364,6 @@ def runReInstall(iteration) {
 
 def runTestStage(stageName, iteration) {
     stage("${stageName} - ${iteration}") {
-        //when {
-        //    expression {params.UNINSTALL_CHAOS_TEST_TYPE != "install.interrupt.uninstall"}
-        //}
         try {
             parallel generateVerifyInfraStages()
             if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
@@ -415,14 +412,19 @@ def vzUninstall(iteration) {
 }
 
 def getUninstallStages(vpoLogsDir) {
-    return [
+    stages = [
          "uninstall-verrazzano": {
                 uninstallVerrazzano(vpoLogsDir)
              },
-         "uninstall-chaos": {
-                kill_vpo_loop(vpoLogsDir)
-             },
-     ]
+    ]
+    if (params.CHAOS_TEST_TYPE == "uninstall.interrupt.uninstall") {
+        stages = stages + [
+             "uninstall-chaos": {
+                    kill_vpo_loop(vpoLogsDir)
+                 },
+        ]
+    }
+    return stages
 }
 
 def uninstallVerrazzano(vpoLogsDir) {
@@ -453,20 +455,18 @@ def uninstallVerrazzano(vpoLogsDir) {
 
 def kill_vpo_loop(vpoLogsDir) {
     script {
-        if (params.UNINSTALL_CHAOS_TEST_TYPE == "uninstall.interrupt.uninstall") {
-            echo "Wait 15 seconds before kill loop"
-            sleep 15
-            for (int count = 1; count <= 2; count++) {
-                sh """
-                    POD=\$(kubectl get pod -l app=verrazzano-platform-operator -n verrazzano-install -o jsonpath="{.items[0].metadata.name}")
-                    mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-                    kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${vpoLogsDir}/verrazzano-platform-operator-before-vpo-killed-pod-${count}.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
-                    kubectl -n verrazzano-install delete po \$POD
-                    POD=\$(kubectl get pod -l app=verrazzano-platform-operator -n verrazzano-install -o jsonpath="{.items[0].metadata.name}")
-                    kubectl -n verrazzano-install wait --for=condition=ready --timeout=600s pod/\$POD
-                    echo "VPO \$POD successfully restarted"
-                """
-            }
+        echo "Wait 15 seconds before kill loop"
+        sleep 15
+        for (int count = 1; count <= 2; count++) {
+            sh """
+                POD=\$(kubectl get pod -l app=verrazzano-platform-operator -n verrazzano-install -o jsonpath="{.items[0].metadata.name}")
+                mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
+                kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${vpoLogsDir}/verrazzano-platform-operator-before-vpo-killed-pod-${count}.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
+                kubectl -n verrazzano-install delete po \$POD
+                POD=\$(kubectl get pod -l app=verrazzano-platform-operator -n verrazzano-install -o jsonpath="{.items[0].metadata.name}")
+                kubectl -n verrazzano-install wait --for=condition=ready --timeout=600s pod/\$POD
+                echo "VPO \$POD successfully restarted"
+            """
         }
     }
 }


### PR DESCRIPTION
- Fix git commit arg in suite pipeline
- Fix CHAOS_TEST_TYPE param in suite pipeline
- Remove redundant env var definitions
- Add back in re-install stages for uninstall.interrupt chaos test
- Move chaos test conditional to stage builder
- Remove some cruft
