### PR TITLE
Fix issues found by go-vet

### DIFF
--- a/tests/e2e/multicluster/examples/example_utils.go
+++ b/tests/e2e/multicluster/examples/example_utils.go
@@ -127,11 +127,8 @@ func VerifyMCResources(kubeconfigPath string, isAdminCluster bool, placedInThisC
 			// the verrazzano-managed label will exist on unwrapped resources in the cluster where
 			// app is placed
 			return mcAppConfExists && vzManagedLabelExists
-		} else {
-			return mcAppConfExists && !vzManagedLabelExists
 		}
-
-		return mcAppConfExists
+		return mcAppConfExists && !vzManagedLabelExists
 	} else {
 		// don't expect
 		return !mcAppConfExists

--- a/tools/generate-profiles/generate.go
+++ b/tools/generate-profiles/generate.go
@@ -55,7 +55,7 @@ func main() {
 
 	parseFlags(defaultDir)
 	if help {
-		fmt.Println(info)
+		fmt.Print(info)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Go vet found two issues:

	$ go vet ./...
	# github.com/verrazzano/verrazzano/tests/e2e/multicluster/examples
	tests/e2e/multicluster/examples/example_utils.go:134:3: unreachable code
	# github.com/verrazzano/verrazzano/tools/generate-profiles
	tools/generate-profiles/generate.go:58:3: fmt.Println arg list ends with redundant newline

Both had trivial fixes: simplify the return statements for the first, and change from Println() to Print() for the second.
