### PR TITLE
VZ-7173. Fix VPO dependency checks.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -114,10 +114,18 @@ func FindComponent(componentName string) (bool, spi.Component) {
 	return false, nil
 }
 
-// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available
+// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available; this is
+// a shallow check of the direct dependencies, with the expectation that any indirect dependencies will be implicitly
+// handled.
+//
+// For now, a dependency is soft; that is, we only care if it's Ready if it's enabled; if not we pass the dependency check
+// so as not to block the dependent.  This would theoretically allow, for example, components that depend on Istio
+// to continue to deploy if it's not enabled.  In the long run, the dependency mechanism should likely go away and
+// allow components to individually make those decisions.
+//
 func ComponentDependenciesMet(c spi.Component, context spi.ComponentContext) bool {
 	log := context.Log()
-	trace, err := checkDependencies(c, context, make(map[string]bool), make(map[string]bool))
+	trace, err := checkDirectDependenciesReady(c, context, make(map[string]bool))
 	if err != nil {
 		log.Error(err.Error())
 		return false
@@ -136,14 +144,10 @@ func ComponentDependenciesMet(c spi.Component, context spi.ComponentContext) boo
 }
 
 // checkDependencies Check the ready state of any dependencies and check for cycles
-func checkDependencies(c spi.Component, context spi.ComponentContext, visited map[string]bool, stateMap map[string]bool) (map[string]bool, error) {
+func checkDirectDependenciesReady(c spi.Component, context spi.ComponentContext, stateMap map[string]bool) (map[string]bool, error) {
 	compName := c.Name()
 	log := context.Log()
 	log.Debugf("Checking %s dependencies", compName)
-	if _, wasVisited := visited[compName]; wasVisited {
-		return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
-	}
-	visited[compName] = true
 	for _, dependencyName := range c.GetDependencies() {
 		if compName == dependencyName {
 			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
@@ -157,19 +161,22 @@ func checkDependencies(c spi.Component, context spi.ComponentContext, visited ma
 		if !found {
 			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
 		}
-		if trace, err := checkDependencies(dependency, context, visited, stateMap); err != nil {
-			return trace, err
-		}
 		// Only check if dependency is ready when the dependency is enabled
-		if dependency.IsEnabled(context.EffectiveCR()) && // Is enabled
-			!isInReadyState(context, dependency) && // CR status does not already indicate ready status
-			!dependency.IsReady(context) {
-			stateMap[dependencyName] = false // dependency is not ready
-			continue
-		}
-		stateMap[dependencyName] = true // dependency is ready
+		stateMap[dependencyName] = isDependencyReady(dependency, context) // dependency is ready
 	}
 	return stateMap, nil
+}
+
+// isDependencyReady Returns true if the component is disabled, is already in the Ready state, or if it's isReady() check is true
+func isDependencyReady(dependency spi.Component, context spi.ComponentContext) bool {
+	if !dependency.IsEnabled(context.EffectiveCR()) {
+		return true
+	}
+	if isInReadyState(context, dependency) {
+		// CR component status indicates ready
+		return true
+	}
+	return dependency.IsReady(context)
 }
 
 func isInReadyState(context spi.ComponentContext, comp spi.Component) bool {

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -231,29 +231,29 @@ func TestComponentDependenciesNotMet(t *testing.T) {
 // GIVEN a component
 //  WHEN I call ComponentDependenciesMet for it
 //  THEN true is still returned if the dependency is not enabled
-//func TestComponentOptionalDependenciesMet(t *testing.T) {
-//	comp := helm2.HelmComponent{
-//		ReleaseName:    "foo",
-//		ChartDir:       "chartDir",
-//		ChartNamespace: "bar",
-//		Dependencies:   []string{nginx.ComponentName},
-//	}
-//	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-//	enabled := false
-//	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Namespace: "foo",
-//		},
-//		Spec: v1alpha1.VerrazzanoSpec{
-//			Components: v1alpha1.ComponentSpec{
-//				Istio: &v1alpha1.IstioComponent{
-//					Enabled: &enabled,
-//				},
-//			},
-//		},
-//	}, nil, false))
-//	assert.True(t, ready)
-//}
+func TestComponentOptionalDependenciesMet(t *testing.T) {
+	comp := helm2.HelmComponent{
+		ReleaseName:    "foo",
+		ChartDir:       "chartDir",
+		ChartNamespace: "bar",
+		Dependencies:   []string{istio.ComponentName},
+	}
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	enabled := false
+	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				Istio: &v1alpha1.IstioComponent{
+					Enabled: &enabled,
+				},
+			},
+		},
+	}, nil, false))
+	assert.True(t, ready)
+}
 
 // TestComponentDependenciesDependencyChartNotInstalled tests ComponentDependenciesMet
 // GIVEN a component
@@ -380,25 +380,50 @@ func TestComponentDependenciesCycle(t *testing.T) {
 // GIVEN a registry of components with dependencies, and some with cycles
 //  WHEN I call ComponentDependenciesMet for it
 //  THEN it returns false if there's a cycle in the dependencies
+func TestIndirectDependencyMetButNotReady(t *testing.T) {
+	// directCycle -> fake1, directCycle
+	indirectDependency := fakeComponent{name: "indirectDependency", enabled: false, ready: true}
+	directDependency := fakeComponent{name: "directDependency", enabled: true, ready: false, dependencies: []string{"indirectDependency"}}
+	dependent := fakeComponent{name: "dependent", enabled: false, ready: false, dependencies: []string{"directDependency"}}
+
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			directDependency,
+			indirectDependency,
+			dependent,
+		}
+	})
+	defer ResetGetComponentsFn()
+
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	assert.True(t, ComponentDependenciesMet(indirectDependency, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
+	assert.True(t, ComponentDependenciesMet(directDependency, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
+	assert.False(t, ComponentDependenciesMet(dependent, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
+}
+
+// TestComponentDependenciesCycles tests ComponentDependenciesMet
+// GIVEN a registry of components with dependencies, and some with cycles
+//  WHEN I call ComponentDependenciesMet for it
+//  THEN it returns false if there's a cycle in the dependencies
 func TestComponentDependenciesCycles(t *testing.T) {
 	// directCycle -> fake1, directCycle
-	directCycle := fakeComponent{name: "directCycle", dependencies: []string{"fake1", "directCycle"}}
+	directCycle := fakeComponent{name: "directCycle", enabled: true, dependencies: []string{"fake1", "directCycle"}}
 	// indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-	indirectCycle1 := fakeComponent{name: "indirectCycle1", dependencies: []string{"fake3"}}
+	indirectCycle1 := fakeComponent{name: "indirectCycle1", enabled: true, dependencies: []string{"fake3"}}
 	// indirectCycle2 -> fake4 -> fake3 -> fake2 -> indirectCycle -> fake3
-	indirectCycle2 := fakeComponent{name: "indirectCycle2", dependencies: []string{"fake4"}}
-	nocycles := fakeComponent{name: "nocycles", dependencies: []string{"fake6", "fake5"}}
-	noDependencies := fakeComponent{name: "fake1"}
+	indirectCycle2 := fakeComponent{name: "indirectCycle2", enabled: true, dependencies: []string{"fake4"}}
+	nocycles := fakeComponent{name: "nocycles", enabled: true, ready: true, dependencies: []string{"fake6", "fake5"}}
+	noDependencies := fakeComponent{name: "fake1", enabled: true, ready: true}
 	OverrideGetComponentsFn(func() []spi.Component {
 		return []spi.Component{
 			noDependencies,
 			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-			fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
+			fakeComponent{name: "fake2", enabled: true, dependencies: []string{"indirectCycle1", "fake1"}},
 			// fake3 -> fake2 -> indirectCycle1 -> fake3
-			fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
-			fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
-			fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
-			fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
+			fakeComponent{name: "fake3", enabled: true, dependencies: []string{"fake2"}},
+			fakeComponent{name: "fake4", enabled: true, dependencies: []string{"fake3"}},
+			fakeComponent{name: "fake5", enabled: true, ready: true, dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake6", enabled: true, ready: true, dependencies: []string{"fake5"}},
 			nocycles,
 			indirectCycle1,
 			indirectCycle2,
@@ -414,72 +439,17 @@ func TestComponentDependenciesCycles(t *testing.T) {
 	assert.True(t, ComponentDependenciesMet(noDependencies, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)))
 }
 
-// TestComponentDependenciesCycles tests ComponentDependenciesMet
-// GIVEN a registry of components with dependencies, and some with cycles
-//  WHEN I call ComponentDependenciesMet for it
-//  THEN it returns false if there's a cycle in the dependencies
-func Test_checkDependencies(t *testing.T) {
-	// directCycle -> fake1, directCycle
-	directCycle := fakeComponent{name: "directCycle", dependencies: []string{"fake1", "directCycle"}}
-	// indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-	indirectCycle1 := fakeComponent{name: "indirectCycle1", dependencies: []string{"fake3"}}
-	// indirectCycle2 -> fake4 -> fake3 -> fake2 -> indirectCycle -> fake3
-	indirectCycle2 := fakeComponent{name: "indirectCycle2", dependencies: []string{"fake4"}}
-	nocycles := fakeComponent{name: "nocycles", dependencies: []string{"fake6", "fake5"}}
-	noDependencies := fakeComponent{name: "fake1"}
-	OverrideGetComponentsFn(func() []spi.Component {
-		return []spi.Component{
-			noDependencies,
-			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
-			fakeComponent{name: "fake2", dependencies: []string{"indirectCycle1", "fake1"}},
-			// fake3 -> fake2 -> indirectCycle1 -> fake3
-			fakeComponent{name: "fake3", dependencies: []string{"fake2"}},
-			fakeComponent{name: "fake4", dependencies: []string{"fake3"}},
-			fakeComponent{name: "fake5", dependencies: []string{"fake1"}},
-			fakeComponent{name: "fake6", dependencies: []string{"fake5"}},
-			nocycles,
-			indirectCycle1,
-			indirectCycle2,
-		}
-	})
-	defer ResetGetComponentsFn()
-
-	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
-	ctx := spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)
-
-	_, err := checkDependencies(directCycle, ctx, make(map[string]bool), make(map[string]bool))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dependency cycle found for directCycle")
-	_, err = checkDependencies(indirectCycle1, ctx, make(map[string]bool), make(map[string]bool))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dependency cycle found for indirectCycle1")
-	_, err = checkDependencies(indirectCycle2, ctx, make(map[string]bool), make(map[string]bool))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dependency cycle found for fake3")
-	dependencies, err := checkDependencies(nocycles, ctx, make(map[string]bool), make(map[string]bool))
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]bool{
-		"fake6": true,
-		"fake5": true,
-		"fake1": true,
-	}, dependencies)
-
-	dependencies, err = checkDependencies(noDependencies, ctx, make(map[string]bool), make(map[string]bool))
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]bool{}, dependencies)
-}
-
 // TestComponentDependenciesCycle tests ComponentDependenciesMet
 // GIVEN a component
 //  WHEN I call ComponentDependenciesMet for it
 //  THEN it returns false if there's a cycle in the dependencies
 func TestComponentDependenciesChainNoCycle(t *testing.T) {
-	chainNoCycle := fakeComponent{name: "chainNoCycle", dependencies: []string{"fake2"}}
-	repeatDepdendency := fakeComponent{name: "repeatDependency", dependencies: []string{"fake1", "fake2", "fake1"}}
+	chainNoCycle := fakeComponent{name: "chainNoCycle", enabled: true, ready: true, dependencies: []string{"fake2"}}
+	repeatDepdendency := fakeComponent{name: "repeatDependency", enabled: true, ready: true, dependencies: []string{"fake1", "fake2", "fake1"}}
 	OverrideGetComponentsFn(func() []spi.Component {
 		return []spi.Component{
-			fakeComponent{name: "fake1"},
-			fakeComponent{name: "fake2", dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake1", enabled: true, ready: true},
+			fakeComponent{name: "fake2", enabled: true, ready: true, dependencies: []string{"fake1"}},
 			chainNoCycle,
 			repeatDepdendency,
 		}
@@ -497,7 +467,64 @@ func TestComponentDependenciesChainNoCycle(t *testing.T) {
 	assert.True(t, ready)
 }
 
-// TestRegistryDependencies tests the default Registry components for cycles
+// TestComponentDependenciesCycles validates the test method checkDependencyCycles, which is used by another test to
+// validate that the production component registry does not have any cycles declared.
+//
+// GIVEN a registry of components with dependencies, and some with cycles
+//  WHEN I call checkDependencyCycles for it
+//  THEN it returns an error if there's a cycle in the dependencies
+func Test_checkDependencyCycles(t *testing.T) {
+	// directCycle -> fake1, directCycle
+	directCycle := fakeComponent{name: "directCycle", enabled: true, dependencies: []string{"fake1", "directCycle"}}
+	// indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
+	indirectCycle1 := fakeComponent{name: "indirectCycle1", enabled: true, dependencies: []string{"fake3"}}
+	// indirectCycle2 -> fake4 -> fake3 -> fake2 -> indirectCycle -> fake3
+	indirectCycle2 := fakeComponent{name: "indirectCycle2", enabled: true, dependencies: []string{"fake4"}}
+	nocycles := fakeComponent{name: "nocycles", enabled: true, dependencies: []string{"fake6", "fake5"}}
+	noDependencies := fakeComponent{name: "fake1", enabled: true, ready: true}
+	OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			noDependencies,
+			// fake2 -> indirectCycle1 -> fake3 -> fake2 -> indirectCycle1
+			fakeComponent{name: "fake2", enabled: true, dependencies: []string{"indirectCycle1", "fake1"}},
+			// fake3 -> fake2 -> indirectCycle1 -> fake3
+			fakeComponent{name: "fake3", enabled: true, dependencies: []string{"fake2"}},
+			fakeComponent{name: "fake4", enabled: true, dependencies: []string{"fake3"}},
+			fakeComponent{name: "fake5", enabled: true, ready: true, dependencies: []string{"fake1"}},
+			fakeComponent{name: "fake6", enabled: true, ready: true, dependencies: []string{"fake5"}},
+			nocycles,
+			indirectCycle1,
+			indirectCycle2,
+		}
+	})
+	defer ResetGetComponentsFn()
+
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	ctx := spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false)
+
+	_, err := checkDependencyCycles(directCycle, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for directCycle")
+	_, err = checkDependencyCycles(indirectCycle1, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for indirectCycle1")
+	_, err = checkDependencyCycles(indirectCycle2, ctx, make(map[string]bool), make(map[string]bool))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle found for fake3")
+	dependencies, err := checkDependencyCycles(nocycles, ctx, make(map[string]bool), make(map[string]bool))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{
+		"fake6": true,
+		"fake5": true,
+		"fake1": true,
+	}, dependencies)
+
+	dependencies, err = checkDependencyCycles(noDependencies, ctx, make(map[string]bool), make(map[string]bool))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{}, dependencies)
+}
+
+// TestRegistryDependencies tests the production Registry components for dependency cycles
 // GIVEN a component
 //  WHEN I call checkDependencies for it
 //  THEN No error is returned that indicates a cycle in the chain
@@ -509,7 +536,7 @@ func TestRegistryDependencies(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
 	for _, comp := range GetComponents() {
-		_, err := checkDependencies(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false, profileDir),
+		_, err := checkDependencyCycles(comp, spi.NewFakeContext(client, &v1alpha1.Verrazzano{}, nil, false, profileDir),
 			make(map[string]bool), make(map[string]bool))
 		assert.NoError(t, err)
 	}
@@ -595,6 +622,37 @@ func runDepenencyStateCheckTest(t *testing.T, state v1alpha1.CompStateType, enab
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
 	ready := ComponentDependenciesMet(comp, spi.NewFakeContext(client, cr, nil, true))
 	assert.Equal(t, expectedResult, ready)
+}
+
+// checkDependencies Check the ready state of any dependencies and check for cycles
+func checkDependencyCycles(c spi.Component, context spi.ComponentContext, visited map[string]bool, stateMap map[string]bool) (map[string]bool, error) {
+	compName := c.Name()
+	log := context.Log()
+	log.Debugf("Checking %s dependencies", compName)
+	if _, wasVisited := visited[compName]; wasVisited {
+		return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
+	}
+	visited[compName] = true
+	for _, dependencyName := range c.GetDependencies() {
+		if compName == dependencyName {
+			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
+		}
+		if _, ok := stateMap[dependencyName]; ok {
+			// dependency already checked
+			log.Debugf("Dependency %s already checked", dependencyName)
+			continue
+		}
+		found, dependency := FindComponent(dependencyName)
+		if !found {
+			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
+		}
+		if trace, err := checkDependencyCycles(dependency, context, visited, stateMap); err != nil {
+			return trace, err
+		}
+		// Only check if dependency is ready when the dependency is enabled
+		stateMap[dependencyName] = true
+	}
+	return stateMap, nil
 }
 
 // Create a new deployment object for testing


### PR DESCRIPTION
Simplify VPO component dependency checks to just check the immediate dependencies of a component
- Check `Enabled` status before `Ready` checks, to short-circuit if a component is disabled
- Remove recursive dependency checks from `ComponentDependenciesMet`
- Remove the dependency cycle check hooks from `ComponentDependenciesMet`, move cycle checks to unit tests only
- Other unit test updates to properly set the `fakeComponent` instance `ready/enabled` states accordingly

With this change, we should implicitly still wait on indirect dependencies via the controller sequence, and the direct dependencies' `Ready` checks.

