### PR TITLE
VZ-6770: Temporarily disable terminate of pods associated with PVC

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -286,6 +286,7 @@ pipeline {
                         failure {
                             script {
                                 TESTS_FAILED = true
+                                dumpK8sCluster('install-fail-cluster-snapshot')
                             }
                         }
                         always {
@@ -334,7 +335,7 @@ pipeline {
                         failure {
                             script {
                                 TESTS_FAILED = true
-                                dumpK8sCluster('ha-reschedule-workers-cluster-snapshot')
+                                dumpK8sCluster('reschedule-fail-cluster-snapshot')
                             }
                         }
                     }
@@ -385,6 +386,7 @@ pipeline {
                         failure {
                             script {
                                 TESTS_FAILED = true
+                                dumpK8sCluster('verify-install-fail-cluster-snapshot')
                             }
                         }
                     }
@@ -428,6 +430,7 @@ pipeline {
                         failure {
                             script {
                                 TESTS_FAILED = true
+                                dumpK8sCluster('rolling-upgrade-fail-cluster-snapshot')
                             }
                         }
                     }
@@ -438,9 +441,6 @@ pipeline {
                 failure {
                     script {
                         METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
-                        if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('ha-rolling-upgrade-cluster-snapshot')
-                        }
                     }
                 }
                 success {

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -349,7 +349,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 					assertPersistentVolume("vmi-system-grafana", size)
 					assertPersistentVolume(esMaster0, size)
 
-					Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
+					Expect(len(vzMonitoringVolumeClaims)).To(Equal(int(expectedPromReplicas)))
 					assertPrometheusVolume(size)
 				} else {
 					Expect(len(volumeClaims)).To(Equal(3))
@@ -365,7 +365,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		t.It("Check persistent volumes for managed cluster profile", func() {
 			if minVer14 {
 				Expect(len(volumeClaims)).To(Equal(0))
-				Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
+				Expect(len(vzMonitoringVolumeClaims)).To(Equal(int(expectedPromReplicas)))
 				assertPrometheusVolume(size)
 			} else {
 				Expect(len(volumeClaims)).To(Equal(1))
@@ -376,7 +376,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		t.It("Check persistent volumes for prod cluster profile", func() {
 			if minVer14 {
 				Expect(len(volumeClaims)).To(Equal(7))
-				Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
+				Expect(len(vzMonitoringVolumeClaims)).To(Equal(int(expectedPromReplicas)))
 				assertPrometheusVolume(size)
 			} else {
 				Expect(len(volumeClaims)).To(Equal(8))

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -338,6 +338,9 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 	minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
 	Expect(err).ToNot(HaveOccurred())
 
+	expectedPromReplicas, err := getExpectedPrometheusReplicaCount(kubeconfig)
+	Expect(err).ToNot(HaveOccurred())
+
 	if pkg.IsDevProfile() {
 		t.It("Check persistent volumes for dev profile", func() {
 			if override != nil {
@@ -346,7 +349,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 					assertPersistentVolume("vmi-system-grafana", size)
 					assertPersistentVolume(esMaster0, size)
 
-					Expect(len(vzMonitoringVolumeClaims)).To(Equal(1))
+					Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
 					assertPrometheusVolume(size)
 				} else {
 					Expect(len(volumeClaims)).To(Equal(3))
@@ -362,7 +365,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		t.It("Check persistent volumes for managed cluster profile", func() {
 			if minVer14 {
 				Expect(len(volumeClaims)).To(Equal(0))
-				Expect(len(vzMonitoringVolumeClaims)).To(Equal(1))
+				Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
 				assertPrometheusVolume(size)
 			} else {
 				Expect(len(volumeClaims)).To(Equal(1))
@@ -373,7 +376,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		t.It("Check persistent volumes for prod cluster profile", func() {
 			if minVer14 {
 				Expect(len(volumeClaims)).To(Equal(7))
-				Expect(len(vzMonitoringVolumeClaims)).To(Equal(1))
+				Expect(len(vzMonitoringVolumeClaims)).To(Equal(expectedPromReplicas))
 				assertPrometheusVolume(size)
 			} else {
 				Expect(len(volumeClaims)).To(Equal(8))


### PR DESCRIPTION
Temporarily disable the termination of pods that are associated with a PVC.  This allows the HA pipeline to get past the scheduling stage, which unblocks other changes from being made to the pipeline while resolving the affinity rules issues.