### PR TITLE
VZ-6703: Bump OpenSearch image versions

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -241,12 +241,12 @@
             },
             {
               "image": "opensearch",
-              "tag": "1.2.3-20220715164419-c1dbc115d8a",
+              "tag": "1.2.3-20220810140719-c1dbc115d8a",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {
               "image": "opensearch-dashboards",
-              "tag": "1.2.0-20220721221818-c206c8b25f",
+              "tag": "1.2.0-20220810140901-c206c8b25f",
               "helmFullImageKey": "monitoringOperator.kibanaImage"
             },
             {


### PR DESCRIPTION
Update the OpenSearch image tags in the BOM to pick up the latest builds.