### PR TITLE
VZ-6971: Upgrade OKE cluster version in HA test pipeline

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -9,6 +9,7 @@ def TESTS_FAILED = false
 def availableRegions = [ "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1",
                          "eu-zurich-1", "me-jeddah-1", "sa-saopaulo-1" ]
 def OKE_CLUSTER_PREFIX = ""
+def OKE_CLUSTER_ID = ""
 Collections.shuffle(availableRegions)
 
 pipeline {
@@ -249,6 +250,11 @@ pipeline {
                             TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=rollingupgrade-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh
                             kubectl get nodes
                         """
+
+                        script {
+                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/terraform/cluster && ./terraform output -raw oke_cluster_id").trim()
+                            echo "OKE cluster id: ${OKE_CLUSTER_ID}"
+                        }
                     }
                     post {
                         failure {

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -9,6 +9,7 @@ def TESTS_FAILED = false
 def availableRegions = [ "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1",
                          "eu-zurich-1", "me-jeddah-1", "sa-saopaulo-1" ]
 def OKE_CLUSTER_PREFIX = ""
+def OKE_CLUSTER_ID = ""
 Collections.shuffle(availableRegions)
 
 pipeline {
@@ -248,7 +249,12 @@ pipeline {
                         sh """
                             TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=rollingupgrade-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh
                             kubectl get nodes
-                       """
+                        """
+
+                        script {
+                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${WORKSPACE}/tests/e2e/config/scripts/terraform/cluster && terraform output -raw cluster_id").trim()
+                            echo "OKE cluster id: ${OKE_CLUSTER_ID}"
+                        }
                     }
                     post {
                         failure {
@@ -353,33 +359,6 @@ pipeline {
                     }
                 }
 
-                stage('Reschedule 50% of Worker Nodes') {
-                    when {
-                        expression { TESTS_FAILED == false }
-                    }
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/scheduling"
-                    }
-                    steps {
-                        runGinkgoRandomize('ha/scheduling')
-                    }
-                    post {
-                        always {
-                            sh """
-                                kubectl get pods -A
-                            """
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                        failure {
-                            script {
-                                TESTS_FAILED = true
-                                dumpK8sCluster('reschedule-fail-cluster-snapshot')
-                            }
-                        }
-                    }
-                }
-
                 stage('Verify Install') {
                     when {
                         expression { TESTS_FAILED == false }
@@ -444,7 +423,7 @@ pipeline {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/rollingupdate"
                             }
                             steps {
-                                runGinkgoRandomize('ha/rollingupdate')
+                                runGinkgoFailFast('ha/inplaceupgrade')
                             }
                         }
                         stage('HA Tests') {
@@ -568,6 +547,15 @@ def runGinkgo(testSuitePath, arguments = '') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
+        """
+    }
+}
+
+def runGinkgoFailFast(testSuitePath, arguments = '') {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -v --fail-fast --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
         """
     }
 }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -252,7 +252,7 @@ pipeline {
                         """
 
                         script {
-                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${WORKSPACE}/tests/e2e/config/scripts/terraform/cluster && terraform output -raw cluster_id").trim()
+                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${WORKSPACE}/tests/e2e/config/scripts/terraform/cluster && ./terraform output -raw cluster_id").trim()
                             echo "OKE cluster id: ${OKE_CLUSTER_ID}"
                         }
                     }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -252,7 +252,7 @@ pipeline {
                         """
 
                         script {
-                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${WORKSPACE}/tests/e2e/config/scripts/terraform/cluster && ./terraform output -raw cluster_id").trim()
+                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/terraform/cluster && ./terraform output -raw cluster_id").trim()
                             echo "OKE cluster id: ${OKE_CLUSTER_ID}"
                         }
                     }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -9,7 +9,6 @@ def TESTS_FAILED = false
 def availableRegions = [ "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1",
                          "eu-zurich-1", "me-jeddah-1", "sa-saopaulo-1" ]
 def OKE_CLUSTER_PREFIX = ""
-def OKE_CLUSTER_ID = ""
 Collections.shuffle(availableRegions)
 
 pipeline {
@@ -250,11 +249,6 @@ pipeline {
                             TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=rollingupgrade-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh
                             kubectl get nodes
                         """
-
-                        script {
-                            OKE_CLUSTER_ID = sh(returnStdout: true, script: "cd ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/terraform/cluster && ./terraform output -raw cluster_id").trim()
-                            echo "OKE cluster id: ${OKE_CLUSTER_ID}"
-                        }
                     }
                     post {
                         failure {

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -421,6 +421,7 @@ pipeline {
                         stage('Rolling Update') {
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/rollingupdate"
+                                OKE_CLUSTER_ID="${OKE_CLUSTER_ID}"
                             }
                             steps {
                                 runGinkgoFailFast('ha/inplaceupgrade')

--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -48,9 +48,6 @@ then
   exit 1
 fi
 
-export OKE_CLUSTER_ID=$($SCRIPT_DIR/terraform output -raw cluster_id)
-echo "OKE_CLUSTER_ID is ${OKE_CLUSTER_ID}"
-
 echo "updating OKE private_workers_seclist to allow pub_lb_subnet access to workers"
 
 # the script would return 0 even if it fails to update OKE private_workers_seclist

--- a/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
+++ b/tests/e2e/config/scripts/terraform/cluster/create-cluster.sh
@@ -48,6 +48,9 @@ then
   exit 1
 fi
 
+export OKE_CLUSTER_ID=$($SCRIPT_DIR/terraform output -raw cluster_id)
+echo "OKE_CLUSTER_ID is ${OKE_CLUSTER_ID}"
+
 echo "updating OKE private_workers_seclist to allow pub_lb_subnet access to workers"
 
 # the script would return 0 even if it fails to update OKE private_workers_seclist

--- a/tests/e2e/config/scripts/terraform/cluster/main.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/main.tf
@@ -55,3 +55,7 @@ module "oke" {
 
   node_pool_image_id = var.node_pool_image_id
 }
+
+output "oke_cluster_id" {
+  value = module.oke.cluster_id
+}

--- a/tests/e2e/config/scripts/terraform/cluster/main.tf
+++ b/tests/e2e/config/scripts/terraform/cluster/main.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 module "oke" {

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_suite_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package inplaceupgrade
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestInPlaceUpgrade(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "OKE in-place cluster upgrade")
+}

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package inplaceupgrade
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/oracle/oci-go-sdk/v53/common"
+	"github.com/oracle/oci-go-sdk/v53/common/auth"
+	ocice "github.com/oracle/oci-go-sdk/v53/containerengine"
+	ocicore "github.com/oracle/oci-go-sdk/v53/core"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/ha"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	clusterIDEnvVar = "OKE_CLUSTER_ID"
+	ociRegionEnvVar = "OCI_CLI_REGION"
+
+	waitTimeout     = 20 * time.Minute
+	pollingInterval = 30 * time.Second
+)
+
+var clientset = k8sutil.GetKubernetesClientsetOrDie()
+var t = framework.NewTestFramework("in_place_upgrade")
+
+var (
+	failed    bool
+	region    string
+	clusterID string
+
+	okeClient     ocice.ContainerEngineClient
+	computeClient ocicore.ComputeClient
+)
+
+var _ = t.AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = t.BeforeSuite(func() {
+	clusterID = os.Getenv(clusterIDEnvVar)
+	region = os.Getenv(ociRegionEnvVar)
+	Expect(clusterID).ToNot(BeEmpty(), fmt.Sprintf("%s env var must be set", clusterIDEnvVar))
+	// region is optional so don't Expect
+
+	var provider common.ConfigurationProvider
+	var err error
+	provider, err = getOCISDKProvider(region)
+	Expect(err).ShouldNot(HaveOccurred(), "Error configuring OCI SDK provider")
+
+	okeClient, err = ocice.NewContainerEngineClientWithConfigurationProvider(provider)
+	Expect(err).ShouldNot(HaveOccurred(), "Error configuring OCI SDK container engine client")
+
+	computeClient, err = ocicore.NewComputeClientWithConfigurationProvider(provider)
+	Expect(err).ShouldNot(HaveOccurred(), "Error configuring OCI SDK compute client")
+})
+
+var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
+	var clusterResponse ocice.GetClusterResponse
+	var upgradeVersion string
+
+	t.It("upgrades the control plane Kubernetes version", func() {
+		// first get the cluster details and find the available upgrade versions
+		var err error
+		clusterResponse, err = okeClient.GetCluster(context.Background(), ocice.GetClusterRequest{ClusterId: &clusterID})
+		Expect(err).ShouldNot(HaveOccurred())
+		t.Logs.Debugf("Cluster response: %+v", clusterResponse)
+		Expect(clusterResponse.AvailableKubernetesUpgrades).ToNot(BeEmpty(), "No available upgrade versions")
+
+		// upgrade the control plane to the first available upgrade version
+		upgradeVersion = clusterResponse.AvailableKubernetesUpgrades[0]
+		t.Logs.Infof("Upgrading the OKE cluster control plane to version: %s", upgradeVersion)
+		details := ocice.UpdateClusterDetails{KubernetesVersion: &upgradeVersion}
+		updateResponse, err := okeClient.UpdateCluster(context.Background(), ocice.UpdateClusterRequest{ClusterId: &clusterID, UpdateClusterDetails: details})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(updateResponse.OpcWorkRequestId).ShouldNot(BeNil())
+
+		// wait for the work request to complete, this can take roughly 5-15 minutes
+		waitForWorkRequest(*updateResponse.OpcWorkRequestId)
+	})
+
+	t.It("upgrades the node pool Kubernetes version", func() {
+		// first get the node pool, the cluster response struct does not have node pools so we have to list the node pools
+		// in the compartment and filter by the cluster id
+		nodePoolsResponse, err := okeClient.ListNodePools(context.Background(), ocice.ListNodePoolsRequest{CompartmentId: clusterResponse.CompartmentId, ClusterId: clusterResponse.Id})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(len(nodePoolsResponse.Items)).To(Equal(1))
+
+		// upgrade the node pool to the same Kubernetes version as the control plane
+		t.Logs.Infof("Upgrading the OKE cluster node pool to version: %s", upgradeVersion)
+		details := ocice.UpdateNodePoolDetails{KubernetesVersion: &upgradeVersion}
+		updateResponse, err := okeClient.UpdateNodePool(context.Background(), ocice.UpdateNodePoolRequest{NodePoolId: nodePoolsResponse.Items[0].Id, UpdateNodePoolDetails: details})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(updateResponse.OpcWorkRequestId).ShouldNot(BeNil())
+
+		// wait for the work request to complete, this can take roughly 5-15 minutes
+		waitForWorkRequest(*updateResponse.OpcWorkRequestId)
+	})
+
+	t.It("replaces each worker node in the node pool", func() {
+		// get the nodes
+		nodes := ha.EventuallyGetNodes(clientset, t.Logs)
+		latestNodes := nodes
+		for _, node := range nodes.Items {
+			if !ha.IsControlPlaneNode(node) {
+				// cordon and drain the node - this function is implemented in kubectl itself and is not available
+				// using a k8s client
+				t.Logs.Infof("Draining node: %s", node.Name)
+				out, err := exec.Command("kubectl", "drain", "--ignore-daemonsets", "--delete-emptydir-data", "--force", node.Name).Output()
+				Expect(err).ShouldNot(HaveOccurred())
+				t.Logs.Infof("Output from kubectl drain command: %s", out)
+
+				// terminate the compute instance that the node is on, OKE will replace it with a new node
+				// running the upgraded Kubernetes version
+				t.Logs.Infof("Terminating compute instance: %s", node.Spec.ProviderID)
+				terminateComputeInstance(node.Spec.ProviderID)
+
+				latestNodes = waitForReplacementNode(latestNodes)
+
+				// wait for all pods to be ready before continuing to the next node
+				t.Logs.Infof("Waiting for all pods to be ready")
+				ha.EventuallyPodsReady(t.Logs, clientset)
+			}
+		}
+	})
+})
+
+// waitForWorkRequest waits for the work request to transition to success
+func waitForWorkRequest(workRequestID string) {
+	Eventually(func() (ocice.WorkRequestStatusEnum, error) {
+		t.Logs.Infof("Waiting for work request with id %s to complete", workRequestID)
+		workRequestResponse, err := okeClient.GetWorkRequest(context.Background(), ocice.GetWorkRequestRequest{WorkRequestId: &workRequestID})
+		if err != nil {
+			return "", err
+		}
+		t.Logs.Debugf("Work request response: %+v", workRequestResponse)
+		return workRequestResponse.Status, nil
+	}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(Equal(ocice.WorkRequestStatusSucceeded))
+}
+
+// terminateComputeInstance terminates a compute instance
+func terminateComputeInstance(instanceID string) error {
+	_, err := computeClient.TerminateInstance(context.Background(), ocicore.TerminateInstanceRequest{InstanceId: &instanceID})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// waitForReplacementNode waits for a replacement node to be ready. It returns the new list of nodes that includes
+// the replacement node.
+func waitForReplacementNode(existingNodes *corev1.NodeList) *corev1.NodeList {
+	var replacement string
+	var latestNodes *corev1.NodeList
+
+	Eventually(func() string {
+		t.Logs.Infof("Waiting for replacement worker node")
+		latestNodes = ha.EventuallyGetNodes(clientset, t.Logs)
+		for _, node := range latestNodes.Items {
+			if !ha.IsControlPlaneNode(node) {
+				if !isExistingNode(&node, existingNodes) {
+					replacement = node.Name
+					break
+				}
+			}
+		}
+		return replacement
+	}).WithTimeout(waitTimeout).WithPolling(pollingInterval).ShouldNot(BeEmpty())
+
+	if len(replacement) > 0 {
+		Eventually(func() (bool, error) {
+			t.Logs.Infof("Waiting for new worker node %s to be ready", replacement)
+			return isNodeReady(replacement)
+		}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(BeTrue())
+	}
+
+	return latestNodes
+}
+
+// isExistingNode returns true if the specified node is in the list of existing nodes
+func isExistingNode(node *corev1.Node, existingNodes *corev1.NodeList) bool {
+	for _, existingNode := range existingNodes.Items {
+		if node.Name == existingNode.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// isNodeReady returns true if the NodeReady condition is true
+func isNodeReady(name string) (bool, error) {
+	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// getOCISDKProvider returns an OCI SDK configuration provider. If a region is specified then
+// use an instance principal auth provider, otherwise use the default provider (auth config comes from
+// an OCI config file or environment variables).
+func getOCISDKProvider(region string) (common.ConfigurationProvider, error) {
+	var provider common.ConfigurationProvider
+	var err error
+
+	if region != "" {
+		t.Logs.Infof("Using OCI SDK instance principal provider with region: %s", region)
+		provider, err = auth.InstancePrincipalConfigurationProviderForRegion(common.StringToRegion(region))
+	} else {
+		t.Logs.Info("Using OCI SDK default provider")
+		provider = common.DefaultConfigProvider()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	defaultRetryPolicy := common.DefaultRetryPolicy()
+	common.GlobalRetry = &defaultRetryPolicy
+	return provider, nil
+}

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -116,7 +116,7 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 				// cordon and drain the node - this function is implemented in kubectl itself and is not available
 				// using a k8s client
 				t.Logs.Infof("Draining node: %s", node.Name)
-				out, err := exec.Command("kubectl", "drain", "--ignore-daemonsets", "--delete-emptydir-data", "--force", node.Name).Output()
+				out, err := exec.Command("kubectl", "drain", "--ignore-daemonsets", "--delete-emptydir-data", "--force", node.Name).Output() //nolint:gosec //#nosec G204
 				Expect(err).ShouldNot(HaveOccurred())
 				t.Logs.Infof("Output from kubectl drain command: %s", out)
 

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -128,7 +128,8 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 				// terminate the compute instance that the node is on, OKE will replace it with a new node
 				// running the upgraded Kubernetes version
 				t.Logs.Infof("Terminating compute instance: %s", node.Spec.ProviderID)
-				terminateComputeInstance(node.Spec.ProviderID)
+				err = terminateComputeInstance(node.Spec.ProviderID)
+				Expect(err).ShouldNot(HaveOccurred())
 
 				latestNodes = waitForReplacementNode(latestNodes)
 

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -65,6 +65,11 @@ var _ = t.BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred(), "Error configuring OCI SDK compute client")
 })
 
+var _ = t.AfterSuite(func() {
+	// signal that the upgrade is done so the tests know to stop
+	ha.EventuallyCreateShutdownSignal(clientset, t.Logs)
+})
+
 var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 	var clusterResponse ocice.GetClusterResponse
 	var upgradeVersion string
@@ -103,7 +108,7 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updateResponse.OpcWorkRequestId).ShouldNot(BeNil())
 
-		// wait for the work request to complete, this can take roughly 5-15 minutes
+		// wait for the work request to complete
 		waitForWorkRequest(*updateResponse.OpcWorkRequestId)
 	})
 

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -168,7 +168,7 @@ func waitForReplacementNode(existingNodes *corev1.NodeList) *corev1.NodeList {
 		latestNodes = ha.EventuallyGetNodes(clientset, t.Logs)
 		for _, node := range latestNodes.Items {
 			if !ha.IsControlPlaneNode(node) {
-				if !isExistingNode(&node, existingNodes) {
+				if !isExistingNode(node, existingNodes) {
 					replacement = node.Name
 					break
 				}
@@ -188,7 +188,7 @@ func waitForReplacementNode(existingNodes *corev1.NodeList) *corev1.NodeList {
 }
 
 // isExistingNode returns true if the specified node is in the list of existing nodes
-func isExistingNode(node *corev1.Node, existingNodes *corev1.NodeList) bool {
+func isExistingNode(node corev1.Node, existingNodes *corev1.NodeList) bool {
 	for _, existingNode := range existingNodes.Items {
 		if node.Name == existingNode.Name {
 			return true


### PR DESCRIPTION
This PR updates the HA test pipeline to more accurately reflect how users will upgrade the Kubernetes version in OKE clusters. There is a new test suite that makes OCI SDK calls to run an in-place upgrade. The algorithm is basically:
1. Get the cluster details to find the allowed upgrade versions
2. Upgrade the control plane k8s version
3. Upgrade the node pool k8s version
4. For each worker node:
     1. Run `kubectl drain`
     2. Terminate the compute instance
     3. Wait for the new worker node to be ready
     4. Wait for all pods to be ready