### PR TITLE
Build E2E tests as part of main build to validate they compile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,6 +317,13 @@ pipeline {
                     // Validate that the E2E tests build successfully before launching downstream tests
                     // - do it here instead of the earlier stage so that it does not slow down the more important
                     //   operator and code validation steps
+                    when {
+                        allOf {
+                            not { buildingTag() }
+                            changeset "tests/e2e/**"
+                            changeset "pkg/**"
+                        }
+                    }
                     steps {
                         buildE2ETests()
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -270,6 +270,19 @@ pipeline {
                     }
                 }
 
+                stage('Build E2E Tests') {
+                    steps {
+                        buildE2ETests()
+                    }
+                    post {
+                        failure {
+                            script {
+                                SKIP_TRIGGERED_TESTS = true
+                            }
+                        }
+                    }
+                }
+
                 stage('Unit Tests') {
                     when { not { buildingTag() } }
                     steps {
@@ -605,6 +618,14 @@ def buildVerrazzanoCLI(dockerImageTag) {
         make go-build DOCKER_IMAGE_TAG=${dockerImageTag}
         ${GO_REPO_PATH}/verrazzano/ci/scripts/save_tooling.sh ${env.BRANCH_NAME} ${SHORT_COMMIT_HASH}
         cp out/linux_amd64/vz ${GO_REPO_PATH}/vz
+    """
+}
+
+// Called in Build E2E stage
+def buildE2ETests() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano
+        ginkgo build ./tests/e2e/...
     """
 }
 

--- a/tests/e2e/pkg/clusterdump.go
+++ b/tests/e2e/pkg/clusterdump.go
@@ -16,8 +16,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/test"
 )
 
-xxx
-
 const (
 	AnalysisReport = "analysis.report"
 	BugReport      = "bug-report.tar.gz"

--- a/tests/e2e/pkg/clusterdump.go
+++ b/tests/e2e/pkg/clusterdump.go
@@ -16,6 +16,8 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/test"
 )
 
+xxx
+
 const (
 	AnalysisReport = "analysis.report"
 	BugReport      = "bug-report.tar.gz"


### PR DESCRIPTION
Add a parallel stage in the build phase to validate that the `e2e` tests build successfully before starting downstream pipelines.