### PR TITLE
VZ-7136 - enable metrics map for velero

### DIFF
--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
@@ -35,6 +35,7 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 		{Key: "initContainers[0].imagePullPolicy", Value: "IfNotPresent"},
 		{Key: "initContainers[0].volumeMounts[0].name", Value: "plugins"},
 		{Key: "initContainers[0].volumeMounts[0].mountPath", Value: "/target"},
+		{Key: "metrics.serviceMonitor.namespace", Value: ComponentNamespace},
 	}
 	kvs = append(kvs, arguments...)
 	return kvs, nil

--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
@@ -6,6 +6,7 @@ package velero
 import (
 	"context"
 	"fmt"
+	prometheusOperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
@@ -72,7 +73,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "velero-override-static-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
-			Dependencies:              []string{},
+			Dependencies:              []string{prometheusOperator.ComponentName},
 		},
 	}
 }

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -3,6 +3,11 @@
 
 image:
   pullPolicy: IfNotPresent
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus-operator
 configuration:
   provider: aws
 backupsEnabled: false

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -38,6 +38,8 @@ import (
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/pushgateway"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancherbackup"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/velero"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/verrazzano"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/vmo"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/weblogic"
@@ -80,6 +82,8 @@ const (
 	jaegeroperatorMetricName       metricName = jaegeroperator.ComponentName
 	consoleMetricName              metricName = console.ComponentName
 	fluentdMetricName              metricName = fluentd.ComponentName
+	veleroMetricName               metricName = velero.ComponentName
+	rancherBackupMetricName        metricName = rancherbackup.ComponentName
 )
 
 func init() {
@@ -174,6 +178,8 @@ func initMetricComponentMap() map[metricName]*MetricsComponent {
 		jaegeroperatorMetricName:       newMetricsComponent("jaeger_operator"),
 		consoleMetricName:              newMetricsComponent("verrazzano_console"),
 		fluentdMetricName:              newMetricsComponent("fluentd"),
+		veleroMetricName:               newMetricsComponent("velero"),
+		rancherBackupMetricName:        newMetricsComponent("rancher-backup"),
 	}
 }
 

--- a/tests/e2e/config/scripts/v1alpha1/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-verrazzano-kind.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   profile: dev
   components:
+    velero:
+      enabled: true
     prometheusOperator:
       enabled: true
       overrides:

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-kind.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   profile: dev
   components:
+    velero:
+      enabled: true
     prometheusOperator:
       enabled: true
       overrides:


### PR DESCRIPTION
1. Enable metrics map for velero and rancher backup
2. Create service monitor for velero 
3. Add prometheus-operator as dependency for velero