### PR TITLE
VZ-6552 Do not run application tests on the managed cluster

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -243,7 +243,7 @@ pipeline {
                             runInstallOnly("Install Verrazzano", count)
                         }
                         runVerifyTests("Run Test", count)
-                        if (params.RUN_APPLICATION_TESTS && count == maxIterations) {
+                        if (params.RUN_APPLICATION_TESTS && count == maxIterations && params.INSTALL_PROFILE != 'managed-cluster') {
                             runApplicationTests()
                         }
                         runUninstall(count)


### PR DESCRIPTION
The managed cluster install in the uninstall resiliency pipeline failed the application test stage. This fix removes that stage for managed clusters.