### PR TITLE
NO JIRA: Move auth proxy ServiceMonitor out of auth proxy helm chart

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -479,8 +479,8 @@ func TestApplySystemMonitors(t *testing.T) {
 	monitors.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"})
 	err = client.List(context.TODO(), monitors)
 	assert.NoError(t, err)
-	// expect that 7 ServiceMonitors are created
-	assert.Len(t, monitors.Items, 7)
+	// expect that 8 ServiceMonitors are created
+	assert.Len(t, monitors.Items, 8)
 }
 
 // TestValidatePrometheusOperator tests the validation of the Prometheus Operator installation and the Verrazzano CR

--- a/platform-operator/thirdparty/manifests/prometheus-operator/auth_proxy_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/auth_proxy_monitor.yaml
@@ -1,17 +1,16 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-  {{- if .Values.config.prometheusOperatorEnabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: authproxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .monitoringNamespace }}
   labels:
     release: prometheus-operator
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ .systemNamespace }}
   selector: {}
   endpoints:
     - path: /metrics
@@ -51,4 +50,3 @@ spec:
         sourceLabels:
         - name
         targetLabel: app
-  {{- end }}


### PR DESCRIPTION
This PR moves the auth proxy Prometheus ServiceMonitor out of the auth proxy helm chart and it will now be installed with Prometheus Operator. Currently when the auth proxy component is installed, it is relying on the fact that the CRD for ServiceMonitor has been installed. During installation, this eventually reconciles but during upgrade, if the CRD has not been installed by the time auth proxy is upgraded, the upgrade fails and retries, but can never complete.

By moving the ServiceMonitor to the Prometheus Operator install, we avoid the situation where the CRD does not exist.