### PR TITLE
VZ-6971: Fix HA test pipeline failures

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -36,7 +36,7 @@ pipeline {
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value
-                choices: [ "VM.Standard2.4-3", "VM.Standard2.4-5" ])
+                choices: [ "VM.Standard2.4-4", "VM.Standard2.4-2" ])
         choice (description: 'OCI region to launch OKE clusters in', name: 'OKE_CLUSTER_REGION',
             // 1st choice is the default value
             choices: availableRegions )

--- a/tests/e2e/config/scripts/terraform/cluster/VM.Standard2.4-4.tfvars
+++ b/tests/e2e/config/scripts/terraform/cluster/VM.Standard2.4-4.tfvars
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 node_pools = {

--- a/tests/e2e/config/scripts/terraform/cluster/VM.Standard2.4-4.tfvars
+++ b/tests/e2e/config/scripts/terraform/cluster/VM.Standard2.4-4.tfvars
@@ -1,0 +1,10 @@
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+node_pools = {
+  "np1" = {
+    shape = "VM.Standard2.4",
+    node_pool_size = 4,
+    boot_volume_size = 50
+  }
+}

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -12,25 +12,25 @@ import (
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {
 		RunningUntilShutdownIt("can access Prometheus endpoint", func() {
-			Expect(pkg.VerifyPrometheusComponent(t.Logs, web.api, web.httpClient, web.users.verrazzano)).To(BeTrue())
+			Expect(pkg.VerifyPrometheusComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("Grafana", func() {
 		RunningUntilShutdownIt("can access Grafana endpoint", func() {
-			Expect(pkg.VerifyGrafanaComponent(t.Logs, web.api, web.httpClient, web.users.verrazzano)).To(BeTrue())
+			Expect(pkg.VerifyGrafanaComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch", func() {
 		RunningUntilShutdownIt("can access OpenSearch endpoint", func() {
-			Expect(pkg.VerifyOpenSearchComponent(t.Logs, web.api, web.httpClient, web.users.verrazzano)).To(BeTrue())
+			Expect(pkg.VerifyOpenSearchComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch Dashboards", func() {
 		RunningUntilShutdownIt("can access OpenSearch Dashboards endpoint", func() {
-			Expect(pkg.VerifyOpenSearchDashboardsComponent(t.Logs, web.api, web.httpClient, web.users.verrazzano)).To(BeTrue())
+			Expect(pkg.VerifyOpenSearchDashboardsComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http"
 	"os"
 	"strings"
@@ -36,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -288,6 +288,21 @@ func GetIngressList(namespace string) (*netv1.IngressList, error) {
 		return nil, err
 	}
 	return ingressList, nil
+}
+
+// GetIngress returns the ingress given a namespace and ingress name
+func GetIngress(namespace string, ingressName string) (*netv1.Ingress, error) {
+	// Get the Kubernetes clientset
+	clientSet, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	ingress, err := clientSet.NetworkingV1().Ingresses(namespace).Get(context.TODO(), ingressName, metav1.GetOptions{})
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get Ingress %s in namespace %s: %v ", ingressName, namespace, err))
+		return nil, err
+	}
+	return ingress, nil
 }
 
 // GetVirtualServiceList returns a list of virtual services in the given namespace


### PR DESCRIPTION
This PR makes two fixes to get the HA test pipeline to pass:

1. The tests expect an even number of k8s worker nodes, so I added a new nodepool config for 4 worker nodes and updated the Jenkinsfile build parameter options to only show even worker node configurations
2. Changed the shared VMI test code to allow using either the Verrazzano auth proxy or a standard k8s client to fetch ingresses. The HA tests pass `nil` for the api instance so they will use the k8s client. This works around a problem where the auth proxy returns HTTP 401 during the node swap, until we can spend time figuring out why that error is happening.