### PR TITLE
WIP: VZ-6691 - Use StatefulSet with ordered ready pod management for Kibana

### DIFF
--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -219,8 +219,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "v1.4.0-20220811123252-03aa4e3",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "v1.4.0-20220812114547-f06adf7",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.4.0-20220814160347-4d1ef81",
+              "tag": "v1.4.0-20220815171607-7086227",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.4.0-20220812114547-f06adf7",
+              "tag": "v1.4.0-20220813204156-740cafb",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.4.0-20220814155027-042c707",
+              "tag": "v1.4.0-20220814160347-4d1ef81",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.4.0-20220813204156-740cafb",
+              "tag": "v1.4.0-20220814155027-042c707",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
When the replica count of Kibana is greater than one, a fresh Verrazzano install usually fails due to the two pods thinking that indices first need to be migrated.  The following changes were made to address that issue:

1. Delay deployment of OpenSearch-Dashboards until ES is green
2. Use a StatefulSet with an ordered-ready-pod management policy, so that one replica starts up at a time (instead of all in parallel)