### PR TITLE
VZ-6532.  Fix Rancher uninstall resiliency issues

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -28,7 +28,9 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "uninstall.interrupt.uninstall", "uninstall.reinstall.loop" ])
 
-        string (description: 'Install loop count', name: 'INSTALL_LOOP_COUNT', defaultValue: "1")
+        string (name: 'INSTALL_LOOP_COUNT',
+                description: 'Install loop count, valid for test type uninstall.reinstall.loop only',
+                defaultValue: "1")
 
         choice (name: 'INSTALL_PROFILE',
                 description: 'Verrazzano install profile name',
@@ -279,7 +281,7 @@ def runInstallStage(iteration) {
                 """
             }
         } finally {
-            dumpVerrazzanoPlatformOperatorLogs("post-install")
+            dumpPodsAndLogs("post-install-${iteration}")
             VZ_TEST_METRIC = metricJobName('')
             metricTimerStart("${VZ_TEST_METRIC}")
             archiveArtifacts artifacts: "**/logs/**,${env.INSTALL_CONFIG_FILE_KIND}", allowEmptyArchive: true
@@ -298,13 +300,7 @@ def runUninstall(iteration) {
             dumpK8sCluster("verrazzano-uninstall-failure-cluster-dump-${iteration}")
             throw err
         } finally {
-            sh """
-                ## dump out VPO logs
-                kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-post-uninstall-${iteration}.log
-                echo "Listing all pods in all namespaces after uninstall"
-                kubectl get pods --all-namespaces
-                echo "-----------------------------------------------------"
-            """
+            dumpPodsAndLogs("post-uninstall-${iteration}")
             listNamespacesAndPods('after Verrazzano uninstall')
             listHelmReleases('after Verrazzano uninstall')
         }
@@ -349,13 +345,7 @@ def runReInstall(iteration) {
             """
             throw err
         } finally {
-            dumpVerrazzanoSystemPods('reinstall')
-            dumpCattleSystemPods('reinstall')
-            dumpNginxIngressControllerLogs('reinstall')
-            dumpVerrazzanoPlatformOperatorLogs('reinstall')
-            dumpVerrazzanoApplicationOperatorLogs('reinstall')
-            dumpOamKubernetesRuntimeLogs('reinstall')
-            dumpVerrazzanoApiLogs('reinstall')
+            dumpPodsAndLogs("reinstall-${iteration}")
             listNamespacesAndPods('after reinstalling Verrazzano')
             listHelmReleases('after reinstalling Verrazzano')
         }
@@ -455,6 +445,7 @@ def uninstallVerrazzano(vpoLogsDir) {
 
 def kill_vpo_loop(vpoLogsDir) {
     script {
+        // Future enhancement, possibly use a random number within a range of 10-30 secs of something
         echo "Wait 15 seconds before kill loop"
         sleep 15
         for (int count = 1; count <= 2; count++) {
@@ -492,12 +483,7 @@ def runGinkgoRandomize(testSuitePath) {
 def runnerCleanup() {
     script {
         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
-            dumpVerrazzanoSystemPods()
-            dumpCattleSystemPods()
-            dumpNginxIngressControllerLogs()
-            dumpVerrazzanoApplicationOperatorLogs()
-            dumpOamKubernetesRuntimeLogs()
-            dumpVerrazzanoApiLogs()
+            dumpPodsAndLogs("runnerCleanup")
         }
     }
 
@@ -523,7 +509,6 @@ def runnerCleanup() {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
         make delete-cluster
-        cd ${WORKSPACE}/verrazzano
         if [ -f ${POST_DUMP_FAILED_FILE} ]; then
           echo "Failures seen during dumping of artifacts, treat post as failed"
           exit 1
@@ -537,77 +522,102 @@ def dumpK8sCluster(dumpDirectory) {
     """
 }
 
-def dumpVerrazzanoSystemPods() {
+def dumpPodsAndLogs(stage) {
+    def dumpPath="${WORKSPACE}/verrazzano/logs/${stage}"
+    dumpVerrazzanoSystemPods(dumpPath)
+    dumpCattleSystemPods(dumpPath)
+    dumpNginxIngressControllerLogs(dumpPath)
+    dumpVerrazzanoPlatformOperatorLogs(dumpPath)
+    dumpVerrazzanoApplicationOperatorLogs(dumpPath)
+    dumpOamKubernetesRuntimeLogs(dumpPath)
+    dumpVerrazzanoApiLogs(dumpPath)
+}
+
+def dumpVerrazzanoSystemPods(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-pods.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/verrazzano-system-pods.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -m "verrazzano system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-certs.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/verrazzano-system-certs.log"
         ./scripts/install/k8s-dump-objects.sh -o cert -n verrazzano-system -m "verrazzano system certs" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-kibana.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/verrazzano-system-kibana.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-kibana-*" -m "verrazzano system kibana log" -l -c kibana || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-system-es-master.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/verrazzano-system-es-master.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-es-master-*" -m "verrazzano system kibana log" -l -c es-master || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
 
-def dumpCattleSystemPods() {
+def dumpCattleSystemPods(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/cattle-system-pods.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/cattle-system-pods.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -m "cattle system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/rancher.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/rancher.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -r "rancher-*" -m "Rancher logs" -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
 
-def dumpNginxIngressControllerLogs() {
+def dumpNginxIngressControllerLogs(dumpPath) {
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/nginx-ingress-controller.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/nginx-ingress-controller.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n ingress-nginx -r "nginx-ingress-controller-*" -m "Nginx Ingress Controller" -c controller -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
     """
 }
 
-def dumpVerrazzanoPlatformOperatorLogs(stage) {
+def dumpVerrazzanoPlatformOperatorLogs(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         ## dump out verrazzano-platform-operator logs
-        mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-        kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-${stage}-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${dumpPath}/verrazzano-platform-operator-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${dumpPath}/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "------------------------------------------"
     """
 }
 
-def dumpVerrazzanoApplicationOperatorLogs() {
+def dumpVerrazzanoApplicationOperatorLogs(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         ## dump out verrazzano-application-operator logs
-        mkdir -p ${WORKSPACE}/verrazzano-application-operator/logs
-        kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator --tail -1 > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator --tail -1 > ${dumpPath}/verrazzano-application-operator-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${dumpPath}/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
         echo "verrazzano-application-operator logs dumped to verrazzano-application-operator-pod.log"
         echo "verrazzano-application-operator pod description dumped to verrazzano-application-operator-pod.out"
         echo "------------------------------------------"
     """
 }
 
-def dumpOamKubernetesRuntimeLogs() {
+def dumpOamKubernetesRuntimeLogs(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         ## dump out oam-kubernetes-runtime logs
-        mkdir -p ${WORKSPACE}/oam-kubernetes-runtime/logs
-        kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime --tail -1 > ${WORKSPACE}/oam-kubernetes-runtime/logs/oam-kubernetes-runtime-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/verrazzano-application-operator/logs/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
-        echo "verrazzano-application-operator logs dumped to oam-kubernetes-runtime-pod.log"
-        echo "verrazzano-application-operator pod description dumped to oam-kubernetes-runtime-pod.out"
+        kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime --tail -1 > ${dumpPath}/oam-kubernetes-runtime-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${dumpPath}/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+        echo "oam-kubernetes-runtime logs dumped to oam-kubernetes-runtime-pod.log"
+        echo "oam-kubernetes-runtime pod description dumped to oam-kubernetes-runtime-pod.out"
         echo "------------------------------------------"
     """
 }
 
-def dumpVerrazzanoApiLogs() {
+def dumpVerrazzanoApiLogs(dumpPath) {
+    createPathIfNecessary(dumpPath)
     sh """
         cd ${GO_REPO_PATH}/verrazzano/platform-operator
-        export DIAGNOSTIC_LOG="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs/verrazzano-authproxy.log"
+        export DIAGNOSTIC_LOG="${dumpPath}/verrazzano-authproxy.log"
         ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-authproxy-*" -m "verrazzano api" -c verrazzano-authproxy -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
+    """
+}
+
+def createPathIfNecessary(pathName) {
+    sh """
+        if [ ! -e ${pathName} ]; then
+            echo "Creating ${pathName}"
+            mkdir -p ${pathName}
+        else
+            echo "Dump path ${pathName} exists"
+        fi
     """
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -321,7 +321,8 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client, vz *vzapi.V
 
 	password, err := common.GetAdminSecret(c)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher admin secret: %s", err.Error())
+		log.Oncef("Skipping Rancher delete local cluster, unable to obtain admin secret: %s", err.Error())
+		return nil
 	}
 	if len(password) == 0 {
 		log.Oncef("Skipping Rancher delete local host because Rancher admin password is missing")
@@ -329,7 +330,8 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client, vz *vzapi.V
 	}
 	rancherHostName, err := getRancherHostname(c, vz)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting Rancher hostname: %s", err.Error())
+		log.Oncef("Skipping Rancher delete local cluster, unable to obtain Rancher hostname: %s", err.Error())
+		return nil
 	}
 	if len(rancherHostName) == 0 {
 		log.Oncef("Skipping Rancher delete local host since Rancher host name is missing")

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -273,13 +273,13 @@ func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 	return nil
 }
 
-// PostUninstall handles the deletion of all Rancher resources after the Helm uninstall
+// postUninstall handles the deletion of all Rancher resources after the Helm uninstall
 func (r rancherComponent) PostUninstall(ctx spi.ComponentContext) error {
 	if ctx.IsDryRun() {
-		ctx.Log().Debug("Rancher PostUninstall dry run")
+		ctx.Log().Debug("Rancher postUninstall dry run")
 		return nil
 	}
-	return PostUninstall(ctx)
+	return postUninstall(ctx)
 }
 
 // MonitorOverrides checks whether monitoring of install overrides is enabled or not

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -53,8 +53,8 @@ var rancherSystemNS = []string{
 	"local",
 }
 
-// PostUninstall removes the objects after the Helm uninstall process finishes
-func PostUninstall(ctx spi.ComponentContext) error {
+// postUninstall removes the objects after the Helm uninstall process finishes
+func postUninstall(ctx spi.ComponentContext) error {
 	ctx.Log().Oncef("Running the Rancher uninstall system tool")
 
 	// List all the namespaces that need to be cleaned from Rancher components

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -318,7 +318,7 @@ func TestPostUninstall(t *testing.T) {
 			crd1 := v12.CustomResourceDefinition{}
 			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
-			err := PostUninstall(ctx)
+			err := postUninstall(ctx)
 			assert.NoError(err)
 
 			// MutatingWebhookConfigurations should not exist

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -239,11 +239,6 @@ func (r *Reconciler) deleteMCResources(ctx spi.ComponentContext) error {
 		if err := r.deleteSecret(ctx.Log(), vzconst.VerrazzanoSystemNamespace, vzconst.MCAgentSecret); err != nil {
 			return err
 		}
-
-		// Run Rancher Post Uninstall to delete the Rancher resources on the managed cluster
-		if err := rancher.PostUninstall(ctx); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -298,7 +293,19 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 		return ctrl.Result{}, err
 	}
 
+	// Run Rancher Post Uninstall to delete the Rancher resources on the managed cluster
+	if err := r.runRancherPostInstall(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return r.deleteNamespaces(ctx.Log())
+}
+
+func (r *Reconciler) runRancherPostInstall(ctx spi.ComponentContext) error {
+	if found, comp := registry.FindComponent(rancher.ComponentName); found {
+		return comp.PostUninstall(ctx.Init(rancher.ComponentName).Operation(vzconst.UninstallOperation))
+	}
+	return nil
 }
 
 // nodeExporterCleanup cleans up any resources from the old node-exporter that was


### PR DESCRIPTION
- Call Rancher PostUninstall() from global cleanup hook in all cases
- Uninstall pipeline tweaks to clean up log gathering and variable usages
