### PR TITLE
VZ-6077 Add Jaeger Operator Helm Chart details to Readme

### DIFF
--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -155,3 +155,18 @@ helm repo update
 helm fetch rancher-charts/rancher-backup-crd --untar=true
 helm fetch rancher-charts/rancher-backup --untar=true
 ```
+
+### Jaeger Operator
+
+The `jaegertracing/jaeger-operator` folder was created by running the following commands:
+
+```shell
+export JAEGER_OPERATOR_CHART_REPO=https://jaegertracing.github.io/helm-charts
+export JAEGER_OPERATOR_CHART_VERSION=2.32.2
+rm -rf jaegertracing/jaeger-operator
+mkdir -p jaegertracing
+cd jaegertracing
+helm repo add jaegertracing ${JAEGER_OPERATOR_CHART_REPO}
+helm repo update
+helm fetch jaegertracing/jaeger-operator --untar=true --version=${JAEGER_OPERATOR_CHART_VERSION}
+```

--- a/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
-description: jaeger-operator Helm chart for Kubernetes
-name: jaeger-operator
-version: 2.32.2
 appVersion: 1.34.1
+description: jaeger-operator Helm chart for Kubernetes
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
-sources:
-  - https://github.com/jaegertracing/jaeger-operator
 maintainers:
-  - email: ctadeu@gmail.com
-    name: cpanato
-  - email: batazor111@gmail.com
-    name: batazor
+- email: ctadeu@gmail.com
+  name: cpanato
+- email: batazor111@gmail.com
+  name: batazor
+name: jaeger-operator
+sources:
+- https://github.com/jaegertracing/jaeger-operator
+version: 2.32.2


### PR DESCRIPTION
Also, followed the same instructions to fetch the Jaeger Operator Helm Chart files and this sorted the Chart.yaml contents. Earlier the Helm Chart files were copied from the github source code.
