### PR TITLE
VZ-7041: Add client role view-users to verrazzano user

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -1563,7 +1563,6 @@ func addClientRoleToUser(ctx spi.ComponentContext, cfg *restclient.Config, cli k
 	kcPod := keycloakPod()
 	addRoleCmd := "/opt/jboss/keycloak/bin/kcadm.sh add-roles -r " + targetRealm + " --uusername " + userName + " --cclientid " + clientID + " --rolename " + roleName
 	ctx.Log().Debugf("addRoleCmd: add role %s to the user %s, command = %s", roleName, userName, addRoleCmd)
-	ctx.Log().Infof("addRoleCmd: %s", addRoleCmd)
 	stdout, stderr, err := k8sutil.ExecPod(cli, cfg, kcPod, ComponentName, bashCMD(addRoleCmd))
 	if err != nil {
 		ctx.Log().Errorf("Adding role %s to the user %s failed: stdout = %s, stderr = %s", roleName, userName, stdout, stderr)

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -54,6 +54,8 @@ const (
 	vzInternalPromUser      = "verrazzano-prom-internal"
 	vzInternalEsUser        = "verrazzano-es-internal"
 	keycloakPodName         = "keycloak-0"
+	realmManagement         = "realm-management"
+	viewUsersRole           = "view-users"
 )
 
 // Define the Keycloak Key:Value pair for init container.
@@ -746,6 +748,11 @@ func configureKeycloakRealms(ctx spi.ComponentContext) error {
 			return err
 		}
 
+		// Add view-users role to verrazzano user
+		err = addClientRoleToUser(ctx, cfg, cli, vzUserName, realmManagement, vzSysRealm, viewUsersRole)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Setting password policy for master
@@ -1549,4 +1556,19 @@ func updateRancherClientSecretForKeycloakAuthConfig(ctx spi.ComponentContext) er
 	authConfig := make(map[string]interface{})
 	authConfig[common.AuthConfigKeycloakAttributeClientSecret] = clientSecret
 	return common.UpdateKeycloakOIDCAuthConfig(ctx, authConfig)
+}
+
+// addClientRoleToUser adds client role to the given user in the target realm
+func addClientRoleToUser(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, userName, clientID, targetRealm, roleName string) error {
+	kcPod := keycloakPod()
+	addRoleCmd := "/opt/jboss/keycloak/bin/kcadm.sh add-roles -r " + targetRealm + " --uusername " + userName + " --cclientid " + clientID + " --rolename " + roleName
+	ctx.Log().Debugf("addRoleCmd: add role %s to the user %s, command = %s", roleName, userName, addRoleCmd)
+	ctx.Log().Infof("addRoleCmd: %s", addRoleCmd)
+	stdout, stderr, err := k8sutil.ExecPod(cli, cfg, kcPod, ComponentName, bashCMD(addRoleCmd))
+	if err != nil {
+		ctx.Log().Errorf("Adding role %s to the user %s failed: stdout = %s, stderr = %s", roleName, userName, stdout, stderr)
+		return err
+	}
+	ctx.Log().Once("Successfully added role to user")
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -1583,3 +1583,19 @@ func TestGetVerrazzanoUserFromKeycloak(t *testing.T) {
 		})
 	}
 }
+
+// TestAddClientRoleToUser adds a client role to the verrazzano user
+// GIVEN a client, and a k8s environment
+// WHEN I call addClientRoleToUser
+// THEN confirm that the function doesn't return an error
+func TestAddClientRoleToUser(t *testing.T) {
+	k8sutil.ClientConfig = fakeRESTConfig
+	k8sutil.NewPodExecutor = k8sutilfake.NewPodExecutor
+	cfg, cli, _ := fakeRESTConfig()
+
+	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	ctx := spi.NewFakeContext(c, testVZ, nil, false)
+
+	err := addClientRoleToUser(ctx, cfg, cli, "testuser", "test-client", "test-realm", "test-role")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Add client role view-users to verrazzano user, to allow verrazzano user to view users in the realm verrazzano-system.
