### PR TITLE
VZ-6483: Conditionally remove VPO related resources during CLI uninstall

### DIFF
--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -150,13 +150,12 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return fmt.Errorf("Failed to uninstall Verrazzano: %s", err.Error())
 	}
 
-	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Successfully uninstalled Verrazzano\n")
 	return nil
 }
 
 // cleanupResources deletes remaining resources that remain after the Verrazzano resource in uninstalled
 // Resources that fail to delete will log an error but will not return
-func cleanupResources(client clipkg.Client, vzHelper helpers.VZHelper) error {
+func cleanupResources(client clipkg.Client, vzHelper helpers.VZHelper) {
 	// Delete verrazzano-install namespace
 	err := deleteNamespace(client, constants.VerrazzanoInstall)
 	if err != nil {
@@ -178,7 +177,6 @@ func cleanupResources(client clipkg.Client, vzHelper helpers.VZHelper) error {
 	if err != nil {
 		_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), err.Error()+"\n")
 	}
-	return nil
 }
 
 // getUninstallJobPodName returns the name of the pod for the verrazzano-uninstall job
@@ -323,8 +321,10 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 	var timeoutErr error
 	select {
 	case result := <-resChan:
-		// Delete remaining Verrazzano resources, excluding CRDs
-		_ = cleanupResources(client, vzHelper)
+		if result == nil {
+			// Delete remaining Verrazzano resources, excluding CRDs
+			cleanupResources(client, vzHelper)
+		}
 		return result
 	case <-time.After(timeout):
 		if timeout.Nanoseconds() != 0 {
@@ -332,8 +332,6 @@ func waitForUninstallToComplete(client client.Client, kubeClient kubernetes.Inte
 			timeoutErr = fmt.Errorf("Timeout %v exceeded waiting for uninstall to complete", timeout.String())
 		}
 	}
-	// Delete remaining Verrazzano resources, excluding CRDs
-	_ = cleanupResources(client, vzHelper)
 	return timeoutErr
 }
 

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -53,7 +53,6 @@ func TestUninstallCmd(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
 	assert.Contains(t, buf.String(), "Uninstalling Verrazzano\n")
-	assert.Contains(t, buf.String(), "Successfully uninstalled Verrazzano\n")
 
 	// Ensure resources have been deleted
 	ensureResourcesDeleted(t, c)
@@ -101,7 +100,6 @@ func TestUninstallCmdUninstallJob(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
 	assert.Contains(t, buf.String(), "Uninstalling Verrazzano\n")
-	assert.Contains(t, buf.String(), "Successfully uninstalled Verrazzano\n")
 
 	// Ensure resources have been deleted
 	ensureResourcesDeleted(t, c)


### PR DESCRIPTION
This pull request changes the CLI uninstall command to not cleanup VPO related resources when:
1. There is an error during uninstall
2. The uninstall command timeouts
3. The uninstall command is invoked with --wait=false