### PR TITLE
VZ-6552 Add application test to Uninstall Resiliency test

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -521,7 +521,7 @@ def testApplication(testSuitePath, dumpDir) {
     environment {
         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/${dumpDir}"
     }
-    steps {
+    step {
         runGinkgo(testSuitePath)
     }
 }

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -521,9 +521,7 @@ def testApplication(testSuitePath, dumpDir) {
     environment {
         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/${dumpDir}"
     }
-    step {
-        runGinkgo(testSuitePath)
-    }
+    runGinkgo(testSuitePath)
 }
 
 

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -229,7 +229,8 @@ pipeline {
 		    }
 		    steps {
 		        script {
-                    for (int count = 1; count <= getMaxIterations(); count++) {
+		            int maxIterations = getMaxIterations()
+                    for (int count = 1; count <= maxIterations; count++) {
                         if (count == 1) {
                             // Create cluster and install
                             runInitialInstall(count)
@@ -238,6 +239,9 @@ pipeline {
                             runInstallOnly("Install Verrazzano", count)
                         }
                         runVerifyTests("Run Test", count)
+                        if (count == maxIterations) {
+                            runApplicationTests()
+                        }
                         runUninstall(count)
                         if (params.CHAOS_TEST_TYPE == "uninstall.interrupt.uninstall") {
                             // Run re-install once and re-verify
@@ -477,6 +481,47 @@ def kill_vpo_loop(vpoLogsDir) {
         }
     }
 }
+
+def runApplicationTests() {
+    stage("Application Tests") {
+        try {
+            parallel getApplicationStages()
+            if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                dumpK8sCluster('verrazzano-application-test-failure-cluster-dump')
+            }
+        } catch (err) {
+            dumpK8sCluster('verrazzano-application-test-failure-cluster-dump')
+            throw err
+        }
+    }
+}
+
+def getApplicationStages() {
+    return [
+       "examples helidon": {
+           testApplication('examples/helidon', 'examples-helidon')
+       },
+       "examples socks": {
+           testApplication('examples/socks', 'examples-socks')
+       },
+       "examples springboot": {
+           testApplication('examples/springboot', 'examples-springboot')
+       },
+       "examples todo": {
+           testApplication('examples/todo', 'examples-todo')
+       },
+   ]
+}
+
+def testApplication(testSuitePath, dumpDir) {
+    environment {
+        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/${dumpDir}"
+    }
+    steps {
+        runGinkgo(testSuitePath)
+    }
+}
+
 
 def runGinkgo(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -37,6 +37,10 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "prod", "dev", "managed-cluster" ])
 
+        booleanParam (name: 'RUN_APPLICATION_TESTS',
+                description: 'Whether to run the application tests for the final install loop',
+                defaultValue: true)
+
         choice (name: 'WILDCARD_DNS_DOMAIN',
                 description: 'This is the wildcard DNS domain',
                 // 1st choice is the default value
@@ -239,7 +243,7 @@ pipeline {
                             runInstallOnly("Install Verrazzano", count)
                         }
                         runVerifyTests("Run Test", count)
-                        if (count == maxIterations) {
+                        if (params.RUN_APPLICATION_TESTS && count == maxIterations) {
                             runApplicationTests()
                         }
                         runUninstall(count)


### PR DESCRIPTION
The application test for the uninstall resiliency now runs in-between the final install and the final uninstall after the loop test has occurred.

There is a parameter that controls the enabling of these application tests