### PR TITLE
VZ-6732 - Update velero images with image tags using datetime and short commit id

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -641,18 +641,18 @@
           "images": [
             {
               "image": "velero",
-              "tag": "v1.8.1-20220617192749-f0db842f",
+              "tag": "v1.8.1-20220811175045-7bc0e55e",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "velero-plugin-for-aws",
-              "tag": "v1.4.1-20220617193554-272b3ebc",
+              "tag": "v1.4.1-20220811172550-645bcc83",
               "helmFullImageKey": "initContainers[0].image"
             },
             {
               "image": "velero-restic-restore-helper",
-              "tag": "v1.8.1-20220617192909-f0db842f",
+              "tag": "v1.8.1-20220811175045-7bc0e55e",
               "helmFullImageKey": "configMaps.restic-restore-action-config.data.image"
             }
           ]


### PR DESCRIPTION
VZ-6732 - BFS builds for Velero related projects were not using the image tags with datetime-short commit id. The latest builds fixed this issue. In order to re-build the images new build had to be triggered after updating the rpm spec version. Docker files were modified to use the latest patched version of Go 1.17 in both OL7 and OL8.
