### PR TITLE
VZ-6769 - Jaeger service monitor should collect metrics for managed cluster Jaeger collector

### DIFF
--- a/platform-operator/thirdparty/manifests/prometheus-operator/jaeger_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/jaeger_monitor.yaml
@@ -30,7 +30,7 @@ spec:
       replacement: local
       targetLabel: verrazzano_cluster
     - action: keep
-      regex: true;jaeger-operator-jaeger-(query|collector);admin-http
+      regex: true;jaeger-(operator-jaeger|verrazzano-managed-cluster)-(query|collector);admin-http
       sourceLabels:
       - __meta_kubernetes_pod_annotation_prometheus_io_scrape
       - __meta_kubernetes_service_name


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
