### PR TITLE
VZ-6898: Convert ha.yaml to v1beta1

### DIFF
--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -28,30 +28,10 @@ spec:
       overrides:
         - values:
             controller:
-              affinity:
-                podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                    - podAffinityTerm:
-                        labelSelector:
-                          matchLabels:
-                            app.kubernetes.io/component: controller
-                            app.kubernetes.io/name: ingress-nginx
-                        topologyKey: kubernetes.io/hostname
-                      weight: 100
               autoscaling:
                 enabled: true
                 minReplicas: 2
             defaultBackend:
-              affinity:
-                podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                    - podAffinityTerm:
-                        labelSelector:
-                          matchLabels:
-                            app.kubernetes.io/component: default-backend
-                            app.kubernetes.io/name: ingress-nginx
-                        topologyKey: kubernetes.io/hostname
-                      weight: 100
               replicaCount: 2
     istio:
       overrides:

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -9,8 +9,9 @@ spec:
   profile: prod
   components:
     authProxy:
-      kubernetes:
-        replicas: 2
+      overrides:
+        - values:
+            replicas: 2
     certManager:
       overrides:
         - values:
@@ -42,12 +43,42 @@ spec:
                 pilot:
                   k8s:
                     replicaCount: 2
-      ingress:
-        kubernetes:
-          replicas: 2
-      egress:
-        kubernetes:
-          replicas: 2
+                ingressGateways:
+                  - enabled: true
+                    k8s:
+                      affinity:
+                        podAntiAffinity:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            - podAffinityTerm:
+                                labelSelector:
+                                  matchExpressions:
+                                    - key: app
+                                      operator: In
+                                      values:
+                                        - istio-ingressgateway
+                                topologyKey: kubernetes.io/hostname
+                              weight: 100
+                      replicaCount: 2
+                      service:
+                        type: LoadBalancer
+                    name: istio-ingressgateway
+                egressGateways:
+                  - enabled: true
+                    k8s:
+                      affinity:
+                        podAntiAffinity:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            - podAffinityTerm:
+                                labelSelector:
+                                  matchExpressions:
+                                    - key: app
+                                      operator: In
+                                      values:
+                                        - istio-egressgateway
+                                topologyKey: kubernetes.io/hostname
+                              weight: 100
+                      replicaCount: 1
+                    name: istio-egressgateway
     keycloak:
       overrides:
         - values:

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -66,6 +66,6 @@ spec:
               prometheusSpec:
                 replicas: 2
     opensearch:
-       nodes:
-         - name: es-ingest
-           replicas: 2
+      nodes:
+        - name: es-ingest
+          replicas: 2

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -24,14 +24,34 @@ spec:
       overrides:
         - values:
             replicas: 2
-    ingress:
+    ingressNGINX:
       overrides:
         - values:
             controller:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: controller
+                            app.kubernetes.io/name: ingress-nginx
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
               autoscaling:
                 enabled: true
                 minReplicas: 2
             defaultBackend:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: default-backend
+                            app.kubernetes.io/name: ingress-nginx
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
               replicaCount: 2
     istio:
       overrides:

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: install.verrazzano.io/v1alpha1
+apiVersion: install.verrazzano.io/v1beta1
 kind: Verrazzano
 metadata:
   name: verrazzano
@@ -52,7 +52,7 @@ spec:
       overrides:
         - values:
             replicas: 2
-    kibana:
+    openearchDashboards:
       replicas: 2
     kiali:
       overrides:
@@ -65,7 +65,7 @@ spec:
             prometheus:
               prometheusSpec:
                 replicas: 2
-    elasticsearch:
-      installArgs:
-        - name: nodes.ingest.replicas
-          value: "2"
+    opensearch:
+       nodes:
+         - name: es-ingest
+           replicas: 2

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -52,7 +52,7 @@ spec:
       overrides:
         - values:
             replicas: 2
-    openearchDashboards:
+    opensearchDashboards:
       replicas: 2
     kiali:
       overrides:

--- a/examples/ha/ha.yaml
+++ b/examples/ha/ha.yaml
@@ -77,7 +77,7 @@ spec:
                                         - istio-egressgateway
                                 topologyKey: kubernetes.io/hostname
                               weight: 100
-                      replicaCount: 1
+                      replicaCount: 2
                     name: istio-egressgateway
     keycloak:
       overrides:


### PR DESCRIPTION
Convert the ha.yaml file to use the v1beta1 API