### PR TITLE
De-duplicate imports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,11 @@
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+linters-settings:
+  stylecheck:
+    go: "1.17"
+    checks: ["ST1019"]
+
 linters:
   enable:
     - govet
@@ -10,6 +15,7 @@ linters:
     - gosec
     - revive
     - unused
+    - stylecheck
   disable-all: true
   fast: true
 

--- a/application-operator/controllers/appconfig/appconfig_controller.go
+++ b/application-operator/controllers/appconfig/appconfig_controller.go
@@ -13,7 +13,6 @@ import (
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -115,7 +114,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, appConfig *oamv1.Applicati
 	}
 
 	// get the user-specified restart version - if it's missing then there's nothing to do here
-	restartVersion, ok := appConfig.Annotations[vzconst.RestartVersionAnnotation]
+	restartVersion, ok := appConfig.Annotations[constants.RestartVersionAnnotation]
 	if !ok || len(restartVersion) == 0 {
 		log.Debug("No restart version annotation found, nothing to do")
 		return reconcile.Result{}, nil
@@ -158,25 +157,25 @@ func (r *Reconciler) restartComponent(ctx context.Context, wlNamespace string, w
 	}
 	// Set the annotation based on the workload kind
 	switch workload.GetKind() {
-	case vzconst.VerrazzanoCoherenceWorkloadKind:
+	case constants.VerrazzanoCoherenceWorkloadKind:
 		log.Debugf("Setting Coherence workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.VerrazzanoWebLogicWorkloadKind:
+	case constants.VerrazzanoWebLogicWorkloadKind:
 		log.Debugf("Setting WebLogic workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.VerrazzanoHelidonWorkloadKind:
+	case constants.VerrazzanoHelidonWorkloadKind:
 		log.Debugf("Setting Helidon workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.ContainerizedWorkloadKind:
+	case constants.ContainerizedWorkloadKind:
 		log.Debugf("Setting Containerized workload %s restart-version", wlName)
 		return updateRestartVersion(ctx, r.Client, &workload, restartVersion, log)
-	case vzconst.DeploymentWorkloadKind:
+	case constants.DeploymentWorkloadKind:
 		log.Debugf("Setting Deployment workload %s restart-version", wlName)
 		return r.restartDeployment(ctx, restartVersion, wlName, wlNamespace, log)
-	case vzconst.StatefulSetWorkloadKind:
+	case constants.StatefulSetWorkloadKind:
 		log.Debugf("Setting StatefulSet workload %s restart-version", wlName)
 		return r.restartStatefulSet(ctx, restartVersion, wlName, wlNamespace, log)
-	case vzconst.DaemonSetWorkloadKind:
+	case constants.DaemonSetWorkloadKind:
 		log.Debugf("Setting DaemonSet workload %s restart-version", wlName)
 		return r.restartDaemonSet(ctx, restartVersion, wlName, wlNamespace, log)
 	default:
@@ -240,7 +239,7 @@ func DoRestartDeployment(ctx context.Context, client client.Client, restartVersi
 			if deployment.Spec.Template.ObjectMeta.Annotations == nil {
 				deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			deployment.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			deployment.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -254,7 +253,7 @@ func DoRestartStatefulSet(ctx context.Context, client client.Client, restartVers
 			if statefulSet.Spec.Template.ObjectMeta.Annotations == nil {
 				statefulSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			statefulSet.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			statefulSet.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -268,7 +267,7 @@ func DoRestartDaemonSet(ctx context.Context, client client.Client, restartVersio
 			if daemonSet.Spec.Template.ObjectMeta.Annotations == nil {
 				daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
-			daemonSet.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = restartVersion
+			daemonSet.Spec.Template.ObjectMeta.Annotations[constants.RestartVersionAnnotation] = restartVersion
 		}
 		return nil
 	})
@@ -290,7 +289,7 @@ func updateRestartVersion(ctx context.Context, client client.Client, u *unstruct
 		if !found {
 			annotations = map[string]string{}
 		}
-		annotations[vzconst.RestartVersionAnnotation] = restartVersion
+		annotations[constants.RestartVersionAnnotation] = restartVersion
 		err = unstructured.SetNestedStringMap(u.Object, annotations, metaAnnotationFields...)
 		if err != nil {
 			log.Errorf("Failed setting NestedStringMap for workload %s: %v", u.GetName(), err)

--- a/application-operator/controllers/appconfig/appconfig_controller_test.go
+++ b/application-operator/controllers/appconfig/appconfig_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
 	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -79,7 +78,7 @@ func newAppConfig() *oamv1.ApplicationConfiguration {
 
 func TestReconcileApplicationConfigurationNotFound(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
@@ -87,11 +86,11 @@ func TestReconcileApplicationConfigurationNotFound(t *testing.T) {
 	request := newRequest(testNamespace, testAppConfigName)
 
 	_, err := reconciler.Reconcile(context.TODO(), request)
-	assert.NoError(err)
+	assertions.NoError(err)
 }
 func TestReconcileNoRestartVersion(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
@@ -99,15 +98,15 @@ func TestReconcileNoRestartVersion(t *testing.T) {
 	request := newRequest(testNamespace, testAppConfigName)
 
 	err := c.Create(context.TODO(), newAppConfig())
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	_, err = reconciler.Reconcile(context.TODO(), request)
-	assert.NoError(err)
+	assertions.NoError(err)
 }
 
 func TestReconcileRestartVersion(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
@@ -117,18 +116,18 @@ func TestReconcileRestartVersion(t *testing.T) {
 	appConfig := newAppConfig()
 	appConfig.Annotations[vzconst.RestartVersionAnnotation] = "1"
 	err := c.Create(context.TODO(), appConfig)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	_, err = reconciler.Reconcile(context.TODO(), request)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	err = c.Get(context.TODO(), request.NamespacedName, appConfig)
-	assert.NoError(err)
+	assertions.NoError(err)
 }
 
 func TestReconcileEmptyRestartVersion(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	_ = oamcore.AddToScheme(k8scheme.Scheme)
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
@@ -138,18 +137,18 @@ func TestReconcileEmptyRestartVersion(t *testing.T) {
 	appConfig := newAppConfig()
 	appConfig.Annotations[vzconst.RestartVersionAnnotation] = ""
 	err := c.Create(context.TODO(), appConfig)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	_, err = reconciler.Reconcile(context.TODO(), request)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	err = c.Get(context.TODO(), request.NamespacedName, appConfig)
-	assert.NoError(err)
+	assertions.NoError(err)
 }
 
 func TestReconcileRestartWeblogic(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -192,13 +191,13 @@ func TestReconcileRestartWeblogic(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileRestartCoherence(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -241,13 +240,13 @@ func TestReconcileRestartCoherence(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileRestartHelidon(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -290,13 +289,13 @@ func TestReconcileRestartHelidon(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileDeploymentRestart(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -346,7 +345,7 @@ func TestReconcileDeploymentRestart(t *testing.T) {
 	cli.EXPECT().
 		Update(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, deploy *appsv1.Deployment, options ...client.UpdateOption) error {
-			assert.Equal(testNewRestartVersion, deploy.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
+			assertions.Equal(testNewRestartVersion, deploy.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
 			return nil
 		})
 	// create a request and reconcile it
@@ -355,13 +354,13 @@ func TestReconcileDeploymentRestart(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestFailedReconcileDeploymentRestart(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -404,13 +403,13 @@ func TestFailedReconcileDeploymentRestart(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(true, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(true, result.Requeue)
 }
 
 func TestReconcileDeploymentNoRestart(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -467,13 +466,13 @@ func TestReconcileDeploymentNoRestart(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileDaemonSetRestartDaemonSet(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -522,7 +521,7 @@ func TestReconcileDaemonSetRestartDaemonSet(t *testing.T) {
 	cli.EXPECT().
 		Update(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, daemonset *appsv1.DaemonSet, options ...client.UpdateOption) error {
-			assert.Equal(testNewRestartVersion, daemonset.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
+			assertions.Equal(testNewRestartVersion, daemonset.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
 			return nil
 		})
 
@@ -532,13 +531,13 @@ func TestReconcileDaemonSetRestartDaemonSet(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileDaemonSetNoRestartDaemonSet(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -594,13 +593,13 @@ func TestReconcileDaemonSetNoRestartDaemonSet(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileStatefulSetRestart(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -649,7 +648,7 @@ func TestReconcileStatefulSetRestart(t *testing.T) {
 	cli.EXPECT().
 		Update(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, statefulset *appsv1.StatefulSet, options ...client.UpdateOption) error {
-			assert.Equal(testNewRestartVersion, statefulset.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
+			assertions.Equal(testNewRestartVersion, statefulset.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation])
 			return nil
 		})
 
@@ -659,13 +658,13 @@ func TestReconcileStatefulSetRestart(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 func TestReconcileStatefulSetNoRestart(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	var mocker = gomock.NewController(t)
 	var cli = mocks.NewMockClient(mocker)
@@ -721,15 +720,15 @@ func TestReconcileStatefulSetNoRestart(t *testing.T) {
 	result, err := reconciler.Reconcile(context.TODO(), request)
 
 	mocker.Finish()
-	assert.NoError(err)
-	assert.Equal(false, result.Requeue)
+	assertions.NoError(err)
+	assertions.Equal(false, result.Requeue)
 }
 
 // TestReconcileKubeSystem tests to make sure we do not reconcile
 // Any resource that belong to the kube-system namespace
 func TestReconcileKubeSystem(t *testing.T) {
 
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	mocker := gomock.NewController(t)
 	cli := mocks.NewMockClient(mocker)
 
@@ -740,24 +739,24 @@ func TestReconcileKubeSystem(t *testing.T) {
 
 	// Validate the results
 	mocker.Finish()
-	assert.Nil(err)
-	assert.True(result.IsZero())
+	assertions.Nil(err)
+	assertions.True(result.IsZero())
 }
 
 // TestReconcileFailed tests to make sure the failure metric is being exposed
 func TestReconcileFailed(t *testing.T) {
 
-	assert := assert.New(t)
+	assertions := assert.New(t)
 	clientBuilder := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	// Create a request and reconcile it
 	reconciler := newReconciler(clientBuilder)
 	request := newRequest(testNamespace, testAppConfigName)
 	reconcileerrorCounterObject, err := metricsexporter.GetSimpleCounterMetric(metricsexporter.AppconfigReconcileError)
-	assert.NoError(err)
+	assertions.NoError(err)
 	// Expect a call to fetch the error
 	reconcileFailedCounterBefore := testutil.ToFloat64(reconcileerrorCounterObject.Get())
 	reconcileerrorCounterObject.Get().Inc()
 	reconciler.Reconcile(context.TODO(), request)
 	reconcileFailedCounterAfter := testutil.ToFloat64(reconcileerrorCounterObject.Get())
-	assert.Equal(reconcileFailedCounterBefore, reconcileFailedCounterAfter-1)
+	assertions.Equal(reconcileFailedCounterBefore, reconcileFailedCounterAfter-1)
 }

--- a/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
+++ b/application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go
@@ -9,7 +9,6 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/clusters"
-	vzConstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	log2 "github.com/verrazzano/verrazzano/pkg/log"
 	vzlog2 "github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -63,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// We do not want any resource to get reconciled if it is in namespace kube-system
 	// This is due to a bug found in OKE, it should not affect functionality of any vz operators
 	// If this is the case then return success
-	if req.Namespace == vzConstants.KubeSystem {
+	if req.Namespace == vzconst.KubeSystem {
 		log := zap.S().With(log2.FieldResourceNamespace, req.Namespace, log2.FieldResourceName, req.Name, log2.FieldController, controllerName)
 		log.Infof("Verrazzano project resource %v should not be reconciled in kube-system namespace, ignoring", req.NamespacedName)
 		return reconcile.Result{}, nil

--- a/application-operator/controllers/logging/fluentd.go
+++ b/application-operator/controllers/logging/fluentd.go
@@ -12,7 +12,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,10 +53,10 @@ type Fluentd struct {
 
 // FluentdPod contains pod information for pods which require FLUENTD integration
 type FluentdPod struct {
-	Containers   []v1.Container
-	Volumes      []v1.Volume
-	VolumeMounts []v1.VolumeMount
-	HandlerEnv   []v1.EnvVar
+	Containers   []corev1.Container
+	Volumes      []corev1.Volume
+	VolumeMounts []corev1.VolumeMount
+	HandlerEnv   []corev1.EnvVar
 	LogPath      string
 }
 
@@ -169,7 +168,7 @@ func (f *Fluentd) ensureFluentdConfigMapExists(namespace string) error {
 }
 
 // createFluentdConfigMap creates the FLUENTD configmap per given namespace.
-func (f *Fluentd) createFluentdConfigMap(namespace string) *v1.ConfigMap {
+func (f *Fluentd) createFluentdConfigMap(namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName + "-" + f.WorkloadType,
@@ -275,16 +274,16 @@ func (f *Fluentd) createFluentdContainer(fluentdPod *FluentdPod, logInfo *LogInf
 			},
 			{
 				Name: "APP_CONF_NAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: "metadata.labels['" + oam.LabelAppName + "']",
 					},
 				},
 			},
 			{
 				Name: "COMPONENT_NAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: "metadata.labels['" + oam.LabelAppComponent + "']",
 					},
 				},

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -246,9 +246,7 @@ func TestDeleteMCAppConfig(t *testing.T) {
 // TestDeleteMCAppConfigNoOAMComponent tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterApplicationConfiguration objects
 // WHEN a MultiClusterApplicationConfiguration object is deleted from the admin cluster that references a
-//
-//	MultiClusterComponent objec.
-//
+// MultiClusterComponent object.
 // THEN ensure that the MultiClusterApplicationConfiguration is deleted and OAM component object is not deleted
 func TestDeleteMCAppConfigNoOAMComponent(t *testing.T) {
 	assert := asserts.New(t)

--- a/application-operator/mcagent/mcagent_appconfig_test.go
+++ b/application-operator/mcagent/mcagent_appconfig_test.go
@@ -17,7 +17,6 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,7 +110,7 @@ func TestCreateMCAppConfigNoOAMComponent(t *testing.T) {
 	// using a MultiClusterComponent instead of a OAM Component in the MultuClusterApplicationConfiguration
 	component := &oamv1alpha2.Component{}
 	err = s.LocalClient.Get(s.Context, types.NamespacedName{Name: testMCComponent.Name, Namespace: testMCComponent.Namespace}, component)
-	assert.True(apierrors.IsNotFound(err))
+	assert.True(errors.IsNotFound(err))
 
 	// Verify MultiClusterApplicationConfiguration got created on local cluster
 	mcAppConfig := &clustersv1alpha1.MultiClusterApplicationConfiguration{}
@@ -247,7 +246,9 @@ func TestDeleteMCAppConfig(t *testing.T) {
 // TestDeleteMCAppConfigNoOAMComponent tests the synchronization method for the following use case.
 // GIVEN a request to sync MultiClusterApplicationConfiguration objects
 // WHEN a MultiClusterApplicationConfiguration object is deleted from the admin cluster that references a
-//   MultiClusterComponent objec.
+//
+//	MultiClusterComponent objec.
+//
 // THEN ensure that the MultiClusterApplicationConfiguration is deleted and OAM component object is not deleted
 func TestDeleteMCAppConfigNoOAMComponent(t *testing.T) {
 	assert := asserts.New(t)

--- a/application-operator/mcagent/mcagent_jaeger_test.go
+++ b/application-operator/mcagent/mcagent_jaeger_test.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -153,7 +152,7 @@ func createMCRegSecret(mutualTLS bool) *corev1.Secret {
 		data[mcconstants.JaegerOSTLSCertKey] = []byte("jaegeropensearchtlscertkey")
 	}
 	return &corev1.Secret{
-		ObjectMeta: v12.ObjectMeta{Name: constants.MCRegistrationSecret,
+		ObjectMeta: metav1.ObjectMeta{Name: constants.MCRegistrationSecret,
 			Namespace: constants.VerrazzanoSystemNamespace},
 		Data: data,
 	}

--- a/application-operator/mcagent/mcagent_metrics_test.go
+++ b/application-operator/mcagent/mcagent_metrics_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,8 +66,8 @@ func TestSyncer_updatePrometheusMonitorsClusterName(t *testing.T) {
 	}
 }
 
-func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *v1.ServiceMonitor, newClusterName string) {
-	retrievedSM := v1.ServiceMonitor{}
+func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *promoperapi.ServiceMonitor, newClusterName string) {
+	retrievedSM := promoperapi.ServiceMonitor{}
 	err := client.Get(context.TODO(), types.NamespacedName{Namespace: sm.Namespace, Name: sm.Name}, &retrievedSM)
 	assert.NoError(t, err)
 	for i, ep := range retrievedSM.Spec.Endpoints {
@@ -76,8 +75,8 @@ func assertServiceMonitorLabel(t *testing.T, client client.WithWatch, sm *v1.Ser
 	}
 }
 
-func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *v1.PodMonitor, newClusterName string) {
-	retrievedPM := v1.PodMonitor{}
+func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *promoperapi.PodMonitor, newClusterName string) {
+	retrievedPM := promoperapi.PodMonitor{}
 	err := client.Get(context.TODO(), types.NamespacedName{Namespace: pm.Namespace, Name: pm.Name}, &retrievedPM)
 	assert.NoError(t, err)
 	assert.Equal(t, len(pm.Spec.PodMetricsEndpoints), len(retrievedPM.Spec.PodMetricsEndpoints))
@@ -86,7 +85,7 @@ func assertPodMonitorLabel(t *testing.T, client client.WithWatch, pm *v1.PodMoni
 	}
 }
 
-func assertRCLabels(t *testing.T, oldRCs []*v1.RelabelConfig, newRCs []*v1.RelabelConfig, clusterName string) {
+func assertRCLabels(t *testing.T, oldRCs []*promoperapi.RelabelConfig, newRCs []*promoperapi.RelabelConfig, clusterName string) {
 	assert.Equal(t, len(oldRCs), len(newRCs))
 	for _, rc := range newRCs {
 		if rc.TargetLabel == prometheusClusterNameLabel {
@@ -95,29 +94,29 @@ func assertRCLabels(t *testing.T, oldRCs []*v1.RelabelConfig, newRCs []*v1.Relab
 	}
 }
 
-func createTestServiceMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.ServiceMonitor {
-	relabelConfigs := []*v1.RelabelConfig{}
+func createTestServiceMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *promoperapi.ServiceMonitor {
+	relabelConfigs := []*promoperapi.RelabelConfig{}
 	if hasClusterNameRelabelConfig {
-		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
+		relabelConfigs = append(relabelConfigs, &promoperapi.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
 	}
-	return &v1.ServiceMonitor{
+	return &promoperapi.ServiceMonitor{
 		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
-		Spec: v1.ServiceMonitorSpec{
-			Endpoints: []v1.Endpoint{
+		Spec: promoperapi.ServiceMonitorSpec{
+			Endpoints: []promoperapi.Endpoint{
 				{RelabelConfigs: relabelConfigs},
 			},
 		}}
 }
 
-func createTestPodMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *v1.PodMonitor {
-	relabelConfigs := []*v1.RelabelConfig{}
+func createTestPodMonitor(hasClusterNameRelabelConfig bool, clusterName string, monitorName string, monitorNS string) *promoperapi.PodMonitor {
+	relabelConfigs := []*promoperapi.RelabelConfig{}
 	if hasClusterNameRelabelConfig {
-		relabelConfigs = append(relabelConfigs, &v1.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
+		relabelConfigs = append(relabelConfigs, &promoperapi.RelabelConfig{TargetLabel: prometheusClusterNameLabel, Replacement: clusterName})
 	}
-	return &v1.PodMonitor{
+	return &promoperapi.PodMonitor{
 		ObjectMeta: v12.ObjectMeta{Name: monitorName, Namespace: monitorNS},
-		Spec: v1.PodMonitorSpec{
-			PodMetricsEndpoints: []v1.PodMetricsEndpoint{
+		Spec: promoperapi.PodMonitorSpec{
+			PodMetricsEndpoints: []promoperapi.PodMetricsEndpoint{
 				{RelabelConfigs: relabelConfigs},
 			},
 		}}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -27,7 +27,6 @@ import (
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/homedir"
@@ -41,9 +40,9 @@ const EnvVarKubeConfig = "KUBECONFIG"
 // EnvVarTestKubeConfig Name of Environment Variable for test KUBECONFIG
 const EnvVarTestKubeConfig = "TEST_KUBECONFIG"
 
-type ClientConfigFunc func() (*restclient.Config, kubernetes.Interface, error)
+type ClientConfigFunc func() (*rest.Config, kubernetes.Interface, error)
 
-var ClientConfig ClientConfigFunc = func() (*restclient.Config, kubernetes.Interface, error) {
+var ClientConfig ClientConfigFunc = func() (*rest.Config, kubernetes.Interface, error) {
 	cfg, err := controllerruntime.GetConfig()
 	if err != nil {
 		return nil, nil, err
@@ -87,11 +86,11 @@ func GetKubeConfigLocation() (string, error) {
 }
 
 // GetKubeConfigGivenPath GetKubeConfig will get the kubeconfig from the given kubeconfigPath
-func GetKubeConfigGivenPath(kubeconfigPath string) (*restclient.Config, error) {
+func GetKubeConfigGivenPath(kubeconfigPath string) (*rest.Config, error) {
 	return buildKubeConfig(kubeconfigPath)
 }
 
-func buildKubeConfig(kubeconfig string) (*restclient.Config, error) {
+func buildKubeConfig(kubeconfig string) (*rest.Config, error) {
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 
@@ -139,7 +138,7 @@ func GetKubernetesClientset() (*kubernetes.Clientset, error) {
 	return GetKubernetesClientsetWithConfig(config)
 }
 
-//GetKubernetesClientsetOrDie returns the kubernetes clientset, panic if it cannot be created.
+// GetKubernetesClientsetOrDie returns the kubernetes clientset, panic if it cannot be created.
 func GetKubernetesClientsetOrDie() *kubernetes.Clientset {
 	clientset, err := GetKubernetesClientset()
 	if err != nil {
@@ -278,7 +277,7 @@ func GetHostnameFromGatewayInCluster(namespace string, appConfigName string, kub
 // NewPodExecutor is to be overridden during unit tests
 var NewPodExecutor = remotecommand.NewSPDYExecutor
 
-//ExecPod runs a remote command a pod, returning the stdout and stderr of the command.
+// ExecPod runs a remote command a pod, returning the stdout and stderr of the command.
 func ExecPod(client kubernetes.Interface, cfg *rest.Config, pod *v1.Pod, container string, command []string) (string, string, error) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/platform-operator/controllers/clusters/sync_prometheus.go
+++ b/platform-operator/controllers/clusters/sync_prometheus.go
@@ -15,7 +15,6 @@ import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -89,7 +88,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.C
 }
 
 // newScrapeConfig will return a prometheus scraper configuration based on the entries in the prometheus info structure provided
-func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(cacrtSecret *v1.Secret, vmc *clustersv1alpha1.VerrazzanoManagedCluster) (*gabs.Container, error) {
+func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(cacrtSecret *corev1.Secret, vmc *clustersv1alpha1.VerrazzanoManagedCluster) (*gabs.Container, error) {
 	var newScrapeConfig *gabs.Container
 	if cacrtSecret == nil || vmc.Status.PrometheusHost == "" {
 		return newScrapeConfig, nil
@@ -156,7 +155,7 @@ func getCAKey(vmc *clustersv1alpha1.VerrazzanoManagedCluster) string {
 
 // mutateAdditionalScrapeConfigs adds and removes scrape config for managed clusters to the additional scrape configurations secret. Prometheus Operator appends the raw scrape config
 // in this secret to the scrape config it generates from PodMonitor and ServiceMonitor resources.
-func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *v1.Secret) error {
+func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *corev1.Secret) error {
 	// get the existing additional scrape config, if the secret doesn't exist we will create it
 	secret, err := r.getSecret(vpoconst.VerrazzanoMonitoringNamespace, constants.PromAdditionalScrapeConfigsSecretName, false)
 	if err != nil && !errors.IsNotFound(err) {
@@ -211,7 +210,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx c
 }
 
 // mutateManagedClusterCACertsSecret adds and removes managed cluster CA certs to/from the managed cluster CA certs secret
-func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterCACertsSecret(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *v1.Secret) error {
+func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterCACertsSecret(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *corev1.Secret) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vpoconst.PromManagedClusterCACertsSecretName,

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -26,7 +26,6 @@ import (
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
-	k8net "k8s.io/api/networking/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -919,7 +918,7 @@ func TestSyncManifestSecretFailRancherRegistration(t *testing.T) {
 	// Expect a call to get the Rancher ingress and return no spec rules, which will cause registration to fail
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherIngressName}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *k8net.Ingress) error {
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *networkingv1.Ingress) error {
 			return nil
 		})
 
@@ -976,7 +975,7 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 	// Expect a call to get the ingress host name but there are no ingress rules
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherIngressName}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *k8net.Ingress) error {
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *networkingv1.Ingress) error {
 			return nil
 		})
 
@@ -995,8 +994,8 @@ func TestRegisterClusterWithRancherK8sErrorCases(t *testing.T) {
 	// Expect a call to get the ingress host name
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherIngressName}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *k8net.Ingress) error {
-			rule := k8net.IngressRule{Host: "rancher.unit-test.com"}
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *networkingv1.Ingress) error {
+			rule := networkingv1.IngressRule{Host: "rancher.unit-test.com"}
 			ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
 			return nil
 		})
@@ -1544,14 +1543,14 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 	if !externalES {
 		mock.EXPECT().
 			Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: vmiIngest}, gomock.Not(gomock.Nil())).
-			DoAndReturn(func(ctx context.Context, name types.NamespacedName, ingress *k8net.Ingress) error {
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, ingress *networkingv1.Ingress) error {
 				ingress.TypeMeta = metav1.TypeMeta{
 					APIVersion: "networking.k8s.io/v1",
 					Kind:       "ingress"}
 				ingress.ObjectMeta = metav1.ObjectMeta{
 					Namespace: name.Namespace,
 					Name:      name.Name}
-				ingress.Spec.Rules = []k8net.IngressRule{{
+				ingress.Spec.Rules = []networkingv1.IngressRule{{
 					Host: "vz-testhost",
 				}}
 				return nil
@@ -1602,7 +1601,7 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 			ingress.ObjectMeta = metav1.ObjectMeta{
 				Namespace: name.Namespace,
 				Name:      name.Name}
-			ingress.Spec.Rules = []k8net.IngressRule{{
+			ingress.Spec.Rules = []networkingv1.IngressRule{{
 				Host: "keycloak",
 			}}
 			return nil
@@ -1835,8 +1834,8 @@ func expectRancherConfigK8sCalls(t *testing.T, k8sMock *mocks.MockClient) {
 	// Expect a call to get the ingress host name
 	k8sMock.EXPECT().
 		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: rancherIngressName}), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *k8net.Ingress) error {
-			rule := k8net.IngressRule{Host: "rancher.unit-test.com"}
+		DoAndReturn(func(ctx context.Context, nsName types.NamespacedName, ingress *networkingv1.Ingress) error {
+			rule := networkingv1.IngressRule{Host: "rancher.unit-test.com"}
 			ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
 			return nil
 		})

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
@@ -35,9 +35,8 @@ var crEnabled = v1alpha1.Verrazzano{
 
 // TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding tests the PostUpgrade function
 // GIVEN a call to PostUpgrade
-//
-//	WHEN a VMC exists but no associated ClusterRoleBinding
-//	THEN no delete of a ClusterRoleBinding
+// WHEN a VMC exists but no associated ClusterRoleBinding
+// THEN no delete of a ClusterRoleBinding
 func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 	clusterName := "managed1"
 	vz := &v1alpha1.Verrazzano{
@@ -63,9 +62,8 @@ func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 
 // TestAppOperatorPostUpgradeDeleteClusterRoleBinding tests the PostUpgrade function
 // GIVEN a call to PostUpgrade
-//
-//	WHEN a VMC exists with an associated ClusterRoleBinding
-//	THEN successful delete of the ClusterRoleBinding
+// WHEN a VMC exists with an associated ClusterRoleBinding
+// THEN successful delete of the ClusterRoleBinding
 func TestAppOperatorPostUpgradeDeleteClusterRoleBinding(t *testing.T) {
 	clusterName := "managed1"
 	vz := &v1alpha1.Verrazzano{
@@ -112,9 +110,8 @@ func newScheme() *runtime.Scheme {
 
 // TestIsEnabledNilApplicationOperator tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN The ApplicationOperator component is nil
-//	THEN true is returned
+// WHEN The ApplicationOperator component is nil
+// THEN true is returned
 func TestIsEnabledNilApplicationOperator(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator = nil
@@ -123,18 +120,16 @@ func TestIsEnabledNilApplicationOperator(t *testing.T) {
 
 // TestIsEnabledNilComponent tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN The ApplicationOperator component is nil
-//	THEN false is returned
+// WHEN The ApplicationOperator component is nil
+// THEN false is returned
 func TestIsEnabledNilComponent(t *testing.T) {
 	assert.True(t, NewComponent().IsEnabled(spi.NewFakeContext(nil, &v1alpha1.Verrazzano{}, nil, false, profilesRelativePath).EffectiveCR()))
 }
 
 // TestIsEnabledNilEnabled tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN The ApplicationOperator component enabled is nil
-//	THEN true is returned
+// WHEN The ApplicationOperator component enabled is nil
+// THEN true is returned
 func TestIsEnabledNilEnabled(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = nil
@@ -143,9 +138,8 @@ func TestIsEnabledNilEnabled(t *testing.T) {
 
 // TestIsEnabledExplicit tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN The ApplicationOperator component is explicitly enabled
-//	THEN true is returned
+// WHEN The ApplicationOperator component is explicitly enabled
+// THEN true is returned
 func TestIsEnabledExplicit(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = getBoolPtr(true)
@@ -154,9 +148,8 @@ func TestIsEnabledExplicit(t *testing.T) {
 
 // TestIsDisableExplicit tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN The ApplicationOperator component is explicitly disabled
-//	THEN false is returned
+// WHEN The ApplicationOperator component is explicitly disabled
+// THEN false is returned
 func TestIsDisableExplicit(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = getBoolPtr(false)

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
-	vmcv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -36,8 +35,9 @@ var crEnabled = v1alpha1.Verrazzano{
 
 // TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding tests the PostUpgrade function
 // GIVEN a call to PostUpgrade
-//  WHEN a VMC exists but no associated ClusterRoleBinding
-//  THEN no delete of a ClusterRoleBinding
+//
+//	WHEN a VMC exists but no associated ClusterRoleBinding
+//	THEN no delete of a ClusterRoleBinding
 func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 	clusterName := "managed1"
 	vz := &v1alpha1.Verrazzano{
@@ -52,7 +52,7 @@ func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
-		&vmcv1alpha1.VerrazzanoManagedCluster{
+		&clustersv1alpha1.VerrazzanoManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName,
 			},
@@ -63,8 +63,9 @@ func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 
 // TestAppOperatorPostUpgradeDeleteClusterRoleBinding tests the PostUpgrade function
 // GIVEN a call to PostUpgrade
-//  WHEN a VMC exists with an associated ClusterRoleBinding
-//  THEN successful delete of the ClusterRoleBinding
+//
+//	WHEN a VMC exists with an associated ClusterRoleBinding
+//	THEN successful delete of the ClusterRoleBinding
 func TestAppOperatorPostUpgradeDeleteClusterRoleBinding(t *testing.T) {
 	clusterName := "managed1"
 	vz := &v1alpha1.Verrazzano{
@@ -79,7 +80,7 @@ func TestAppOperatorPostUpgradeDeleteClusterRoleBinding(t *testing.T) {
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
-		&vmcv1alpha1.VerrazzanoManagedCluster{
+		&clustersv1alpha1.VerrazzanoManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName,
 			},
@@ -111,8 +112,9 @@ func newScheme() *runtime.Scheme {
 
 // TestIsEnabledNilApplicationOperator tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN The ApplicationOperator component is nil
-//  THEN true is returned
+//
+//	WHEN The ApplicationOperator component is nil
+//	THEN true is returned
 func TestIsEnabledNilApplicationOperator(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator = nil
@@ -121,16 +123,18 @@ func TestIsEnabledNilApplicationOperator(t *testing.T) {
 
 // TestIsEnabledNilComponent tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN The ApplicationOperator component is nil
-//  THEN false is returned
+//
+//	WHEN The ApplicationOperator component is nil
+//	THEN false is returned
 func TestIsEnabledNilComponent(t *testing.T) {
 	assert.True(t, NewComponent().IsEnabled(spi.NewFakeContext(nil, &v1alpha1.Verrazzano{}, nil, false, profilesRelativePath).EffectiveCR()))
 }
 
 // TestIsEnabledNilEnabled tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN The ApplicationOperator component enabled is nil
-//  THEN true is returned
+//
+//	WHEN The ApplicationOperator component enabled is nil
+//	THEN true is returned
 func TestIsEnabledNilEnabled(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = nil
@@ -139,8 +143,9 @@ func TestIsEnabledNilEnabled(t *testing.T) {
 
 // TestIsEnabledExplicit tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN The ApplicationOperator component is explicitly enabled
-//  THEN true is returned
+//
+//	WHEN The ApplicationOperator component is explicitly enabled
+//	THEN true is returned
 func TestIsEnabledExplicit(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = getBoolPtr(true)
@@ -149,8 +154,9 @@ func TestIsEnabledExplicit(t *testing.T) {
 
 // TestIsDisableExplicit tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN The ApplicationOperator component is explicitly disabled
-//  THEN false is returned
+//
+//	WHEN The ApplicationOperator component is explicitly disabled
+//	THEN false is returned
 func TestIsDisableExplicit(t *testing.T) {
 	cr := crEnabled
 	cr.Spec.Components.ApplicationOperator.Enabled = getBoolPtr(false)

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -14,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/helm"
-	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzos "github.com/verrazzano/verrazzano/pkg/os"
 	"github.com/verrazzano/verrazzano/pkg/yaml"
@@ -221,11 +220,11 @@ func (h HelmComponent) IsReady(context spi.ComponentContext) bool {
 	}
 
 	// Does the Helm installed app_version number match the chart?
-	chartInfo, err := helmcli.GetChartInfo(h.ChartDir)
+	chartInfo, err := helm.GetChartInfo(h.ChartDir)
 	if err != nil {
 		return false
 	}
-	releaseAppVersion, err := helmcli.GetReleaseAppVersion(h.ReleaseName, h.ChartNamespace)
+	releaseAppVersion, err := helm.GetReleaseAppVersion(h.ReleaseName, h.ChartNamespace)
 	if err != nil {
 		return false
 	}
@@ -358,7 +357,7 @@ func (h HelmComponent) Uninstall(context spi.ComponentContext) error {
 		context.Log().Infof("%s already uninstalled", h.Name())
 		return nil
 	}
-	_, stderr, err := helmcli.Uninstall(context.Log(), h.ReleaseName, h.resolveNamespace(context), context.IsDryRun())
+	_, stderr, err := helm.Uninstall(context.Log(), h.ReleaseName, h.resolveNamespace(context), context.IsDryRun())
 	if err != nil {
 		context.Log().Errorf("Error uninstalling %s, error: %s, stderr: %s", h.Name(), err.Error(), stderr)
 		return err

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -26,7 +26,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -586,7 +585,7 @@ func updateKeycloakIngress(ctx spi.ComponentContext) error {
 }
 
 // updateKeycloakUris invokes kcadm.sh in Keycloak pod to update the client with Keycloak rewrite and weborigin uris
-func updateKeycloakUris(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *v1.Pod, clientID string, uriTemplate string) error {
+func updateKeycloakUris(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *corev1.Pod, clientID string, uriTemplate string) error {
 	data, err := populateSubdomainInTemplate(ctx, "{"+uriTemplate+"}")
 	if err != nil {
 		return err
@@ -838,8 +837,8 @@ func bashCMD(command string) []string {
 	}
 }
 
-func keycloakPod() *v1.Pod {
-	return &v1.Pod{
+func keycloakPod() *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keycloakPodName,
 			Namespace: ComponentNamespace,
@@ -1147,7 +1146,7 @@ func removeLoginConfigFile(ctx spi.ComponentContext, cfg *restclient.Config, cli
 }
 
 // getKeycloakGroups returns a structure of Groups in Realm verrazzano-system
-func getKeycloakGroups(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *v1.Pod) (KeycloakGroups, error) {
+func getKeycloakGroups(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *corev1.Pod) (KeycloakGroups, error) {
 	var keycloakGroups KeycloakGroups
 	// Get the Client ID JSON array
 	cmd := fmt.Sprintf("/opt/jboss/keycloak/bin/kcadm.sh get groups -r %s", vzSysRealm)
@@ -1199,7 +1198,7 @@ func getGroupID(keycloakGroups KeycloakGroups, groupName string) string {
 }
 
 // getKeycloakRoless returns a structure of Groups in Realm verrazzano-system
-func getKeycloakRoles(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *v1.Pod) (KeycloakRoles, error) {
+func getKeycloakRoles(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *corev1.Pod) (KeycloakRoles, error) {
 	var keycloakRoles KeycloakRoles
 	// Get the Client ID JSON array
 	out, _, err := k8sutil.ExecPod(cli, cfg, kcPod, ComponentName, bashCMD("/opt/jboss/keycloak/bin/kcadm.sh get-roles -r "+vzSysRealm))
@@ -1231,7 +1230,7 @@ func roleExists(keycloakRoles KeycloakRoles, roleName string) bool {
 }
 
 // getKeycloakUsers returns a structure of Users in Realm verrazzano-system
-func getKeycloakUsers(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *v1.Pod) ([]KeycloakUser, error) {
+func getKeycloakUsers(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, kcPod *corev1.Pod) ([]KeycloakUser, error) {
 	var keycloakUsers []KeycloakUser
 	// Get the Client ID JSON array
 	out, _, err := k8sutil.ExecPod(cli, cfg, kcPod, ComponentName, bashCMD("/opt/jboss/keycloak/bin/kcadm.sh get users -r "+vzSysRealm))
@@ -1309,7 +1308,7 @@ func isKeycloakReady(ctx spi.ComponentContext) bool {
 }
 
 // isPodReady determines if the pod is running by checking for a Ready condition with Status equal True
-func isPodReady(pod *v1.Pod) bool {
+func isPodReady(pod *corev1.Pod) bool {
 	conditions := pod.Status.Conditions
 	for j := range conditions {
 		if conditions[j].Type == "Ready" && conditions[j].Status == "True" {
@@ -1483,7 +1482,7 @@ func GetRancherClientSecretFromKeycloak(ctx spi.ComponentContext) (string, error
 	return clientSecret.Value, nil
 }
 
-func generateClientSecret(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, clientName string, createClientOutput string, kcPod *v1.Pod) error {
+func generateClientSecret(ctx spi.ComponentContext, cfg *restclient.Config, cli kubernetes.Interface, clientName string, createClientOutput string, kcPod *corev1.Pod) error {
 	if len(createClientOutput) == 0 {
 		err := fmt.Errorf("Component Keycloak failed; %s client ID from Keycloak is zero length", clientName)
 		ctx.Log().Error(err)

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
@@ -29,9 +29,8 @@ func init() {
 
 // TestGetInstallOverrides tests the GetInstallOverrides function
 // GIVEN a call to GetInstallOverrides
-//
-//	WHEN there is a valid MySQL Operator configuration
-//	THEN the correct Helm overrides are returned
+// WHEN there is a valid MySQL Operator configuration
+// THEN the correct Helm overrides are returned
 func TestGetInstallOverrides(t *testing.T) {
 	vz := &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
@@ -56,9 +55,8 @@ func TestGetInstallOverrides(t *testing.T) {
 
 // TestIsEnabled tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//
-//	WHEN varying the enabled states of keycloak and MySQL Operator
-//	THEN check for the expected response
+// WHEN varying the enabled states of keycloak and MySQL Operator
+// THEN check for the expected response
 func TestIsEnabled(t *testing.T) {
 	trueValue := true
 	falseValue := false
@@ -118,9 +116,8 @@ func TestIsEnabled(t *testing.T) {
 
 // TestIsMySQLOperatorReady tests the isReady function
 // GIVEN a call to isReady
-//
-//	WHEN the deployment object has enough replicas available
-//	THEN true is returned
+// WHEN the deployment object has enough replicas available
+// THEN true is returned
 func TestIsMySQLOperatorReady(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 		&appsv1.Deployment{
@@ -164,9 +161,8 @@ func TestIsMySQLOperatorReady(t *testing.T) {
 
 // TestIsMySQLOperatorNotReady tests the isReady function
 // GIVEN a call to isReady
-//
-//	WHEN the deployment object does NOT have enough replicas available
-//	THEN false is returned
+// WHEN the deployment object does NOT have enough replicas available
+// THEN false is returned
 func TestIsMySQLOperatorNotReady(t *testing.T) {
 	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
 		return helm.ChartStatusDeployed, nil
@@ -189,9 +185,8 @@ func TestIsMySQLOperatorNotReady(t *testing.T) {
 
 // TestIsInstalled tests the isInstalled function
 // GIVEN a call to isInstalled
-//
-//	WHEN the deployment object exists
-//	THEN true is returned
+// WHEN the deployment object exists
+// THEN true is returned
 func TestIsInstalled(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 		&appsv1.Deployment{
@@ -213,9 +208,8 @@ func TestIsInstalled(t *testing.T) {
 
 // TestIsInstalledFalse tests the isInstalled function
 // GIVEN a call to isInstalled
-//
-//	WHEN the deployment object does not exist
-//	THEN false is returned
+// WHEN the deployment object does not exist
+// THEN false is returned
 func TestIsInstalledFalse(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
 
@@ -224,9 +218,8 @@ func TestIsInstalledFalse(t *testing.T) {
 
 // TestValidateInstall tests the ValidateInstall function
 // GIVEN a call to ValidateInstall
-//
-//	WHEN there is a valid MySQL Operator configuration
-//	THEN the correct Helm overrides are returned
+// WHEN there is a valid MySQL Operator configuration
+// THEN the correct Helm overrides are returned
 func TestValidateInstall(t *testing.T) {
 	trueValue := true
 	falseValue := false
@@ -301,9 +294,8 @@ func TestValidateInstall(t *testing.T) {
 
 // TestAppendOverrides tests the AppendOverrides function
 // GIVEN a call to AppendOverrides
-//
-//	WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
-//	THEN the correct Helm overrides are returned
+// WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
+// THEN the correct Helm overrides are returned
 func TestAppendOverrides(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -322,9 +314,8 @@ func TestAppendOverrides(t *testing.T) {
 
 // TestAppendOverridesNoSecret tests the AppendOverrides function
 // GIVEN a call to AppendOverrides
-//
-//	WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
-//	THEN the correct Helm overrides are returned
+// WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
+// THEN the correct Helm overrides are returned
 func TestAppendOverridesNoSecret(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
@@ -15,8 +15,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
@@ -24,14 +23,15 @@ import (
 var testScheme = runtime.NewScheme()
 
 func init() {
-	_ = clientgoscheme.AddToScheme(testScheme)
+	_ = scheme.AddToScheme(testScheme)
 	_ = vzapi.AddToScheme(testScheme)
 }
 
 // TestGetInstallOverrides tests the GetInstallOverrides function
 // GIVEN a call to GetInstallOverrides
-//  WHEN there is a valid MySQL Operator configuration
-//  THEN the correct Helm overrides are returned
+//
+//	WHEN there is a valid MySQL Operator configuration
+//	THEN the correct Helm overrides are returned
 func TestGetInstallOverrides(t *testing.T) {
 	vz := &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
@@ -56,8 +56,9 @@ func TestGetInstallOverrides(t *testing.T) {
 
 // TestIsEnabled tests the IsEnabled function
 // GIVEN a call to IsEnabled
-//  WHEN varying the enabled states of keycloak and MySQL Operator
-//  THEN check for the expected response
+//
+//	WHEN varying the enabled states of keycloak and MySQL Operator
+//	THEN check for the expected response
 func TestIsEnabled(t *testing.T) {
 	trueValue := true
 	falseValue := false
@@ -117,8 +118,9 @@ func TestIsEnabled(t *testing.T) {
 
 // TestIsMySQLOperatorReady tests the isReady function
 // GIVEN a call to isReady
-//  WHEN the deployment object has enough replicas available
-//  THEN true is returned
+//
+//	WHEN the deployment object has enough replicas available
+//	THEN true is returned
 func TestIsMySQLOperatorReady(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 		&appsv1.Deployment{
@@ -162,8 +164,9 @@ func TestIsMySQLOperatorReady(t *testing.T) {
 
 // TestIsMySQLOperatorNotReady tests the isReady function
 // GIVEN a call to isReady
-//  WHEN the deployment object does NOT have enough replicas available
-//  THEN false is returned
+//
+//	WHEN the deployment object does NOT have enough replicas available
+//	THEN false is returned
 func TestIsMySQLOperatorNotReady(t *testing.T) {
 	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
 		return helm.ChartStatusDeployed, nil
@@ -186,8 +189,9 @@ func TestIsMySQLOperatorNotReady(t *testing.T) {
 
 // TestIsInstalled tests the isInstalled function
 // GIVEN a call to isInstalled
-//  WHEN the deployment object exists
-//  THEN true is returned
+//
+//	WHEN the deployment object exists
+//	THEN true is returned
 func TestIsInstalled(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 		&appsv1.Deployment{
@@ -209,8 +213,9 @@ func TestIsInstalled(t *testing.T) {
 
 // TestIsInstalledFalse tests the isInstalled function
 // GIVEN a call to isInstalled
-//  WHEN the deployment object does not exist
-//  THEN false is returned
+//
+//	WHEN the deployment object does not exist
+//	THEN false is returned
 func TestIsInstalledFalse(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
 
@@ -219,8 +224,9 @@ func TestIsInstalledFalse(t *testing.T) {
 
 // TestValidateInstall tests the ValidateInstall function
 // GIVEN a call to ValidateInstall
-//  WHEN there is a valid MySQL Operator configuration
-//  THEN the correct Helm overrides are returned
+//
+//	WHEN there is a valid MySQL Operator configuration
+//	THEN the correct Helm overrides are returned
 func TestValidateInstall(t *testing.T) {
 	trueValue := true
 	falseValue := false
@@ -295,8 +301,9 @@ func TestValidateInstall(t *testing.T) {
 
 // TestAppendOverrides tests the AppendOverrides function
 // GIVEN a call to AppendOverrides
-//  WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
-//  THEN the correct Helm overrides are returned
+//
+//	WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
+//	THEN the correct Helm overrides are returned
 func TestAppendOverrides(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -304,7 +311,7 @@ func TestAppendOverrides(t *testing.T) {
 			Name:      constants.GlobalImagePullSecName,
 		},
 	}
-	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(secret).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secret).Build()
 
 	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
 	assert.Nil(t, err)
@@ -315,10 +322,11 @@ func TestAppendOverrides(t *testing.T) {
 
 // TestAppendOverridesNoSecret tests the AppendOverrides function
 // GIVEN a call to AppendOverrides
-//  WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
-//  THEN the correct Helm overrides are returned
+//
+//	WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
+//	THEN the correct Helm overrides are returned
 func TestAppendOverridesNoSecret(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
 	assert.Nil(t, err)
 	assert.Len(t, kvs, 1)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -13,7 +13,6 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
-	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -27,7 +26,6 @@ import (
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -58,7 +55,7 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(testScheme)
+	_ = k8scheme.AddToScheme(testScheme)
 	_ = vzapi.AddToScheme(testScheme)
 	_ = certapiv1.AddToScheme(testScheme)
 	_ = istioclisec.AddToScheme(testScheme)
@@ -99,7 +96,7 @@ func TestIsPrometheusOperatorReady(t *testing.T) {
 						UpdatedReplicas:   1,
 					},
 				},
-				&v1.Pod{
+				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: ComponentNamespace,
 						Name:      deploymentName + "-95d8c5d96-m6mbr",
@@ -256,7 +253,7 @@ func TestPreInstallUpgrade(t *testing.T) {
 	err := preInstallUpgrade(ctx)
 	assert.NoError(t, err)
 
-	ns := v1.Namespace{}
+	ns := corev1.Namespace{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: ComponentNamespace}, &ns)
 	assert.NoError(t, err)
 }
@@ -343,7 +340,7 @@ func TestAppendIstioOverrides(t *testing.T) {
 				},
 				{
 					Key:   fmt.Sprintf("%s[0].emptyDir.medium", volumeKey),
-					Value: string(v1.StorageMediumMemory),
+					Value: string(corev1.StorageMediumMemory),
 				},
 			},
 		},
@@ -492,7 +489,7 @@ func TestApplySystemMonitors(t *testing.T) {
 
 // TestValidatePrometheusOperator tests the validation of the Prometheus Operator installation and the Verrazzano CR
 func TestUpdateApplicationAuthorizationPolicies(t *testing.T) {
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 	scheme := k8scheme.Scheme
 	_ = vzapi.AddToScheme(scheme)
 	_ = istioclisec.AddToScheme(scheme)
@@ -500,7 +497,7 @@ func TestUpdateApplicationAuthorizationPolicies(t *testing.T) {
 	testNsName := "test-ns"
 	testAuthPolicyName := "test-authpolicy"
 	principal := "cluster.local/ns/verrazzano-monitoring/sa/prometheus-operator-kube-p-prometheus"
-	namespace := v1.Namespace{
+	namespace := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   testNsName,
 			Labels: map[string]string{vzconst.VerrazzanoManagedLabelKey: "true"},
@@ -743,20 +740,20 @@ func TestUpdateApplicationAuthorizationPolicies(t *testing.T) {
 			fakes := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
 			ctx := spi.NewFakeContext(fakes, &vzapi.Verrazzano{}, nil, false)
 			err := updateApplicationAuthorizationPolicies(ctx)
-			assert.NoError(err)
+			assertions.NoError(err)
 			if tt.expectedPrincipals != nil {
-				nsList := v1.NamespaceList{}
+				nsList := corev1.NamespaceList{}
 				err = fakes.List(context.TODO(), &nsList)
-				assert.NoError(err)
+				assertions.NoError(err)
 				for _, ns := range nsList.Items {
 					authPolicyList := istioclisec.AuthorizationPolicyList{}
 					err = fakes.List(context.TODO(), &authPolicyList, &client.ListOptions{Namespace: ns.Name})
-					assert.NoError(err)
+					assertions.NoError(err)
 					for _, authPolicy := range authPolicyList.Items {
 						foundPrincipals := []string{}
 						for _, principal := range authPolicy.Spec.Rules[0].From[0].Source.Principals {
-							assert.NotContains(foundPrincipals, principal)
-							assert.Contains(*tt.expectedPrincipals, principal)
+							assertions.NotContains(foundPrincipals, principal)
+							assertions.Contains(*tt.expectedPrincipals, principal)
 							foundPrincipals = append(foundPrincipals, principal)
 						}
 					}
@@ -768,7 +765,7 @@ func TestUpdateApplicationAuthorizationPolicies(t *testing.T) {
 
 // TestCreateOrUpdatePrometheusAuthPolicy tests the createOrUpdatePrometheusAuthPolicy function
 func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
-	assert := asserts.New(t)
+	assertions := assert.New(t)
 
 	// GIVEN Prometheus Operator is being installed or upgraded
 	// WHEN  we call the createOrUpdatePrometheusAuthPolicy function
@@ -777,18 +774,18 @@ func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
 	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false)
 
 	err := createOrUpdatePrometheusAuthPolicy(ctx)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	authPolicy := &istioclisec.AuthorizationPolicy{}
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: prometheusAuthPolicyName}, authPolicy)
-	assert.NoError(err)
+	assertions.NoError(err)
 
-	assert.Len(authPolicy.Spec.Rules, 3)
-	assert.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-authproxy")
-	assert.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
-	assert.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/vmi-system-kiali")
-	assert.Contains(authPolicy.Spec.Rules[1].From[0].Source.Principals, serviceAccount)
-	assert.Contains(authPolicy.Spec.Rules[2].From[0].Source.Principals, "cluster.local/ns/verrazzano-monitoring/sa/jaeger-operator-jaeger")
+	assertions.Len(authPolicy.Spec.Rules, 3)
+	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-authproxy")
+	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
+	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/vmi-system-kiali")
+	assertions.Contains(authPolicy.Spec.Rules[1].From[0].Source.Principals, serviceAccount)
+	assertions.Contains(authPolicy.Spec.Rules[2].From[0].Source.Principals, "cluster.local/ns/verrazzano-monitoring/sa/jaeger-operator-jaeger")
 
 	// GIVEN Prometheus Operator is being installed or upgraded
 	// AND   Istio is disabled
@@ -807,11 +804,11 @@ func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
 	ctx = spi.NewFakeContext(client, vz, nil, false)
 
 	err = createOrUpdatePrometheusAuthPolicy(ctx)
-	assert.NoError(err)
+	assertions.NoError(err)
 
 	authPolicy = &istioclisec.AuthorizationPolicy{}
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: prometheusAuthPolicyName}, authPolicy)
-	assert.ErrorContains(err, "not found")
+	assertions.ErrorContains(err, "not found")
 }
 
 // TestCreateOrUpdateNetworkPolicies tests the createOrUpdateNetworkPolicies function

--- a/platform-operator/controllers/verrazzano/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/uninstall_component.go
@@ -5,8 +5,7 @@ package verrazzano
 
 import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -42,7 +41,7 @@ type componentUninstallContext struct {
 }
 
 // UninstallComponents will Uninstall the components as required
-func (r *Reconciler) uninstallComponents(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano, tracker *UninstallTracker) (ctrl.Result, error) {
+func (r *Reconciler) uninstallComponents(log vzlog.VerrazzanoLogger, cr *v1alpha1.Verrazzano, tracker *UninstallTracker) (ctrl.Result, error) {
 	spiCtx, err := spi.NewContext(log, r.Client, cr, nil, r.DryRun)
 	if err != nil {
 		return newRequeueWithDelay(), err
@@ -94,7 +93,7 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				UninstallContext.state = compStateUninstallEnd
 				continue
 			}
-			if err := r.updateComponentStatus(compContext, "Uninstall started", vzapi.CondUninstallStarted); err != nil {
+			if err := r.updateComponentStatus(compContext, "Uninstall started", v1alpha1.CondUninstallStarted); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
 			compLog.Oncef("Component %s is starting to uninstall", compName)
@@ -134,7 +133,7 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 			UninstallContext.state = compStateUninstalledone
 
 		case compStateUninstalledone:
-			if err := r.updateComponentStatus(compContext, "Uninstall complete", vzapi.CondUninstallComplete); err != nil {
+			if err := r.updateComponentStatus(compContext, "Uninstall complete", v1alpha1.CondUninstallComplete); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
 			compLog.Oncef("Component %s has successfully uninstalled", compName)

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	helm2 "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
@@ -49,7 +48,7 @@ import (
 // unitTestBomFIle is used for unit test
 const unitTestBomFile = "../../verrazzano-bom.json"
 
-//ingress list constants
+// ingress list constants
 const dnsDomain = "myenv.testverrazzano.com"
 const keycloakURL = "keycloak." + dnsDomain
 const esURL = "elasticsearch." + dnsDomain
@@ -1756,7 +1755,7 @@ func TestInstanceRestoreWithPopulatedStatus(t *testing.T) {
 						Type: vzapi.CondInstallComplete,
 					},
 				},
-				Components: func() v1alpha1.ComponentStatusMap {
+				Components: func() vzapi.ComponentStatusMap {
 					statusMap := makeVerrazzanoComponentStatusMap()
 					statusMap[keycloak.ComponentName].State = vzapi.CompStateDisabled
 					statusMap[istio.ComponentName].State = vzapi.CompStateDisabled

--- a/platform-operator/internal/k8s/status/certificates_test.go
+++ b/platform-operator/internal/k8s/status/certificates_test.go
@@ -18,8 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func getScheme() *runtime.Scheme {
@@ -45,7 +43,7 @@ func TestCheckCertificatesReady(t *testing.T) {
 	}
 	cmEnabled := true
 	vz := &v1alpha1.Verrazzano{
-		ObjectMeta: v1.ObjectMeta{Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
 				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
@@ -60,7 +58,7 @@ func TestCheckCertificatesReady(t *testing.T) {
 
 	client := fake.NewFakeClientWithScheme(getScheme(),
 		&certv1.Certificate{
-			ObjectMeta: v1.ObjectMeta{Name: certNames[0].Name, Namespace: certNames[0].Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: certNames[0].Name, Namespace: certNames[0].Namespace},
 			Spec:       certv1.CertificateSpec{},
 			Status: certv1.CertificateStatus{
 				Conditions: []certv1.CertificateCondition{
@@ -71,7 +69,7 @@ func TestCheckCertificatesReady(t *testing.T) {
 			},
 		},
 		&certv1.Certificate{
-			ObjectMeta: v1.ObjectMeta{Name: certNames[1].Name, Namespace: certNames[1].Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: certNames[1].Name, Namespace: certNames[1].Namespace},
 			Spec:       certv1.CertificateSpec{},
 			Status: certv1.CertificateStatus{
 				Conditions: []certv1.CertificateCondition{
@@ -100,7 +98,7 @@ func TestCheckCertificatesNotReady(t *testing.T) {
 	}
 	cmEnabled := true
 	vz := &v1alpha1.Verrazzano{
-		ObjectMeta: v1.ObjectMeta{Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
 				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
@@ -114,7 +112,7 @@ func TestCheckCertificatesNotReady(t *testing.T) {
 
 	client := fake.NewFakeClientWithScheme(getScheme(),
 		&certv1.Certificate{
-			ObjectMeta: v1.ObjectMeta{Name: certNames[0].Name, Namespace: certNames[0].Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: certNames[0].Name, Namespace: certNames[0].Namespace},
 			Spec:       certv1.CertificateSpec{},
 			Status: certv1.CertificateStatus{
 				Conditions: []certv1.CertificateCondition{
@@ -124,7 +122,7 @@ func TestCheckCertificatesNotReady(t *testing.T) {
 			},
 		},
 		&certv1.Certificate{
-			ObjectMeta: v1.ObjectMeta{Name: certNames[1].Name, Namespace: certNames[1].Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: certNames[1].Name, Namespace: certNames[1].Namespace},
 			Spec:       certv1.CertificateSpec{},
 			Status: certv1.CertificateStatus{
 				Conditions: []certv1.CertificateCondition{
@@ -150,7 +148,7 @@ func TestCheckCertificatesNotReadyCertManagerDisabled(t *testing.T) {
 
 	cmEnabled := false
 	vz := &v1alpha1.Verrazzano{
-		ObjectMeta: v1.ObjectMeta{Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
 				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
@@ -171,7 +169,7 @@ func TestCheckCertificatesNotReadyCertManagerDisabled(t *testing.T) {
 func TestCheckCertificatesNotReadyNoCertsPassed(t *testing.T) {
 	cmEnabled := true
 	vz := &v1alpha1.Verrazzano{
-		ObjectMeta: v1.ObjectMeta{Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
 				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},

--- a/platform-operator/internal/k8s/status/daemonset_ready.go
+++ b/platform-operator/internal/k8s/status/daemonset_ready.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DaemonSetsAreReady Check that the named daemonsets have the minimum number of specified nodes ready and available
@@ -65,7 +64,7 @@ func DaemonSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, namesp
 
 // podsReadyDaemonSet checks for an expected number of pods to be using the latest controllerRevision resource and are
 // running and ready
-func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedNodes int32, prefix string) bool {
+func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client client.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedNodes int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
 	pods := status.GetPodsList(log, client, namespacedName, selector)
 	if pods == nil {

--- a/platform-operator/internal/k8s/status/statefulset_ready.go
+++ b/platform-operator/internal/k8s/status/statefulset_ready.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // pod label used to identify the controllerRevision resource for daemonsets and statefulsets
@@ -52,7 +51,7 @@ func StatefulSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, name
 }
 
 // DoStatefulSetsExist checks if the named statefulsets exist
-func DoStatefulSetsExist(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedNames []types.NamespacedName, _ int32, prefix string) bool {
+func DoStatefulSetsExist(log vzlog.VerrazzanoLogger, client client.Client, namespacedNames []types.NamespacedName, _ int32, prefix string) bool {
 	for _, namespacedName := range namespacedNames {
 		statuefulset := appsv1.StatefulSet{}
 		if err := client.Get(context.TODO(), namespacedName, &statuefulset); err != nil {
@@ -69,7 +68,7 @@ func DoStatefulSetsExist(log vzlog.VerrazzanoLogger, client clipkg.Client, names
 
 // podsReadyStatefulSet checks for an expected number of pods to be using the latest controllerRevision resource and are
 // running and ready
-func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
+func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client client.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
 	pods := status.GetPodsList(log, client, namespacedName, selector)
 	if pods == nil {

--- a/tests/e2e/istio/authz/authpolicy_test.go
+++ b/tests/e2e/istio/authz/authpolicy_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	testpkg "github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -485,7 +484,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// THEN they should be created to use the https protocol
 	t.It("Verify that ServiceMonitor authpolicy-appconf-foo-springboot-frontend is using https for scraping.", func() {
 		Eventually(func() bool {
-			serviceMonitor, err := testpkg.GetServiceMonitor(fooNamespace, "authpolicy-appconf-foo-springboot-frontend")
+			serviceMonitor, err := pkg.GetServiceMonitor(fooNamespace, "authpolicy-appconf-foo-springboot-frontend")
 			if err != nil {
 				return false
 			}
@@ -499,7 +498,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// THEN they should be created to use the https protocol
 	t.It("Verify that ServiceMonitor authpolicy-appconf-bar-springboot-frontend is using https for scraping.", func() {
 		Eventually(func() bool {
-			serviceMonitor, err := testpkg.GetServiceMonitor(barNamespace, "authpolicy-appconf-bar-springboot-frontend")
+			serviceMonitor, err := pkg.GetServiceMonitor(barNamespace, "authpolicy-appconf-bar-springboot-frontend")
 			if err != nil {
 				return false
 			}
@@ -513,7 +512,7 @@ var _ = t.Describe("Verify Auth Policy Prometheus Scrape Targets", func() {
 	// THEN they should be created to use the http protocol
 	t.It("Verify that ServiceMonitor authpolicy-appconf-noistio-springboot-frontend is using http for scraping.", func() {
 		Eventually(func() bool {
-			serviceMonitor, err := testpkg.GetServiceMonitor(noIstioNamespace, "authpolicy-appconf-noistio-springboot-frontend")
+			serviceMonitor, err := pkg.GetServiceMonitor(noIstioNamespace, "authpolicy-appconf-noistio-springboot-frontend")
 			if err != nil {
 				return false
 			}

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/pkg/test/framework/metrics"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	testpkg "github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +70,7 @@ var _ = clusterDump.BeforeSuite(func() {
 
 	// Create a service in VZ versions 1.4.0 and greater, so that a servicemonitor will be generated
 	// by Verrazzano for Prometheus Operator
-	isVzMinVer14, _ := testpkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+	isVzMinVer14, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
 	if isVzMinVer14 {
 		Eventually(func() error {
 			promJobName, err := getPromJobName()
@@ -152,7 +151,7 @@ func undeployMetricsApplication() {
 		return podsNotRunning
 	}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 
-	isVzMinVer14, _ := testpkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+	isVzMinVer14, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
 	if isVzMinVer14 {
 		Eventually(func() bool {
 			serviceName, err := getPromJobName()
@@ -189,14 +188,14 @@ var _ = t.Describe("DeployMetrics Application test", Label("f:app-lcm.oam"), fun
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			isVzMinVer14, _ := testpkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+			isVzMinVer14, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
 			if isVzMinVer14 {
 				serviceName, err := getPromJobName()
 				if err != nil {
 					pkg.Log(pkg.Error, fmt.Sprintf(errGenerateSvcMonJobFmt, err))
 				}
 				Eventually(func() (*promoperapi.ServiceMonitor, error) {
-					monitor, err := testpkg.GetServiceMonitor(namespace, serviceName)
+					monitor, err := pkg.GetServiceMonitor(namespace, serviceName)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf("Failed to get the Service Monitor from the cluster: %v", err))
 					}
@@ -295,7 +294,7 @@ func getPromJobName() (string, error) {
 		return kubeconfig, err
 	}
 	if usesServiceMonitor {
-		return testpkg.GetAppServiceMonitorName(namespace, deploymetricsAppName, "deploymetrics-deployment"), nil
+		return pkg.GetAppServiceMonitorName(namespace, deploymetricsAppName, "deploymetrics-deployment"), nil
 	}
 	// For VZ versions prior to 1.4.0, the job name in prometheus scrape config was of the old format
 	// <app_name>_default_<app_namespace>_<app_component_name>

--- a/tools/vz/cmd/analyze/analyze_test.go
+++ b/tools/vz/cmd/analyze/analyze_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	pkghelper "github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/test/helpers"
-	testhelper "github.com/verrazzano/verrazzano/tools/vz/test/helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,8 +31,9 @@ const ingressIPNotFound = "../../pkg/analysis/test/cluster/ingress-ip-not-found"
 
 // TestAnalyzeCommandDefault
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute without specifying flag capture-dir
-//  THEN expect the command to analyze the live cluster
+//
+//	WHEN I call cmd.Execute without specifying flag capture-dir
+//	THEN expect the command to analyze the live cluster
 func TestAnalyzeCommandDefault(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -58,8 +58,9 @@ func TestAnalyzeCommandDefault(t *testing.T) {
 
 // TestAnalyzeCommandDetailedReport
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute with a valid capture-dir and report-format set to "detailed"
-//  THEN expect the command to provide the report containing all the details for one or more issues reported
+//
+//	WHEN I call cmd.Execute with a valid capture-dir and report-format set to "detailed"
+//	THEN expect the command to provide the report containing all the details for one or more issues reported
 func TestAnalyzeCommandDetailedReport(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -76,8 +77,9 @@ func TestAnalyzeCommandDetailedReport(t *testing.T) {
 
 // TestAnalyzeCommandSummaryReport
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute with a valid capture-dir and report-format set to "summary"
-//  THEN expect the command to provide the report containing only summary for one or more issues reported
+//
+//	WHEN I call cmd.Execute with a valid capture-dir and report-format set to "summary"
+//	THEN expect the command to provide the report containing only summary for one or more issues reported
 func TestAnalyzeCommandSummaryReport(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -94,8 +96,9 @@ func TestAnalyzeCommandSummaryReport(t *testing.T) {
 
 // TestAnalyzeCommandInvalidReportFormat
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute with an invalid value for report-format
-//  THEN expect the command to fail with an appropriate error message to indicate the issue
+//
+//	WHEN I call cmd.Execute with an invalid value for report-format
+//	THEN expect the command to fail with an appropriate error message to indicate the issue
 func TestAnalyzeCommandInvalidReportFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -111,8 +114,9 @@ func TestAnalyzeCommandInvalidReportFormat(t *testing.T) {
 
 // TestAnalyzeCommandDefaultReportFormat
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute without report-format
-//  THEN expect the command to take the default value of summary for report-format and perform the analysis
+//
+//	WHEN I call cmd.Execute without report-format
+//	THEN expect the command to take the default value of summary for report-format and perform the analysis
 func TestAnalyzeCommandDefaultReportFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -128,8 +132,9 @@ func TestAnalyzeCommandDefaultReportFormat(t *testing.T) {
 
 // TestAnalyzeCommandWithReportFile
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute with a valid report-file
-//  THEN expect the command to create the report file, containing the analysis report
+//
+//	WHEN I call cmd.Execute with a valid report-file
+//	THEN expect the command to create the report file, containing the analysis report
 func TestAnalyzeCommandWithReportFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -148,8 +153,9 @@ func TestAnalyzeCommandWithReportFile(t *testing.T) {
 
 // TestAnalyzeCommandInvalidCapturedDir
 // GIVEN a CLI analyze command
-//  WHEN I call cmd.Execute with capture-dir not containing the cluster snapshot
-//  THEN expect the command to fail with an appropriate error message
+//
+//	WHEN I call cmd.Execute with capture-dir not containing the cluster snapshot
+//	THEN expect the command to fail with an appropriate error message
 func TestAnalyzeCommandInvalidCapturedDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -206,7 +212,7 @@ func getClientWithWatch() client.WithWatch {
 func installVZ(t *testing.T, c client.WithWatch) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
-	rc := testhelper.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
 	cmd := installcmd.NewCmdInstall(rc)
 	assert.NotNil(t, cmd)

--- a/tools/vz/cmd/analyze/analyze_test.go
+++ b/tools/vz/cmd/analyze/analyze_test.go
@@ -31,9 +31,8 @@ const ingressIPNotFound = "../../pkg/analysis/test/cluster/ingress-ip-not-found"
 
 // TestAnalyzeCommandDefault
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute without specifying flag capture-dir
-//	THEN expect the command to analyze the live cluster
+// WHEN I call cmd.Execute without specifying flag capture-dir
+// THEN expect the command to analyze the live cluster
 func TestAnalyzeCommandDefault(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -58,9 +57,8 @@ func TestAnalyzeCommandDefault(t *testing.T) {
 
 // TestAnalyzeCommandDetailedReport
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute with a valid capture-dir and report-format set to "detailed"
-//	THEN expect the command to provide the report containing all the details for one or more issues reported
+// WHEN I call cmd.Execute with a valid capture-dir and report-format set to "detailed"
+// THEN expect the command to provide the report containing all the details for one or more issues reported
 func TestAnalyzeCommandDetailedReport(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -77,9 +75,8 @@ func TestAnalyzeCommandDetailedReport(t *testing.T) {
 
 // TestAnalyzeCommandSummaryReport
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute with a valid capture-dir and report-format set to "summary"
-//	THEN expect the command to provide the report containing only summary for one or more issues reported
+// WHEN I call cmd.Execute with a valid capture-dir and report-format set to "summary"
+// THEN expect the command to provide the report containing only summary for one or more issues reported
 func TestAnalyzeCommandSummaryReport(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -96,9 +93,8 @@ func TestAnalyzeCommandSummaryReport(t *testing.T) {
 
 // TestAnalyzeCommandInvalidReportFormat
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute with an invalid value for report-format
-//	THEN expect the command to fail with an appropriate error message to indicate the issue
+// WHEN I call cmd.Execute with an invalid value for report-format
+// THEN expect the command to fail with an appropriate error message to indicate the issue
 func TestAnalyzeCommandInvalidReportFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -114,9 +110,8 @@ func TestAnalyzeCommandInvalidReportFormat(t *testing.T) {
 
 // TestAnalyzeCommandDefaultReportFormat
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute without report-format
-//	THEN expect the command to take the default value of summary for report-format and perform the analysis
+// WHEN I call cmd.Execute without report-format
+// THEN expect the command to take the default value of summary for report-format and perform the analysis
 func TestAnalyzeCommandDefaultReportFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -132,9 +127,8 @@ func TestAnalyzeCommandDefaultReportFormat(t *testing.T) {
 
 // TestAnalyzeCommandWithReportFile
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute with a valid report-file
-//	THEN expect the command to create the report file, containing the analysis report
+// WHEN I call cmd.Execute with a valid report-file
+// THEN expect the command to create the report file, containing the analysis report
 func TestAnalyzeCommandWithReportFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -153,9 +147,8 @@ func TestAnalyzeCommandWithReportFile(t *testing.T) {
 
 // TestAnalyzeCommandInvalidCapturedDir
 // GIVEN a CLI analyze command
-//
-//	WHEN I call cmd.Execute with capture-dir not containing the cluster snapshot
-//	THEN expect the command to fail with an appropriate error message
+// WHEN I call cmd.Execute with capture-dir not containing the cluster snapshot
+// THEN expect the command to fail with an appropriate error message
 func TestAnalyzeCommandInvalidCapturedDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	pkghelper "github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/test/helpers"
-	testhelper "github.com/verrazzano/verrazzano/tools/vz/test/helpers"
 	"io/ioutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,8 +29,9 @@ import (
 
 // TestBugReportHelp
 // GIVEN a CLI bug-report command
-//  WHEN I call cmd.Help for bug-report
-//  THEN expect the help for the command in the standard output
+//
+//	WHEN I call cmd.Help for bug-report
+//	THEN expect the help for the command in the standard output
 func TestBugReportHelp(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -47,8 +47,9 @@ func TestBugReportHelp(t *testing.T) {
 
 // TestBugReportExistingReportFile
 // GIVEN a CLI bug-report command using an existing file for flag --report-file
-//  WHEN I call cmd.Execute for bug-report
-//  THEN expect an error
+//
+//	WHEN I call cmd.Execute for bug-report
+//	THEN expect an error
 func TestBugReportExistingReportFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -75,8 +76,9 @@ func TestBugReportExistingReportFile(t *testing.T) {
 
 // TestBugReportExistingDir
 // GIVEN a CLI bug-report command with flag --report-file pointing to an existing directory
-//  WHEN I call cmd.Execute for bug-report
-//  THEN expect an error
+//
+//	WHEN I call cmd.Execute for bug-report
+//	THEN expect an error
 func TestBugReportExistingDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -100,8 +102,9 @@ func TestBugReportExistingDir(t *testing.T) {
 
 // TestBugReportNonExistingFileDir
 // GIVEN a CLI bug-report command with flag --report-file pointing to a file, where the directory doesn't exist
-//  WHEN I call cmd.Execute for bug-report
-//  THEN expect an error
+//
+//	WHEN I call cmd.Execute for bug-report
+//	THEN expect an error
 func TestBugReportNonExistingFileDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -123,8 +126,9 @@ func TestBugReportNonExistingFileDir(t *testing.T) {
 
 // TestBugReportFileNoPermission
 // GIVEN a CLI bug-report command with flag --report-file pointing to a file, where there is no write permission
-//  WHEN I call cmd.Execute for bug-report
-//  THEN expect an error
+//
+//	WHEN I call cmd.Execute for bug-report
+//	THEN expect an error
 func TestBugReportFileNoPermission(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -149,8 +153,9 @@ func TestBugReportFileNoPermission(t *testing.T) {
 
 // TestBugReportSuccess
 // GIVEN a CLI bug-report command
-//  WHEN I call cmd.Execute
-//  THEN expect the command to show the resources captured in the standard output and create the bug report file
+//
+//	WHEN I call cmd.Execute
+//	THEN expect the command to show the resources captured in the standard output and create the bug report file
 func TestBugReportSuccess(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -210,8 +215,9 @@ func TestBugReportSuccess(t *testing.T) {
 
 // TestBugReportDefaultReportFile
 // GIVEN a CLI bug-report command
-//  WHEN I call cmd.Execute, without specifying --report-file
-//  THEN expect the command to create the report bug-report.tar.gz under the current directory
+//
+//	WHEN I call cmd.Execute, without specifying --report-file
+//	THEN expect the command to create the report bug-report.tar.gz under the current directory
 func TestBugReportDefaultReportFile(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -249,8 +255,9 @@ func TestBugReportDefaultReportFile(t *testing.T) {
 
 // TestBugReportNoVerrazzano
 // GIVEN a CLI bug-report command
-//  WHEN I call cmd.Execute without Verrazzano installed
-//  THEN expect the command to display a message indicating Verrazzano is not installed
+//
+//	WHEN I call cmd.Execute without Verrazzano installed
+//	THEN expect the command to display a message indicating Verrazzano is not installed
 func TestBugReportNoVerrazzano(t *testing.T) {
 	c := getClientWithWatch()
 	buf := new(bytes.Buffer)
@@ -275,8 +282,9 @@ func TestBugReportNoVerrazzano(t *testing.T) {
 
 // TestBugReportFailureUsingInvalidClient
 // GIVEN a CLI bug-report command
-//  WHEN I call cmd.Execute without Verrazzano installed and using an invalid client
-//  THEN expect the command to fail with a message indicating Verrazzano is not installed and no resource captured
+//
+//	WHEN I call cmd.Execute without Verrazzano installed and using an invalid client
+//	THEN expect the command to fail with a message indicating Verrazzano is not installed and no resource captured
 func TestBugReportFailureUsingInvalidClient(t *testing.T) {
 	c := getInvalidClient()
 	buf := new(bytes.Buffer)
@@ -372,7 +380,7 @@ func getInvalidClient() client.WithWatch {
 func installVZ(t *testing.T, c client.WithWatch) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
-	rc := testhelper.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	rc := helpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
 	cmd := installcmd.NewCmdInstall(rc)
 	assert.NotNil(t, cmd)

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -29,9 +29,8 @@ import (
 
 // TestBugReportHelp
 // GIVEN a CLI bug-report command
-//
-//	WHEN I call cmd.Help for bug-report
-//	THEN expect the help for the command in the standard output
+// WHEN I call cmd.Help for bug-report
+// THEN expect the help for the command in the standard output
 func TestBugReportHelp(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -47,9 +46,8 @@ func TestBugReportHelp(t *testing.T) {
 
 // TestBugReportExistingReportFile
 // GIVEN a CLI bug-report command using an existing file for flag --report-file
-//
-//	WHEN I call cmd.Execute for bug-report
-//	THEN expect an error
+// WHEN I call cmd.Execute for bug-report
+// THEN expect an error
 func TestBugReportExistingReportFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -76,9 +74,8 @@ func TestBugReportExistingReportFile(t *testing.T) {
 
 // TestBugReportExistingDir
 // GIVEN a CLI bug-report command with flag --report-file pointing to an existing directory
-//
-//	WHEN I call cmd.Execute for bug-report
-//	THEN expect an error
+// WHEN I call cmd.Execute for bug-report
+// THEN expect an error
 func TestBugReportExistingDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -102,9 +99,8 @@ func TestBugReportExistingDir(t *testing.T) {
 
 // TestBugReportNonExistingFileDir
 // GIVEN a CLI bug-report command with flag --report-file pointing to a file, where the directory doesn't exist
-//
-//	WHEN I call cmd.Execute for bug-report
-//	THEN expect an error
+// WHEN I call cmd.Execute for bug-report
+// THEN expect an error
 func TestBugReportNonExistingFileDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -126,9 +122,8 @@ func TestBugReportNonExistingFileDir(t *testing.T) {
 
 // TestBugReportFileNoPermission
 // GIVEN a CLI bug-report command with flag --report-file pointing to a file, where there is no write permission
-//
-//	WHEN I call cmd.Execute for bug-report
-//	THEN expect an error
+// WHEN I call cmd.Execute for bug-report
+// THEN expect an error
 func TestBugReportFileNoPermission(t *testing.T) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -153,9 +148,8 @@ func TestBugReportFileNoPermission(t *testing.T) {
 
 // TestBugReportSuccess
 // GIVEN a CLI bug-report command
-//
-//	WHEN I call cmd.Execute
-//	THEN expect the command to show the resources captured in the standard output and create the bug report file
+// WHEN I call cmd.Execute
+// THEN expect the command to show the resources captured in the standard output and create the bug report file
 func TestBugReportSuccess(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -215,9 +209,8 @@ func TestBugReportSuccess(t *testing.T) {
 
 // TestBugReportDefaultReportFile
 // GIVEN a CLI bug-report command
-//
-//	WHEN I call cmd.Execute, without specifying --report-file
-//	THEN expect the command to create the report bug-report.tar.gz under the current directory
+// WHEN I call cmd.Execute, without specifying --report-file
+// THEN expect the command to create the report bug-report.tar.gz under the current directory
 func TestBugReportDefaultReportFile(t *testing.T) {
 	c := getClientWithWatch()
 	installVZ(t, c)
@@ -255,9 +248,8 @@ func TestBugReportDefaultReportFile(t *testing.T) {
 
 // TestBugReportNoVerrazzano
 // GIVEN a CLI bug-report command
-//
-//	WHEN I call cmd.Execute without Verrazzano installed
-//	THEN expect the command to display a message indicating Verrazzano is not installed
+// WHEN I call cmd.Execute without Verrazzano installed
+// THEN expect the command to display a message indicating Verrazzano is not installed
 func TestBugReportNoVerrazzano(t *testing.T) {
 	c := getClientWithWatch()
 	buf := new(bytes.Buffer)
@@ -282,9 +274,8 @@ func TestBugReportNoVerrazzano(t *testing.T) {
 
 // TestBugReportFailureUsingInvalidClient
 // GIVEN a CLI bug-report command
-//
-//	WHEN I call cmd.Execute without Verrazzano installed and using an invalid client
-//	THEN expect the command to fail with a message indicating Verrazzano is not installed and no resource captured
+// WHEN I call cmd.Execute without Verrazzano installed and using an invalid client
+// THEN expect the command to fail with a message indicating Verrazzano is not installed and no resource captured
 func TestBugReportFailureUsingInvalidClient(t *testing.T) {
 	c := getInvalidClient()
 	buf := new(bytes.Buffer)

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -56,7 +55,7 @@ func setWaitRetries(retries int) { uninstallWaitRetries = retries }
 func resetWaitRetries()          { uninstallWaitRetries = uninstallDefaultWaitRetries }
 
 var propagationPolicy = metav1.DeletePropagationBackground
-var deleteOptions = &clipkg.DeleteOptions{PropagationPolicy: &propagationPolicy}
+var deleteOptions = &client.DeleteOptions{PropagationPolicy: &propagationPolicy}
 
 var logsEnum = cmdhelpers.LogFormatSimple
 
@@ -169,7 +168,7 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 
 // cleanupResources deletes remaining resources that remain after the Verrazzano resource in uninstalled
 // Resources that fail to delete will log an error but will not return
-func cleanupResources(client clipkg.Client, vzHelper helpers.VZHelper) {
+func cleanupResources(client client.Client, vzHelper helpers.VZHelper) {
 	// Delete verrazzano-install namespace
 	err := deleteNamespace(client, constants.VerrazzanoInstall)
 	if err != nil {
@@ -380,7 +379,7 @@ func deleteNamespace(client client.Client, name string) error {
 }
 
 // deleteWebhookConfiguration deletes a given ValidatingWebhookConfiguration
-func deleteWebhookConfiguration(client clipkg.Client, name string) error {
+func deleteWebhookConfiguration(client client.Client, name string) error {
 	vwc := &adminv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -395,7 +394,7 @@ func deleteWebhookConfiguration(client clipkg.Client, name string) error {
 }
 
 // deleteClusterRoleBinding deletes a given ClusterRoleBinding
-func deleteClusterRoleBinding(client clipkg.Client, name string) error {
+func deleteClusterRoleBinding(client client.Client, name string) error {
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
I used staticcheck to find all instances of packages being imported twice into the same file.  E.g.

	$ staticcheck -go 1.19 -checks ST1019 ./...
	application-operator/controllers/appconfig/appconfig_controller.go:15:2: package "github.com/verrazzano/verrazzano/pkg/constants" is being imported more than once (ST1019)
			application-operator/controllers/appconfig/appconfig_controller.go:16:2: other import of "github.com/verrazzano/verrazzano/pkg/constants"
	application-operator/controllers/appconfig/appconfig_controller_test.go:16:2: package "github.com/stretchr/testify/assert" is being imported more than once (ST1019)
			application-operator/controllers/appconfig/appconfig_controller_test.go:17:2: other import of "github.com/stretchr/testify/assert"
	application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go:12:2: package "github.com/verrazzano/verrazzano/pkg/constants" is being imported more than once (ST1019)
			application-operator/controllers/clusters/verrazzanoproject/verrazzanoproject_controller.go:13:2: other import of "github.com/verrazzano/verrazzano/pkg/constants"
	...

This commit removes redundant imports.  I tried to favor short aliases, or no alias if none was needed.  Per @gilbode 's suggestion, I updated `.golangci.yaml` to narrowly run the ST1019 check (to prevent recidivism).
