### PR TITLE
VZ-6703: Bump jaeger image versions

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -559,7 +559,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -570,7 +570,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -581,7 +581,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -592,7 +592,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -603,7 +603,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -614,7 +614,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.34.1-20220714175451-1fdab0ff",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -625,7 +625,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.34.1-20220718052137-ae4bd702",
+              "tag": "1.34.1-20220809161126-ae4bd702",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]


### PR DESCRIPTION
Update jaeger image tags in BOM to pick up the latest image builds. Note that the jaeger-operator image was already updated in a previous PR. This updates the rest of the images.