### PR TITLE
Put mysql-operator back into the BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -410,6 +410,25 @@
       ]
     },
     {
+      "name": "mysql-operator",
+      "version": "8.0.30",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "mysql-operator",
+          "images": [
+            {
+              "image": "mysql-operator",
+              "tag": "8.0.30-2.0.6",
+              "helmRegKey": "image.registry",
+              "helmRepoKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "keycloak",
       "version": "15.0.2",
       "subcomponents": [


### PR DESCRIPTION
Put mysql-operator back into the BOM - it was accidentally removed when the bitnami charts were reverted