### PR TITLE
VZ-6955: fix profile output for vz CLI status command 

### DIFF
--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -170,7 +170,11 @@ func runCmdStatus(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		"verrazzano_namespace": vz.Namespace,
 		"verrazzano_version":   vz.Status.Version,
 		"verrazzano_state":     string(vz.Status.State),
-		"install_profile":      string(vz.Spec.Profile),
+	}
+	if vz.Spec.Profile == "" {
+		templateValues["install_profile"] = string(vzapi.Prod)
+	} else {
+		templateValues["install_profile"] = string(vz.Spec.Profile)
 	}
 	addAccessEndpoints(vz.Status.VerrazzanoInstance, templateValues)
 	addComponents(vz.Status.Components, templateValues)


### PR DESCRIPTION
This pull request fixes the vz CLI status output for a default prod profile install.  Before this change the profile would show an empty string.