### PR TITLE
Enabling Jaeger E2E Tests

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -420,6 +420,14 @@ pipeline {
                                 runGinkgo('examples/helidon')
                             }
                         }
+                        stage('jaeger helidon') {
+                            environment {
+                               DUMP_DIRECTORY="${TEST_DUMP_ROOT}/jaeger-helidon"
+                            }
+                            steps {
+                               runGinkgo('jaeger/helidon')
+                            }
+                        }
                         stage('JWT Workload Component') {
                             when {
                                 expression {params.ENABLE_JWT_TESTING == true}

--- a/platform-operator/controllers/verrazzano/install.go
+++ b/platform-operator/controllers/verrazzano/install.go
@@ -92,6 +92,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			if err := r.updateComponentStatus(compContext, "Component is Ready", vzapi.CondInstallComplete); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
+			r.ClearWatch(comp.GetJSONName())
 			continue
 		case vzapi.CompStateDisabled:
 			if !comp.IsEnabled(compContext.EffectiveCR()) {
@@ -160,7 +161,6 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext) (ctr
 			compLog.Progressf("Component %s waiting to finish installing", compName)
 			requeue = true
 		}
-		r.ClearWatch(comp.GetJSONName())
 	}
 	if requeue {
 		return newRequeueWithDelay(), nil

--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -42,3 +42,5 @@ spec:
         minIndexAge: "7d"
         rollover:
           minIndexAge: "1d"
+    jaegerOperator:
+      enabled: true

--- a/tests/e2e/jaeger/helidon/jaeger_helidon_suite_test.go
+++ b/tests/e2e/jaeger/helidon/jaeger_helidon_suite_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidon
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var namespace string
+var istioInjection string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
+	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
+}
+
+func TestJaegerHelidonTracing(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Jaeger Tracing Suite")
+}

--- a/tests/e2e/jaeger/helidon/jaeger_helidon_test.go
+++ b/tests/e2e/jaeger/helidon/jaeger_helidon_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidon
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"strings"
+	"time"
+)
+
+const (
+	shortPollingInterval     = 10 * time.Second
+	shortWaitTimeout         = 5 * time.Minute
+	imagePullWaitTimeout     = 40 * time.Minute
+	imagePullPollingInterval = 30 * time.Second
+)
+
+const (
+	testAppComponentFilePath     = "testdata/jaeger/helidon/helidon-tracing-comp.yaml"
+	testAppConfigurationFilePath = "testdata/jaeger/helidon/helidon-tracing-app.yaml"
+	jaegerOperatorSampleMetric   = "jaeger_operator_instances_managed"
+	jaegerAgentSampleMetric      = "jaeger_agent_collector_proxy_total"
+	jaegerQuerySampleMetric      = "jaeger_query_requests_total"
+	jaegerCollectorSampleMetric  = "jaeger_collector_queue_capacity"
+)
+
+var (
+	t                        = framework.NewTestFramework("jaeger")
+	generatedNamespace       = pkg.GenerateNamespace("jaeger-tracing")
+	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
+	waitTimeout              = 10 * time.Minute
+	pollingInterval          = 30 * time.Second
+	failed                   = false
+	beforeSuitePassed        = false
+	start                    = time.Now()
+)
+
+func WhenJaegerOperatorEnabledIt(text string, args ...interface{}) {
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		t.It(text, func() {
+			Fail(err.Error())
+		})
+	}
+	if pkg.IsJaegerOperatorEnabled(kubeconfig) {
+		t.ItMinimumVersion(text, "1.3.0", kubeconfig, args...)
+	}
+	t.Logs.Infof("Skipping spec, Jaeger Operator is disabled")
+}
+
+var _ = t.BeforeSuite(func() {
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(err.Error())
+	}
+	if !pkg.IsJaegerOperatorEnabled(kubeconfig) {
+		pkg.Log(pkg.Info, "Skipping BeforeSuite as Jaeger Operator is disabled.")
+		return
+	}
+
+	start = time.Now()
+	Eventually(func() (*v1.Namespace, error) {
+		nsLabels := map[string]string{
+			"verrazzano-managed": "true",
+			"istio-injection":    istioInjection}
+		return pkg.CreateNamespace(namespace, nsLabels)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(BeNil())
+
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(testAppComponentFilePath, namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return pkg.CreateOrUpdateResourceFromFileInGeneratedNamespace(testAppConfigurationFilePath, namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(HaveOccurred())
+
+	Eventually(func() bool {
+		return pkg.ContainerImagePullWait(namespace, expectedPodsHelloHelidon)
+	}).WithPolling(imagePullPollingInterval).WithTimeout(imagePullWaitTimeout).Should(BeTrue())
+
+	// Verify hello-helidon-workload pod is running
+	Eventually(helloHelidonPodsRunning, waitTimeout, pollingInterval).Should(BeTrue())
+	beforeSuitePassed = true
+	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var _ = t.AfterSuite(func() {
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		Fail(err.Error())
+	}
+	if !pkg.IsJaegerOperatorEnabled(kubeconfig) {
+		pkg.Log(pkg.Info, "Skipping BeforeSuite as Jaeger Operator is disabled.")
+		return
+	}
+	if failed || !beforeSuitePassed {
+		pkg.ExecuteClusterDumpWithEnvVarConfig()
+	}
+	// undeploy the application here
+	start := time.Now()
+
+	t.Logs.Info("Delete application")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(testAppComponentFilePath, namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Delete components")
+	Eventually(func() error {
+		return pkg.DeleteResourceFromFileInGeneratedNamespace(testAppConfigurationFilePath, namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for application pods to terminate")
+	Eventually(func() bool {
+		podsTerminated, _ := pkg.PodsNotRunning(namespace, expectedPodsHelloHelidon)
+		return podsTerminated
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+
+	t.Logs.Info("Delete namespace")
+	Eventually(func() error {
+		return pkg.DeleteNamespace(namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).ShouldNot(HaveOccurred())
+
+	t.Logs.Info("Wait for Finalizer to be removed")
+	Eventually(func() bool {
+		return pkg.CheckNamespaceFinalizerRemoved(namespace)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+
+	t.Logs.Info("Wait for namespace to be deleted")
+	Eventually(func() bool {
+		_, err := pkg.GetNamespace(namespace)
+		return err != nil && errors.IsNotFound(err)
+	}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+
+	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
+})
+
+var _ = t.Describe("Jaeger Operator", Label("f:jaeger.helidon-workload"), func() {
+	t.Context("after successful installation", func() {
+		// GIVEN the Jaeger Operator is enabled and a sample application is installed,
+		// WHEN we check for traces for that service,
+		// THEN we are able to get the traces
+		WhenJaegerOperatorEnabledIt("should have a verrazzano-monitoring namespace", func() {
+			Eventually(func() (bool, error) {
+				// Check if the service name is registered in Jaeger and traces are present for that service
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				if err != nil {
+					return false, err
+				}
+				tracesFound := false
+				servicesWithJaegerTraces := pkg.ListServicesInJaeger(kubeconfigPath)
+				for _, serviceName := range servicesWithJaegerTraces {
+					if strings.HasPrefix(serviceName, "hello-helidon") {
+						traceIds := pkg.ListJaegerTraces(kubeconfigPath, serviceName)
+						tracesFound = len(traceIds) > 0
+						if !tracesFound {
+							pkg.Log(pkg.Error, fmt.Sprintf("traces not found for service: %s", serviceName))
+							return false, fmt.Errorf("traces not found for service: %s", serviceName)
+						}
+						break
+					}
+				}
+				return tracesFound, nil
+			}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+		})
+
+		// GIVEN the Jaeger Operator component is enabled,
+		// WHEN a sample application is installed,
+		// THEN the traces are found in OpenSearch Backend
+		WhenJaegerOperatorEnabledIt("should have running pods", func() {
+			Eventually(func() (bool, error) {
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				if err != nil {
+					return false, err
+				}
+				return pkg.JaegerSpanRecordFoundInOpenSearch(kubeconfigPath, start, "hello-helidon")
+			}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+		})
+
+		// GIVEN the Jaeger Operator component is enabled,
+		// WHEN we check for metrics related to Jaeger operator
+		// THEN we see that the metrics are present in prometheus
+		WhenJaegerOperatorEnabledIt("should have the correct default Jaeger images", func() {
+			Eventually(func() bool {
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				if err != nil {
+					return false
+				}
+				return pkg.IsJaegerMetricFound(kubeconfigPath, jaegerOperatorSampleMetric, nil)
+			}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+
+		})
+
+		// GIVEN the Jaeger Operator component is installed with default Jaeger CR enabled
+		// WHEN we check for metrics related to Jaeger Components (jaeger-query, jaeger-collector, jaeger-agent)
+		// THEN we see that the metrics are present in prometheus
+		WhenJaegerOperatorEnabledIt("should have the correct Jaeger Operator CRDs", func() {
+			Eventually(func() bool {
+				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+				if err != nil {
+					return false
+				}
+				return pkg.IsJaegerMetricFound(kubeconfigPath, jaegerCollectorSampleMetric, nil) &&
+					pkg.IsJaegerMetricFound(kubeconfigPath, jaegerQuerySampleMetric, nil) &&
+					pkg.IsJaegerMetricFound(kubeconfigPath, jaegerAgentSampleMetric, nil)
+			}).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+		})
+	})
+
+})
+
+//helloHelidonPodsRunning checks if the helidon pods are running
+func helloHelidonPodsRunning() bool {
+	result, err := pkg.PodsRunning(namespace, expectedPodsHelloHelidon)
+	if err != nil {
+		AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
+	}
+	return result
+}

--- a/tests/e2e/jaeger/helidon/jaeger_helidon_test.go
+++ b/tests/e2e/jaeger/helidon/jaeger_helidon_test.go
@@ -143,12 +143,12 @@ var _ = t.AfterSuite(func() {
 	metrics.Emit(t.Metrics.With("undeployment_elapsed_time", time.Since(start).Milliseconds()))
 })
 
-var _ = t.Describe("Jaeger Operator", Label("f:jaeger.helidon-workload"), func() {
+var _ = t.Describe("Helidon App with Jaeger Traces", Label("f:jaeger.helidon-workload"), func() {
 	t.Context("after successful installation", func() {
 		// GIVEN the Jaeger Operator is enabled and a sample application is installed,
 		// WHEN we check for traces for that service,
 		// THEN we are able to get the traces
-		WhenJaegerOperatorEnabledIt("should have a verrazzano-monitoring namespace", func() {
+		WhenJaegerOperatorEnabledIt("traces for the helidon app should be available when queried from Jaeger", func() {
 			Eventually(func() (bool, error) {
 				// Check if the service name is registered in Jaeger and traces are present for that service
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
@@ -175,7 +175,7 @@ var _ = t.Describe("Jaeger Operator", Label("f:jaeger.helidon-workload"), func()
 		// GIVEN the Jaeger Operator component is enabled,
 		// WHEN a sample application is installed,
 		// THEN the traces are found in OpenSearch Backend
-		WhenJaegerOperatorEnabledIt("should have running pods", func() {
+		WhenJaegerOperatorEnabledIt("traces for the helidon app should be available in the OS backend storage.", func() {
 			Eventually(func() (bool, error) {
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 				if err != nil {
@@ -188,7 +188,7 @@ var _ = t.Describe("Jaeger Operator", Label("f:jaeger.helidon-workload"), func()
 		// GIVEN the Jaeger Operator component is enabled,
 		// WHEN we check for metrics related to Jaeger operator
 		// THEN we see that the metrics are present in prometheus
-		WhenJaegerOperatorEnabledIt("should have the correct default Jaeger images", func() {
+		WhenJaegerOperatorEnabledIt("metrics of jaeger operator are available in prometheus", func() {
 			Eventually(func() bool {
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 				if err != nil {
@@ -202,7 +202,7 @@ var _ = t.Describe("Jaeger Operator", Label("f:jaeger.helidon-workload"), func()
 		// GIVEN the Jaeger Operator component is installed with default Jaeger CR enabled
 		// WHEN we check for metrics related to Jaeger Components (jaeger-query, jaeger-collector, jaeger-agent)
 		// THEN we see that the metrics are present in prometheus
-		WhenJaegerOperatorEnabledIt("should have the correct Jaeger Operator CRDs", func() {
+		WhenJaegerOperatorEnabledIt("metrics of jaeger components are available in prometheus", func() {
 			Eventually(func() bool {
 				kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 				if err != nil {

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -293,6 +293,7 @@ func ListCronJobNamesMatchingLabels(namespace string, matchLabels map[string]str
 	return cronjobNames, nil
 }
 
+// listV1CronJobNames lists the cronjob under batch/v1 api version for k8s version > 1.20
 func listV1CronJobNames(clientset *kubernetes.Clientset, namespace string, listOptions metav1.ListOptions) ([]v1.CronJob, error) {
 	var cronJobs []v1.CronJob
 	cronJobList, err := clientset.BatchV1().CronJobs(namespace).List(context.TODO(), listOptions)
@@ -303,6 +304,7 @@ func listV1CronJobNames(clientset *kubernetes.Clientset, namespace string, listO
 	return cronJobList.Items, nil
 }
 
+// listV1Beta1CronJobNames lists the cronjob under batch/v1beta1 api version for k8s version <= 1.20
 func listV1Beta1CronJobNames(clientset *kubernetes.Clientset, namespace string, listOptions metav1.ListOptions) ([]v1beta1.CronJob, error) {
 	var cronJobs []v1beta1.CronJob
 	cronJobList, err := clientset.BatchV1beta1().CronJobs(namespace).List(context.TODO(), listOptions)

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -1,0 +1,337 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	jaegerSpanIndexPrefix  = "verrazzano-jaeger-span"
+	jaegerClusterNameLabel = "verrazzano_cluster"
+	jaegerClusterName      = "local"
+)
+
+type JaegerTraceData struct {
+	TraceID string `json:"traceID"`
+	Spans   []struct {
+		TraceID       string `json:"traceID"`
+		SpanID        string `json:"spanID"`
+		Flags         int    `json:"flags"`
+		OperationName string `json:"operationName"`
+		References    []struct {
+			RefType string `json:"refType"`
+			TraceID string `json:"traceID"`
+			SpanID  string `json:"spanID"`
+		} `json:"references"`
+		StartTime int64 `json:"startTime"`
+		Duration  int   `json:"duration"`
+		Tags      []struct {
+			Key   string      `json:"key"`
+			Type  string      `json:"type"`
+			Value interface{} `json:"value"`
+		} `json:"tags"`
+		Logs []struct {
+			Timestamp int64 `json:"timestamp"`
+			Fields    []struct {
+				Key   string `json:"key"`
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"fields"`
+		} `json:"logs"`
+		ProcessID string      `json:"processID"`
+		Warnings  interface{} `json:"warnings"`
+	} `json:"spans"`
+	Processes struct {
+		P1 struct {
+			ServiceName string `json:"serviceName"`
+			Tags        []struct {
+				Key   string `json:"key"`
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"tags"`
+		} `json:"p1"`
+	} `json:"processes"`
+	Warnings interface{} `json:"warnings"`
+}
+
+type JaegerTraceDataWrapper struct {
+	Data   []JaegerTraceData `json:"data"`
+	Total  int               `json:"total"`
+	Limit  int               `json:"limit"`
+	Offset int               `json:"offset"`
+	Errors interface{}       `json:"errors"`
+}
+
+//IsJaegerInstanceCreated checks whether the default Jaeger CR is created
+func IsJaegerInstanceCreated() (bool, error) {
+	deployments, err := ListDeployments(constants.VerrazzanoMonitoringNamespace)
+	if err != nil {
+		return false, err
+	}
+	if len(deployments.Items) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+//JaegerSpanRecordFoundInOpenSearch checks if jaeger span records are found in OpenSearch storage
+func JaegerSpanRecordFoundInOpenSearch(kubeconfigPath string, after time.Time, serviceName string) (bool, error) {
+	indexName, err := GetJaegerSpanIndexName(kubeconfigPath)
+	if err != nil {
+		return false, err
+	}
+	fields := map[string]string{
+		"process.serviceName": serviceName,
+	}
+	searchResult := querySystemElasticSearch(indexName, fields, kubeconfigPath)
+	if len(searchResult) == 0 {
+		Log(Info, fmt.Sprintf("Expected to find log record matching fields %v", fields))
+		return false, nil
+	}
+	found := findJaegerSpanHits(searchResult, &after)
+	if !found {
+		Log(Error, fmt.Sprintf("Failed to find recent jaeger span record for service %s", serviceName))
+	}
+	return found, nil
+}
+
+//GetJaegerSpanIndexName returns the index name used in OpenSearch used for storage
+func GetJaegerSpanIndexName(kubeconfigPath string) (string, error) {
+	var jaegerIndices []string
+	for _, indexName := range listSystemElasticSearchIndices(kubeconfigPath) {
+		if strings.HasPrefix(indexName, jaegerSpanIndexPrefix) {
+			jaegerIndices = append(jaegerIndices, indexName)
+			break
+		}
+	}
+	if len(jaegerIndices) > 0 {
+		return jaegerIndices[0], nil
+	}
+	return "", fmt.Errorf("Jaeger Span index not found")
+}
+
+// IsJaegerMetricFound validates if the given jaeger metrics contain the labels with values specified as key-value pairs of the map
+func IsJaegerMetricFound(kubeconfigPath, metricName string, kv map[string]string) bool {
+	compMetrics, err := QueryMetricWithLabel(metricName, kubeconfigPath, jaegerClusterNameLabel, jaegerClusterName)
+	if err != nil {
+		return false
+	}
+	metrics := JTq(compMetrics, "data", "result").([]interface{})
+	for _, metric := range metrics {
+		metricFound := true
+		for key, value := range kv {
+			if Jq(metric, "metric", key) != value {
+				metricFound = false
+				break
+			}
+		}
+		return metricFound
+	}
+	return false
+}
+
+//ListJaegerTraces lists all trace ids for a given service.
+func ListJaegerTraces(kubeconfigPath string, serviceName string) []string {
+	var traces []string
+	url := fmt.Sprintf("%s/api/traces?service=%s", getJaegerURL(kubeconfigPath), serviceName)
+	username, password, err := getJaegerUsernamePassword(kubeconfigPath)
+	if err != nil {
+		return traces
+	}
+	resp, err := getJaegerWithBasicAuth(url, "", username, password, kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting Jaeger traces: url=%s, error=%v", url, err))
+		return traces
+	}
+	if resp.StatusCode != http.StatusOK {
+		Log(Error, fmt.Sprintf("Error retrieving Jaeger traces: url=%s, status=%d", url, resp.StatusCode))
+		return traces
+	}
+	Log(Debug, fmt.Sprintf("traces: %s", resp.Body))
+	var jaegerTraceDataWrapper JaegerTraceDataWrapper
+	json.Unmarshal(resp.Body, &jaegerTraceDataWrapper)
+	for _, traceObj := range jaegerTraceDataWrapper.Data {
+		traces = append(traces, traceObj.TraceID)
+	}
+	return traces
+}
+
+//ListServicesInJaeger lists the services whose traces are available in Jaeger
+func ListServicesInJaeger(kubeconfigPath string) []string {
+	var services []string
+	url := fmt.Sprintf("%s/api/services", getJaegerURL(kubeconfigPath))
+	username, password, err := getJaegerUsernamePassword(kubeconfigPath)
+	if err != nil {
+		return services
+	}
+	resp, err := getJaegerWithBasicAuth(url, "", username, password, kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting Jaeger traces: url=%s, error=%v", url, err))
+		return services
+	}
+	if resp.StatusCode != http.StatusOK {
+		Log(Error, fmt.Sprintf("Error retrieving Jaeger traces: url=%s, status=%d", url, resp.StatusCode))
+		return services
+	}
+	Log(Debug, fmt.Sprintf("traces: %s", resp.Body))
+	var serviceMap map[string][]string
+	json.Unmarshal(resp.Body, &serviceMap)
+	services = append(services, serviceMap["data"]...)
+	return services
+}
+
+// DoesCronJobExist returns whether a cronjob with the given name and namespace exists for the cluster
+func DoesCronJobExist(namespace string, name string) (bool, error) {
+	cronjobs, err := ListCronJobsMatchingLabels(namespace, nil)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed listing deployments in cluster for namespace %s: %v", namespace, err))
+		return false, err
+	}
+	for i := range cronjobs.Items {
+		if strings.HasPrefix(cronjobs.Items[i].Name, name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ListDeploymentsMatchingLabels returns the list of deployments in a given namespace matching the given labels for the cluster
+func ListDeploymentsMatchingLabels(namespace string, matchLabels map[string]string) (*appsv1.DeploymentList, error) {
+	// Get the Kubernetes clientset
+	clientset, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	listOptions := metav1.ListOptions{}
+	if matchLabels != nil {
+		var selector labels.Selector
+		for k, v := range matchLabels {
+			selectorLabel, _ := labels.NewRequirement(k, selection.Equals, []string{v})
+			selector = labels.NewSelector()
+			selector = selector.Add(*selectorLabel)
+		}
+		listOptions.LabelSelector = selector.String()
+	}
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to list deployments in namespace %s: %v", namespace, err))
+		return nil, err
+	}
+	return deployments, nil
+}
+
+// ListCronJobs returns the list of cronjobs in a given namespace
+func ListCronJobs(namespace string) (*batchv1.CronJobList, error) {
+	return ListCronJobsMatchingLabels(namespace, nil)
+}
+
+// ListCronJobsMatchingLabels returns the list of cronjobs in a given namespace matching the given labels for the cluster
+func ListCronJobsMatchingLabels(namespace string, matchLabels map[string]string) (*batchv1.CronJobList, error) {
+	// Get the Kubernetes clientset
+	clientset, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	listOptions := metav1.ListOptions{}
+	if matchLabels != nil {
+		var selector labels.Selector
+		for k, v := range matchLabels {
+			selectorLabel, _ := labels.NewRequirement(k, selection.Equals, []string{v})
+			selector = labels.NewSelector()
+			selector = selector.Add(*selectorLabel)
+		}
+		listOptions.LabelSelector = selector.String()
+	}
+	cronjobs, err := clientset.BatchV1().CronJobs(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to list cronjobs in namespace %s: %v", namespace, err))
+		return nil, err
+	}
+	return cronjobs, nil
+}
+
+// getJaegerWithBasicAuth access Jaeger with GET using basic auth, using a given kubeconfig
+func getJaegerWithBasicAuth(url string, hostHeader string, username string, password string, kubeconfigPath string) (*HTTPResponse, error) {
+	retryableClient, err := getJaegerClient(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return doReq(url, "GET", "", hostHeader, username, password, nil, retryableClient)
+}
+
+// getJaegerClient returns the Jaeger client which can be used for GET/POST operations using a given kubeconfig
+func getJaegerClient(kubeconfigPath string) (*retryablehttp.Client, error) {
+	client, err := GetVerrazzanoHTTPClient(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return client, err
+}
+
+// getJaegerURL returns Jaeger URL from the corresponding ingress resource using the given kubeconfig
+func getJaegerURL(kubeconfigPath string) string {
+	clientset, err := GetKubernetesClientsetForCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get clientset for cluster %v", err))
+		return ""
+	}
+	ingressList, _ := clientset.NetworkingV1().Ingresses(VerrazzanoNamespace).List(context.TODO(), metav1.ListOptions{})
+	for _, ingress := range ingressList.Items {
+		if ingress.Name == "verrazzano-jaeger" {
+			Log(Info, fmt.Sprintf("Found Jaeger Ingress %v, host %s", ingress.Name, ingress.Spec.Rules[0].Host))
+			return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host)
+		}
+	}
+	return ""
+}
+
+// getJaegerUsernamePassword returns the username/password for connecting to Jaeger
+func getJaegerUsernamePassword(kubeconfigPath string) (username, password string, err error) {
+	password, err = GetVerrazzanoPasswordInCluster(kubeconfigPath)
+	if err != nil {
+		return "", "", err
+	}
+	return "verrazzano", password, err
+}
+
+// findJaegerSpanHits returns the number of span hits that are older than the given time
+func findJaegerSpanHits(searchResult map[string]interface{}, after *time.Time) bool {
+	hits := Jq(searchResult, "hits", "hits")
+	if hits == nil {
+		Log(Info, "Expected to find hits in span record query results")
+		return false
+	}
+	Log(Info, fmt.Sprintf("Found %d records", len(hits.([]interface{}))))
+	if len(hits.([]interface{})) == 0 {
+		Log(Info, "Expected span record query results to contain at least one hit")
+		return false
+	}
+	if after == nil {
+		return true
+	}
+	for _, hit := range hits.([]interface{}) {
+		timestamp := Jq(hit, "_source", "startTimeMillis")
+		t := time.UnixMilli(int64(timestamp.(float64)))
+		if t.After(*after) {
+			Log(Info, fmt.Sprintf("Found recent record: %f", timestamp))
+			return true
+		}
+		Log(Info, fmt.Sprintf("Found old record: %f", timestamp))
+	}
+	return true
+}

--- a/tests/e2e/pkg/keycloak.go
+++ b/tests/e2e/pkg/keycloak.go
@@ -216,7 +216,9 @@ func (c *KeycloakRESTClient) DeleteUser(userRealm string, userID string) error {
 		return fmt.Errorf("invalid response")
 	}
 	defer response.Body.Close()
-	if response.StatusCode != 200 {
+	// all responses in the 200 range are acceptable
+	// in practice, this call returns 204 (No Content) for success
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return fmt.Errorf("invalid response status: %d", response.StatusCode)
 	}
 	return nil

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -767,7 +767,7 @@ func IsJaegerOperatorEnabled(kubeconfigPath string) bool {
 		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
 		return false
 	}
-	if vz.Spec.Components.JaegerOperator == nil || vz.Spec.Components.JaegerOperator.Enabled == nil {
+	if vz == nil || vz.Spec.Components.JaegerOperator == nil || vz.Spec.Components.JaegerOperator.Enabled == nil {
 		return false
 	}
 	return *vz.Spec.Components.JaegerOperator.Enabled

--- a/tests/e2e/verify-install/jaeger-operator/jaeger_operator_test.go
+++ b/tests/e2e/verify-install/jaeger-operator/jaeger_operator_test.go
@@ -17,15 +17,11 @@ import (
 )
 
 const (
-	waitTimeout                    = 3 * time.Minute
-	pollingInterval                = 10 * time.Second
-	jaegerOperatorName             = "jaeger-operator"
-	minVZVersion                   = "1.3.0"
-	minVZVersionForDefaultInstance = "1.4.0"
-	//JaegerCollectorDeploymentName is the name of the Jaeger instance collector deployment.
-	JaegerCollectorDeploymentName = "jaeger-operator-jaeger-collector"
-	//JaegerQueryDeploymentName is the name of the Jaeger instance query deployment.
-	JaegerQueryDeploymentName = "jaeger-operator-jaeger-query"
+	waitTimeout             = 3 * time.Minute
+	pollingInterval         = 10 * time.Second
+	jaegerOperatorName      = "jaeger-operator"
+	minVZVersion            = "1.3.0"
+	jaegerESIndexCleanerJob = "jaeger-operator-jaeger-es-index-cleaner"
 )
 
 var (
@@ -47,33 +43,17 @@ var (
 
 var t = framework.NewTestFramework("jaegeroperator")
 
-func isJaegerOperatorEnabled() bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+func WhenJaegerOperatorEnabledIt(text string, args ...interface{}) {
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
-		AbortSuite(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
-	}
-	return pkg.IsJaegerOperatorEnabled(kubeconfigPath)
-}
-
-// 'It' Wrapper to only run spec if the Jaeger operator is supported on the current Verrazzano version
-func WhenJaegerOperatorInstalledIt(minVersion string, description string, f func()) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		t.It(description, func() {
-			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
+		t.It(text, func() {
+			Fail(err.Error())
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion(minVersion, kubeconfigPath)
-	if err != nil {
-		t.It(description, func() {
-			Fail(fmt.Sprintf("Failed to check Verrazzano version %s: %s", minVersion, err.Error()))
-		})
+	if pkg.IsJaegerOperatorEnabled(kubeconfig) {
+		t.ItMinimumVersion(text, minVZVersion, kubeconfig, args...)
 	}
-	if supported {
-		t.It(description, f)
-	} else {
-		t.Logs.Infof("Skipping check '%v', the Jaeger Operator is not supported", description)
-	}
+	t.Logs.Infof("Skipping spec, Jaeger Operator is disabled")
 }
 
 var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
@@ -81,23 +61,20 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 		// GIVEN the Jaeger Operator is installed
 		// WHEN we check to make sure the namespace exists
 		// THEN we successfully find the namespace
-		WhenJaegerOperatorInstalledIt(minVZVersion, "should have a verrazzano-monitoring namespace", func() {
+		WhenJaegerOperatorEnabledIt("should have a verrazzano-monitoring namespace", func() {
 			Eventually(func() (bool, error) {
-				if !isJaegerOperatorEnabled() {
-					return true, nil
-				}
 				return pkg.DoesNamespaceExist(constants.VerrazzanoMonitoringNamespace)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		// GIVEN the Jaeger Operator is installed
-		// WHEN we check to make sure the pods are running
+		// WHEN we check to make sure the Jaeger pods are running
 		// THEN we successfully find the running pods
-		WhenJaegerOperatorInstalledIt(minVZVersion, "should have running pods", func() {
+		// For 1.3.0, only the jaeger-operator pod gets created and its status is validated
+		// For 1.4.0 and later, jaeger-operator, jaeger-operator-jaeger-query, jaeger-operator-jaeger-collector
+		//     pods gets created and their status is validated.
+		WhenJaegerOperatorEnabledIt("should have running pods", func() {
 			jaegerOperatorPodsRunning := func() bool {
-				if !isJaegerOperatorEnabled() {
-					return true
-				}
 				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, []string{jaegerOperatorName})
 				if err != nil {
 					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", jaegerOperatorName, constants.VerrazzanoMonitoringNamespace, err))
@@ -110,41 +87,39 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 		// GIVEN the Jaeger Operator is installed
 		// WHEN we check to make sure the default Jaeger images are from Verrazzano
 		// THEN we see that the env is correctly populated
-		WhenJaegerOperatorInstalledIt(minVZVersion, "should have the correct default Jaeger images", func() {
+		WhenJaegerOperatorEnabledIt("should have the correct default Jaeger images", func() {
 			verifyImages := func() bool {
-				if isJaegerOperatorEnabled() {
-					// Check if Jaeger operator is running with the expected Verrazzano Jaeger Operator image
-					image, err := pkg.GetContainerImage(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
-					if err != nil {
-						pkg.Log(pkg.Error, fmt.Sprintf("Container %s is not running in the namespace: %s, error: %v", jaegerOperatorName, constants.VerrazzanoMonitoringNamespace, err))
-						return false
-					}
-					if !strings.HasPrefix(image, operatorImage) {
-						pkg.Log(pkg.Error, fmt.Sprintf("Container %s image %s is not running with the expected image %s in the namespace: %s", jaegerOperatorName, image, operatorImage, constants.VerrazzanoMonitoringNamespace))
-						return false
-					}
-					// Check if Jaeger operator env has been set to use Verrazzano Jaeger images
-					containerEnv, err := pkg.GetContainerEnv(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
-					if err != nil {
-						pkg.Log(pkg.Error, fmt.Sprintf("Not able to get the environment variables in the container %s, error: %v", jaegerOperatorName, err))
-						return false
-					}
-					for name, val := range expectedJaegerImages {
-						found := false
-						for _, actualEnv := range containerEnv {
-							if actualEnv.Name == name {
-								if !strings.HasPrefix(actualEnv.Value, val) {
-									pkg.Log(pkg.Error, fmt.Sprintf("The value %s of the env %s for the container %s does not have the image %s as expected",
-										actualEnv.Value, actualEnv.Name, jaegerOperatorName, val))
-									return false
-								}
-								found = true
+				// Check if Jaeger operator is running with the expected Verrazzano Jaeger Operator image
+				image, err := pkg.GetContainerImage(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
+				if err != nil {
+					pkg.Log(pkg.Error, fmt.Sprintf("Container %s is not running in the namespace: %s, error: %v", jaegerOperatorName, constants.VerrazzanoMonitoringNamespace, err))
+					return false
+				}
+				if !strings.HasPrefix(image, operatorImage) {
+					pkg.Log(pkg.Error, fmt.Sprintf("Container %s image %s is not running with the expected image %s in the namespace: %s", jaegerOperatorName, image, operatorImage, constants.VerrazzanoMonitoringNamespace))
+					return false
+				}
+				// Check if Jaeger operator env has been set to use Verrazzano Jaeger images
+				containerEnv, err := pkg.GetContainerEnv(constants.VerrazzanoMonitoringNamespace, jaegerOperatorName, jaegerOperatorName)
+				if err != nil {
+					pkg.Log(pkg.Error, fmt.Sprintf("Not able to get the environment variables in the container %s, error: %v", jaegerOperatorName, err))
+					return false
+				}
+				for name, val := range expectedJaegerImages {
+					found := false
+					for _, actualEnv := range containerEnv {
+						if actualEnv.Name == name {
+							if !strings.HasPrefix(actualEnv.Value, val) {
+								pkg.Log(pkg.Error, fmt.Sprintf("The value %s of the env %s for the container %s does not have the image %s as expected",
+									actualEnv.Value, actualEnv.Name, jaegerOperatorName, val))
+								return false
 							}
+							found = true
 						}
-						if !found {
-							pkg.Log(pkg.Error, fmt.Sprintf("The env %s not set for the container %s", name, jaegerOperatorName))
-							return false
-						}
+					}
+					if !found {
+						pkg.Log(pkg.Error, fmt.Sprintf("The env %s not set for the container %s", name, jaegerOperatorName))
+						return false
 					}
 				}
 				return true
@@ -152,46 +127,36 @@ var _ = t.Describe("Jaeger Operator", Label("f:platform-lcm.install"), func() {
 			Eventually(verifyImages, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 
-		WhenJaegerOperatorInstalledIt(minVZVersion, "should have the correct Jaeger Operator CRDs", func() {
+		// GIVEN the Jaeger Operator is installed
+		// WHEN we check the CRDs created by Jaeger Operator
+		// THEN we successfully find the Jaeger CRDs
+		WhenJaegerOperatorEnabledIt("should have the correct Jaeger Operator CRDs", func() {
 			verifyCRDList := func() (bool, error) {
-				if isJaegerOperatorEnabled() {
-					for _, crd := range jaegerOperatorCrds {
-						exists, err := pkg.DoesCRDExist(crd)
-						if err != nil || !exists {
-							return exists, err
-						}
+				for _, crd := range jaegerOperatorCrds {
+					exists, err := pkg.DoesCRDExist(crd)
+					if err != nil || !exists {
+						return exists, err
 					}
-					return true, nil
 				}
 				return true, nil
 			}
 			Eventually(verifyCRDList, waitTimeout, pollingInterval).Should(BeTrue())
 		})
-		WhenJaegerOperatorInstalledIt(minVZVersionForDefaultInstance, "should have a default instance Collector pod running", func() {
-			verifyDefaultInstanceCollectorPod := func() bool {
-				if !isJaegerOperatorEnabled() {
-					return true
-				}
-				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, []string{JaegerCollectorDeploymentName})
+
+		// GIVEN the Jaeger Operator is installed
+		// WHEN we check to make sure the Jaeger OpenSearch Index Cleaner cron job exists
+		// THEN we successfully find the expected cron job
+		WhenJaegerOperatorEnabledIt("should have a Jaeger OpenSearch Index Cleaner cron job", func() {
+			Eventually(func() (bool, error) {
+				create, err := pkg.IsJaegerInstanceCreated()
 				if err != nil {
-					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", JaegerCollectorDeploymentName, constants.VerrazzanoMonitoringNamespace, err))
+					pkg.Log(pkg.Error, fmt.Sprintf("Error checking if Jaeger CR is available %s", err.Error()))
 				}
-				return result
-			}
-			Eventually(verifyDefaultInstanceCollectorPod, waitTimeout, pollingInterval).Should(BeTrue())
-		})
-		WhenJaegerOperatorInstalledIt(minVZVersionForDefaultInstance, "should have a default instance Query pod running", func() {
-			verifyDefaultInstanceQueryPods := func() bool {
-				if !isJaegerOperatorEnabled() {
-					return true
+				if create {
+					return pkg.DoesCronJobExist(constants.VerrazzanoMonitoringNamespace, jaegerESIndexCleanerJob)
 				}
-				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, []string{JaegerQueryDeploymentName})
-				if err != nil {
-					AbortSuite(fmt.Sprintf("Pod %v is not running in the namespace: %v, error: %v", JaegerQueryDeploymentName, constants.VerrazzanoMonitoringNamespace, err))
-				}
-				return result
-			}
-			Eventually(verifyDefaultInstanceQueryPods, waitTimeout, pollingInterval).Should(BeTrue())
+				return false, nil
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 })

--- a/tests/testdata/jaeger/helidon/helidon-tracing-app.yaml
+++ b/tests/testdata/jaeger/helidon/helidon-tracing-app.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: hello-helidon-appconf
+  annotations:
+    version: v1.0.0
+    description: "Hello Helidon application"
+spec:
+  components:
+    - componentName: hello-helidon-component
+      traits:
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: MetricsTrait
+            spec:
+              scraper: verrazzano-system/vmi-system-prometheus-0
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: IngressTrait
+            metadata:
+              name: hello-helidon-ingress
+            spec:
+              rules:
+                - paths:
+                    - path: "/greet"
+                      pathType: Prefix

--- a/tests/testdata/jaeger/helidon/helidon-tracing-comp.yaml
+++ b/tests/testdata/jaeger/helidon/helidon-tracing-comp.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
+metadata:
+  name: hello-helidon-component
+spec:
+  workload:
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoHelidonWorkload
+    metadata:
+      name: hello-helidon-workload
+      annotations:
+        "sidecar.jaegertracing.io/inject": "true"
+      labels:
+        app: hello-helidon
+        version: v1
+    spec:
+      deploymentTemplate:
+        metadata:
+          name: hello-helidon-deployment
+          annotations:
+            "sidecar.jaegertracing.io/inject": "true"
+        podSpec:
+          containers:
+            - name: hello-helidon-container
+              image: "ghcr.io/verrazzano/example-helidon-greet-app-v1:1.0.0-1-20220513221156-7da0d32"
+              env:
+                - name: "TRACING_SERVICE"
+                  value: "hello-helidon"
+                - name: "TRACING_PORT"
+                  value: "9411"
+                - name: "TRACING_HOST"
+                  value: "jaeger-operator-jaeger-collector.verrazzano-monitoring.svc.cluster.local"
+              ports:
+                - containerPort: 8080
+                  name: http


### PR DESCRIPTION
Fixed the failures in Kind AT tests with K8S 1.20 where cronjobs are not available in `v1` and instead available only in `v1beta`. Verified the stability of the tests using push triggerred acceptance tests and upgrade paths tests.
