### PR TITLE
VZ 6605: Add V1Alpha1 deprecation notice

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -35,6 +35,7 @@ const (
 // +kubebuilder:resource:shortName=vz;vzs
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1:].type",description="The current status of the install/uninstall"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The current version of the Verrazzano installation"
+// +kubebuilder:deprecatedversion:warning="install.verrazzano.io/v1alpha1 Verrazzano is deprecated; see https://verrazzano.io/latest/docs/releasenotes/#v140 for instructions to migrate to install.verrazzano.io/v1beta1 Verrazzano"
 // +genclient
 
 // Verrazzano is the Schema for the verrazzanos API

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -33,9 +33,9 @@ const (
 // +kubebuilder:resource:path=verrazzanos
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=vz;vzs
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1:].type",description="The current status of the install/uninstall"
-// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The current version of the Verrazzano installation"
-// +kubebuilder:deprecatedversion:warning="install.verrazzano.io/v1alpha1 Verrazzano is deprecated; see https://verrazzano.io/latest/docs/releasenotes/#v140 for instructions to migrate to install.verrazzano.io/v1beta1 Verrazzano"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1:].type",description="The current status of the install/uninstall."
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The current version of the Verrazzano installation."
+// +kubebuilder:deprecatedversion:warning="install.verrazzano.io/v1alpha1 Verrazzano is deprecated. To migrate to install.verrazzano.io/v1beta1 Verrazzano, see https://verrazzano.io/latest/docs/releasenotes/#v140."
 // +genclient
 
 // Verrazzano is the Schema for the verrazzanos API

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_types.go
@@ -34,8 +34,8 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vz;vzs
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1:].type",description="The current status of the install/uninstall"
-// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The current version of the Verrazzano installation"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1:].type",description="The current status of the install/uninstall."
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The current version of the Verrazzano installation."
 // +genclient
 
 // Verrazzano is the Schema for the verrazzanos API

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .status.version
       name: Version
       type: string
+    deprecated: true
+    deprecationWarning: install.verrazzano.io/v1alpha1 Verrazzano is deprecated; see
+      https://verrazzano.io/latest/docs/releasenotes/#v140 for instructions to migrate
+      to install.verrazzano.io/v1beta1 Verrazzano
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/crds/install.verrazzano.io_verrazzanos.yaml
@@ -21,18 +21,17 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The current status of the install/uninstall
+    - description: The current status of the install/uninstall.
       jsonPath: .status.conditions[-1:].type
       name: Status
       type: string
-    - description: The current version of the Verrazzano installation
+    - description: The current version of the Verrazzano installation.
       jsonPath: .status.version
       name: Version
       type: string
     deprecated: true
-    deprecationWarning: install.verrazzano.io/v1alpha1 Verrazzano is deprecated; see
-      https://verrazzano.io/latest/docs/releasenotes/#v140 for instructions to migrate
-      to install.verrazzano.io/v1beta1 Verrazzano
+    deprecationWarning: install.verrazzano.io/v1alpha1 Verrazzano is deprecated. To
+      migrate to install.verrazzano.io/v1beta1 Verrazzano, see https://verrazzano.io/latest/docs/releasenotes/#v140.
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -3936,11 +3935,11 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: The current status of the install/uninstall
+    - description: The current status of the install/uninstall.
       jsonPath: .status.conditions[-1:].type
       name: Status
       type: string
-    - description: The current version of the Verrazzano installation
+    - description: The current version of the Verrazzano installation.
       jsonPath: .status.version
       name: Version
       type: string


### PR DESCRIPTION
This is how the warning message goes when you use the deprecated API:

Warning: install.verrazzano.io/v1alpha1 Verrazzano is deprecated; see https://verrazzano.io/latest/docs/releasenotes/#v140 for instructions to migrate to install.verrazzano.io/v1beta1 Verrazzano