### PR TITLE
VZ-6456: Sync Rancher clusters with VMCs

### DIFF
--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -546,7 +546,7 @@ func doRequest(req *http.Request, rc *rancherConfig, log vzlog.VerrazzanoLogger)
 
 		// retry any HTTP 500 errors
 		if resp != nil && resp.StatusCode >= 500 && resp.StatusCode <= 599 {
-			log.Infof("HTTP status %v executing HTTP request %v, retrying", resp.StatusCode, req)
+			log.ErrorfThrottled("HTTP status %v executing HTTP request %v, retrying", resp.StatusCode, req)
 			return false, err
 		}
 

--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -6,7 +6,7 @@ package clusters
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec //#gosec G501 // package used for caching only, not security
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -207,7 +207,7 @@ func getAllClustersInRancher(rc *rancherConfig, log vzlog.VerrazzanoLogger) ([]s
 	reqURL := rc.baseURL + clustersPath
 	headers := map[string]string{"Authorization": "Bearer " + rc.apiAccessToken}
 
-	hash := md5.New()
+	hash := md5.New() //nolint:gosec //#gosec G401
 	clusterNames := []string{}
 	for {
 		response, responseBody, err := sendRequest(http.MethodGet, reqURL, headers, "", rc, log)

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -29,7 +29,10 @@ const (
 // on the managed cluster to create resources needed there. The YAML has multiple Kubernetes
 // resources separated by 3 hyphens ( --- ), so that applying the YAML will create/update multiple
 // resources at once.  This YAML is stored in the Verrazzano manifest secret.
-func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Context, vmc *clusterapi.VerrazzanoManagedCluster) error {
+// This function returns a boolean and an error, where the boolean is true if the VMC was created by
+// Verrazzano and the Rancher cluster ID has not yet been set in the status. This allows the
+// calling function to requeue and process the VMC again before marking the VMC ready.
+func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Context, vmc *clusterapi.VerrazzanoManagedCluster) (bool, error) {
 	// Builder used to build up the full YAML
 	// For each secret, generate the YAML and append to the full YAML which contains multiple resources
 	var sb = strings.Builder{}
@@ -38,7 +41,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	agentYaml, err := r.getSecretAsYaml(GetAgentSecretName(vmc.Name), vmc.Namespace,
 		constants.MCAgentSecret, constants.VerrazzanoSystemNamespace)
 	if err != nil {
-		return err
+		return false, err
 	}
 	sb.Write([]byte(yamlSep))
 	sb.Write(agentYaml)
@@ -47,15 +50,18 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	regYaml, err := r.getSecretAsYaml(GetRegistrationSecretName(vmc.Name), vmc.Namespace,
 		constants.MCRegistrationSecret, constants.VerrazzanoSystemNamespace)
 	if err != nil {
-		return err
+		return false, err
 	}
 	sb.Write([]byte(yamlSep))
 	sb.Write(regYaml)
 
 	// if we created the VMC from a Rancher cluster, then wait for the cluster id to be populated in the status before we
 	// attempt to fetch the registration manifest YAML
+	vzVMCWaitingForClusterID := false
+
 	if vmc.Labels != nil && vmc.Labels[createdByLabel] == createdByVerrazzano && len(vmc.Status.RancherRegistration.ClusterID) == 0 {
 		r.log.Infof("Waiting for Verrazzano-created VMC named %s to have a cluster id in the status before attempting to fetch Rancher registration manifest", vmc.Name)
+		vzVMCWaitingForClusterID = true
 	} else {
 		// register the cluster with Rancher - the cluster will show as "pending" until the
 		// Rancher YAML is applied on the managed cluster
@@ -84,7 +90,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	// create/update the manifest secret with the YAML
 	_, err = r.createOrUpdateManifestSecret(vmc, sb.String())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Save the ClusterRegistrationSecret name in the VMC
@@ -93,10 +99,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	// finally, update the VMC
 	err = r.Update(context.TODO(), vmc)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return vzVMCWaitingForClusterID, nil
 }
 
 // syncCACertSecret gets the CA cert from the managed cluster (if the cluster is active) and creates

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -90,7 +90,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	// create/update the manifest secret with the YAML
 	_, err = r.createOrUpdateManifestSecret(vmc, sb.String())
 	if err != nil {
-		return false, err
+		return vzVMCWaitingForClusterID, err
 	}
 
 	// Save the ClusterRegistrationSecret name in the VMC
@@ -99,7 +99,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	// finally, update the VMC
 	err = r.Update(context.TODO(), vmc)
 	if err != nil {
-		return false, err
+		return vzVMCWaitingForClusterID, err
 	}
 
 	return vzVMCWaitingForClusterID, nil

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -60,7 +60,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	vzVMCWaitingForClusterID := false
 
 	if vmc.Labels != nil && vmc.Labels[createdByLabel] == createdByVerrazzano && len(vmc.Status.RancherRegistration.ClusterID) == 0 {
-		r.log.Infof("Waiting for Verrazzano-created VMC named %s to have a cluster id in the status before attempting to fetch Rancher registration manifest", vmc.Name)
+		r.log.Progressf("Waiting for Verrazzano-created VMC named %s to have a cluster id in the status before attempting to fetch Rancher registration manifest", vmc.Name)
 		vzVMCWaitingForClusterID = true
 	} else {
 		// register the cluster with Rancher - the cluster will show as "pending" until the

--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/log"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	createdByLabel      = "app.kubernetes.io/created-by"
+	createdByVerrazzano = "verrazzano"
+	localClusterName    = "local"
+)
+
+// clustersResponseHash is the hash of the Rancher clusters API response body, used to determine if processing can be
+// skipped when there are no cluster changes
+var clustersResponseHash []byte
+
+type RancherClusterSyncer struct {
+	client.Client
+}
+
+// StartSyncing starts the Rancher cluster synchronization loop
+func (r *RancherClusterSyncer) StartSyncing() {
+	log := r.initLogger()
+	log.Info("Starting Rancher cluster synchronizing loop")
+
+	// prevent a panic from taking down the operator
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("Panic caught: %v", err)
+		}
+	}()
+
+	for {
+		r.syncRancherClusters(log)
+		time.Sleep(time.Minute)
+	}
+}
+
+// initLogger initializes the Verrazzano logger
+func (r *RancherClusterSyncer) initLogger() vzlog.VerrazzanoLogger {
+	zaplog, err := log.BuildZapLogger(2)
+	if err != nil {
+		// failed so fall back to the basic zap sugared logger
+		zaplog = zap.S()
+	}
+	return vzlog.EnsureContext("rancher_cluster_sync").EnsureLogger("syncer", zaplog, zaplog)
+}
+
+// syncRancherClusters gets the list of clusters from Rancher and creates and deletes VMC resources
+func (r *RancherClusterSyncer) syncRancherClusters(log vzlog.VerrazzanoLogger) {
+	log.Info("Synchronizing Rancher clusters and VMCs")
+
+	// first check to see if the Rancher admin secret exists, if not then either Rancher is not installed
+	// or this is not an admin cluster, so just log a debug message and there is nothing else to do
+	if _, err := getAdminSecret(r.Client); err != nil {
+		log.Debug("Unable to get Rancher admin secret, either Rancher is not installed or this is not an admin cluster, skipping Rancher cluster sync")
+		return
+	}
+
+	// call Rancher to get the list of clusters
+	rc, err := newRancherConfig(r.Client, log)
+	if err != nil {
+		log.Errorf("Error connecting to Rancher admin server: %v", err)
+		return
+	}
+
+	var clusterNames []string
+	previousHash := clustersResponseHash
+	clusterNames, clustersResponseHash, err = getAllClustersInRancher(rc, log)
+	if err != nil {
+		log.Errorf("Error getting cluster list from Rancher: %v", err)
+		return
+	}
+
+	// if the Rancher response did not change, there is nothing to do
+	if bytes.Equal(previousHash, clustersResponseHash) {
+		log.Debug("Rancher clusters response did not change, nothing to sync")
+		return
+	}
+
+	// for every cluster (ignoring "local") make sure a VMC exists
+	r.ensureVMCs(clusterNames, log)
+
+	// for any auto-created VMC objects that do not have a Rancher cluster, delete the VMC resource
+	r.deleteVMCs(clusterNames, log)
+}
+
+// ensureVMCs ensures that there is a VMC resource for every cluster in Rancher, creating VMCs as necessary
+func (r *RancherClusterSyncer) ensureVMCs(rancherClusterNames []string, log vzlog.VerrazzanoLogger) {
+	for _, clusterName := range rancherClusterNames {
+		// ignore the "local" cluster
+		if clusterName == localClusterName {
+			continue
+		}
+
+		cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
+		if err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr); err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("Creating empty VMC for discovered Rancher cluster with name: %s", clusterName)
+				vmc := newVMC(clusterName)
+				if err := r.Create(context.TODO(), vmc); err != nil {
+					log.Infof("Unable to create VMC with name %s: %v", clusterName, err)
+				}
+				continue
+			}
+			log.Infof("Unable to get VMC with name %s: %v", clusterName, err)
+			continue
+		}
+	}
+}
+
+// newVMC returns a minimally populated VMC object
+func newVMC(name string) *clustersv1alpha1.VerrazzanoManagedCluster {
+	return &clustersv1alpha1.VerrazzanoManagedCluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Labels: map[string]string{
+				createdByLabel: createdByVerrazzano,
+			},
+		},
+	}
+}
+
+// deleteVMCs deletes any auto-created VMCs that are no longer in Rancher
+func (r *RancherClusterSyncer) deleteVMCs(rancherClusterNames []string, log vzlog.VerrazzanoLogger) {
+	// list the VMCs using a selector to only get the auto-created resources
+	clusterList := &clustersv1alpha1.VerrazzanoManagedClusterList{}
+	selector := &client.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{createdByLabel: createdByVerrazzano})}
+	if err := r.List(context.TODO(), clusterList, &client.ListOptions{Namespace: constants.VerrazzanoMultiClusterNamespace}, selector); err != nil {
+		log.Infof("Unable to list VMCs: %v", err)
+		return
+	}
+
+	// for each VMC, if it does not exist in Rancher, delete it
+	for _, cluster := range clusterList.Items {
+		if cluster.Name == localClusterName {
+			continue
+		}
+		if !vzstring.SliceContainsString(rancherClusterNames, cluster.Name) {
+			log.Infof("Deleting VMC %s because it is no longer in Rancher")
+			if err := r.Delete(context.TODO(), &cluster); err != nil {
+				log.Infof("Unable to delete VMC: %v", err)
+			}
+		}
+	}
+}

--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -150,7 +150,8 @@ func (r *RancherClusterSyncer) deleteVMCs(rancherClusterNames []string, log vzlo
 	}
 
 	// for each VMC, if it does not exist in Rancher, delete it
-	for _, cluster := range clusterList.Items {
+	for i := range clusterList.Items {
+		cluster := clusterList.Items[i] // avoids "G601: Implicit memory aliasing in for loop" linter error
 		if cluster.Name == localClusterName {
 			continue
 		}

--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -66,14 +66,14 @@ func (r *RancherClusterSyncer) initLogger() vzlog.VerrazzanoLogger {
 
 // syncRancherClusters gets the list of clusters from Rancher and creates and deletes VMC resources
 func (r *RancherClusterSyncer) syncRancherClusters(log vzlog.VerrazzanoLogger) {
-	log.Progress("Synchronizing Rancher clusters and VMCs")
-
 	// first check to see if the Rancher admin secret exists, if not then either Rancher is not installed
 	// or this is not an admin cluster, so just log a debug message and there is nothing else to do
 	if _, err := getAdminSecret(r.Client); err != nil {
 		log.Debug("Unable to get Rancher admin secret, either Rancher is not installed or this is not an admin cluster, skipping Rancher cluster sync")
 		return
 	}
+
+	log.Progress("Synchronizing Rancher clusters and VMCs")
 
 	// call Rancher to get the list of clusters
 	rc, err := newRancherConfig(r.Client, log)

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -81,15 +81,15 @@ func TestSyncRancherClusters(t *testing.T) {
 	mocker.Finish()
 
 	// we should have created two VMCs
-	// note that the VMCs we create are named using the Rancher cluster id
+	// note that the VMCs we create are named using the Rancher cluster name
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
@@ -136,21 +136,21 @@ func TestSyncRancherClustersWithPaging(t *testing.T) {
 	mocker.Finish()
 
 	// we should have created three VMCs (2 from the first page of the clusters API response and one from the 2nd)
-	// note that the VMCs we create are named using the Rancher cluster id
+	// note that the VMCs we create are named using the Rancher cluster name
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID2, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -52,9 +51,10 @@ func init() {
 
 // TestSyncRancherClusters tests the SyncRancherClusters function.
 // GIVEN clusters that exist in Rancher that do not have VMCs
-//   AND VMCs that do not have corresponding clusters in Rancher
-//  WHEN the SyncRancherClusters function is called
-//  THEN VMCs are created and deleted appropriately so that they are in sync
+//
+//	 AND VMCs that do not have corresponding clusters in Rancher
+//	WHEN the SyncRancherClusters function is called
+//	THEN VMCs are created and deleted appropriately so that they are in sync
 func TestSyncRancherClusters(t *testing.T) {
 	asserts := assert.New(t)
 
@@ -106,9 +106,10 @@ func TestSyncRancherClusters(t *testing.T) {
 
 // TestSyncRancherClustersWithPaging tests the SyncRancherClusters function with Rancher API paging.
 // GIVEN clusters that exist in Rancher that do not have VMCs
-//  WHEN the SyncRancherClusters function is called
-//   AND the Rancher API call to retrieve clusters results in multiple pages of clusters
-//  THEN VMCs are created for clusters returned in all pages
+//
+//	WHEN the SyncRancherClusters function is called
+//	 AND the Rancher API call to retrieve clusters results in multiple pages of clusters
+//	THEN VMCs are created for clusters returned in all pages
 func TestSyncRancherClustersWithPaging(t *testing.T) {
 	asserts := assert.New(t)
 
@@ -201,7 +202,7 @@ func expectHTTPCalls(httpMock *mocks.MockRequestSender, testPaging bool) {
 	httpMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(strings.Split(loginPath, "?")[0])).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
-			r := ioutil.NopCloser(bytes.NewReader([]byte(`{"token":"unit-test-token"}`)))
+			r := io.NopCloser(bytes.NewReader([]byte(`{"token":"unit-test-token"}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       r,
@@ -219,10 +220,10 @@ func expectHTTPCalls(httpMock *mocks.MockRequestSender, testPaging bool) {
 				// if we're testing paging, include a next page URL
 				data := `{"pagination":{"next":"https://host` + clustersPath + `?token=test"}, "data":[{"name":"` +
 					clusterName1 + `","id":"` + clusterID1 + `"},{"name":"` + clusterName2 + `","id":"` + clusterID2 + `"}]}`
-				r = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+				r = io.NopCloser(bytes.NewReader([]byte(data)))
 			} else {
 				data := `{"data":[{"name":"` + clusterName1 + `","id":"` + clusterID1 + `"},{"name":"` + clusterName2 + `","id":"` + clusterID2 + `"}]}`
-				r = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+				r = io.NopCloser(bytes.NewReader([]byte(data)))
 			}
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
@@ -238,7 +239,7 @@ func expectHTTPCalls(httpMock *mocks.MockRequestSender, testPaging bool) {
 			Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clustersPath)).
 			DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
 				data := `{"data":[{"name":"` + clusterName3 + `","id":"` + clusterID3 + `"}]}`
-				r := ioutil.NopCloser(bytes.NewReader([]byte(data)))
+				r := io.NopCloser(bytes.NewReader([]byte(data)))
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       r,

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
+	k8net "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	clusterName1                 = "test-cluster-1"
+	clusterName2                 = "test-cluster-2"
+	preExistingClusterNotLabeled = "test-cluster-not-labeled"
+	preExistingClusterLabeled    = "test-cluster-labeled"
+)
+
+var testScheme = runtime.NewScheme()
+
+func init() {
+	_ = clientgoscheme.AddToScheme(testScheme)
+	_ = clustersv1alpha1.AddToScheme(testScheme)
+}
+
+// TestSyncRancherClusters tests the SyncRancherClusters function.
+// GIVEN clusters that exist in Rancher that do not have VMCs
+//   AND VMCs that do not have corresponding clusters in Rancher
+//  WHEN the SyncRancherClusters function is called
+//  THEN VMCs are created and deleted appropriately so that they are in sync
+func TestSyncRancherClusters(t *testing.T) {
+	asserts := assert.New(t)
+
+	// create mocks and set the Rancher HTTP client to use the HTTP mock
+	mocker := gomock.NewController(t)
+	httpMock := mocks.NewMockRequestSender(mocker)
+	savedRancherHTTPClient := rancherHTTPClient
+	defer func() {
+		rancherHTTPClient = savedRancherHTTPClient
+	}()
+	rancherHTTPClient = httpMock
+
+	// create the k8s fake populated with resources
+	k8sFake := createK8sFake()
+
+	// expect HTTP calls
+	expectHTTPCalls(t, httpMock, false)
+
+	// call the syncer
+	r := &RancherClusterSyncer{Client: k8sFake}
+	log := r.initLogger()
+	r.syncRancherClusters(log)
+
+	mocker.Finish()
+
+	// we should have created two VMCs
+	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	asserts.NoError(err)
+	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	asserts.NoError(err)
+	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+
+	// the pre-existing VMC that is not labeled (so not auto-created) should still be here
+	err = r.Get(context.TODO(), types.NamespacedName{Name: preExistingClusterNotLabeled, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	asserts.NoError(err)
+
+	// the pre-existing VMC that is labeled (so auto-created) should have been deleted
+	err = r.Get(context.TODO(), types.NamespacedName{Name: preExistingClusterLabeled, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	asserts.True(errors.IsNotFound(err))
+}
+
+// createK8sFake creates a k8s fake populated with resources for testing
+func createK8sFake() client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: rancherNamespace,
+				Name:      rancherAdminSecret,
+			},
+		},
+		&k8net.Ingress{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: rancherNamespace,
+				Name:      rancherIngressName,
+			},
+			Spec: k8net.IngressSpec{
+				Rules: []k8net.IngressRule{
+					{
+						Host: "rancher-ingress",
+					},
+				},
+			},
+		},
+		&clustersv1alpha1.VerrazzanoManagedCluster{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      preExistingClusterNotLabeled,
+				Namespace: constants.VerrazzanoMultiClusterNamespace,
+			},
+		},
+		&clustersv1alpha1.VerrazzanoManagedCluster{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      preExistingClusterLabeled,
+				Namespace: constants.VerrazzanoMultiClusterNamespace,
+				Labels: map[string]string{
+					createdByLabel: createdByVerrazzano,
+				},
+			},
+		}).Build()
+}
+
+// expectHTTPCalls mocks the HTTP calls we expect the Rancher client to make
+func expectHTTPCalls(t *testing.T, httpMock *mocks.MockRequestSender, testPaging bool) {
+	asserts := assert.New(t)
+
+	// expect an HTTP request to fetch the admin token from Rancher
+	httpMock.EXPECT().
+		Do(gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			urlParts := strings.Split(loginPath, "?")
+			asserts.Equal(urlParts[0], req.URL.Path)
+			asserts.Equal(urlParts[1], req.URL.RawQuery)
+
+			r := ioutil.NopCloser(bytes.NewReader([]byte(`{"token":"unit-test-token"}`)))
+			resp := &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodPost},
+			}
+			return resp, nil
+		})
+
+	// expect an HTTP request to fetch all of the clusters from Rancher
+	httpMock.EXPECT().
+		Do(gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			asserts.Equal(clustersPath, req.URL.Path)
+
+			var r io.ReadCloser
+			if testPaging {
+				r = ioutil.NopCloser(bytes.NewReader([]byte(`{"pagination":{"next":"https://test?token=test"}, "data":[{"name":"` + clusterName1 + `"},{"name":"` + clusterName2 + `"}]}`)))
+			} else {
+				r = ioutil.NopCloser(bytes.NewReader([]byte(`{"data":[{"name":"` + clusterName1 + `"},{"name":"` + clusterName2 + `"}]}`)))
+			}
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodGet},
+			}
+			return resp, nil
+		})
+}

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/test/mockmatchers"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -80,15 +81,18 @@ func TestSyncRancherClusters(t *testing.T) {
 	mocker.Finish()
 
 	// we should have created two VMCs
+	// note that the VMCs we create are named using the Rancher cluster id
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID2, cr.Status.RancherRegistration.ClusterID)
 
 	// the pre-existing VMC that is not labeled (so not auto-created) should still be here
@@ -131,20 +135,24 @@ func TestSyncRancherClustersWithPaging(t *testing.T) {
 	mocker.Finish()
 
 	// we should have created three VMCs (2 from the first page of the clusters API response and one from the 2nd)
+	// note that the VMCs we create are named using the Rancher cluster id
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID2, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
+	asserts.Equal("true", cr.Labels[vzconst.VerrazzanoManagedLabelKey])
 	asserts.Equal(clusterID3, cr.Status.RancherRegistration.ClusterID)
 }
 

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -99,6 +99,9 @@ func TestSyncRancherClusters(t *testing.T) {
 	err = r.Get(context.TODO(), types.NamespacedName{Name: preExistingClusterNotLabeled, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 
+	// also assert that the pre-existing VMC did not have labels added
+	asserts.Empty(cr.Labels)
+
 	// the pre-existing VMC that is labeled (so auto-created) should have been deleted
 	err = r.Get(context.TODO(), types.NamespacedName{Name: preExistingClusterLabeled, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.True(errors.IsNotFound(err))

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -81,12 +81,12 @@ func TestSyncRancherClusters(t *testing.T) {
 
 	// we should have created two VMCs
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal(clusterID2, cr.Status.RancherRegistration.ClusterID)
@@ -132,17 +132,17 @@ func TestSyncRancherClustersWithPaging(t *testing.T) {
 
 	// we should have created three VMCs (2 from the first page of the clusters API response and one from the 2nd)
 	cr := &clustersv1alpha1.VerrazzanoManagedCluster{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterID1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: clusterName1, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal(clusterID1, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName2, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal(clusterID2, cr.Status.RancherRegistration.ClusterID)
 
-	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterID3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: clusterName3, Namespace: constants.VerrazzanoMultiClusterNamespace}, cr)
 	asserts.NoError(err)
 	asserts.Equal(createdByVerrazzano, cr.Labels[createdByLabel])
 	asserts.Equal(clusterID3, cr.Status.RancherRegistration.ClusterID)

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -336,7 +336,7 @@ func (r *VerrazzanoManagedClusterReconciler) handleError(ctx context.Context, vm
 	r.setStatusConditionNotReady(ctx, vmc, fullMsg)
 	statusErr := r.updateStatus(ctx, vmc)
 	if statusErr != nil {
-		log.Errorf("Failed to update status for VMC %s: %v", vmc.Name, statusErr)
+		log.ErrorfThrottled("Failed to update status for VMC %s: %v", vmc.Name, statusErr)
 	}
 }
 

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -954,11 +954,12 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 	reconciler := newVMCReconciler(mock)
 	reconciler.log = vzlog.DefaultLogger()
 
-	err := reconciler.syncManifestSecret(context.TODO(), &vmc)
+	vzVMCWaitingForClusterID, err := reconciler.syncManifestSecret(context.TODO(), &vmc)
 
 	// Validate the results
 	mocker.Finish()
 	asserts.NoError(err)
+	asserts.False(vzVMCWaitingForClusterID)
 }
 
 // TestRegisterClusterWithRancherK8sErrorCases tests errors cases using the Kubernetes


### PR DESCRIPTION
This PR adds synchronizing of clusters in Rancher with VMCs. When clusters are added in Rancher, we create corresponding empty VMC resources. For any VMC resources that do not have a corresponding Rancher cluster, we delete the VMC.
