### PR TITLE
NO JIRA: More Prometheus install/upgrade fixes

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/prometheus.go
+++ b/platform-operator/controllers/verrazzano/component/common/prometheus.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const keycloakHTTPService = "keycloak-http"
+
+// UpdatePrometheusAnnotations updates annotations on the Prometheus CR to include the outbound IP for Keycloak
+func UpdatePrometheusAnnotations(ctx spi.ComponentContext, prometheusNamespace string, promOperComponentName string) error {
+	// Get a list of Prometheus in the verrazzano-monitoring namespace
+	promList := promoperapi.PrometheusList{}
+	err := ctx.Client().List(context.TODO(), &promList, &client.ListOptions{
+		Namespace:     prometheusNamespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{constants.VerrazzanoComponentLabelKey: promOperComponentName}),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "no matches for kind") || strings.Contains(err.Error(), "no kind is registered") {
+			ctx.Log().Info("Prometheus CRD not installed, skip updating annotations for Keycloak on the Prometheus instance")
+			return nil
+		}
+		return ctx.Log().ErrorfNewErr("Failed to list Prometheus in the %s namespace: %v", prometheusNamespace, err)
+	}
+
+	// Get the Keycloak service to retrieve the cluster IP for the Prometheus annotation
+	svc := corev1.Service{}
+	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Name: keycloakHTTPService, Namespace: constants.KeycloakNamespace}, &svc)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			ctx.Log().Info("keycloak-http service not found, skip updating annotations for Keycloak on the Prometheus instance")
+			return nil
+		}
+		return ctx.Log().ErrorfNewErr("Failed to get keycloak-http service: %v", err)
+	}
+
+	// If the ClusterIP is not empty, update the Prometheus annotation
+	// The includeOutboundIPRanges implies all others are excluded.
+	// This is done by adding the traffic.sidecar.istio.io/includeOutboundIPRanges=<Keycloak IP>/32 annotation.
+	if svc.Spec.ClusterIP != "" {
+		for _, prom := range promList.Items {
+			_, err = controllerutil.CreateOrUpdate(context.TODO(), ctx.Client(), prom, func() error {
+				if prom.Spec.PodMetadata == nil {
+					prom.Spec.PodMetadata = &promoperapi.EmbeddedObjectMetadata{}
+				}
+				if prom.Spec.PodMetadata.Annotations == nil {
+					prom.Spec.PodMetadata.Annotations = make(map[string]string)
+				}
+				delete(prom.Spec.PodMetadata.Annotations, "traffic.sidecar.istio.io/excludeOutboundIPRanges")
+				prom.Spec.PodMetadata.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"] = fmt.Sprintf("%s/32", svc.Spec.ClusterIP)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/common/prometheus_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/prometheus_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	clusterIP             = "1.2.3.4"
+	promOperComponentName = "prometheus-operator"
+	testPrometheusName    = "test-prometheus"
+)
+
+var promTestScheme = runtime.NewScheme()
+
+func init() {
+	_ = clientgoscheme.AddToScheme(promTestScheme)
+	_ = promoperapi.AddToScheme(promTestScheme)
+}
+
+// TestUpdatePrometheusAnnotations tests the UpdatePrometheusAnnotations function
+// GIVEN the Prometheus CR and keycloak-http service exist
+// WHEN  the UpdatePrometheusAnnotations function is called
+// THEN  the Prometheus CR pod annotations are updated with the keycloak IP
+func TestUpdatePrometheusAnnotations(t *testing.T) {
+	asserts := assert.New(t)
+
+	// create the k8s mock populated with resources
+	k8sMock := createK8sMock()
+
+	ctx := spi.NewFakeContext(k8sMock, &vzapi.Verrazzano{}, false)
+	err := UpdatePrometheusAnnotations(ctx, constants.VerrazzanoMonitoringNamespace, promOperComponentName)
+	asserts.NoError(err)
+
+	prom := &promoperapi.Prometheus{}
+	err = k8sMock.Get(context.TODO(), types.NamespacedName{Namespace: constants.VerrazzanoMonitoringNamespace, Name: testPrometheusName}, prom)
+	asserts.NoError(err)
+	asserts.Equal(clusterIP+"/32", prom.Spec.PodMetadata.Annotations["traffic.sidecar.istio.io/includeOutboundIPRanges"])
+}
+
+// TestUpdatePrometheusAnnotationsErrorConditions tests the UpdatePrometheusAnnotations function error conditions
+func TestUpdatePrometheusAnnotationsErrorConditions(t *testing.T) {
+	asserts := assert.New(t)
+
+	// GIVEN the Prometheus CRDs have not been installed
+	// WHEN  the UpdatePrometheusAnnotations function is called
+	// THEN  no error is returned
+
+	// create the k8s mock without the Prometheus types
+	schemeMissingPromTypes := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(schemeMissingPromTypes)
+
+	k8sMock := fake.NewClientBuilder().WithScheme(schemeMissingPromTypes).Build()
+
+	ctx := spi.NewFakeContext(k8sMock, &vzapi.Verrazzano{}, false)
+	err := UpdatePrometheusAnnotations(ctx, constants.VerrazzanoMonitoringNamespace, promOperComponentName)
+	asserts.NoError(err)
+
+	// GIVEN the keycloak-http service has not been created
+	// WHEN  the UpdatePrometheusAnnotations function is called
+	// THEN  no error is returned
+
+	// create the k8s mock without the keycloak-http service
+	k8sMock = fake.NewClientBuilder().WithScheme(promTestScheme).Build()
+
+	ctx = spi.NewFakeContext(k8sMock, &vzapi.Verrazzano{}, false)
+	err = UpdatePrometheusAnnotations(ctx, constants.VerrazzanoMonitoringNamespace, promOperComponentName)
+	asserts.NoError(err)
+}
+
+// createK8sMock creates the k8s mock populated with test resources
+func createK8sMock() client.Client {
+	return fake.NewClientBuilder().WithScheme(promTestScheme).WithObjects(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: constants.KeycloakNamespace,
+				Name:      keycloakHTTPService,
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: clusterIP,
+			},
+		},
+		&promoperapi.Prometheus{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: constants.VerrazzanoMonitoringNamespace,
+				Name:      testPrometheusName,
+				Labels: map[string]string{
+					constants.VerrazzanoComponentLabelKey: promOperComponentName,
+				},
+			},
+		}).Build()
+}

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -154,7 +154,7 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 
 	// Update the Prometheus annotations to include the Keycloak service as an outbound IP address
 	if promoperator.NewComponent().IsEnabled(ctx.EffectiveCR()) {
-		err = updatePrometheusAnnotations(ctx)
+		err = common.UpdatePrometheusAnnotations(ctx, promoperator.ComponentNamespace, promoperator.ComponentName)
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func (c KeycloakComponent) PostUpgrade(ctx spi.ComponentContext) error {
 
 	// Update the Prometheus annotations to include the Keycloak service as an outbound IP address
 	if promoperator.NewComponent().IsEnabled(ctx.EffectiveCR()) {
-		err := updatePrometheusAnnotations(ctx)
+		err := common.UpdatePrometheusAnnotations(ctx, promoperator.ComponentNamespace, promoperator.ComponentName)
 		if err != nil {
 			return err
 		}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -120,8 +120,10 @@ func postInstallUpgrade(ctx spi.ComponentContext) error {
 	if err := createOrUpdatePrometheusAuthPolicy(ctx); err != nil {
 		return err
 	}
-
 	if err := createOrUpdateNetworkPolicies(ctx); err != nil {
+		return err
+	}
+	if err := common.UpdatePrometheusAnnotations(ctx, ComponentNamespace, ComponentName); err != nil {
 		return err
 	}
 	// if there is a persistent volume that was migrated from the VMO-managed Prometheus, make sure the reclaim policy is set

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -11,6 +11,7 @@ import (
 
 	certapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -60,6 +61,7 @@ func init() {
 	_ = vzapi.AddToScheme(testScheme)
 	_ = certapiv1.AddToScheme(testScheme)
 	_ = istioclisec.AddToScheme(testScheme)
+	_ = promoperapi.AddToScheme(testScheme)
 }
 
 // TestIsPrometheusOperatorReady tests the isPrometheusOperatorReady function for the Prometheus Operator
@@ -479,8 +481,8 @@ func TestApplySystemMonitors(t *testing.T) {
 	monitors.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"})
 	err = client.List(context.TODO(), monitors)
 	assert.NoError(t, err)
-	// expect that 8 ServiceMonitors are created
-	assert.Len(t, monitors.Items, 8)
+	// expect that 9 ServiceMonitors are created
+	assert.Len(t, monitors.Items, 9)
 }
 
 // TestValidatePrometheusOperator tests the validation of the Prometheus Operator installation and the Verrazzano CR

--- a/platform-operator/thirdparty/manifests/prometheus-operator/fluentd_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/fluentd_monitor.yaml
@@ -1,24 +1,24 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-  {{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: fluentd
+  namespace: {{ .monitoringNamespace }}
   labels:
     release: prometheus-operator
 spec:
   namespaceSelector:
     matchNames:
-      - verrazzano-system
+      - {{ .systemNamespace }}
   selector:
     matchLabels:
       app: fluentd
   endpoints:
     - path: /metrics
       targetPort: http-metrics
-    {{ if .Values.monitoring.useIstioCerts }}
+    {{ if .isIstioEnabled }}
       scheme: https
       tlsConfig:
         caFile: /etc/istio-certs/root-cert.pem
@@ -28,4 +28,3 @@ spec:
     {{ else }}
       scheme: http
     {{ end }}
-  {{- end }}


### PR DESCRIPTION
This PR fixes two more problems uncovered when the bug was fixed to prevent Prometheus from being installed as soon as the VPO is upgraded:
1. The Fluentd ServiceMonitor needed to move out of the Verrazzano helm chart and into the Prometheus Operator component install. It turns out Rancher also creates the ServiceMonitor, etc. CRDs and when installing on a managed cluster, Rancher is not installed, so the ServiceMonitor CRD does not exist when Fluentd is installed. This hung the upgrade.
2. There is code that updates the Prometheus CR to add an annotation for the Keycloak IP in the Keycloak post install processing. When upgrading, Keycloak is upgraded before Prometheus is installed, so the code to update the Prom CR annotations failed and the upgrade hung. I refactored that code so that it could be called from both Keycloak and Prom Operator, and also made it more lenient wrt error conditions.