### PR TITLE
VZ-6693: Add --verbose flag for bug-report

### DIFF
--- a/tools/vz/cmd/analyze/analyze_test.go
+++ b/tools/vz/cmd/analyze/analyze_test.go
@@ -48,7 +48,7 @@ func TestAnalyzeCommandDefault(t *testing.T) {
 	err = cmd.Execute()
 	assert.Nil(t, err)
 	// This should generate a report from the live cluster
-	assert.Contains(t, buf.String(), "Analyzing Verrazzano resource", "No issues detected or to report for the cluster")
+	assert.Contains(t, buf.String(), "Verrazzano analysis CLI did not detect any issue in the cluster")
 }
 
 func TestAnalyzeCommandValidCapturedDir(t *testing.T) {

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -115,9 +115,9 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// set the flag to control the display the resources captured
 	isVerbose, err := cmd.PersistentFlags().GetBool(constants.BugReportVerboseFlagName)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading values for the flag %s: %s", constants.BugReportVerboseFlagName, err.Error())
+		return fmt.Errorf("an error occurred while reading value for the flag %s: %s", constants.BugReportVerboseFlagName, err.Error())
 	}
-	helpers.SetVerboseBugReport(isVerbose)
+	helpers.SetVerboseOutput(isVerbose)
 
 	var msgPrefix string
 	if helpers.GetIsLiveCluster() {

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -46,6 +46,7 @@ const minLineLength = 100
 
 func NewCmdBugReport(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd := cmdhelpers.NewCommand(vzHelper, CommandName, helpShort, helpLong)
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runCmdBugReport(cmd, args, vzHelper)
 	}
@@ -53,7 +54,7 @@ func NewCmdBugReport(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.Example = helpExample
 	cmd.PersistentFlags().StringP(constants.BugReportFileFlagName, constants.BugReportFileFlagShort, constants.BugReportFileFlagValue, constants.BugReportFileFlagUsage)
 	cmd.PersistentFlags().StringSliceP(constants.BugReportIncludeNSFlagName, constants.BugReportIncludeNSFlagShort, []string{}, constants.BugReportIncludeNSFlagUsage)
-
+	cmd.PersistentFlags().BoolP(constants.BugReportVerboseFlagName, constants.BugReportVerboseFlagShort, constants.BugReportVerboseFlagDefault, constants.BugReportVerboseFlagUsage)
 	return cmd
 }
 
@@ -110,6 +111,21 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 		return fmt.Errorf("an error occurred while creating the directory to place cluster resources: %s", err.Error())
 	}
 	defer os.RemoveAll(bugReportDir)
+
+	// set the flag to control the display the resources captured
+	isVerbose, err := cmd.PersistentFlags().GetBool(constants.BugReportVerboseFlagName)
+	if err != nil {
+		return fmt.Errorf("an error occurred while reading values for the flag %s: %s", constants.BugReportVerboseFlagName, err.Error())
+	}
+	helpers.SetVerboseBugReport(isVerbose)
+
+	var msgPrefix string
+	if helpers.GetIsLiveCluster() {
+		msgPrefix = constants.AnalysisMsgPrefix
+	} else {
+		msgPrefix = constants.BugReportMsgPrefix
+	}
+	fmt.Fprintf(vzHelper.GetOutputStream(), msgPrefix+" resources from the cluster ...\n")
 
 	// Capture cluster snapshot
 	err = vzbugreport.CaptureClusterSnapshot(kubeClient, dynamicClient, client, bugReportDir, moreNS, vzHelper)

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -173,16 +173,38 @@ func TestBugReportSuccess(t *testing.T) {
 	bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
 	cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
 	cmd.PersistentFlags().Set(constants.BugReportIncludeNSFlagName, "dummy,verrazzano-install,default")
+	cmd.PersistentFlags().Set(constants.BugReportVerboseFlagName, "true")
 	err = cmd.Execute()
 	if err != nil {
 		assert.Error(t, err)
 	}
 
 	assert.NoError(t, err)
-	assert.Contains(t, buf.String(), "Capturing Verrazzano resource",
+	assert.Contains(t, buf.String(), "Capturing  resources from the cluster", "Capturing Verrazzano resource",
 		"Capturing log from pod verrazzano-platform-operator in verrazzano-install namespace",
 		"Successfully created the bug report",
 		"WARNING: Please examine the contents of the bug report for sensitive data", "Namespace dummy not found in the cluster")
+	assert.FileExists(t, bugRepFile)
+
+	// Validate the fact that --verbose is disabled by default
+	buf = new(bytes.Buffer)
+	errBuf = new(bytes.Buffer)
+	rc = helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc.SetClient(c)
+	bugRepFile = tmpDir + string(os.PathSeparator) + "bug-report-verbose-false.tgz"
+	cmd = NewCmdBugReport(rc)
+	cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
+	err = cmd.Execute()
+	if err != nil {
+		assert.Error(t, err)
+	}
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Capturing  resources from the cluster",
+		"Successfully created the bug report",
+		"WARNING: Please examine the contents of the bug report for sensitive data")
+	assert.NotContains(t, buf.String(), "Capturing Verrazzano resource",
+		"Capturing log from pod verrazzano-platform-operator in verrazzano-install namespace")
 	assert.FileExists(t, bugRepFile)
 }
 
@@ -204,6 +226,7 @@ func TestBugReportDefaultReportFile(t *testing.T) {
 	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
 	cmd := NewCmdBugReport(rc)
+	cmd.PersistentFlags().Set(constants.BugReportVerboseFlagName, "true")
 	assert.NotNil(t, cmd)
 	err = cmd.Execute()
 	if err != nil {

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -110,6 +110,11 @@ const (
 	BugReportIncludeNSFlagShort = "i"
 	BugReportIncludeNSFlagUsage = "A comma separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times like --include-namespaces ns1 --include-namespaces ns..."
 
+	BugReportVerboseFlagName    = "verbose"
+	BugReportVerboseFlagShort   = "v"
+	BugReportVerboseFlagDefault = false
+	BugReportVerboseFlagUsage   = "Enable verbose output for the bug-report command"
+
 	BugReportDir = "bug-report"
 
 	// File name for the log captured from the pod
@@ -153,4 +158,8 @@ const (
 	// Label for application
 	AppLabel    = "app"
 	K8SAppLabel = "k8s-app"
+
+	// Message prefix for bug-report and live cluster analysis
+	BugReportMsgPrefix = "Capturing "
+	AnalysisMsgPrefix  = "Analyzing "
 )

--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -37,13 +37,11 @@ var containerStartLog = "==== START logs for container %s of pod %s/%s ====\n"
 var containerEndLog = "==== END logs for container %s of pod %s/%s ====\n"
 
 var isError bool
+var isLiveCluster bool
+var isVerbose bool
+
 var multiWriterOut io.Writer
 var multiWriterErr io.Writer
-
-var isLiveCluster bool
-
-const bugReportMsgPrefix = "Capturing "
-const analysisMsgPrefix = "Analyzing "
 
 // CreateReportArchive creates the .tar.gz file specified by bugReportFile, from the files in captureDir
 func CreateReportArchive(captureDir string, bugRepFile *os.File) error {
@@ -667,7 +665,12 @@ func IsErrorReported() bool {
 
 // SetMultiWriterOut sets MultiWriter for standard output
 func SetMultiWriterOut(outStream io.Writer, outFile *os.File) {
-	multiWriterOut = io.MultiWriter(outStream, outFile)
+	// When verbose output is disabled, log the resources captured to outFile alone
+	if isVerbose {
+		multiWriterOut = io.MultiWriter(outStream, outFile)
+	} else {
+		multiWriterOut = io.MultiWriter(outFile)
+	}
 }
 
 // GetMultiWriterOut returns the MultiWriter for standard output
@@ -677,7 +680,12 @@ func GetMultiWriterOut() io.Writer {
 
 // SetMultiWriterErr sets MultiWriter for standard error
 func SetMultiWriterErr(errStream io.Writer, errFile *os.File) {
-	multiWriterErr = io.MultiWriter(errStream, errFile)
+	// When verbose output is disabled, log the error capturing resources to errFile alone
+	if isVerbose {
+		multiWriterErr = io.MultiWriter(errStream, errFile)
+	} else {
+		multiWriterErr = io.MultiWriter(errFile)
+	}
 }
 
 // GetMultiWriterErr returns the MultiWriter for standard error
@@ -697,9 +705,14 @@ func GetIsLiveCluster() bool {
 
 // LogMessage logs a message to the standard output
 func LogMessage(msg string) {
-	msgPrefix := bugReportMsgPrefix
+	msgPrefix := constants.BugReportMsgPrefix
 	if isLiveCluster {
-		msgPrefix = analysisMsgPrefix
+		msgPrefix = constants.AnalysisMsgPrefix
 	}
 	fmt.Fprintf(GetMultiWriterOut(), msgPrefix+msg)
+}
+
+// SetVerboseBugReport sets the verbose output for the bug-report command
+func SetVerboseBugReport(enableVerbose bool) {
+	isVerbose = enableVerbose
 }

--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -712,7 +712,7 @@ func LogMessage(msg string) {
 	fmt.Fprintf(GetMultiWriterOut(), msgPrefix+msg)
 }
 
-// SetVerboseBugReport sets the verbose output for the bug-report command
-func SetVerboseBugReport(enableVerbose bool) {
+// SetVerboseOutput sets the verbose output for the bug-report command
+func SetVerboseOutput(enableVerbose bool) {
 	isVerbose = enableVerbose
 }


### PR DESCRIPTION
Adds a new flag to enable verbose output for the bug-report command. By default, bug-report will no longer display the details about the resources being captured with this change.