### PR TITLE
VZ-6865, VZ-6802: Update release pipeline for open-source distribution

### DIFF
--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         PERIODIC_JOB_OBJECT_PREFIX = "${CLEAN_BRANCH_NAME}-last-clean-periodic-test"
         PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano-${params.TARGET_VERSION}-open-source.zip"
+        PERIODIC_PRODUCT_COMMERCIAL_OBJECT_NAME = "verrazzano-${params.TARGET_VERSION}-commerical.zip"
     }
 
     stages {
@@ -263,11 +264,27 @@ pipeline {
                     // NOTE - this copy operation is asynchronous. The assumption here is that it will complete
                     // by the time the images are pushed to OCR (next build stage), and the release stage2, which uses
                     // these objects, is run.
+                    // Copy open-source distribution, commerical distribution and the SHA256 files for the distribution bundles
                     sh """
                         oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
                           -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \
                           --source-object-name ${PERIODIC_JOB_OBJECT_PREFIX}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME} \
                           --destination-object-name ${CLEAN_BRANCH_NAME}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME}
+
+                        oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
+                          -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \
+                          --source-object-name ${PERIODIC_JOB_OBJECT_PREFIX}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME}.sha256 \
+                          --destination-object-name ${CLEAN_BRANCH_NAME}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME}.sha256
+
+                        oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
+                          -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \
+                          --source-object-name ${PERIODIC_JOB_OBJECT_PREFIX}/${PERIODIC_PRODUCT_COMMERCIAL_OBJECT_NAME} \
+                          --destination-object-name ${CLEAN_BRANCH_NAME}/${PERIODIC_PRODUCT_COMMERCIAL_OBJECT_NAME}
+
+                        oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
+                          -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \
+                          --source-object-name ${PERIODIC_JOB_OBJECT_PREFIX}/${PERIODIC_PRODUCT_COMMERCIAL_OBJECT_NAME}.sha256 \
+                          --destination-object-name ${CLEAN_BRANCH_NAME}/${PERIODIC_PRODUCT_COMMERCIAL_OBJECT_NAME}.sha256
 
                         oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
                           -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \

--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -60,8 +60,8 @@ pipeline {
 
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         PERIODIC_JOB_OBJECT_PREFIX = "${CLEAN_BRANCH_NAME}-last-clean-periodic-test"
-        PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano_periodic.zip"
-
+        //PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano_periodic.zip"
+        PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano-${params.TARGET_VERSION}-open-source.zip"
     }
 
     stages {
@@ -268,7 +268,7 @@ pipeline {
                         oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
                           -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \
                           --source-object-name ${PERIODIC_JOB_OBJECT_PREFIX}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME} \
-                          --destination-object-name ${CLEAN_BRANCH_NAME}/verrazzano_${params.TARGET_VERSION}.zip
+                          --destination-object-name ${CLEAN_BRANCH_NAME}/${PERIODIC_PRODUCT_ZIP_OBJECT_NAME}
 
                         oci --region ${OCI_OS_REGION} os object copy --namespace ${OCI_OS_NAMESPACE} \
                           -bn ${OCI_OS_BUCKET} --destination-bucket ${OCI_OS_BUCKET} \

--- a/release/builds/Jenkinsfile
+++ b/release/builds/Jenkinsfile
@@ -60,7 +60,6 @@ pipeline {
 
         CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
         PERIODIC_JOB_OBJECT_PREFIX = "${CLEAN_BRANCH_NAME}-last-clean-periodic-test"
-        //PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano_periodic.zip"
         PERIODIC_PRODUCT_ZIP_OBJECT_NAME = "verrazzano-${params.TARGET_VERSION}-open-source.zip"
     }
 

--- a/release/builds/JenkinsfilePostPRT
+++ b/release/builds/JenkinsfilePostPRT
@@ -119,7 +119,6 @@ pipeline {
                     timeout(time: 90, unit: 'MINUTES') {
                         sh """
                             cd ${WORKSPACE}/release/scripts
-                            unset BUNDLE_TO_SCAN
                             ./scan_release_binaries.sh ${params.RELEASE_BRANCH} ${RELEASE_BINARIES_DIR}
                         """
                    }

--- a/release/builds/JenkinsfilePostPRT
+++ b/release/builds/JenkinsfilePostPRT
@@ -44,6 +44,8 @@ pipeline {
 
         RELEASE_BINARIES_DIR = "${WORKSPACE}/release/scripts/release_work"
         TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+
+        RELEASE_VERSION = "${params.RELEASE_VERSION}"
     }
 
     stages {
@@ -117,7 +119,8 @@ pipeline {
                     timeout(time: 90, unit: 'MINUTES') {
                         sh """
                             cd ${WORKSPACE}/release/scripts
-                            ./scan_release_binaries.sh ${params.RELEASE_BRANCH} ${RELEASE_BINARIES_DIR} ${params.RELEASE_VERSION}
+                            unset BUNDLE_TO_SCAN
+                            ./scan_release_binaries.sh ${params.RELEASE_BRANCH} ${RELEASE_BINARIES_DIR}
                         """
                    }
                 }
@@ -139,7 +142,7 @@ pipeline {
                     echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
 
                     cd ${WORKSPACE}/release/scripts
-                    ./create_github_release.sh ${params.RELEASE_VERSION} ${params.RELEASE_COMMIT} ${RELEASE_BINARIES_DIR} ${TEST_RUN}
+                    ./create_github_release.sh ${params.RELEASE_COMMIT} ${RELEASE_BINARIES_DIR} ${TEST_RUN}
                   """
                 }
             }

--- a/release/builds/JenkinsfileScanReleaseBundle
+++ b/release/builds/JenkinsfileScanReleaseBundle
@@ -1,0 +1,108 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+pipeline {
+    options {
+        skipDefaultCheckout true
+        timestamps ()
+    }
+
+    agent {
+       docker {
+            image "${RELEASE_RUNNER_IMAGE}"
+            args "${RELEASE_RUNNER_DOCKER_ARGS}"
+            registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
+            registryCredentialsId 'ocir-pull-and-push-account'
+            label "internal"
+        }
+    }
+
+    parameters {
+        string (description: 'The release branch', name: 'RELEASE_BRANCH', defaultValue: 'NONE', trim: true)
+        string (description: 'The release version (major.minor.patch format, e.g. 1.0.1)', name: 'RELEASE_VERSION', defaultValue: 'NONE', trim: true)
+        choice (name: 'DISTRIBUTION_VARIANT',
+                description: 'Verrazzano Distribution Variant to use for scanning',
+                choices: ["commercial", "open-source"])
+    }
+
+    environment {
+        OCR_CREDS = credentials('ocr-pull-and-push-account')
+        NETRC_FILE = credentials('netrc')
+        DOCKER_CREDS = credentials('github-packages-credentials-rw')
+        DOCKER_REPO = 'ghcr.io'
+        IS_PATCH_RELEASE = 'false'
+
+        OBJECT_STORAGE_NS = credentials('oci-os-namespace')
+        OBJECT_STORAGE_BUCKET="verrazzano-builds"
+        OCI_REGION="us-phoenix-1"
+        OCI_CLI_AUTH="api_key"
+        OCI_CLI_TENANCY = credentials('oci-tenancy')
+        OCI_CLI_USER = credentials('oci-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-api-key')
+
+        RELEASE_BINARIES_DIR = "${WORKSPACE}/release/scripts/release_work"
+        TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+        BUNDLE_TO_SCAN = "${params.DISTRIBUTION_VARIANT}"
+    }
+
+    stages {
+        stage('Clean workspace and checkout') {
+            steps {
+                sh """
+                    echo "${NODE_LABELS}"
+                """
+                script {
+                    def scmInfo = checkout scm
+                    env.GIT_COMMIT = scmInfo.GIT_COMMIT
+                    env.GIT_BRANCH = scmInfo.GIT_BRANCH
+                    echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
+                }
+                sh """
+                    cp -f "${NETRC_FILE}" $HOME/.netrc
+                    chmod 600 $HOME/.netrc
+                """
+
+                script {
+                    def props = readProperties file: '.verrazzano-development-version'
+                    VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+                }
+            }
+        }
+
+        stage('Scan Release Binaries') {
+            environment {
+                SCANNER_ARCHIVE_LOCATION = credentials('scanner-archive-location')
+                SCANNER_ARCHIVE_FILE = credentials('scanner-archive-file')
+                VIRUS_DEFINITION_LOCATION = credentials('virus-definition-location')
+                NO_PROXY_SUFFIX = credentials('cdn-no-proxy')
+            }
+           steps {
+                script {
+                    // The scan alone takes around 55 minutes, so setting a higher timeout
+                    timeout(time: 240, unit: 'MINUTES') {
+                        sh """
+                            cd ${WORKSPACE}/release/scripts
+
+                            if [ ${params.RELEASE_BRANCH} == "NONE" ]; then
+                              ./scan_release_binaries.sh ${env.BRANCH_NAME.replace("/", "%2F")}-last-clean-periodic-test ${RELEASE_BINARIES_DIR} ${params.RELEASE_VERSION}
+                            else
+                              ./scan_release_binaries.sh "${params.RELEASE_BRANCH}-last-clean-periodic-test" ${RELEASE_BINARIES_DIR} ${params.RELEASE_VERSION}
+                            fi
+                        """
+                   }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: "**/scan_report*.out,**/scan_summary*.out,", allowEmptyArchive: true
+        }
+        cleanup {
+            deleteDir()
+        }
+    }
+}
+

--- a/release/scripts/common.sh
+++ b/release/scripts/common.sh
@@ -7,16 +7,19 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "This script expects environment variable RELEASE_VERSION"
+  exit 1
+fi
+
 # Release artifacts
 declare -a releaseArtifacts=("operator.yaml"
-                             "vz-darwin-amd64.tar.gz"
-                             "vz-darwin-amd64.tar.gz.sha256"
-                             "vz-darwin-arm64.tar.gz"
-                             "vz-darwin-arm64.tar.gz.sha256"
-                             "vz-linux-amd64.tar.gz"
-                             "vz-linux-amd64.tar.gz.sha256"
-                             "vz-linux-arm64.tar.gz"
-                             "vz-linux-arm64.tar.gz.sha256")
+                             "operator.yaml.sha256"
+                             "README.md"
+                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz.sha256"
+                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz.sha256")
 
 # Validates whether OCI CLI is installed
 function validate_oci_cli() {

--- a/release/scripts/create_github_release.sh
+++ b/release/scripts/create_github_release.sh
@@ -25,7 +25,12 @@ EOM
     exit 0
 }
 
-[ -z "$1" ] || [ -z "$2" ] || [ "$1" == "-h" ] || [ -z "$RELEASE_VERSION" ] && { usage; }
+[ -z "$1" ] || [ -z "$2" ] || [ "$1" == "-h" ] && { usage; }
+
+if [ -z "${RELEASE_VERSION}" ] ; then
+    echo "The script requires environment variable RELEASE_VERSION, in the format major.minor.patch (for example, 1.0.3)"
+    exit 1
+fi
 
 RELEASE_COMMIT=${1}
 RELEASE_BINARIES_DIR=${2}

--- a/release/scripts/create_github_release.sh
+++ b/release/scripts/create_github_release.sh
@@ -14,7 +14,7 @@ usage() {
   Creates a Github release.
 
   Usage:
-    $(basename $0) <new version for the release> <hash of commit to release> <directory containing the release binaries> <a boolean to indicate test run, defaults to true>
+    $(basename $0) <hash of commit to release> <directory containing the release binaries> <a boolean to indicate test run, defaults to true>
 
   Example:
     $(basename $0) v1.0.1 aa94949a4e8e9b50bc0674035898f2579f2519cb ~/go/src/github.com/verrazzano/verrazzano/release
@@ -25,12 +25,13 @@ EOM
     exit 0
 }
 
-[ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ "$1" == "-h" ] && { usage; }
+[ -z "$1" ] || [ -z "$2" ] || [ "$1" == "-h" ] || [ -z "$RELEASE_VERSION" ] && { usage; }
 
-VERSION=${1}
-RELEASE_COMMIT=${2}
-RELEASE_BINARIES_DIR=${3}
-TEST_RUN=${4:-true}
+RELEASE_COMMIT=${1}
+RELEASE_BINARIES_DIR=${2}
+TEST_RUN=${3:-true}
+
+VERSION=${RELEASE_VERSION}
 
 if [[ $VERSION != v* ]] ; then
   VERSION="v${1}"

--- a/release/scripts/scan_release_binaries.sh
+++ b/release/scripts/scan_release_binaries.sh
@@ -80,7 +80,6 @@ function scan_release_binaries() {
   cd $RELEASE_BUNDLE_DIR
   unzip $RELEASE_TAR_BALL
   rm $RELEASE_TAR_BALL
-  gunzip $VERRAZZANO_TAR_GZ_FILE
 
   count_files=$(ls -1q *.* | wc -l)
   ls $RELEASE_BUNDLE_DIR

--- a/release/scripts/scan_release_binaries.sh
+++ b/release/scripts/scan_release_binaries.sh
@@ -56,14 +56,11 @@ RELEASE_BUNDLE_DIR="$WORK_DIR/release_bundle"
 function download_release_tarball() {
   cd $WORK_DIR
   mkdir -p $RELEASE_BUNDLE_DIR
-  echo "Downloading release bundle to $RELEASE_BUNDLE_DIR/${RELEASE_TAR_BALL} ..."
   oci --region ${OCI_REGION} os object get \
         --namespace ${OBJECT_STORAGE_NS} \
         -bn ${OBJECT_STORAGE_BUCKET} \
         --name "${BRANCH}/${RELEASE_TAR_BALL}" \
         --file "$RELEASE_BUNDLE_DIR/${RELEASE_TAR_BALL}"
-  echo "Successfully downloaded the release bundle"
-  ls -ltr $RELEASE_BUNDLE_DIR
 }
 
 function install_scanner() {


### PR DESCRIPTION
This change updates the release build pipelines for Github release Verrazzano open-source distribution. As part of this change, a new pipeline is added to perform the malware scan of release bundles.