### PR TITLE
De-duplicate imports in application-controller

### DIFF
--- a/application-operator/controllers/appconfig/appconfig_controller.go
+++ b/application-operator/controllers/appconfig/appconfig_controller.go
@@ -13,7 +13,6 @@ import (
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -115,7 +114,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, appConfig *oamv1.Applicati
 	}
 
 	// get the user-specified restart version - if it's missing then there's nothing to do here
-	restartVersion, ok := appConfig.Annotations[vzconst.RestartVersionAnnotation]
+	restartVersion, ok := appConfig.Annotations[constants.RestartVersionAnnotation]
 	if !ok || len(restartVersion) == 0 {
 		log.Debug("No restart version annotation found, nothing to do")
 		return reconcile.Result{}, nil
@@ -158,25 +157,25 @@ func (r *Reconciler) restartComponent(ctx context.Context, wlNamespace string, w
 	}
 	// Set the annotation based on the workload kind
 	switch workload.GetKind() {
-	case vzconst.VerrazzanoCoherenceWorkloadKind:
+	case constants.VerrazzanoCoherenceWorkloadKind:
 		log.Debugf("Setting Coherence workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.VerrazzanoWebLogicWorkloadKind:
+	case constants.VerrazzanoWebLogicWorkloadKind:
 		log.Debugf("Setting WebLogic workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.VerrazzanoHelidonWorkloadKind:
+	case constants.VerrazzanoHelidonWorkloadKind:
 		log.Debugf("Setting Helidon workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.ContainerizedWorkloadKind:
+	case constants.ContainerizedWorkloadKind:
 		log.Debugf("Setting Containerized workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.DeploymentWorkloadKind:
+	case constants.DeploymentWorkloadKind:
 		log.Debugf("Setting Deployment workload %s restart-version", wlName)
 		return r.restartDeployment(ctx, restartVersion, wlName, wlNamespace, log)
-	case vzconst.StatefulSetWorkloadKind:
+	case constants.StatefulSetWorkloadKind:
 		log.Debugf("Setting StatefulSet workload %s restart-version", wlName)
 		return r.restartStatefulSet(ctx, restartVersion, wlName, wlNamespace, log)
-	case vzconst.DaemonSetWorkloadKind:
+	case constants.DaemonSetWorkloadKind:
 		log.Debugf("Setting DaemonSet workload %s restart-version", wlName)
 		return r.restartDaemonSet(ctx, restartVersion, wlName, wlNamespace, log)
 	default:
@@ -240,7 +239,7 @@ func DoRestartDeployment(ctx context.Context, client client.Client, restartVersi
 			if deployment.Spec.Template.ObjectMeta.Annotations == nil {
 				deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			deployment.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			deployment.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -254,7 +253,7 @@ func DoRestartStatefulSet(ctx context.Context, client client.Client, restartVers
 			if statefulSet.Spec.Template.ObjectMeta.Annotations == nil {
 				statefulSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			statefulSet.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			statefulSet.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -268,7 +267,7 @@ func DoRestartDaemonSet(ctx context.Context, client client.Client, restartVersio
 			if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
 				daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			daemonSet.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			daemonSet.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -290,7 +289,7 @@ func updateRestartVersion(ctx context.Context, client client.Client, u *unstruct
 		if !found {
 			annotations = map[string]string{}
 		}
-		annotations[vzconst.RestartVersionAnnotation] = restartVersion
+		annotations[constants.RestartVersionAnnotation] = restartVersion
 		err = unstructured.SetNestedStringMap(u.Object, annotations, metaAnnotationFields...)
 		if err != nil {
 			log.Errorf("Failed setting NestedStringMap for workload %s: %v", u.GetName(), err)

--- a/application-operator/controllers/appconfig/appconfig_controller_test.go
+++ b/application-operator/controllers/appconfig/appconfig_controller_test.go
@@ -13,7 +13,6 @@ import (
 	oamv1 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
@@ -747,7 +746,7 @@ func TestReconcileKubeSystem(t *testing.T) {
 // TestReconcileFailed tests to make sure the failure metric is being exposed
 func TestReconcileFailed(t *testing.T) {
 
-	assert := assert.New(t)
+	assert := asserts.New(t)
 	clientBuilder := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	// Create a request and reconcile it
 	reconciler := newReconciler(clientBuilder)

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -9,7 +9,6 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
-	vzConstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	log2 "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -63,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == vzConstants.KubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
 		log := zap.S().With(log2.FieldResourceNamespace, req.Namespace, log2.FieldResourceName, req.Name, log2.FieldController, controllerName)
 		log.Infof("Verrazzano project resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil

--- a/application-operator/controllers/logging/fluentd.go
+++ b/application-operator/controllers/logging/fluentd.go
@@ -12,7 +12,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,10 +53,10 @@ type Fluentd struct {
 
 // FluentdPod contains pod information for pods which require FLUENTD integration
 type FluentdPod struct {
-	Containers   []v1.Container
-	Volumes      []v1.Volume
-	VolumeMounts []v1.VolumeMount
-	HandlerEnv   []v1.EnvVar
+	Containers   []corev1.Container
+	Volumes      []corev1.Volume
+	VolumeMounts []corev1.VolumeMount
+	HandlerEnv   []corev1.EnvVar
 	LogPath      string
 }
 
@@ -169,7 +168,7 @@ func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
 }
 
 // createFluentdConfigMap creates the FLUENTD configmap per given namespace.
-func (f *Fluentd) createFluentdConfigMap(namespace string) *v1.ConfigMap {
+func (f *Fluentd) createFluentdConfigMap(namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName + "-" + f.WorkloadType,
@@ -275,16 +274,16 @@ func (f *Fluentd) createFluentdContainer(fluentdPod *FluentdPod, logInfo *LogInf
 			},
 			{
 				Name: "APP_CONF_NAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: "metadata.labels['" + oam.LabelAppName + "']",
 					},
 				},
 			},
 			{
 				Name: "COMPONENT_NAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: "metadata.labels['" + oam.LabelAppComponent + "']",
 					},
 				},

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -17,7 +17,6 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,7 +110,7 @@ func TestCreateMCAppConfigNoOAMComponent(t *testing.T) {
 	// using a MultiClusterComponent instead of a OAM Component in the MultuClusterApplicationConfiguration
 	component := &oamv1alpha2.Component{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testMCComponent.Name, Namespace: testMCComponent.Namespace}, component)
-	assert.True(apierrors.IsNotFound(err))
+	assert.True(errors.IsNotFound(err))
 
 	// Verify MultiClusterApplicationConfiguration got created on local cluster
 	mcAppConfig := &clustersv1alpha1.MultiClusterApplicationConfiguration{}

--- a/application-operator/mcagent/mcagent_jaeger_test.go
+++ b/application-operator/mcagent/mcagent_jaeger_test.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -153,7 +152,7 @@ func createMCRegSecret(mutualTLS bool) *corev1.Secret {
 		data[mcconstants.JaegerOSTLSCertKey] = []byte("jaegeropensearchtlscertkey")
 	}
 	return &corev1.Secret{
-		ObjectMeta: v12.ObjectMeta{Name: constants.MCRegistrationSecret,
+		ObjectMeta: metav1.ObjectMeta{Name: constants.MCRegistrationSecret,
 			Namespace: constants.VerrazzanoSystemNamespace},
 		Data: data,
 	}

--- a/application-operator/mcagent/mcagent_metrics_test.go
+++ b/application-operator/mcagent/mcagent_metrics_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,8 +66,8 @@ func TestSyncer_updatePrometheusMonitorsClusterName(t *testing.T) {
 	}
 }
 
-func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *v1.ServiceMonitor, newClusterName string) {
-	retrievedSM := v1.ServiceMonitor{}
+func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *promoperapi.ServiceMonitor, newClusterName string) {
+	retrievedSM := promoperapi.ServiceMonitor{}
 	err := client.Get(context.TODO(), types.NamespacedName{Namespace: sm.Namespace, Name: sm.Name}, &retrievedSM)
 	assert.NoError(t, err)
 	for i, ep := range retrievedSM.Spec.Endpoints {
@@ -76,8 +75,8 @@ func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *v1.Ser
 	}
 }
 
-func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *v1.PodMonitor, newClusterName string) {
-	retrievedPM := v1.PodMonitor{}
+func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *promoperapi.PodMonitor, newClusterName string) {
+	retrievedPM := promoperapi.PodMonitor{}
 	err := client.Get(context.TODO(), types.NamespacedName{Namespace: pm.Namespace, Name: pm.Name}, &retrievedPM)
 	assert.NoError(t, err)
 	assert.Equal(t, len(pm.Spec.PodMetricsEndpoints), len(retrievedPM.Spec.PodMetricsEndpoints))
@@ -86,7 +85,7 @@ func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *v1.PodMoni
 	}
 }
 
-func assertRCLabels(t *testing.T, oldRCs []*v1.RelabelConfig, newRCs []*v1.RelabelConfig, clusterName string) {
+func assertRCLabels(t *testing.T, oldRCs []*promoperapi.RelabelConfig, newRCs []*promoperapi.RelabelConfig, clusterName string) {
 	assert.Equal(t, len(oldRCs), len(newRCs))
 	for _, rc := range newRCs {
 		if rc.TargetLabel == prometheusClusterNameLabel {
@@ -95,29 +94,29 @@ func assertRCLabels(t *testing.T, oldRCs []*v1.RelabelConfig, newRCs []*v1.Relab
 	}
 }
 
-func createTestServiceMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.ServiceMonitor {
-	relabelConfigs := []*v1.RelabelConfig{}
+func createTestServiceMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *promoperapi.ServiceMonitor {
+	relabelConfigs := []*promoperapi.RelabelConfig{}
 	if hasClusterNameRelabelConfig {
-		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
+		relabelConfigs = append(relabelConfigs, &promoperapi.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
 	}
-	return &v1.ServiceMonitor{
+	return &promoperapi.ServiceMonitor{
 		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
-		Spec: v1.ServiceMonitorSpec{
-			Endpoints: []v1.Endpoint{
+		Spec: promoperapi.ServiceMonitorSpec{
+			Endpoints: []promoperapi.Endpoint{
 				{RelabelConfigs: relabelConfigs},
 			},
 		}}
 }
 
-func createTestPodMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.PodMonitor {
-	relabelConfigs := []*v1.RelabelConfig{}
+func createTestPodMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *promoperapi.PodMonitor {
+	relabelConfigs := []*promoperapi.RelabelConfig{}
 	if hasClusterNameRelabelConfig {
-		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
+		relabelConfigs = append(relabelConfigs, &promoperapi.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
 	}
-	return &v1.PodMonitor{
+	return &promoperapi.PodMonitor{
 		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
-		Spec: v1.PodMonitorSpec{
-			PodMetricsEndpoints: []v1.PodMetricsEndpoint{
+		Spec: promoperapi.PodMonitorSpec{
+			PodMetricsEndpoints: []promoperapi.PodMetricsEndpoint{
 				{RelabelConfigs: relabelConfigs},
 			},
 		}}


### PR DESCRIPTION
`staticcheck` reported several "package ... is being imported more than once" warnings in the application-controller:

	$ staticcheck -go 1.17 -checks ST1019 ./application-operator/...
	application-operator/controllers/appconfig/appconfig_controller.go:15:2: package "github.com/verrazzano/verrazzano/pkg/constants" is being imported more than once (ST1019)
		application-operator/controllers/appconfig/appconfig_controller.go:16:2: other import of "github.com/verrazzano/verrazzano/pkg/constants"
	application-operator/controllers/appconfig/appconfig_controller_test.go:16:2: package "github.com/stretchr/testify/assert" is being imported more than once (ST1019)
		application-operator/controllers/appconfig/appconfig_controller_test.go:17:2: other import of "github.com/stretchr/testify/assert"
	application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go:12:2: package "github.com/verrazzano/verrazzano/pkg/constants" is being imported more than once (ST1019)
		application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go:13:2: other import of "github.com/verrazzano/verrazzano/pkg/constants"
	application-operator/controllers/logging/fluentd.go:14:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
		application-operator/controllers/logging/fluentd.go:15:2: other import of "k8s.io/api/core/v1"
	application-operator/mcagent/mcagent_appconfig_test.go:19:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
		application-operator/mcagent/mcagent_appconfig_test.go:20:2: other import of "k8s.io/apimachinery/pkg/api/errors"
	application-operator/mcagent/mcagent_jaeger_test.go:17:2: package "k8s.io/apimachinery/pkg/apis/meta/v1" is being imported more than once (ST1019)
		application-operator/mcagent/mcagent_jaeger_test.go:18:2: other import of "k8s.io/apimachinery/pkg/apis/meta/v1"
	application-operator/mcagent/mcagent_metrics_test.go:10:2: package "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1" is being imported more than once (ST1019)
		application-operator/mcagent/mcagent_metrics_test.go:11:2: other import of "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"

I removed one of the imports in each case, sometimes favoring the smallest change, sometimes favoring the alias that seemed most conventional.

Signed-off-by: Eric R. Rath <eric.rath@oracle.com>
