### PR TITLE
VZ-7115 Configure backoffLimit for Jaeger OpenSearch index cleaner job

### DIFF
--- a/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
@@ -25,6 +25,8 @@ jaeger:
         # Number of days to wait before deleting a record
         numberOfDays: 7
         schedule: "55 23 * * *"
+        # Number of times to retry before considering the job as failed
+        backoffLimit: 2
       options:
         es:
           index-prefix: verrazzano


### PR DESCRIPTION
Currently if the Jaeger OpenSearch Index cleaner job fails for some reason, it keeps retrying and create a new pod for each retry. Added backoffLimit to restrict the number of retries. See https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy for details.