### PR TITLE
Disabling Jaeger Component in E2E tests to fix test stability issues caused due to istio

### DIFF
--- a/tests/e2e/config/scripts/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/install-verrazzano-kind.yaml
@@ -42,5 +42,3 @@ spec:
         minIndexAge: "7d"
         rollover:
           minIndexAge: "1d"
-    jaegerOperator:
-      enabled: true


### PR DESCRIPTION

Periodic tests are not stable and there are random, but consistent failures in `examples_logging` and `opensearch_logging` suite. Re-triggerring the tests also does not help in most of the situations. Most of the failures logs point at `istio-proxy` container not being in ready state. Since enabling Jaeger component is causing istio to reconcile (https://github.com/verrazzano/verrazzano/pull/3030), there is a suspicion that the recent change done to enable Jaeger in the test is causing these failures.