### PR TITLE
VZ-6318 Support custom Jaeger secret in verrazzano-install namespace

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/secret.go
+++ b/platform-operator/controllers/verrazzano/component/common/secret.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"context"
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+// copySecret copies a secret from the verrazzano-install namespace to the specified namespace. If
+// the target secret already exists, then it will be updated if necessary.
+func CopySecret(ctx spi.ComponentContext, secretName string, destNamespace string, logMsg string) error {
+	vzLog := ctx.Log()
+	vzLog.Debugf("Copying %s secret %s to %s namespace", logMsg, secretName, globalconst.VerrazzanoSystemNamespace)
+
+	targetSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: destNamespace,
+		},
+	}
+	opResult, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &targetSecret, func() error {
+		sourceSecret := corev1.Secret{}
+		nsn := types.NamespacedName{Name: secretName, Namespace: constants.VerrazzanoInstallNamespace}
+		if err := ctx.Client().Get(context.TODO(), nsn, &sourceSecret); err != nil {
+			return err
+		}
+		targetSecret.Type = sourceSecret.Type
+		targetSecret.Immutable = sourceSecret.Immutable
+		targetSecret.StringData = sourceSecret.StringData
+		targetSecret.Data = sourceSecret.Data
+		return nil
+	})
+
+	vzLog.Debugf("Copy %s secret result: %s", logMsg, opResult)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return ctx.Log().ErrorfNewErr("Failed in create/update for CopySecret: %v", err)
+		}
+		return vzLog.ErrorfNewErr("Failed, the %s secret %s not found in namespace %s", logMsg, secretName, constants.VerrazzanoInstallNamespace)
+	}
+
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/common/secret.go
+++ b/platform-operator/controllers/verrazzano/component/common/secret.go
@@ -15,7 +15,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
-// copySecret copies a secret from the verrazzano-install namespace to the specified namespace. If
+// CopySecret copies a secret from the verrazzano-install namespace to the specified namespace. If
 // the target secret already exists, then it will be updated if necessary.
 func CopySecret(ctx spi.ComponentContext, secretName string, destNamespace string, logMsg string) error {
 	vzLog := ctx.Log()

--- a/platform-operator/controllers/verrazzano/component/common/secret.go
+++ b/platform-operator/controllers/verrazzano/component/common/secret.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package common
 
 import (

--- a/platform-operator/controllers/verrazzano/component/common/secret_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/secret_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+var testScheme = runtime.NewScheme()
+
+func init() {
+	_ = vzapi.AddToScheme(testScheme)
+	_ = clientgoscheme.AddToScheme(testScheme)
+	// +kubebuilder:scaffold:testScheme
+}
+
+// TestCopySecret tests the CopySecret function
+func TestCopySecret(t *testing.T) {
+	secretName := "test-secret"
+	invalidSecret := "nonExistentSecret"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: constants.VerrazzanoInstallNamespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte("test"),
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(secret).Build()
+	ctx := spi.NewFakeContext(fakeClient, nil, false)
+	err := CopySecret(ctx, secretName, constants.VerrazzanoSystemNamespace, "test secret")
+	assert.NoError(t, err)
+	destSecret := &corev1.Secret{}
+	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Name: secretName,
+		Namespace: constants.VerrazzanoSystemNamespace}, destSecret)
+	assert.NoError(t, err)
+	assert.Equal(t, secret.Data, destSecret.Data)
+	err = CopySecret(ctx, invalidSecret, constants.VerrazzanoSystemNamespace, "test secret")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "secret "+invalidSecret+" not found in namespace "+constants.VerrazzanoInstallNamespace)
+}

--- a/platform-operator/controllers/verrazzano/component/common/secret_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/secret_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package common
 
 import (

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
@@ -380,7 +380,7 @@ func generateOverridesFile(ctx spi.ComponentContext, contents []byte) (string, e
 
 // createJaegerSecret creates a Jaeger secret for storing credentials needed to access OpenSearch.
 func createJaegerSecret(ctx spi.ComponentContext) error {
-	// Check if the user has specified a jaeger secret override. As the user is expected to create the secret in
+	// Check if the user has specified a Jaeger secret override. As the user is expected to create the secret in
 	// verrazzano-install namespace, copy it to verrazzano-monitoring namespace.
 	jaegerSecretOverride, err := getOverrideVal(ctx, jaegerSecNameField)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
@@ -163,7 +163,7 @@ func (c jaegerOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	}
 	installed, err := helmcli.IsReleaseInstalled(ComponentName, ComponentNamespace)
 	if err != nil {
-		ctx.Log().ErrorfNewErr("Failed searching for Jaeger release: %v", err)
+		return ctx.Log().ErrorfNewErr("Failed searching for Jaeger release: %v", err)
 	}
 	if !installed && doDefaultJaegerInstanceDeploymentsExists(ctx) {
 		return ctx.Log().ErrorfNewErr("Conflicting Jaeger instance %s/%s exists! Either disable the Verrazzano's default Jaeger instance creation by overriding jaeger.create Helm value for Jaeger Operator component to false or delete and recreate the existing Jaeger deployment in a different namespace: %v", ComponentNamespace, JaegerInstanceName, err)
@@ -177,8 +177,8 @@ func (c jaegerOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 	if createInstance {
-		// Create Jaeger secret with the credentials present in the verrazzano-es-internal secret
-		createJaegerSecret(ctx)
+		// Create Jaeger secret with the OpenSearch credentials
+		return createJaegerSecret(ctx)
 	}
 	return nil
 }


### PR DESCRIPTION
To support external OpenSearch as storage for the default Jaeger
instance, the user has to create a Jaeger secret himself. As the
verrazzano-monitoring namespace will not be available prior to the
Verrazzano installation, the user is supposed to create the required
secrets in the verrazzano-install namespace. Changes are done similar to
fluentd external OpenSearch support to copy the secret from
verrazzano-install namespace to verrazzano-monitoring namespace, prior to
the creation of the Jaeger instance.
