### PR TITLE
Change upgrade jobs default kind k8s version to 1.21

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.20", "1.21", "1.22", "1.23", "1,24" ])
+                choices: ["1.21", "1.22", "1.23", "1,24" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.1.2',
                 description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.20", "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.1.2',
                 description: 'This is the Verrazzano version for install before doing an upgrade.  By default, the v1.0.2 release will be installed',

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.20", "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.1.2',
                 description: 'This is the Verrazzano version for install before doing an upgrade.  By default, the v1.1.2 release will be installed',

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -47,7 +47,6 @@ pipeline {
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
-
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',
                         description: 'This is for manually testing only where someone needs to use a specific operator image, otherwise the default value of NONE is used',

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -43,7 +43,7 @@ pipeline {
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.20", "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -40,9 +40,14 @@ pipeline {
                 trim: true)
         choice (description: 'Predefined config permutations for Verrazzano installation. Prod profile is the default profile for NONE', name: 'VZ_INSTALL_CONFIG',
                 choices: ["NONE", "dev-kind-persistence"])
+        choice (name: 'KIND_CLUSTER_VERSION',
+                description: 'Kubernetes Version for KIND Cluster',
+                // 1st choice is the default value
+                choices: [ "1.20", "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
+
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',
                         description: 'This is for manually testing only where someone needs to use a specific operator image, otherwise the default value of NONE is used',

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.20", "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.1.2',
                 description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',


### PR DESCRIPTION
This PR changes the default kind k8s version to 1.21
- Adds a kind cluster version param to minor upgrade release jenkinsfile