### PR TITLE
Updated velero container images to use datetime, commit based tags

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -641,18 +641,18 @@
           "images": [
             {
               "image": "velero",
-              "tag": "v1.8.1",
+              "tag": "v1.8.1-20220617192749-f0db842f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "velero-plugin-for-aws",
-              "tag": "v1.4.1",
+              "tag": "v1.4.1-20220617193554-272b3ebc",
               "helmFullImageKey": "initContainers[0].image"
             },
             {
               "image": "velero-restic-restore-helper",
-              "tag": "v1.8.1",
+              "tag": "v1.8.1-20220617192909-f0db842f",
               "helmFullImageKey": "configMaps.restic-restore-action-config.data.image"
             }
           ]


### PR DESCRIPTION
Velero images in ghcr.io did not have tags of the format `v<version>-datetime-commit_id`. The current PR is to update the BOM file with the correct image format. The respective images are correctly tagged and pushed to ghcr.io already.
