### PR TITLE
VZ-6352.  Uninstall loop resiliency tests.

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -395,7 +395,7 @@ def metricBuildDuration() {
 
 def getCronSchedule() {
     if (env.BRANCH_NAME.equals("master")) {
-        return "H */2 * * *"
+        return "H */12 * * *"
     } else if (env.BRANCH_NAME.startsWith("release-1")) {
         return "@daily"
     }

--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -151,7 +151,7 @@ pipeline {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'INSTALL_LOOP_COUNT', value: "1"),
+                                    string(name: 'INSTALL_LOOP_COUNT', value: "5"),
                                     string(name: 'INSTALL_PROFILE', value: "prod"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
@@ -164,13 +164,13 @@ pipeline {
                         }
                     }
                 }
-                /*stage('Install Loop - Dev') {
+                stage('Install Loop - Dev') {
                     steps {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'INSTALL_LOOP_COUNT', value: "3"),
+                                    string(name: 'INSTALL_LOOP_COUNT', value: "5"),
                                     string(name: 'INSTALL_PROFILE', value: "dev"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
@@ -183,13 +183,13 @@ pipeline {
                         }
                     }
                 }
-                stage('Install Loop - Managed Cluster') {
+                /*stage('Install Loop - Managed Cluster') {
                     steps {
                         script {
                             build job: "/verrazzano-uninstall-resiliency-test/${CLEAN_BRANCH_NAME}",
                                 parameters: [
                                     string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'INSTALL_LOOP_COUNT', value: "3"),
+                                    string(name: 'INSTALL_LOOP_COUNT', value: "5"),
                                     string(name: 'INSTALL_PROFILE', value: "managed-cluster"),
                                     string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                     string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -229,14 +229,20 @@ pipeline {
 		    }
 		    steps {
 		        script {
-		            int loopMax = params.INSTALL_LOOP_COUNT.toInteger()
-                    for (int count = 1; count <= loopMax; count++) {
-                        runInstallStage(count)
-                        runTestStage("Run Test", count)
+                    for (int count = 1; count <= getMaxIterations(); count++) {
+                        if (count == 1) {
+                            // Create cluster and install
+                            runInitialInstall(count)
+                        } else {
+                            // Run just the install again
+                            runInstallOnly(count)
+                        }
+                        runVerifyTests("Run Test", count)
                         runUninstall(count)
                         if (params.CHAOS_TEST_TYPE == "uninstall.interrupt.uninstall") {
-                            runReInstall(count)
-                            runTestStage("Rerun Test", count)
+                            // Run re-install once and re-verify
+                            runInstallOnly(count)
+                            runVerifyTests("Rerun Test", count)
                         }
                     }
 		        }
@@ -268,8 +274,17 @@ pipeline {
     }
 }
 
-def runInstallStage(iteration) {
-    stage("Install Verrazzano - ${iteration}") {
+def getMaxIterations() {
+    int maxIterations = 1
+    if (params.CHAOS_TEST_TYPE == "uninstall.reinstall.loop") {
+        maxIterations = params.INSTALL_LOOP_COUNT.toInteger()
+        echo "Max loop count: $maxIterations"
+    }
+    return maxIterations
+}
+
+def runInitialInstall(iteration) {
+    stage("Install Verrazzano #${iteration}") {
         env.CLUSTER_DUMP_DIR="${WORKSPACE}/verrazzano/build/resources-${iteration}/pre-install-resources"
         try {
             script {
@@ -290,7 +305,7 @@ def runInstallStage(iteration) {
 }
 
 def runUninstall(iteration) {
-    stage("Uninstall Verrazzano - ${iteration}") {
+    stage("Uninstall Verrazzano #${iteration}") {
         try {
             vzUninstall(iteration)
             if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
@@ -305,7 +320,7 @@ def runUninstall(iteration) {
             listHelmReleases('after Verrazzano uninstall')
         }
     }
-    stage("Verify Uninstall - ${iteration}") {
+    stage("Verify Uninstall #${iteration}") {
         try {
             sh """
                 ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources-${iteration}/post-uninstall-resources false
@@ -321,8 +336,8 @@ def runUninstall(iteration) {
     }
 }
 
-def runReInstall(iteration) {
-    stage("Reinstall Verrazzano - ${iteration}") {
+def runInstallOnly(iteration) {
+    stage("Install Verrazzano #${iteration}") {
         def vpoLogsDir = "${WORKSPACE}/verrazzano-platform-operator/scripts/reinstall/build/logs/${iteration}"
         echo "Platform operator reinstall logs dir: ${vpoLogsDir}"
         try {
@@ -352,8 +367,8 @@ def runReInstall(iteration) {
     }
 }
 
-def runTestStage(stageName, iteration) {
-    stage("${stageName} - ${iteration}") {
+def runVerifyTests(stageName, iteration) {
+    stage("${stageName} #${iteration}") {
         try {
             parallel generateVerifyInfraStages()
             if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
@@ -391,7 +406,7 @@ def generateVerifyInfraStages() {
 
 // vzUninstall - Start parallel uninstall and chaos stages
 def vzUninstall(iteration) {
-    stage("Uninstall - ${iteration}") {
+    stage("Uninstall #${iteration}") {
         script {
             def vpoLogsDir = "${WORKSPACE}/verrazzano-platform-operator/logs/${iteration}"
             echo "Platform operator uninstall logs dir: ${vpoLogsDir}"

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -304,7 +304,7 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 }
 
 func (r *Reconciler) runRancherPostInstall(ctx spi.ComponentContext) error {
-	// Look up the rancher component and call PostUninstall expliclity, without checking if it's installed;
+	// Look up the Rancher component and call PostUninstall expliclity, without checking if it's installed;
 	// this is to catch any lingering managed cluster resources
 	if found, comp := registry.FindComponent(rancher.ComponentName); found {
 		return comp.PostUninstall(ctx.Init(rancher.ComponentName).Operation(vzconst.UninstallOperation))

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -293,7 +293,9 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 		return ctrl.Result{}, err
 	}
 
-	// Run Rancher Post Uninstall to delete the Rancher resources on the managed cluster
+	// Run Rancher Post Uninstall explicilty to delete any remaining Rancher resources; this may be needed in case
+	// the uninstall was interrupted during uninstall, or if the cluster is a managed cluster where Rancher is not
+	// installed explicilty.
 	if err := r.runRancherPostInstall(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -302,6 +304,8 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 }
 
 func (r *Reconciler) runRancherPostInstall(ctx spi.ComponentContext) error {
+	// Look up the rancher component and call PostUninstall expliclity, without checking if it's installed;
+	// this is to catch any lingering managed cluster resources
 	if found, comp := registry.FindComponent(rancher.ComponentName); found {
 		return comp.PostUninstall(ctx.Init(rancher.ComponentName).Operation(vzconst.UninstallOperation))
 	}


### PR DESCRIPTION
Enable uninstall looping resiliency tests.  Suite will periodically invoke new uninstall resiliency pipeline to run 
- Chaos tests (interrupt uninstall)
- Prod re-install loop, 5 iterations
- Dev re-install loop, 5 iterations
- Run suite every 12 hours in master, daily in older release lines

Change details
- Set max iterations based on param if looping test
- Enable looping tests from suite, dev x 5, prod x 5
- Clean up stage names and install func name
- Add some comments to the global rancher uninstall hooks
