### PR TITLE
VZ 6999: vz install fails for v1.3.4

### DIFF
--- a/tools/vz/cmd/analyze/analyze_test.go
+++ b/tools/vz/cmd/analyze/analyze_test.go
@@ -206,6 +206,7 @@ func installVZ(t *testing.T, c client.WithWatch) {
 	cmd := installcmd.NewCmdInstall(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.WaitFlag, "false")
+	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
 
 	// Run install command
 	err := cmd.Execute()

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -382,6 +382,7 @@ func installVZ(t *testing.T, c client.WithWatch) {
 	cmd := installcmd.NewCmdInstall(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.WaitFlag, "false")
+	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
 
 	// Run install command
 	err := cmd.Execute()

--- a/tools/vz/cmd/helpers/overlay.go
+++ b/tools/vz/cmd/helpers/overlay.go
@@ -101,7 +101,7 @@ func overlayVerrazzano(gv schema.GroupVersion, baseYAML string, overlayYAML stri
 	}
 
 	// Merge the two json representations
-	mergedJSON, err := strategicpatch.StrategicMergePatch(baseJSON, overlayJSON, helpers.NewVerrazzanoForVersion(gv)())
+	mergedJSON, err := strategicpatch.StrategicMergePatch(baseJSON, overlayJSON, helpers.NewVerrazzanoForGroupVersion(gv)())
 	if err != nil {
 		return "", fmt.Errorf("Failed to merge yaml: %s\n base object:\n%s\n override object:\n%s", err.Error(), baseJSON, overlayJSON)
 	}

--- a/tools/vz/cmd/helpers/overlay_test.go
+++ b/tools/vz/cmd/helpers/overlay_test.go
@@ -134,7 +134,7 @@ func TestMergeYAMLFilesNotFound(t *testing.T) {
 // THEN the call returns a vz resource with the two source merged
 func TestMergeSetFlags(t *testing.T) {
 	yamlString := "spec:\n  environmentName: test"
-	vz, err := helpers.NewDefaultVerrazzano()
+	_, vz, err := helpers.NewVerrazzanoForVZVersion("1.4.0")
 	assert.NoError(t, err)
 	obj, err := MergeSetFlags(v1beta1.SchemeGroupVersion, vz, yamlString)
 	assert.NoError(t, err)

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -40,7 +40,7 @@ func TestInstallCmdDefaultNoWait(t *testing.T) {
 	assert.Equal(t, "", errBuf.String())
 
 	// Verify the vz resource is as expected
-	vz := v1beta1.Verrazzano{}
+	vz := v1alpha1.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vz)
 	assert.NoError(t, err)
 }
@@ -111,7 +111,7 @@ func TestInstallCmdJsonLogFormat(t *testing.T) {
 	assert.Equal(t, "", errBuf.String())
 
 	// Verify the vz resource is as expected
-	vz := v1beta1.Verrazzano{}
+	vz := v1alpha1.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vz)
 	assert.NoError(t, err)
 }
@@ -216,10 +216,10 @@ func TestInstallCmdSets(t *testing.T) {
 	assert.Equal(t, "", errBuf.String())
 
 	// Verify the vz resource is as expected
-	vz := v1beta1.Verrazzano{}
+	vz := v1alpha1.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vz)
 	assert.NoError(t, err)
-	assert.Equal(t, v1beta1.Dev, vz.Spec.Profile)
+	assert.Equal(t, v1alpha1.Dev, vz.Spec.Profile)
 	assert.Equal(t, "test", vz.Spec.EnvironmentName)
 }
 
@@ -292,7 +292,7 @@ func TestInstallCmdOperatorFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify the vz resource is as expected
-	vz := v1beta1.Verrazzano{}
+	vz := v1alpha1.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vz)
 	assert.NoError(t, err)
 }

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -6,6 +6,7 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"time"
 
@@ -133,7 +134,12 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		vz, err = helpers.GetVerrazzanoResource(client, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name})
 		if err == nil {
 			vz.Spec.Version = version
-			err = client.Update(context.TODO(), vz)
+			vzV1Alpha1 := &v1alpha1.Verrazzano{}
+			err = vzV1Alpha1.ConvertFrom(vz) // upgrade version may not support v1beta1
+			if err == nil {
+				err = client.Update(context.TODO(), vz)
+			}
+
 		}
 		if err != nil {
 			if retry == 5 {

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -17,6 +17,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,21 +40,44 @@ type VZHelper interface {
 	GetDynamicClient(cmd *cobra.Command) (dynamic.Interface, error)
 }
 
-const defaultVerrazzano = `apiVersion: install.verrazzano.io/v1beta1
+const defaultVerrazzanoTmpl = `apiVersion: install.verrazzano.io/%s
 kind: Verrazzano
 metadata:
   name: verrazzano
   namespace: default`
 
-func NewDefaultVerrazzano() (client.Object, error) {
+const v1beta1MinVersion = "1.4.0"
+
+func NewVerrazzanoForVZVersion(version string) (schema.GroupVersion, client.Object, error) {
+	if version == "" {
+		// default to a v1alpha1 compatible verison if not specified
+		version = "1.3.0"
+	}
+	actualVersion, err := semver.NewSemVersion(version)
+	if err != nil {
+		return schema.GroupVersion{}, nil, err
+	}
+	minVersion, err := semver.NewSemVersion(v1beta1MinVersion)
+	if err != nil {
+		return schema.GroupVersion{}, nil, err
+	}
+	if actualVersion.IsLessThan(minVersion) {
+		o, err := newVerazzanoWithAPIVersion(v1alpha1.SchemeGroupVersion.Version)
+		return v1alpha1.SchemeGroupVersion, o, err
+	}
+	o, err := newVerazzanoWithAPIVersion(v1beta1.SchemeGroupVersion.Version)
+	return v1beta1.SchemeGroupVersion, o, err
+}
+
+func newVerazzanoWithAPIVersion(version string) (client.Object, error) {
 	vz := &unstructured.Unstructured{}
-	if err := yaml.Unmarshal([]byte(defaultVerrazzano), vz); err != nil {
+	if err := yaml.Unmarshal([]byte(fmt.Sprintf(defaultVerrazzanoTmpl, version)), vz); err != nil {
 		return nil, err
 	}
 	return vz, nil
 }
 
-func NewVerrazzanoForVersion(groupVersion schema.GroupVersion) func() interface{} {
+func NewVerrazzanoForGroupVersion(groupVersion schema.GroupVersion) func() interface{} {
 	switch groupVersion {
 	case v1alpha1.SchemeGroupVersion:
 		return func() interface{} {
@@ -87,7 +111,7 @@ func FindVerrazzanoResource(client client.Client) (*v1beta1.Verrazzano, error) {
 func GetVerrazzanoResource(client client.Client, namespacedName types.NamespacedName) (*v1beta1.Verrazzano, error) {
 	vz := &v1beta1.Verrazzano{}
 	if err := client.Get(context.TODO(), namespacedName, vz); err != nil {
-		if meta.IsNoMatchError(err) {
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
 			return getVerrazzanoResourceV1Alpha1(client, namespacedName)
 		}
 		return nil, failedToGetResourceError(err)

--- a/tools/vz/pkg/helpers/vzhelper_test.go
+++ b/tools/vz/pkg/helpers/vzhelper_test.go
@@ -43,7 +43,7 @@ func TestNewVerrazzanoForVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.o, NewVerrazzanoForVersion(tt.gv)())
+			assert.Equal(t, tt.o, NewVerrazzanoForGroupVersion(tt.gv)())
 		})
 	}
 }


### PR DESCRIPTION
Detect default verrazzano API version. If less than 1.4.0, use v1alpha1.