### PR TITLE
Add OpenSearch to Jaeger dependencies

### DIFF
--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
@@ -6,18 +6,20 @@ package operator
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/opensearch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"path/filepath"
 )
 
 const (
@@ -81,7 +83,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:    "image.imagePullSecrets[0].name",
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "jaeger-operator-values.yaml"),
-			Dependencies:              []string{certmanager.ComponentName},
+			Dependencies:              []string{certmanager.ComponentName, opensearch.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component_test.go
@@ -6,6 +6,8 @@ package operator
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -15,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -113,10 +114,10 @@ func TestGetMinVerrazzanoVersion(t *testing.T) {
 	assert.Equal(t, constants.VerrazzanoVersion1_3_0, NewComponent().GetMinVerrazzanoVersion())
 }
 
-// TestGetDependencies tests whether cert-manager component is a dependency
-// that needs to be installed prior to Jaeger operator
+// TestGetDependencies tests whether the cert-manager and opensearch components are dependencies
+// that need to be installed prior to Jaeger operator
 func TestGetDependencies(t *testing.T) {
-	assert.Equal(t, []string{"cert-manager"}, NewComponent().GetDependencies())
+	assert.Equal(t, []string{"cert-manager", "opensearch"}, NewComponent().GetDependencies())
 }
 
 // TestIsReady tests the IsReady function for the Jaeger Operator


### PR DESCRIPTION
This PR adds the `opensearch` component as a dependency to Jaeger. This ensures that, if OpenSearch is installed, it is ready before the Jaeger installation starts.