### PR TITLE
VZ-6756: Add HA test to hit hello-helidon app endpoint during upgrade

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -411,7 +411,7 @@ pipeline {
                     }
                 }
 
-                stage('Parallel HA Tests and Rolling Update') {
+                stage('Parallel HA Tests and K8s Upgrade') {
                     when {
                         expression { TESTS_FAILED == false }
                     }
@@ -419,7 +419,7 @@ pipeline {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/ha-tests"
                     }
                     parallel {
-                        stage('Rolling Update') {
+                        stage('K8s In-place Upgrade') {
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/inplaceupgrade"
                                 OKE_CLUSTER_ID="${OKE_CLUSTER_ID}"

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -115,6 +115,7 @@ pipeline {
         INSTALL_PROFILE = "prod"
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
+        HELIDON_TEST_NAMESPACE = "ha-hello-helidon"
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test
         DATABASE_PSW = credentials('todo-mysql-password') // required by console ingress test
@@ -341,7 +342,7 @@ pipeline {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/helidon-install"
                     }
                     steps{
-                        runGinkgo('examples/helidon', '--namespace=hello-helidon --skipUndeploy=true --appconfig=examples/hello-helidon/hello-helidon-app-scaler-trait.yaml')
+                        runGinkgo("examples/helidon", "--namespace=${HELIDON_TEST_NAMESPACE} --skipUndeploy=true --appconfig=examples/hello-helidon/hello-helidon-app-scaler-trait.yaml")
                     }
                     post {
                         always {
@@ -430,6 +431,11 @@ pipeline {
                         stage('HA Tests') {
                             steps {
                                 runGinkgoRandomize('ha/monitor')
+                            }
+                        }
+                        stage('Access Hello Helidon') {
+                            steps {
+                                runGinkgo("ha/helidon", "--namespace=${HELIDON_TEST_NAMESPACE}")
                             }
                         }
                         stage ('console') {

--- a/tests/e2e/ha/helidon/helidon_example_suite_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_suite_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidon
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var namespace string
+
+func init() {
+	flag.StringVar(&namespace, "namespace", "ha-hello-helidon", "namespace is the app namespace")
+}
+
+func TestHAHelidonExample(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "HA Hello Helidon Suite")
+}

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -129,13 +129,12 @@ func readResponseBody(resp *http.Response) (string, error) {
 
 // getVerrazzanoHTTPClientWithRetries gets a retryable HTTP client configured with the Verrazzano CA cert.
 // Since this makes k8s calls that result in VPO webhook calls, we need to retry long enough to allow
-// the VPO to be migrated to another node, which can take minutes.
+// the VPO to be migrated to another node, which can take several minutes.
 func getVerrazzanoHTTPClientWithRetries(kubeconfigPath string) (*retryablehttp.Client, error) {
 	var httpClient *retryablehttp.Client
 	var err error
 
-	// this will retry for a max of 4 minutes
-	for i := 1; i <= 15; i++ {
+	for i := 1; i <= 25; i++ {
 		httpClient, err = pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
 		if err == nil {
 			break

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -137,12 +137,13 @@ func getVerrazzanoHTTPClientWithRetries(kubeconfigPath string) (*retryablehttp.C
 	var httpClient *retryablehttp.Client
 	var err error
 
-	for i := 1; i <= 5; i++ {
+	// this will retry for a max of 4 minutes
+	for i := 1; i <= 15; i++ {
 		httpClient, err = pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
 		if err == nil {
 			break
 		}
-		time.Sleep(time.Duration(i) * time.Second)
+		time.Sleep(2 * time.Duration(i) * time.Second)
 	}
 	if err != nil {
 		return nil, err

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tests/e2e/ha"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 )
 
 const (
@@ -58,7 +58,7 @@ var _ = t.Describe("HA Hello Helidon app endpoint test", Label("f:app-lcm.helido
 			url = fmt.Sprintf("https://%s/greet", host)
 		})
 
-		ha.RunningUntilShutdownIt(t, "accesses /greet app URL", clientset, true, func() {
+		hacommon.RunningUntilShutdownIt(t, "accesses /greet app URL", clientset, true, func() {
 			Expect(appEndpointAccessible(url, host)).Should(BeTrue())
 			time.Sleep(time.Second)
 		})

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -77,7 +77,7 @@ func appEndpointAccessible(url string, hostname string) bool {
 	req.Host = hostname
 	req.Close = true
 	resp, err := httpClient.Do(req)
-	if resp.Body != nil {
+	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -26,69 +26,52 @@ const (
 )
 
 var (
-	t           = framework.NewTestFramework("ha-helidon")
-	clusterDump = pkg.NewClusterDumpWrapper(namespace)
-	clientset   = k8sutil.GetKubernetesClientsetOrDie()
+	t              = framework.NewTestFramework("ha-helidon")
+	clusterDump    = pkg.NewClusterDumpWrapper(namespace)
+	clientset      = k8sutil.GetKubernetesClientsetOrDie()
+	kubeconfigPath = ""
 )
 
-var _ = clusterDump.BeforeSuite(func() {}) // Needed to initialize cluster dump flags
-var _ = clusterDump.AfterEach(func() {})   // Dump cluster if spec fails
-
-var _ = t.Describe("HA Hello Helidon app test", Label("f:app-lcm.helidon-workload"), func() {
-	var host string
-	var url string
+var _ = clusterDump.BeforeSuite(func() {
 	var err error
+	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+	Expect(err).ToNot(HaveOccurred())
+})
 
-	// Get the host from the Istio gateway resource.
-	// GIVEN the Istio gateway for the hello-helidon namespace
-	// WHEN GetHostnameFromGateway is called
-	// THEN return the host name found in the gateway.
-	t.BeforeEach(func() {
-		Eventually(func() (string, error) {
-			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
-			t.Logs.Infof("Host is: %s", host)
-			return host, err
-		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
-		url = fmt.Sprintf("https://%s/greet", host)
-	})
+var _ = t.Describe("HA Hello Helidon app endpoint test", Label("f:app-lcm.helidon-workload"), func() {
 
-	// Verify Hello Helidon app is working
-	// GIVEN OAM hello-helidon app is deployed
-	// WHEN the component and appconfig with ingress trait are created
-	// THEN the application endpoint must be accessible
-	t.Describe("for Ingress.", Label("f:mesh.ingress"), func() {
-		RunningUntilShutdownIt("access /greet app URL", func() {
+	// GIVEN the hello-helidon app is deployed
+	// WHEN we access the app endpoint repeatedly during a Kubernetes cluster upgrade
+	// THEN the application endpoint must be accessible during the upgrade
+	t.Context("accesses the endpoint", Label("f:mesh.ingress"), func() {
+		var host string
+		var url string
+
+		t.It("fetches the ingress", func() {
+			Eventually(func() (string, error) {
+				var err error
+				host, err = k8sutil.GetHostnameFromGateway(namespace, "")
+				return host, err
+			}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
+
+			url = fmt.Sprintf("https://%s/greet", host)
+		})
+
+		ha.RunningUntilShutdownIt(t, "accesses /greet app URL", clientset, true, func() {
 			Expect(appEndpointAccessible(url, host)).Should(BeTrue())
 			time.Sleep(time.Second)
 		})
 	})
 })
 
-func RunningUntilShutdownIt(description string, test func()) {
-	t.It(description, func() {
-		for {
-			test()
-			// break out of the loop if we are not running the suite continuously,
-			// or the shutdown signal is set
-			if ha.IsShutdownSignalSet(clientset) {
-				t.Logs.Info("Shutting down...")
-				break
-			}
-		}
-	})
-}
-
+// appEndpointAccessible hits the hello-helidon app endpoint and validates that the
+// response text matches the expected text
 func appEndpointAccessible(url string, hostname string) bool {
 	req, err := retryablehttp.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Logs.Errorf("Unexpected error while creating new request=%v", err)
-		return false
-	}
-
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		t.Logs.Errorf("Unexpected error while getting kubeconfig location=%v", err)
 		return false
 	}
 
@@ -100,32 +83,30 @@ func appEndpointAccessible(url string, hostname string) bool {
 	req.Host = hostname
 	req.Close = true
 	resp, err := httpClient.Do(req)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		t.Logs.Errorf("Unexpected error while making http request=%v", err)
-		if resp != nil && resp.Body != nil {
-			bodyRaw, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)
-				return false
-			}
-
-			t.Logs.Errorf("Error Response=%v", string(bodyRaw))
-			resp.Body.Close()
+		bodyStr, err := readResponseBody(resp)
+		if err != nil {
+			t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)
+			return false
 		}
+
+		t.Logs.Errorf("Error Response=%v", bodyStr)
 		return false
 	}
 
-	bodyRaw, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		t.Logs.Errorf("Unexpected error marshallling response=%v", err)
-		return false
-	}
 	if resp.StatusCode != http.StatusOK {
 		t.Logs.Errorf("Unexpected status code=%v", resp.StatusCode)
 		return false
 	}
-	bodyStr := string(bodyRaw)
+	bodyStr, err := readResponseBody(resp)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error marshallling response=%v", err)
+		return false
+	}
 	if !strings.Contains(bodyStr, "Hello World") {
 		t.Logs.Errorf("Unexpected response body=%v", bodyStr)
 		return false
@@ -133,6 +114,22 @@ func appEndpointAccessible(url string, hostname string) bool {
 	return true
 }
 
+// readResponseBody reads the response body bytes and returns it as a string
+func readResponseBody(resp *http.Response) (string, error) {
+	var body string
+	if resp != nil && resp.Body != nil {
+		bodyRaw, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		body = string(bodyRaw)
+	}
+	return body, nil
+}
+
+// getVerrazzanoHTTPClientWithRetries gets a retryable HTTP client configured with the Verrazzano CA cert.
+// Since this makes k8s calls that result in VPO webhook calls, we need to retry long enough to allow
+// the VPO to be migrated to another node, which can take minutes.
 func getVerrazzanoHTTPClientWithRetries(kubeconfigPath string) (*retryablehttp.Client, error) {
 	var httpClient *retryablehttp.Client
 	var err error

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helidon
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/ha"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	shortPollingInterval = 10 * time.Second
+	shortWaitTimeout     = 5 * time.Minute
+)
+
+var (
+	t         = framework.NewTestFramework("ha-helidon")
+	clientset = k8sutil.GetKubernetesClientsetOrDie()
+)
+
+var _ = t.Describe("HA Hello Helidon app test", Label("f:app-lcm.helidon-workload"), func() {
+	var host string
+	var url string
+	var err error
+
+	// Get the host from the Istio gateway resource.
+	// GIVEN the Istio gateway for the hello-helidon namespace
+	// WHEN GetHostnameFromGateway is called
+	// THEN return the host name found in the gateway.
+	t.BeforeEach(func() {
+		Eventually(func() (string, error) {
+			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
+			t.Logs.Infof("Host is: %s", host)
+			return host, err
+		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
+
+		url = fmt.Sprintf("https://%s/greet", host)
+	})
+
+	// Verify Hello Helidon app is working
+	// GIVEN OAM hello-helidon app is deployed
+	// WHEN the component and appconfig with ingress trait are created
+	// THEN the application endpoint must be accessible
+	t.Describe("for Ingress.", Label("f:mesh.ingress"), func() {
+		RunningUntilShutdownIt("access /greet app URL", func() {
+			Expect(appEndpointAccessible(url, host)).Should(BeTrue())
+			time.Sleep(time.Second)
+		})
+	})
+})
+
+func RunningUntilShutdownIt(description string, test func()) {
+	t.It(description, func() {
+		for {
+			test()
+			// break out of the loop if we are not running the suite continuously,
+			// or the shutdown signal is set
+			if ha.IsShutdownSignalSet(clientset) {
+				t.Logs.Info("Shutting down...")
+				break
+			}
+		}
+	})
+}
+
+func appEndpointAccessible(url string, hostname string) bool {
+	req, err := retryablehttp.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while creating new request=%v", err)
+		return false
+	}
+
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while getting kubeconfig location=%v", err)
+		return false
+	}
+
+	httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while getting new httpClient=%v", err)
+		return false
+	}
+	req.Host = hostname
+	req.Close = true
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while making http request=%v", err)
+		if resp != nil && resp.Body != nil {
+			bodyRaw, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)
+				return false
+			}
+
+			t.Logs.Errorf("Error Response=%v", string(bodyRaw))
+			resp.Body.Close()
+		}
+		return false
+	}
+
+	bodyRaw, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Logs.Errorf("Unexpected error marshallling response=%v", err)
+		return false
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Logs.Errorf("Unexpected status code=%v", resp.StatusCode)
+		return false
+	}
+	// HTTP Server headers should never be returned.
+	for headerName, headerValues := range resp.Header {
+		if strings.EqualFold(headerName, "Server") {
+			t.Logs.Errorf("Unexpected Server header=%v", headerValues)
+			return false
+		}
+	}
+	bodyStr := string(bodyRaw)
+	if !strings.Contains(bodyStr, "Hello World") {
+		t.Logs.Errorf("Unexpected response body=%v", bodyStr)
+		return false
+	}
+	return true
+}

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -31,7 +31,8 @@ var (
 	clientset   = k8sutil.GetKubernetesClientsetOrDie()
 )
 
-var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
+var _ = clusterDump.BeforeSuite(func() {}) // Needed to initialize cluster dump flags
+var _ = clusterDump.AfterEach(func() {})   // Dump cluster if spec fails
 
 var _ = t.Describe("HA Hello Helidon app test", Label("f:app-lcm.helidon-workload"), func() {
 	var host string

--- a/tests/e2e/ha/helidon/helidon_example_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_test.go
@@ -26,9 +26,12 @@ const (
 )
 
 var (
-	t         = framework.NewTestFramework("ha-helidon")
-	clientset = k8sutil.GetKubernetesClientsetOrDie()
+	t           = framework.NewTestFramework("ha-helidon")
+	clusterDump = pkg.NewClusterDumpWrapper(namespace)
+	clientset   = k8sutil.GetKubernetesClientsetOrDie()
 )
+
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
 var _ = t.Describe("HA Hello Helidon app test", Label("f:app-lcm.helidon-workload"), func() {
 	var host string

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -6,6 +6,7 @@ package inplaceupgrade
 import (
 	"errors"
 	"fmt"
+	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 	"os"
 	"os/exec"
 	"time"

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -6,12 +6,9 @@ package inplaceupgrade
 import (
 	"errors"
 	"fmt"
-	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 	"os"
 	"os/exec"
 	"time"
-
-	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,11 +16,13 @@ import (
 	"github.com/oracle/oci-go-sdk/v53/common/auth"
 	ocice "github.com/oracle/oci-go-sdk/v53/containerengine"
 	ocicore "github.com/oracle/oci-go-sdk/v53/core"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
+	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 )
 
 const (

--- a/tests/e2e/ha/monitor/ha_setup_test.go
+++ b/tests/e2e/ha/monitor/ha_setup_test.go
@@ -8,14 +8,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"k8s.io/client-go/kubernetes"
 )
 
 // config for HA monitoring test suite
 type config struct {
 	api        *pkg.APIEndpoint
 	httpClient *retryablehttp.Client
-	clientset  *kubernetes.Clientset
 	hosts      struct {
 		rancher string
 		kiali   string
@@ -32,8 +30,7 @@ var _ = clusterDump.BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred())
 	web.api = pkg.EventuallyGetAPIEndpoint(kubeconfigPath)
 	web.httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
-	web.clientset = k8sutil.GetKubernetesClientsetOrDie()
 	web.users.verrazzano = pkg.EventuallyGetSystemVMICredentials()
 	web.hosts.rancher = pkg.EventuallyGetURLForIngress(t.Logs, web.api, "cattle-system", "rancher", "https")
-	web.hosts.kiali = pkg.EventuallyGetKialiHost(web.clientset)
+	web.hosts.kiali = pkg.EventuallyGetKialiHost(clientset)
 })

--- a/tests/e2e/ha/monitor/ha_setup_test.go
+++ b/tests/e2e/ha/monitor/ha_setup_test.go
@@ -27,7 +27,7 @@ type config struct {
 
 var web = config{}
 
-var _ = t.BeforeSuite(func() {
+var _ = clusterDump.BeforeSuite(func() {
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	Expect(err).ShouldNot(HaveOccurred())
 	web.api = pkg.EventuallyGetAPIEndpoint(kubeconfigPath)

--- a/tests/e2e/ha/monitor/monitor_suite_test.go
+++ b/tests/e2e/ha/monitor/monitor_suite_test.go
@@ -5,11 +5,11 @@ package monitor
 
 import (
 	"flag"
+	"testing"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
-	"testing"
 )
 
 var runContinuous bool
@@ -22,18 +22,4 @@ func init() {
 func TestHAMonitor(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "HA Monitoring Suite")
-}
-
-func RunningUntilShutdownIt(description string, test func()) {
-	t.It(description, func() {
-		for {
-			test()
-			// break out of the loop if we are not running the suite continuously,
-			// or the shutdown signal is set
-			if !runContinuous || ha.IsShutdownSignalSet(web.clientset) {
-				t.Logs.Info("Shutting down...")
-				break
-			}
-		}
-	})
 }

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
+var clusterDump = pkg.NewClusterDumpWrapper()
+
+var _ = clusterDump.BeforeSuite(func() {}) // Needed to initialize cluster dump flags
+var _ = clusterDump.AfterEach(func() {})   // Dump cluster if spec fails
+
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {
 		RunningUntilShutdownIt("can access Prometheus endpoint", func() {

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/tests/e2e/ha"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	hacommon "github.com/verrazzano/verrazzano/tests/e2e/pkg/ha"
 )
 
 var (
@@ -20,31 +20,31 @@ var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {
-		ha.RunningUntilShutdownIt(t, "can access Prometheus endpoint", clientset, runContinuous, func() {
+		hacommon.RunningUntilShutdownIt(t, "can access Prometheus endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyPrometheusComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch", func() {
-		ha.RunningUntilShutdownIt(t, "can access OpenSearch endpoint", clientset, runContinuous, func() {
+		hacommon.RunningUntilShutdownIt(t, "can access OpenSearch endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch Dashboards", func() {
-		ha.RunningUntilShutdownIt(t, "can access OpenSearch Dashboards endpoint", clientset, runContinuous, func() {
+		hacommon.RunningUntilShutdownIt(t, "can access OpenSearch Dashboards endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchDashboardsComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("Rancher", func() {
-		ha.RunningUntilShutdownIt(t, "can get a Rancher admin token", clientset, runContinuous, func() {
+		hacommon.RunningUntilShutdownIt(t, "can get a Rancher admin token", clientset, runContinuous, func() {
 			Expect(pkg.GetRancherAdminToken(t.Logs, web.httpClient, web.hosts.rancher)).ShouldNot(BeEmpty())
 		})
 	})
 
 	t.Context("Kiali", func() {
-		ha.RunningUntilShutdownIt(t, "can access Kiali endpoint", clientset, runContinuous, func() {
+		hacommon.RunningUntilShutdownIt(t, "can access Kiali endpoint", clientset, runContinuous, func() {
 			Expect(pkg.AssertBearerAuthorized(web.httpClient, web.hosts.kiali)).To(BeTrue())
 		})
 	})

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -6,41 +6,45 @@ package monitor
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/ha"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
-var clusterDump = pkg.NewClusterDumpWrapper()
+var (
+	clusterDump = pkg.NewClusterDumpWrapper()
+	clientset   = k8sutil.GetKubernetesClientsetOrDie()
+)
 
 var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {
-		ha.RunningUntilShutdownIt(t, "can access Prometheus endpoint", web.clientset, runContinuous, func() {
+		ha.RunningUntilShutdownIt(t, "can access Prometheus endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyPrometheusComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch", func() {
-		ha.RunningUntilShutdownIt(t, "can access OpenSearch endpoint", web.clientset, runContinuous, func() {
+		ha.RunningUntilShutdownIt(t, "can access OpenSearch endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch Dashboards", func() {
-		ha.RunningUntilShutdownIt(t, "can access OpenSearch Dashboards endpoint", web.clientset, runContinuous, func() {
+		ha.RunningUntilShutdownIt(t, "can access OpenSearch Dashboards endpoint", clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchDashboardsComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("Rancher", func() {
-		ha.RunningUntilShutdownIt(t, "can get a Rancher admin token", web.clientset, runContinuous, func() {
+		ha.RunningUntilShutdownIt(t, "can get a Rancher admin token", clientset, runContinuous, func() {
 			Expect(pkg.GetRancherAdminToken(t.Logs, web.httpClient, web.hosts.rancher)).ShouldNot(BeEmpty())
 		})
 	})
 
 	t.Context("Kiali", func() {
-		ha.RunningUntilShutdownIt(t, "can access Kiali endpoint", web.clientset, runContinuous, func() {
+		ha.RunningUntilShutdownIt(t, "can access Kiali endpoint", clientset, runContinuous, func() {
 			Expect(pkg.AssertBearerAuthorized(web.httpClient, web.hosts.kiali)).To(BeTrue())
 		})
 	})

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -11,8 +11,7 @@ import (
 
 var clusterDump = pkg.NewClusterDumpWrapper()
 
-var _ = clusterDump.BeforeSuite(func() {}) // Needed to initialize cluster dump flags
-var _ = clusterDump.AfterEach(func() {})   // Dump cluster if spec fails
+var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {

--- a/tests/e2e/ha/monitor/web_ha_test.go
+++ b/tests/e2e/ha/monitor/web_ha_test.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/ha"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 )
 
@@ -15,31 +16,31 @@ var _ = clusterDump.AfterEach(func() {}) // Dump cluster if spec fails
 
 var _ = t.Describe("Web Access", Label("f:platform-lcm:ha"), func() {
 	t.Context("Prometheus", func() {
-		RunningUntilShutdownIt("can access Prometheus endpoint", func() {
+		ha.RunningUntilShutdownIt(t, "can access Prometheus endpoint", web.clientset, runContinuous, func() {
 			Expect(pkg.VerifyPrometheusComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch", func() {
-		RunningUntilShutdownIt("can access OpenSearch endpoint", func() {
+		ha.RunningUntilShutdownIt(t, "can access OpenSearch endpoint", web.clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("OpenSearch Dashboards", func() {
-		RunningUntilShutdownIt("can access OpenSearch Dashboards endpoint", func() {
+		ha.RunningUntilShutdownIt(t, "can access OpenSearch Dashboards endpoint", web.clientset, runContinuous, func() {
 			Expect(pkg.VerifyOpenSearchDashboardsComponent(t.Logs, nil, web.httpClient, web.users.verrazzano)).To(BeTrue())
 		})
 	})
 
 	t.Context("Rancher", func() {
-		RunningUntilShutdownIt("can get a Rancher admin token", func() {
+		ha.RunningUntilShutdownIt(t, "can get a Rancher admin token", web.clientset, runContinuous, func() {
 			Expect(pkg.GetRancherAdminToken(t.Logs, web.httpClient, web.hosts.rancher)).ShouldNot(BeEmpty())
 		})
 	})
 
 	t.Context("Kiali", func() {
-		RunningUntilShutdownIt("can access Kiali endpoint", func() {
+		ha.RunningUntilShutdownIt(t, "can access Kiali endpoint", web.clientset, runContinuous, func() {
 			Expect(pkg.AssertBearerAuthorized(web.httpClient, web.hosts.kiali)).To(BeTrue())
 		})
 	})

--- a/tests/e2e/pkg/ha/nodes.go
+++ b/tests/e2e/pkg/ha/nodes.go
@@ -5,13 +5,11 @@ package ha
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/onsi/gomega"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,47 +33,6 @@ func EventuallyGetNodes(cs *kubernetes.Clientset, log *zap.SugaredLogger) *corev
 		return true
 	}, WaitTimeout, PollingInterval).Should(gomega.BeTrue())
 	return nodes
-}
-
-func EventuallySetNodeScheduling(cs *kubernetes.Clientset, name string, unschedulable bool, log *zap.SugaredLogger) {
-	gomega.Eventually(func() bool {
-		node, err := cs.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
-			log.Errorf("Failed to refresh node[%s]: %v", name, err)
-			return false
-		}
-		node.Spec.Unschedulable = unschedulable
-		if _, err := cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{}); err != nil {
-			log.Errorf("Failed to update node[%s] scheduling: %v", name, err)
-			return false
-		}
-		return true
-	}).Should(gomega.BeTrue())
-	log.Infof("Set node[%s].spec.unschedulable=%v", name, unschedulable)
-}
-
-func EventuallyEvictNode(cs *kubernetes.Clientset, name string, log *zap.SugaredLogger) {
-	gomega.Eventually(func() bool {
-		pods, err := cs.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("spec.nodeName=%s", name),
-		})
-		if err != nil {
-			log.Errorf("Failed to get pods for node[%s]: %v", name, err)
-			return false
-		}
-
-		for i := range pods.Items {
-			pod := &pods.Items[i]
-			if err := cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
-				if !errors.IsNotFound(err) {
-					log.Errorf("Failed to delete pod[%s] for node[%s]: %v", pod.Name, name, err)
-					return false
-				}
-			}
-		}
-		return true
-	}, WaitTimeout, PollingInterval).Should(gomega.BeTrue())
-	log.Infof("Evicted node[%s]", name)
 }
 
 func IsControlPlaneNode(node corev1.Node) bool {

--- a/tests/e2e/pkg/ha/nodes.go
+++ b/tests/e2e/pkg/ha/nodes.go
@@ -5,11 +5,13 @@ package ha
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/gomega"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -33,6 +35,47 @@ func EventuallyGetNodes(cs *kubernetes.Clientset, log *zap.SugaredLogger) *corev
 		return true
 	}, WaitTimeout, PollingInterval).Should(gomega.BeTrue())
 	return nodes
+}
+
+func EventuallySetNodeScheduling(cs *kubernetes.Clientset, name string, unschedulable bool, log *zap.SugaredLogger) {
+	gomega.Eventually(func() bool {
+		node, err := cs.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			log.Errorf("Failed to refresh node[%s]: %v", name, err)
+			return false
+		}
+		node.Spec.Unschedulable = unschedulable
+		if _, err := cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{}); err != nil {
+			log.Errorf("Failed to update node[%s] scheduling: %v", name, err)
+			return false
+		}
+		return true
+	}).Should(gomega.BeTrue())
+	log.Infof("Set node[%s].spec.unschedulable=%v", name, unschedulable)
+}
+
+func EventuallyEvictNode(cs *kubernetes.Clientset, name string, log *zap.SugaredLogger) {
+	gomega.Eventually(func() bool {
+		pods, err := cs.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", name),
+		})
+		if err != nil {
+			log.Errorf("Failed to get pods for node[%s]: %v", name, err)
+			return false
+		}
+
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if err := cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
+				if !errors.IsNotFound(err) {
+					log.Errorf("Failed to delete pod[%s] for node[%s]: %v", pod.Name, name, err)
+					return false
+				}
+			}
+		}
+		return true
+	}, WaitTimeout, PollingInterval).Should(gomega.BeTrue())
+	log.Infof("Evicted node[%s]", name)
 }
 
 func IsControlPlaneNode(node corev1.Node) bool {

--- a/tests/e2e/pkg/ha/signal.go
+++ b/tests/e2e/pkg/ha/signal.go
@@ -49,6 +49,7 @@ func IsShutdownSignalSet(cs *kubernetes.Clientset) bool {
 // test is only run one time.
 func RunningUntilShutdownIt(t *framework.TestFramework, description string, clientset *kubernetes.Clientset, runContinuous bool, test func()) {
 	t.It(description, func() {
+		gomega.Expect(clientset).ToNot(gomega.BeNil())
 		for {
 			test()
 			// break out of the loop if we are not running the suite continuously,

--- a/tests/e2e/pkg/ha/signal.go
+++ b/tests/e2e/pkg/ha/signal.go
@@ -5,7 +5,10 @@ package ha
 
 import (
 	"context"
+	"time"
+
 	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +18,9 @@ import (
 const (
 	shutdownSignalName      = "ha-shutdown-signal"
 	shutdownSignalNamespace = "default"
+
+	shortWaitTimeout     = time.Minute
+	shortPollingInterval = 5 * time.Second
 )
 
 func EventuallyCreateShutdownSignal(cs *kubernetes.Clientset, log *zap.SugaredLogger) {
@@ -30,11 +36,27 @@ func EventuallyCreateShutdownSignal(cs *kubernetes.Clientset, log *zap.SugaredLo
 			return false
 		}
 		return true
-	}).Should(gomega.BeTrue())
+	}).WithTimeout(shortWaitTimeout).WithPolling(shortPollingInterval).Should(gomega.BeTrue())
 	log.Infof("Created shutdown signal %s", shutdownSignalName)
 }
 
 func IsShutdownSignalSet(cs *kubernetes.Clientset) bool {
 	_, err := cs.CoreV1().Secrets(shutdownSignalNamespace).Get(context.TODO(), shutdownSignalName, metav1.GetOptions{})
 	return err == nil
+}
+
+// RunningUntilShutdownIt runs the test function repeatedly until the shutdown signal is set. If the "runContinues" flag is false, the
+// test is only run one time.
+func RunningUntilShutdownIt(t *framework.TestFramework, description string, clientset *kubernetes.Clientset, runContinuous bool, test func()) {
+	t.It(description, func() {
+		for {
+			test()
+			// break out of the loop if we are not running the suite continuously,
+			// or the shutdown signal is set
+			if !runContinuous || IsShutdownSignalSet(clientset) {
+				t.Logs.Info("Shutting down...")
+				break
+			}
+		}
+	})
 }


### PR DESCRIPTION
This PR adds an HA test suite that repeatedly hits the hello-helidon app endpoint during the K8s cluster upgrade. This tests that the app endpoint can be successfully accessed during the entire cluster upgrade.

I refactored the `RunningUntilShutdownIt` function so that it could be shared between test suites. I also did some minor refactoring (renaming, etc.) and fixed a bug (one instance of an `Eventually` did not specify a timeout or polling interval, and the defaults for those are so low that the Eventually function would only ever be run once).

I also added more cluster dump hooks as cluster dumps were not being generated in all failure cases.