### PR TITLE
Deploymetrics test servicemonitor name is no longer long enough to be truncated - fix test to account for that

### DIFF
--- a/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
+++ b/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
@@ -175,7 +175,7 @@ func helidonConfigPodsRunning() bool {
 }
 
 func serviceMonitorExists() bool {
-	smName := pkg.GetAppServiceMonitorName(namespace, "hello-helidon")
+	smName := pkg.GetAppServiceMonitorName(namespace, "hello-helidon", "")
 	sm, err := pkg.GetServiceMonitor(namespace, smName)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get the Service Monitor from the cluster: %v", err))

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -295,7 +295,7 @@ func getPromJobName() (string, error) {
 		return kubeconfig, err
 	}
 	if usesServiceMonitor {
-		return testpkg.GetAppServiceMonitorName(namespace, deploymetricsAppName), nil
+		return testpkg.GetAppServiceMonitorName(namespace, deploymetricsAppName, "deploymetrics-deployment"), nil
 	}
 	// For VZ versions prior to 1.4.0, the job name in prometheus scrape config was of the old format
 	// <app_name>_default_<app_namespace>_<app_component_name>

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -244,10 +244,18 @@ func getPromOperatorClient() (client.Client, error) {
 
 // GetAppServiceMonitorName returns the service monitor name used in VZ 1.4+ for the given
 // namespace and app name
-func GetAppServiceMonitorName(namespace string, appName string) string {
+func GetAppServiceMonitorName(namespace string, appName string, component string) string {
 	// For VZ versions starting from 1.4.0, the service monitor name for prometheus is of the format
 	// <app_name>_<app_namespace>
-	smName := fmt.Sprintf("%s-%s", appName, namespace)
+	var smName string
+	if component == "" {
+		smName = fmt.Sprintf("%s-%s", appName, namespace)
+	} else {
+		smName = fmt.Sprintf("%s-%s-%s", appName, namespace, component)
+		if len(smName) > 63 {
+			smName = fmt.Sprintf("%s-%s", appName, namespace)
+		}
+	}
 	if len(smName) > 63 {
 		smName = smName[:63]
 	}


### PR DESCRIPTION


Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
