### PR TITLE
VZ-6700: Increment  ES ingest replica count to 2 for ha.yaml

### DIFF
--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -68,4 +68,4 @@ spec:
     elasticsearch:
       installArgs:
         - name: nodes.ingest.replicas
-          value: "3"
+          value: "2"

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -65,3 +65,7 @@ spec:
             prometheus:
               prometheusSpec:
                 replicas: 2
+    elasticsearch:
+      installArgs:
+        - name: nodes.ingest.replicas
+          value: "3"


### PR DESCRIPTION
When using the high availability configuration, configure two ES ingest pods.