### PR TITLE
VZ-7147: Add InnoDBCluster status check when checking for MySQL component to be ready

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -24,6 +24,9 @@ import (
 // ComponentName is the name of the component
 const ComponentName = "mysql"
 
+// helmReleaseName is the name of the helm release
+const helmReleaseName = ComponentName
+
 // ComponentNamespace is the namespace of the component
 const ComponentNamespace = vzconst.KeycloakNamespace
 
@@ -52,7 +55,7 @@ func NewComponent() spi.Component {
 
 	return mysqlComponent{
 		helm.HelmComponent{
-			ReleaseName:               ComponentName,
+			ReleaseName:               helmReleaseName,
 			JSONName:                  ComponentJSONName,
 			ChartDir:                  filepath.Join(config.GetThirdPartyDir(), ComponentName),
 			ChartNamespace:            ComponentNamespace,


### PR DESCRIPTION
The MySQL install component "is ready" check now includes checking the InnoDBCluster resource status to make sure it's online before reporting that the component is ready.