### PR TITLE
Fix multicluster and upgrade-paths pipelines, to extract the bug report for each cluster

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1249,7 +1249,7 @@ def dumpK8sCluster(dumpDirectory) {
 
                 mkdir -p ${dumpDirectory}/bug-report-${count}/bug-report
                 ${GO_REPO_PATH}/vz bug-report --report-file ${dumpDirectory}/bug-report-${count}/bug-report.tar.gz
-                tar -xvf ${dumpDirectory}/bug-report.tar.gz -C ${dumpDirectory}/bug-report-${count}/bug-report
+                tar -xvf ${dumpDirectory}/bug-report-${count}/bug-report.tar.gz -C ${dumpDirectory}/bug-report-${count}/bug-report
             """
             }
         }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1461,7 +1461,7 @@ def dumpK8sSpecificCluster(count, dumpDirectory) {
 
                 mkdir -p ${dumpDirectory}/bug-report-${count}/bug-report
                 ${GO_REPO_PATH}/vz bug-report --report-file ${dumpDirectory}/bug-report-${count}/bug-report.tar.gz
-                tar -xvf ${dumpDirectory}/bug-report.tar.gz -C ${dumpDirectory}/bug-report-${count}/bug-report
+                tar -xvf ${dumpDirectory}/bug-report-${count}/bug-report.tar.gz -C ${dumpDirectory}/bug-report-${count}/bug-report
             """
         }
     }

--- a/tests/e2e/pkg/clusterdump.go
+++ b/tests/e2e/pkg/clusterdump.go
@@ -176,7 +176,6 @@ func analyzeBugReport(kubeConfig, vzCommand, bugReportDirectory string) error {
 	os.Remove(filepath.Join(bugReportFile))
 	reportFile := filepath.Join(bugReportDirectory, AnalysisReport)
 	cmd = exec.Command(vzCommand, "analyze", "--capture-dir", bugReportDirectory, "--report-format", "detailed", "--report-file", reportFile)
-	fmt.Println(cmd.String())
 	if err := cmd.Start(); err != nil {
 		fmt.Printf("Failed to start the command analyze %v \n", err)
 		return err


### PR DESCRIPTION
This PR fixes the multicluster and upgrade-paths pipelines, to extract the bug report for each cluster.
