### PR TITLE
VZ-6500 backport error message for pending External IPs

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -252,6 +252,17 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 		context.Log().Progressf("%s is waiting for istioctl verify-install to successfully complete", prefix)
 		return false
 	}
+
+	// istioctl verify-install does not check that the Load Balancer service has an external IP address,
+	// so we have to check this manually to get a useful error message
+	_, err = verifyIstioIngressGatewayIP(context.Client(), context.EffectiveCR())
+	if err != nil {
+		// Only log for the Istio component context
+		if context.GetComponent() == ComponentName {
+			context.Log().Errorf("Ingress external IP pending for component %s: %v", ComponentName, err)
+		}
+		return false
+	}
 	return true
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -5,18 +5,21 @@ package istio
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/istio"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	os2 "github.com/verrazzano/verrazzano/pkg/os"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	istiosec "istio.io/api/security/v1beta1"
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -374,4 +378,32 @@ func removeTempFiles(log vzlog.VerrazzanoLogger) {
 	if err := os2.RemoveTempFiles(log.GetZapLogger(), istioTmpFileCleanPattern); err != nil {
 		log.Errorf("Unexpected error removing temp files: %v", err.Error())
 	}
+}
+
+// getIstioIngressGatewayServiceType returns the service type of the Istio ingress service for use in checking its status
+func getIstioIngressGatewayServiceType(vz *vzapi.Verrazzano) (vzapi.IngressType, error) {
+	istioComp := vz.Spec.Components.Istio
+	if istioComp == nil {
+		return vzapi.LoadBalancer, nil
+	}
+	ingressConfig := istioComp.Ingress
+	if ingressConfig == nil || len(ingressConfig.Type) == 0 {
+		return vzapi.LoadBalancer, nil
+	}
+	switch ingressConfig.Type {
+	case vzapi.NodePort, vzapi.LoadBalancer:
+		return ingressConfig.Type, nil
+	default:
+		return "", fmt.Errorf("Unrecognized ingress type %s", ingressConfig.Type)
+	}
+}
+
+// verifyIstioIngressGatewayIP checks the status of the Istio Ingress service and
+// returns an error if not found or missing external IP
+func verifyIstioIngressGatewayIP(client client.Client, vz *vzapi.Verrazzano) (string, error) {
+	serviceType, err := getIstioIngressGatewayServiceType(vz)
+	if err != nil {
+		return "", err
+	}
+	return vzconfig.GetExternalIP(client, serviceType, IstioIngressgatewayDeployment, globalconst.IstioSystemNamespace)
 }

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -41,12 +41,19 @@ func isNginxReady(context spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())
-	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	// Verify that the ingress-nginx service has an external IP before completing post-install
+	_, err := vzconfig.GetIngressIP(context.Client(), context.EffectiveCR())
+	// Only log the message for if the request comes from this component's context
+	// Otherwise, the message is logged for each component that checks the status of the ingress controller
+	if err != nil && context.GetComponent() == ComponentName {
+		context.Log().Errorf("Ingress external IP pending for component %s: %v", ComponentName, err)
+	}
+	return err == nil && status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 }
 
 func AppendOverrides(context spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	cr := context.EffectiveCR()
-	ingressType, err := vzconfig.GetServiceType(cr)
+	ingressType, err := vzconfig.GetIngressServiceType(cr)
 	if err != nil {
 		return []bom.KeyValue{}, err
 	}

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -148,8 +149,17 @@ func TestIsNGINXReady(t *testing.T) {
 				UpdatedReplicas:   1,
 			},
 		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vpoconst.NGINXControllerServiceName,
+				Namespace: vpoconst.IngressNginxNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalIPs: []string{"127.0.0.1"},
+			},
+		},
 	).Build()
-	assert.True(t, isNginxReady(spi.NewFakeContext(fakeClient, nil, false)))
+	assert.True(t, isNginxReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)))
 }
 
 // TestIsNGINXNotReady tests the IsReady function
@@ -180,7 +190,7 @@ func TestIsNGINXNotReady(t *testing.T) {
 			},
 		},
 	).Build()
-	assert.False(t, isNginxReady(spi.NewFakeContext(fakeClient, nil, false)))
+	assert.False(t, isNginxReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, false)))
 }
 
 // TestPostInstallWithPorts tests the PostInstall function

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -233,6 +233,15 @@ func TestPostInstallWithPorts(t *testing.T) {
 				},
 			},
 		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						IP: "0.0.0.0",
+					},
+				},
+			},
+		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(svc).Build()
 	err := PostInstall(spi.NewFakeContext(fakeClient, vz, false), ComponentName, ComponentNamespace)

--- a/platform-operator/internal/vzconfig/external_service.go
+++ b/platform-operator/internal/vzconfig/external_service.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzconfig
+
+import (
+	"context"
+	"fmt"
+
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetExternalIP Returns the ingress IP of the service given the service type, name, and namespace
+func GetExternalIP(client client.Client, serviceType vzapi.IngressType, name, namespace string) (string, error) {
+	// Default for NodePort services
+	// - On MAC and Windows, container IP is not accessible.  Port forwarding from 127.0.0.1 to container IP is needed.
+	externalIP := "127.0.0.1"
+	if serviceType == vzapi.LoadBalancer || serviceType == vzapi.NodePort {
+		svc := v1.Service{}
+		if err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &svc); err != nil {
+			return "", err
+		}
+		// If externalIPs exists, use it; else use IP from status
+		if len(svc.Spec.ExternalIPs) > 0 {
+			// In case of OLCNE, the Status.LoadBalancer.Ingress field will be empty, so use the external IP if present
+			externalIP = svc.Spec.ExternalIPs[0]
+		} else if len(svc.Status.LoadBalancer.Ingress) > 0 {
+			externalIP = svc.Status.LoadBalancer.Ingress[0].IP
+		} else {
+			return "", fmt.Errorf("No IP found for service %v with type %v", svc.Name, serviceType)
+		}
+	}
+	return externalIP, nil
+}

--- a/platform-operator/internal/vzconfig/external_service_test.go
+++ b/platform-operator/internal/vzconfig/external_service_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzconfig
+
+import (
+	"testing"
+
+	asserts "github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	fakes "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestGetExternalIP tests retrieving the external IP from a given service
+// GIVEN a call to TestGetExternalIP
+// WHEN the service has an external IP
+// THEN no error and the external IP address is returned
+func TestGetExternalIP(t *testing.T) {
+	assert := asserts.New(t)
+
+	svcName := "foo"
+	svcNamespace := "bar"
+	ipaddr := "0.0.0.0"
+	svcNoIP := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: svcNamespace,
+		},
+	}
+
+	svcIPExt := svcNoIP.DeepCopy()
+	svcIPExt.Spec.ExternalIPs = []string{ipaddr}
+
+	svcIPStatus := svcNoIP.DeepCopy()
+	svcIPStatus.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
+		{
+			IP: ipaddr,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		ingType      vzapi.IngressType
+		svcName      string
+		svcNamespace string
+		service      *v1.Service
+		expectError  bool
+	}{
+		{
+			name:         "test empty",
+			ingType:      vzapi.LoadBalancer,
+			svcName:      svcName,
+			svcNamespace: svcNamespace,
+			service:      &v1.Service{},
+			expectError:  true,
+		},
+		{
+			name:         "test standard service",
+			ingType:      vzapi.LoadBalancer,
+			svcName:      svcName,
+			svcNamespace: svcNamespace,
+			service:      svcNoIP,
+			expectError:  true,
+		},
+		{
+			name:         "test service external IP",
+			ingType:      vzapi.LoadBalancer,
+			svcName:      svcName,
+			svcNamespace: svcNamespace,
+			service:      svcIPExt,
+			expectError:  false,
+		},
+		{
+			name:         "test service status IP",
+			ingType:      vzapi.NodePort,
+			svcName:      svcName,
+			svcNamespace: svcNamespace,
+			service:      svcIPStatus,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			cli := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(tt.service).Build()
+			ip, err := GetExternalIP(cli, tt.ingType, tt.svcName, tt.svcNamespace)
+			if tt.expectError {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(ip, ipaddr)
+		})
+	}
+}

--- a/platform-operator/internal/vzconfig/ingress.go
+++ b/platform-operator/internal/vzconfig/ingress.go
@@ -3,14 +3,12 @@
 package vzconfig
 
 import (
-	"context"
 	"fmt"
 
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -67,7 +65,7 @@ func GetDNSSuffix(client client.Client, vz *vzapi.Verrazzano) (string, error) {
 }
 
 // Identify the service type, LB vs NodePort
-func GetServiceType(cr *vzapi.Verrazzano) (vzapi.IngressType, error) {
+func GetIngressServiceType(cr *vzapi.Verrazzano) (vzapi.IngressType, error) {
 	ingressConfig := cr.Spec.Components.Ingress
 	if ingressConfig == nil || len(ingressConfig.Type) == 0 {
 		return vzapi.LoadBalancer, nil
@@ -83,29 +81,11 @@ func GetServiceType(cr *vzapi.Verrazzano) (vzapi.IngressType, error) {
 // GetIngressIP Returns the ingress IP of the LoadBalancer
 // - port of install scripts function get_verrazzano_ingress_ip in config.sh
 func GetIngressIP(client client.Client, vz *vzapi.Verrazzano) (string, error) {
-	// Default for NodePort services
-	// - On MAC and Windows, container IP is not accessible.  Port forwarding from 127.0.0.1 to container IP is needed.
-	ingressIP := "127.0.0.1"
-	serviceType, err := GetServiceType(vz)
+	serviceType, err := GetIngressServiceType(vz)
 	if err != nil {
 		return "", err
 	}
-	if serviceType == vzapi.LoadBalancer || serviceType == vzapi.NodePort {
-		svc := v1.Service{}
-		if err := client.Get(context.TODO(), types.NamespacedName{Name: vpoconst.NGINXControllerServiceName, Namespace: globalconst.IngressNamespace}, &svc); err != nil {
-			return "", err
-		}
-		// If externalIPs exists, use it; else use IP from status
-		if len(svc.Spec.ExternalIPs) > 0 {
-			// In case of OLCNE, the Status.LoadBalancer.Ingress field will be empty, so use the external IP if present
-			ingressIP = svc.Spec.ExternalIPs[0]
-		} else if len(svc.Status.LoadBalancer.Ingress) > 0 {
-			ingressIP = svc.Status.LoadBalancer.Ingress[0].IP
-		} else {
-			return "", fmt.Errorf("No IP found for service %v with type %v", svc.Name, serviceType)
-		}
-	}
-	return ingressIP, nil
+	return GetExternalIP(client, serviceType, vpoconst.NGINXControllerServiceName, globalconst.IngressNamespace)
 }
 
 // BuildDNSDomain Constructs the full DNS subdomain for the deployment

--- a/platform-operator/internal/vzconfig/ingress_test.go
+++ b/platform-operator/internal/vzconfig/ingress_test.go
@@ -36,7 +36,7 @@ func Test_getServiceTypeLoadBalancer(t *testing.T) {
 		},
 	}
 
-	svcType, err := GetServiceType(vz)
+	svcType, err := GetIngressServiceType(vz)
 	assert.NoError(t, err)
 	assert.Equal(t, vzapi.LoadBalancer, svcType)
 }
@@ -57,7 +57,7 @@ func Test_getServiceTypeNodePort(t *testing.T) {
 		},
 	}
 
-	svcType, err := GetServiceType(vz)
+	svcType, err := GetIngressServiceType(vz)
 	assert.NoError(t, err)
 	assert.Equal(t, vzapi.NodePort, svcType)
 }
@@ -78,7 +78,7 @@ func Test_getServiceTypeInvalidType(t *testing.T) {
 		},
 	}
 
-	svcType, err := GetServiceType(vz)
+	svcType, err := GetIngressServiceType(vz)
 	assert.Error(t, err)
 	assert.Equal(t, vzapi.IngressType(""), svcType)
 }


### PR DESCRIPTION
Backport of a fix to introduce better error messaging for external services that do not get IP addresses.
