### PR TITLE
Fix the path to capture_cluster_snapshot.sh in OCI DNS pipelines

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -649,7 +649,7 @@ def runGinkgoFailFast(testSuitePath) {
 
 def dumpK8sCluster(dumpDirectory) {
     sh """
-        ${GO_REPO_PATH}/verrazzano/ci/scripts/capture_cluster_snapshot.sh ${dumpDirectory}
+        ${WORKSPACE}/ci/scripts/capture_cluster_snapshot.sh ${dumpDirectory}
     """
 }
 


### PR DESCRIPTION
Fixes the path to capture_cluster_snapshot.sh in OCI DNS pipelines