### PR TITLE
NO JIRA: Bump VMO tag in BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.4.0-20220805165147-c395bfe",
+              "tag": "v1.4.0-20220809122807-fe60640",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Bump the VMO version to pick up fixes in the latest image.