### PR TITLE
Move common release stuff that requires RELEASE_VERSION to be supplie…

### DIFF
--- a/release/scripts/common-release.sh
+++ b/release/scripts/common-release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Common script used to automate the release process.
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "This script expects environment variable RELEASE_VERSION"
+  exit 1
+fi
+
+# Release artifacts
+declare -a releaseArtifacts=("operator.yaml"
+                             "operator.yaml.sha256"
+                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz.sha256"
+                             "verrazzano-${RELEASE_VERSION}-darwin-arm64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-darwin-arm64.tar.gz.sha256"
+                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz.sha256"
+                             "verrazzano-${RELEASE_VERSION}-linux-arm64.tar.gz"
+                             "verrazzano-${RELEASE_VERSION}-linux-arm64.tar.gz.sha256")

--- a/release/scripts/common.sh
+++ b/release/scripts/common.sh
@@ -7,23 +7,6 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-if [ -z "$RELEASE_VERSION" ]; then
-  echo "This script expects environment variable RELEASE_VERSION"
-  exit 1
-fi
-
-# Release artifacts
-declare -a releaseArtifacts=("operator.yaml"
-                             "operator.yaml.sha256"
-                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz"
-                             "verrazzano-${RELEASE_VERSION}-darwin-amd64.tar.gz.sha256"
-                             "verrazzano-${RELEASE_VERSION}-darwin-arm64.tar.gz"
-                             "verrazzano-${RELEASE_VERSION}-darwin-arm64.tar.gz.sha256"
-                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz"
-                             "verrazzano-${RELEASE_VERSION}-linux-amd64.tar.gz.sha256"
-                             "verrazzano-${RELEASE_VERSION}-linux-arm64.tar.gz"
-                             "verrazzano-${RELEASE_VERSION}-linux-arm64.tar.gz.sha256")
-
 # Validates whether OCI CLI is installed
 function validate_oci_cli() {
      command -v oci >/dev/null 2>&1 || {

--- a/release/scripts/create_github_release.sh
+++ b/release/scripts/create_github_release.sh
@@ -8,6 +8,7 @@ set -e
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 . $SCRIPT_DIR/common.sh
+. $SCRIPT_DIR/common-release.sh
 
 usage() {
     cat <<EOM

--- a/release/scripts/get_release_artifacts.sh
+++ b/release/scripts/get_release_artifacts.sh
@@ -65,6 +65,9 @@ function get_vz_release_artifacts() {
     rm -f ${_file}.sha256
 }
 
+# Validate OCI CLI
+validate_oci_cli || exit 1
+
 mkdir -p $RELEASE_BINARIES_DIR
 
 # Download the release artifacts

--- a/release/scripts/scan_release_binaries.sh
+++ b/release/scripts/scan_release_binaries.sh
@@ -19,7 +19,7 @@ usage() {
   Example:
     $(basename $0) release_bundle_dir scanner_home scan_report_dir
 
-  The script expects the OCI CLI is installed. It also expects the following environment variables -
+  The script expects the following environment variables -
     RELEASE_VERSION - release version (major.minor.patch format, e.g. 1.0.1)
     SCANNER_ARCHIVE_LOCATION - command line scanner
     SCANNER_ARCHIVE_FILE - scanner archive

--- a/release/scripts/verify_github_release.sh
+++ b/release/scripts/verify_github_release.sh
@@ -8,6 +8,7 @@ set -e
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 . $SCRIPT_DIR/common.sh
+. $SCRIPT_DIR/common-release.sh
 
 usage() {
     cat <<EOM


### PR DESCRIPTION
Not all of the scripts/jobs will have RELEASE_VERSION set, moving the common stuff that does need it set into a separate script that can be sourced by the stuff that does need it.