### PR TITLE
Update CLI cluster command to new KIND fork version and CNE default image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ tests/e2e/**/*.test
 **/.DS_Store
 **/.vscode
 ATTRIBUTION-HELPER-DEPS
+**/.terraform

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,20 +1,25 @@
 === Public License Template ===
 github.com/verrazzano/verrazzano
 -------- Copyrights
-Copyright (c) 2020, 2021, Oracle America, Inc. and its affiliates.
+Copyright (c) 2020, 2022, Oracle America, Inc. and its affiliates.
 Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 Copyright (c) 2021, Oracle and/or its affiliates.
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
-Copyright (c) 2020, 2022, Oracle and/or its affiliates.
-Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (C) 2022, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
 Copyright (C) 2022, Oracle and/or its affiliates.' | cat - generated_assets.go > tmp && mv tmp generated_assets.go
 Copyright 2020, Oracle Corporation and/or its affiliates.
 Copyright (c) 2015-2021 Bitnami
+Copyright (c) 2019 Oracle and/or its affiliates.
+Copyright (c) 2019 Oracle and/or its associates. All rights reserved.
+Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+Copyright (c) 2019, 2020 Oracle and/or its associates. All rights reserved.
+Copyright (c) 2019, 2021 Oracle and/or its associates.
 Copyright (c) 2020, Oracle and/or its affiliates.
 Copyright (c) 2021, Oracle and/or its affiliates.")
 Copyright (c) 2021, Oracle and/or its affiliates. -->")
@@ -49,10 +54,10 @@ github.com/google/cel-go
 -------- Copyrights
 Copyright 2019 Google LLC
 Copyright 2021 Google LLC
-Copyright 2020 Google LLC
-Copyright 2018 Google LLC
-Copyright 2022 Google LLC
 Copyright (c) 2018 The Go Authors. All rights reserved.
+Copyright 2020 Google LLC
+Copyright 2022 Google LLC
+Copyright 2018 Google LLC
 
 -------- Dependencies Summary
 github.com/google/cel-go
@@ -379,8 +384,8 @@ cloud.google.com/go/compute
 -------- Copyrights
 Copyright 2022 Google LLC
 Copyright 2021 Google LLC
-Copyright 2018 Google LLC
 Copyright 2016 Google LLC
+Copyright 2018 Google LLC
 Copyright 2014 Google LLC
 
 -------- Dependency
@@ -392,8 +397,8 @@ Copyright 2014 Alexander Okoli
 github.com/crossplane/crossplane-runtime
 -------- Copyrights
 Copyright 2019 The Crossplane Authors.
-Copyright 2020 The Crossplane Authors.
 Copyright 2016 The Crossplane Authors. All rights reserved.
+Copyright 2020 The Crossplane Authors.
 
 -------- Dependency
 github.com/crossplane/oam-kubernetes-runtime
@@ -448,10 +453,10 @@ github.com/golang/mock
 -------- Copyrights
 Copyright 2011 Google Inc.
 Copyright 2020 Google LLC
-Copyright 2020 Google Inc.
 Copyright 2010 Google Inc.
-Copyright 2019 Google LLC
+Copyright 2020 Google Inc.
 Copyright 2012 Google Inc.
+Copyright 2019 Google LLC
 
 -------- Dependency
 github.com/google/btree
@@ -483,8 +488,6 @@ github.com/jetstack/cert-manager
 -------- Copyrights
 Copyright 2020 The cert-manager Authors.
 Copyright 2021 The cert-manager Authors.
-Copyright 2022 The cert-manager Authors.
-Copyright 2015 The Kubernetes Authors.
 Copyright (c) 2014 Alex Saskevich
 Copyright (c) 2021 Microsoft
 Copyright (c) 2015 Microsoft Corporation
@@ -610,6 +613,8 @@ Copyright 2014 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors
 Copyright (c) 2014 Sam Ghods
 Copyright (c) 2015, 2018, 2019 Opsmate, Inc. All rights reserved.
+Copyright 2022 The cert-manager Authors.
+Copyright 2015 The Kubernetes Authors.
 Copyright (c) 2015-2017 Sebastian Erhart
 Copyright 2017 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
@@ -617,9 +622,9 @@ Copyright 2016 The Kubernetes Authors.
 -------- Dependency
 github.com/matttproud/golang_protobuf_extensions
 -------- Copyrights
-Copyright 2016 Matt T. Proud
-Copyright 2013 Matt T. Proud
 Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+Copyright 2013 Matt T. Proud
+Copyright 2016 Matt T. Proud
 -------- Notices
 Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 
@@ -629,8 +634,8 @@ github.com/moby/spdystream
 -------- Copyrights
 Copyright 2014-2021 Docker Inc.
 Copyright 2013-2021 Docker, inc. Released under the [Apache 2.0 license](LICENSE).
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 -------- Notices
 SpdyStream
 Copyright 2014-2021 Docker Inc.
@@ -671,17 +676,17 @@ Copyright 2021 The prometheus-operator Authors
 github.com/prometheus/client_golang
 -------- Copyrights
 Copyright 2018 The Prometheus Authors
-Copyright 2015 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2014 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
 Copyright 2012-2015 The Prometheus Authors
 Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
 Copyright 2010 The Go Authors
 Copyright 2013 Matt T. Proud
+Copyright 2015 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
 Copyright 2022 The Prometheus Authors
 Copyright (c) 2013, The Prometheus Authors
 -------- Notices
@@ -726,10 +731,10 @@ SoundCloud Ltd. (http://soundcloud.com/).
 -------- Dependency
 github.com/prometheus/common
 -------- Copyrights
-Copyright 2018 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
 Copyright 2015 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
 Copyright 2014 The Prometheus Authors
 Copyright 2020 The Prometheus Authors
 Copyright (c) 2011, Open Knowledge Foundation Ltd.
@@ -748,13 +753,13 @@ SoundCloud Ltd. (http://soundcloud.com/).
 github.com/prometheus/procfs
 -------- Copyrights
 Copyright 2019 The Prometheus Authors
-Copyright 2018 The Prometheus Authors
 Copyright 2017 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2014 Prometheus Team
-Copyright 2021 The Prometheus Authors
-Copyright 2017 Prometheus Team
 Copyright 2014-2015 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2014 Prometheus Team
+Copyright 2020 The Prometheus Authors
+Copyright 2017 Prometheus Team
 -------- Notices
 procfs provides functions to retrieve system, kernel and process
 metrics from the pseudo-filesystem proc.
@@ -770,33 +775,32 @@ github.com/spf13/afero
 -------- Copyrights
 Copyright © 2014 Steve Francia <spf@spf13.com>.
 Copyright 2013 tsuru authors. All rights reserved.
-Copyright © 2021 Vasily Ovchinnikov <vasily@remerge.io>.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright © 2016 Steve Francia <spf@spf13.com>.
 Copyright © 2018 Steve Francia <spf@spf13.com>.
+Copyright © 2021 Vasily Ovchinnikov <vasily@remerge.io>.
 Copyright © 2015 Steve Francia <spf@spf13.com>.
-Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
 Copyright 2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
 
 -------- Dependency
 github.com/spf13/cobra
 -------- Copyrights
 Copyright © 2020 Steve Francia <spf@spf13.com>
 Copyright © 2015 Steve Francia <spf@spf13.com>.
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
 Copyright © 2013 Steve Francia <spf@spf13.com>.
 Copyright 2015 Red Hat Inc. All rights reserved.
 Copyright 2016 French Ben. All rights reserved.
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
 
 -------- Dependency
 github.com/verrazzano/kind
 -------- Copyrights
 Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 Copyright (c) 2015-2018 gimme contributors
 Copyright 2020 The Kubernetes Authors.
-Copyright (c) 2022, Oracle and/or its affiliates.
-Copyright 2022 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
@@ -810,13 +814,13 @@ gomodules.xyz/jsonpatch/v2
 google.golang.org/genproto
 -------- Copyrights
 Copyright 2020 Google LLC.
-Copyright 2020 Google LLC
 Copyright 2021 Google LLC
-Copyright 2022 Google LLC
-Copyright 2015 Google LLC
-Copyright 2019 Google LLC.
-Copyright 2016 Google LLC
+Copyright 2020 Google LLC
 Copyright 2018 Google LLC
+Copyright 2019 Google LLC.
+Copyright 2015 Google LLC
+Copyright 2022 Google LLC
+Copyright 2016 Google LLC
 Copyright 2017 Google Inc.
 Copyright 2018 Google Inc.
 Copyright 2016 Google Inc.
@@ -834,9 +838,9 @@ Copyright 2021 gRPC authors.
 Copyright 2019 gRPC authors.
 Copyright 2017 gRPC authors.
 Copyright 2020 gRPC authors.
-Copyright 2018 gRPC authors.
 Copyright 2016 gRPC authors.
 Copyright 2015 The gRPC Authors
+Copyright 2018 gRPC authors.
 Copyright 2022 gRPC authors.
 Copyright 2018 The gRPC Authors
 Copyright 2015 gRPC authors.
@@ -871,8 +875,8 @@ Copyright 2015 Unknwon
 -------- Dependency
 gopkg.in/yaml.v2
 -------- Copyrights
-Copyright (c) 2006 Kirill Simonov
 Copyright 2011-2016 Canonical Ltd.
+Copyright (c) 2006 Kirill Simonov
 -------- Notices
 Copyright 2011-2016 Canonical Ltd.
 
@@ -907,8 +911,8 @@ Copyright (c) 2012, Martin Angers
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2015-2017 Nick Galbreath
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-Copyright 2014-2015 Docker, Inc.
 Copyright (c) 2012 Elazar Leibovich. All rights reserved.
+Copyright 2014-2015 Docker, Inc.
 Copyright (c) 2012,2013 Ernest Micklei
 Copyright (c) 2014, Evan Phoenix
 Copyright (c) 2012 fsnotify Authors. All rights reserved.
@@ -950,24 +954,24 @@ istio.io/client-go
 Copyright 2019 Istio Authors
 Copyright 2016-2020 Istio Authors
 Copyright 2015 Microsoft Corporation
+Copyright (c) 2013 TOML authors
+Copyright (c) 2015 The New York Times Company
+Copyright (c) 2012, Martin Angers
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2015-2017 Nick Galbreath
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 Copyright (c) 2012 Dave Grijalva
-Copyright (c) 2013 TOML authors
-Copyright (c) 2012 Elazar Leibovich. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright (c) 2012 fsnotify Authors. All rights reserved.
 Copyright 2014-2015 Docker, Inc.
-Copyright (c) 2014 Sam Ghods
-Copyright (c) 2014, Evan Phoenix
+Copyright (c) 2012 Elazar Leibovich. All rights reserved.
 Copyright (c) 2012,2013 Ernest Micklei
+Copyright (c) 2014, Evan Phoenix
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
+Copyright (c) 2014 Sam Ghods
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright (c) 2015 The New York Times Company
-Copyright (c) 2012, Martin Angers
-Copyright 2009-2017 Andrea Leofreddi <a.leofreddi@vleo.net>. All rights reserved.
-Copyright (c) 2015-2017 Nick Galbreath
 Copyright 2010-2017 Mike Bostock
+Copyright 2009-2017 Andrea Leofreddi <a.leofreddi@vleo.net>. All rights reserved.
 Copyright (c) 2009,2014 Google Inc. All rights reserved.
 Copyright 2016, Google Inc.
 Copyright 2012-2013 Rackspace, Inc.
@@ -985,9 +989,9 @@ Copyright (c) 2011 Keith Rarick
 Copyright (c) 2016 Mail.Ru Group
 Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved.
 Copyright (c) 2013-2014 Onsi Fakhouri
+Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright (c) 2011-2012 Peter Bourgon
 Copyright (c) 2013, Patrick Mezard
-Copyright (c) 2016 Yasuhiro Matsumoto
 Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2014 Stretchr, Inc.
 Copyright (c) 2017-2018 objx contributors
@@ -1030,18 +1034,18 @@ Copyright 2018 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 Copyright 2020 Google LLC
 Copyright 2022 Google LLC
-Copyright 2016 The Kubernetes Authors.
 
 -------- Dependency
 k8s.io/apimachinery
 -------- Copyrights
 Copyright 2021 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
@@ -1054,13 +1058,13 @@ Copyright 2009 The Go Authors. All rights reserved.
 k8s.io/apiserver
 -------- Copyrights
 Copyright 2021 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
 
 -------- Dependency
@@ -1070,8 +1074,8 @@ Copyright 2021 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 
@@ -1082,9 +1086,9 @@ Copyright 2021 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -1102,9 +1106,9 @@ k8s.io/component-base
 -------- Copyrights
 Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
@@ -1112,9 +1116,9 @@ Copyright 2020 The Kubernetes Authors.
 -------- Dependency
 k8s.io/klog/v2
 -------- Copyrights
+Copyright 2013 Google Inc. All Rights Reserved.
 Copyright 2022 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
-Copyright 2013 Google Inc. All Rights Reserved.
 Copyright 2014 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
@@ -1126,16 +1130,16 @@ k8s.io/kube-aggregator
 Copyright 2019 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 
 -------- Dependency
 k8s.io/kube-openapi
 -------- Copyrights
 Copyright 2018 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
@@ -1149,8 +1153,8 @@ k8s.io/utils
 Copyright 2018 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
@@ -1174,15 +1178,15 @@ Copyright 2014 The Kubernetes Authors.
 -------- Dependency
 sigs.k8s.io/controller-runtime
 -------- Copyrights
-Copyright 2020 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
+Copyright 2018 The Kubernetes authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
 Copyright 2017 The Kubernetes Authors.
-Copyright 2018 The Kubernetes authors.
-Copyright 2014 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
 
 -------- Dependency
 sigs.k8s.io/kustomize/api
@@ -1199,10 +1203,10 @@ Copyright 2019 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
-Copyright 2011-2016 Canonical Ltd.
 Copyright (c) 2006-2010 Kirill Simonov
 Copyright (c) 2006-2011 Kirill Simonov
 Copyright (c) 2011-2019 Canonical Ltd
+Copyright 2011-2016 Canonical Ltd.
 Copyright (c) 2018 QRI, Inc.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2014 The Kubernetes Authors.
@@ -1613,11 +1617,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 github.com/oracle/oci-go-sdk/v53
 -------- Copyrights
 Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.
+Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
 Copyright © 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 Copyright © 2013 The Go Authors. All rights reserved.
 Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 Copyright (c) 2013 The Go Authors. All rights reserved.
-Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
 -------- Notices
@@ -1716,13 +1720,13 @@ END OF TERMS AND CONDITIONS
 sigs.k8s.io/json
 -------- Copyrights
 Copyright 2021 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 
 -------- Dependencies Summary
 sigs.k8s.io/json
@@ -1973,9 +1977,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 github.com/davecgh/go-spew
 -------- Copyrights
 Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2013 Dave Collins <dave@davec.name>
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2013 Dave Collins <dave@davec.name>
+Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
 
 -------- Dependencies Summary
 github.com/davecgh/go-spew
@@ -2401,12 +2405,12 @@ Copyright 2010 The Go Authors. All rights reserved.
 -------- Dependency
 github.com/emicklei/go-restful
 -------- Copyrights
-Copyright 2013 Ernest Micklei. All rights reserved.
+Copyright (c) 2012,2013 Ernest Micklei
 Copyright 2015 Ernest Micklei. All rights reserved.
+Copyright 2013 Ernest Micklei. All rights reserved.
 Copyright 2014 Ernest Micklei. All rights reserved.
 Copyright 2018 Ernest Micklei. All rights reserved.
 Copyright 2021 Ernest Micklei. All rights reserved.
-Copyright (c) 2012,2013 Ernest Micklei
 
 -------- Dependency
 github.com/gertd/go-pluralize
@@ -2502,9 +2506,9 @@ Copyright (c) 2011-2012 Peter Bourgon
 -------- Dependency
 github.com/shopspring/decimal
 -------- Copyrights
+Copyright 2009 The Go Authors. All rights reserved.
 Copyright (c) 2015 Spring, Inc.
 Copyright (c) 2013 Oguz Bilgic
-Copyright 2009 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/sony/gobreaker
@@ -2514,8 +2518,8 @@ Copyright 2015 Sony Corporation
 -------- Dependency
 github.com/spf13/cast
 -------- Copyrights
-Copyright (c) 2014 Steve Francia
 Copyright © 2014 Steve Francia <spf@spf13.com>.
+Copyright (c) 2014 Steve Francia
 Copyright 2011 The Go Authors. All rights reserved.
 
 -------- Dependency
@@ -2528,10 +2532,10 @@ Copyright (c) 2014 Steve Francia
 github.com/spf13/viper
 -------- Copyrights
 Copyright (c) 2014 Steve Francia
+Copyright (c) 2017 Canonical Ltd.
+Copyright © 2015 Steve Francia <spf@spf13.com>.
 Copyright © 2014 Steve Francia <spf@spf13.com>.
 Copyright © 2016 Steve Francia <spf@spf13.com>.
-Copyright © 2015 Steve Francia <spf@spf13.com>.
-Copyright (c) 2017 Canonical Ltd.
 
 -------- Dependency
 github.com/stoewer/go-strcase
@@ -2577,8 +2581,8 @@ go.uber.org/zap
 -------- Copyrights
 Copyright (c) 2016-2017 Uber Technologies, Inc.
 Copyright (c) 2016 Uber Technologies, Inc.
-Copyright (c) 2020 Uber Technologies, Inc.
 Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
 Copyright (c) 2021 Uber Technologies, Inc.
 Copyright (c) 2016, 2017 Uber Technologies, Inc.
 Copyright (c) 2018 Uber Technologies, Inc.
@@ -2658,10 +2662,10 @@ Copyright (c) 2012 The Go Authors. All rights reserved.
 -------- Dependency
 github.com/fsnotify/fsnotify
 -------- Copyrights
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
@@ -2673,18 +2677,18 @@ github.com/gogo/protobuf
 -------- Copyrights
 Copyright (c) 2015, The GoGo Authors. All rights reserved.
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
-Copyright 2016 The Go Authors.  All rights reserved.
-Copyright 2015 The Go Authors.  All rights reserved.
-Copyright (c) 2018, The GoGo Authors. All rights reserved.
-Copyright 2011 The Go Authors.  All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2017 The Go Authors.  All rights reserved.
+Copyright 2016 The Go Authors.  All rights reserved.
+Copyright 2010 The Go Authors.
+Copyright 2015 The Go Authors.  All rights reserved.
+Copyright 2011 The Go Authors.  All rights reserved.
+Copyright (c) 2018, The GoGo Authors. All rights reserved.
 Copyright 2018 The Go Authors.  All rights reserved.
 Copyright (c) 2016, The GoGo Authors. All rights reserved.
+Copyright 2017 The Go Authors.  All rights reserved.
 Copyright 2014 The Go Authors.  All rights reserved.
 Copyright 2012 The Go Authors.  All rights reserved.
 Copyright 2013 The Go Authors.  All rights reserved.
-Copyright 2010 The Go Authors.
 Copyright (c) 2019, The GoGo Authors. All rights reserved.
 Copyright (c) 2017, The GoGo Authors. All rights reserved.
 Copyright (c) 2015, The GoGo Authors.  rights reserved.
@@ -2692,30 +2696,31 @@ Copyright (c) 2015, The GoGo Authors.  rights reserved.
 -------- Dependency
 github.com/golang/protobuf
 -------- Copyrights
+Copyright 2010 The Go Authors.  All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors.  All rights reserved.
-Copyright 2010 The Go Authors.  All rights reserved.
 
 -------- Dependency
 github.com/google/go-cmp
 -------- Copyrights
-Copyright 2019, The Go Authors. All rights reserved.
-Copyright 2017, The Go Authors. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright 2018, The Go Authors. All rights reserved.
 Copyright 2020, The Go Authors. All rights reserved.
+Copyright 2017, The Go Authors. All rights reserved.
+Copyright 2018, The Go Authors. All rights reserved.
+Copyright 2019, The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/google/go-github/v45
 -------- Copyrights
+Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
 Copyright 2020 The go-github AUTHORS. All rights reserved.
 Copyright 2021 The go-github AUTHORS. All rights reserved.
 Copyright 2013 The go-github AUTHORS. All rights reserved.
@@ -2723,16 +2728,15 @@ Copyright 2014 The go-github AUTHORS. All rights reserved.
 Copyright 2016 The go-github AUTHORS. All rights reserved.
 Copyright 2019 The go-github AUTHORS. All rights reserved.
 Copyright 2017 The go-github AUTHORS. All rights reserved.
-Copyright 2015 The go-github AUTHORS. All rights reserved.
-Copyright 2022 The go-github AUTHORS. All rights reserved.
 Copyright 2018 The go-github AUTHORS. All rights reserved.
-Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
+Copyright 2022 The go-github AUTHORS. All rights reserved.
+Copyright 2015 The go-github AUTHORS. All rights reserved.
 
 -------- Dependency
 github.com/google/go-querystring
 -------- Copyrights
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright (c) 2013 Google. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/google/uuid
@@ -2762,31 +2766,31 @@ Copyright 2009 The Go Authors. All rights reserved.
 -------- Dependency
 github.com/spf13/pflag
 -------- Copyrights
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
 Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 
 -------- Dependency
 golang.org/x/crypto
 -------- Copyrights
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 Copyright (c) 2019 The Go Authors. All rights reserved.
+Copyright (c) 2021 The Go Authors. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
 Copyright (c) 2020 The Go Authors. All rights reserved.
-Copyright (c) 2021 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
 -------- Patents
@@ -2850,17 +2854,17 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/net
 -------- Copyrights
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright (C) 2009 Apple Inc. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright (C) 2009 Apple Inc. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
@@ -2896,12 +2900,12 @@ golang.org/x/oauth2
 -------- Copyrights
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2017 The oauth2 Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2015 The oauth2 Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2022 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
@@ -2911,18 +2915,18 @@ Copyright 2018 The oauth2 Authors. All rights reserved.
 -------- Dependency
 golang.org/x/sys
 -------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2022 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
@@ -2956,9 +2960,9 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/term
 -------- Copyrights
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 -------- Patents
@@ -2989,8 +2993,8 @@ shall terminate as of the date such litigation is filed.
 -------- Dependency
 golang.org/x/text
 -------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
@@ -3069,9 +3073,9 @@ Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors.  All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright © 1994-1999 Lucent Technologies Inc.  All rights reserved.
 Copyright © 1995-1997 C H Forsyth (forsyth@terzarima.net)
@@ -3116,8 +3120,8 @@ golang.org/x/xerrors
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
 Copyright (c) 2019 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
 -------- Patents
 Additional IP Rights Grant (Patents)
 
@@ -3392,8 +3396,8 @@ Copyright (C) 2020, Oracle and/or its affiliates.
 Copyright 2019 The Kubernetes Authors.
 Copyright (C) 2022, Oracle and/or its affiliates.
 Copyright (c) 2022, Oracle and/or its affiliates.
-Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
+Copyright (C) 2021, 2022, Oracle and/or its affiliates.
 Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 
@@ -3685,4 +3689,4 @@ License:
 
 === ATTRIBUTION-HELPER-GENERATED:
 === Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-51-g062e3964 GitCommit:062e3964c5761de4ac8015d8019bb8814d4a12fd GitTreeState:clean BuildDate:2022-08-19T20:24:46Z GoVersion:go1.17.8 Compiler:gc Platform:darwin/amd64}
-=== License file based on go.mod with md5 sum: 91af86e457faa7befbf4d7130bba2508
+=== License file based on go.mod with md5 sum: c3d922edf4bb5dcc07885567b70dd557

--- a/go.mod
+++ b/go.mod
@@ -178,5 +178,5 @@ replace (
 	golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.2
-	sigs.k8s.io/kind => github.com/verrazzano/kind v0.14.1-0.20220829220959-81d706e29010
+	sigs.k8s.io/kind => github.com/verrazzano/kind v0.14.1-0.20220901151917-d1f46433d223
 )

--- a/go.sum
+++ b/go.sum
@@ -1312,8 +1312,8 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/verrazzano/kind v0.14.1-0.20220829220959-81d706e29010 h1:uAw2eJza9yhQfSLsteKsNRAdlY1PyiQLnLvEGzf/fUI=
-github.com/verrazzano/kind v0.14.1-0.20220829220959-81d706e29010/go.mod h1:k2A8wzCSRpQUmPPrKhLGe8TN2DkGVS1Sn/7kTmYSttY=
+github.com/verrazzano/kind v0.14.1-0.20220901151917-d1f46433d223 h1:mlP5wCdzSMIEDXFshfJPY/1MldF9iDSrCz33/n6637s=
+github.com/verrazzano/kind v0.14.1-0.20220901151917-d1f46433d223/go.mod h1:t5GndzzvtTW702bHZ/6dpkbd/eC4SaTenEmivLVnBKA=
 github.com/verrazzano/pkg v0.0.2/go.mod h1:l9utTv9KBQZlJI/HYnw2NQwisYTeHeHl82XOlCiZygM=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.29-0.20220810134448-c6e8df57abb2 h1:eBRnz7U/thF3u7jlUztyapqNaOT5023CISdOO9nOfys=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.29-0.20220810134448-c6e8df57abb2/go.mod h1:oA+BTeIz1HtMU91xR0ak+d+TLax6oESkXuYvxZBGugo=

--- a/pkg/capi/kind_bootstrap_provider.go
+++ b/pkg/capi/kind_bootstrap_provider.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultCNEBootstrapNodeImage  = "ghcr.io/verrazzano/kind-ocne:v0.14.0-20220829221147-81d706e2"
+	defaultCNEBootstrapNodeImage  = "ghcr.io/verrazzano/kind-ocne:v0.14.0-20220901152106-d1f46433"
 	defaultKindBootstrapNodeImage = "kindest/node:v1.24.0"
 
 	defaultCNEBootstrapConfig = `kind: Cluster


### PR DESCRIPTION
Take up API new version from the VZ KinD fork, and a new default OCNE image
- Also add `.terraform` dirs to the .gitignores list