### PR TITLE
VZ-6521 (subtask of story VZ-6448) Use Rancher URL as server address (with corresponding CA) in the admin kubeconfig provided to managed clusters. Functionality is behind feature flag pending work for VZ-6449.

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -20,9 +20,6 @@ const MCRegistrationSecret = "verrazzano-cluster-registration" //nolint:gosec //
 // Thos is created at Verrazzano install.
 const MCLocalRegistrationSecret = "verrazzano-local-registration" //nolint:gosec //#gosec G101
 
-// AdminKubeconfigData - the field name in MCRegistrationSecret that contains the admin cluster's kubeconfig
-const AdminKubeconfigData = "admin-kubeconfig"
-
 // ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
 const ClusterNameData = "managed-cluster-name"
 

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -210,9 +211,9 @@ func validateAgentSecret(secret *corev1.Secret) error {
 	}
 
 	// The secret must contain a kubeconfig
-	_, ok = secret.Data[constants.AdminKubeconfigData]
+	_, ok = secret.Data[mcconstants.KubeconfigKey]
 	if !ok {
-		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, constants.AdminKubeconfigData)
+		return fmt.Errorf("the secret named %s in namespace %s is missing the required field %s", secret.Name, secret.Namespace, mcconstants.KubeconfigKey)
 	}
 
 	return nil
@@ -226,7 +227,7 @@ func getAdminClient(secret *corev1.Secret) (client.Client, error) {
 		return nil, err
 	}
 
-	err = ioutil.WriteFile(tmpFile.Name(), secret.Data[constants.AdminKubeconfigData], 0600)
+	err = ioutil.WriteFile(tmpFile.Name(), secret.Data[mcconstants.KubeconfigKey], 0600)
 	defer os.Remove(tmpFile.Name())
 	if err != nil {
 		return nil, err

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	platformopclusters "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,7 +34,7 @@ var validSecret = corev1.Secret{
 		Name:      constants.MCAgentSecret,
 		Namespace: constants.VerrazzanoSystemNamespace,
 	},
-	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), constants.AdminKubeconfigData: []byte("kubeconfig")},
+	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), mcconstants.KubeconfigKey: []byte("kubeconfig")},
 }
 
 // TestProcessAgentThreadNoProjects tests agent thread when no projects exist
@@ -191,7 +192,7 @@ func TestValidateSecret(t *testing.T) {
 
 	// A secret without a cluster name
 	invalidSecret := validSecret
-	invalidSecret.Data = map[string][]byte{constants.AdminKubeconfigData: []byte("kubeconfig")}
+	invalidSecret.Data = map[string][]byte{mcconstants.KubeconfigKey: []byte("kubeconfig")}
 	err = validateAgentSecret(&invalidSecret)
 	assert.Error(err)
 	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", constants.ClusterNameData))
@@ -200,7 +201,7 @@ func TestValidateSecret(t *testing.T) {
 	invalidSecret.Data = map[string][]byte{constants.ClusterNameData: []byte("cluster1")}
 	err = validateAgentSecret(&invalidSecret)
 	assert.Error(err)
-	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", constants.AdminKubeconfigData))
+	assert.Contains(err.Error(), fmt.Sprintf("missing the required field %s", mcconstants.KubeconfigKey))
 }
 
 // Test_getEnvValue tests getEnvValue

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -199,19 +199,19 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAgentSecret(secret *corev1.Se
 func (r *VerrazzanoManagedClusterReconciler) getRancherCACert() (string, error) {
 	ingressSecret := corev1.Secret{}
 
-	errAddlTLS := r.Client.Get(context.TODO(), client.ObjectKey{
+	err := r.Client.Get(context.TODO(), client.ObjectKey{
 		Namespace: vzconst.RancherSystemNamespace,
 		Name:      vzconst.AdditionalTLS,
 	}, &ingressSecret)
-	if client.IgnoreNotFound(errAddlTLS) != nil {
-		return "", errAddlTLS
+	if client.IgnoreNotFound(err) != nil {
+		return "", err
 	}
 
 	var caData []byte
-	if errAddlTLS == nil {
+	if err == nil {
 		caData = ingressSecret.Data[vzconst.AdditionalTLSCAKey]
 	} else {
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: rancherTLSSecret, Namespace: vzconst.RancherSystemNamespace}, &ingressSecret)
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: rancherTLSSecret, Namespace: vzconst.RancherSystemNamespace}, &ingressSecret)
 		if err != nil {
 			return "", err
 		}

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -8,12 +8,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"io/ioutil"
+
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	clusterapi "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vzk8s "github.com/verrazzano/verrazzano/platform-operator/internal/k8s"
-
-	"io/ioutil"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -70,7 +70,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	}
 
 	// Build the kubeconfig
-	kc, err := r.buildKubeConfig(serviceAccountSecret)
+	kc, err := r.buildKubeConfigUsingRancherURL(serviceAccountSecret)
+	if err != nil {
+		kc, err = r.buildKubeConfigUsingAdminConfigMap(serviceAccountSecret)
+	}
 	if err != nil {
 		return fmt.Errorf("Failed to create kubeconfig for cluster %s: %v", vmc.Name, err)
 	}
@@ -88,17 +91,26 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	return nil
 }
 
+func (r *VerrazzanoManagedClusterReconciler) buildKubeConfigUsingRancherURL(serviceAccountSecret corev1.Secret) (*vzk8s.KubeConfig, error) {
+	vz, err := r.getVerrazzanoResource()
+	if err != nil {
+		return nil, r.log.ErrorfNewErr("Failed to build admin kubeconfig using Rancher URL. Could not find Verrazzano resource")
+	}
+	rancherURL := vz.Status.VerrazzanoInstance.RancherURL
+	if rancherURL == nil {
+		return nil, r.log.ErrorfNewErr("Failed to build admin kubeconfig using Rancher URL. No Rancher URL found in Verrazzano resource status")
+	}
+	caCert, err := r.getRancherCACert()
+	if err != nil {
+		return nil, err
+	}
+	userToken := serviceAccountSecret.Data[mcconstants.TokenKey]
+	return buildAdminKubeConfig(*rancherURL, caCert, string(userToken))
+}
+
 // buildKubeConfig builds the kubeconfig from the user-provided admin cluster URL and
 // CA cert of the local cluster configuration
-func (r *VerrazzanoManagedClusterReconciler) buildKubeConfig(serviceAccountSecret corev1.Secret) (*vzk8s.KubeConfig, error) {
-	// These names are used internally in the generated kubeconfig. The names
-	// are meant to be descriptive and the actual values don't affect behavior.
-	const (
-		clusterName = "admin"
-		userName    = "mcAgent"
-		contextName = "defaultContext"
-	)
-
+func (r *VerrazzanoManagedClusterReconciler) buildKubeConfigUsingAdminConfigMap(serviceAccountSecret corev1.Secret) (*vzk8s.KubeConfig, error) {
 	// Get client config, this has some of the info needed to build a kubeconfig
 	config, err := getConfigFunc()
 	if err != nil {
@@ -114,14 +126,27 @@ func (r *VerrazzanoManagedClusterReconciler) buildKubeConfig(serviceAccountSecre
 	if err != nil {
 		return nil, err
 	}
+	return buildAdminKubeConfig(serverURL, b64Cert, string(token))
+}
+
+// buildAdminKubeConfig builds the kubeconfig for the admin i.e. local cluster, given the API server
+// URL, user credentials and server CA data
+func buildAdminKubeConfig(serverURL string, caCert string, userToken string) (*vzk8s.KubeConfig, error) {
+	// These names are used internally in the generated kubeconfig. The names
+	// are meant to be descriptive and the actual values don't affect behavior.
+	const (
+		clusterName = "admin"
+		userName    = "mcAgent"
+		contextName = "defaultContext"
+	)
 
 	// Load the kubeconfig struct and build the kubeconfig
 	kb := vzk8s.KubeconfigBuilder{
 		ClusterName: clusterName,
 		Server:      serverURL,
-		CertAuth:    b64Cert,
+		CertAuth:    caCert,
 		UserName:    userName,
-		UserToken:   string(token),
+		UserToken:   userToken,
 		ContextName: contextName,
 	}
 	kc := kb.Build()
@@ -150,6 +175,17 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAgentSecret(secret *corev1.Se
 		mcconstants.ManagedClusterNameKey: []byte(manageClusterName),
 	}
 	return nil
+}
+
+// getRancherCACert returns the certificate authority data from Rancher's TLS secret
+func (r *VerrazzanoManagedClusterReconciler) getRancherCACert() (string, error) {
+	ingressSecret := corev1.Secret{}
+	// TODO what about tls-ca-additional?
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: rancherTLSSecret, Namespace: vzconst.RancherSystemNamespace}, &ingressSecret)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(ingressSecret.Data["ca.crt"]), nil
 }
 
 // Get the CAData from memory or a file

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -104,6 +104,8 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	return nil
 }
 
+// buildKubeConfigUsingRancherURL builds the kubeconfig using the Rancher URL as the api server, and
+// the CA cert of the Rancher ingress as the cert authority
 func (r *VerrazzanoManagedClusterReconciler) buildKubeConfigUsingRancherURL(serviceAccountSecret corev1.Secret) (*vzk8s.KubeConfig, error) {
 	vz, err := r.getVerrazzanoResource()
 	if err != nil {

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -10,6 +10,7 @@ import (
 
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
@@ -323,8 +324,8 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatus(ctx context.Context, v
 	if vmc.Status.LastAgentConnectTime != nil {
 
 		currentTime := metav1.Now()
-		//Using the current plus added time to find the difference with lastAgentConnectTime to validate
-		//if it exceeds the max allowed time before changing the state of the vmc resource.
+		// Using the current plus added time to find the difference with lastAgentConnectTime to validate
+		// if it exceeds the max allowed time before changing the state of the vmc resource.
 		maxPollingTime := currentTime.Add(vzconstants.VMCAgentPollingTimeInterval * vzconstants.MaxTimesVMCAgentPollingTime)
 		timeDiff := maxPollingTime.Sub(vmc.Status.LastAgentConnectTime.Time)
 		if int(timeDiff.Minutes()) > vzconstants.MaxTimesVMCAgentPollingTime {
@@ -337,6 +338,17 @@ func (r *VerrazzanoManagedClusterReconciler) updateStatus(ctx context.Context, v
 	}
 	r.log.Debugf("Updating Status of VMC %s with condition type %s = %s: %v", vmc.Name, condition.Type, condition.Status, vmc.Status.Conditions)
 	return r.Status().Update(ctx, vmc)
+}
+
+// getVerrazzanoResource gets the installed Verrazzano resource in the cluster (of which only one is expected)
+func (r *VerrazzanoManagedClusterReconciler) getVerrazzanoResource() (*v1alpha1.Verrazzano, error) {
+	// Get the Verrazzano resource
+	verrazzano := v1alpha1.VerrazzanoList{}
+	err := r.Client.List(context.TODO(), &verrazzano, &client.ListOptions{})
+	if err != nil || len(verrazzano.Items) == 0 {
+		return nil, fmt.Errorf("Verrazzano must be installed: %v", err)
+	}
+	return &verrazzano.Items[0], nil
 }
 
 // Create a new Result that will cause a reconcile requeue after a short delay

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -72,8 +72,14 @@ type secretAssertFn func(secret *corev1.Secret) error
 // TestCreateVMC tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an VerrazzanoManagedCluster resource
 // WHEN a VerrazzanoManagedCluster resource has been applied in a cluster where Rancher is enabled
-// THEN ensure all the objects are created correctly
+// THEN ensure all the objects are created correctly (USES feature flag rancherBasedKubeconfigEnabled)
 func TestCreateVMCRancherEnabled(t *testing.T) {
+	// with feature flag disabled (which triggers different asserts/mocks from enabled)
+	doTestCreateVMC(t, true)
+
+	// with feature flag enabled
+	rancherBasedKubeConfigEnabled = true
+	defer func() { rancherBasedKubeConfigEnabled = false }()
 	doTestCreateVMC(t, true)
 }
 
@@ -82,7 +88,7 @@ func TestCreateVMCRancherEnabled(t *testing.T) {
 // WHEN a VerrazzanoManagedCluster resource has been applied in a cluster where Rancher is DISABLED
 // THEN ensure all the objects are created correctly
 func TestCreateVMCRancherDisabled(t *testing.T) {
-	doTestCreateVMC(t, true)
+	doTestCreateVMC(t, false)
 }
 
 func doTestCreateVMC(t *testing.T, rancherEnabled bool) {
@@ -1453,24 +1459,26 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 			return nil
 		})
 
-	// Expect a call to list Verrazzanos - return a Verrazzano that does NOT have Rancher URL in status
-	mock.EXPECT().
-		List(gomock.Any(), &vzapi.VerrazzanoList{}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, list *vzapi.VerrazzanoList, opts ...client.ListOption) error {
-			var status vzapi.VerrazzanoStatus
-			if rancherEnabled {
-				status = vzapi.VerrazzanoStatus{
-					VerrazzanoInstance: &vzapi.InstanceInfo{RancherURL: &rancherURL},
+	// ONLY if the rancherBasedKubeconfig feature flag is enabled - Expect a call to list Verrazzanos
+	// and return a Verrazzano that has Rancher URL in status only if rancherEnabled is true
+	if rancherBasedKubeConfigEnabled {
+		mock.EXPECT().
+			List(gomock.Any(), &vzapi.VerrazzanoList{}, gomock.Not(gomock.Nil())).
+			DoAndReturn(func(ctx context.Context, list *vzapi.VerrazzanoList, opts ...client.ListOption) error {
+				var status vzapi.VerrazzanoStatus
+				if rancherEnabled {
+					status = vzapi.VerrazzanoStatus{
+						VerrazzanoInstance: &vzapi.InstanceInfo{RancherURL: &rancherURL},
+					}
 				}
-			}
-			vz := vzapi.Verrazzano{
-				Spec:   vzapi.VerrazzanoSpec{},
-				Status: status,
-			}
-			list.Items = append(list.Items, vz)
-			return nil
-		})
-
+				vz := vzapi.Verrazzano{
+					Spec:   vzapi.VerrazzanoSpec{},
+					Status: status,
+				}
+				list.Items = append(list.Items, vz)
+				return nil
+			})
+	}
 	// Expect a call to get the service token secret, return the secret with the token
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: saSecretName}, gomock.Not(gomock.Nil())).
@@ -1481,7 +1489,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 			return nil
 		})
 
-	if rancherEnabled {
+	if rancherEnabled && rancherBasedKubeConfigEnabled {
 		// Expect a call to get the tls-ca-additional secret, return the secret as not found
 		mock.EXPECT().
 			Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: constants.AdditionalTLS}, gomock.Not(gomock.Nil())).
@@ -1518,7 +1526,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
 			adminKubeconfig := string(secret.Data[constants2.AdminKubeconfigData])
-			if rancherEnabled {
+			if rancherEnabled && rancherBasedKubeConfigEnabled {
 				assert.Contains(t, adminKubeconfig, "server: "+rancherURL)
 			} else {
 				assert.Contains(t, adminKubeconfig, "server: "+userAPIServerURL)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -388,7 +388,7 @@ func TestCreateVMCFetchCACertFromManagedCluster(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, false)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, true)
 	expectSyncRegistration(t, mock, testManagedCluster, true)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncCACertRancherHTTPCalls(t, mockRequestSender, `{"data":{"ca.crt":"base64-ca-cert"}}`)

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	constants2 "github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
@@ -42,8 +43,6 @@ import (
 
 const apiVersion = "clusters.verrazzano.io/v1alpha1"
 const kind = "VerrazzanoManagedCluster"
-
-const testServerData = "https://testurl"
 
 const (
 	token                = "tokenData"
@@ -72,9 +71,21 @@ type secretAssertFn func(secret *corev1.Secret) error
 
 // TestCreateVMC tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an VerrazzanoManagedCluster resource
-// WHEN a VerrazzanoManagedCluster resource has been applied
-// THEN ensure all the objects are created
-func TestCreateVMC(t *testing.T) {
+// WHEN a VerrazzanoManagedCluster resource has been applied in a cluster where Rancher is enabled
+// THEN ensure all the objects are created correctly
+func TestCreateVMCRancherEnabled(t *testing.T) {
+	doTestCreateVMC(t, true)
+}
+
+// TestCreateVMC tests the Reconcile method for the following use case
+// GIVEN a request to reconcile an VerrazzanoManagedCluster resource
+// WHEN a VerrazzanoManagedCluster resource has been applied in a cluster where Rancher is DISABLED
+// THEN ensure all the objects are created correctly
+func TestCreateVMCRancherDisabled(t *testing.T) {
+	doTestCreateVMC(t, true)
+}
+
+func doTestCreateVMC(t *testing.T, rancherEnabled bool) {
 	namespace := constants.VerrazzanoMultiClusterNamespace
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
@@ -95,7 +106,8 @@ func TestCreateVMC(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	// Agent secret sync checks depend on whether Rancher is enabled
+	expectSyncAgent(t, mock, testManagedCluster, rancherEnabled)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, "", "", true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -164,7 +176,7 @@ func TestCreateVMCWithExternalES(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, true)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, "", "", true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -233,7 +245,7 @@ func TestCreateVMCOCIDNS(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, "", "", true, "", func(configMap *corev1.ConfigMap) error {
@@ -302,7 +314,7 @@ func TestCreateVMCNoCACert(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, false)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, true)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncCACertRancherHTTPCalls(t, mockRequestSender, "")
@@ -451,7 +463,7 @@ scrape_configs:
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, prometheusYaml, jobs, true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -532,7 +544,7 @@ scrape_configs:
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, prometheusYaml, jobs, true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -603,7 +615,7 @@ func TestCreateVMCClusterAlreadyRegistered(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, true, rancherManifestYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, "", "", true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -1290,7 +1302,7 @@ func TestRegisterClusterWithRancherOverrideRegistry(t *testing.T) {
 	expectVmcGetAndUpdate(t, mock, testManagedCluster, true)
 	expectSyncServiceAccount(t, mock, testManagedCluster, true)
 	expectSyncRoleBinding(t, mock, testManagedCluster, true)
-	expectSyncAgent(t, mock, testManagedCluster)
+	expectSyncAgent(t, mock, testManagedCluster, false)
 	expectSyncRegistration(t, mock, testManagedCluster, false)
 	expectSyncManifest(t, mock, mockStatus, mockRequestSender, testManagedCluster, false, expectedRancherYAML)
 	expectSyncPrometheusScraper(mock, testManagedCluster, "", "", true, getCaCrt(), func(configMap *corev1.ConfigMap) error {
@@ -1426,9 +1438,11 @@ func expectSyncServiceAccount(t *testing.T, mock *mocks.MockClient, name string,
 }
 
 // Expect syncAgent related calls
-func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
+func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherEnabled bool) {
 	saSecretName := "saSecret"
-
+	rancherURL := "http://rancher-url"
+	rancherCAData := "rancherCAData"
+	userAPIServerURL := "https://testurl"
 	// Expect a call to get the ServiceAccount, return one with the secret testManagedCluster set
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: generateManagedResourceName(name)}, gomock.Not(gomock.Nil())).
@@ -1436,6 +1450,24 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
 			sa.Secrets = []corev1.ObjectReference{{
 				Name: saSecretName,
 			}}
+			return nil
+		})
+
+	// Expect a call to list Verrazzanos - return a Verrazzano that does NOT have Rancher URL in status
+	mock.EXPECT().
+		List(gomock.Any(), &vzapi.VerrazzanoList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, list *vzapi.VerrazzanoList, opts ...client.ListOption) error {
+			var status vzapi.VerrazzanoStatus
+			if rancherEnabled {
+				status = vzapi.VerrazzanoStatus{
+					VerrazzanoInstance: &vzapi.InstanceInfo{RancherURL: &rancherURL},
+				}
+			}
+			vz := vzapi.Verrazzano{
+				Spec:   vzapi.VerrazzanoSpec{},
+				Status: status,
+			}
+			list.Items = append(list.Items, vz)
 			return nil
 		})
 
@@ -1449,15 +1481,32 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
 			return nil
 		})
 
-	// Expect a call to get the verrazzano-admin-cluster configmap
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: vpoconstants.AdminClusterConfigMapName}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, cm *corev1.ConfigMap) error {
-			cm.Data = map[string]string{
-				vpoconstants.ServerDataKey: testServerData,
-			}
-			return nil
-		})
+	if rancherEnabled {
+		// Expect a call to get the tls-ca-additional secret, return the secret as not found
+		mock.EXPECT().
+			Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: constants.AdditionalTLS}, gomock.Not(gomock.Nil())).
+			Return(errors.NewNotFound(schema.GroupResource{Group: constants.RancherSystemNamespace, Resource: "Secret"}, constants.AdditionalTLS))
+
+		// Expect a call to get the Rancher ingress tls secret, return the secret with the fields set
+		mock.EXPECT().
+			Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: rancherTLSSecret}, gomock.Not(gomock.Nil())).
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+				secret.Data = map[string][]byte{
+					mcconstants.CaCrtKey: []byte(rancherCAData),
+				}
+				return nil
+			})
+	} else {
+		// Expect a call to get the verrazzano-admin-cluster configmap
+		mock.EXPECT().
+			Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: vpoconstants.AdminClusterConfigMapName}, gomock.Not(gomock.Nil())).
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, cm *corev1.ConfigMap) error {
+				cm.Data = map[string]string{
+					vpoconstants.ServerDataKey: userAPIServerURL,
+				}
+				return nil
+			})
+	}
 
 	// Expect a call to get the Agent secret - return that it does not exist
 	mock.EXPECT().
@@ -1468,6 +1517,12 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string) {
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
+			adminKubeconfig := string(secret.Data[constants2.AdminKubeconfigData])
+			if rancherEnabled {
+				assert.Contains(t, adminKubeconfig, "server: "+rancherURL)
+			} else {
+				assert.Contains(t, adminKubeconfig, "server: "+userAPIServerURL)
+			}
 			return nil
 		})
 }

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	constants2 "github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
@@ -1525,7 +1524,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 	mock.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
-			adminKubeconfig := string(secret.Data[constants2.AdminKubeconfigData])
+			adminKubeconfig := string(secret.Data[mcconstants.KubeconfigKey])
 			if rancherEnabled && rancherBasedKubeConfigEnabled {
 				assert.Contains(t, adminKubeconfig, "server: "+rancherURL)
 			} else {

--- a/platform-operator/internal/k8s/adminclusterconfig.go
+++ b/platform-operator/internal/k8s/adminclusterconfig.go
@@ -13,7 +13,7 @@ import (
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetAPIServerURL gets the external URL of the API server
+// GetAPIServerURL gets the external URL of the API server provided by the user
 func GetAPIServerURL(client clipkg.Client) (string, error) {
 	// Get the configmap which has the info needed to build the URL
 	var cm corev1.ConfigMap

--- a/platform-operator/internal/k8s/adminclusterconfig.go
+++ b/platform-operator/internal/k8s/adminclusterconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package k8s

--- a/platform-operator/internal/k8s/adminclusterconfig.go
+++ b/platform-operator/internal/k8s/adminclusterconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package k8s

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -37,11 +37,11 @@ echo MANAGED_KUBECONFIG: ${MANAGED_KUBECONFIG}
 echo MANAGED_CLUSTER_ENV: ${MANAGED_CLUSTER_ENV}
 echo ACME_ENVIRONMENT: ${ACME_ENVIRONMENT}
 
-# DO NOT create configmap "verrazzano-admin-cluster" on admin - should now automatically use Rancher API URL
-#if ! kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc get configmap verrazzano-admin-cluster ; then
-#  export ADMIN_K8S_SERVER_ADDRESS=$(cat ${ADMIN_KUBECONFIG} | grep "server:" | awk '{ print $2 }')
-#  kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc create configmap verrazzano-admin-cluster --from-literal=server=${ADMIN_K8S_SERVER_ADDRESS}
-#fi
+# create configmap "verrazzano-admin-cluster" on admin
+if ! kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc get configmap verrazzano-admin-cluster ; then
+  export ADMIN_K8S_SERVER_ADDRESS=$(cat ${ADMIN_KUBECONFIG} | grep "server:" | awk '{ print $2 }')
+  kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc create configmap verrazzano-admin-cluster --from-literal=server=${ADMIN_K8S_SERVER_ADDRESS}
+fi
 
 # create managed cluster ca secret yaml on managed
 CA_SECRET_FILE=${MANAGED_CLUSTER_NAME}.yaml

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -37,11 +37,11 @@ echo MANAGED_KUBECONFIG: ${MANAGED_KUBECONFIG}
 echo MANAGED_CLUSTER_ENV: ${MANAGED_CLUSTER_ENV}
 echo ACME_ENVIRONMENT: ${ACME_ENVIRONMENT}
 
-# create configmap "verrazzano-admin-cluster" on admin
-if ! kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc get configmap verrazzano-admin-cluster ; then
-  export ADMIN_K8S_SERVER_ADDRESS=$(cat ${ADMIN_KUBECONFIG} | grep "server:" | awk '{ print $2 }')
-  kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc create configmap verrazzano-admin-cluster --from-literal=server=${ADMIN_K8S_SERVER_ADDRESS}
-fi
+# DO NOT create configmap "verrazzano-admin-cluster" on admin - should now automatically use Rancher API URL
+#if ! kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc get configmap verrazzano-admin-cluster ; then
+#  export ADMIN_K8S_SERVER_ADDRESS=$(cat ${ADMIN_KUBECONFIG} | grep "server:" | awk '{ print $2 }')
+#  kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc create configmap verrazzano-admin-cluster --from-literal=server=${ADMIN_K8S_SERVER_ADDRESS}
+#fi
 
 # create managed cluster ca secret yaml on managed
 CA_SECRET_FILE=${MANAGED_CLUSTER_NAME}.yaml


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
