### PR TITLE
VZ-6502 Remove presetting of Prometheus URL for Jaeger SPM feature

### DIFF
--- a/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
@@ -24,7 +24,3 @@ jaeger:
       options:
         es:
           index-prefix: verrazzano
-    query:
-      options:
-        prometheus:
-          server-url: http://prometheus-operator-kube-p-prometheus.verrazzano-monitoring.svc.cluster.local:9090


### PR DESCRIPTION
Jaeger Query expects Prometheus URL to be set only when the metrics
storage type is set to "prometheus" otherwise it fails to recognize the
option prometheus.server-url and throws an error "unknown flag: --prometheus.server-url".
