### PR TITLE
NO JIRA: Fix Prometheus storage settings in VMI on release-1.3 branch

### DIFF
--- a/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/vmi.go
@@ -20,7 +20,7 @@ func updateFunc(ctx spi.ComponentContext, storage *common.ResourceRequestValues,
 	return nil
 }
 
-func newPrometheus(cr *vzapi.Verrazzano, storage *common.ResourceRequestValues, vmi *vmov1.VerrazzanoMonitoringInstance) vmov1.Prometheus {
+func newPrometheus(cr *vzapi.Verrazzano, storage *common.ResourceRequestValues, existingVMI *vmov1.VerrazzanoMonitoringInstance) vmov1.Prometheus {
 	if cr.Spec.Components.Prometheus == nil {
 		return vmov1.Prometheus{}
 	}
@@ -33,8 +33,11 @@ func newPrometheus(cr *vzapi.Verrazzano, storage *common.ResourceRequestValues, 
 		Storage: vmov1.Storage{},
 	}
 	common.SetStorageSize(storage, &prometheus.Storage)
-	if vmi != nil {
-		prometheus.Storage = vmi.Spec.Prometheus.Storage
+	if existingVMI != nil {
+		// preserve PVC names since these are set by the VMO
+		if len(existingVMI.Spec.Prometheus.Storage.PvcNames) > 0 {
+			prometheus.Storage.PvcNames = existingVMI.Spec.Prometheus.Storage.PvcNames
+		}
 	}
 
 	return prometheus


### PR DESCRIPTION
When installing 1.3.2 with VMI persistent storage settings, the VMO fails to attach storage to Prometheus because the VMI storage settings are missing. This worked in 1.3.0 and 1.3.1, so I'm not sure why the behavior changed. In any event, the code that sets Prometheus storage in the VMI was wrong so this PR fixes it.