### PR TITLE
VZ-6064: Upgrade path tests with external opensearch installation 

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -194,6 +194,29 @@ pipeline {
                         }
                     }
                 }
+                stage('Upgrade Path Tests with External ES') {
+                    steps {
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                def latestRelease = getLatestReleaseVersion()
+                                build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
+                                        booleanParam(name: 'EXTERNAL_ELASTICSEARCH', value: true),
+                                        string(name: 'VERSION_FOR_INSTALL', value: latestRelease),
+                                        string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
+                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
+                                    ], wait: true
+                            }
+                        }
+                    }
+                }
                 stage('Uninstall Tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {


### PR DESCRIPTION
This PR integrates upgrade path tests with external opensearch installation with the push triggered acceptance tests. 