### PR TITLE
VZ-6616: Fix for Verrazzano console upgrade from 1.3.2 to 1.4.0

### DIFF
--- a/platform-operator/controllers/verrazzano/component/console/console_component.go
+++ b/platform-operator/controllers/verrazzano/component/console/console_component.go
@@ -42,6 +42,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorUninstall: true,
 			Dependencies:              []string{authproxy.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
+			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_4_0,
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			GetInstallOverridesFunc:   GetOverrides,
 		},


### PR DESCRIPTION
This PR fixes console upgrade from 1.3.2 to 1.4.0. Added minimum Verrazzano version 1.4.0 to the console component to skip the installation of the console before Verrazzano upgrade. 