### PR TITLE
VZ-6632 - Add verrazzano-managed=true label on managed cluster resources created by Verrazzano

### DIFF
--- a/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterapplicationconfiguration/controller_test.go
@@ -6,18 +6,19 @@ package multiclusterapplicationconfiguration
 import (
 	"context"
 	"encoding/json"
-	"github.com/go-logr/logr"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -429,6 +430,10 @@ func assertAppConfigValid(assert *asserts.Assertions, app *v1alpha2.ApplicationC
 	assert.Equal(namespace, app.ObjectMeta.Namespace)
 	assert.Equal(crName, app.ObjectMeta.Name)
 	assert.Equal(mcAppConfig.Spec.Template.Spec, app.Spec)
+
+	// assert that the app config is labeled verrazzano-managed=true since it was created by Verrazzano
+	assert.NotNil(app.Labels)
+	assert.Equal(constants.LabelVerrazzanoManagedDefault, app.Labels[vzconst.VerrazzanoManagedLabelKey])
 
 	// assert some fields on the app config spec (e.g. in the case of update, these fields should
 	// be different from the mock pre existing OAM app config)

--- a/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustercomponent/controller_test.go
@@ -6,10 +6,12 @@ package multiclustercomponent
 import (
 	"context"
 	"encoding/json"
-	"github.com/go-logr/logr"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
@@ -432,6 +434,10 @@ func assertComponentValid(assert *asserts.Assertions, c *v1alpha2.Component, mcC
 	assert.Equal(namespace, c.ObjectMeta.Namespace)
 	assert.Equal(crName, c.ObjectMeta.Name)
 	assert.Equal(mcComp.Spec.Template.Spec, c.Spec)
+
+	// assert that the component is labeled verrazzano-managed=true since it was created by Verrazzano
+	assert.NotNil(c.Labels)
+	assert.Equal(constants.LabelVerrazzanoManagedDefault, c.Labels[vzconst.VerrazzanoManagedLabelKey])
 
 	// assert some fields on the component spec (e.g. in the case of update, these fields should
 	// be different from the mock pre existing OAM component)

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller.go
@@ -5,9 +5,11 @@ package multiclusterconfigmap
 
 import (
 	"context"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
-	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
@@ -42,7 +44,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == constants.KubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
 		log.Infof("Multi-cluster application configuration resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
@@ -156,6 +158,11 @@ func (r *Reconciler) mutateConfigMap(mcConfigMap clustersv1alpha1.MultiClusterCo
 	configMap.BinaryData = mcConfigMap.Spec.Template.BinaryData
 	configMap.Immutable = mcConfigMap.Spec.Template.Immutable
 	configMap.Labels = mcConfigMap.Spec.Template.Metadata.Labels
+	if configMap.Labels == nil {
+		configMap.Labels = map[string]string{}
+	}
+	configMap.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
+
 	configMap.Annotations = mcConfigMap.Spec.Template.Metadata.Annotations
 }
 

--- a/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
+++ b/application-operator/controllers/clusters/multiclusterconfigmap/controller_test.go
@@ -6,11 +6,13 @@ package multiclusterconfigmap
 import (
 	"context"
 	"encoding/json"
-	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
-	"github.com/go-logr/logr"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"path/filepath"
 	"testing"
+
+	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
@@ -424,7 +426,9 @@ func assertConfigMapValid(assert *asserts.Assertions, cm *v1.ConfigMap, mcConfig
 	assert.Equal(crName, cm.ObjectMeta.Name)
 	assert.Equal(mcConfigMap.Spec.Template.Data, cm.Data)
 	assert.Equal(mcConfigMap.Spec.Template.BinaryData, cm.BinaryData)
-
+	// assert that the configmap is labeled verrazzano-managed=true since it was created by Verrazzano
+	assert.NotNil(cm.Labels)
+	assert.Equal(constants.LabelVerrazzanoManagedDefault, cm.Labels[vzconst.VerrazzanoManagedLabelKey])
 }
 
 // getMCConfigMap creates and returns a sample MultiClusterConfigMap used in tests

--- a/application-operator/controllers/clusters/multiclustersecret/controller.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller.go
@@ -5,9 +5,11 @@ package multiclustersecret
 
 import (
 	"context"
+
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
-	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzlogInit "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"go.uber.org/zap"
@@ -41,7 +43,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == constants.KubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
 		log := zap.S().With(vzlogInit.FieldResourceNamespace, req.Namespace, vzlogInit.FieldResourceName, req.Name, vzlogInit.FieldController, controllerName)
 		log.Infof("Multi-cluster secret resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil
@@ -163,5 +165,9 @@ func (r *Reconciler) mutateSecret(mcSecret clustersv1alpha1.MultiClusterSecret, 
 	secret.Data = mcSecret.Spec.Template.Data
 	secret.StringData = mcSecret.Spec.Template.StringData
 	secret.Labels = mcSecret.Spec.Template.Metadata.Labels
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
 	secret.Annotations = mcSecret.Spec.Template.Metadata.Annotations
 }

--- a/application-operator/controllers/clusters/multiclustersecret/controller_test.go
+++ b/application-operator/controllers/clusters/multiclustersecret/controller_test.go
@@ -5,10 +5,12 @@ package multiclustersecret
 
 import (
 	"context"
+	"testing"
+
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/go-logr/logr"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
@@ -413,6 +415,9 @@ func assertSecretValid(assert *asserts.Assertions, s *v1.Secret, secretData map[
 	assert.Equal(namespace, s.ObjectMeta.Namespace)
 	assert.Equal(crName, s.ObjectMeta.Name)
 	assert.Equal(secretData, s.Data)
+	// assert that the secret is labeled verrazzano-managed=true since it was created by Verrazzano
+	assert.NotNil(s.Labels)
+	assert.Equal(constants.LabelVerrazzanoManagedDefault, s.Labels[vzconst.VerrazzanoManagedLabelKey])
 }
 
 // getSampleMCSecret creates and returns a sample MultiClusterSecret used in tests

--- a/application-operator/mcagent/mcagent_component.go
+++ b/application-operator/mcagent/mcagent_component.go
@@ -6,6 +6,8 @@ package mcagent
 import (
 	"fmt"
 
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
@@ -91,6 +93,13 @@ func mutateMCComponent(mcComponent clustersv1alpha1.MultiClusterComponent, mcCom
 	mcComponentNew.Spec.Placement = mcComponent.Spec.Placement
 	mcComponentNew.Spec.Template = mcComponent.Spec.Template
 	mcComponentNew.Labels = mcComponent.Labels
+	// Mark the MC component we synced from Admin cluster with verrazzano-managed=true, to
+	// distinguish from any (though unlikely) that the user might have created on managed cluster
+	if mcComponentNew.Labels == nil {
+		mcComponentNew.Labels = map[string]string{}
+	}
+	mcComponentNew.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
+
 }
 
 // componentPlacedOnCluster returns boolean indicating if the list contains the object with the specified name and namespace

--- a/application-operator/mcagent/mcagent_component_test.go
+++ b/application-operator/mcagent/mcagent_component_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,8 +27,10 @@ import (
 const testMCComponentName = "unit-mccomp"
 const testMCComponentNamespace = "unit-mccomp-namespace"
 
-var mcComponentTestLabels = map[string]string{"label1": "test1"}
-var mcComponentTestUpdatedLabels = map[string]string{"label1": "test1updated"}
+var mcComponentTestExpectedLabels = map[string]string{"label1": "test1",
+	vzconst.VerrazzanoManagedLabelKey: constants.LabelVerrazzanoManagedDefault}
+var mcComponentTestExpectedLabelsOnUpdate = map[string]string{"label1": "test1updated",
+	vzconst.VerrazzanoManagedLabelKey: constants.LabelVerrazzanoManagedDefault}
 
 // TestCreateMCComponent tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterComponent objects
@@ -71,7 +75,7 @@ func TestCreateMCComponent(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcComponent *clustersv1alpha1.MultiClusterComponent, opts ...client.CreateOption) error {
 			assert.Equal(testMCComponentNamespace, mcComponent.Namespace, "mccomponent namespace did not match")
 			assert.Equal(testMCComponentName, mcComponent.Name, "mccomponent name did not match")
-			assert.Equal(mcComponentTestLabels, mcComponent.Labels, "mccomponent labels did not match")
+			assert.Equal(mcComponentTestExpectedLabels, mcComponent.Labels, "mccomponent labels did not match")
 			assert.Equal(testClusterName, mcComponent.Spec.Placement.Clusters[0].Name, "mccomponent does not contain expected placement")
 			return nil
 		})
@@ -149,7 +153,7 @@ func TestUpdateMCComponent(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcComponent *clustersv1alpha1.MultiClusterComponent, opts ...client.UpdateOption) error {
 			assert.Equal(testMCComponentNamespace, mcComponent.Namespace, "mccomponent namespace did not match")
 			assert.Equal(testMCComponentName, mcComponent.Name, "mccomponent name did not match")
-			assert.Equal(mcComponentTestUpdatedLabels, mcComponent.Labels, "mccomponent labels did not match")
+			assert.Equal(mcComponentTestExpectedLabelsOnUpdate, mcComponent.Labels, "mccomponent labels did not match")
 			workload := v1alpha2.ContainerizedWorkload{}
 			err := json.Unmarshal(mcComponent.Spec.Template.Spec.Workload.Raw, &workload)
 			assert.NoError(err, "failed to unmarshal the containerized workload")

--- a/application-operator/mcagent/mcagent_configmap.go
+++ b/application-operator/mcagent/mcagent_configmap.go
@@ -6,6 +6,8 @@ package mcagent
 import (
 	"fmt"
 
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
@@ -91,6 +93,13 @@ func mutateMCConfigMap(mcConfigMap clustersv1alpha1.MultiClusterConfigMap, mcCon
 	mcConfigMapNew.Spec.Placement = mcConfigMap.Spec.Placement
 	mcConfigMapNew.Spec.Template = mcConfigMap.Spec.Template
 	mcConfigMapNew.Labels = mcConfigMap.Labels
+	// Mark the MC ConfigMap we synced from Admin cluster with verrazzano-managed=true, to
+	// distinguish from any (though unlikely) that the user might have created on managed cluster
+	if mcConfigMapNew.Labels == nil {
+		mcConfigMapNew.Labels = map[string]string{}
+	}
+	mcConfigMapNew.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
+
 }
 
 // configMapPlacedOnCluster returns boolean indicating if the list contains the object with the specified name and namespace

--- a/application-operator/mcagent/mcagent_configmap_test.go
+++ b/application-operator/mcagent/mcagent_configmap_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/golang/mock/gomock"
 	asserts "github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/application-operator/constants"
 	clusterstest "github.com/verrazzano/verrazzano/application-operator/controllers/clusters/test"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -24,8 +26,10 @@ import (
 const testMCConfigMapName = "unit-mccm"
 const testMCConfigMapNamespace = "unit-mccm-namespace"
 
-var mcConfigMapTestLabels = map[string]string{"label1": "test1"}
-var mcConfigMapTestUpdatedLabels = map[string]string{"label1": "test1updated"}
+var mcConfigMapTestExpectedLabels = map[string]string{"label1": "test1",
+	vzconst.VerrazzanoManagedLabelKey: constants.LabelVerrazzanoManagedDefault}
+var mcConfigMapTestUpdatedLabels = map[string]string{"label1": "test1updated",
+	vzconst.VerrazzanoManagedLabelKey: constants.LabelVerrazzanoManagedDefault}
 
 // TestCreateMCConfigMap tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterConfigMap objects
@@ -70,7 +74,7 @@ func TestCreateMCConfigMap(t *testing.T) {
 		DoAndReturn(func(ctx context.Context, mcConfigMap *clustersv1alpha1.MultiClusterConfigMap, opts ...client.CreateOption) error {
 			assert.Equal(testMCConfigMapNamespace, mcConfigMap.Namespace, "mcConfigMap namespace did not match")
 			assert.Equal(testMCConfigMapName, mcConfigMap.Name, "mcConfigMap name did not match")
-			assert.Equal(mcConfigMapTestLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
+			assert.Equal(mcConfigMapTestExpectedLabels, mcConfigMap.Labels, "mcConfigMap labels did not match")
 			assert.Equal(testClusterName, mcConfigMap.Spec.Placement.Clusters[0].Name, "mcConfigMap does not contain expected placement")
 			assert.Equal("simplevalue", mcConfigMap.Spec.Template.Data["simple.key"])
 			return nil
@@ -112,7 +116,7 @@ func TestUpdateMCConfigMap(t *testing.T) {
 	// Managed cluster mocks
 	mcMocker := gomock.NewController(t)
 	mcMock := mocks.NewMockClient(mcMocker)
-	//mcMockStatusWriter := mocks.NewMockStatusWriter(mcMocker)
+	// mcMockStatusWriter := mocks.NewMockStatusWriter(mcMocker)
 
 	// Admin cluster mocks
 	adminMocker := gomock.NewController(t)

--- a/application-operator/mcagent/mcagent_k8ssecret.go
+++ b/application-operator/mcagent/mcagent_k8ssecret.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
@@ -108,7 +110,6 @@ func (s *Syncer) createOrUpdateSecret(secret corev1.Secret, mcAppConfigName stri
 	var secretNew corev1.Secret
 	secretNew.Namespace = secret.Namespace
 	secretNew.Name = secret.Name
-
 	// Create or update on the local cluster
 	return controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &secretNew, func() error {
 		mutateSecret(s.ManagedClusterName, mcAppConfigName, secret, &secretNew)
@@ -127,7 +128,9 @@ func mutateSecret(managedClusterName string, mcAppConfigName string, secret core
 
 	secretNew.Labels[mcAppConfigsLabel] = vzstring.AppendToCommaSeparatedString(secretNew.Labels[mcAppConfigsLabel], mcAppConfigName)
 	secretNew.Labels[managedClusterLabel] = managedClusterName
-
+	// Mark the secret synced from Admin cluster with verrazzano-managed=true, to distinguish
+	// those directly created by user on managed cluster
+	secretNew.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
 	secretNew.Annotations = secret.Annotations
 	secretNew.Type = secret.Type
 	secretNew.Immutable = secret.Immutable

--- a/application-operator/mcagent/mcagent_project.go
+++ b/application-operator/mcagent/mcagent_project.go
@@ -9,6 +9,7 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -109,6 +110,16 @@ func (s *Syncer) updateVerrazzanoProjectStatus(name types.NamespacedName, newCon
 func mutateVerrazzanoProject(vp clustersv1alpha1.VerrazzanoProject, vpNew *clustersv1alpha1.VerrazzanoProject) {
 	vpNew.Spec.Template = vp.Spec.Template
 	vpNew.Spec.Placement = vp.Spec.Placement
+	// Mark the VerrazzanoProject we synced from Admin cluster with verrazzano-managed=true, to
+	// distinguish from any (though unlikely) that the user might have created on managed cluster
+	if vpNew.Labels == nil {
+		vpNew.Labels = map[string]string{}
+	}
+	if vp.Labels != nil {
+		vpNew.Labels = vp.Labels
+	}
+	vpNew.Labels[vzconst.VerrazzanoManagedLabelKey] = constants.LabelVerrazzanoManagedDefault
+	vpNew.Annotations = vp.Annotations
 }
 
 // projectListContains returns boolean indicating if the list contains the object with the specified name and namespace

--- a/application-operator/mcagent/mcagent_project_test.go
+++ b/application-operator/mcagent/mcagent_project_test.go
@@ -275,6 +275,8 @@ func TestDeleteVerrazzanoProject(t *testing.T) {
 					vp.Name = tt.fields.vpName
 					vp.Spec.Template.Namespaces = tt.fields.nsList
 					vp.Spec.Placement.Clusters = tt.fields.clusters
+					vp.Labels = testProj.Labels
+					vp.Annotations = testProj.Annotations
 					return nil
 				})
 
@@ -593,6 +595,5 @@ func getTestVerrazzanoProject(vpNamespace string, vpName string, nsNames []clust
 	proj.Name = vpName
 	proj.Spec.Template.Namespaces = nsNames
 	proj.Spec.Placement.Clusters = clusters
-
 	return proj, err
 }

--- a/application-operator/mcagent/testdata/multicluster-component-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-component-update.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: clusters.verrazzano.io/v1alpha1
@@ -8,6 +8,7 @@ metadata:
   namespace: unit-mccomp-namespace
   labels:
     label1: test1updated
+    verrazzano-managed: "true"
 spec:
   template:
     spec:

--- a/application-operator/mcagent/testdata/multicluster-component.yaml
+++ b/application-operator/mcagent/testdata/multicluster-component.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: unit-mccomp-namespace
   labels:
     label1: test1
+    verrazzano-managed: "true"
 spec:
   template:
     spec:

--- a/application-operator/mcagent/testdata/multicluster-component.yaml
+++ b/application-operator/mcagent/testdata/multicluster-component.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: clusters.verrazzano.io/v1alpha1

--- a/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap-update.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterConfigMap
@@ -7,6 +7,7 @@ metadata:
   namespace: unit-mccm-namespace
   labels:
     label1: test1updated
+    verrazzano-managed: "true"
 spec:
   template:
     metadata:

--- a/application-operator/mcagent/testdata/multicluster-configmap.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: clusters.verrazzano.io/v1alpha1
 kind: MultiClusterConfigMap

--- a/application-operator/mcagent/testdata/multicluster-configmap.yaml
+++ b/application-operator/mcagent/testdata/multicluster-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: unit-mccm-namespace
   labels:
     label1: test1
+    verrazzano-managed: "true"
 spec:
   template:
     metadata:

--- a/application-operator/mcagent/testdata/verrazzanoproject.yaml
+++ b/application-operator/mcagent/testdata/verrazzanoproject.yaml
@@ -6,6 +6,8 @@ kind: VerrazzanoProject
 metadata:
   name: VP_NAME
   namespace: VP_NS
+  labels:
+    verrazzano-managed: "true"
 spec:
   template:
     namespaces:

--- a/application-operator/mcagent/testdata/verrazzanoproject.yaml
+++ b/application-operator/mcagent/testdata/verrazzanoproject.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: clusters.verrazzano.io/v1alpha1

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -10,9 +10,9 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	oamv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	constants2 "github.com/verrazzano/verrazzano/application-operator/constants"
+	constants3 "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -250,8 +250,8 @@ func verrazzanoManagedLabelExists(kubeconfigPath string, namespace string) bool 
 	}
 	appLabels := appconf.GetLabels()
 	compLabels := comp.GetLabels()
-	return appLabels[constants.VerrazzanoManagedLabel] == constants2.LabelVerrazzanoManagedDefault &&
-		compLabels[constants.VerrazzanoManagedLabel] == constants2.LabelVerrazzanoManagedDefault
+	return appLabels[constants3.VerrazzanoManagedLabelKey] == constants2.LabelVerrazzanoManagedDefault &&
+		compLabels[constants3.VerrazzanoManagedLabelKey] == constants2.LabelVerrazzanoManagedDefault
 }
 
 func componentExists(kubeconfigPath string, namespace string) bool {

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -28,17 +28,19 @@ const (
 	appConfigName         = helloHelidon
 	componentName         = "hello-helidon-component"
 	workloadName          = "hello-helidon-workload"
+	oamGroup              = "core.oam.dev"
+	oamVersion            = "v1alpha2"
 )
 
 var expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
 var compGvr = schema.GroupVersionResource{
-	Group:    oamv1alpha1.SchemeGroupVersion.Group,
-	Version:  oamv1alpha1.SchemeGroupVersion.Version,
+	Group:    oamGroup,
+	Version:  oamVersion,
 	Resource: "components",
 }
 var appConfGvr = schema.GroupVersionResource{
-	Group:    oamv1alpha1.SchemeGroupVersion.Group,
-	Version:  oamv1alpha1.SchemeGroupVersion.Version,
+	Group:    oamGroup,
+	Version:  oamVersion,
 	Resource: "applicationconfigurations",
 }
 

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -146,6 +146,7 @@ func VerifyMCResourcesV100(kubeconfigPath string, isAdminCluster bool, placedInT
 		} else {
 			ok = ok && !vzManagedLabelExists
 		}
+		return ok
 	} else {
 		// don't expect either
 		return !mcAppConfExists && !mcCompExists

--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -9,8 +9,8 @@ import (
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	oamv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
-	constants2 "github.com/verrazzano/verrazzano/application-operator/constants"
-	constants3 "github.com/verrazzano/verrazzano/pkg/constants"
+	appopconst "github.com/verrazzano/verrazzano/application-operator/constants"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -250,8 +250,8 @@ func verrazzanoManagedLabelExists(kubeconfigPath string, namespace string) bool 
 	}
 	appLabels := appconf.GetLabels()
 	compLabels := comp.GetLabels()
-	return appLabels[constants3.VerrazzanoManagedLabelKey] == constants2.LabelVerrazzanoManagedDefault &&
-		compLabels[constants3.VerrazzanoManagedLabelKey] == constants2.LabelVerrazzanoManagedDefault
+	return appLabels[vzconst.VerrazzanoManagedLabelKey] == appopconst.LabelVerrazzanoManagedDefault &&
+		compLabels[vzconst.VerrazzanoManagedLabelKey] == appopconst.LabelVerrazzanoManagedDefault
 }
 
 func componentExists(kubeconfigPath string, namespace string) bool {

--- a/tests/e2e/pkg/keycloak.go
+++ b/tests/e2e/pkg/keycloak.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"io/ioutil"
 
@@ -216,7 +217,9 @@ func (c *KeycloakRESTClient) DeleteUser(userRealm string, userID string) error {
 		return fmt.Errorf("invalid response")
 	}
 	defer response.Body.Close()
-	if response.StatusCode != 200 {
+	// all responses in the 200 range are acceptable
+	// in practice, this call returns 204 (No Content) for success
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return fmt.Errorf("invalid response status: %d", response.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
