### PR TITLE
VZ-6425: Add ha.yaml as example and update HA pipeline to use it

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -341,8 +341,8 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
                         if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sCluster('ha-rolling-upgrade-cluster-dump')
+                            dumpK8sClusterFromBugReport('ha-rolling-upgrade-cluster-dump')
                         }
                     }
                 }
@@ -350,8 +350,8 @@ pipeline {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
                         if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('new-kind-acceptance-tests-cluster-dump')
-                            dumpK8sClusterFromBugReport('new-kind-acceptance-tests-cluster-dump')
+                            dumpK8sCluster('ha-rolling-upgrade-cluster-dump')
+                            dumpK8sClusterFromBugReport('ha-rolling-upgrade-cluster-dump')
                         }
                     }
                 }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -79,7 +79,7 @@ pipeline {
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
         IMAGE_PULL_SECRET = 'verrazzano-container-registry'
-        INSTALL_CONFIG_FILE_KIND = "./tests/e2e/config/scripts/install-verrazzano-kind.yaml"
+        INSTALL_CONFIG_FILE_KIND = "./examples/ha/ha.yaml"
         INSTALL_PROFILE = "dev"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: verrazzano
+spec:
+  profile: prod
+  components:
+    authproxy:
+      kubernetes:
+        replicas: 2
+    certManager:
+      overrides:
+        - values:
+            replicaCount: 2
+            cainjector:
+              replicaCount: 2
+            webhook:
+              replicaCount: 2
+    console:
+      overrides:
+        - values:
+            replicas: 2
+    ingress:
+      overrides:
+        - values:
+            controller:
+              autoscaling:
+                enabled: true
+                minReplicas: 2
+            defaultBackend:
+              replicaCount: 2
+    istio:
+      overrides:
+        - values:
+            apiVersion: install.istio.io/v1alpha1
+            kind: IstioOperator
+            spec:
+              components:
+                pilot:
+                  k8s:
+                    replicaCount: 2
+      ingress:
+        kubernetes:
+          replicas: 2
+      egress:
+        kubernetes:
+          replicas: 2
+    keycloak:
+      overrides:
+        - values:
+            replicas: 2
+    kibana:
+      replicas: 2
+    kiali:
+      overrides:
+        - values:
+            deployment:
+              replicas: 2
+    prometheusOperator:
+      overrides:
+        - values:
+            prometheus:
+              prometheusSpec:
+                replicas: 2

--- a/tests/e2e/verify-install/istio/istio_test.go
+++ b/tests/e2e/verify-install/istio/istio_test.go
@@ -185,7 +185,7 @@ func getPilotReplicaCount(vz *vzapi.Verrazzano) uint32 {
 				if err != nil {
 					return 1
 				}
-				if container := jsonString.Path("spec.components.pilot.k8s.replicas"); container != nil {
+				if container := jsonString.Path("spec.components.pilot.k8s.replicaCount"); container != nil {
 					if val, ok := container.Data().(float64); ok {
 						return uint32(val)
 					}

--- a/tests/e2e/verify-install/istio/istio_test.go
+++ b/tests/e2e/verify-install/istio/istio_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -173,8 +174,24 @@ func getEgressReplicaCount(vz *vzapi.Verrazzano) uint32 {
 
 func getPilotReplicaCount(vz *vzapi.Verrazzano) uint32 {
 	istio := vz.Spec.Components.Istio
-	if istio != nil && !isIstioEnabled(istio) {
-		return 0
+	if istio != nil {
+		if !isIstioEnabled(istio) {
+			return 0
+		}
+
+		for _, override := range istio.ValueOverrides {
+			if override.Values != nil {
+				jsonString, err := gabs.ParseJSON(override.Values.Raw)
+				if err != nil {
+					return 1
+				}
+				if container := jsonString.Path("spec.components.pilot.k8s.replicas"); container != nil {
+					if val, ok := container.Data().(float64); ok {
+						return uint32(val)
+					}
+				}
+			}
+		}
 	}
 	return 1
 }

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -89,6 +89,8 @@ func isPrometheusOperatorEnabled() bool {
 	return pkg.IsPrometheusOperatorEnabled(kubeconfigPath)
 }
 
+// areOverridesEnabled - return true if the override value prometheusOperator.podAnnotations.override
+// is present and set to "true"
 func areOverridesEnabled() bool {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
@@ -105,7 +107,7 @@ func areOverridesEnabled() bool {
 		return false
 	}
 
-	// Look for the operator value
+	// The overrides are enabled if the override value prometheusOperator.podAnnotations.override = "true"
 	for _, override := range promOper.ValueOverrides {
 		if override.Values != nil {
 			jsonString, err := gabs.ParseJSON(override.Values.Raw)


### PR DESCRIPTION
Provide an example configuration file, named ha.yaml, that has the suggested configuration to install a highly available prod environment.  Update the rolling upgrade pipeline to use the ha.yaml configuration.

Fix some tests to work with the ha.yaml configuration.
