### PR TITLE
Versioning analysisadvice links

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,7 @@ pipeline {
         DOCKER_OAM_PUBLISH_IMAGE_NAME = 'verrazzano-application-operator'
         DOCKER_OAM_IMAGE_NAME = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_OAM_PUBLISH_IMAGE_NAME : env.DOCKER_OAM_CI_IMAGE_NAME}"
         CREATE_LATEST_TAG = "${env.BRANCH_NAME == 'master' ? '1' : '0'}"
+        USE_V8O_DOC_STAGE = "${env.BRANCH_NAME == 'master' ? 'true' : 'false'}"
         GOPATH = '/home/opc/go'
         GO_REPO_PATH = "${GOPATH}/src/github.com/verrazzano"
         DOCKER_CREDS = credentials('github-packages-credentials-rw')

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -21,7 +21,7 @@ endif
 DIST_DIR:=dist
 ENV_NAME=vz
 GO=GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go
-CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.cliVersion=${CLI_VERSION}'
+CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.CliVersion=${CLI_VERSION}'
 
 #
 # CLI

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -21,7 +21,7 @@ endif
 DIST_DIR:=dist
 ENV_NAME=vz
 GO=GO111MODULE=on GOPRIVATE=github.com/verrazzano/* go
-CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.CliVersion=${CLI_VERSION}'
+CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.cliVersion=${CLI_VERSION}'
 
 #
 # CLI

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -11,7 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
 )
 
-var cliVersion string
+var CliVersion string
 var buildDate string
 var gitCommit string
 
@@ -42,7 +42,7 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 func runCmdVersion(vzHelper helpers.VZHelper) error {
 
 	templateValues := map[string]string{
-		"cli_version": cliVersion,
+		"cli_version": CliVersion,
 		"build_date":  buildDate,
 		"git_commit":  gitCommit,
 	}

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -9,9 +9,11 @@ import (
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/templates"
+	"os"
+	"regexp"
 )
 
-var CliVersion string
+var cliVersion string
 var buildDate string
 var gitCommit string
 
@@ -42,7 +44,7 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 func runCmdVersion(vzHelper helpers.VZHelper) error {
 
 	templateValues := map[string]string{
-		"cli_version": CliVersion,
+		"cli_version": cliVersion,
 		"build_date":  buildDate,
 		"git_commit":  gitCommit,
 	}
@@ -53,4 +55,13 @@ func runCmdVersion(vzHelper helpers.VZHelper) error {
 	}
 	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), result)
 	return nil
+}
+
+func GetEffectiveDocsVersion() string {
+	if os.Getenv("USE_V8O_DOC_STAGE") == "true" || len(cliVersion) == 0 {
+		return "devel"
+	}
+	var re = regexp.MustCompile(`(?m)(\d.\d)(.*)`)
+	s := re.FindAllStringSubmatch(cliVersion, -1)[0][1] //This will get the group 1 of 1st match which is "1.4.0" to "1.4"
+	return fmt.Sprintf("v%s", s)                        //return v1.4 by appending prefex 'v'
 }

--- a/tools/vz/cmd/version/version_test.go
+++ b/tools/vz/cmd/version/version_test.go
@@ -17,7 +17,7 @@ import (
 // TestVersionCmd - check that command reports not implemented yet
 func TestVersionCmd(t *testing.T) {
 
-	CliVersion = "1.2.3"
+	cliVersion = "1.2.3"
 	buildDate = "2022-06-10T13:57:03Z"
 	gitCommit = "9dbc916b58ab9781f7b4c25e51748fb31ec940f8"
 
@@ -37,4 +37,18 @@ func TestVersionCmd(t *testing.T) {
 	assert.Regexp(t, `^(Version: )?(v)?(\d+\.)?(\d+\.)?(\d+)$`, version)
 	assert.Regexp(t, `^(BuildDate: )?(\d+\-)?(\d+\-)?(\d+T)?(\d+\:)?(\d+\:)?(\d+Z)$`, build)
 	assert.Regexp(t, `^(GitCommit: )?(\w{40})$`, commit)
+}
+
+func TestGetEffectiveDocsVersion(t *testing.T) {
+	cliVersion = "1.2.3"
+	assert.True(t, GetEffectiveDocsVersion() == "v1.2")
+}
+
+func TestGetEffectiveDocsVersionWhenDocStageEnabled(t *testing.T) {
+	cliVersion = "1.2.3"
+	t.Setenv("USE_V8O_DOC_STAGE", "true")
+	assert.True(t, GetEffectiveDocsVersion() == "devel")
+
+	t.Setenv("USE_V8O_DOC_STAGE", "false")
+	assert.True(t, GetEffectiveDocsVersion() == "v1.2")
 }

--- a/tools/vz/cmd/version/version_test.go
+++ b/tools/vz/cmd/version/version_test.go
@@ -17,7 +17,7 @@ import (
 // TestVersionCmd - check that command reports not implemented yet
 func TestVersionCmd(t *testing.T) {
 
-	cliVersion = "1.2.3"
+	CliVersion = "1.2.3"
 	buildDate = "2022-06-10T13:57:03Z"
 	gitCommit = "9dbc916b58ab9781f7b4c25e51748fb31ec940f8"
 

--- a/tools/vz/pkg/analysis/internal/util/report/action.go
+++ b/tools/vz/pkg/analysis/internal/util/report/action.go
@@ -7,7 +7,10 @@ package report
 import (
 	"errors"
 	"fmt"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"go.uber.org/zap"
+	"os"
+	"regexp"
 )
 
 // TODO: Add helpers for working with Actions
@@ -33,6 +36,18 @@ func (action *Action) Validate(log *zap.SugaredLogger) (err error) {
 	return nil
 }
 
+func GetEffectiveDocsVersion() string {
+	if os.Getenv("USE_V8O_DOC_STAGE") == "true" {
+		fmt.Println("USE_V8O_DOC_STAGE is enabled, so returning 'devel' version for docs")
+		return "devel"
+	}
+	cliVersion := version.CliVersion
+	var re = regexp.MustCompile(`(?m)(\d.\d)(.*)`)
+	s := re.FindAllStringSubmatch(cliVersion, -1)[0][1] //This will get the group 1 of 1st match which is "1.4.0" to "1.4"
+	fmt.Println("Extracted version for docs is: ", s)
+	return fmt.Sprintf("v%s", s) //return v1.4 by appending prefex 'v'
+}
+
 // Standard Action Summaries
 const (
 	ConsultRunbook = "Consult %s using supporting details identified in the report"
@@ -40,20 +55,20 @@ const (
 
 // RunbookLinks are known runbook links
 var RunbookLinks = map[string][]string{
-	ImagePullBackOff:          {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/imagepullbackoff"},
-	ImagePullRateLimit:        {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/imagepullratelimit"},
-	ImagePullNotFound:         {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/imagepullnotfound"},
-	ImagePullService:          {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/imagepullservice"},
-	InsufficientMemory:        {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/insufficientmemory"},
-	IngressInstallFailure:     {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressinstallfailure"},
-	IngressLBLimitExceeded:    {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingresslblimitexceeded"},
-	IngressNoLoadBalancerIP:   {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
-	IngressOciIPLimitExceeded: {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded"},
-	InstallFailure:            {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/installfailure"},
-	PendingPods:               {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/pendingpods"},
-	PodProblemsNotReported:    {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/podproblemsnotreported"},
-	IngressNoIPFound:          {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
-	IngressShapeInvalid:       {"https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape"},
+	ImagePullBackOff:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullbackoff"},
+	ImagePullRateLimit:        {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullratelimit"},
+	ImagePullNotFound:         {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullnotfound"},
+	ImagePullService:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullservice"},
+	InsufficientMemory:        {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/insufficientmemory"},
+	IngressInstallFailure:     {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinstallfailure"},
+	IngressLBLimitExceeded:    {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingresslblimitexceeded"},
+	IngressNoLoadBalancerIP:   {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
+	IngressOciIPLimitExceeded: {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded"},
+	InstallFailure:            {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/installfailure"},
+	PendingPods:               {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/pendingpods"},
+	PodProblemsNotReported:    {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/podproblemsnotreported"},
+	IngressNoIPFound:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
+	IngressShapeInvalid:       {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape"},
 }
 
 // KnownActions are Standard Action types

--- a/tools/vz/pkg/analysis/internal/util/report/action.go
+++ b/tools/vz/pkg/analysis/internal/util/report/action.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"go.uber.org/zap"
-	"os"
-	"regexp"
 )
 
 // TODO: Add helpers for working with Actions
@@ -36,16 +34,6 @@ func (action *Action) Validate(log *zap.SugaredLogger) (err error) {
 	return nil
 }
 
-func GetEffectiveDocsVersion() string {
-	if os.Getenv("USE_V8O_DOC_STAGE") == "true" {
-		return "devel"
-	}
-	cliVersion := version.CliVersion
-	var re = regexp.MustCompile(`(?m)(\d.\d)(.*)`)
-	s := re.FindAllStringSubmatch(cliVersion, -1)[0][1] //This will get the group 1 of 1st match which is "1.4.0" to "1.4"
-	return fmt.Sprintf("v%s", s)                        //return v1.4 by appending prefex 'v'
-}
-
 // Standard Action Summaries
 const (
 	ConsultRunbook = "Consult %s using supporting details identified in the report"
@@ -53,20 +41,20 @@ const (
 
 // RunbookLinks are known runbook links
 var RunbookLinks = map[string][]string{
-	ImagePullBackOff:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullbackoff"},
-	ImagePullRateLimit:        {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullratelimit"},
-	ImagePullNotFound:         {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullnotfound"},
-	ImagePullService:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullservice"},
-	InsufficientMemory:        {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/insufficientmemory"},
-	IngressInstallFailure:     {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinstallfailure"},
-	IngressLBLimitExceeded:    {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingresslblimitexceeded"},
-	IngressNoLoadBalancerIP:   {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
-	IngressOciIPLimitExceeded: {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded"},
-	InstallFailure:            {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/installfailure"},
-	PendingPods:               {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/pendingpods"},
-	PodProblemsNotReported:    {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/podproblemsnotreported"},
-	IngressNoIPFound:          {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
-	IngressShapeInvalid:       {"https://verrazzano.io/" + GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape"},
+	ImagePullBackOff:          {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullbackoff"},
+	ImagePullRateLimit:        {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullratelimit"},
+	ImagePullNotFound:         {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullnotfound"},
+	ImagePullService:          {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/imagepullservice"},
+	InsufficientMemory:        {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/insufficientmemory"},
+	IngressInstallFailure:     {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinstallfailure"},
+	IngressLBLimitExceeded:    {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingresslblimitexceeded"},
+	IngressNoLoadBalancerIP:   {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
+	IngressOciIPLimitExceeded: {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded"},
+	InstallFailure:            {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/installfailure"},
+	PendingPods:               {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/pendingpods"},
+	PodProblemsNotReported:    {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/podproblemsnotreported"},
+	IngressNoIPFound:          {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip"},
+	IngressShapeInvalid:       {"https://verrazzano.io/" + version.GetEffectiveDocsVersion() + "/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape"},
 }
 
 // KnownActions are Standard Action types

--- a/tools/vz/pkg/analysis/internal/util/report/action.go
+++ b/tools/vz/pkg/analysis/internal/util/report/action.go
@@ -38,14 +38,12 @@ func (action *Action) Validate(log *zap.SugaredLogger) (err error) {
 
 func GetEffectiveDocsVersion() string {
 	if os.Getenv("USE_V8O_DOC_STAGE") == "true" {
-		fmt.Println("USE_V8O_DOC_STAGE is enabled, so returning 'devel' version for docs")
 		return "devel"
 	}
 	cliVersion := version.CliVersion
 	var re = regexp.MustCompile(`(?m)(\d.\d)(.*)`)
 	s := re.FindAllStringSubmatch(cliVersion, -1)[0][1] //This will get the group 1 of 1st match which is "1.4.0" to "1.4"
-	fmt.Println("Extracted version for docs is: ", s)
-	return fmt.Sprintf("v%s", s) //return v1.4 by appending prefex 'v'
+	return fmt.Sprintf("v%s", s)                        //return v1.4 by appending prefex 'v'
 }
 
 // Standard Action Summaries


### PR DESCRIPTION
This PR have changes to analysis package and made CliVersion globally accessible
Summary of changes:
> Util function in action.go to get devel or va.b version
> Making the CliVersion variable globally accessible

Validation:
```
[14:02:14 bash vz]$vz analyze --capture-dir pkg/analysis/test/cluster/ | grep analysisadvice
        Consult https://verrazzano.io/v1.4/docs/troubleshooting/diagnostictools/analysisadvice/installfailure using supporting details identified in the report
        Consult https://verrazzano.io/v1.4/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip using supporting details identified in the report
        Consult https://verrazzano.io/v1.4/docs/troubleshooting/diagnostictools/analysisadvice/ingressnoloadbalancerip using supporting details identified in the report
        Consult https://verrazzano.io/v1.4/docs/troubleshooting/diagnostictools/analysisadvice/installfailure using supporting details identified in the report
        Consult https://verrazzano.io/v1.4/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded using supporting details identified in the report
[14:02:20 bash vz]$
[14:02:30 bash vz]$export USE_V8O_DOC_STAGE="true"
[14:02:48 bash vz]$vz analyze --capture-dir pkg/analysis/test/cluster/ | grep analysisadvice
        Consult https://verrazzano.io/devel/docs/troubleshooting/diagnostictools/analysisadvice/installfailure using supporting details identified in the report
        Consult https://verrazzano.io/devel/docs/troubleshooting/diagnostictools/analysisadvice/ingressociiplimitexceeded using supporting details identified in the report
        Consult https://verrazzano.io/devel/docs/troubleshooting/diagnostictools/analysisadvice/podproblemsnotreported using supporting details identified in the report
[14:02:51 bash vz]$
```