### PR TITLE
VZ-6703: Bump Istio image versions

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -102,12 +102,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.13.5",
+              "tag": "1.13.5-1-20220810173142-0bd9ab4d",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.13.5",
+              "tag": "1.13.5-1-20220810173142-0bd9ab4d",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -181,7 +181,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.13.5",
+              "tag": "1.13.5-1-20220810173142-0bd9ab4d",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -226,7 +226,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.13.5",
+              "tag": "1.13.5-1-20220810173142-0bd9ab4d",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {


### PR DESCRIPTION
Update the Istio pilot and proxyv2 images in the BOM to pick up the latest builds.