### PR TITLE
WIP: updated install code and beginnings of update code

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -107,18 +107,6 @@ func (c KeycloakComponent) PreInstall(ctx spi.ComponentContext) error {
 			constants.VerrazzanoSystemNamespace, constants.Verrazzano, err)
 		return err
 	}
-	// Create secret for the keycloak DB user if it doesn't exist
-	err = createKeycloakDBSecret(ctx)
-	if err != nil {
-		return err
-	}
-
-	// create the keycloak user and database
-	err = setupDatabase(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Create secret for the keycloakadmin user if it doesn't exist
 	err = createAuthSecret(ctx, ComponentNamespace, "keycloak-http", "keycloakadmin")
 	if err != nil {
@@ -166,10 +154,7 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 // PreUpgrade - component level processing for pre-upgrade
 func (c KeycloakComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	// Determine if additional processing is required for the upgrade of the StatefulSet
-	if err := upgradeStatefulSet(ctx); err != nil {
-		return err
-	}
-	return recreateDBIfEphemeralStorage(ctx)
+	return upgradeStatefulSet(ctx)
 }
 
 // PostUpgrade Keycloak-post-upgrade processing, create or update the Kiali ingress

--- a/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.legacyUpgrade }}
+{{- $cluster_name :=  default "mysql" .Release.Name }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: load-dump
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      initContainers:
+        - command:
+            - bash
+            - -c
+            - chown -R 27:27 /var/lib/dump
+          image: {{ if .Values.legacyUpgrade.registry }}{{ .Values.legacyUpgrade.registry }}/{{- end }}{{- if .Values.legacyUpgrade.repository }}{{ .Values.legacyUpgrade.repository }}/{{ end }}{{ .Values.legacyUpgrade.initContainer.image.name }}:{{ .Values.legacyUpgrade.initContainer.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: IfNotPresent
+          name: fixdumpdir
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/dump
+              name: keycloak-dump
+      volumes:
+        - name: keycloak-dump
+          persistentVolumeClaim:
+            claimName: {{ .Values.legacyUpgrade.claimName }}
+      containers:
+        - command: ["bash"]
+          args:
+            - -c
+            - >-
+              while ! mysqladmin ping -h"{{ $cluster_name }}.{{ .Release.Namespace }}.svc.cluster.local" --silent; do sleep 1; done &&
+              mysqlsh -u root -p{{ .Values.credentials.root.password }} -h {{ $cluster_name }}.{{ .Release.Namespace }}.svc.cluster.local -e 'util.loadDump("/var/lib/dump/dump", {includeSchemas: ["keycloak"], includeUsers: ["keycloak"], loadUsers: true})'
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: rootPassword
+                  name: {{ $cluster_name }}-cluster-secret
+            - name: MYSQL_HOST
+              value: {{ $cluster_name }}
+          image: {{ if .Values.legacyUpgrade.registry }}{{ .Values.legacyUpgrade.registry }}/{{- end }}{{- if .Values.legacyUpgrade.repository }}{{ .Values.legacyUpgrade.repository }}/{{ end }}{{ .Values.legacyUpgrade.container.image.name }}:{{ .Values.legacyUpgrade.container.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: IfNotPresent
+          name: mysqlsh-load-dump
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /var/lib/dump
+              name: keycloak-dump
+      restartPolicy: Never
+{{- end -}}

--- a/platform-operator/thirdparty/charts/mysql/templates/configmap_configurationfiles.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/configmap_configurationfiles.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configurationFiles }}
+{{- $cluster_name :=  default "mysql" .Release.Name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $cluster_name }}-configuration
+  namespace: {{ .Release.Namespace }}
+data:
+{{- range $key, $val := .Values.configurationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/platform-operator/thirdparty/charts/mysql/templates/configmap_initdb.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/configmap_initdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.initdbScripts }}
+{{- $cluster_name :=  default "mysql" .Release.Name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: initsql
+  namespace: {{ .Release.Namespace }}
+data:
+{{- range $key, $val := .Values.initdbScripts }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
@@ -43,7 +43,55 @@ spec:
 {{- end }}
 {{ if ((.Values).podSpec) }}
   podSpec:
-{{ toYaml ((.Values).podSpec) | indent 4 }}
+{{ if ((.Values).podSpec.affinity) }}
+    affinity:
+{{ toYaml ((.Values).podSpec.affinity) | indent 6 }}
+{{ end }}
+{{ if (.Values).configurationFiles }}
+    containers:
+      - name: mysql
+        volumeMounts:
+{{- range $key, $val := .Values.configurationFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.configurationFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+{{- end -}}
+{{ end }}
+{{ if(.Values).initdbScripts }}
+    initContainers:
+    - name: initmysql
+      volumeMounts:
+{{- range $key, $val := .Values.initdbScripts }}
+      - name: custominitsql
+        mountPath: /docker-entrypoint-initdb.d/{{ $key }}
+        subPath: {{ $key }}
+{{- end -}}
+{{ end }}
+{{ if (or (.Values).initdbScripts (.Values).configurationFiles) }}
+    volumes:
+{{- if .Values.configurationFiles }}
+    - name: configurations
+      configMap:
+        name: {{ $cluster_name }}-configuration
+        defaultMode: 0755
+        items:
+{{- range $key, $val := .Values.configurationFiles }}
+          - key: {{ $key }}
+            path: {{ $key }}
+{{- end -}}
+{{- end -}}
+{{- if .Values.initdbScripts }}
+    - name: custominitsql
+      configMap:
+        name: initsql
+        defaultMode: 0755
+        items:
+{{- range $key, $val := .Values.initdbScripts }}
+          - key: {{ $key }}
+            path: {{ $key }}
+{{- end -}}
+{{- end -}}
+{{ end }}
 {{ end }}
 {{- if ((.Values).serverConfig) }}
   {{- if (((.Values).serverConfig).mycnf) }}

--- a/platform-operator/thirdparty/charts/mysql/values.yaml
+++ b/platform-operator/thirdparty/charts/mysql/values.yaml
@@ -98,3 +98,25 @@ baseServerId: 1000
 #          prefix : /
 #          bucketName: idbcluster_backup
 #          credentials: oci-credentials
+
+#initdbScripts: {}
+
+# Custom mysql configuration files path
+configurationFilesPath: /etc/mysql/conf.d/
+
+# Custom mysql configuration files
+# configurationFiles: {}
+
+#legacyUpgrade:
+#  registry:
+#  repository: mysql
+#  pullPolicy: IfNotPresent
+#  initContainer:
+#    image:
+#      name: mysql-operator
+#      tag: ""
+#  container:
+#    image:
+#      name: mysql-server
+#      tag: ""
+#  claimName: dump-claim


### PR DESCRIPTION
Main points:
- this code re-implements the use of the init DB scripts approach and re-introduces the mysql hook script @aamitra @ayaranga 
- The templates for MySQL have been updated to make modification/update of the podSpec more straightforward and easier to code/maintain - manipulating the contents of the pod spec across multiple code locations seems less than optimal.  This, to me, seems more straightforward to code and maintain.
- given the above the keycloak code component no longer required all the DB manipulation code
- There are the beginnings of the upgrade code here but I'll probably hold off on merging that code (or all of that code) till upgrade is completed (cluster_upgrade_job.yaml, values.yaml)