### PR TITLE
Rename stages in periodic job to indicate the private registry used, clean up generate_vz_distribution.sh

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -540,7 +540,7 @@ pipeline {
                 }
             }
             stages {
-                stage("Upload Periodic Run Artifacts") {
+                stage("Build Release Distributions") {
                     steps {
                         sh """
                             ci/scripts/update_periodic_on_success.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH} ${VERRAZZANO_DEV_VERSION}

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -548,7 +548,7 @@ pipeline {
                     }
                 }
 
-                stage('Private Registry Tests') {
+                stage('Private Registry Tests - OCIR') {
                     when {
                         allOf {
                             not { buildingTag() }
@@ -559,7 +559,7 @@ pipeline {
                         }
                     }
                     parallel {
-                        stage('Verrazzano Lite Distribution') {
+                        stage('Private Registry - Lite Distribution') {
                             steps {
                                 retry(count: JOB_PROMOTION_RETRIES) {
                                     script {
@@ -573,7 +573,7 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Verrazzano Full Distribution') {
+                        stage('Private Registry - Full Distribution') {
                             steps {
                                 retry(count: JOB_PROMOTION_RETRIES) {
                                     script {

--- a/ci/scripts/generate_vz_distribution.sh
+++ b/ci/scripts/generate_vz_distribution.sh
@@ -111,19 +111,8 @@ includeCommonFiles() {
   cp ${VZ_DISTRIBUTION_COMMON}/verrazzano-platform-operator.yaml ${distDir}/manifests/k8s/verrazzano-platform-operator.yaml
   cp -r ${VZ_REPO_ROOT}/platform-operator/helm_config/charts/verrazzano-platform-operator ${distDir}/manifests/charts
 
-  # Copy profiles
-  copyProfiles ${distributionDirectory}/manifests/profiles
-
   # Copy Bill Of Materials, containing the list of images
   cp ${VZ_DISTRIBUTION_COMMON}/verrazzano-bom.json ${distDir}/manifests/verrazzano-bom.json
-}
-
-# Copy profiles from the source repository to the directory from where the distribution bundles will be built
-copyProfiles() {
-  local profileDirectory=$1
-  echo "Copying profiles to ${profileDirectory} ..."
-
-  # Placeholder to copy profiles
 }
 
 # Create a text file containing the contents of the bundle
@@ -272,17 +261,16 @@ includeProfiles() {
   sanitizeProfiles ${distDir}/managed-cluster.yaml
 }
 
+# Remove status and metadata.creationTimestamp from the generated profiles
 sanitizeProfiles() {
   filePath=$1
   yq eval -i 'del(.status, .metadata.creationTimestamp)' ${filePath}
 }
+
 # Clean-up workspace after uploading the distribution bundles
 cleanupWorkspace() {
   rm -rf ${VZ_DISTRIBUTION_COMMON}
   rm -rf ${VZ_LITE_ROOT}
-  # Do not delete the generated files, which is required to push bundles to last_clean_periodic object
-  # rm -rf ${VZ_LITE_GENERATED}
-  # rm -rf ${VZ_FULL_GENERATED}
 }
 
 # List of files in storage


### PR DESCRIPTION
This change, renames stages in periodic job to indicate the private registry used. Also some clean-up is done in generate_vz_distribution.sh
