### PR TITLE
VZ-6956.  Restrict OKE clusters to single-AD regions in HA rolling upgrade pipeline

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -6,8 +6,8 @@ def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def TESTS_FAILED = false
 
-def availableRegions = [ "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1",
-                         "eu-zurich-1", "me-jeddah-1", "sa-saopaulo-1", "uk-london-1" ]
+def availableRegions = [ "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1",
+                         "eu-zurich-1", "me-jeddah-1", "sa-saopaulo-1" ]
 def OKE_CLUSTER_PREFIX = ""
 Collections.shuffle(availableRegions)
 
@@ -43,6 +43,10 @@ pipeline {
         string (name: 'GIT_COMMIT_TO_USE',
                 defaultValue: 'NONE',
                 description: 'This is the full git commit hash from the source build to be used for all jobs',
+                trim: true)
+        string (name: 'VERRAZZANO_OPERATOR_IMAGE',
+                defaultValue: 'NONE',
+                description: 'Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the operator.yaml from VZ repo will be leveraged to create VZ platform operator',
                 trim: true)
         choice (name: 'WILDCARD_DNS_DOMAIN',
                 description: 'This is the wildcard DNS domain',
@@ -270,9 +274,6 @@ pipeline {
                         sh """
                             cd ${GO_REPO_PATH}/verrazzano
 
-                            echo "Downloading platform operator from object storage"
-                            oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-operator.yaml
-
                             echo "Create the verrazzano-install namespace"
                             kubectl create namespace verrazzano-install
 
@@ -282,8 +283,16 @@ pipeline {
                             ./tests/e2e/config/scripts/create-image-pull-secret.sh ocr "${OCR_REPO}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}"
                             ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
+                            if [ "NONE" == "${VERRAZZANO_OPERATOR_IMAGE}" ]; then
+                                echo "Downloading platform operator from object storage"
+                                oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/platform-operator.yaml
+                            else
+                                echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"
+                                env IMAGE_PULL_SECRETS=${IMAGE_PULL_SECRET} DOCKER_IMAGE=${VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/platform-operator.yaml
+                            fi
+
                             echo "Installing Verrazzano"
-                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/downloaded-operator.yaml
+                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/platform-operator.yaml
                        """
                     }
                     post {
@@ -294,7 +303,7 @@ pipeline {
                             }
                         }
                         always {
-                            archiveArtifacts artifacts: '**/downloaded-operator.yaml', allowEmptyArchive: true
+                            archiveArtifacts artifacts: '**/platform-operator.yaml', allowEmptyArchive: true
                             // enable debug logging of Verrazzano api istio proxy
                             script {
                                 if (params.ENABLE_API_ENVOY_LOGGING) {


### PR DESCRIPTION
Restrict HA pipeline to single-AD regions
- also add hooks for explicitly setting VPO image
