### PR TITLE
VZ-6502 Set Prometheus server URL Jaeger override

### DIFF
--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
@@ -183,6 +183,14 @@ func TestAppendOverrides(t *testing.T) {
 			numKeyValues: 1,
 			expectedErr:  nil,
 		},
+		{
+			name:         "OverrideMetricsStorageType",
+			description:  "Test overriding metrics storage type",
+			expectedYAML: "testdata/jaegerOperatorOverrideValues.yaml",
+			actualCR:     "testdata/jaegerOperatorOverrideMetricsStorageVz.yaml",
+			numKeyValues: 2,
+			expectedErr:  nil,
+		},
 	}
 	defer resetWriteFileFunc()
 	for _, test := range tests {
@@ -241,6 +249,11 @@ func TestAppendOverrides(t *testing.T) {
 			_, err = os.Stat(tempFilePath)
 			asserts.NoError(err, "Unexpected error checking for temp file %s: %s", tempFilePath, err)
 			cleanTempFiles(fakeContext)
+
+			if test.name == "OverrideMetricsStorageType" {
+				asserts.Equal(kvs[1].Key, prometheusServerField)
+				asserts.Equal(kvs[1].Value, prometheusURL)
+			}
 		})
 	}
 	// Verify temp files are deleted

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideMetricsStorageVz.yaml
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideMetricsStorageVz.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: example-verrazzano
+spec:
+  profile: dev
+  components:
+    jaegerOperator:
+      enabled: true
+      overrides:
+        - values:
+            jaeger:
+              spec:
+                query:
+                  metricsStorage:
+                    type: prometheus


### PR DESCRIPTION
Automatically set prometheus server URL if Jaeger Query metrics storage
type override is set to "prometheus" in VZ CR.
