### PR TITLE
VZ-6786 - MySQLOperator follow-up validation

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
@@ -5,6 +5,7 @@ package mysqloperator
 
 import (
 	"fmt"
+
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
@@ -9,6 +9,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
+	config "github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -53,8 +54,7 @@ func (c mysqlOperatorComponent) validateMySQLOperator(vz *vzapi.Verrazzano) erro
 		}
 	}
 	// Must be enabled if Keycloak is enabled
-	keycloakComp := vz.Spec.Components.Keycloak
-	if keycloakComp == nil || keycloakComp.Enabled == nil || *keycloakComp.Enabled {
+	if config.IsKeycloakEnabled(vz) {
 		if !c.IsEnabled(vz) {
 			return fmt.Errorf("MySQLOperator must be enabled if Keycloak is enabled")
 		}

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// GetOverrides gets the install overrides
-func GetOverrides(effectiveCR *vzapi.Verrazzano) []vzapi.Overrides {
+// getOverrides gets the install overrides
+func getOverrides(effectiveCR *vzapi.Verrazzano) []vzapi.Overrides {
 	if effectiveCR.Spec.Components.MySQLOperator != nil {
 		return effectiveCR.Spec.Components.MySQLOperator.ValueOverrides
 	}

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -47,7 +47,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:      vpocons.VerrazzanoVersion1_4_0,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "mysql-operator-values.yaml"),
 			Dependencies:              []string{},
-			GetInstallOverridesFunc:   GetOverrides,
+			GetInstallOverridesFunc:   getOverrides,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -5,10 +5,11 @@ package mysqloperator
 
 import (
 	"context"
+	"fmt"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpocons "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -51,7 +52,14 @@ func NewComponent() spi.Component {
 	}
 }
 
-// IsEnabled?? check if keycloak enabled?
+// IsEnabled returns true if the component is enabled for install
+func (c mysqlOperatorComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
+	comp := effectiveCR.Spec.Components.MySQLOperator
+	if comp == nil || comp.Enabled == nil {
+		return true
+	}
+	return *comp.Enabled
+}
 
 // IsReady - component specific ready-check
 func (c mysqlOperatorComponent) IsReady(context spi.ComponentContext) bool {
@@ -64,25 +72,6 @@ func (c mysqlOperatorComponent) IsReady(context spi.ComponentContext) bool {
 // IsInstalled returns true if the component is installed
 func (c mysqlOperatorComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return isInstalled(ctx), nil
-}
-
-// IsEnabled returns true if the component is enabled for install
-// MySQLOperator must be enabled if Keycloak is enabled
-func (c mysqlOperatorComponent) IsEnabled(effectiveCR *vzapi.Verrazzano) bool {
-	// Must be enabled if Keycloak is enabled
-	keycloakComp := effectiveCR.Spec.Components.Keycloak
-	if keycloakComp == nil || keycloakComp.Enabled == nil {
-		return true
-	}
-
-	// If Keycloak is not enabled, check if MySQLOperator is explicitly enabled
-	if !*keycloakComp.Enabled {
-		comp := effectiveCR.Spec.Components.MySQLOperator
-		if comp != nil && comp.Enabled != nil {
-			return *comp.Enabled
-		}
-	}
-	return true
 }
 
 // PreInstall runs before components are installed
@@ -99,4 +88,17 @@ func (c mysqlOperatorComponent) PreInstall(compContext spi.ComponentContext) err
 	}
 
 	return nil
+}
+
+// ValidateInstall checks if the specified Verrazzano CR is valid for this component to be installed
+func (c mysqlOperatorComponent) ValidateInstall(vz *vzapi.Verrazzano) error {
+	return c.validateMySQLOperator(vz)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c mysqlOperatorComponent) ValidateUpdate(old *vzapi.Verrazzano, new *vzapi.Verrazzano) error {
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.validateMySQLOperator(new)
 }

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -6,10 +6,10 @@ package mysqloperator
 import (
 	"context"
 	"fmt"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vpocons "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"


### PR DESCRIPTION
Fixes VZ-6786

This PR adds a ValidateInstall/Update method to the MySQLOperator component to preserve component dependencies at the CR level
