### PR TITLE
VZ 6728: Metrics uses init()

### DIFF
--- a/application-operator/controllers/appconfig/appconfig_controller_test.go
+++ b/application-operator/controllers/appconfig/appconfig_controller_test.go
@@ -78,7 +78,7 @@ func newAppConfig() *oamv1.ApplicationConfiguration {
 }
 
 func TestReconcileApplicationConfigurationNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
@@ -90,7 +90,7 @@ func TestReconcileApplicationConfigurationNotFound(t *testing.T) {
 	assert.NoError(err)
 }
 func TestReconcileNoRestartVersion(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
@@ -106,7 +106,7 @@ func TestReconcileNoRestartVersion(t *testing.T) {
 }
 
 func TestReconcileRestartVersion(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
@@ -127,7 +127,7 @@ func TestReconcileRestartVersion(t *testing.T) {
 }
 
 func TestReconcileEmptyRestartVersion(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
@@ -148,7 +148,7 @@ func TestReconcileEmptyRestartVersion(t *testing.T) {
 }
 
 func TestReconcileRestartWeblogic(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -197,7 +197,7 @@ func TestReconcileRestartWeblogic(t *testing.T) {
 }
 
 func TestReconcileRestartCoherence(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -246,7 +246,7 @@ func TestReconcileRestartCoherence(t *testing.T) {
 }
 
 func TestReconcileRestartHelidon(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -295,7 +295,7 @@ func TestReconcileRestartHelidon(t *testing.T) {
 }
 
 func TestReconcileDeploymentRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -360,7 +360,7 @@ func TestReconcileDeploymentRestart(t *testing.T) {
 }
 
 func TestFailedReconcileDeploymentRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -409,7 +409,7 @@ func TestFailedReconcileDeploymentRestart(t *testing.T) {
 }
 
 func TestReconcileDeploymentNoRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -472,7 +472,7 @@ func TestReconcileDeploymentNoRestart(t *testing.T) {
 }
 
 func TestReconcileDaemonSetRestartDaemonSet(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -537,7 +537,7 @@ func TestReconcileDaemonSetRestartDaemonSet(t *testing.T) {
 }
 
 func TestReconcileDaemonSetNoRestartDaemonSet(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -599,7 +599,7 @@ func TestReconcileDaemonSetNoRestartDaemonSet(t *testing.T) {
 }
 
 func TestReconcileStatefulSetRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -664,7 +664,7 @@ func TestReconcileStatefulSetRestart(t *testing.T) {
 }
 
 func TestReconcileStatefulSetNoRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -728,7 +728,7 @@ func TestReconcileStatefulSetNoRestart(t *testing.T) {
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	cli := mocks.NewMockClient(mocker)
@@ -746,7 +746,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 
 // TestReconcileFailed tests to make sure the failure metric is being exposed
 func TestReconcileFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := assert.New(t)
 	clientBuilder := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	// Create a request and reconcile it

--- a/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
+++ b/application-operator/controllers/cohworkload/coherenceworkload_controller_test.go
@@ -62,7 +62,6 @@ var specJvmArgsFields = []string{specField, jvmField, argsField}
 // WHEN the controller is created
 // THEN verify no error is returned
 func TestReconcilerSetupWithManager(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker *gomock.Controller
@@ -95,7 +94,6 @@ func TestReconcilerSetupWithManager(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Coherence CR to be written
 func TestReconcileCreateCoherence(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -210,7 +208,7 @@ func TestReconcileCreateCoherence(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Coherence CR to be written
 func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -337,7 +335,7 @@ func TestReconcileCreateCoherenceWithLogging(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Coherence CR to be written
 func TestReconcileCreateCoherenceWithCustomLogging(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -539,7 +537,7 @@ func TestReconcileCreateCoherenceWithCustomLogging(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Coherence CR to be written
 func TestReconcileCreateCoherenceWithCustomLoggingConfigMapExists(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -707,7 +705,7 @@ func TestReconcileCreateCoherenceWithCustomLoggingConfigMapExists(t *testing.T) 
 // WHEN the controller Reconcile function is called
 // THEN the Fluentd image should be replaced in the Fluentd sidecar
 func TestReconcileUpdateFluentdImage(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -838,7 +836,7 @@ func TestReconcileUpdateFluentdImage(t *testing.T) {
 // WHEN the controller Reconcile function is called and the Coherence CR already exists
 // THEN the Coherence CR is updated
 func TestReconcileUpdateCR(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -959,9 +957,7 @@ func TestReconcileUpdateCR(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Coherence CR to be written with the combined JVM args
 func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
-
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
 	mockStatus := mocks.NewMockStatusWriter(mocker)
@@ -1086,9 +1082,7 @@ func TestReconcileWithLoggingWithJvmArgs(t *testing.T) {
 // WHEN the controller Reconcile function is called and there is an error creating the Coherence CR
 // THEN expect an error to be returned
 func TestReconcileErrorOnCreate(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
-
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
 
@@ -1176,7 +1170,6 @@ func TestReconcileErrorOnCreate(t *testing.T) {
 // WHEN the controller Reconcile function is called and we attempt to fetch the workload
 // THEN return success from the controller as there is nothing more to do
 func TestReconcileWorkloadNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1205,7 +1198,6 @@ func TestReconcileWorkloadNotFound(t *testing.T) {
 // WHEN the controller Reconcile function is called and we attempt to fetch the workload and get an error
 // THEN return the error
 func TestReconcileFetchWorkloadError(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1233,7 +1225,6 @@ func TestReconcileFetchWorkloadError(t *testing.T) {
 // WHEN the controller createOrUpdateDestinationRule function is called
 // THEN expect no error to be returned and destination rule is created
 func TestCreateUpdateDestinationRuleCreate(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1291,7 +1282,6 @@ func TestCreateUpdateDestinationRuleCreate(t *testing.T) {
 // WHEN the controller createOrUpdateDestinationRule function is called
 // THEN expect no error to be returned and destination rule is updated
 func TestCreateUpdateDestinationRuleUpdate(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1354,7 +1344,6 @@ func TestCreateUpdateDestinationRuleUpdate(t *testing.T) {
 // WHEN the controller createOrUpdateDestinationRule function is called
 // THEN expect an error to be returned
 func TestCreateUpdateDestinationRuleNoOamLabel(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	reconciler := Reconciler{}
@@ -1370,7 +1359,6 @@ func TestCreateUpdateDestinationRuleNoOamLabel(t *testing.T) {
 // WHEN the controller createOrUpdateDestinationRule function is called
 // THEN expect an error to be returned
 func TestCreateUpdateDestinationRuleNoLabel(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	reconciler := Reconciler{}
@@ -1431,7 +1419,6 @@ func getUnstructuredConfigMapList() *unstructured.UnstructuredList {
 // WHEN the controller Reconcile function is called and the restart-version is specified in annotations
 // THEN the restart-version annotation written  to the Coherence CR
 func TestReconcileRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1562,7 +1549,7 @@ func TestReconcileRestart(t *testing.T) {
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -1582,7 +1569,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 func TestReconcileFailed(t *testing.T) {
 	testAppConfigName := "unit-test-app-config"
 	testNamespace := "test-ns"
-	metricsexporter.RequiredInitialization()
+
 	scheme := k8scheme.Scheme
 	assert := asserts.New(t)
 	clientBuilder := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
+++ b/application-operator/controllers/helidonworkload/helidonworkload_controller_test.go
@@ -81,7 +81,7 @@ func TestReconcilerSetupWithManager(t *testing.T) {
 // WHEN the controller Reconcile function is called and we attempt to fetch the workload
 // THEN return success from the controller as there is nothing more to do
 func TestReconcileWorkloadNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -110,7 +110,7 @@ func TestReconcileWorkloadNotFound(t *testing.T) {
 // WHEN the controller Reconcile function is called and we attempt to fetch the workload and get an error
 // THEN return the error
 func TestReconcileFetchWorkloadError(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -139,7 +139,7 @@ func TestReconcileFetchWorkloadError(t *testing.T) {
 // WHEN the controller Reconcile function is called and we attempt to validate the workload and get an error
 // THEN return the error
 func TestReconcileWorkloadMissingData(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -200,7 +200,7 @@ func TestReconcileWorkloadMissingData(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Deployment and Service to be written
 func TestReconcileCreateHelidon(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -320,7 +320,7 @@ func TestReconcileCreateHelidon(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Deployment and Service to be written with multiple containers
 func TestReconcileCreateHelidonWithMultipleContainers(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -453,7 +453,7 @@ func TestReconcileCreateHelidonWithMultipleContainers(t *testing.T) {
 // WHEN the controller Reconcile function is called
 // THEN expect a Deployment, Service and Configmap to be written
 func TestReconcileCreateVerrazzanoHelidonWorkloadWithLoggingScope(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -567,7 +567,7 @@ func TestReconcileCreateVerrazzanoHelidonWorkloadWithLoggingScope(t *testing.T) 
 // THEN expect a Deployment, Service and Configmap to be written
 // AND expect that each application container has an associated logging sidecar container
 func TestReconcileCreateVerrazzanoHelidonWorkloadWithMultipleContainersAndLoggingScope(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -807,7 +807,7 @@ func annotateRestartVersion(deployment *appsv1.Deployment, restartVersion string
 // WHEN the controller Reconcile function is called and the restart-version is specified
 // THEN the restart-version written
 func TestReconcileRestart(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -944,7 +944,7 @@ func TestReconcileRestart(t *testing.T) {
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -965,7 +965,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 func TestReconcileFailed(t *testing.T) {
 	testAppConfigName := "unit-test-app-config"
 	testNamespace := "test-ns"
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	clientBuilder := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	// Create a request and reconcile it

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -89,7 +89,6 @@ var (
 // WHEN the controller is created
 // THEN verify no error is returned
 func TestReconcilerSetupWithManager(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 
 	var mocker *gomock.Controller
@@ -120,7 +119,6 @@ func TestReconcilerSetupWithManager(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the trait is created.
 func TestSuccessfullyCreateNewIngress(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -207,7 +205,6 @@ func TestSuccessfullyCreateNewIngress(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the trait is created.
 func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -291,7 +288,6 @@ func TestSuccessfullyCreateNewIngressWithCertSecret(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the trait and the authorization policy are created.
 func TestSuccessfullyCreateNewIngressWithAuthorizationPolicy(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -401,7 +397,6 @@ func TestSuccessfullyCreateNewIngressWithAuthorizationPolicy(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the trait and the authorization policy are created.
 func TestSuccessfullyCreateNewIngressWithAuthorizationPolicyMultipleRules(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -520,7 +515,6 @@ func TestSuccessfullyCreateNewIngressWithAuthorizationPolicyMultipleRules(t *tes
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the trait and the authorization policy are not created.
 func TestFailureCreateNewIngressWithAuthorizationPolicyNoFromClause(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -629,7 +623,6 @@ func TestFailureCreateNewIngressWithAuthorizationPolicyNoFromClause(t *testing.T
 // WHEN the trait and ingress/gateway exist
 // THEN ensure that the trait is updated with the expected hosts.
 func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -741,7 +734,6 @@ func TestSuccessfullyUpdateIngressWithCertSecret(t *testing.T) {
 // WHEN the secret is specified but no associated hosts are configured
 // THEN ensure that the trait creation fails
 func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -818,7 +810,6 @@ func TestFailureCreateNewIngressWithSecretNoHosts(t *testing.T) {
 // WHEN the trait exists but doesn't specify an oam app label
 // THEN ensure that an error is generated
 func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -885,7 +876,6 @@ func TestFailureCreateGatewayCertNoAppName(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the service workload is unwrapped and the trait is created.
 func TestSuccessfullyCreateNewIngressForServiceComponent(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -996,7 +986,6 @@ func TestSuccessfullyCreateNewIngressForServiceComponent(t *testing.T) {
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the workload is unwrapped and the trait is created.
 func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1153,7 +1142,6 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkload(t *testing.T) {
 // WHEN the workload related to the trait cannot be found
 // THEN ensure that an error is returned
 func TestFailureToGetWorkload(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1204,7 +1192,6 @@ func TestFailureToGetWorkload(t *testing.T) {
 // WHEN the workload definition of the workload related to the trait cannot be found
 // THEN ensure that an error is returned
 func TestFailureToGetWorkloadDefinition(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1260,7 +1247,6 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 // WHEN the request to update the trait status fails
 // THEN ensure an error is returned
 func TestFailureToUpdateStatus(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1321,7 +1307,7 @@ func TestFailureToUpdateStatus(t *testing.T) {
 // WHEN the ingress domain is not nip.io
 // THEN ensure that the correct DNS name is built
 func TestBuildAppHostNameForDNS(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1365,7 +1351,7 @@ func TestBuildAppHostNameForDNS(t *testing.T) {
 // WHEN the buildAppFullyQualifiedHostName function is called
 // THEN ensure that the correct DNS name is built and that the wildcard and empty names are ignored
 func TestBuildAppHostNameIgnoreWildcardForDNS(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1415,7 +1401,7 @@ func TestBuildAppHostNameIgnoreWildcardForDNS(t *testing.T) {
 // WHEN the ingress domain is not nip.io and the Verrazzano annotation is missing
 // THEN ensure that an error is returned
 func TestFailureBuildAppHostNameForDNS(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1458,7 +1444,7 @@ func TestFailureBuildAppHostNameForDNS(t *testing.T) {
 // WHEN the ingress domain is nip.io and LoadBalancer is used
 // THEN ensure that the correct DNS name is built
 func TestBuildAppHostNameLoadBalancerNIP(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1518,7 +1504,7 @@ func TestBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 // WHEN the ingress domain is nip.io and an external LoadBalancer is used
 // THEN ensure that the correct DNS name is built
 func TestBuildAppHostNameExternalLoadBalancerNIP(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1576,7 +1562,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIP(t *testing.T) {
 // WHEN the ingress domain is nip.io and an external LoadBalancer is used and LoadBalancer ise also used in Istio Ingress
 // THEN ensure that the correct DNS name is built
 func TestBuildAppHostNameBothInternalAndExternalLoadBalancerNIP(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1637,7 +1623,7 @@ func TestBuildAppHostNameBothInternalAndExternalLoadBalancerNIP(t *testing.T) {
 // WHEN the ingress domain is nip.io and an external LoadBalancer is used, but no IP is found
 // THEN ensure that an error is returned
 func TestBuildAppHostNameExternalLoadBalancerNIPNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1693,7 +1679,7 @@ func TestBuildAppHostNameExternalLoadBalancerNIPNotFound(t *testing.T) {
 // WHEN the ingress domain is nip.io and LoadBalancer is used, but an error occurs
 // THEN ensure that the correct error is returned
 func TestFailureBuildAppHostNameLoadBalancerNIP(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1750,7 +1736,7 @@ func TestFailureBuildAppHostNameLoadBalancerNIP(t *testing.T) {
 // WHEN the ingress domain is nip.io and NodePort is used together with ExternalIPs
 // THEN ensure that the correct DNS name is built
 func TestBuildAppHostNameNodePortExternalIP(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1808,7 +1794,7 @@ func TestBuildAppHostNameNodePortExternalIP(t *testing.T) {
 // WHEN a failure occurs getting the ingress trait resource
 // THEN the error is propagated
 func TestGetTraitFailurePropagated(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1831,7 +1817,7 @@ func TestGetTraitFailurePropagated(t *testing.T) {
 // WHEN a failure occurs indicating the resource is not found
 // THEN the error is propagated
 func TestGetNotFoundResource(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1851,7 +1837,7 @@ func TestGetNotFoundResource(t *testing.T) {
 // WHEN converting to the related CRD namespaced name
 // THEN ensure the conversion is correct
 func TestConvertCRAPIVersionAndKindToCRDNamespacedName(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	actual := convertAPIVersionAndKindToNamespacedName("core.oam.dev/v1alpha2", "ContainerizedWorkload")
 	expect := types.NamespacedName{Namespace: "", Name: "containerizedworkloads.core.oam.dev"}
@@ -1860,7 +1846,7 @@ func TestConvertCRAPIVersionAndKindToCRDNamespacedName(t *testing.T) {
 
 // TestCreateVirtualServiceMatchUriFromIngressTraitPath tests various use cases of createVirtualServiceMatchURIFromIngressTraitPath
 func TestCreateVirtualServiceMatchUriFromIngressTraitPath(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var path vzapi.IngressPath
 	var match *istionet.StringMatch
@@ -1911,7 +1897,7 @@ func TestCreateVirtualServiceMatchUriFromIngressTraitPath(t *testing.T) {
 // WHEN a host slice DNS domain exists in the ingress
 // THEN verify that only the default host is used
 func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -1958,7 +1944,7 @@ func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
 
 // TestCreateHostsFromIngressTraitRule tests various use cases of createHostsFromIngressTraitRule
 func TestCreateHostsFromIngressTraitRule(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var rule vzapi.IngressRule
 	var hosts []string
@@ -2014,7 +2000,7 @@ func TestGetPathsFromTrait(t *testing.T) {
 
 // TestCreateDestinationFromService test various use cases of createDestinationFromService
 func TestCreateDestinationFromService(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var services []*k8score.Service
 	var dest *istionet.HTTPRouteDestination
@@ -2150,7 +2136,7 @@ func TestCreateDestinationFromService(t *testing.T) {
 
 // TestCreateDestinationForWeblogicWorkload test various use cases of createDestinationFromService for weblogic workload
 func TestCreateDestinationForWeblogicWorkload(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var services []*k8score.Service
 	var dest *istionet.HTTPRouteDestination
@@ -2210,7 +2196,7 @@ func TestCreateDestinationForWeblogicWorkload(t *testing.T) {
 
 // TestCreateDestinationFromRuleOrService test various use cases of createDestinationFromRuleOrService
 func TestCreateDestinationFromRuleOrService(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	var rule vzapi.IngressRule
 	var services []*k8score.Service
@@ -2351,7 +2337,7 @@ func TestCreateDestinationFromRuleOrService(t *testing.T) {
 // WHEN extracting the services
 // THEN ensure the returned service is the child from the list
 func TestExtractServicesOnlyOneService(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	workload := &unstructured.Unstructured{}
@@ -2378,7 +2364,7 @@ func TestExtractServicesOnlyOneService(t *testing.T) {
 // WHEN extracting the services
 // THEN ensure the returned services has details of all the services
 func TestExtractServicesMultipleServices(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	workload := &unstructured.Unstructured{}
@@ -2414,7 +2400,7 @@ func TestExtractServicesMultipleServices(t *testing.T) {
 // WHEN an ingress trait is reconciled
 // THEN verify gateway and virtual service are created correctly.
 func TestSelectExistingServiceForVirtualServiceDestination(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -2515,7 +2501,7 @@ func TestSelectExistingServiceForVirtualServiceDestination(t *testing.T) {
 // WHEN the ingress trait is reconciled
 // THEN verify the correct gateway and virtual services are created.
 func TestExplicitServiceProvidedForVirtualServiceDestination(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -2617,7 +2603,7 @@ func TestExplicitServiceProvidedForVirtualServiceDestination(t *testing.T) {
 // WHEN the ingress trait is reconciled
 // THEN verify the correct gateway and virtual services are created.
 func TestMultiplePortsOnDiscoveredService(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -2723,7 +2709,7 @@ func TestMultiplePortsOnDiscoveredService(t *testing.T) {
 // WHEN the ingress trait is reconciled
 // THEN verify the correct gateway and virtual services are created.
 func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -2855,7 +2841,7 @@ func TestMultipleServicesForNonWebLogicWorkloadWithoutExplicitIngressDestination
 // THEN create a service as the WebLogic operator would
 // THEN verity that the expected gateway and virtual services are created.
 func TestSelectExistingServiceForVirtualServiceDestinationAfterRetry(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -3151,7 +3137,7 @@ func createResourceFromTemplate(cli client.Client, template string, data interfa
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the workload is unwrapped and the trait is created.
 func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookieIstioEnabled(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -3335,7 +3321,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookieIstioEna
 // WHEN the trait exists but the ingress does not
 // THEN ensure that the workload is unwrapped and the trait is created.
 func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookieIstioDisabled(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -3519,7 +3505,7 @@ func TestSuccessfullyCreateNewIngressForVerrazzanoWorkloadWithHTTPCookieIstioDis
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	var mocker = gomock.NewController(t)
@@ -3540,7 +3526,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 // WHEN no existing Servers are present in the Gateway
 // THEN ensure that a new Gateway is appended to the servers list
 func TestUpdateGatewayServersList(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	reconciler := createReconcilerWithFake()
@@ -3561,7 +3547,7 @@ func TestUpdateGatewayServersList(t *testing.T) {
 // WHEN we are upgrading from a release before 1.3 where the Gateway maintains a single Server object for all hosts for an application
 // THEN ensure that the resulting servers list contains only an entry for the single IngressTrait being reconciled
 func TestUpdateGatewayServersUpgrade(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	reconciler := createReconcilerWithFake()
@@ -3601,7 +3587,7 @@ func TestUpdateGatewayServersUpgrade(t *testing.T) {
 // WHEN when the Server object for existing Trait has an updated hosts list
 // THEN ensure the returned Servers list has the new Server for the IngressTrait
 func TestUpdateGatewayServersUpdateTraitHosts(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	reconciler := createReconcilerWithFake()
@@ -3649,7 +3635,7 @@ func TestUpdateGatewayServersUpdateTraitHosts(t *testing.T) {
 // WHEN we are adding a new IngressTrait
 // THEN ensure the returned Servers list has the new Server for the IngressTrait
 func TestUpdateGatewayServersNewTraitHost(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	reconciler := createReconcilerWithFake()
@@ -3680,7 +3666,7 @@ func TestUpdateGatewayServersNewTraitHost(t *testing.T) {
 // WHEN a new Trate/TraitRule is added
 // THEN ensure the returned Servers list has the new Server for the IngressTrait
 func TestMutateGatewayAddTrait(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	trait1Hosts := []string{"trait1host1", "trait1host2"}
@@ -3744,7 +3730,7 @@ func createWorkloadReference(appName string) oamrt.TypedReference {
 // WHEN a new TraitRule has been added or remvoed to an existing Trait with new hosts
 // THEN ensure the gateway Server hosts lists for the Trait has been updated accordingly
 func TestMutateGatewayHostsAddRemoveTraitRule(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 
 	trait1Hosts := []string{"trait1host1", "trait1host2"}
@@ -4119,7 +4105,7 @@ func getIngressTraitResourceExpectations(mock *mocks.MockClient, assert *asserts
 // WHEN the IngressTrait is found as being deleted
 // THEN cert and secret are deleted and gateway spec is cleaned up
 func TestIngressTraitIsDeleted(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 	params := map[string]string{
@@ -4238,7 +4224,7 @@ func createReconcilerWithFake(initObjs ...client.Object) Reconciler {
 
 // TestReconcileFailed tests to make sure the failure metric is being exposed
 func TestReconcileFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := asserts.New(t)
 	cli := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	// Create a request and reconcile it

--- a/application-operator/controllers/webhooks/appconfig_defaulter_test.go
+++ b/application-operator/controllers/webhooks/appconfig_defaulter_test.go
@@ -42,7 +42,7 @@ func decoder() *admission.Decoder {
 //  WHEN Handle is called with an invalid admission.Request containing no content
 //  THEN Handle should return an error with http.StatusBadRequest
 func TestAppConfigDefaulterHandleError(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	decoder := decoder()
 	defaulter := &AppConfigWebhook{}
 	_ = defaulter.InjectDecoder(decoder)
@@ -57,7 +57,7 @@ func TestAppConfigDefaulterHandleError(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig
 //  THEN Handle should return a patch response
 func TestAppConfigDefaulterHandle(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	decoder := decoder()
 	defaulter := &AppConfigWebhook{}
 	_ = defaulter.InjectDecoder(decoder)
@@ -73,7 +73,7 @@ func TestAppConfigDefaulterHandle(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig
 //  THEN Handle should return an Allowed response with no patch
 func TestAppConfigWebhookHandleDelete(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	testAppConfigWebhookHandleDelete(t, true, true, false)
 }
 
@@ -82,7 +82,7 @@ func TestAppConfigWebhookHandleDelete(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig and set for a dry run
 //  THEN Handle should return an Allowed response with no patch
 func TestAppConfigWebhookHandleDeleteDryRun(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	testAppConfigWebhookHandleDelete(t, true, true, true)
 }
 
@@ -91,7 +91,7 @@ func TestAppConfigWebhookHandleDeleteDryRun(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig and the cert is not found
 //  THEN Handle should return an Allowed response with no patch
 func TestAppConfigWebhookHandleDeleteCertNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	testAppConfigWebhookHandleDelete(t, false, true, false)
 }
 
@@ -100,7 +100,7 @@ func TestAppConfigWebhookHandleDeleteCertNotFound(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig and the secret is not found
 //  THEN Handle should return an Allowed response with no patch
 func TestAppConfigWebhookHandleDeleteSecretNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	testAppConfigWebhookHandleDelete(t, true, false, false)
 }
 
@@ -109,7 +109,7 @@ func TestAppConfigWebhookHandleDeleteSecretNotFound(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing appconfig
 //  THEN Handle should return error with http.StatusInternalServerError
 func TestAppConfigDefaulterHandleMarshalError(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	decoder := decoder()
 	defaulter := &AppConfigWebhook{}
 	_ = defaulter.InjectDecoder(decoder)
@@ -139,7 +139,7 @@ func (*mockErrorDefaulter) Cleanup(appConfig *oamv1.ApplicationConfiguration, dr
 //  WHEN Handle is called with an admission.Request containing appconfig
 //  THEN Handle should return error with http.StatusInternalServerError
 func TestAppConfigDefaulterHandleDefaultError(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	decoder := decoder()
 	defaulter := &AppConfigWebhook{Defaulters: []AppConfigDefaulter{&mockErrorDefaulter{}}}
 	_ = defaulter.InjectDecoder(decoder)
@@ -152,7 +152,7 @@ func TestAppConfigDefaulterHandleDefaultError(t *testing.T) {
 
 // TestHandleFailed tests to make sure the failure metric is being exposed
 func TestHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := assert.New(t)
 	// Create a request and decode(Handle) it
 	decoder := decoder()

--- a/application-operator/controllers/webhooks/istio_defaulter_test.go
+++ b/application-operator/controllers/webhooks/istio_defaulter_test.go
@@ -31,7 +31,7 @@ import (
 //  WHEN Handle is called with an invalid admission.Request containing no content
 //  THEN Handle should return an error with http.StatusBadRequest
 func TestHandleBadRequest(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	decoder := decoder()
 	defaulter := &IstioWebhook{}
 	err := defaulter.InjectDecoder(decoder)
@@ -47,7 +47,7 @@ func TestHandleBadRequest(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing a pod resource with Istio disabled
 //  THEN Handle should return an Allowed response with no action required
 func TestHandleIstioDisabled(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	defaulter := &IstioWebhook{
 		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
 		KubeClient:    fake.NewSimpleClientset(),
@@ -84,7 +84,7 @@ func TestHandleIstioDisabled(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing a pod resource with no owner references
 //  THEN Handle should return an Allowed response with no action required
 func TestHandleNoOnwerReference(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	defaulter := &IstioWebhook{
 		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
 		KubeClient:    fake.NewSimpleClientset(),
@@ -118,7 +118,7 @@ func TestHandleNoOnwerReference(t *testing.T) {
 //  WHEN Handle is called with an admission.Request containing a pod resource with no parent appconfig owner references
 //  THEN Handle should return an Allowed response with no action required
 func TestHandleNoAppConfigOnwerReference(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	defaulter := &IstioWebhook{
 		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
 		KubeClient:    fake.NewSimpleClientset(),
@@ -187,7 +187,7 @@ func TestHandleNoAppConfigOnwerReference(t *testing.T) {
 //    and a default service account referenced by the pod
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleAppConfigOnwerReference1(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -261,7 +261,7 @@ func TestHandleAppConfigOnwerReference1(t *testing.T) {
 //    and a non-default service account referenced by the pod
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleAppConfigOnwerReference2(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -347,7 +347,7 @@ func TestHandleAppConfigOnwerReference2(t *testing.T) {
 //    A different service account is used on each call.
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleAppConfigOnwerReference3(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -489,7 +489,7 @@ func TestHandleAppConfigOnwerReference3(t *testing.T) {
 //    The same service account is used on each call.
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleAppConfigOnwerReference4(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -621,7 +621,7 @@ func TestHandleAppConfigOnwerReference4(t *testing.T) {
 //	  and a project that matches the namespace of pod resource
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleProject1(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -715,7 +715,7 @@ func TestHandleProject1(t *testing.T) {
 //	  and a project that matches the namespace of pod resource. There are 2 different appconfigs.
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleProject2(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -873,7 +873,7 @@ func TestHandleProject2(t *testing.T) {
 //	  and a project that does not matches the namespace of pod resource.  There are 2 different appconfigs.
 //  THEN Handle should return an Allowed response with patch values
 func TestHandleProject3(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	scheme := runtime.NewScheme()
 	err := cluv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err, "Unexpected error adding to scheme")
@@ -1025,7 +1025,7 @@ func TestHandleProject3(t *testing.T) {
 
 // TestHandleFailed tests to make sure the failure metric is being exposed
 func TestIstioHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := assert.New(t)
 	// Create a request and decode(Handle) it
 	decoder := decoder()

--- a/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
+++ b/application-operator/controllers/webhooks/metrics-binding-labeler-pod_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
-	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +43,6 @@ func newLabelerPodWebhook() LabelerPodWebhook {
 // WHEN the pod resource has no owner references
 // THEN the Handle function should succeed and the pod is mutated
 func TestNoOwnerReferences(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	a := newLabelerPodWebhook()
 
 	// Test data
@@ -71,7 +69,6 @@ func TestNoOwnerReferences(t *testing.T) {
 // WHEN the pod resource has one owner reference
 // THEN the Handle function should succeed and the pod is mutated
 func TestOwnerReference(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	a := newLabelerPodWebhook()
 
 	// Create a replica set with no owner reference
@@ -117,7 +114,6 @@ func TestOwnerReference(t *testing.T) {
 //   is the workload resource
 // THEN the Handle function should succeed and the pod is mutated
 func TestMultipleOwnerReference(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	a := newLabelerPodWebhook()
 
 	// Create a deployment with no owner reference
@@ -181,7 +177,6 @@ func TestMultipleOwnerReference(t *testing.T) {
 //   a workload resource
 // THEN the Handle function should fail and return an error
 func TestMultipleOwnerReferenceAndWorkloadResources(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	a := newLabelerPodWebhook()
 
 	// Create a deployment with no owner reference
@@ -261,7 +256,6 @@ func TestMultipleOwnerReferenceAndWorkloadResources(t *testing.T) {
 // WHEN the pod has Prometheus annotations
 // THEN the Handle function should not overwrite those annotations
 func TestPodPrometheusAnnotations(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	a := newLabelerPodWebhook()
 
 	// Test data

--- a/application-operator/controllers/webhooks/metrics-binding-updater-workload_test.go
+++ b/application-operator/controllers/webhooks/metrics-binding-updater-workload_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	vzapp "github.com/verrazzano/verrazzano/application-operator/apis/app/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
-	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -67,7 +66,7 @@ func newGeneratorWorkloadRequest(op admissionv1.Operation, kind string, obj inte
 // WHEN the Pod is properly formed
 // THEN the validation should succeed
 func TestHandlePod(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -90,7 +89,7 @@ func TestHandlePod(t *testing.T) {
 // WHEN the Deployment is properly formed
 // THEN the validation should succeed
 func TestHandleDeployment(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -113,7 +112,7 @@ func TestHandleDeployment(t *testing.T) {
 // WHEN the ReplicaSet is properly formed
 // THEN the validation should succeed
 func TestHandleReplicaSet(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -136,7 +135,7 @@ func TestHandleReplicaSet(t *testing.T) {
 // WHEN the StatefulSet is properly formed
 // THEN the validation should succeed
 func TestHandleStatefulSet(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -159,7 +158,7 @@ func TestHandleStatefulSet(t *testing.T) {
 // WHEN the workload resource has owner references
 // THEN the Handle function should succeed and no metricsBinding is not created
 func TestHandleOwnerRefs(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -191,7 +190,7 @@ func TestHandleOwnerRefs(t *testing.T) {
 // WHEN the workload resource has  "app.verrazzano.io/metrics": "none"
 // THEN the Handle function should succeed and the metricsBinding is not created
 func TestHandleMetricsNone(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -221,7 +220,7 @@ func TestHandleMetricsNone(t *testing.T) {
 // WHEN the workload resource has  "app.verrazzano.io/metrics": "none"
 // THEN the Handle function should succeed and the metricsBinding is not created
 func TestHandleMetricsNoneNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -251,7 +250,7 @@ func TestHandleMetricsNoneNamespace(t *testing.T) {
 //    Generate an error for a pre-VZ 1.4 app with existing metrics binding
 //    Allow the workload for an app with no existing metrics binding
 func TestHandleInvalidMetricsTemplate(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                 string
 		metricsBindingExists bool
@@ -308,7 +307,7 @@ func TestHandleInvalidMetricsTemplate(t *testing.T) {
 // WHEN the workload resource has a valid metrics template reference
 // THEN the Handle function should succeed and the existing MetricsBinding is updated
 func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                       string
 		metricsBindingExists       bool
@@ -398,7 +397,7 @@ func TestHandleMetricsTemplateWorkloadNamespace(t *testing.T) {
 //    AND for a pre-VZ 1.4 app with existing MetricsBinding, the metricsBinding is updated
 //    BUT for an app with no existing MetricsBinding, no action is taken
 func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                       string
 		metricsBindingExists       bool
@@ -487,7 +486,7 @@ func TestHandleMetricsTemplateSystemNamespace(t *testing.T) {
 //    Allow the workload for an app with no existing metrics binding
 
 func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                      string
 		metricsBindingExists      bool
@@ -565,7 +564,7 @@ func TestHandleMetricsTemplateConfigMapNotFound(t *testing.T) {
 //    AND for a pre-VZ 1.4 app, the existing legacy MetricsBinding is updated
 //    BUT for an app with no existing MetricsBinding, no action is taken. It's up to user to create a monitor resource.
 func TestHandleMatchWorkloadNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                       string
 		metricsBindingExists       bool
@@ -659,7 +658,7 @@ func TestHandleMatchWorkloadNamespace(t *testing.T) {
 //    AND for a pre-VZ 1.4 app, the existing legacy MetricsBinding is updated
 //    BUT for an app with no existing MetricsBinding, no action is taken. It's up to user to create a monitor resource.
 func TestHandleMatchSystemNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                       string
 		metricsBindingExists       bool
@@ -753,7 +752,7 @@ func TestHandleMatchSystemNamespace(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and no metricsBinding is created
 func TestHandleMatchNotFound(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -814,7 +813,7 @@ func TestHandleMatchNotFound(t *testing.T) {
 // WHEN the workload resource has no metrics template reference
 // THEN the Handle function should succeed and no metricsBinding is created
 func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -864,7 +863,7 @@ func TestHandleMatchTemplateNoWorkloadSelector(t *testing.T) {
 // WHEN the workload resource has a metrics template reference
 // THEN the Handle function should succeed and no metricsBinding is created
 func TestHandleNoConfigMap(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data
@@ -908,7 +907,7 @@ func TestHandleNoConfigMap(t *testing.T) {
 // WHEN the namespace has a metrics template reference
 // THEN the Handle function should succeed and a metricsBinding is created
 func TestHandleNamespaceAnnotation(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	tests := []struct {
 		name                       string
 		metricsBindingExists       bool
@@ -1006,7 +1005,7 @@ func TestHandleNamespaceAnnotation(t *testing.T) {
 // WHEN the webhook Handle is called
 // THEN the metrics binding should be modified to use the Pormetheus Operator additionalScrapeConfigs secret instead
 func TestExistingMetricsBindingVmiConfigMap(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newGeneratorWorkloadWebhook()
 
 	// Test data

--- a/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclusterapplicationconfiguration_webhook_test.go
@@ -36,7 +36,6 @@ func newMultiClusterApplicationConfigurationValidator() MultiClusterApplicationC
 // WHEN the MultiClusterApplicationConfiguration resource is missing Placement information
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterApplicationConfigurationCreationWithoutTargetClusters(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterApplicationConfigurationValidator()
 	p := v1alpha12.MultiClusterApplicationConfiguration{
@@ -64,7 +63,6 @@ func TestValidationFailureForMultiClusterApplicationConfigurationCreationWithout
 // WHEN the MultiClusterApplicationConfiguration resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterApplicationConfigurationCreationTargetingMissingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterApplicationConfigurationValidator()
 	p := v1alpha12.MultiClusterApplicationConfiguration{
@@ -96,7 +94,6 @@ func TestValidationFailureForMultiClusterApplicationConfigurationCreationTargeti
 // WHEN the MultiClusterApplicationConfiguration resource references a VerrazzanoManagedCluster that does exist
 // THEN the validation should pass.
 func TestValidationSuccessForMultiClusterApplicationConfigurationCreationTargetingExistingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterApplicationConfigurationValidator()
 	mc := v1alpha1.VerrazzanoManagedCluster{
@@ -158,7 +155,6 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationTargeti
 // AND the validation is being done on a managed cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForMultiClusterApplicationConfigurationCreationWithoutTargetClustersOnManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterApplicationConfigurationValidator()
 	s := corev1.Secret{
@@ -214,7 +210,6 @@ func TestValidationSuccessForMultiClusterApplicationConfigurationCreationWithout
 // THEN the validation should succeed or fail based on what secrets are specified in the
 //   MultiClusterApplicationConfiguration resource
 func TestValidateSecrets(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterApplicationConfigurationValidator()
 
@@ -288,7 +283,6 @@ func TestValidateSecrets(t *testing.T) {
 
 // TestMultiClusterAppConfigHandleFailed tests to make sure the failure metric is being exposed
 func TestMultiClusterAppConfigHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := assert.New(t)
 	// Create a request and decode(Handle)
 	decoder := decoder()

--- a/application-operator/controllers/webhooks/multiclustercomponent_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclustercomponent_webhook_test.go
@@ -35,7 +35,6 @@ func newMultiClusterComponentValidator() MultiClusterComponentValidator {
 // WHEN the MultiClusterComponent resource is missing Placement information
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterComponentCreationWithoutTargetClusters(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterComponentValidator()
 	p := v1alpha12.MultiClusterComponent{
@@ -63,7 +62,6 @@ func TestValidationFailureForMultiClusterComponentCreationWithoutTargetClusters(
 // WHEN the MultiClusterComponent resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterComponentCreationTargetingMissingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterComponentValidator()
 	p := v1alpha12.MultiClusterComponent{
@@ -95,7 +93,6 @@ func TestValidationFailureForMultiClusterComponentCreationTargetingMissingManage
 // WHEN the MultiClusterComponent resource references a VerrazzanoManagedCluster that does exist
 // THEN the validation should pass.
 func TestValidationSuccessForMultiClusterComponentCreationTargetingExistingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterComponentValidator()
 	mc := v1alpha1.VerrazzanoManagedCluster{
@@ -157,7 +154,6 @@ func TestValidationSuccessForMultiClusterComponentCreationTargetingExistingManag
 // AND the validation is being done on a managed cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForMultiClusterComponentCreationWithoutTargetClustersOnManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterComponentValidator()
 	s := corev1.Secret{
@@ -212,7 +208,6 @@ func TestValidationSuccessForMultiClusterComponentCreationWithoutTargetClustersO
 // WHEN the MultiClusterComponent resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestMultiClusterComponentHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := assert.New(t)
 	mcc := v1alpha12.MultiClusterComponent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/application-operator/controllers/webhooks/multiclusterconfigmap_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclusterconfigmap_webhook_test.go
@@ -35,7 +35,6 @@ func newMultiClusterConfigmapValidator() MultiClusterConfigmapValidator {
 // WHEN the MultiClusterConfigMap resource is missing Placement information
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterConfigMapCreationWithoutTargetClusters(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterConfigmapValidator()
 	p := v1alpha12.MultiClusterConfigMap{
@@ -63,7 +62,6 @@ func TestValidationFailureForMultiClusterConfigMapCreationWithoutTargetClusters(
 // WHEN the MultiClusterConfigMap resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterConfigMapCreationTargetingMissingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterConfigmapValidator()
 	p := v1alpha12.MultiClusterConfigMap{
@@ -95,7 +93,6 @@ func TestValidationFailureForMultiClusterConfigMapCreationTargetingMissingManage
 // WHEN the MultiClusterConfigMap resource references a VerrazzanoManagedCluster that does exist
 // THEN the validation should pass.
 func TestValidationSuccessForMultiClusterConfigMapCreationTargetingExistingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterConfigmapValidator()
 	c := v1alpha1.VerrazzanoManagedCluster{
@@ -157,7 +154,6 @@ func TestValidationSuccessForMultiClusterConfigMapCreationTargetingExistingManag
 // AND the validation is being done on a managed cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForMultiClusterConfigMapCreationWithoutTargetClustersOnManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterConfigmapValidator()
 	s := corev1.Secret{
@@ -212,7 +208,6 @@ func TestValidationSuccessForMultiClusterConfigMapCreationWithoutTargetClustersO
 // WHEN the MultiClusterConfigMap resource is failing
 // THEN the validation should fail.
 func TestMultiClusterConfigmapHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := assert.New(t)
 	mcc := v1alpha12.MultiClusterComponent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/application-operator/controllers/webhooks/multiclustersecret_webhook_test.go
+++ b/application-operator/controllers/webhooks/multiclustersecret_webhook_test.go
@@ -35,7 +35,6 @@ func newMultiClusterSecretValidator() MultiClusterSecretValidator {
 // WHEN the MultiClusterSecret resource is missing Placement information
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterSecretCreationWithoutTargetClusters(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterSecretValidator()
 	p := v1alpha12.MultiClusterSecret{
@@ -63,7 +62,6 @@ func TestValidationFailureForMultiClusterSecretCreationWithoutTargetClusters(t *
 // WHEN the MultiClusterSecret resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestValidationFailureForMultiClusterSecretCreationTargetingMissingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterSecretValidator()
 	p := v1alpha12.MultiClusterSecret{
@@ -95,7 +93,6 @@ func TestValidationFailureForMultiClusterSecretCreationTargetingMissingManagedCl
 // WHEN the MultiClusterSecret resource references a VerrazzanoManagedCluster that does exist
 // THEN the validation should pass.
 func TestValidationSuccessForMultiClusterSecretCreationTargetingExistingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterSecretValidator()
 	c := v1alpha1.VerrazzanoManagedCluster{
@@ -157,7 +154,6 @@ func TestValidationSuccessForMultiClusterSecretCreationTargetingExistingManagedC
 // AND the validation is being done on a managed cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForMultiClusterSecretCreationWithoutTargetClustersOnManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asrt := assert.New(t)
 	v := newMultiClusterSecretValidator()
 	s := corev1.Secret{
@@ -212,7 +208,6 @@ func TestValidationSuccessForMultiClusterSecretCreationWithoutTargetClustersOnMa
 // WHEN the MultiClusterConfigMap resource is failing
 // THEN the validation should fail.
 func TestMultiClusterSecretHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	assert := assert.New(t)
 	mcc := v1alpha12.MultiClusterComponent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/application-operator/controllers/webhooks/verrazzanoproject_webhook_test.go
+++ b/application-operator/controllers/webhooks/verrazzanoproject_webhook_test.go
@@ -35,7 +35,7 @@ func newVerrazzanoProjectValidator() VerrazzanoProjectValidator {
 // WHEN the VerrazzanoProject is properly formed
 // THEN the validation should succeed
 func TestVerrazzanoProject(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 
@@ -58,7 +58,7 @@ func TestVerrazzanoProject(t *testing.T) {
 // WHEN the VerrazzanoProject contains an invalid namespace
 // THEN the validation should fail
 func TestInvalidNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 
@@ -86,7 +86,7 @@ func TestInvalidNamespace(t *testing.T) {
 // WHEN the VerrazzanoProject contains an invalid namespace list
 // THEN the validation should fail
 func TestInvalidNamespaces(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 
@@ -114,7 +114,7 @@ func TestInvalidNamespaces(t *testing.T) {
 // WHEN the VerrazzanoProject has a NetworkPolicyTemplate with a namespace that exists in the project
 // THEN the validation should succeed
 func TestNetworkPolicyNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 
@@ -139,7 +139,7 @@ func TestNetworkPolicyNamespace(t *testing.T) {
 // WHEN the VerrazzanoProject has a NetworkPolicyTemplate with a namespace that does not exist in the project
 // THEN the validation should fail
 func TestNetworkPolicyMissingNamespace(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 
@@ -167,7 +167,7 @@ func TestNetworkPolicyMissingNamespace(t *testing.T) {
 // WHEN the VerrazzanoProject has a a namespace that conflicts with any pre-existing projects
 // THEN the validation should fail
 func TestNamespaceUniquenessForProjects(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	v := newVerrazzanoProjectValidator()
 
 	// When creating the fake client, prepopulate it with 2 Verrazzano projects
@@ -390,7 +390,7 @@ func TestValidationFailureForProjectCreationWithoutTargetClusters(t *testing.T) 
 // WHEN the VerrazzanoProject resource references a VerrazzanoManagedCluster that does not exist
 // THEN the validation should fail.
 func TestValidationFailureForProjectCreationTargetingMissingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 	p := v1alpha12.VerrazzanoProject{
@@ -431,7 +431,7 @@ func TestValidationFailureForProjectCreationTargetingMissingManagedCluster(t *te
 // WHEN the VerrazzanoProject resource references a VerrazzanoManagedCluster that does exist
 // THEN the validation should pass.
 func TestValidationSuccessForProjectCreationTargetingExistingManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 	c := v1alpha1.VerrazzanoManagedCluster{
@@ -483,7 +483,7 @@ func TestValidationSuccessForProjectCreationTargetingExistingManagedCluster(t *t
 // AND the validation is being done on a managed cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForProjectCreationWithoutTargetClustersOnManagedCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 	s := corev1.Secret{
@@ -530,7 +530,7 @@ func TestValidationSuccessForProjectCreationWithoutTargetClustersOnManagedCluste
 // AND the validation is being done on the admin cluster
 // THEN the validation should succeed.
 func TestValidationSuccessForProjectCreationTargetingLocalCluster(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	asrt := assert.New(t)
 	v := newVerrazzanoProjectValidator()
 	p := v1alpha12.VerrazzanoProject{
@@ -568,7 +568,7 @@ func TestValidationSuccessForProjectCreationTargetingLocalCluster(t *testing.T) 
 // WHEN the VerrazzanoProject resource is failing
 // THEN the validation should fail.
 func TestVzProjHandleFailed(t *testing.T) {
-	metricsexporter.RequiredInitialization()
+
 	assert := assert.New(t)
 	// Create a request and Handle
 	v := newVerrazzanoProjectValidator()

--- a/application-operator/main.go
+++ b/application-operator/main.go
@@ -339,7 +339,7 @@ func main() {
 	agentChannel := make(chan clusters.StatusUpdateMessage, constants.StatusUpdateChannelBufferSize)
 
 	// Initialize the metricsExporter
-	if err := metricsexporter.InitRegisterStart(log); err != nil {
+	if err := metricsexporter.StartMetricsServer(); err != nil {
 		log.Errorf("Failed to create metrics exporter: %v", err)
 		os.Exit(1)
 	}

--- a/application-operator/metricsexporter/metricsexporter_test.go
+++ b/application-operator/metricsexporter/metricsexporter_test.go
@@ -15,7 +15,6 @@ import (
 var logForTest = zap.S()
 
 func TestCollectReconcileMetrics(t *testing.T) {
-	RequiredInitialization()
 	assert := asserts.New(t)
 	test := struct {
 		name string
@@ -44,5 +43,4 @@ func TestCollectReconcileMetrics(t *testing.T) {
 		time.Sleep(time.Second)
 		reconcileDurationCount.TimerStop()
 	})
-
 }

--- a/application-operator/metricsexporter/metricsexporter_utils.go
+++ b/application-operator/metricsexporter/metricsexporter_utils.go
@@ -62,18 +62,8 @@ const (
 )
 
 func init() {
-	vlog, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
-		Name:           "",
-		Namespace:      "",
-		ID:             "",
-		Generation:     0,
-		ControllerName: "metricsexporter",
-	})
-	if err != nil {
-		panic(err)
-	}
 	RequiredInitialization()
-	RegisterMetrics(vlog)
+	RegisterMetrics()
 }
 
 // RequiredInitialization initalizes the metrics object, but does not register the metrics
@@ -88,9 +78,9 @@ func RequiredInitialization() {
 }
 
 // RegisterMetrics begins the process of registering metrics
-func RegisterMetrics(log vzlog.VerrazzanoLogger) {
+func RegisterMetrics() {
 	InitializeAllMetricsArray()
-	go registerMetricsHandlers(log)
+	go registerMetricsHandlers(zap.S())
 }
 
 // InitializeAllMetricsArray initalizes the allMetrics array
@@ -347,12 +337,12 @@ func registerMetricsHandlersHelper() error {
 }
 
 // registerMetricsHandlers registers the metrics and provides error handling
-func registerMetricsHandlers(log vzlog.VerrazzanoLogger) {
+func registerMetricsHandlers(log *zap.SugaredLogger) {
 	// Get list of metrics to register initially
 	initializeFailedMetricsArray()
 	// Loop until there is no error in registering
 	for err := registerMetricsHandlersHelper(); err != nil; err = registerMetricsHandlersHelper() {
-		log.Oncef("Failed to register metrics for VMI %v \n", err)
+		log.Infof("Failed to register metrics for VMI %v", err)
 		time.Sleep(time.Second)
 	}
 }

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -100,7 +100,6 @@ func TestGetUninstallJobName(t *testing.T) {
 // THEN ensure all the objects are already created and
 //      ensure a finalizer is added if it doesn't exist
 func TestInstall(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	tests := []struct {
 		namespace string
 		name      string
@@ -1297,7 +1296,6 @@ func TestNonIntersectingMergeNestedMap(t *testing.T) {
 // WHEN the reconcile function is called
 // THEN an error occurs and the error counter metric is incremented
 func TestReconcileErrorCounter(t *testing.T) {
-	metricsexporter.RequiredInitialization()
 	asserts := assert.New(t)
 	clientBuilder := fakes.NewClientBuilder()
 	fakeClient := clientBuilder.Build()

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -197,7 +197,7 @@ func main() {
 
 	installv1alpha1.SetComponentValidator(validator.ComponentValidatorImpl{})
 
-	metricsexporter.InitRegisterStart(log)
+	metricsexporter.StartMetricsServer(log)
 
 	// Setup the reconciler
 	reconciler := vzcontroller.Reconciler{

--- a/platform-operator/metricsexporter/metricsexporter_test.go
+++ b/platform-operator/metricsexporter/metricsexporter_test.go
@@ -26,7 +26,6 @@ const (
 // GIVEN a call to Inc
 // THEN the function should update that internal metric by one
 func TestReconcileCounterAndErrorIncrement(t *testing.T) {
-	RequiredInitialization()
 	assert := asserts.New(t)
 	test := struct {
 		name                             string
@@ -58,7 +57,6 @@ func TestReconcileCounterAndErrorIncrement(t *testing.T) {
 // WHEN a VZ CR with or without timestamps is passed to the fn
 // THEN the function properly updates or does nothing to the component's metric
 func TestAnalyzeVerrazzanoResourceMetrics(t *testing.T) {
-	RequiredInitialization()
 	assert := asserts.New(t)
 	emptyVZCR := installv1alpha1.Verrazzano{}
 	disabledComponentVZCR := installv1alpha1.Verrazzano{

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -82,11 +82,9 @@ const (
 	fluentdMetricName              metricName = fluentd.ComponentName
 )
 
-// This function initalizes the metrics object, registers the metrics, and then starts the server
-func InitRegisterStart(log *zap.SugaredLogger) {
+func init() {
 	RequiredInitialization()
-	RegisterMetrics(log)
-	StartMetricsServer(log)
+	RegisterMetrics(zap.S())
 }
 
 // This function initalizes the metrics object, but does not register the metrics

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -224,7 +224,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.4.0-20220824125256-dfc917d",
+              "tag": "v1.4.0-20220825162747-94d2305",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Fixup metricsexporter implementation to use golang init() function