### PR TITLE
Change timeout to 12 hours, have upgrade testing run 6 in parallel

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -47,7 +47,7 @@ def verrazzanoDistributionsFile = "verrazzano_distributions.html"
 
 pipeline {
     options {
-        timeout(time: 9, unit: 'HOURS')
+        timeout(time: 12, unit: 'HOURS')
         skipDefaultCheckout true
         disableConcurrentBuilds()
         timestamps ()
@@ -343,6 +343,7 @@ pipeline {
                             script {
                                 build job: "/verrazzano-push-triggered-upgrade-minor-release-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
+                                        string(name: 'N_JOBS_FOR_EACH_BATCH', value: '6'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),


### PR DESCRIPTION
Backport change to adjust timeout for periodics from 9 to 12 hours, and have the upgrade tests use 6 parallel jobs to help pull the time in for that.
