### PR TITLE
VZ-6960  Integrate Multicluster Jaeger tests to the pipeline.

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -59,7 +59,7 @@ func StartAgent(client client.Client, statusUpdateChannel chan clusters.StatusUp
 		}
 		s.updateDeployment("verrazzano-monitoring-operator")
 		s.configureLogging(false)
-		s.configureJaegerCR()
+		s.configureJaegerCR(false)
 		if !s.AgentReadyToSync() {
 			// there is no admin cluster we are connected to, so nowhere to send any status updates
 			// received - discard them
@@ -138,7 +138,7 @@ func (s *Syncer) ProcessAgentThread() error {
 		// configure logging and force a restart of the fluentd daemonset since CA or registration
 		// were updated
 		s.configureLogging(true)
-		s.configureJaegerCR()
+		s.configureJaegerCR(true)
 	}
 	return nil
 }

--- a/application-operator/mcagent/mcagent_jaeger_test.go
+++ b/application-operator/mcagent/mcagent_jaeger_test.go
@@ -5,6 +5,8 @@ package mcagent
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -20,7 +22,6 @@ import (
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 var deployment = &appsv1.Deployment{
@@ -67,7 +68,7 @@ func TestConfigureJaegerCR(t *testing.T) {
 				Log:         zap.S().With(tt.name),
 				Context:     context.TODO(),
 			}
-			s.configureJaegerCR()
+			s.configureJaegerCR(false)
 			if tt.fields.jaegerCreate {
 				assertJaegerSecret(t, mgdClient, tt.fields.mcRegSecret, tt.fields.mutualTLS)
 				assertJaegerCR(t, mgdClient)

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -487,9 +487,16 @@ pipeline {
                     }
                 }
                 stage("verify-jaeger-apps") {
-                    steps {
-                        script {
-                            parallel verifyJaegerApps()
+                    parallel {
+                        stage('Jaeger Helidon App') {
+                            steps {
+                                runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
+                            }
+                        }
+                        stage('Jaeger Hot R.O.D App') {
+                            steps {
+                                runGinkgo("multicluster/verify-jaeger/hotrod", "${TEST_DUMP_ROOT}/jaeger-hotrod")
+                            }
                         }
                     }
                 }
@@ -1664,18 +1671,6 @@ def verifyExamples() {
         },
         "Coherence Workload": {
             runGinkgo("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/coherence-workload")
-        },
-    ]
-}
-
-
-def verifyJaegerApps() {
-    return [
-        "Jaeger Helidon": {
-            runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
-        },
-        "Jaeger Hotrod": {
-            runGinkgo("multicluster/verify-jaeger/hotrod", "${TEST_DUMP_ROOT}/jaeger-hotrod")
         },
     ]
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -486,6 +486,13 @@ pipeline {
                         }
                     }
                 }
+                stage("verify-jaeger-apps") {
+                    steps {
+                        script {
+                            parallel verifyJaegerApps()
+                        }
+                    }
+                }
                 stage("verify-cert-manager-update") {
                     steps {
                         script {
@@ -1658,6 +1665,12 @@ def verifyExamples() {
         "Coherence Workload": {
             runGinkgo("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/coherence-workload")
         },
+    ]
+}
+
+
+def verifyJaegerApps() {
+    return [
         "Jaeger Helidon": {
             runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
         },

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -487,16 +487,9 @@ pipeline {
                     }
                 }
                 stage("verify-jaeger-apps") {
-                    parallel {
-                        stage('Jaeger Helidon App') {
-                            steps {
-                                runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
-                            }
-                        }
-                        stage('Jaeger Hot R.O.D App') {
-                            steps {
-                                runGinkgo("multicluster/verify-jaeger/hotrod", "${TEST_DUMP_ROOT}/jaeger-hotrod")
-                            }
+                    steps {
+                        script {
+                            parallel verifyJaegerApps()
                         }
                     }
                 }
@@ -1671,6 +1664,18 @@ def verifyExamples() {
         },
         "Coherence Workload": {
             runGinkgo("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/coherence-workload")
+        },
+    ]
+}
+
+
+def verifyJaegerApps() {
+    return [
+        "Jaeger Helidon": {
+            runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
+        },
+        "Jaeger Hotrod": {
+            runGinkgo("multicluster/verify-jaeger/hotrod", "${TEST_DUMP_ROOT}/jaeger-hotrod")
         },
     ]
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1635,6 +1635,9 @@ def verifyInfra() {
         "verify-infra jaeger-install": {
             runGinkgoRandomize('multicluster/verify-jaeger/install')
         },
+        "verify-infra jaeger-system": {
+            runGinkgoRandomize('multicluster/verify-jaeger/system')
+        },
     ]
 }
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -862,12 +862,10 @@ def installVerrazzanoOnCluster(count, verrazzanoConfig) {
                 ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/cluster${count}/pre-install-resources
 
                 if [ "false" == "${params.UPGRADE_VERRAZZANO}" ] ; then
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = true' ${verrazzanoConfig}
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = true' ${verrazzanoConfig}
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = true' ${verrazzanoConfig}
+                    # Update VZ CR to enable required components
+                  ./tests/e2e/config/scripts/multicluster_edit_vz.sh ${count} ${verrazzanoConfig}
                 fi
 
-                echo "Applying \$verrazzanoConfig"
                 kubectl apply -f ${verrazzanoConfig}
 
                 # wait for Verrazzano install to complete
@@ -924,15 +922,10 @@ def upgradeVerrazzano() {
                 cp ${v8oInstallFile} ${v8oUpgradeFile}
                 ${TEST_SCRIPTS_DIR}/process_upgrade_yaml.sh  ${VERRAZZANO_DEV_VERSION}  ${v8oUpgradeFile}
 
-                if [ "true" == "${params.UPGRADE_VERRAZZANO}" ] ; then
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = true' ${v8oUpgradeFile}
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = true' ${v8oUpgradeFile}
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = true' ${v8oUpgradeFile}
-                fi
+                # Update VZ CR to enable required components
+                ./tests/e2e/config/scripts/multicluster_edit_vz.sh ${count} ${v8oUpgradeFile}
 
                 # Do the upgrade
-                echo "Following is the verrazzano CR file with the new version:"
-                cat ${v8oUpgradeFile}
                 kubectl apply -f ${v8oUpgradeFile}
                 # wait for the upgrade to complete
                 kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
@@ -1639,6 +1632,12 @@ def verifyInfra() {
         "verify-infra vmi": {
             runGinkgoRandomize('verify-infra/vmi')
         },
+        "verify-infra jaeger-install": {
+            runGinkgoRandomize('multicluster/verify-jaeger/install')
+        },
+        "verify-infra jaeger-system": {
+            runGinkgoRandomize('multicluster/verify-jaeger/system')
+        },
     ]
 }
 
@@ -1658,6 +1657,12 @@ def verifyExamples() {
         },
         "Coherence Workload": {
             runGinkgo("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/coherence-workload")
+        },
+        "Jaeger Helidon": {
+            runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
+        },
+        "Jaeger Hotrod": {
+            runGinkgo("multicluster/verify-jaeger/hotrod", "${TEST_DUMP_ROOT}/jaeger-hotrod")
         },
     ]
 }

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -486,13 +486,6 @@ pipeline {
                         }
                     }
                 }
-                stage("verify-jaeger-apps") {
-                    steps {
-                        script {
-                            parallel verifyJaegerApps()
-                        }
-                    }
-                }
                 stage("verify-cert-manager-update") {
                     steps {
                         script {
@@ -1665,12 +1658,6 @@ def verifyExamples() {
         "Coherence Workload": {
             runGinkgo("multicluster/workloads/mccoherence", "${TEST_DUMP_ROOT}/coherence-workload")
         },
-    ]
-}
-
-
-def verifyJaegerApps() {
-    return [
         "Jaeger Helidon": {
             runGinkgo("multicluster/verify-jaeger/helidon", "${TEST_DUMP_ROOT}/jaeger-helidon")
         },

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1635,9 +1635,6 @@ def verifyInfra() {
         "verify-infra jaeger-install": {
             runGinkgoRandomize('multicluster/verify-jaeger/install')
         },
-        "verify-infra jaeger-system": {
-            runGinkgoRandomize('multicluster/verify-jaeger/system')
-        },
     ]
 }
 

--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -271,7 +271,7 @@ spec:
       to:
         - operation:
             ports: ["15090", "14269"]
-
+---
 #
 # Istio AuthorizationPolicy for Jaeger Query deployed by Verrazzano
 #

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -20,10 +20,10 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[0].value = "true"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[1].name = "meshConfig.defaultConfig.tracing.sampling"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring:9411"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.tlsSettings.mode"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "ISTIO_MUTUAL' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.tlsSettings.mode"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "ISTIO_MUTUAL' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring.svc.cluster.local.:9411"' "${VZ_CR_FILE}"
 fi
 
 echo "VZ CR to be applied:"

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -20,10 +20,8 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[0].value = "true"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[1].name = "meshConfig.defaultConfig.tracing.sampling"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "global.proxy.holdApplicationUntilProxyStarts"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "true"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring.svc.cluster.local.:9411"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring:9411"' "${VZ_CR_FILE}"
 fi
 
 echo "VZ CR to be applied:"

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -21,7 +21,7 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[1].name = "meshConfig.defaultConfig.tracing.sampling"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.tlsSettings.mode"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "ISTIO_MUTUAL' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "ISTIO_MUTUAL"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring.svc.cluster.local.:9411"' "${VZ_CR_FILE}"
 fi

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -22,7 +22,7 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring:9411"' "${VZ_CR_FILE}"
-    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.tlsSettings"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.tlsSettings.mode"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "ISTIO_MUTUAL' "${VZ_CR_FILE}"
 fi
 

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# This script edits the Verrazzano CR file in yaml format to enable components that are disabled by default,
+# but required by the multi cluster test pipeline.
+set -x
+CLUSTER_COUNT=${1}
+VZ_CR_FILE=${2}
+
+yq -i eval '.spec.components.prometheusAdapter.enabled = true' "${VZ_CR_FILE}"
+yq -i eval '.spec.components.kubeStateMetrics.enabled = true' "${VZ_CR_FILE}"
+yq -i eval '.spec.components.prometheusPushgateway.enabled = true' "${VZ_CR_FILE}"
+yq -i eval '.spec.components.jaegerOperator.enabled = true' "${VZ_CR_FILE}"
+# For managed clusters, enable Jaeger operator and update the istio tracing configuration
+if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
+    yq -i eval '.spec.components.istio.istioInstallArgs[0].name = "meshConfig.enableTracing"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[0].value = "true"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[1].name = "meshConfig.defaultConfig.tracing.sampling"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "global.proxy.holdApplicationUntilProxyStarts"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "true"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring.svc.cluster.local.:9411"' "${VZ_CR_FILE}"
+fi
+
+echo "VZ CR to be applied:"
+cat "${VZ_CR_FILE}"

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -22,6 +22,8 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[1].value = "90.0"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[2].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring:9411"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.tlsSettings"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "ISTIO_MUTUAL' "${VZ_CR_FILE}"
 fi
 
 echo "VZ CR to be applied:"

--- a/tests/e2e/config/scripts/multicluster_edit_vz.sh
+++ b/tests/e2e/config/scripts/multicluster_edit_vz.sh
@@ -24,6 +24,8 @@ if [ "${CLUSTER_COUNT}" -gt 1 ] ; then
     yq -i eval '.spec.components.istio.istioInstallArgs[2].value = "ISTIO_MUTUAL"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[3].name = "meshConfig.defaultConfig.tracing.zipkin.address"' "${VZ_CR_FILE}"
     yq -i eval '.spec.components.istio.istioInstallArgs[3].value = "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring.svc.cluster.local.:9411"' "${VZ_CR_FILE}"
+    yq -i eval '.spec.components.istio.istioInstallArgs[4].name = "global.proxy.holdApplicationUntilProxyStarts"' ${VZ_CR_FILE}
+    yq -i eval '.spec.components.istio.istioInstallArgs[4].value = "true"' ${VZ_CR_FILE}
 fi
 
 echo "VZ CR to be applied:"

--- a/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_test.go
@@ -18,8 +18,6 @@ import (
 const (
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute
-	longPollingInterval  = 30 * time.Second
-	longWaitTimeout      = 10 * time.Minute
 	projectName          = "hello-helidon-jaeger"
 )
 
@@ -138,7 +136,7 @@ var _ = t.Describe("Helidon App with Jaeger Traces", Label("f:jaeger.helidon-wor
 		// THEN we are able to get the traces
 		t.It("traces for the helidon app should be available when queried from Jaeger", func() {
 			validatorFn := pkg.ValidateApplicationTracesInCluster(adminKubeconfig, start, helloHelidonServiceName, managedClusterName)
-			Eventually(validatorFn).WithPolling(longPollingInterval).WithTimeout(longWaitTimeout).Should(BeTrue())
+			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 		})
 
 	})

--- a/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_test.go
@@ -18,13 +18,15 @@ import (
 const (
 	shortPollingInterval = 10 * time.Second
 	shortWaitTimeout     = 5 * time.Minute
-	projectName          = "hello-helidon"
+	longPollingInterval  = 30 * time.Second
+	longWaitTimeout      = 10 * time.Minute
+	projectName          = "hello-helidon-jaeger"
 )
 
 const (
-	testAppComponentFilePath     = "testdata/jaeger/helidon/mc-helidon-tracing-comp.yaml"
-	testAppConfigurationFilePath = "examples/multicluster/hello-helidon/mc-hello-helidon-app.yaml"
-	verrazzanoProjectFilePath    = "examples/multicluster/hello-helidon/verrazzano-project.yaml"
+	testAppComponentFilePath     = "testdata/jaeger/helidon/multicluster/mc-helidon-tracing-comp.yaml"
+	testAppConfigurationFilePath = "testdata/jaeger/helidon/multicluster/mc-helidon-tracing-app.yaml"
+	verrazzanoProjectFilePath    = "testdata/jaeger/helidon/multicluster/helidon-verrazzano-project.yaml"
 )
 
 var (
@@ -33,7 +35,7 @@ var (
 	beforeSuitePassed        = false
 	failed                   = false
 	start                    = time.Now()
-	helloHelidonServiceName  = "hello-helidon-mc"
+	helloHelidonServiceName  = "hello-helidon-jaeger-mc"
 )
 
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
@@ -81,7 +83,7 @@ var _ = t.BeforeSuite(func() {
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 	err := pkg.GenerateTrafficForTraces(projectName, "", "greet", managedKubeconfig)
 	if err != nil {
-		AbortSuite("Unable to send traffic requests to generate traces")
+		pkg.Log(pkg.Error, "Unable to send traffic requests to generate traces")
 	}
 	beforeSuitePassed = true
 })
@@ -136,7 +138,7 @@ var _ = t.Describe("Helidon App with Jaeger Traces", Label("f:jaeger.helidon-wor
 		// THEN we are able to get the traces
 		t.It("traces for the helidon app should be available when queried from Jaeger", func() {
 			validatorFn := pkg.ValidateApplicationTracesInCluster(adminKubeconfig, start, helloHelidonServiceName, managedClusterName)
-			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+			Eventually(validatorFn).WithPolling(longPollingInterval).WithTimeout(longWaitTimeout).Should(BeTrue())
 		})
 
 	})

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -48,11 +48,11 @@ var (
 	// common services running in both admin and managed cluster
 	managedClusterSystemServiceNames = []string{
 		"fluentd.verrazzano-system",
+		"verrazzano-authproxy.verrazzano-system",
 	}
 
 	// services that are common plus the ones unique to admin cluster
 	adminClusterSystemServiceNames = append(managedClusterSystemServiceNames,
-		"verrazzano-authproxy.verrazzano-system",
 		"jaeger-operator-jaeger.verrazzano-monitoring",
 		"system-es-master.verrazzano-system")
 )

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -47,12 +47,12 @@ const (
 var (
 	// common services running in both admin and managed cluster
 	managedClusterSystemServiceNames = []string{
-		"verrazzano-authproxy.verrazzano-system",
 		"fluentd.verrazzano-system",
 	}
 
 	// services that are common plus the ones unique to admin cluster
 	adminClusterSystemServiceNames = append(managedClusterSystemServiceNames,
+		"verrazzano-authproxy.verrazzano-system",
 		"jaeger-operator-jaeger.verrazzano-monitoring",
 		"system-es-master.verrazzano-system")
 )

--- a/tests/testdata/jaeger/helidon/multicluster/helidon-verrazzano-project.yaml
+++ b/tests/testdata/jaeger/helidon/multicluster/helidon-verrazzano-project.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: VerrazzanoProject
+metadata:
+  name: hello-helidon-jaeger
+  namespace: verrazzano-mc
+spec:
+  template:
+    namespaces:
+      - metadata:
+          name: hello-helidon-jaeger
+  placement:
+    clusters:
+      - name: managed1

--- a/tests/testdata/jaeger/helidon/multicluster/mc-helidon-tracing-app.yaml
+++ b/tests/testdata/jaeger/helidon/multicluster/mc-helidon-tracing-app.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: clusters.verrazzano.io/v1alpha1
+kind: MultiClusterApplicationConfiguration
+metadata:
+  name: hello-helidon-appconf
+  namespace: hello-helidon-jaeger
+spec:
+  template:
+    metadata:
+      annotations:
+        version: v1.0.0
+        description: "Hello Helidon application"
+    spec:
+      components:
+        - componentName: hello-helidon-component
+          traits:
+            - trait:
+                apiVersion: oam.verrazzano.io/v1alpha1
+                kind: MetricsTrait
+                spec:
+                  scraper: verrazzano-system/vmi-system-prometheus-0
+            - trait:
+                apiVersion: oam.verrazzano.io/v1alpha1
+                kind: IngressTrait
+                metadata:
+                  name: hello-helidon-ingress
+                spec:
+                  rules:
+                    - paths:
+                        - path: "/"
+                          pathType: Prefix
+  placement:
+    clusters:
+      - name: managed1

--- a/tests/testdata/jaeger/helidon/multicluster/mc-helidon-tracing-comp.yaml
+++ b/tests/testdata/jaeger/helidon/multicluster/mc-helidon-tracing-comp.yaml
@@ -4,6 +4,7 @@ apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: hello-helidon-component
+  namespace: hello-helidon-jaeger
 spec:
   workload:
     apiVersion: oam.verrazzano.io/v1alpha1
@@ -23,11 +24,11 @@ spec:
               image: "ghcr.io/verrazzano/example-helidon-greet-app-v1:1.0.0-1-20220513221156-7da0d32"
               env:
                 - name: "TRACING_SERVICE"
-                  value: "hello-helidon"
+                  value: "hello-helidon-jaeger-mc"
                 - name: "TRACING_PORT"
                   value: "9411"
                 - name: "TRACING_HOST"
-                  value: "jaeger-operator-jaeger-collector.verrazzano-monitoring"
+                  value: "jaeger-verrazzano-managed-cluster-collector.verrazzano-monitoring"
               ports:
                 - containerPort: 8080
                   name: http


### PR DESCRIPTION
VZ-6960 - Jaeger test suite for multicluster was not enabled in the multicluster pipeline due to bugs VZ-6907 and VZ-6921. They are now resolved. So enabling these tests in the multicluster pipeline.

When enabling the tests, I found 2 issues 
VZ-6983 - If cert manager settings are updated in the admin cluster, only the Jaeger secret is updated with no update to the Jaeger CR. This causes error when connecting to the OS in admin cluster using stale certificates.
VZ-6965 - If part of Istio configuration is overridden, then the default values are lost. This bug is observed post build #2990
Current change includes a work around by having all Istio configurations explicitly overridden in the test setup script.