### PR TITLE
Fix Jaeger operator ServiceAccount template

### DIFF
--- a/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/service-account.yaml
+++ b/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/service-account.yaml
@@ -10,10 +10,8 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
-{{- if .Values.image.imagePullSecrets }}
+{{- with .Values.image.imagePullSecrets }}
 imagePullSecrets:
-{{- range .Values.image.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fixes the rendering of the Jaeger operator SA manifest for the private registry scenario.

The Jaeger operator's ServiceAccount template in its chart doesn't seem to be correct, it's generating an `imagePullSecret` list like this:

```
imagePullSecrets:
- name: map[name:verrazzano-container-registry]
```

when it should be 

```
imagePullSecrets:
- name: verrazzano-container-registry
```

This is fixed by modifying the SA template to list out the secrets properly.