### PR TITLE
VZ-6064: Enable retry for failed jobs, Fix ginkgo race condition

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -500,7 +500,7 @@ pipeline {
             parallel {
                 stage('verify-scripts') {
                     steps {
-                        runGinkgoRandomizeParallel('scripts')
+                        runGinkgoRandomizeParallel('scripts/install')
                     }
                 }
                 stage('verify-infra restapi') {
@@ -1246,7 +1246,8 @@ def runGinkgoRandomize(count, clusterName, testSuitePath) {
                 export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 export CLUSTER_NAME="${clusterName}"
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+                ginkgo build ${testSuitePath}/
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
             """
         }
     }
@@ -1261,7 +1262,8 @@ def runGinkgoRandomizeAdmin(testSuitePath, clusterDumpDirectory) {
             export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
             export DUMP_DIRECTORY="${clusterDumpDirectory}"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            ginkgo build ${testSuitePath}/
+            ginkgo -p --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
         """
     }
 }
@@ -1275,7 +1277,8 @@ def runGinkgoRandomizeSerialAdmin(testSuitePath, clusterDumpDirectory) {
             export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
             export DUMP_DIRECTORY="${clusterDumpDirectory}"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            ginkgo build ${testSuitePath}/
+            ginkgo --randomize-all -v --keep-going --no-color -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
         """
     }
 }
@@ -1288,7 +1291,8 @@ def runGinkgoVerify(testSuitePath, clusterDumpDirectory, skipDeploy, skipUndeplo
             export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/1/kube_config"
             export DUMP_DIRECTORY="${clusterDumpDirectory}"
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
+            ginkgo build ${testSuitePath}/
+            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
         """
     }
 }
@@ -1323,7 +1327,8 @@ def runGinkgoVerifyInCluster(count, clusterName, testSuitePath, clusterDumpDirec
                 export DUMP_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 export DUMP_DIRECTORY="${clusterDumpDirectory}${clusterName}"
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
+                ginkgo build ${testSuitePath}/
+                ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test -- --skipDeploy=${skipDeploy} --skipUndeploy=${skipUndeploy} --skipVerify=${skipVerify} --namespace=${namespace}
             """
         }
     }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1108,7 +1108,8 @@ def verifyRegisterManagedCluster(count, minimalVerification) {
                 export MANAGED_CLUSTER_NAME="managed${count-1}"
                 export MANAGED_KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" multicluster/verify-register/... -- --minimalVerification=${minimalVerification}
+                ginkgo build multicluster/verify-register/
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" multicluster/verify-register/*.test -- --minimalVerification=${minimalVerification}
             """
         }
     }
@@ -1138,7 +1139,8 @@ def verifyDeregisterManagedCluster(count) {
                 export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 kubectl -n verrazzano-system delete secret verrazzano-cluster-registration
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" multicluster/verify-deregister/...
+                ginkgo build multicluster/verify-deregister/
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" multicluster/verify-deregister/*.test
             """
         }
     }
@@ -1209,7 +1211,8 @@ def runGinkgoRandomizeSerial(testSuitePath) {
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+                    ginkgo build ${testSuitePath}/
+                    ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
                 """
             }
         }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1234,6 +1234,12 @@ def runGinkgoRandomizeParallel(testSuitePath) {
                 } else {
                     clusterName="managed${count-1}"
                 }
+                sh """
+                    export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
+                    export CLUSTER_NAME="${clusterName}"
+                    cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+                    ginkgo build ${testSuitePath}/
+                """
                 runGinkgoRandomizeStages["${count} - Executing ginkgo test suite ${testSuitePath}"] = runGinkgoRandomize(count, clusterName, testSuitePath)
             }
             parallel runGinkgoRandomizeStages
@@ -1249,7 +1255,6 @@ def runGinkgoRandomize(count, clusterName, testSuitePath) {
                 export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                 export CLUSTER_NAME="${clusterName}"
                 cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                ginkgo build ${testSuitePath}/
                 ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
             """
         }

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1211,8 +1211,7 @@ def runGinkgoRandomizeSerial(testSuitePath) {
                     export KUBECONFIG="${KUBECONFIG_DIR}/${count}/kube_config"
                     export CLUSTER_NAME="${clusterName}"
                     cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-                    ginkgo build ${testSuitePath}/
-                    ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/*.test
+                    ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
                 """
             }
         }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -409,7 +409,7 @@ List extractReleaseTags(final String fileContent) {
 def getStageOfUpgradeJob(job) {
     return {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-            retry(count: JOB_PROMOTION_RETRIES) {
+           // retry(count: JOB_PROMOTION_RETRIES) {
                 script {
                     try {
                         echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
@@ -429,14 +429,19 @@ def getStageOfUpgradeJob(job) {
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
                     }catch(err){
-                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                        retry(2){
+                            echo "Caught: ${err}"
+                            echo "Retrying..."
+                        }
+                        /*catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
                             sh "exit 1"
-                        }
+                        }*/
                         // currentBuild.result = 'FAILURE'
+                        sh "exit 1"
                     }
                 }
-            }
+           // }
         }
     }
 }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -408,11 +408,12 @@ List extractReleaseTags(final String fileContent) {
 
 def getStageOfUpgradeJob(job) {
     return {
-       retry(count: JOB_PROMOTION_RETRIES) {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-                script {
-                    try {
-                        echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
+            script {
+                try {
+                    echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
+                    retry(count: JOB_PROMOTION_RETRIES) {
+                        echo "Retrying the build due to failure"
                         def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                         parameters: [
                             string(name: 'GIT_COMMIT_TO_USE', value: params.GIT_COMMIT_TO_USE),
@@ -428,13 +429,13 @@ def getStageOfUpgradeJob(job) {
                             string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
-                    }catch(err){
-                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
-                            echo "Caught: ${err}"
-                            sh "exit 1"
-                        }
-                        // currentBuild.result = 'FAILURE'
                     }
+                }catch(err){
+                    catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                        echo "Caught: ${err}"
+                        sh "exit 1"
+                    }
+                    // currentBuild.result = 'FAILURE'
                 }
             }
         }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -435,7 +435,6 @@ def getStageOfUpgradeJob(job) {
                         echo "Caught: ${err}"
                         sh "exit 1"
                     }
-                    // currentBuild.result = 'FAILURE'
                 }
             }
         }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -431,9 +431,9 @@ def getStageOfUpgradeJob(job) {
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
                     }catch(err){
-                        //catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
-                            //sh "exit 1"
+                            sh "exit 1"
                         }
                         // currentBuild.result = 'FAILURE'
                     }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -431,7 +431,7 @@ def getStageOfUpgradeJob(job) {
                     }catch(err){
                         catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
-                            sh "exit 1"
+                            //sh "exit 1"
                         }
                         // currentBuild.result = 'FAILURE'
                     }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -409,7 +409,9 @@ List extractReleaseTags(final String fileContent) {
 def getStageOfUpgradeJob(job) {
     return {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-            retry(count: JOB_PROMOTION_RETRIES) {
+                        options {
+                            retry(2)
+                        }
                 script {
                     try {
                         echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
@@ -429,14 +431,14 @@ def getStageOfUpgradeJob(job) {
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
                     }catch(err){
-                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                        //catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
                             //sh "exit 1"
                         }
                         // currentBuild.result = 'FAILURE'
                     }
                 }
-            }
+
         }
     }
 }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -431,7 +431,7 @@ def getStageOfUpgradeJob(job) {
                     }catch(err){
                         catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
-                            //sh "exit 1"
+                            sh "exit 1"
                         }
                         // currentBuild.result = 'FAILURE'
                     }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -429,9 +429,10 @@ def getStageOfUpgradeJob(job) {
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
                     }catch(err){
-                        retry(2){
+                        retry(JOB_PROMOTION_RETRIES){
                             echo "Caught: ${err}"
                             echo "Retrying..."
+                            getStageOfUpgradeJob(job)
                         }
                         /*catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -409,30 +409,32 @@ List extractReleaseTags(final String fileContent) {
 def getStageOfUpgradeJob(job) {
     return {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-            script {
-                try {
-                    echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
-                    def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
-                    parameters: [
-                        string(name: 'GIT_COMMIT_TO_USE', value: params.GIT_COMMIT_TO_USE),
-                        string(name: 'VERSION_FOR_INSTALL', value: job[0]),
-                        string(name: 'VERSION_FOR_UPGRADE', value: job[1]),
-                        string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
-                        string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
-                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
-                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
-                    ],  wait: true, propagate: true
-                }catch(err){
-                    catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
-                        echo "Caught: ${err}"
-                        sh "exit 1"
+            retry(count: JOB_PROMOTION_RETRIES) {
+                script {
+                    try {
+                        echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
+                        def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
+                        parameters: [
+                            string(name: 'GIT_COMMIT_TO_USE', value: params.GIT_COMMIT_TO_USE),
+                            string(name: 'VERSION_FOR_INSTALL', value: job[0]),
+                            string(name: 'VERSION_FOR_UPGRADE', value: job[1]),
+                            string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
+                            string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
+                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                            string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
+                            booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
+                        ],  wait: true, propagate: true
+                    }catch(err){
+                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                            echo "Caught: ${err}"
+                            sh "exit 1"
+                        }
+                        // currentBuild.result = 'FAILURE'
                     }
-                   // currentBuild.result = 'FAILURE'
                 }
             }
         }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -408,8 +408,8 @@ List extractReleaseTags(final String fileContent) {
 
 def getStageOfUpgradeJob(job) {
     return {
+       retry(count: JOB_PROMOTION_RETRIES) {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-           // retry(count: JOB_PROMOTION_RETRIES) {
                 script {
                     try {
                         echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
@@ -429,20 +429,14 @@ def getStageOfUpgradeJob(job) {
                             booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
                         ],  wait: true, propagate: true
                     }catch(err){
-                        retry(JOB_PROMOTION_RETRIES){
-                            echo "Caught: ${err}"
-                            echo "Retrying..."
-                            getStageOfUpgradeJob(job)
-                        }
-                        /*catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
                             sh "exit 1"
-                        }*/
+                        }
                         // currentBuild.result = 'FAILURE'
-                        sh "exit 1"
                     }
                 }
-           // }
+            }
         }
     }
 }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -413,7 +413,6 @@ def getStageOfUpgradeJob(job) {
                 try {
                     echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
                     retry(count: JOB_PROMOTION_RETRIES) {
-                        echo "Retrying the build due to failure"
                         def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                         parameters: [
                             string(name: 'GIT_COMMIT_TO_USE', value: params.GIT_COMMIT_TO_USE),

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -409,9 +409,7 @@ List extractReleaseTags(final String fileContent) {
 def getStageOfUpgradeJob(job) {
     return {
         stage("Upgrade Verrazzano from version ${job[0]} to  ${job[1].replace('_', " ")}"){
-                        options {
-                            retry(2)
-                        }
+            retry(count: JOB_PROMOTION_RETRIES) {
                 script {
                     try {
                         echo "Running upgrade job from version ${job[0]} to ${job[1].replace('_', " ")}"
@@ -433,12 +431,12 @@ def getStageOfUpgradeJob(job) {
                     }catch(err){
                         catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE'){
                             echo "Caught: ${err}"
-                            sh "exit 1"
+                            //sh "exit 1"
                         }
                         // currentBuild.result = 'FAILURE'
                     }
                 }
-
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes ginkgo race condition that causes compilation failure when tests run parallel and enables retry for the failed upgrade jobs. 