### PR TITLE
HA test pipeline fixes

### DIFF
--- a/tests/e2e/ha/nodes.go
+++ b/tests/e2e/ha/nodes.go
@@ -17,8 +17,10 @@ import (
 )
 
 const (
-	WaitTimeout     = 10 * time.Minute
-	PollingInterval = 10 * time.Second
+	WaitTimeout         = 10 * time.Minute
+	longWaitTimeout     = 20 * time.Minute
+	PollingInterval     = 10 * time.Second
+	longPollingInterval = 30 * time.Second
 )
 
 func EventuallyGetNodes(cs *kubernetes.Clientset, log *zap.SugaredLogger) *corev1.NodeList {


### PR DESCRIPTION
This PR contains two changes to the HA test pipeline:
1. Increase timeout when waiting for all pods to be ready from 10 minutes to 20 minutes
2. Change the `Eventually` when waiting for pods to be ready so that it displays the pod found to not be ready when it times out
