### PR TITLE
VZ-6425: Restore prod profile to have a single replica for most components

### DIFF
--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -11,7 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
-        replicas: 2
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,12 +31,6 @@ spec:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
       overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
         - values:
             replicaCount: 1
             affinity:
@@ -75,8 +69,6 @@ spec:
     console:
       enabled: true
       overrides:
-        - values:
-            replicas: 2
         - values:
             replicas: 1
             affinity:
@@ -123,13 +115,6 @@ spec:
         - values:
             controller:
               autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-                replicaCount: 2
-        - values:
-            controller:
-              autoscaling:
                 enabled: false
                 minReplicas: 1
               affinity:
@@ -164,14 +149,6 @@ spec:
               components:
                 pilot:
                   k8s:
-                    replicaCount: 2
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
                     affinity:
                       podAntiAffinity:
                         preferredDuringSchedulingIgnoredDuringExecution:
@@ -183,7 +160,7 @@ spec:
                             weight: 100
       ingress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -198,7 +175,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
       egress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -216,9 +193,6 @@ spec:
       overrides:
         - values:
             deployment:
-              replicas: 2
-        - values:
-            deployment:
               replicas: 1
               affinity:
                 pod_anti:
@@ -233,8 +207,6 @@ spec:
       enabled: true
       overrides:
         - values:
-            replicas: 2
-        - values:
             replicas: 1
             affinity: |
               podAntiAffinity:
@@ -248,7 +220,7 @@ spec:
                       topologyKey: kubernetes.io/hostname
     kibana:
       enabled: true
-      replicas: 2
+      replicas: 1
     oam:
       enabled: true
     prometheus:
@@ -259,13 +231,13 @@ spec:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: 128Mi
         - values:
             prometheus:
               prometheusSpec:
+                replicas: 1
                 affinity:
                   podAntiAffinity:
                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -275,7 +247,6 @@ spec:
                               app.kubernetes.io/name: prometheus
                           topologyKey: kubernetes.io/hostname
                         weight: 100
-                replicas: 1
     rancher:
       enabled: true
     verrazzano:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -21,7 +21,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
-        replicas: 2
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -41,12 +41,6 @@ spec:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
       overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
         - values:
             replicaCount: 1
             affinity:
@@ -85,8 +79,6 @@ spec:
     console:
       enabled: true
       overrides:
-        - values:
-            replicas: 2
         - values:
             replicas: 1
             affinity:
@@ -133,13 +125,6 @@ spec:
         - values:
             controller:
               autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-              replicaCount: 2
-        - values:
-            controller:
-              autoscaling:
                 enabled: false
                 minReplicas: 1
               affinity:
@@ -174,14 +159,6 @@ spec:
               components:
                 pilot:
                   k8s:
-                    replicaCount: 2
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
                     affinity:
                       podAntiAffinity:
                         preferredDuringSchedulingIgnoredDuringExecution:
@@ -193,7 +170,7 @@ spec:
                             weight: 100
       ingress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -208,7 +185,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
       egress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -226,9 +203,6 @@ spec:
       overrides:
         - values:
             deployment:
-              replicas: 2
-        - values:
-            deployment:
               replicas: 1
               affinity:
                 pod_anti:
@@ -243,8 +217,6 @@ spec:
       enabled: true
       overrides:
         - values:
-            replicas: 2
-        - values:
             replicas: 1
             affinity: |
               podAntiAffinity:
@@ -258,7 +230,7 @@ spec:
                       topologyKey: kubernetes.io/hostname
     kibana:
       enabled: true
-      replicas: 2
+      replicas: 1
     oam:
       enabled: true
     prometheus:
@@ -269,7 +241,6 @@ spec:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: 128Mi

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
@@ -11,7 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
-        replicas: 2
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,12 +31,6 @@ spec:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
       overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
         - values:
             replicaCount: 1
             affinity:
@@ -75,8 +69,6 @@ spec:
     console:
       enabled: true
       overrides:
-        - values:
-            replicas: 2
         - values:
             replicas: 1
             affinity:
@@ -123,13 +115,6 @@ spec:
         - values:
             controller:
               autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-              replicaCount: 2
-        - values:
-            controller:
-              autoscaling:
                 enabled: false
                 minReplicas: 1
               affinity:
@@ -164,14 +149,6 @@ spec:
               components:
                 pilot:
                   k8s:
-                    replicaCount: 2
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
                     affinity:
                       podAntiAffinity:
                         preferredDuringSchedulingIgnoredDuringExecution:
@@ -183,7 +160,7 @@ spec:
                             weight: 100
       ingress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -198,7 +175,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
       egress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -216,9 +193,6 @@ spec:
       overrides:
         - values:
             deployment:
-              replicas: 2
-        - values:
-            deployment:
               replicas: 1
               affinity:
                 pod_anti:
@@ -233,8 +207,6 @@ spec:
       enabled: true
       overrides:
         - values:
-            replicas: 2
-        - values:
             replicas: 1
             affinity: |
               podAntiAffinity:
@@ -248,7 +220,7 @@ spec:
                       topologyKey: kubernetes.io/hostname
     kibana:
       enabled: true
-      replicas: 2
+      replicas: 1
     oam:
       enabled: true
     prometheus:
@@ -259,7 +231,6 @@ spec:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: 128Mi

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -11,7 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
-        replicas: 2
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,12 +31,6 @@ spec:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
       overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
         - values:
             replicaCount: 1
             affinity:
@@ -75,8 +69,6 @@ spec:
     console:
       enabled: true
       overrides:
-        - values:
-            replicas: 2
         - values:
             replicas: 1
             affinity:
@@ -128,13 +120,6 @@ spec:
         - values:
             controller:
               autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-              replicaCount: 2
-        - values:
-            controller:
-              autoscaling:
                 enabled: false
                 minReplicas: 1
               affinity:
@@ -169,14 +154,6 @@ spec:
               components:
                 pilot:
                   k8s:
-                    replicaCount: 2
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
                     affinity:
                       podAntiAffinity:
                         preferredDuringSchedulingIgnoredDuringExecution:
@@ -188,7 +165,7 @@ spec:
                             weight: 100
       ingress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -203,7 +180,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
       egress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -221,9 +198,6 @@ spec:
       overrides:
         - values:
             deployment:
-              replicas: 2
-        - values:
-            deployment:
               replicas: 1
               affinity:
                 pod_anti:
@@ -238,8 +212,6 @@ spec:
       enabled: true
       overrides:
         - values:
-            replicas: 2
-        - values:
             replicas: 1
             affinity: |
               podAntiAffinity:
@@ -253,7 +225,7 @@ spec:
                       topologyKey: kubernetes.io/hostname
     kibana:
       enabled: true
-      replicas: 2
+      replicas: 1
     oam:
       enabled: true
     prometheus:
@@ -264,13 +236,13 @@ spec:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: 128Mi
         - values:
             prometheus:
               prometheusSpec:
+                replicas: 1
                 affinity:
                   podAntiAffinity:
                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -280,7 +252,6 @@ spec:
                               app.kubernetes.io/name: prometheus
                           topologyKey: kubernetes.io/hostname
                         weight: 100
-                replicas: 1
     rancher:
       enabled: true
     verrazzano:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -11,7 +11,7 @@ spec:
     authProxy:
       enabled: true
       kubernetes:
-        replicas: 2
+        replicas: 1
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -31,12 +31,6 @@ spec:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
       overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
         - values:
             replicaCount: 1
             affinity:
@@ -75,8 +69,6 @@ spec:
     console:
       enabled: true
       overrides:
-        - values:
-            replicas: 2
         - values:
             replicas: 1
             affinity:
@@ -142,13 +134,6 @@ spec:
         - values:
             controller:
               autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-              replicaCount: 2
-        - values:
-            controller:
-              autoscaling:
                 enabled: false
                 minReplicas: 1
               affinity:
@@ -183,14 +168,6 @@ spec:
               components:
                 pilot:
                   k8s:
-                    replicaCount: 2
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
                     affinity:
                       podAntiAffinity:
                         preferredDuringSchedulingIgnoredDuringExecution:
@@ -210,7 +187,7 @@ spec:
             - 11.22.33.44
       ingress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -225,7 +202,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
       egress:
         kubernetes:
-          replicas: 2
+          replicas: 1
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -243,9 +220,6 @@ spec:
       overrides:
         - values:
             deployment:
-              replicas: 2
-        - values:
-            deployment:
               replicas: 1
               affinity:
                 pod_anti:
@@ -260,8 +234,6 @@ spec:
       enabled: true
       overrides:
         - values:
-            replicas: 2
-        - values:
             replicas: 1
             affinity: |
               podAntiAffinity:
@@ -275,7 +247,7 @@ spec:
                       topologyKey: kubernetes.io/hostname
     kibana:
       enabled: true
-      replicas: 2
+      replicas: 1
     oam:
       enabled: true
     prometheus:
@@ -286,13 +258,13 @@ spec:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: 128Mi
         - values:
             prometheus:
               prometheusSpec:
+                replicas: 1
                 affinity:
                   podAntiAffinity:
                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -302,7 +274,6 @@ spec:
                               app.kubernetes.io/name: prometheus
                           topologyKey: kubernetes.io/hostname
                         weight: 100
-                replicas: 1
     rancher:
       enabled: true
     verrazzano:

--- a/platform-operator/manifests/profiles/prod.yaml
+++ b/platform-operator/manifests/profiles/prod.yaml
@@ -22,68 +22,17 @@ spec:
         value: "50Gi"
       - name: nodes.master.requests.storage
         value: "50Gi"
-    authproxy:
-      kubernetes:
-        replicas: 2
     certManager:
       enabled: true
       certificate:
         ca:
           secretName: "verrazzano-ca-certificate-secret"
           clusterResourceNamespace: "cert-manager"
-      overrides:
-        - values:
-            replicaCount: 2
-            cainjector:
-              replicaCount: 2
-            webhook:
-              replicaCount: 2
-    console:
-      overrides:
-        - values:
-            replicas: 2
-    ingress:
-      overrides:
-        - values:
-            controller:
-              autoscaling:
-                enabled: true
-                minReplicas: 2
-            defaultBackend:
-              replicaCount: 2
-    istio:
-      overrides:
-        - values:
-            apiVersion: install.istio.io/v1alpha1
-            kind: IstioOperator
-            spec:
-              components:
-                pilot:
-                  k8s:
-                    replicaCount: 2
-      ingress:
-        kubernetes:
-          replicas: 2
-      egress:
-        kubernetes:
-          replicas: 2
-    keycloak:
-      overrides:
-        - values:
-            replicas: 2
-    kibana:
-      replicas: 2
-    kiali:
-      overrides:
-        - values:
-            deployment:
-              replicas: 2
     prometheusOperator:
       overrides:
         - values:
             prometheus:
               prometheusSpec:
-                replicas: 2
                 resources:
                   requests:
                     memory: "128Mi"

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -378,7 +378,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		t.It("Check persistent volumes for prod cluster profile", func() {
 			if minVer14 {
 				Expect(len(volumeClaims)).To(Equal(7))
-				Expect(len(vzMonitoringVolumeClaims)).To(Equal(2))
+				Expect(len(vzMonitoringVolumeClaims)).To(Equal(1))
 				assertPrometheusVolume(size)
 			} else {
 				Expect(len(volumeClaims)).To(Equal(8))
@@ -611,9 +611,6 @@ func getExpectedPrometheusReplicaCount(kubeconfig string) (int32, error) {
 		return 0, err
 	}
 	var expectedReplicas int32 = 1
-	if pkg.IsProdProfile() {
-		expectedReplicas = 2
-	}
 	if vz.Spec.Components.PrometheusOperator == nil {
 		return expectedReplicas, nil
 	}

--- a/tests/e2e/verify-install/istio/istio_test.go
+++ b/tests/e2e/verify-install/istio/istio_test.go
@@ -5,19 +5,19 @@ package istio
 
 import (
 	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
 const (
@@ -155,9 +155,6 @@ func getIngressReplicaCount(vz *vzapi.Verrazzano) uint32 {
 			}
 		}
 	}
-	if pkg.IsProdProfile() {
-		return 2
-	}
 	return 1
 }
 
@@ -171,9 +168,6 @@ func getEgressReplicaCount(vz *vzapi.Verrazzano) uint32 {
 			return istio.Egress.Kubernetes.Replicas
 		}
 	}
-	if pkg.IsProdProfile() {
-		return 2
-	}
 	return 1
 }
 
@@ -181,9 +175,6 @@ func getPilotReplicaCount(vz *vzapi.Verrazzano) uint32 {
 	istio := vz.Spec.Components.Istio
 	if istio != nil && !isIstioEnabled(istio) {
 		return 0
-	}
-	if pkg.IsProdProfile() {
-		return 2
 	}
 	return 1
 }


### PR DESCRIPTION
Restore prod profile to have a single replica for most components.  In some cases a component requires more than one (e.g. OpenSearch).  An alternative approach will be used to select HA settings which will include higher replica counts.