### PR TITLE
Tvlatas/fix upgrade resiliency

### DIFF
--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -60,15 +60,17 @@ pipeline {
         KUBERNETES_VERSION = '1.20,1.21,1.22,1.23,1.24'
         PROMETHEUS_GW_URL = credentials('prometheus-dev-url')
         SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
+
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_BUCKET="verrazzano-builds"
+        STABLE_COMMIT_OS_LOCATION = "${CLEAN_BRANCH_NAME}/last-stable-commit.txt"
+        STABLE_COMMIT_LOCATION = "${WORKSPACE}/last-stable-commit.txt"
     }
 
     stages {
         stage('Clean workspace and checkout') {
             steps {
-                sh """
-                    echo "${NODE_LABELS}"
-                """
-
                 sh """
                     echo "${NODE_LABELS}"
                     echo "Downloading latest stable commit info from object storage"

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -3,6 +3,7 @@
 
 def agentLabel = env.JOB_NAME.contains('master') ? "phxsmall" : "VM.Standard2.2"
 def branchSpecificSchedule = getCronSchedule()
+def GIT_COMMIT_TO_USE = ""
 
 pipeline {
     options {
@@ -25,10 +26,6 @@ pipeline {
     }
 
     parameters {
-        string (name: 'GIT_COMMIT_TO_USE',
-                        defaultValue: 'NONE',
-                        description: 'This is the full git commit hash from the source build to be used for all jobs. A full pipeline specifies a valid commit hash here. NONE can be used for manually triggered jobs, however even for those a commit hash value is preferred to be supplied',
-                        trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',
                         description: 'This is for manually testing only where someone needs to use a specific operator image, otherwise the default value of NONE is used',
@@ -72,24 +69,25 @@ pipeline {
                     echo "${NODE_LABELS}"
                 """
 
-                // REVIEW: I'm not sure that we actually need to fetch the sources here, but I'm doing here as it was easier
-                // to test working with the SCM checkout settings starting from this job. We should be able to trigger this job
-                // with parameters directly (ie: based on a previous build), in that situation doing this gives us a single point
-                // to ensure the commit matches what was intended before triggering a bunch of downstream jobs that will
-                // all fail if it wasn't correct. So we may want to keep it here unless there is a compelling reason not to do so.
-                // I haven't looked at the executor resource usage yet in all of this, so it may be that could have constraints for
-                // using flyweight executors (still need to look at that)
+                sh """
+                    echo "${NODE_LABELS}"
+                    echo "Downloading latest stable commit info from object storage"
+                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${STABLE_COMMIT_OS_LOCATION} --file ${STABLE_COMMIT_LOCATION}
+                """
+
+                // This job is triggered based on a cron schedule but it works the same way as the PERIODIC tests
+                // It will get the COMMIT to use based on the last stable commit for this branch, and use that. If that doesn't exist you need to set that up
+                // in the same way that you would if you were running a PERIODIC test in a branch (push triggered job needs to be clean or you need to force a stable commit there)
                 script {
-                    if (params.GIT_COMMIT_TO_USE == "NONE") {
-                        echo "Specific GIT commit was not specified, use current head"
-                        def scmInfo = checkout scm
-                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
-                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
-                    } else {
-                        echo "SCM checkout of ${params.GIT_COMMIT_TO_USE}"
+                    // Get the last stable commit ID to pass the triggered tests
+                    def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
+                    GIT_COMMIT_TO_USE = stableCommitProps['git-commit']
+                    echo "Last stable commit: ${GIT_COMMIT_TO_USE}"
+
+                    echo "SCM checkout of ${GIT_COMMIT_TO_USE}"
                         def scmInfo = checkout([
                             $class: 'GitSCM',
-                            branches: [[name: params.GIT_COMMIT_TO_USE]],
+                            branches: [[name: GIT_COMMIT_TO_USE]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [],
                             submoduleCfg: [],
@@ -97,8 +95,8 @@ pipeline {
                         env.GIT_COMMIT = scmInfo.GIT_COMMIT
                         env.GIT_BRANCH = scmInfo.GIT_BRANCH
                         // If the commit we were handed is not what the SCM says we are using, fail
-                        if (!env.GIT_COMMIT.equals(params.GIT_COMMIT_TO_USE)) {
-                            echo "SCM didn't checkout the commit we expected. Expected: ${params.GIT_COMMIT_TO_USE}, Found: ${scmInfo.GIT_COMMIT}"
+                        if (!env.GIT_COMMIT.equals(GIT_COMMIT_TO_USE)) {
+                            echo "SCM didn't checkout the commit we expected. Expected: ${GIT_COMMIT_TO_USE}, Found: ${scmInfo.GIT_COMMIT}"
                             exit 1
                         }
                     }
@@ -111,7 +109,7 @@ pipeline {
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
-                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
                     def currentCommitHash = env.GIT_COMMIT
                     def commitList = getCommitList()
                     withCredentials([file(credentialsId: 'jenkins-to-slack-users', variable: 'JENKINS_TO_SLACK_JSON')]) {

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -87,20 +87,19 @@ pipeline {
                     echo "Last stable commit: ${GIT_COMMIT_TO_USE}"
 
                     echo "SCM checkout of ${GIT_COMMIT_TO_USE}"
-                        def scmInfo = checkout([
-                            $class: 'GitSCM',
-                            branches: [[name: GIT_COMMIT_TO_USE]],
-                            doGenerateSubmoduleConfigurations: false,
-                            extensions: [],
-                            submoduleCfg: [],
-                            userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
-                        env.GIT_COMMIT = scmInfo.GIT_COMMIT
-                        env.GIT_BRANCH = scmInfo.GIT_BRANCH
-                        // If the commit we were handed is not what the SCM says we are using, fail
-                        if (!env.GIT_COMMIT.equals(GIT_COMMIT_TO_USE)) {
-                            echo "SCM didn't checkout the commit we expected. Expected: ${GIT_COMMIT_TO_USE}, Found: ${scmInfo.GIT_COMMIT}"
-                            exit 1
-                        }
+                    def scmInfo = checkout([
+                        $class: 'GitSCM',
+                        branches: [[name: GIT_COMMIT_TO_USE]],
+                        doGenerateSubmoduleConfigurations: false,
+                        extensions: [],
+                        submoduleCfg: [],
+                        userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
+                    env.GIT_COMMIT = scmInfo.GIT_COMMIT
+                    env.GIT_BRANCH = scmInfo.GIT_BRANCH
+                    // If the commit we were handed is not what the SCM says we are using, fail
+                    if (!env.GIT_COMMIT.equals(GIT_COMMIT_TO_USE)) {
+                        echo "SCM didn't checkout the commit we expected. Expected: ${GIT_COMMIT_TO_USE}, Found: ${scmInfo.GIT_COMMIT}"
+                        exit 1
                     }
                     echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
                 }


### PR DESCRIPTION
These tests are being triggered on a cron schedule but are picking up the tip of master. This causes a timing window when the timer kicks off before the master build has kicked off and populated dependencies into object storage.

We will be moving these into the periodics, but this should address the timing window and false alerts due to that for now
