### PR TITLE
A couple of HA test and pipeline fixes

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -445,6 +445,11 @@ pipeline {
                             steps {
                                 sh "CONSOLE_REPO_BRANCH=${params.CONSOLE_REPO_BRANCH} ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh"
                             }
+                            post {
+                                failure {
+                                    sh "${GO_REPO_PATH}/verrazzano/ci/scripts/save_console_test_artifacts.sh"
+                                }
+                            }
                         }
                     }
                     post {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -353,7 +353,7 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**,**/Screenshot*.png,**/ConsoleLog*.log', allowEmptyArchive: true
                             junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
                     }

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -123,7 +123,15 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 				// cordon and drain the node - this function is implemented in kubectl itself and is not available
 				// using a k8s client
 				t.Logs.Infof("Draining node: %s", node.Name)
-				out, err := exec.Command("kubectl", "drain", "--ignore-daemonsets", "--delete-emptydir-data", "--force", "--skip-wait-for-delete-timeout=600", node.Name).Output() //nolint:gosec //#nosec G204
+				kubectlArgs := []string{
+					"drain",
+					"--ignore-daemonsets",
+					"--delete-emptydir-data",
+					"--force",
+					"--skip-wait-for-delete-timeout=600",
+					"--timeout=15m",
+				}
+				out, err := exec.Command("kubectl", kubectlArgs[], node.Name).Output() //nolint:gosec //#nosec G204
 				Expect(err).ShouldNot(HaveOccurred())
 				t.Logs.Infof("Output from kubectl drain command: %s", out)
 

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -130,8 +130,9 @@ var _ = t.Describe("OKE In-Place Upgrade", Label("f:platform-lcm:ha"), func() {
 					"--force",
 					"--skip-wait-for-delete-timeout=600",
 					"--timeout=15m",
+					node.Name,
 				}
-				out, err := exec.Command("kubectl", kubectlArgs[], node.Name).Output() //nolint:gosec //#nosec G204
+				out, err := exec.Command("kubectl", kubectlArgs...).Output() //nolint:gosec //#nosec G204
 				Expect(err).ShouldNot(HaveOccurred())
 				t.Logs.Infof("Output from kubectl drain command: %s", out)
 


### PR DESCRIPTION
1. Add a timeout switch to the `kubectl drain` command to prevent it from hanging.
2. Add archiving of Console test screenshots in the HA pipeline