### PR TITLE
VZ-5823: Update private registry README.md install instructions

### DIFF
--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -72,9 +72,9 @@ $ kubectl create secret docker-registry verrazzano-container-registry \
 Next, install the Verrazzano Platform Operator using the image defined by `$MYREG/$MYREPO/$VPO_IMAGE`.  
 
 ```
-helm upgrade --install myv8o ./charts/verrazzano-platform-operator \
+helm template --include-crds ./charts/verrazzano-platform-operator \
     --set image=${MYREG}/${MYREPO}/${VPO_IMAGE} --set global.registry=${MYREG} \
-    --set global.repository=${MYREPO} --wait
+    --set global.repository=${MYREPO} --set global.imagePullSecrets={verrazzano-container-registry} | kubectl apply -f -
 ```
 
 After the Verrazzano Platform Operator is running, proceed with installing Verrazzano as documented at https://verrazzano.io/latest/docs/setup/install/installation/.


### PR DESCRIPTION
This PR addresses the following private registry install/upgrade failure:

1. User installs Verrazzano from a private registry
2. User upgrades the VPO from an `operator.yaml` in github
3. User upgrades their Verrazzano CR

At that point the VPO attempts to upgrade images but pulls them from the private registry instead of from ghcr.io. The upgrade never completes.

To fix this, I have updated the private registry installation instructions to use `helm template` instead of `helm upgrade`. I tested these steps and the upgrade from ghcr.io completes successfully, with images pulled from ghcr.io instead of the private registry.
