### PR TITLE
Use latest stable commit for upgrade resiliency

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -147,9 +147,9 @@ pipeline {
                         echo "Specific GIT commit was not specified, using last stable commit"
                         def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
                         env.GIT_COMMIT = stableCommitProps['git-commit']
-                        echo "SCM checkout of ${env.GIT_COMMIT}"
+                        echo "SCM checkout of commit ${env.GIT_COMMIT}"
                     } else {
-                        echo "SCM checkout of ${params.GIT_COMMIT_FOR_UPGRADE}"
+                        echo "SCM checkout of commit ${params.GIT_COMMIT_FOR_UPGRADE}"
                         def scmInfo = checkout([
                                 $class: 'GitSCM',
                                 branches: [[name: params.GIT_COMMIT_FOR_UPGRADE]],

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -140,32 +140,31 @@ pipeline {
                 """
 
                 script {
-
                     EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
-                    if (params.GIT_COMMIT_FOR_UPGRADE == "NONE") {
-                        // Get the last stable commit ID to pass the triggered tests
+                    COMMIT_FOR_UPGRADE = params.GIT_COMMIT_FOR_UPGRADE
+                    if (COMMIT_FOR_UPGRADE == "NONE") {
                         echo "Specific GIT commit was not specified, using last stable commit"
                         def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
-                        env.GIT_COMMIT = stableCommitProps['git-commit']
-                        echo "SCM checkout of commit ${env.GIT_COMMIT}"
-                    } else {
-                        echo "SCM checkout of commit ${params.GIT_COMMIT_FOR_UPGRADE}"
-                        def scmInfo = checkout([
-                                $class: 'GitSCM',
-                                branches: [[name: params.GIT_COMMIT_FOR_UPGRADE]],
-                                doGenerateSubmoduleConfigurations: false,
-                                extensions: [],
-                                submoduleCfg: [],
-                                userRemoteConfigs: [[refspec: '+refs/heads/*:refs/remotes/origin/*', url: env.SCM_VERRAZZANO_GIT_URL]]])
-                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
-                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
-                        // If the commit we were handed is not what the SCM says we are using, fail
-                        if (!env.GIT_COMMIT.equals(params.GIT_COMMIT_FOR_UPGRADE)) {
-                            echo "SCM didn't checkout the commit we expected. Expected: ${params.GIT_COMMIT_FOR_UPGRADE}, Found: ${scmInfo.GIT_COMMIT}"
-                            exit 1
-                        }
-                        echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
+                        COMMIT_FOR_UPGRADE = stableCommitProps['git-commit']
                     }
+                    echo "Checking out commit ${COMMIT_FOR_UPGRADE}"
+                    def scmInfo = checkout([
+                            $class: 'GitSCM',
+                            branches: [[name: COMMIT_FOR_UPGRADE]],
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions: [],
+                            submoduleCfg: [],
+                            userRemoteConfigs: [[refspec: '+refs/heads/*:refs/remotes/origin/*', url: env.SCM_VERRAZZANO_GIT_URL]]])
+                    env.GIT_COMMIT = scmInfo.GIT_COMMIT
+                    env.GIT_BRANCH = scmInfo.GIT_BRANCH
+
+                    // If the commit we were handed is not what the SCM says we are using, fail
+                    if (!env.GIT_COMMIT.equals(COMMIT_FOR_UPGRADE)) {
+                        echo "SCM didn't checkout the commit we expected. Expected: ${COMMIT_FOR_UPGRADE}, Found: ${scmInfo.GIT_COMMIT}"
+                        exit 1
+                    }
+                    echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
+
                 }
 
                 sh """

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 trim: true)
         string (name: 'GIT_COMMIT_FOR_UPGRADE',
                 defaultValue: 'NONE',
-                description: 'This is the full git commit hash for the target upgrade.  By default, the Verrazzano tip will be used.',
+                description: 'This is the full git commit hash for the target upgrade.  By default, the Verrazzano last stable commit will be used.',
                 trim: true)
         choice (name: 'WILDCARD_DNS_DOMAIN',
                 description: 'This is the wildcard DNS domain',
@@ -105,19 +105,19 @@ pipeline {
         APP_NAMEPACES="'todo-list bobs-books hello-helidon springboot sockshop'"
 
         // used to emit metrics
-         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
-         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
-         TEST_ENV_LABEL = "kind"
-         K8S_VERSION_LABEL = "${params.KUBERNETES_CLUSTER_VERSION}"
-         TEST_ENV = "KIND"
-         SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
-         SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
-         SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
+        PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
+        PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
+        TEST_ENV_LABEL = "kind"
+        K8S_VERSION_LABEL = "${params.KUBERNETES_CLUSTER_VERSION}"
+        TEST_ENV = "KIND"
+        SEARCH_HTTP_ENDPOINT = credentials('search-gw-url')
+        SEARCH_PASSWORD = "${PROMETHEUS_CREDENTIALS_PSW}"
+        SEARCH_USERNAME = "${PROMETHEUS_CREDENTIALS_USR}"
 
-         // used to generate Ginkgo test reports
-         TEST_REPORT = "test-report.xml"
-         GINKGO_REPORT_ARGS = "--junit-report=${TEST_REPORT} --keep-separate-reports=true"
-         TEST_REPORT_DIR = "${WORKSPACE}/tests/e2e"
+        // used to generate Ginkgo test reports
+        TEST_REPORT = "test-report.xml"
+        GINKGO_REPORT_ARGS = "--junit-report=${TEST_REPORT} --keep-separate-reports=true"
+        TEST_REPORT_DIR = "${WORKSPACE}/tests/e2e"
     }
 
     stages {
@@ -125,25 +125,29 @@ pipeline {
             environment {
                 OCI_CLI_AUTH="instance_principal"
                 OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+                OCI_OS_BUCKET="verrazzano-builds"
                 OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
                 VZ_CLI_TARGZ="vz-linux-amd64.tar.gz"
+                CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+                STABLE_COMMIT_OS_LOCATION = "${CLEAN_BRANCH_NAME}/last-stable-commit.txt"
+                STABLE_COMMIT_LOCATION = "${WORKSPACE}/last-stable-commit.txt"
             }
             steps {
                 sh """
                     echo "${NODE_LABELS}"
+                    echo "Downloading latest stable commit info from object storage"
+                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${STABLE_COMMIT_OS_LOCATION} --file ${STABLE_COMMIT_LOCATION}
                 """
 
                 script {
+
                     EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
                     if (params.GIT_COMMIT_FOR_UPGRADE == "NONE") {
-                        echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = checkout([
-                                $class: 'GitSCM',
-                                branches: [[name: env.BRANCH_NAME]],
-                                extensions: [[$class: 'LocalBranch']],
-                                userRemoteConfigs: [[refspec: '+refs/heads/*:refs/remotes/origin/*', url: env.SCM_VERRAZZANO_GIT_URL]]])
-                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
-                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
+                        // Get the last stable commit ID to pass the triggered tests
+                        echo "Specific GIT commit was not specified, using last stable commit"
+                        def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
+                        env.GIT_COMMIT = stableCommitProps['git-commit']
+                        echo "SCM checkout of ${env.GIT_COMMIT}"
                     } else {
                         echo "SCM checkout of ${params.GIT_COMMIT_FOR_UPGRADE}"
                         def scmInfo = checkout([
@@ -160,8 +164,8 @@ pipeline {
                             echo "SCM didn't checkout the commit we expected. Expected: ${params.GIT_COMMIT_FOR_UPGRADE}, Found: ${scmInfo.GIT_COMMIT}"
                             exit 1
                         }
+                        echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
                     }
-                    echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
                 }
 
                 sh """


### PR DESCRIPTION
Change upgrade chaos to use latest stable commit as upgrade target.
