### PR TITLE
VZ-7100: Change job restart policy to OnFailure, set explicit backoffLimit

### DIFF
--- a/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
@@ -9,6 +9,7 @@ metadata:
     app: mysql
     component: restore-keycloak-db
 spec:
+  backoffLimit: 6
   template:
     spec:
       initContainers:
@@ -55,5 +56,5 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/dump
               name: keycloak-dump
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end -}}


### PR DESCRIPTION
This PR changes the mysql db load job restart policy to "OnFailure" and explicitly sets the `backoffLimit` field.

I ran two separate manual tests on a kind cluster. In both of these tests I installed Verrazzano 1.3.5 using a dev profile with mysql persistence enabled. I then upgraded to the latest code on this branch with these changes applied.

Test 1:
Change the job shell command from `mysqlsh ...` to `timeout 2 mysqlsh ...` so that the shell command would fail after 2 seconds, and I observed that the job was retried the expected number of times before giving up:
```
NAME                                   READY   STATUS                RESTARTS   AGE
load-dump--1-mmgvc             1/2     Error                           0             73s
load-dump--1-mmgvc             2/2     Running                     1 (1s ago)    74s
load-dump--1-mmgvc             1/2     Error                           1 (9s ago)    82s
load-dump--1-mmgvc             1/2     CrashLoopBackOff   1 (16s ago)   98s
load-dump--1-mmgvc             2/2     Running                     2 (16s ago)   98s
load-dump--1-mmgvc             1/2     Error                           2 (24s ago)   106s
load-dump--1-mmgvc             1/2     CrashLoopBackOff   2 (12s ago)   118s
load-dump--1-mmgvc             2/2     Running                     3 (27s ago)   2m13s
load-dump--1-mmgvc             1/2     Error                           3 (36s ago)   2m22s
load-dump--1-mmgvc             1/2     CrashLoopBackOff   3 (16s ago)   2m37s
load-dump--1-mmgvc             2/2     Running                     4 (56s ago)   3m17s
load-dump--1-mmgvc             1/2     Error                           4 (64s ago)   3m25s
load-dump--1-mmgvc             1/2     CrashLoopBackOff   4 (14s ago)   3m38s
load-dump--1-mmgvc             2/2     Running                     5 (93s ago)   4m57s
load-dump--1-mmgvc             1/2     Error                           5 (101s ago)   5m5s
load-dump--1-mmgvc             1/2     CrashLoopBackOff   5 (12s ago)    5m17s
load-dump--1-mmgvc             2/2     Running                     6 (2m50s ago)   7m55s
load-dump--1-mmgvc             2/2     Terminating               6 (2m50s ago)   7m55s
load-dump--1-mmgvc             0/2     Terminating               6 (2m58s ago)   8m3s
load-dump--1-mmgvc             0/2     Terminating               6 (2m58s ago)   8m3s
load-dump--1-mmgvc             0/2     Terminating               6 (2m58s ago)   8m3s
```

Test 2
Change the job shell command from `mysqlsh ...` to `timeout 10 mysqlsh ...` so that the shell command would fail after 10 seconds, and I observed that the job was retried 4 times but eventually succeeded. The Verrazzano installation completed successfully and the database was successfully loaded. I logged into the Keycloak UI and all of the expected data was there.
```
NAME                                   READY   STATUS                RESTARTS   AGE
load-dump--1-qck5m             2/2     Running                     1 (1s ago)    78s
load-dump--1-qck5m             1/2     Error                           1 (22s ago)   99s
load-dump--1-qck5m             1/2     CrashLoopBackOff   1 (14s ago)   112s
load-dump--1-qck5m             2/2     Running                     2 (15s ago)   113s
load-dump--1-qck5m             1/2     Error                           2 (31s ago)   2m9s
load-dump--1-qck5m             1/2     CrashLoopBackOff   2 (16s ago)   2m24s
load-dump--1-qck5m             2/2     Running                     3 (29s ago)   2m37s
load-dump--1-qck5m             1/2     Error                           3 (45s ago)   2m53s
load-dump--1-qck5m             1/2     CrashLoopBackOff   3 (15s ago)   3m7s
load-dump--1-qck5m             2/2     Running                     4 (43s ago)   3m35s
load-dump--1-qck5m             1/2     NotReady                   4 (57s ago)   3m49s
load-dump--1-qck5m             1/2     Terminating                4 (57s ago)   3m49s
keycloak-0                               2/2     Terminating        0             24m
load-dump--1-qck5m             1/2     Terminating        4             3m50s
keycloak-0                               0/2     Terminating        0             24m
keycloak-0                               0/2     Terminating        0             24m
keycloak-0                               0/2     Terminating        0             24m
keycloak-0                               0/2     Pending            0             0s
keycloak-0                               0/2     Pending            0             0s
keycloak-0                               0/2     Init:0/2           0             0s
load-dump--1-qck5m             0/2     Terminating        4             3m56s
load-dump--1-qck5m             0/2     Terminating        4             3m56s
load-dump--1-qck5m             0/2     Terminating        4             3m56s
keycloak-0                               0/2     Init:1/2           0             1s
keycloak-0                               0/2     PodInitializing    0             2s
keycloak-0                               0/2     Running            0             3s
keycloak-0                               1/2     Running            0             5s
keycloak-0                               1/2     Running            0             36s
keycloak-0                               2/2     Running            0             36s
mysql-0                                    3/3     Running            1 (16m ago)   16m
mysql-0                                    3/3     Running            1 (16m ago)   16m
mysql-0                                    3/3     Running            1 (16m ago)   16m
```

