### PR TITLE
VZ-6987 Changes to OpenSearch URL used by default Jaeger instance

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -128,7 +128,7 @@ const TestPrometheusScrapeJob = "test_job"
 const DefaultOpensearchURL = "http://verrazzano-authproxy-elasticsearch:8775"
 
 // Default Jaeger OpenSearch URL
-const DefaultJaegerOSURL = "http://verrazzano-authproxy-elasticsearch.verrazzano-system.svc.cluster.local:8775"
+const DefaultJaegerOSURL = "http://verrazzano-authproxy-elasticsearch.verrazzano-system:8775"
 
 // DefaultJaegerSecretName is the Jaeger secret name used by the default Jaeger instance
 // #nosec

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
@@ -68,8 +68,8 @@ const (
 	prometheusServerField = "jaeger.spec.query.options.prometheus.server-url"
 	jaegerHostName        = "jaeger"
 	jaegerCertificateName = "jaeger-tls"
-	openSearchURL         = "http://verrazzano-authproxy-elasticsearch.verrazzano-system.svc.cluster.local:8775"
-	prometheusURL         = "http://prometheus-operator-kube-p-prometheus.verrazzano-monitoring.svc.cluster.local:9090"
+	openSearchURL         = globalconst.DefaultJaegerOSURL
+	prometheusURL         = "http://prometheus-operator-kube-p-prometheus.verrazzano-monitoring:9090"
 	componentPrefixFmt    = "Component %s"
 )
 

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorOverrideValues.yaml
@@ -24,6 +24,6 @@ jaeger:
       type: elasticsearch
       options:
         es:
-          server-urls: "http://verrazzano-authproxy-elasticsearch.verrazzano-system.svc.cluster.local:8775"
+          server-urls: "http://verrazzano-authproxy-elasticsearch.verrazzano-system:8775"
           num-replicas: 0
       secretName: "verrazzano-jaeger-secret"

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorProdOverrideValues.yaml
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/testdata/jaegerOperatorProdOverrideValues.yaml
@@ -24,6 +24,6 @@ jaeger:
       type: elasticsearch
       options:
         es:
-          server-urls: "http://verrazzano-authproxy-elasticsearch.verrazzano-system.svc.cluster.local:8775"
+          server-urls: "http://verrazzano-authproxy-elasticsearch.verrazzano-system:8775"
           num-replicas: 1
       secretName: "verrazzano-jaeger-secret"


### PR DESCRIPTION
Use only the service and namespace names in the OpenSearch URL to resolve the DNS lookup issue seen for Jaeger instance. The same change is done for the Prometheus URL used by Jaeger instance as well.
