### PR TITLE
VZ-6691. Add support for skipping the k8s upgrade in he HA pipeline

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -41,6 +41,9 @@ pipeline {
         choice (description: 'OCI region to launch OKE clusters in', name: 'OKE_CLUSTER_REGION',
             // 1st choice is the default value
             choices: availableRegions )
+        booleanParam (name: 'SKIP_KUBERNETES_UPGRADE',
+            description: 'Skip Kubernetes version upgrade (simulate upgrade, drain and replace worker nodes only)',
+            defaultValue: false)
         string (name: 'GIT_COMMIT_TO_USE',
                 defaultValue: 'NONE',
                 description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,8 +27,9 @@ import (
 )
 
 const (
-	clusterIDEnvVar = "OKE_CLUSTER_ID"
-	ociRegionEnvVar = "OCI_CLI_REGION"
+	clusterIDEnvVar   = "OKE_CLUSTER_ID"
+	ociRegionEnvVar   = "OCI_CLI_REGION"
+	skipUpgradeEnvVar = "SKIP_KUBERNETES_UPGRADE"
 
 	waitTimeout     = 20 * time.Minute
 	pollingInterval = 30 * time.Second
@@ -37,9 +39,10 @@ var clientset = k8sutil.GetKubernetesClientsetOrDie()
 var t = framework.NewTestFramework("in_place_upgrade")
 
 var (
-	failed    bool
-	region    string
-	clusterID string
+	failed                    bool
+	region                    string
+	clusterID                 string
+	skipClusterVersionUpgrade bool
 
 	okeClient     ocice.ContainerEngineClient
 	computeClient ocicore.ComputeClient
@@ -52,6 +55,13 @@ var _ = t.AfterEach(func() {
 var _ = t.BeforeSuite(func() {
 	clusterID = os.Getenv(clusterIDEnvVar)
 	region = os.Getenv(ociRegionEnvVar)
+
+	if skipUpgradeVal, set := os.LookupEnv(skipUpgradeEnvVar); set {
+		var parseErr error
+		skipClusterVersionUpgrade, parseErr = strconv.ParseBool(skipUpgradeVal)
+		Expect(parseErr).ShouldNot(HaveOccurred(), fmt.Sprintf("Invalid value for %s: %s", skipUpgradeVal, skipUpgradeVal))
+	}
+
 	Expect(clusterID).ToNot(BeEmpty(), fmt.Sprintf("%s env var must be set", clusterIDEnvVar))
 	// region is optional so don't Expect
 
@@ -77,6 +87,11 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 	var upgradeVersion string
 
 	t.It("upgrades the control plane Kubernetes version", func() {
+		if skipClusterVersionUpgrade {
+			t.Logs.Infof("%s=%v, skipping cluster Control Plane upgrade", skipUpgradeEnvVar, skipClusterVersionUpgrade)
+			return
+		}
+
 		// first get the cluster details and find the available upgrade versions
 		var err error
 		clusterResponse, err = okeClient.GetCluster(context.Background(), ocice.GetClusterRequest{ClusterId: &clusterID})
@@ -97,6 +112,10 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 	})
 
 	t.It("upgrades the node pool Kubernetes version", func() {
+		if skipClusterVersionUpgrade {
+			t.Logs.Infof("%s=%v, skipping node pool upgrade", skipUpgradeEnvVar, skipClusterVersionUpgrade)
+			return
+		}
 		// first get the node pool, the cluster response struct does not have node pools so we have to list the node pools
 		// in the compartment and filter by the cluster id
 		nodePoolsResponse, err := okeClient.ListNodePools(context.Background(), ocice.ListNodePoolsRequest{CompartmentId: clusterResponse.CompartmentId, ClusterId: clusterResponse.Id})
@@ -144,6 +163,10 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 	})
 
 	t.It("validates the k8s version of each worker node in the node pool", func() {
+		if skipClusterVersionUpgrade {
+			t.Logs.Infof("%s=%v, skipping node pool verification", skipUpgradeEnvVar, skipClusterVersionUpgrade)
+			return
+		}
 		// get the nodes and check both the kube proxy and kubelet versions
 		nodes := hacommon.EventuallyGetNodes(clientset, t.Logs)
 		for _, node := range nodes.Items {


### PR DESCRIPTION
Adds support in the pipeline for skipping the CP/NP upgrade, and just recycle the nodes simulating it. This is to help speed up the round-trip time debugging failures.

- Add SKIP_KUBERNETES_UPGRADE env var to allow user to bypass the k8s upgrade
- Add parameter to the pipeline
