### PR TITLE
go fix

### DIFF
--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go
@@ -11,13 +11,13 @@ import (
 	"strconv"
 	"time"
 
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v53/common"
 	"github.com/oracle/oci-go-sdk/v53/common/auth"
 	ocice "github.com/oracle/oci-go-sdk/v53/containerengine"
 	ocicore "github.com/oracle/oci-go-sdk/v53/core"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
I ran `go fix`; it found an old context import, and updated it:

	$ go fix ./...
	tests/e2e/ha/inplaceupgrade/in_place_upgrade_test.go: fixed context

Signed-off-by: Eric R. Rath <eric.rath@oracle.com>

Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
