### PR TITLE
Tvlatas/periodic issue

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -676,7 +676,15 @@ def getLastCleanPeriodicCommit() {
         ).trim()
     echo "command out: ${lastPeriodicCommitCommandOutput}"
     if (lastPeriodicCommitCommandOutput.length() > 0) {
-        assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+        // We can get warning messages here as well even when the command succeeded, so be more precise on the checking
+        if lastPeriodicCommitCommandOutput =~ /(.*)status(.*)\d{1,4}(.*)/ {
+            // If we think we had a status: NNN, we ignore 404 and fail for others
+            assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+        } else {
+            // If we got here, we have some message that may or may not be an error. If we don't see the file, we assume it was an error
+            File file = new File("${CLEAN_PERIODIC_LOCATION}")
+            assert file.exists() : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+        }
     }
     // Get the commit ID for the last known clean pass of the Periodic tests
     def cleanPeriodicsCommitProps = readProperties file: "${CLEAN_PERIODIC_LOCATION}"

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -682,8 +682,12 @@ def getLastCleanPeriodicCommit() {
             assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
         } else {
             // If we got here, we have some message that may or may not be an error. If we don't see the file, we assume it was an error
-            File file = new File("${CLEAN_PERIODIC_LOCATION}")
-            assert file.exists() : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+            sh """
+                if [ ! -f ${CLEAN_PERIODIC_LOCATION} ]; then
+                    echo "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
+                    exit 1
+                fi
+            """
         }
     }
     // Get the commit ID for the last known clean pass of the Periodic tests

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -677,7 +677,7 @@ def getLastCleanPeriodicCommit() {
     echo "command out: ${lastPeriodicCommitCommandOutput}"
     if (lastPeriodicCommitCommandOutput.length() > 0) {
         // We can get warning messages here as well even when the command succeeded, so be more precise on the checking
-        if lastPeriodicCommitCommandOutput =~ /(.*)status(.*)\d{1,4}(.*)/ {
+        if (lastPeriodicCommitCommandOutput =~ /(.*)status(.*)\d{1,4}(.*)/) {
             // If we think we had a status: NNN, we ignore 404 and fail for others
             assert lastPeriodicCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last periodic commit from ObjectStore: ${lastPeriodicCommitCommandOutput}"
         } else {


### PR DESCRIPTION
We started seeing a python warning from the OCI CLI, which confused a check which was intended to ignore 404's when looking for the last clean periodic commit. This caused the periodics to fail.

Updated the check to be more precise for request status failures, and to base the decision of whether a message seen was an error or not based on whether the file exists.
