### PR TITLE
VZ-7101: Obfuscate password in mysql db load job spec

### DIFF
--- a/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/cluster_upgrade_job.yaml
@@ -38,7 +38,7 @@ spec:
             - -c
             - >-
               while ! mysqladmin ping -h"{{ $cluster_name }}.{{ .Release.Namespace }}.svc.cluster.local" --silent; do sleep 1; done &&
-              mysqlsh -u root -p{{ .Values.credentials.root.password }} -h {{ $cluster_name }}.{{ .Release.Namespace }}.svc.cluster.local -e 'util.loadDump("/var/lib/dump/{{ .Values.legacyUpgrade.dumpDir }}", {includeSchemas: ["keycloak"], includeUsers: ["keycloak"], loadUsers: true})'
+              mysqlsh -u root -p$(MYSQL_ROOT_PASSWORD) -h {{ $cluster_name }}.{{ .Release.Namespace }}.svc.cluster.local -e 'util.loadDump("/var/lib/dump/{{ .Values.legacyUpgrade.dumpDir }}", {includeSchemas: ["keycloak"], includeUsers: ["keycloak"], loadUsers: true})'
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:


### PR DESCRIPTION
Change the command to use the environment variable for the MySQL password instead of putting it directly in the command args.

I tested manually and it works, and I also created a test job that dumps out the command and it correctly substitutes the env var.