### PR TITLE
Remove duplicate default value for flag report-format, in the help for analyze command

### DIFF
--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -101,7 +101,7 @@ const (
 	ReportFileFlagUsage = "Name of report output file. (default stdout)"
 
 	ReportFormatFlagName  = "report-format"
-	ReportFormatFlagUsage = "The format of the report output. Valid report formats are \"summary\" and \"detailed\". (default summary)"
+	ReportFormatFlagUsage = "The format of the report output. Valid report formats are \"summary\" and \"detailed\"."
 
 	SummaryReport  = "summary"
 	DetailedReport = "detailed"


### PR DESCRIPTION
This PR removes the default value for flag report-format, appearing twice in the help for vz analyze command. With this change, the CLI displays the default value set on persistent FlagSet of the command. 