### PR TITLE
Fix cleanup code so we continue to cleanup the OCNE cluster if the VZ…

### DIFF
--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -512,8 +512,12 @@ pipeline {
             script {
                 if (params.KEEP_RESOURCES_AFTER_RUN == false) {
                     if (env.installedVZ && env.installedVZ == "true") {
-                        echo "[INFO] Deleting Verrazzano"
-                        deleteVerrazzano()
+                        try {
+                            echo "[INFO] Deleting Verrazzano"
+                            deleteVerrazzano()
+                        } catch (error) {
+                            echo "Failed to delete Verrazzano"
+                        }
                     }
                     if (env.createdOLCNECluster && env.createdOLCNECluster == "true") {
                         echo "[INFO] Deleting OLCNE Cluster"


### PR DESCRIPTION
The OCNE job was not cleaning up the OCNE cluster if the VZ uninstall that was being performed during the job cleanup fails for any reason.