### PR TITLE
Reduced the system services for trace check and reordered Jaeger update tests

### DIFF
--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -401,22 +401,6 @@ pipeline {
                     }
                 }
 
-                stage('Jaeger Update Tests') {
-                    environment {
-                        TEST_ENV = "KIND"
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/jaeger-update"
-                    }
-                    steps {
-                        runGinkgo('update/jaeger')
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                    }
-                }
-
                 stage('AuthProxy Update Tests') {
                     environment {
                         TEST_ENV = "KIND"
@@ -489,6 +473,22 @@ pipeline {
                     }
                     steps {
                         runGinkgo('update/opensearch')
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                        }
+                    }
+                }
+
+                stage('Jaeger Update Tests') {
+                    environment {
+                        TEST_ENV = "KIND"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/jaeger-update"
+                    }
+                    steps {
+                        runGinkgo('update/jaeger')
                     }
                     post {
                         always {

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -54,8 +54,6 @@ var (
 	// services that are common plus the ones unique to admin cluster
 	adminClusterSystemServiceNames = append(managedClusterSystemServiceNames,
 		"jaeger-operator-jaeger.verrazzano-monitoring",
-		"verrazzano-monitoring-operator.verrazzano-system",
-		"ingress-controller-ingress-nginx-controller.ingress-nginx",
 		"system-es-master.verrazzano-system")
 )
 


### PR DESCRIPTION
The Jaeger post config update tests were failing randomly. Reduced the number of system services for which we check for the traces in Jaeger. Since only 1% of all traffic gets traced by default, the tests were unstable and failing randomly. Also moved the Jaeger tests to the end of the pipeline, so that there is sufficient traffic created by other tests.