### PR TITLE
VZ-6971: More HA test fixes and enhancements

### DIFF
--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -141,6 +141,15 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 			}
 		}
 	})
+
+	t.It("validates the k8s version of each worker node in the node pool", func() {
+		// get the nodes and check both the kube proxy and kubelet versions
+		nodes := ha.EventuallyGetNodes(clientset, t.Logs)
+		for _, node := range nodes.Items {
+			Expect(node.Status.NodeInfo.KubeProxyVersion).To(Equal(upgradeVersion), "kube proxy version is incorrect")
+			Expect(node.Status.NodeInfo.KubeletVersion).To(Equal(upgradeVersion), "kubelet version is incorrect")
+		}
+	})
 })
 
 // waitForWorkRequest waits for the work request to transition to success


### PR DESCRIPTION
This PR adds retries around the k8s client calls to fetch the VMI ingress. Transient errors can happen making calls to the k8s API server so this adds resiliency to the tests.

I also added validation in the in-place upgrade test to confirm that the worker nodes were actually upgraded to the request version.