### PR TITLE
NO JIRA: Fix bug, prevent previously disabled components from being installed when VPO is upgraded

### DIFF
--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -105,6 +105,13 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 					comp.Name(), comp.GetMinVerrazzanoVersion())
 				continue
 			}
+			if cr.Status.State == vzapi.VzStateReady {
+				// This is the case where the component was previously disabled but is now enabled in the effective CR, so
+				// we need to prevent the component from being installed when the VPO is upgraded and wait for the user
+				// to initiate the upgrade via the VZ CR
+				compLog.Oncef("Component %s was previously disabled and upgrade is not in progress, skipping install", compName)
+				continue
+			}
 			if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}


### PR DESCRIPTION
This PR addresses the following upgrade scenario:
1. Install Verrazzano 1.3.x
2. Upgrade the VPO to 1.4
3. After a short period of time (1-2 minutes), the VPO will start installing components that were disabled by default in 1.3 but are now enabled by default in 1.4 (specifically Prometheus Operator and Prometheus Node Exporter)

The fix is to check the VZ state and skip installing the previously disabled component if the state is "ready". I'm not crazy about this solution but it's simple and seems to work. If there's a better way to solve this problem I'm open to changing it.

This PR relies on https://github.com/verrazzano/verrazzano/pull/3777 being merged first, otherwise the upgrade of auth proxy will hang because the ServiceMonitor CRD does not exist (which got installed because of the above behavior).

VPO logs during upgrade tests:

After VPO is upgraded to 1.4:
```
{"level":"info","@timestamp":"2022-08-05T14:06:02.477Z","caller":"verrazzano/install.go:112","message":"Component prometheus-node-exporter was previously disabled and upgrade is not in progress, skipping install","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"prometheus-node-exporter","operation":"install"}
```
After VZ CR is upgraded:
```
{"level":"info","@timestamp":"2022-08-05T14:16:00.396Z","caller":"verrazzano/upgrade_component.go:92","message":"Component prometheus-operator is not installed; upgrade being skipped","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"prometheus-operator","operation":"upgrade"}
...
{"level":"info","@timestamp":"2022-08-05T14:18:16.328Z","caller":"verrazzano/install.go:42","message":"Component prometheus-operator is being reconciled","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"prometheus-operator","operation":"install"}
{"level":"info","@timestamp":"2022-08-05T14:19:25.866Z","caller":"verrazzano/install.go:126","message":"Component prometheus-operator pre-install is running ","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"prometheus-operator","operation":"install"}
...
{"level":"info","@timestamp":"2022-08-05T14:22:31.198Z","caller":"verrazzano/install.go:152","message":"Component prometheus-operator successfully installed","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"prometheus-operator","operation":"install"}
```