### PR TITLE
VZ-6739.  Remove cleanup on pull_and_save_images

### DIFF
--- a/tools/scripts/vz-registry-image-helper.sh
+++ b/tools/scripts/vz-registry-image-helper.sh
@@ -409,11 +409,6 @@ function pull_and_save_images() {
       done
     done
   done
-  if [ "${DRY_RUN}" != "true" ]; then
-    tar -czf $tarFile -C $imagesDir .
-    echo "Cleaning up images from ${imagesDir}"
-    rm ${imagesDir}/*.tar
-  fi
 }
 
 output_bom_components() {


### PR DESCRIPTION
Remove cleanup of local images on pull_and_save functionality, as it's breaking the periodics pipeline.