### PR TITLE
VZ-6703: Bump jaeger-operator version

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -547,7 +547,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.34.1-20220705001411-cfb06635",
+              "tag": "1.34.1-20220808210031-cfb06635",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Update BOM to use latest version of jaeger-operator image.