### PR TITLE
VZ-6772 Update E2E test to create a service account token secret

### DIFF
--- a/tests/e2e/security/rbac/rbac_test.go
+++ b/tests/e2e/security/rbac/rbac_test.go
@@ -332,10 +332,7 @@ var _ = t.Describe("Test Verrazzano API Service Account", func() {
 
 		t.It("Validate the secret of the Service Account of Verrazzano API", Label("f:security.apiproxy"), func() {
 			t.Logs.Info("DEBUG - This test fails on 1.21 - extra debugging added")
-			// Get secret for the SA
 			var pods *corev1.PodList
-			saSecret := serviceAccount.Secrets[0]
-			t.Logs.Info("SA SECRET: " + saSecret.String())
 			var clientset *kubernetes.Clientset
 			Eventually(func() (*kubernetes.Clientset, error) {
 				var err error
@@ -357,6 +354,9 @@ var _ = t.Describe("Test Verrazzano API Service Account", func() {
 
 			secretMatched := false
 			if minor <= 20 {
+				// Get secret for the SA. In k8s 1.24 and later, secret is not created for service accounts.
+				saSecret := serviceAccount.Secrets[0]
+				t.Logs.Info("SA SECRET: " + saSecret.String())
 				// in k8s 1.20 and lower, the SA token is mounted as a regular volume mounted secret
 				for i := range pods.Items {
 					// Get the secret of the API proxy pod


### PR DESCRIPTION
From k8s 1.24 onwards, when a ServiceAccount is created, no more Secret
is created automatically. Updated E2E test to create a service account
token secret if not exists.
