### PR TITLE
VZ-4762: Backport changes for uploading daily scan reports (master -> release-1.2)

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -4,6 +4,7 @@
 pipeline {
     options {
         timestamps ()
+        copyArtifactPermission('/upload-scan-report')
     }
 
     agent {
@@ -77,6 +78,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                build job: '/upload-scan-report', parameters: [
+                    string(name: 'UPSTREAM_JOB', value: "${env.JOB_NAME}"),
+                    string(name: 'UPSTREAM_BUILD', value: "${env.BUILD_NUMBER}")
+                ], propagate: false, wait: false
             }
         }
     }

--- a/ci/scan-results/JenkinsfileUpload
+++ b/ci/scan-results/JenkinsfileUpload
@@ -23,6 +23,7 @@ pipeline {
 
     environment {
         upload_filename = "consolidated-upload.json"
+        copy_artifact_filter = "scan-results/latest-periodic/${upload_filename}"
         upload_url = "${env.SCANMANAGER_URL}"
     }
 
@@ -31,14 +32,14 @@ pipeline {
             steps {
                 script {
                     sh """
-                        echo "Copying ${upload_filename} from upstream pipeline"
+                        echo "Copying ${copy_artifact_filter} from upstream pipeline"
                         echo "UPSTREAM_JOB = ${params.UPSTREAM_JOB}"
                         echo "UPSTREAM_BUILD = ${params.UPSTREAM_BUILD}"
                     """
                     copyArtifacts(
                         projectName: "/${params.UPSTREAM_JOB}",
                         selector: specific("${params.UPSTREAM_BUILD}"),
-                        filter: "${upload_filename}",
+                        filter: "${copy_artifact_filter}",
                         flatten: true,
                         optional: false,
                         fingerprintArtifacts: false
@@ -46,7 +47,7 @@ pipeline {
                     sh """
                         echo "Got file ${upload_filename}:"
                         ls -l
-                        head ${upload_filename}
+                        head -8 ${upload_filename}
                     """
                 }
             }
@@ -57,7 +58,7 @@ pipeline {
                 script {
                     sh """
                     echo "Uploading ${upload_filename} to ${upload_url}"
-                    echo curl -k -v -X POST -H "Content-Type: application/json" -d@${upload_filename} ${upload_url}
+                    curl -k -v -X POST -H "Content-Type: application/json" -d@${upload_filename} ${upload_url}
                     echo "File uploaded"
                     """
                 }

--- a/ci/scan-results/JenkinsfileUpload
+++ b/ci/scan-results/JenkinsfileUpload
@@ -1,0 +1,78 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+pipeline {
+    options {
+        skipDefaultCheckout true
+        timestamps ()
+    }
+
+    agent {
+        docker {
+            image "${RUNNER_DOCKER_IMAGE}"
+            args "${RUNNER_DOCKER_ARGS}"
+            registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
+            label 'internal'
+        }
+    }
+
+    parameters {
+        string (name: 'UPSTREAM_JOB', defaultValue: 'NONE', description: 'Name of the upstream job')
+        string (name: 'UPSTREAM_BUILD', defaultValue: 'NONE', description: 'Build number to copy the upload file from')
+    }
+
+    environment {
+        upload_filename = "consolidated-upload.json"
+        upload_url = "${env.SCANMANAGER_URL}"
+    }
+
+    stages {
+        stage('Fetch Scan Report') {
+            steps {
+                script {
+                    sh """
+                        echo "Copying ${upload_filename} from upstream pipeline"
+                        echo "UPSTREAM_JOB = ${params.UPSTREAM_JOB}"
+                        echo "UPSTREAM_BUILD = ${params.UPSTREAM_BUILD}"
+                    """
+                    copyArtifacts(
+                        projectName: "/${params.UPSTREAM_JOB}",
+                        selector: specific("${params.UPSTREAM_BUILD}"),
+                        filter: "${upload_filename}",
+                        flatten: true,
+                        optional: false,
+                        fingerprintArtifacts: false
+                    )
+                    sh """
+                        echo "Got file ${upload_filename}:"
+                        ls -l
+                        head ${upload_filename}
+                    """
+                }
+            }
+        }
+
+        stage("Upload Scan Report") {
+            steps {
+                script {
+                    sh """
+                    echo "Uploading ${upload_filename} to ${upload_url}"
+                    echo curl -k -v -X POST -H "Content-Type: application/json" -d@${upload_filename} ${upload_url}
+                    echo "File uploaded"
+                    """
+                }
+            }
+        }
+
+    }
+
+    post {
+        cleanup {
+            sh """
+                echo "Removing upload file ${upload_filename}"
+                rm -f ${upload_filename}
+            """
+        }
+    }
+}
+

--- a/release/scripts/generate_upload_file.sh
+++ b/release/scripts/generate_upload_file.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+declare reportName="Daily Scan Results"
+declare reportType="VZ_DAILY_SCAN"
+declare reportRelease=
+declare reportBranch=
+declare reportTimestamp=
+declare resultVersion=
+
+get_timestamp_from_csv_file () {
+    local csv_file="${1}"
+    head -1 ${csv_file} | cut -f4 -d,
+}
+
+get_branch_from_csv_file () {
+    local csv_file="${1}"
+    head -1 ${csv_file} | cut -f2 -d,
+}
+
+get_release_from_branch_name () {
+    local branch_name="${1}"
+    local url_prefix="https://raw.githubusercontent.com/verrazzano/verrazzano"
+    local version_file=".verrazzano-development-version"
+    curl -s ${url_prefix}/${branch_name}/${version_file} | grep -- "^verrazzano-development-version=" | cut -f2 -d=
+}
+
+output_report_prologue () {
+    echo "{"
+    echo "    \"reportType\": \"${reportType}\","
+    echo "    \"reportName\": \"${reportName}\","
+    echo "    \"reportRelease\": \"${reportRelease}\","
+    echo "    \"reportBranch\": \"${reportBranch}\","
+    echo "    \"reportTimestamp\": \"${reportTimestamp}\","
+    echo "    \"reportResults\": ["
+}
+
+output_report_epilogue () {
+    echo "        }"
+    echo "    ]"
+    echo "}"
+}
+
+output_scan_result () {
+
+    oIFS="$IFS"
+    IFS=","
+    set -- ${1}
+    IFS="${oIFS}"
+
+    if [[ ${_firstLine} = false ]] ; then
+        echo "        },"
+    fi
+
+    echo "        {"
+    echo "            \"vulnerabilityId\" : \"${7}\","
+    echo "            \"vulnerabilitySeverity\" : \"${8}\","
+    echo "            \"reportingScanner\" : \"${6}\","
+    echo "            \"artifactName\" : \"${9%%:*}\","
+    echo "            \"artifactVersion\" : \"${9#*:}\","
+    echo "            \"verrazzanoVersion\" : \"${resultVersion}\""
+}
+
+declare _inputFile="${1}"
+if [[ -z ${_inputFile} || ! -f ${_inputFile} ]] ; then
+    echo "Input file '${_inputFile}' not found"
+    exit 1
+fi
+
+if [[ -n "${2}" ]] ; then
+    reportName="${reportName} (${2})"
+fi
+
+reportBranch=$(get_branch_from_csv_file ${_inputFile})
+reportRelease=$(get_release_from_branch_name ${reportBranch})
+reportTimestamp=$(get_timestamp_from_csv_file ${_inputFile})
+resultVersion=$(echo ${reportRelease} | cut -f1,2 -d.)
+reportRelease=${resultVersion}
+
+output_report_prologue
+
+declare _line=
+declare _firstLine=first
+cat ${_inputFile} | while read _line
+do
+    output_scan_result "${_line}"
+    _firstLine=false
+done
+
+output_report_epilogue
+

--- a/release/scripts/generate_vulnerability_report.sh
+++ b/release/scripts/generate_vulnerability_report.sh
@@ -4,8 +4,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
-#!/usr/bin/env bash
-
 #
 # Data
 #


### PR DESCRIPTION
Backport of VZ-4762.

Note that the upload-scan-results Jenkins job is *not* a multi-branch pipeline -- it always uses the JenkinsfileUpload file from master. JenkinsfileUpload is included in the backport to keep the source consistent across branches, and because it's possible we'll want to run it in a multi-branch pipeline at some point in the future.