### PR TITLE
VZ-7115 Configure backoffLimit for Jaeger OpenSearch index cleaner job (#4158)

### DIFF
--- a/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
@@ -25,6 +25,8 @@ jaeger:
         # Number of days to wait before deleting a record
         numberOfDays: 7
         schedule: "55 23 * * *"
+        # Number of times to retry before considering the job as failed
+        backoffLimit: 2
       options:
         es:
           index-prefix: verrazzano


### PR DESCRIPTION
Backporting https://github.com/verrazzano/verrazzano/pull/4158 to 1.4.