### PR TITLE
VZ- 7060 don't look at version to enable or disable Keycloak AuthConfig

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -557,6 +557,7 @@ func configureKeycloakOIDC(ctx spi.ComponentContext) error {
 	authConfig[common.AuthConfigKeycloakAttributeClientSecret] = clientSecret
 	authConfig[AuthConfigKeycloakAttributeIssuer] = keycloakURL + AuthConfigKeycloakURLPathIssuer
 	authConfig[AuthConfigKeycloakAttributeRancherURL] = rancherURL + AuthConfigKeycloakURLPathVerifyAuth
+	authConfig[AuthConfigAttributeEnabled] = AuthConfigAttributeEnabled
 
 	return common.UpdateKeycloakOIDCAuthConfig(ctx, authConfig)
 }
@@ -654,29 +655,6 @@ func createOrUpdateClusterRoleTemplateBinding(ctx spi.ComponentContext, clusterR
 	data[ClusterRoleTemplateBindingAttributeRoleTemplateName] = clusterRole
 
 	return createOrUpdateResource(ctx, nsn, GVKClusterRoleTemplateBinding, data)
-}
-
-// disableOrEnableAuthProvider disables Keycloak as an Auth Provider
-func disableOrEnableAuthProvider(ctx spi.ComponentContext, name string) error {
-	log := ctx.Log()
-	c := ctx.Client()
-	enableKeycloak := isKeycloakAuthEnabled(ctx.ActualCR())
-	authConfig := unstructured.Unstructured{}
-	authConfig.SetGroupVersionKind(common.GVKAuthConfig)
-	authConfigName := types.NamespacedName{Name: name}
-	err := c.Get(context.Background(), authConfigName, &authConfig)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("failed to set enabled to %v for authconfig %s, unable to fetch, error: %s", enableKeycloak, name, err.Error())
-	}
-
-	authConfigData := authConfig.UnstructuredContent()
-	authConfigData[AuthConfigAttributeEnabled] = enableKeycloak
-	err = c.Update(context.Background(), &authConfig, &client.UpdateOptions{})
-	if err != nil {
-		return log.ErrorfThrottledNewErr("failed to set enabled to %v for authconfig %s, error: %s", enableKeycloak, name, err.Error())
-	}
-
-	return nil
 }
 
 // disableFirstLogin disables the verrazzano user first log in

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -557,7 +557,7 @@ func configureKeycloakOIDC(ctx spi.ComponentContext) error {
 	authConfig[common.AuthConfigKeycloakAttributeClientSecret] = clientSecret
 	authConfig[AuthConfigKeycloakAttributeIssuer] = keycloakURL + AuthConfigKeycloakURLPathIssuer
 	authConfig[AuthConfigKeycloakAttributeRancherURL] = rancherURL + AuthConfigKeycloakURLPathVerifyAuth
-	authConfig[AuthConfigAttributeEnabled] = AuthConfigAttributeEnabled
+	authConfig[AuthConfigAttributeEnabled] = true
 
 	return common.UpdateKeycloakOIDCAuthConfig(ctx, authConfig)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -425,13 +425,6 @@ func isKeycloakAuthEnabled(vz *vzapi.Verrazzano) bool {
 	return true
 }
 
-func formatBool(isTrue bool, trueValue string, falseValue string) string {
-	if isTrue {
-		return trueValue
-	}
-	return falseValue
-}
-
 // configureUISettings configures Rancher setting ui-pl, ui-logo-light and ui-logo-dark.
 func configureUISettings(ctx spi.ComponentContext) error {
 	log := ctx.Log()

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
@@ -276,7 +275,7 @@ func (r rancherComponent) PostInstall(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("Failed removing Rancher bootstrap secret: %s", err.Error())
 	}
 
-	if err := configureAuthProviders(ctx, false); err != nil {
+	if err := configureAuthProviders(ctx); err != nil {
 		return log.ErrorfThrottledNewErr("failed configuring rancher auth providers: %s", err.Error())
 	}
 
@@ -319,7 +318,7 @@ func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	if err := configureAuthProviders(ctx, true); err != nil {
+	if err := configureAuthProviders(ctx); err != nil {
 		return log.ErrorfThrottledNewErr("failed configuring rancher auth providers: %s", err.Error())
 	}
 
@@ -355,7 +354,7 @@ func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
 // +creates or updates admin clusterRole binding for  user verrazzano.
 // +disables first login setting to disable prompting for password on first login.
 // +enables or disables Keycloak Auth provider.
-func configureAuthProviders(ctx spi.ComponentContext, isUpgrade bool) error {
+func configureAuthProviders(ctx spi.ComponentContext) error {
 	log := ctx.Log()
 	if vzconfig.IsKeycloakEnabled(ctx.ActualCR()) {
 		if err := configureKeycloakOIDC(ctx); err != nil {
@@ -383,8 +382,8 @@ func configureAuthProviders(ctx spi.ComponentContext, isUpgrade bool) error {
 		}
 	}
 
-	if err := toggleKeycloakAuthProvider(ctx, isUpgrade); err != nil {
-		return log.ErrorfThrottledNewErr("failed enabling or disbling auth providers: %s", err.Error())
+	if err := disableOrEnableAuthProvider(ctx, common.AuthConfigKeycloak); err != nil {
+		return log.ErrorfThrottledNewErr("failed enabling or disabling auth providers: %s", err.Error())
 	}
 
 	return nil
@@ -410,97 +409,20 @@ func createOrUpdateClusterRoleTemplateBindings(ctx spi.ComponentContext) error {
 	return nil
 }
 
-func parseVersions(ctx spi.ComponentContext, isUpgrade bool) (*semver.SemVersion, *semver.SemVersion, *semver.SemVersion, error) {
-	ver140, err := semver.NewSemVersion("v" + constants.VerrazzanoVersion1_4_0)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	var vzSourceVersion, vzTargetVersion *semver.SemVersion
-	vz := ctx.ActualCR()
-
-	if vz.Spec.Version != "" {
-		vzTargetVersion, err = semver.NewSemVersion(vz.Spec.Version)
-		if err != nil {
-			return nil, nil, nil, ctx.Log().ErrorfNewErr("Failed Rancher post-%v: Invalid Verrazzano spec version: %v", formatBool(isUpgrade, "upgrade", "install"), err)
-		}
-	}
-
-	if vz.Status.Version != "" {
-		vzSourceVersion, err = semver.NewSemVersion(vz.Status.Version)
-		if err != nil {
-			return nil, nil, nil, ctx.Log().ErrorfNewErr("Failed Rancher post-%v: Invalid Verrazzano status version: %v", formatBool(isUpgrade, "upgrade", "install"), err)
-		}
-	}
-
-	return ver140, vzSourceVersion, vzTargetVersion, nil
-}
-
-func authProviderForRancherImplemented(ver140 *semver.SemVersion, vzSourceVersion *semver.SemVersion, vzTargetVersion *semver.SemVersion, isUpgrade bool) (bool, error) {
-	var version *semver.SemVersion
-	if isUpgrade {
-		version = vzTargetVersion
-	} else {
-		version = vzSourceVersion
-	}
-
-	return version == nil || version.IsGreaterThanOrEqualTo(ver140), nil
-}
-
 // isKeycloakAuthEnabled checks if Keycloak as an Auth provider is enabled for Rancher
 // +returns false if Keycloak component is itself disabled.
-// +returns true when the keycloakAuthEnabled attribute is set to true in rancher component of VZ CR.
-// +when keycloakAuthEnabled is not specified, returns true for new installs and in case of upgrades between versions>=1.4.
-// +returns false otherwise.
-func isKeycloakAuthEnabled(isUpgrade bool, vz *vzapi.Verrazzano, ver140 *semver.SemVersion, vzSourceVersion *semver.SemVersion, vzTargetVersion *semver.SemVersion) bool {
+// +returns the value of the keycloakAuthEnabled attribute if it is set in rancher component of VZ CR.
+// +returns true otherwise.
+func isKeycloakAuthEnabled(vz *vzapi.Verrazzano) bool {
 	if !vzconfig.IsKeycloakEnabled(vz) {
 		return false
 	}
 
-	if vz.Spec.Components.Rancher != nil && vz.Spec.Components.Rancher.KeycloakAuthEnabled != nil && *vz.Spec.Components.Rancher.KeycloakAuthEnabled {
-		return true
+	if vz.Spec.Components.Rancher != nil && vz.Spec.Components.Rancher.KeycloakAuthEnabled != nil {
+		return *vz.Spec.Components.Rancher.KeycloakAuthEnabled
 	}
 
-	if vz.Spec.Components.Rancher == nil || vz.Spec.Components.Rancher.KeycloakAuthEnabled == nil {
-		if !isUpgrade {
-			return true
-		}
-
-		if vzSourceVersion != nil && vzSourceVersion.IsGreaterThanOrEqualTo(ver140) && vzTargetVersion != nil && vzTargetVersion.IsGreaterThanOrEqualTo(vzSourceVersion) {
-			return true
-		}
-
-	}
-
-	return false
-}
-
-// toggleKeycloakAuthProvider enables/disables Keycloak as Auth provider
-func toggleKeycloakAuthProvider(ctx spi.ComponentContext, isUpgrade bool) error {
-	ver140, vzSourceVersion, vzTargetVersion, err := parseVersions(ctx, isUpgrade)
-	if err != nil {
-		return err
-	}
-
-	checkAuthProvider, err := authProviderForRancherImplemented(ver140, vzSourceVersion, vzTargetVersion, isUpgrade)
-	if err != nil {
-		return err
-	}
-
-	if !checkAuthProvider {
-		ctx.Log().Debug("Rancher Keycloak AuthProvider not implemented")
-		return nil
-	}
-
-	log := ctx.Log()
-	vz := ctx.ActualCR()
-	enableKeycloak := isKeycloakAuthEnabled(isUpgrade, vz, ver140, vzSourceVersion, vzTargetVersion)
-	if err := disableOrEnableAuthProvider(ctx, common.AuthConfigKeycloak, enableKeycloak); err != nil {
-		return log.ErrorfThrottledNewErr("failed to %s keycloak oidc auth provider, error: %s", formatBool(enableKeycloak, "enable", "disable"), err.Error())
-	}
-
-	return nil
-
+	return true
 }
 
 func formatBool(isTrue bool, trueValue string, falseValue string) string {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -356,7 +356,7 @@ func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
 // +enables or disables Keycloak Auth provider.
 func configureAuthProviders(ctx spi.ComponentContext) error {
 	log := ctx.Log()
-	if vzconfig.IsKeycloakEnabled(ctx.ActualCR()) {
+	if vzconfig.IsKeycloakEnabled(ctx.ActualCR()) && isKeycloakAuthEnabled(ctx.ActualCR()) {
 		if err := configureKeycloakOIDC(ctx); err != nil {
 			return log.ErrorfThrottledNewErr("failed configuring keycloak oidc provider: %s", err.Error())
 		}
@@ -380,10 +380,6 @@ func configureAuthProviders(ctx spi.ComponentContext) error {
 		if err := disableFirstLogin(ctx); err != nil {
 			return log.ErrorfThrottledNewErr("failed disabling first login setting: %s", err.Error())
 		}
-	}
-
-	if err := disableOrEnableAuthProvider(ctx, common.AuthConfigKeycloak); err != nil {
-		return log.ErrorfThrottledNewErr("failed enabling or disabling auth providers: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
This change removes the logic to look at versions or whether it's an upgrade when deciding to set the kecloakoidc authconfig enabled to true or false. The keycloakoidc authconfig will be enabled unless it is explicitly disabled in the Rancher spec.