### PR TITLE
Simplify component dependency checks in VPO

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -155,14 +155,14 @@ func checkDependencies(c spi.Component, context spi.ComponentContext, visited ma
 		if !found {
 			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
 		}
-		if trace, err := checkDependencies(dependency, context, visited, stateMap); err != nil {
-			return trace, err
-		}
 		// Only check if dependency is ready when the dependency is enabled
-		if dependency.IsEnabled(context.EffectiveCR()) && // Is enabled
-			!isInReadyState(context, dependency) && // CR status does not already indicate ready status
-			!dependency.IsReady(context) {
-			stateMap[dependencyName] = false // dependency is not ready
+		if !dependency.IsEnabled(context.EffectiveCR()) {
+			stateMap[dependencyName] = false
+			continue
+		}
+		if !isInReadyState(context, dependency) && // CR status does not already indicate ready status
+			!dependency.IsReady(context) { // Component is not ready
+			stateMap[dependencyName] = false // Mark the dependency is not ready
 			continue
 		}
 		stateMap[dependencyName] = true // dependency is ready

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -220,7 +220,7 @@ func TestComponentOptionalDependenciesMet(t *testing.T) {
 			},
 		},
 	}, nil, false))
-	assert.False(t, ready)
+	assert.True(t, ready)
 }
 
 // TestComponentDependenciesDependencyChartNotInstalled tests ComponentDependenciesMet
@@ -365,7 +365,7 @@ func TestIndirectDependencyMetButNotReady(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	assert.True(t, ComponentDependenciesMet(indirectDependency, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
-	assert.False(t, ComponentDependenciesMet(directDependency, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
+	assert.True(t, ComponentDependenciesMet(directDependency, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
 	assert.False(t, ComponentDependenciesMet(dependent, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
 }
 
@@ -407,61 +407,6 @@ func TestComponentDependenciesCycles(t *testing.T) {
 	assert.True(t, ComponentDependenciesMet(noDependencies, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
 }
 
-// TestComponentDependenciesCycles tests ComponentDependenciesMet
-// GIVEN a registry of components with dependencies, and some with cycles
-//  WHEN I call ComponentDependenciesMet for it
-//  THEN it returns false if there's a cycle in the dependencies
-func Test_checkDependencies(t *testing.T) {
-	// directCycle -> fake1, directCycle
-	directCycle := fakeComponent{name: "directCycle", enabled: true, dependencies: []string{"fake1", "directCycle"}}
-	// indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-	indirectCycle1 := fakeComponent{name: "indirectCycle1", enabled: true, dependencies: []string{"fake3"}}
-	// indirectCycle2 -> fake4 -> fake3 -> fake2 -> indirectCycle -> fake3
-	indirectCycle2 := fakeComponent{name: "indirectCycle2", enabled: true, dependencies: []string{"fake4"}}
-	nocycles := fakeComponent{name: "nocycles", enabled: true, dependencies: []string{"fake6", "fake5"}}
-	noDependencies := fakeComponent{name: "fake1", enabled: true, ready: true}
-	OverrideGetComponentsFn(func() []spi.Component {
-		return []spi.Component{
-			noDependencies,
-			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-			fakeComponent{name: "fake2", enabled: true, dependencies: []string{"indirectCycle1", "fake1"}},
-			// fake3 -> fake2 -> indirectCycle1 -> fake3
-			fakeComponent{name: "fake3", enabled: true, dependencies: []string{"fake2"}},
-			fakeComponent{name: "fake4", enabled: true, dependencies: []string{"fake3"}},
-			fakeComponent{name: "fake5", enabled: true, ready: true, dependencies: []string{"fake1"}},
-			fakeComponent{name: "fake6", enabled: true, ready: true, dependencies: []string{"fake5"}},
-			nocycles,
-			indirectCycle1,
-			indirectCycle2,
-		}
-	})
-	defer ResetGetComponentsFn()
-
-	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	ctx := spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)
-
-	_, err := checkDependencies(directCycle, ctx, make(map[string]bool), make(map[string]bool))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dependency cycle found for directCycle")
-	//_, err = checkDependencies(indirectCycle1, ctx, make(map[string]bool), make(map[string]bool))
-	//assert.Error(t, err)
-	//assert.Contains(t, err.Error(), "dependency cycle found for indirectCycle1")
-	//_, err = checkDependencies(indirectCycle2, ctx, make(map[string]bool), make(map[string]bool))
-	//assert.Error(t, err)
-	//assert.Contains(t, err.Error(), "dependency cycle found for fake3")
-	dependencies, err := checkDependencies(nocycles, ctx, make(map[string]bool), make(map[string]bool))
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]bool{
-		"fake6": true,
-		"fake5": true,
-		//"fake1": true,
-	}, dependencies)
-
-	dependencies, err = checkDependencies(noDependencies, ctx, make(map[string]bool), make(map[string]bool))
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]bool{}, dependencies)
-}
-
 // TestComponentDependenciesCycle tests ComponentDependenciesMet
 // GIVEN a component
 //  WHEN I call ComponentDependenciesMet for it
@@ -490,7 +435,64 @@ func TestComponentDependenciesChainNoCycle(t *testing.T) {
 	assert.True(t, ready)
 }
 
-// TestRegistryDependencies tests the default Registry components for cycles
+// TestComponentDependenciesCycles validates the test method checkDependencyCycles, which is used by another test to
+// validate that the production component registry does not have any cycles declared.
+//
+// GIVEN a registry of components with dependencies, and some with cycles
+//  WHEN I call checkDependencyCycles for it
+//  THEN it returns an error if there's a cycle in the dependencies
+func Test_checkDependencyCycles(t *testing.T) {
+	// directCycle -> fake1, directCycle
+	directCycle := fakeComponent{name: "directCycle", enabled: true, dependencies: []string{"fake1", "directCycle"}}
+	// indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
+	indirectCycle1 := fakeComponent{name: "indirectCycle1", enabled: true, dependencies: []string{"fake3"}}
+	// indirectCycle2 -> fake4 -> fake3 -> fake2 -> indirectCycle -> fake3
+	indirectCycle2 := fakeComponent{name: "indirectCycle2", enabled: true, dependencies: []string{"fake4"}}
+	nocycles := fakeComponent{name: "nocycles", enabled: true, dependencies: []string{"fake6", "fake5"}}
+	noDependencies := fakeComponent{name: "fake1", enabled: true, ready: true}
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			noDependencies,
+			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
+			fakeComponent{name: "fake2", enabled: true, dependencies: []string{"indirectCycle1", "fake1"}},
+			// fake3 -> fake2 -> indirectCycle1 -> fake3
+			fakeComponent{name: "fake3", enabled: true, dependencies: []string{"fake2"}},
+			fakeComponent{name: "fake4", enabled: true, dependencies: []string{"fake3"}},
+			fakeComponent{name: "fake5", enabled: true, ready: true, dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake6", enabled: true, ready: true, dependencies: []string{"fake5"}},
+			nocycles,
+			indirectCycle1,
+			indirectCycle2,
+		}
+	})
+	defer ResetGetComponentsFn()
+
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	ctx := spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)
+
+	_, err := checkDependencyCycles(directCycle, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for directCycle")
+	_, err = checkDependencyCycles(indirectCycle1, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for indirectCycle1")
+	_, err = checkDependencyCycles(indirectCycle2, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for fake3")
+	dependencies, err := checkDependencyCycles(nocycles, ctx, make(map[string]bool), make(map[string]bool))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{
+		"fake6": true,
+		"fake5": true,
+		"fake1": true,
+	}, dependencies)
+
+	dependencies, err = checkDependencyCycles(noDependencies, ctx, make(map[string]bool), make(map[string]bool))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{}, dependencies)
+}
+
+// TestRegistryDependencies tests the production Registry components for dependency cycles
 // GIVEN a component
 //  WHEN I call checkDependencies for it
 //  THEN No error is returned that indicates a cycle in the chain
@@ -502,7 +504,7 @@ func TestRegistryDependencies(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
 	for _, comp := range GetComponents() {
-		_, err := checkDependencies(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false, profileDir),
+		_, err := checkDependencyCycles(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false, profileDir),
 			make(map[string]bool), make(map[string]bool))
 		assert.NoError(t, err)
 	}
@@ -588,6 +590,37 @@ func runDepenencyStateCheckTest(t *testing.T, state v1alpha1.CompStateType, enab
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
 	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, cr, nil, true))
 	assert.Equal(t, expectedResult, ready)
+}
+
+// checkDependencies Check the ready state of any dependencies and check for cycles
+func checkDependencyCycles(c spi.Component, context spi.ComponentContext, visited map[string]bool, stateMap map[string]bool) (map[string]bool, error) {
+	compName := c.Name()
+	log := context.Log()
+	log.Debugf("Checking %s dependencies", compName)
+	if _, wasVisited := visited[compName]; wasVisited {
+		return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
+	}
+	visited[compName] = true
+	for _, dependencyName := range c.GetDependencies() {
+		if compName == dependencyName {
+			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
+		}
+		if _, ok := stateMap[dependencyName]; ok {
+			// dependency already checked
+			log.Debugf("Dependency %s already checked", dependencyName)
+			continue
+		}
+		found, dependency := FindComponent(dependencyName)
+		if !found {
+			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
+		}
+		if trace, err := checkDependencyCycles(dependency, context, visited, stateMap); err != nil {
+			return trace, err
+		}
+		// Only check if dependency is ready when the dependency is enabled
+		stateMap[dependencyName] = true
+	}
+	return stateMap, nil
 }
 
 // Create a new deployment object for testing


### PR DESCRIPTION
Simplify dependency checks to just check the immediate dependencies of a component
- should implicitly still wait on indirect dependencies
- Changes behavior to return false if a dependency is not enabled; previously
  was treating it as a soft requirement and return ready to not block a dependent
- update unit tests
