### PR TITLE
VZ-6937: check for resp being null in helidon example test

### DIFF
--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -208,7 +208,7 @@ func appEndpointAccessible(url string, hostname string) bool {
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		t.Logs.Errorf("Unexpected error=%v", err)
-		if resp.Body != nil {
+		if resp != nil && resp.Body != nil {
 			bodyRaw, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)


### PR DESCRIPTION
Fixes helidon_example_test to fix build failure

