### PR TITLE
VZ-6499: Update BOM images for 1.3.3 version update

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -197,7 +197,7 @@
             },
             {
               "image": "console",
-              "tag": "1.3.2-20220621221812-89399a3",
+              "tag": "1.3.3-20220725125103-4776062",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "1.3.2-20220621221617-8c10419",
+              "tag": "1.3.3-20220725124917-d42202b",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Updates the BOM image versions for Console and VMO for version 1.3.3.

Contributes to VZ-6499
