### PR TITLE
Pmackin/vz 6996 uninstall

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -48,6 +48,10 @@ var _ spi.Component = mysqlComponent{}
 
 // NewComponent returns a new MySQL component
 func NewComponent() spi.Component {
+
+	// Cannot include mysqloperatorcomponent because of import cycle
+	const MySQLOperatorComponentName = "mysql-operator"
+
 	return mysqlComponent{
 		helm.HelmComponent{
 			ReleaseName:               ComponentName,
@@ -60,7 +64,7 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "mysql-values.yaml"),
 			AppendOverridesFunc:       appendMySQLOverrides,
-			Dependencies:              []string{istio.ComponentName},
+			Dependencies:              []string{istio.ComponentName, MySQLOperatorComponentName},
 			GetInstallOverridesFunc:   GetOverrides,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -6,6 +6,7 @@ package mysqloperator
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
 	"path/filepath"
 	"strconv"
 
@@ -116,6 +117,38 @@ func (c mysqlOperatorComponent) PreUpgrade(compContext spi.ComponentContext) err
 	}); err != nil {
 		return ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 	}
+	return nil
+}
+
+// PreUninstall waits until MySQL has been uninstalled. This is needed since the pods have finalizers
+// that are processed by the MySQL operator
+func (c mysqlOperatorComponent) PreUninstall(compContext spi.ComponentContext) error {
+	// Keycloak enabled determines if MySQL is enabled
+	if !vzconfig.IsKeycloakEnabled(compContext.EffectiveCR()) {
+		return nil
+	}
+
+	// Create a component context for mysql
+	spiCtx, err := spi.NewContext(compContext.Log(), compContext.Client(), compContext.ActualCR(), compContext.ActualCRV1Beta1(), compContext.IsDryRun())
+	if err != nil {
+		spiCtx.Log().Errorf("Failed to create component context: %v", err)
+		return err
+	}
+	mySQLContext := spiCtx.Init(mysql.ComponentName).Operation(vpocons.UninstallOperation)
+
+	// Check if MySQL is installed
+	mySQLComp := mysql.NewComponent()
+	installed, err := mySQLComp.IsInstalled(mySQLContext)
+	if err != nil {
+		spiCtx.Log().Errorf("Failed to check if MySQL is installed: %v", err)
+		return err
+	}
+	if installed {
+		spiCtx.Log().Progressf("MySQL operator uninstall is waiting for MySQL to be uninstalled")
+		return ctrlerrors.RetryableError{}
+	}
+
+	// MySQL is not installed, safe to uninstall MySQL operator
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -145,7 +145,7 @@ func (c mysqlOperatorComponent) PreUninstall(compContext spi.ComponentContext) e
 	}
 	if installed {
 		spiCtx.Log().Progressf("MySQL operator uninstall is waiting for MySQL to be uninstalled")
-		return ctrlerrors.RetryableError{}
+		return ctrlerrors.RetryableError{Source: ComponentName}
 	}
 
 	// MySQL is not installed, safe to uninstall MySQL operator

--- a/platform-operator/controllers/verrazzano/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/uninstall_component.go
@@ -50,8 +50,9 @@ func (r *Reconciler) uninstallComponents(log vzlog.VerrazzanoLogger, cr *install
 
 	var requeue bool
 
-	// Loop through all of the Verrazzano components and Uninstall each one.
-	// Don't block uninstalling the next component if the current one has an error, could just be waiting for a condition
+	// Loop through the Verrazzano components and Uninstall each one.
+	// Don't block uninstalling the next component if the current one has an error.
+	// It is normal for a component to return an error if it is waiting for some condition.
 	for _, comp := range registry.GetComponents() {
 		UninstallContext := tracker.getComponentUninstallContext(comp.Name())
 		result, err := r.uninstallSingleComponent(spiCtx, UninstallContext, comp)


### PR DESCRIPTION
MySQL pods have finalizers that the MySQL operator has to remove after it has done cleanup.  If the MySQL operator is uninstalled before it has a chance to cleanup the MySQL pods, then the finalizers never get removed and the MySQL pods don't get deleted.  This change will cause MySQL operator PreUninstall to wait until MySQL has been uninstalled.

