### PR TITLE
VZ-6462: Update multicluster e2e tests for CA cert secret auto sync

### DIFF
--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -76,11 +76,11 @@ func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.C
 
 	// The additional scrape configs and managed cluster TLS secrets are needed by the Prometheus Operator Prometheus
 	// because the federated scrape config can't be represented in a PodMonitor, ServiceMonitor, etc.
-	err := r.mutateAdditionalScrapeConfigs(ctx, vmc, &secret)
+	err := r.mutateManagedClusterCACertsSecret(ctx, vmc, &secret)
 	if err != nil {
 		return err
 	}
-	err = r.mutateManagedClusterCACertsSecret(ctx, vmc, &secret)
+	err = r.mutateAdditionalScrapeConfigs(ctx, vmc, &secret)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -30,6 +30,9 @@ import (
 const waitTimeout = 10 * time.Minute
 const pollingInterval = 10 * time.Second
 
+const longWaitTimeout = 20 * time.Minute
+const longPollingInterval = 30 * time.Second
+
 const multiclusterNamespace = "verrazzano-mc"
 const verrazzanoSystemNamespace = "verrazzano-system"
 
@@ -216,7 +219,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 			pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric with label %s with value %s", clusterNameMetricsLabel, managedClusterName))
 			Eventually(func() bool {
 				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName)
-			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find a metrics from managed cluster")
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find metrics from managed cluster")
 		})
 
 		t.It("Fluentd should point to the correct ES", func() {


### PR DESCRIPTION
The VMC code now automatically fetches the CA cert secret from the managed clusters so that users do not need to manually create the secret and populate the VMC `caSecret` field. This PR adds testing of that functionality.

The script that registers the managed cluster now checks the installed Verrazzano version and if the version is >= 1.4, we skip fetching the CA secret, creating the secret, and filling it in the `caCert` field in the VMC. For versions prior to 1.4, the script still does the manual work.

I also made a change to fix an issue I saw in the tests where the Prometheus config is updated to reference the CA secret before the CA secret is created. It eventually resolves itself but I changed the code so that the secret is created first and then the config that references it is updated. This results in Prometheus scraping from the managed cluster Prometheus a little bit sooner than it had previously.