### PR TITLE
VZ-6460: Automatically pull CA cert secret from managed cluster

### DIFF
--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -302,7 +302,7 @@ func getCACertFromManagedCluster(rc *rancherConfig, clusterID string, log vzlog.
 
 // getCACertFromManagedClusterSecret attempts to get the CA cert from a secret on the managed cluster using the Rancher API proxy
 func getCACertFromManagedClusterSecret(rc *rancherConfig, clusterID, namespace, secretName, secretKey string, log vzlog.VerrazzanoLogger) (string, error) {
-	const k8sAPISecretPattern = "%s/api/v1/namespaces/%s/secrets/%s"
+	const k8sAPISecretPattern = "%s/api/v1/namespaces/%s/secrets/%s" //nolint:gosec //#gosec G101
 
 	// use the Rancher API proxy on the managed cluster to fetch the secret
 	baseReqURL := rc.baseURL + k8sClustersPath + clusterID

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -84,15 +84,9 @@ var rancherHTTPClient requestSender = &httpRequestSender{}
 
 // registerManagedClusterWithRancher registers a managed cluster with Rancher and returns a chunk of YAML that
 // must be applied on the managed cluster to complete the registration.
-func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, log vzlog.VerrazzanoLogger) (string, string, error) {
+func registerManagedClusterWithRancher(rc *rancherConfig, clusterName string, log vzlog.VerrazzanoLogger) (string, string, error) {
 	log.Oncef("Registering managed cluster in Rancher with name: %s", clusterName)
 
-	rc, err := newRancherConfig(rdr, log)
-	if err != nil {
-		return "", "", err
-	}
-
-	log.Oncef("Importing cluster %s into to Rancher", clusterName)
 	clusterID, err := importClusterToRancher(rc, clusterName, log)
 	if err != nil {
 		log.Errorf("Failed to import cluster to Rancher: %v", err)
@@ -252,12 +246,7 @@ func getClusterIDFromRancher(rc *rancherConfig, clusterName string, log vzlog.Ve
 }
 
 // isManagedClusterActive returns true if the managed cluster is active
-func isManagedClusterActive(rdr client.Reader, clusterID string, log vzlog.VerrazzanoLogger) (bool, error) {
-	rc, err := newRancherConfig(rdr, log)
-	if err != nil {
-		return false, err
-	}
-
+func isManagedClusterActive(rc *rancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (bool, error) {
 	reqURL := rc.baseURL + clustersPath + "/" + clusterID
 	headers := map[string]string{"Authorization": "Bearer " + rc.apiAccessToken}
 
@@ -281,12 +270,7 @@ func isManagedClusterActive(rdr client.Reader, clusterID string, log vzlog.Verra
 
 // getCACertFromManagedCluster attempts to get the CA cert from the managed cluster using the Rancher API proxy. It first checks for
 // the Rancher TLS secret and if that is not found it looks for the Verrazzano system TLS secret.
-func getCACertFromManagedCluster(rdr client.Reader, clusterID string, log vzlog.VerrazzanoLogger) (string, error) {
-	rc, err := newRancherConfig(rdr, log)
-	if err != nil {
-		return "", err
-	}
-
+func getCACertFromManagedCluster(rc *rancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (string, error) {
 	// first look for the Rancher TLS secret
 	caCert, err := getCACertFromManagedClusterSecret(rc, clusterID, rancherNamespace, cons.AdditionalTLS, "ca-additional.pem", log)
 	if err != nil {

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -264,8 +264,14 @@ func isManagedClusterActive(rc *rancherConfig, clusterID string, log vzlog.Verra
 	if err != nil {
 		return false, err
 	}
+	agentImage, err := httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "agentImage", "unable to find agent image in Rancher response")
+	if err != nil {
+		return false, err
+	}
 
-	return state == clusterStateActive, nil
+	// Rancher temporarily sets the state of a new cluster to "active" before setting it to "pending", so we also check for the "agentImage" field
+	// to know that the cluster is really active
+	return state == clusterStateActive && len(agentImage) > 0, nil
 }
 
 // getCACertFromManagedCluster attempts to get the CA cert from the managed cluster using the Rancher API proxy. It first checks for

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
 	cons "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -36,13 +37,18 @@ const (
 	rancherTLSSecret   = "tls-rancher-ingress"  //nolint:gosec //#gosec G101
 
 	clusterPath         = "/v3/cluster"
+	clustersPath        = "/v3/clusters"
 	clustersByNamePath  = "/v3/clusters?name="
 	clusterRegTokenPath = "/v3/clusterregistrationtoken" //nolint:gosec //#gosec G101
 	manifestPath        = "/v3/import/"
 	loginPath           = "/v3-public/localProviders/local?action=login"
 
+	k8sClustersPath = "/k8s/clusters/"
+
 	// this host resolves to the cluster IP
 	nginxIngressHostName = "ingress-controller-ingress-nginx-controller.ingress-nginx"
+
+	clusterStateActive = "active"
 )
 
 type rancherConfig struct {
@@ -78,9 +84,35 @@ var rancherHTTPClient requestSender = &httpRequestSender{}
 
 // registerManagedClusterWithRancher registers a managed cluster with Rancher and returns a chunk of YAML that
 // must be applied on the managed cluster to complete the registration.
-func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, log vzlog.VerrazzanoLogger) (string, error) {
+func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, log vzlog.VerrazzanoLogger) (string, string, error) {
 	log.Oncef("Registering managed cluster in Rancher with name: %s", clusterName)
 
+	rc, err := newRancherConfig(rdr, log)
+	if err != nil {
+		return "", "", err
+	}
+
+	log.Oncef("Importing cluster %s into to Rancher", clusterName)
+	clusterID, err := importClusterToRancher(rc, clusterName, log)
+	if err != nil {
+		log.Errorf("Failed to import cluster to Rancher: %v", err)
+		return "", "", err
+	}
+
+	log.Once("Getting registration YAML from Rancher")
+	regYAML, err := getRegistrationYAMLFromRancher(rc, clusterID, log)
+	if err != nil {
+		log.Errorf("Failed to get registration YAML from Rancher: %v", err)
+		return "", "", err
+	}
+
+	regYAML = overrideRancherImageLocation(regYAML, log)
+
+	return regYAML, clusterID, nil
+}
+
+// newRancherConfig returns a populated rancherConfig struct that can be used to make calls to the Rancher API
+func newRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*rancherConfig, error) {
 	rc := &rancherConfig{baseURL: "https://" + nginxIngressHostName}
 
 	// Rancher host name is needed for TLS
@@ -88,7 +120,7 @@ func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, lo
 	hostname, err := getRancherIngressHostname(rdr)
 	if err != nil {
 		log.Errorf("Failed to get Rancher ingress host name: %v", err)
-		return "", err
+		return nil, err
 	}
 	rc.host = hostname
 
@@ -96,7 +128,7 @@ func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, lo
 	caCert, err := common.GetRootCA(rdr)
 	if err != nil {
 		log.Errorf("Failed to get Rancher TLS root CA: %v", err)
-		return "", err
+		return nil, err
 	}
 	rc.certificateAuthorityData = caCert
 
@@ -107,27 +139,11 @@ func registerManagedClusterWithRancher(rdr client.Reader, clusterName string, lo
 	adminToken, err := getAdminTokenFromRancher(rdr, rc, log)
 	if err != nil {
 		log.Errorf("Failed to get admin token from Rancher: %v", err)
-		return "", err
+		return nil, err
 	}
 	rc.apiAccessToken = adminToken
 
-	log.Oncef("Importing cluster %s into to Rancher", clusterName)
-	clusterID, err := importClusterToRancher(rc, clusterName, log)
-	if err != nil {
-		log.Errorf("Failed to import cluster to Rancher: %v", err)
-		return "", err
-	}
-
-	log.Once("Getting registration YAML from Rancher")
-	regYAML, err := getRegistrationYAMLFromRancher(rc, clusterID, log)
-	if err != nil {
-		log.Errorf("Failed to get registration YAML from Rancher: %v", err)
-		return "", err
-	}
-
-	regYAML = overrideRancherImageLocation(regYAML, log)
-
-	return regYAML, nil
+	return rc, nil
 }
 
 // overrideRancherImageLocation patches the Rancher agent image when the Verrazzano installation overrides
@@ -233,7 +249,103 @@ func getClusterIDFromRancher(rc *rancherConfig, clusterName string, log vzlog.Ve
 	}
 
 	return httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "data.0.id", "unable to find clusterId in Rancher response")
+}
 
+// isManagedClusterActive returns true if the managed cluster is active
+func isManagedClusterActive(rdr client.Reader, clusterID string, log vzlog.VerrazzanoLogger) (bool, error) {
+	rc, err := newRancherConfig(rdr, log)
+	if err != nil {
+		return false, err
+	}
+
+	reqURL := rc.baseURL + clustersPath + "/" + clusterID
+	headers := map[string]string{"Authorization": "Bearer " + rc.apiAccessToken}
+
+	response, responseBody, err := sendRequest(http.MethodGet, reqURL, headers, "", rc, log)
+
+	if response != nil && response.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("tried to get cluster from Rancher but failed, response code: %d", response.StatusCode)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	state, err := httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "state", "unable to find cluster state in Rancher response")
+	if err != nil {
+		return false, err
+	}
+
+	return state == clusterStateActive, nil
+}
+
+// getCACertFromManagedCluster attempts to get the CA cert from the managed cluster using the Rancher API proxy. It first checks for
+// the Rancher TLS secret and if that is not found it looks for the Verrazzano system TLS secret.
+func getCACertFromManagedCluster(rdr client.Reader, clusterID string, log vzlog.VerrazzanoLogger) (string, error) {
+	rc, err := newRancherConfig(rdr, log)
+	if err != nil {
+		return "", err
+	}
+
+	// first look for the Rancher TLS secret
+	caCert, err := getCACertFromManagedClusterSecret(rc, clusterID, rancherNamespace, cons.AdditionalTLS, "ca-additional.pem", log)
+	if err != nil {
+		return "", err
+	}
+
+	if caCert != "" {
+		return caCert, nil
+	}
+
+	// didn't find the Rancher secret so next look for the verrazzano-tls secret
+	caCert, err = getCACertFromManagedClusterSecret(rc, clusterID, cons.VerrazzanoSystemNamespace, constants.VerrazzanoIngressSecret, "ca.crt", log)
+	if err != nil {
+		return "", err
+	}
+
+	if caCert != "" {
+		return caCert, nil
+	}
+
+	return "", nil
+}
+
+// getCACertFromManagedClusterSecret attempts to get the CA cert from a secret on the managed cluster using the Rancher API proxy
+func getCACertFromManagedClusterSecret(rc *rancherConfig, clusterID, namespace, secretName, secretKey string, log vzlog.VerrazzanoLogger) (string, error) {
+	const k8sAPISecretPattern = "%s/api/v1/namespaces/%s/secrets/%s"
+
+	// use the Rancher API proxy on the managed cluster to fetch the secret
+	baseReqURL := rc.baseURL + k8sClustersPath + clusterID
+	headers := map[string]string{"Authorization": "Bearer " + rc.apiAccessToken}
+
+	reqURL := fmt.Sprintf(k8sAPISecretPattern, baseReqURL, namespace, secretName)
+	response, responseBody, err := sendRequest(http.MethodGet, reqURL, headers, "", rc, log)
+
+	if response != nil {
+		if response.StatusCode == http.StatusNotFound {
+			return "", nil
+		}
+		if response.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("tried to get managed cluster CA cert %s/%s from Rancher but failed, response code: %d", namespace, secretName, response.StatusCode)
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// parse the response and pull out the secretKey value from the secret data
+	jsonString, err := gabs.ParseJSON([]byte(responseBody))
+	if err != nil {
+		return "", err
+	}
+
+	if data, ok := jsonString.Path("data").Data().(map[string]interface{}); ok {
+		if caCert, ok := data[secretKey].(string); ok {
+			return caCert, nil
+		}
+	}
+
+	return "", nil
 }
 
 // getRegistrationYAMLFromRancher creates a registration token in Rancher for the managed cluster and uses the

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -111,7 +111,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncCACertSecret(vmc *clusterapi.Ve
 		return "", nil
 	}
 
-	isActive, err := isManagedClusterActive(rc, clusterID, r.log)
+	isActive, err := isManagedClusterActiveInRancher(rc, clusterID, r.log)
 	if err != nil {
 		return "", err
 	}

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -165,14 +165,13 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 
 	if vmc.Status.PrometheusHost == "" {
 		log.Infof("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
-		return ctrl.Result{}, nil
-	}
-
-	log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
-	err = r.syncPrometheusScraper(ctx, vmc)
-	if err != nil {
-		r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)
-		return newRequeueWithDelay(), err
+	} else {
+		log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
+		err = r.syncPrometheusScraper(ctx, vmc)
+		if err != nil {
+			r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)
+			return newRequeueWithDelay(), err
+		}
 	}
 
 	return ctrl.Result{Requeue: true, RequeueAfter: constants.ReconcileLoopRequeueInterval}, nil

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -1958,7 +1958,7 @@ func expectSyncCACertRancherHTTPCalls(t *testing.T, requestSenderMock *mocks.Moc
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
 			asserts.Equal("/v3/clusters/unit-test-cluster-id", req.URL.Path)
 
-			r := ioutil.NopCloser(bytes.NewReader([]byte(`{"state":"active"}`)))
+			r := ioutil.NopCloser(bytes.NewReader([]byte(`{"state":"active","agentImage":"test-image:1.0.0"}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -875,7 +875,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 			return nil
 		})
 
-	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -903,7 +903,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 			return errors.NewResourceExpired("something bad happened")
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -944,7 +944,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err := registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -987,7 +987,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1042,7 +1042,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1110,7 +1110,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	regYAML, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
+	regYAML, _, err = registerManagedClusterWithRancher(mock, testManagedCluster, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1164,7 +1164,7 @@ func TestRegisterClusterWithRancherRetryRequest(t *testing.T) {
 			return resp, nil
 		}).Times(retrySteps)
 
-	_, err := registerManagedClusterWithRancher(mock, clusterName, vzlog.DefaultLogger())
+	_, _, err := registerManagedClusterWithRancher(mock, clusterName, vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1889,11 +1889,6 @@ func getJob(scrapeConfigs []*gabs.Container, name string) *gabs.Container {
 		}
 	}
 	return job
-}
-
-// getCASecretName returns the ca secret for testManagedCluster
-func getCASecretName(name string) string {
-	return fmt.Sprintf("ca-secret-%s", name)
 }
 
 // getPrometheusHost returns the prometheus host for testManagedCluster


### PR DESCRIPTION
This PR adds processing to the VMC reconcile logic that:

1. Waits for the managed cluster to become active in Rancher
2. Reaches into the managed cluster (using the Rancher API proxy) and gets the CA cert secret
3. Creates/updates the CA cert secret on the admin cluster
4. Sets the `caSecret` field in the VMC spec to reference the secret

I tested this locally in a multi-cluster setup by:

1. Created an empty VMC on the admin cluster
2. Navigated to the Rancher UI and saw that the managed cluster was pending
3. Copied the command to register the cluster
4. Ran the command on the managed cluster
5. Examined the VPO logs and saw that it pulled the CA secret
6. Described the VMC and saw that the `caSecret` field was now populated
7. Dumped the contents of the CA secret

Included in this work was some refactoring in `rancher.go` to be able to re-use the code to login to Rancher and create a session token so that it could be used to make multiple calls.