### PR TITLE
Fixed trigger pipeline checkout

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -94,6 +94,7 @@ pipeline {
                         echo "Specific GIT commit was not specified, use current head"
                         def scmInfo = checkout([
                             $class: 'GitSCM',
+                            branches: [[name: env.BRANCH_NAME]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [],
                             submoduleCfg: [],

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -92,10 +92,8 @@ pipeline {
                 script {
                     if (params.GIT_COMMIT_TO_USE == "NONE") {
                         echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = checkout scm
-                            scmInfo = checkout([
+                        def scmInfo = checkout([
                             $class: 'GitSCM',
-                            branches: [[name: scmInfo.GIT_COMMIT]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [],
                             submoduleCfg: [],

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -92,10 +92,9 @@ pipeline {
                 script {
                     if (params.GIT_COMMIT_TO_USE == "NONE") {
                         echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = checkout scm
-                            scmInfo = checkout([
+                        def scmInfo = checkout([
                             $class: 'GitSCM',
-                            branches: [[name: scmInfo.GIT_COMMIT]],
+                            branches: [[name: env.BRANCH_NAME]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [],
                             submoduleCfg: [],


### PR DESCRIPTION
Fixed trigger pipeline checkout

The `checkout`  directive was executed twice with the same `scmInfo` variable being set twice as well. It looks like the `scmInfo.GIT_COMMIT` was not initialized intermittently causing the issue.