### PR TITLE
added rancher dashboard to BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -128,6 +128,7 @@
             {
               "image": "rancher",
               "tag": "v2.6.8-20220915024629-46df1b595",
+              "dashboard": "v2.6.7-20220915023507-27ac2fda",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },


### PR DESCRIPTION
Added an attribute to the BOM so that the included Rancher Dashboard version could be easily tracked.  Updates to this attribute and the image tag will be automated.
