### PR TITLE
Anders/vz 6991

### DIFF
--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -315,6 +315,9 @@ func reportInstallIssue(log *zap.SugaredLogger, clusterRoot string, compsNotRead
 		return err
 	}
 
+	if len(allPodFiles) < 1 {
+		return fmt.Errorf("Failed to find Verrazzano Platform Operator pod.")
+	}
 	// We should get only one pod file, use the first element rather than going through the slice
 	vpoLog := allPodFiles[0]
 	messages := make(StringSlice, 1)

--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -316,7 +316,7 @@ func reportInstallIssue(log *zap.SugaredLogger, clusterRoot string, compsNotRead
 	}
 
 	if len(allPodFiles) < 1 {
-		return fmt.Errorf("Failed to find Verrazzano Platform Operator pod.")
+		return fmt.Errorf("failed to find Verrazzano Platform Operator pod")
 	}
 	// We should get only one pod file, use the first element rather than going through the slice
 	vpoLog := allPodFiles[0]

--- a/tools/vz/pkg/analysis/internal/util/cluster/pods.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/pods.go
@@ -100,9 +100,9 @@ func analyzePods(log *zap.SugaredLogger, clusterRoot string, podFile string) (re
 	return reported, nil
 }
 
-// IsPodReadyOrCompleted will return true if the Pod has containers that are neither Ready nor Completed
+// IsPodNotReadyNorCompleted will return true if the Pod has containers that are neither Ready nor Completed
 // TODO: Extend for transition time correlation (ie: change from bool to struct)
-func IsPodReadyOrCompleted(podStatus corev1.PodStatus) bool {
+func IsPodNotReadyNorCompleted(podStatus corev1.PodStatus) bool {
 	for _, containerStatus := range podStatus.ContainerStatuses {
 		state := containerStatus.State
 		if state.Terminated != nil && state.Terminated.Reason != "Completed" {
@@ -319,7 +319,7 @@ func IsPodProblematic(pod corev1.Pod) bool {
 	if pod.Status.Phase == corev1.PodRunning ||
 		pod.Status.Phase == corev1.PodSucceeded {
 		// The Pod indicates it is Running/Succeeded, check if there are containers that are not ready
-		return IsPodReadyOrCompleted(pod.Status)
+		return IsPodNotReadyNorCompleted(pod.Status)
 	}
 	return true
 }

--- a/tools/vz/pkg/analysis/internal/util/cluster/pods_test.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/pods_test.go
@@ -2,4 +2,46 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package cluster
 
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
 // TODO: Add more tests
+
+func TestPodConditionMessage(t *testing.T) {
+	ns := "test"
+	var tests = []struct {
+		name      string
+		condition corev1.PodCondition
+		message   string
+	}{
+		{
+			"pod-no-message-nor-reason",
+			corev1.PodCondition{
+				Type:   corev1.PodInitialized,
+				Status: corev1.ConditionFalse,
+			},
+			"Namespace test, Pod pod-no-message-nor-reason, ConditionType Initialized, Status False",
+		},
+		{
+			"pod-with-message-and-reason",
+			corev1.PodCondition{
+				Type:    corev1.ContainersReady,
+				Status:  corev1.ConditionTrue,
+				Message: "foo",
+				Reason:  "bar",
+			},
+			"Namespace test, Pod pod-with-message-and-reason, ConditionType ContainersReady, Status True, Reason bar, Message foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := podConditionMessage(tt.name, ns, tt.condition)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.message, msg)
+		})
+	}
+}


### PR DESCRIPTION
1. use pod container statuses to determine if the pod is healthy or not. Terminated pods with 'Completed' reasons are accepted is non-problematic
2. enhance supporting data messages to accurately emit container status as strings using a template. See example output:
```
Namespace cattle-system, Pod rancher-76b9bdf5f4-8x5bp, Type Initialized, Status True
Namespace cattle-system, Pod rancher-76b9bdf5f4-8x5bp, Type Ready, Status False, Reason ContainersNotReady, Message containers with unready status: [rancher]
Namespace cattle-system, Pod rancher-76b9bdf5f4-8x5bp, Type ContainersReady, Status False, Reason ContainersNotReady, Message containers with unready status: [rancher]
Namespace cattle-system, Pod rancher-76b9bdf5f4-8x5bp, Type PodScheduled, Status True
```

Previous output had empty columns, missing type:
```
Namespace cattle-system, Pod helm-operation-8z9pw, Status True, Reason , Message 
Namespace cattle-system, Pod helm-operation-8z9pw, Status False, Reason ContainersNotReady, Message containers with unready status: [helm]
Namespace cattle-system, Pod helm-operation-8z9pw, Status False, Reason ContainersNotReady, Message containers with unready status: [helm]
Namespace cattle-system, Pod helm-operation-8z9pw, Status True, Reason , Message 
```