### PR TITLE
VZ-6064: Increase timeout for verify metrics for system components and enable upgrade tests with the periodic job. 

### DIFF
--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -41,7 +41,7 @@ pipeline {
         choice (description: 'Predefined config permutations for Verrazzano installation. Prod profile is the default profile for NONE', name: 'VZ_INSTALL_CONFIG',
                 choices: ["NONE", "dev-kind-persistence"])
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.1.2, v1.2.0, v1.2.1, v1.2.2",
+                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -20,8 +20,8 @@ import (
 const (
 	metricsVersion = "1.4.0"
 
-	longPollingInterval = 8 * time.Second
-	longWaitTimeout     = 10 * time.Minute
+	longPollingInterval = 10 * time.Second
+	longWaitTimeout     = 15 * time.Minute
 
 	// Constants for sample metrics of system components validated by the test
 	ingressControllerSuccess       = "nginx_ingress_controller_success"


### PR DESCRIPTION
This PR will increase the timeout for the verify metric tests for system components and enables upgrade tests for 1.1.1, 1.1.2, and 1.2.x releases with the periodic job. 