### PR TITLE
VZ-6709 update the Alertmanager image with OL8 update

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -450,7 +450,7 @@
           "images": [
             {
               "image": "alertmanager",
-              "tag": "v0.24.0",
+              "tag": "v0.24.0-20220805222028-0a54aa20",
               "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
               "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
             }


### PR DESCRIPTION
This new Alertmanager image has an updated Oracle Linux build.

The image tag has a different format because it was build from the feature branch. This is the most effective way to rebuild the image, but it results in the longer tag format.