### PR TITLE
VZ-7117 CLI should not fail on Kubernetes API call failure

### DIFF
--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -234,6 +234,7 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 				vz, err := helpers.GetVerrazzanoResource(client, namespacedName)
 				if err != nil {
 					// Retry if there is a problem getting the resource
+					time.Sleep(10 * time.Second)
 					continue
 				}
 				for _, condition := range vz.Status.Conditions {

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -233,7 +233,8 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 				// Return when the Verrazzano operation has completed
 				vz, err := helpers.GetVerrazzanoResource(client, namespacedName)
 				if err != nil {
-					// Retry if there is a problem getting the resource
+					// Retry if there is a problem getting the resource.  It is ok to keep retrying since
+					// WaitForOperationToComplete main routine will timeout.
 					time.Sleep(10 * time.Second)
 					continue
 				}

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -233,8 +233,8 @@ func WaitForOperationToComplete(client clipkg.Client, kubeClient kubernetes.Inte
 				// Return when the Verrazzano operation has completed
 				vz, err := helpers.GetVerrazzanoResource(client, namespacedName)
 				if err != nil {
-					resChan <- err
-					return
+					// Retry if there is a problem getting the resource
+					continue
 				}
 				for _, condition := range vz.Status.Conditions {
 					// Operation condition met for install/upgrade


### PR DESCRIPTION
VZ-7117 CLI should not fail if Kuberenets API server failure.   Put in retry in case of error.
