### PR TITLE
VZ-6537 Updated console version to uptake the fix in console code

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -191,7 +191,7 @@
             },
             {
               "image": "console",
-              "tag": "1.4.0-20220722132540-d8a58fc",
+              "tag": "1.4.0-20220728085214-87d3cd5",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
VZ-6537 - Fix for bug in the Verrazzano console to show only the instance URLs which are enabled in the VZ CR.