### PR TITLE
Disable full bundle validation from periodic temporarily

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -652,6 +652,7 @@ pipeline {
                                 }
                             }
                         }
+                        /*
                         stage('Verrazzano Full Distribution') {
                             steps {
                                 retry(count: JOB_PROMOTION_RETRIES) {
@@ -666,6 +667,7 @@ pipeline {
                                 }
                             }
                         }
+                        */
                     }
                 }
 


### PR DESCRIPTION
Disable the full build validation temporarily, to overcome the "Method code too large" issue from periodic pipeline