### PR TITLE
VZ-6921 Upgrade fails when Jaeger Operator component is enabled

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring.go
+++ b/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring.go
@@ -1,27 +1,41 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package prometheus
+package common
 
 import (
+	"context"
+
 	v8oconst "github.com/verrazzano/verrazzano/pkg/constants"
-	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 )
+
+// EnsureVerrazzanoMonitoringNamespace ensures that the verrazzano-monitoring namespace is created with the right labels.
+func EnsureVerrazzanoMonitoringNamespace(ctx spi.ComponentContext) error {
+	// Create the verrazzano-monitoring namespace
+	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.VerrazzanoMonitoringNamespace}}
+	_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &namespace, func() error {
+		MutateVerrazzanoMonitoringNamespace(ctx, &namespace)
+		return nil
+	})
+	return err
+}
 
 // MutateVerrazzanoMonitoringNamespace modifies the given namespace for the Monitoring subcomponents
 // with the appropriate labels, in one location. If the provided namespace is not the Verrazzano
 // monitoring namespace, it is ignored.
 func MutateVerrazzanoMonitoringNamespace(ctx spi.ComponentContext, namespace *corev1.Namespace) {
-	if namespace.Name != vpoconst.VerrazzanoMonitoringNamespace {
+	if namespace.Name != constants.VerrazzanoMonitoringNamespace {
 		return
 	}
 	if namespace.Labels == nil {
 		namespace.Labels = map[string]string{}
 	}
-	namespace.Labels[v8oconst.LabelVerrazzanoNamespace] = vpoconst.VerrazzanoMonitoringNamespace
+	namespace.Labels[v8oconst.LabelVerrazzanoNamespace] = constants.VerrazzanoMonitoringNamespace
 
 	istio := ctx.EffectiveCR().Spec.Components.Istio
 	if istio != nil && istio.IsInjectionEnabled() {
@@ -34,7 +48,7 @@ func MutateVerrazzanoMonitoringNamespace(ctx spi.ComponentContext, namespace *co
 func GetVerrazzanoMonitoringNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: vpoconst.VerrazzanoMonitoringNamespace,
+			Name: constants.VerrazzanoMonitoringNamespace,
 		},
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +12,15 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var trueValue = true
+var falseValue = false
 
 // TestMutateVerrazzanoMonitoringNamespace tests the MutateVerrazzanoMonitoringNamespace function.
 func TestMutateVerrazzanoMonitoringNamespace(t *testing.T) {
@@ -68,10 +76,133 @@ func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
 
 // TestEnsureMonitoringOperatorNamespace asserts the verrazzano-monitoring namespaces can be created
 func TestEnsureMonitoringOperatorNamespace(t *testing.T) {
-	// GIVEN a Verrazzano CR with Jaeger Component enabled,
-	// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
-	// THEN no error is returned.
-	ctx := spi.NewFakeContext(fake.NewClientBuilder().WithScheme(testScheme).Build(), &vzapi.Verrazzano{}, nil, false)
-	err := EnsureVerrazzanoMonitoringNamespace(ctx)
-	assert.NoError(t, err)
+	tests := []struct {
+		name              string
+		cr                *vzapi.Verrazzano
+		existingNamespace *corev1.Namespace
+		expectedLabels    map[string]string
+	}{
+		{
+			// GIVEN a default Verrazzano CR and no verrazzano-monitoring namespace,
+			// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
+			// THEN no error is returned and the namespace is created with the required labels.
+			"Default VZ CR with no namespace",
+			&vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Istio: &vzapi.IstioComponent{
+							InjectionEnabled: &trueValue,
+						},
+					},
+				},
+			},
+			nil,
+			map[string]string{
+				v8oconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
+				v8oconst.LabelIstioInjection:      "enabled",
+			},
+		},
+		{
+			// GIVEN a default Verrazzano CR having prior verrazzano-monitoring namespace with no labels,
+			// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
+			// THEN no error is returned and the namespace is created with the required labels.
+			"Default VZ CR with already existing namespace",
+			&vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Istio: &vzapi.IstioComponent{
+							InjectionEnabled: &trueValue,
+						},
+					},
+				},
+			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.VerrazzanoMonitoringNamespace,
+				},
+			},
+			map[string]string{
+				v8oconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
+				v8oconst.LabelIstioInjection:      "enabled",
+			},
+		},
+		{
+			// GIVEN a Verrazzano CR with istio disabled, and prior verrazzano-monitoring namespace with no labels,
+			// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
+			// THEN no error is returned and the existing namespace is mutated without the istio label
+			"Istio disabled VZ CR with already existing namespace",
+			&vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Istio: &vzapi.IstioComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.VerrazzanoMonitoringNamespace,
+				},
+			},
+			map[string]string{
+				v8oconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
+			},
+		},
+		{
+			// GIVEN a Verrazzano CR with istio disabled, and prior verrazzano-monitoring namespace with istio labels,
+			// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
+			// THEN no error is returned and the existing namespace is mutated without the istio label
+			"Istio disabled VZ CR with already existing namespace with istio labels",
+			&vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Istio: &vzapi.IstioComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.VerrazzanoMonitoringNamespace,
+					Labels: map[string]string{
+						v8oconst.LabelIstioInjection:      "enabled",
+						v8oconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
+					},
+				},
+			},
+			map[string]string{
+				v8oconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
+				v8oconst.LabelIstioInjection:      "enabled",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var existingNamespaces []runtime.Object
+			if tt.existingNamespace != nil {
+				existingNamespaces = append(existingNamespaces, tt.existingNamespace)
+			}
+			fakeclient := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(existingNamespaces...).Build()
+			ctx := spi.NewFakeContext(fakeclient, tt.cr, nil, false)
+			err := EnsureVerrazzanoMonitoringNamespace(ctx)
+			assert.NoError(t, err)
+			actualNamespace := corev1.Namespace{}
+			err = fakeclient.Get(context.TODO(),
+				types.NamespacedName{
+					Name: constants.VerrazzanoMonitoringNamespace,
+				}, &actualNamespace)
+			assert.NoError(t, err)
+			for labelKey, labelValue := range tt.expectedLabels {
+				assert.Equal(t, labelValue, actualNamespace.Labels[labelKey])
+			}
+			// check the name matches verrazzano-monitoring
+			assert.Equal(t, constants.VerrazzanoMonitoringNamespace, actualNamespace.Name)
+			// check there are no additional labels
+			assert.Equal(t, len(tt.expectedLabels), len(actualNamespace.Labels))
+		})
+	}
+
 }

--- a/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/verrazzano_monitoring_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package prometheus
+package common
 
 import (
 	"testing"
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	v8oconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestMutateVerrazzanoMonitoringNamespace tests the MutateVerrazzanoMonitoringNamespace function.
@@ -33,8 +34,8 @@ func TestMutateVerrazzanoMonitoringNamespace(t *testing.T) {
 	ns := GetVerrazzanoMonitoringNamespace()
 	MutateVerrazzanoMonitoringNamespace(ctx, ns)
 	assert.Equal(t, "enabled", ns.Labels[v8oconst.LabelIstioInjection])
-	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
-	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
+	assert.Equal(t, constants.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
+	assert.Equal(t, constants.VerrazzanoMonitoringNamespace, ns.Name)
 
 	// GIVEN a Verrazzano CR with Istio injection disabled
 	//  WHEN we call the function to create the Verrazzano monitoring namespace struct
@@ -54,13 +55,23 @@ func TestMutateVerrazzanoMonitoringNamespace(t *testing.T) {
 	ns = GetVerrazzanoMonitoringNamespace()
 	MutateVerrazzanoMonitoringNamespace(ctx, ns)
 	assert.NotContains(t, ns.Labels, v8oconst.LabelIstioInjection)
-	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
-	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
+	assert.Equal(t, constants.VerrazzanoMonitoringNamespace, ns.Labels[v8oconst.LabelVerrazzanoNamespace])
+	assert.Equal(t, constants.VerrazzanoMonitoringNamespace, ns.Name)
 }
 
 // TestGetVerrazzanoMonitoringNamespace tests the GetVerrazzanoMonitoringNamespace function.
 func TestGetVerrazzanoMonitoringNamespace(t *testing.T) {
 	ns := GetVerrazzanoMonitoringNamespace()
-	assert.Equal(t, vpoconst.VerrazzanoMonitoringNamespace, ns.Name)
+	assert.Equal(t, constants.VerrazzanoMonitoringNamespace, ns.Name)
 	assert.Nil(t, ns.Labels)
+}
+
+// TestEnsureMonitoringOperatorNamespace asserts the verrazzano-monitoring namespaces can be created
+func TestEnsureMonitoringOperatorNamespace(t *testing.T) {
+	// GIVEN a Verrazzano CR with Jaeger Component enabled,
+	// WHEN we call the EnsureVerrazzanoMonitoringNamespace function,
+	// THEN no error is returned.
+	ctx := spi.NewFakeContext(fake.NewClientBuilder().WithScheme(testScheme).Build(), &vzapi.Verrazzano{}, nil, false)
+	err := EnsureVerrazzanoMonitoringNamespace(ctx)
+	assert.NoError(t, err)
 }

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
@@ -7,6 +7,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"text/template"
+
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -19,8 +24,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-	"io/fs"
-	"io/ioutil"
 	adminv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,10 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"os"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"text/template"
 )
 
 var (
@@ -152,7 +153,8 @@ func preInstall(ctx spi.ComponentContext) error {
 	}
 
 	// Create the verrazzano-monitoring namespace if not already created
-	if err := ensureVerrazzanoMonitoringNamespace(ctx); err != nil {
+	ctx.Log().Debugf("Creating namespace %s for the Jaeger Operator", constants.VerrazzanoMonitoringNamespace)
+	if err := common.EnsureVerrazzanoMonitoringNamespace(ctx); err != nil {
 		return err
 	}
 
@@ -342,37 +344,6 @@ func GetOverrides(effectiveCR *vzapi.Verrazzano) []vzapi.Overrides {
 		return effectiveCR.Spec.Components.JaegerOperator.ValueOverrides
 	}
 	return []vzapi.Overrides{}
-}
-
-func ensureVerrazzanoMonitoringNamespace(ctx spi.ComponentContext) error {
-	// Create the verrazzano-monitoring namespace
-	ctx.Log().Debugf("Creating namespace %s for the Jaeger Operator", ComponentNamespace)
-	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ComponentNamespace}}
-	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &namespace, func() error {
-		MutateVerrazzanoMonitoringNamespace(ctx, &namespace)
-		return nil
-	}); err != nil {
-		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)
-	}
-	return nil
-}
-
-// MutateVerrazzanoMonitoringNamespace modifies the given namespace for the Monitoring subcomponents
-// with the appropriate labels, in one location. If the provided namespace is not the Verrazzano
-// monitoring namespace, it is ignored.
-func MutateVerrazzanoMonitoringNamespace(ctx spi.ComponentContext, namespace *corev1.Namespace) {
-	if namespace.Name != constants.VerrazzanoMonitoringNamespace {
-		return
-	}
-	if namespace.Labels == nil {
-		namespace.Labels = map[string]string{}
-	}
-	namespace.Labels[globalconst.LabelVerrazzanoNamespace] = constants.VerrazzanoMonitoringNamespace
-
-	istio := ctx.EffectiveCR().Spec.Components.Istio
-	if istio != nil && istio.IsInjectionEnabled() {
-		namespace.Labels[globalconst.LabelIstioInjection] = "enabled"
-	}
 }
 
 func generateOverridesFile(ctx spi.ComponentContext, contents []byte) (string, error) {

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
@@ -6,9 +6,11 @@ package operator
 import (
 	"context"
 	"fmt"
-	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"path/filepath"
+
+	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
@@ -171,7 +173,7 @@ func (c jaegerOperatorComponent) ValidateUpdateV1Beta1(old *installv1beta1.Verra
 func (c jaegerOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	ctx.Log().Debugf("Jaeger pre-upgrade")
 	// Create the verrazzano-monitoring namespace if not already created
-	if err := ensureVerrazzanoMonitoringNamespace(ctx); err != nil {
+	if err := common.EnsureVerrazzanoMonitoringNamespace(ctx); err != nil {
 		return err
 	}
 	installed, err := helmcli.IsReleaseInstalled(ComponentName, ComponentNamespace)

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
@@ -264,9 +264,9 @@ func TestAppendOverrides(t *testing.T) {
 			tempFilePath := kvs[0].Value
 			files = append(files, tempFilePath)
 			_, err = os.Stat(tempFilePath)
-			asserts.NoError(err, "Unexpected error checking for temp file %s: %s", tempFilePath, err.Error())
+			asserts.NoError(err, "Unexpected error checking for temp file %s: %v", tempFilePath, err)
 			err = cleanFile(tempFilePath)
-			asserts.NoError(err, "Unexpected error when cleaning up temp files %s: %s", tempFilePath, err.Error())
+			asserts.NoError(err, "Unexpected error when cleaning up temp files %s: %v", tempFilePath, err)
 
 			if test.name == "OverrideMetricsStorageType" {
 				asserts.Equal(kvs[1].Key, prometheusServerField)

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_test.go
@@ -5,11 +5,12 @@ package operator
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -263,8 +264,9 @@ func TestAppendOverrides(t *testing.T) {
 			tempFilePath := kvs[0].Value
 			files = append(files, tempFilePath)
 			_, err = os.Stat(tempFilePath)
-			asserts.NoError(err, "Unexpected error checking for temp file %s: %s", tempFilePath, err)
-			cleanFile(tempFilePath)
+			asserts.NoError(err, "Unexpected error checking for temp file %s: %s", tempFilePath, err.Error())
+			err = cleanFile(tempFilePath)
+			asserts.NoError(err, "Unexpected error when cleaning up temp files %s: %s", tempFilePath, err.Error())
 
 			if test.name == "OverrideMetricsStorageType" {
 				asserts.Equal(kvs[1].Key, prometheusServerField)
@@ -291,16 +293,6 @@ func cleanFile(file string) error {
 func fileExists(name string) bool {
 	_, err := os.Stat(name)
 	return !os.IsNotExist(err)
-}
-
-// TestEnsureMonitoringOperatorNamespace asserts the verrazzano-monitoring namespaces can be created
-func TestEnsureMonitoringOperatorNamespace(t *testing.T) {
-	// GIVEN a Verrazzano CR with Jaeger Component enabled,
-	// WHEN we call the ensureVerrazzanoMonitoringNamespace function,
-	// THEN no error is returned.
-	ctx := spi.NewFakeContext(fake.NewClientBuilder().WithScheme(testScheme).Build(), jaegerEnabledCR, nil, false)
-	err := ensureVerrazzanoMonitoringNamespace(ctx)
-	assert.NoError(t, err)
 }
 
 // TestBuildJaegerDNSNames asserts if the generated DNS name for Jaeger is correct.

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,9 +37,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Adapter", ComponentNamespace)
-	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	ns := common.GetVerrazzanoMonitoringNamespace()
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
-		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
+		common.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,9 +39,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for Kube State Metrics", ComponentNamespace)
-	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	ns := common.GetVerrazzanoMonitoringNamespace()
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
-		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
+		common.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	corev1 "k8s.io/api/core/v1"
@@ -48,9 +48,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Node-Exporter", ComponentNamespace)
-	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	ns := common.GetVerrazzanoMonitoringNamespace()
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
-		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
+		common.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -18,7 +18,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
@@ -77,9 +76,9 @@ func preInstallUpgrade(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating/updating namespace %s for the Prometheus Operator", ComponentNamespace)
-	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	ns := common.GetVerrazzanoMonitoringNamespace()
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
-		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
+		common.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,9 +39,9 @@ func preInstall(ctx spi.ComponentContext) error {
 
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Prometheus Pushgateway Component", ComponentNamespace)
-	ns := prometheus.GetVerrazzanoMonitoringNamespace()
+	ns := common.GetVerrazzanoMonitoringNamespace()
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), ns, func() error {
-		prometheus.MutateVerrazzanoMonitoringNamespace(ctx, ns)
+		common.MutateVerrazzanoMonitoringNamespace(ctx, ns)
 		return nil
 	}); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create or update the %s namespace: %v", ComponentNamespace, err)

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -75,10 +75,12 @@ func verrazzanoPreUpgrade(ctx spi.ComponentContext) error {
 	if err := common.EnsureVMISecret(ctx.Client()); err != nil {
 		return err
 	}
-	// Auth policies and Network policies created in the helm chart requires verrazzano-monitoring namespace
-	ctx.Log().Debugf("Creating namespace %s for the Verrazzano component", constants.VerrazzanoMonitoringNamespace)
-	if err := common.EnsureVerrazzanoMonitoringNamespace(ctx); err != nil {
-		return err
+	if vzconfig.IsJaegerOperatorEnabled(ctx.EffectiveCR()) || vzconfig.IsPrometheusOperatorEnabled(ctx.EffectiveCR()) {
+		// Auth policies and Network policies created in the helm chart requires verrazzano-monitoring namespace
+		ctx.Log().Debugf("Creating namespace %s for the Verrazzano component", constants.VerrazzanoMonitoringNamespace)
+		if err := common.EnsureVerrazzanoMonitoringNamespace(ctx); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano.go
@@ -387,6 +387,7 @@ func removeNodeExporterService(ctx spi.ComponentContext) {
 	}
 }
 
+// ensureVerrazzanoMonitoringNamespace ensures that the verrazzano-monitoring namespace is created with the right labels.
 func ensureVerrazzanoMonitoringNamespace(ctx spi.ComponentContext) error {
 	// Create the verrazzano-monitoring namespace
 	ctx.Log().Debugf("Creating namespace %s for the Verrazzano Operator", constants.VerrazzanoMonitoringNamespace)

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -5,6 +5,8 @@ package verrazzano
 
 import (
 	"fmt"
+	"path/filepath"
+
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -21,7 +23,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -112,7 +113,7 @@ func (c verrazzanoComponent) PreUpgrade(ctx spi.ComponentContext) error {
 			return err
 		}
 	}
-	return verrazzanoPreUpgrade(ctx, ComponentNamespace)
+	return verrazzanoPreUpgrade(ctx)
 }
 
 // Upgrade Verrazzano component upgrade processing


### PR DESCRIPTION
VZ-6921 When Verrazzano is upgraded with Jaeger Operator enabled in the CR, then the upgrade fails as the verrazzano component upgrade was failing. This was due to Jaeger Auth and network policy (added as part of the Verrazzano chart templates) are created in newly created `verrazzano-monitoring` namespace. This issue is fixed by creating the required namespace as part of the pre-upgrade part of the Verrazzano component.
