### PR TITLE
VZ:V4234 update backup-restore-operator image tag for new branch name

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -668,7 +668,7 @@
           "images": [
             {
               "image": "backup-restore-operator",
-              "tag": "v2.1.0-20220728055921-09d528e",
+              "tag": "v2.1.0-20220803210954-09d528e",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Update the backup-restore-operator image tag to the image built from the new branch
