### PR TITLE
moving how we coordinated verrazzano-helper

### DIFF
--- a/ci/ticket-commits/JenkinsfileCommits
+++ b/ci/ticket-commits/JenkinsfileCommits
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 pipeline {
@@ -9,7 +9,7 @@ pipeline {
 
     agent {
        docker {
-            image "${V8O_HELPER_DOCKER_IMAGE}"
+            image "${RUNNER_DOCKER_IMAGE}"
             args "${RUNNER_DOCKER_ARGS}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
@@ -22,6 +22,21 @@ pipeline {
                         defaultValue: '',
                         description: 'Record all ticket commits after (and including) this commit hash (defaults to using Jenkins change set)',
                         trim: true)
+        string (name: 'VERRAZZANO_HELPER_BRANCH',
+                        defaultValue: 'master',
+                        description: 'verrazzano-helper branch. master is used for 1.3+, release-1.2 is used for 1.2 and earlier, user branch name is used when testing verrazzano-helper changes',
+                        trim: true)
+    }
+    environment {
+        OCI_CLI_AUTH="api_key"
+        OCI_CLI_TENANCY = credentials('oci-tenancy')
+        OCI_CLI_USER = credentials('oci-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-api-key')
+        OCI_CLI_REGION = "us-phoenix-1"
+        OCI_REGION = "${env.OCI_CLI_REGION}"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_SHARED_BUCKET="build-shared-files"
     }
 
     stages {
@@ -51,13 +66,20 @@ pipeline {
                         tar cf - . | (cd ${GO_REPO_PATH}/verrazzano/ ; tar xf -)
                     """
                 }
+                script {
+                    sh """
+                        echo "Downloading verrazzano-helper from object storage"
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
+                        chmod uog+x ${WORKSPACE}/verrazzano-helper
+                    """
+                }
             }
         }
 
-        stage('Update JIRA tickets with commits') {
+        stage('Update tracking tickets with commits') {
             environment {
-                JIRA_USERNAME = credentials('jira-username')
-                JIRA_PASSWORD = credentials('jira-password')
+                TICKET_SERVICE_USERNAME = credentials('ticket-service-username')
+                TICKET_SERVICE_PASSWORD = credentials('ticket-service-password')
             }
             steps {
                 script {
@@ -77,7 +99,7 @@ pipeline {
                         echo Processing commits:
                         cat ${tmpfile}; echo
 
-                        verrazzano-helper update ticket-commits --commit-file "${tmpfile}" --backport-labels --token unused --jira-env=prod
+                        ${WORKSPACE}/verrazzano-helper update ticket-commits --commit-file "${tmpfile}" --backport-labels --token unused --ticket-env=prod
                     """
                 }
             }

--- a/ci/ticket-commits/JenkinsfilePullRequests
+++ b/ci/ticket-commits/JenkinsfilePullRequests
@@ -8,12 +8,29 @@ pipeline {
 
     agent {
        docker {
-            image "${V8O_HELPER_DOCKER_IMAGE}"
+            image "${RUNNER_DOCKER_IMAGE}"
             args "${RUNNER_DOCKER_ARGS}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "internal"
         }
+    }
+    parameters {
+        string (name: 'VERRAZZANO_HELPER_BRANCH',
+                        defaultValue: 'master',
+                        description: 'verrazzano-helper branch. master is used for 1.3+, release-1.2 is used for 1.2 and earlier, user branch name is used when testing verrazzano-helper changes',
+                        trim: true)
+    }
+    environment {
+        OCI_CLI_AUTH="api_key"
+        OCI_CLI_TENANCY = credentials('oci-tenancy')
+        OCI_CLI_USER = credentials('oci-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-api-key')
+        OCI_CLI_REGION = "us-phoenix-1"
+        OCI_REGION = "${env.OCI_CLI_REGION}"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_SHARED_BUCKET="build-shared-files"
     }
 
     stages {
@@ -35,25 +52,32 @@ pipeline {
                     mkdir -p ${GO_REPO_PATH}/verrazzano
                     tar cf - . | (cd ${GO_REPO_PATH}/verrazzano/ ; tar xf -)
                 """
+                script {
+                    sh """
+                        echo "Downloading verrazzano-helper from object storage"
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
+                        chmod uog+x ${WORKSPACE}/verrazzano-helper
+                    """
+                }
             }
         }
 
-        stage('Update JIRA tickets with pull request') {
+        stage('Update tracking tickets with pull request') {
             environment {
-                JIRA_USERNAME = credentials('jira-username')
-                JIRA_PASSWORD = credentials('jira-password')
+                TICKET_SERVICE_USERNAME = credentials('ticket-service-username')
+                TICKET_SERVICE_PASSWORD = credentials('ticket-service-password')
             }
             steps {
                 script {
-                    // Do not add a comment to the JIRA if an existing pull request is being updated
+                    // Do not add a comment to the tracking ticket if an existing pull request is being updated
                     if (currentBuild.changeSets.size() == 0) {
                         // Escape double quotes in the PR title
                         env.PR_TITLE = sh(script:'echo "${CHANGE_TITLE}" | sed \'s/"/\\\\"/g\'', returnStdout: true).trim()
                         sh """
-                            verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.PR_TITLE}" --pr-target "${env.CHANGE_TARGET}" --token unused --jira-env=prod
+                            ${WORKSPACE}/verrazzano-helper update ticket-commits --pr-url "${env.CHANGE_URL}" --pr-title "${env.PR_TITLE}" --pr-target "${env.CHANGE_TARGET}" --token unused --ticket-env=prod
                         """
                     } else {
-                        echo "Existing pull request updated, skipping update of JIRA ticket"
+                        echo "Existing pull request updated, skipping update of tracking ticket"
                     }
                 }
             }

--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -33,6 +33,10 @@ pipeline {
         booleanParam (description: 'Whether to copy the product zip into the release object store from the last clean periodic test',
                 name: 'COPY_PRODUCT_ZIP_FROM_PERIODIC', defaultValue: false)
         booleanParam (description: 'Indicate whether this is a test run', name: 'TEST_RUN', defaultValue: false)
+        string (name: 'VERRAZZANO_HELPER_BRANCH',
+                        defaultValue: 'master',
+                        description: 'verrazzano-helper branch. master is used for 1.3+, release-1.2 is used for 1.2 and earlier, user branch name is used when testing verrazzano-helper changes',
+                        trim: true)
     }
 
     environment {
@@ -47,6 +51,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_BUCKET="verrazzano-builds"
         OCI_OS_REGION="us-phoenix-1"
+        OCI_OS_SHARED_BUCKET="build-shared-files"
         OCI_CLI_AUTH="api_key"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -105,6 +110,13 @@ pipeline {
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.COMMIT_TO_USE
                 }
+                script {
+                    sh """
+                        echo "Downloading verrazzano-helper from object storage"
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
+                        chmod uog+x ${WORKSPACE}/verrazzano-helper
+                    """
+                }
             }
         }
 
@@ -142,8 +154,8 @@ pipeline {
             }
             environment {
                 IGNORE_FAILURES = "${params.IGNORE_PRE_RELEASE_VALIDATION_FAILURES}"
-                JIRA_USERNAME = credentials('jira-username')
-                JIRA_PASSWORD = credentials('jira-password')
+                TICKET_SERVICE_USERNAME = credentials('ticket-service-username')
+                TICKET_SERVICE_PASSWORD = credentials('ticket-service-password')
             }
             steps {
                 script {

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -28,6 +28,10 @@ pipeline {
     parameters {
         string (description: 'The source commit for the release (required for full release)', name: 'COMMIT_TO_USE', defaultValue: 'NONE', trim: true )
         booleanParam (description: 'Create a release candidate EVEN if pre-release validations fail', name: 'IGNORE_PRE_RELEASE_VALIDATION_FAILURES', defaultValue: false)
+        string (name: 'VERRAZZANO_HELPER_BRANCH',
+                        defaultValue: 'master',
+                        description: 'verrazzano-helper branch. master is used for 1.3+, release-1.2 is used for 1.2 and earlier, user branch name is used when testing verrazzano-helper changes',
+                        trim: true)
     }
 
     environment {
@@ -39,6 +43,14 @@ pipeline {
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
         PERIODIC_JOB_PROJECT_NAME = 'verrazzano-periodic-triggered-tests'
+        OCI_CLI_AUTH="api_key"
+        OCI_CLI_TENANCY = credentials('oci-tenancy')
+        OCI_CLI_USER = credentials('oci-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-api-key')
+        OCI_CLI_REGION = "us-phoenix-1"
+        OCI_REGION = "${env.OCI_CLI_REGION}"
+        OCI_OS_SHARED_BUCKET="build-shared-files"
     }
 
     stages {
@@ -87,14 +99,21 @@ pipeline {
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.COMMIT_TO_USE
                 }
+                script {
+                    sh """
+                        echo "Downloading verrazzano-helper from object storage"
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
+                        chmod uog+x ${WORKSPACE}/verrazzano-helper
+                    """
+                }
             }
         }
 
         stage('Release Candidate Validation Checks') {
             environment {
                 IGNORE_FAILURES = "false"
-                JIRA_USERNAME = credentials('jira-username')
-                JIRA_PASSWORD = credentials('jira-password')
+                TICKET_SERVICE_USERNAME = credentials('ticket-service-username')
+                TICKET_SERVICE_PASSWORD = credentials('ticket-service-password')
                 OCI_OS_NAMESPACE = credentials('oci-os-namespace')
                 OCI_OS_BUCKET="verrazzano-builds"
                 OCI_CLI_AUTH="api_key"

--- a/release/builds/JenkinsfilePreRelease
+++ b/release/builds/JenkinsfilePreRelease
@@ -43,6 +43,7 @@ pipeline {
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
         PERIODIC_JOB_PROJECT_NAME = 'verrazzano-periodic-triggered-tests'
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_CLI_AUTH="api_key"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -114,7 +115,6 @@ pipeline {
                 IGNORE_FAILURES = "false"
                 TICKET_SERVICE_USERNAME = credentials('ticket-service-username')
                 TICKET_SERVICE_PASSWORD = credentials('ticket-service-password')
-                OCI_OS_NAMESPACE = credentials('oci-os-namespace')
                 OCI_OS_BUCKET="verrazzano-builds"
                 OCI_CLI_AUTH="api_key"
                 OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/release/scripts/prerelease_validation.sh
+++ b/release/scripts/prerelease_validation.sh
@@ -45,14 +45,14 @@ echo ""
 if [[ "$VERSION" == *.0 ]]; then
     echo "Not a patch release, skipping backported commits check"
 else
-    if ! command -v verrazzano-helper &> /dev/null
+    if ! command -v ${WORKSPACE}/verrazzano-helper &> /dev/null
     then
-      echo "verrazzano-helper must be in path"
+      echo "verrazzano-helper must be in the top level of the workspace"
       EXIT_CODE=1
     fi
 
     echo "Checking for missing backport commits..."
-    verrazzano-helper get ticket-backports $VERSION --jira-env prod --token unused
+    ${WORKSPACE}/verrazzano-helper get ticket-backports $VERSION --ticket-env prod --token unused
     ((EXIT_CODE |= $?))
 fi
 


### PR DESCRIPTION
This moves where we are retrieving the verrazzano-helper from, all jobs that use it will now get it from object storage. This also picks up the latest verrazzano-helper from object storage which changes up some parameters related to the ticketing service.

Testing was done separately with a runner that has the helper removed already, the new runner and agent that caches it will be swapped in separately. This PR can go in before that and will avoid any bad interactions (if we do things in reverse order there will be problems).
