### PR TITLE
golangci-lint updates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 linters:
@@ -6,10 +6,10 @@ linters:
     - govet
     - ineffassign
     - gofmt
-    - golint
     - gosimple
-    - deadcode
     - gosec
+    - revive
+    - unused
   disable-all: true
   fast: true
 

--- a/application-operator/metricsexporter/metricsexporter_utils.go
+++ b/application-operator/metricsexporter/metricsexporter_utils.go
@@ -368,7 +368,11 @@ func StartMetricsServer() error {
 	}
 	go wait.Until(func() {
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(":9100", nil)
+		server := &http.Server{
+			Addr:              ":9100",
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+		err := server.ListenAndServe()
 		if err != nil {
 			vlog.Oncef("Failed to start metrics server for VMI: %v", err)
 		}

--- a/image-patch-operator/controllers/imagejob/job.go
+++ b/image-patch-operator/controllers/imagejob/job.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package imagejob
@@ -23,8 +23,8 @@ type JobConfig struct {
 
 // NewJob returns a job resource for building an ImageBuildRequest
 func NewJob(jobConfig *JobConfig) *batchv1.Job {
-	var annotations map[string]string = nil
-	var backoffLimit int32 = 0
+	var annotations map[string]string
+	var backoffLimit int32
 	if jobConfig.DryRun {
 		annotations = make(map[string]string, 1)
 		annotations[k8s.DryRunAnnotationName] = strconv.FormatBool(jobConfig.DryRun)

--- a/pkg/k8s/status/pod_ready.go
+++ b/pkg/k8s/status/pod_ready.go
@@ -39,7 +39,7 @@ func GetPodsList(log vzlog.VerrazzanoLogger, client clipkg.Client, namespacedNam
 // EnsurePodsAreReady makes sure pods using the latest workload revision are ready.
 // A list of pods using the latest revision are passed to this function.
 func EnsurePodsAreReady(log vzlog.VerrazzanoLogger, podsToCheck []corev1.Pod, expectedPods int32, prefix string) (int32, bool) {
-	var podsReady int32 = 0
+	var podsReady int32
 	for _, pod := range podsToCheck {
 		// Check that init containers are ready
 		for _, initContainerStatus := range pod.Status.InitContainerStatuses {

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -24,7 +24,7 @@ type SemVersion struct {
 	Build      string
 }
 
-var compiledRegEx *regexp.Regexp = nil
+var compiledRegEx *regexp.Regexp
 
 func getRegex() (*regexp.Regexp, error) {
 	if compiledRegEx != nil {
@@ -72,7 +72,7 @@ func NewSemVersion(version string) (*SemVersion, error) {
 		return nil, err
 	}
 
-	var patchVer int64 = 0
+	var patchVer int64
 	if numComponents > 3 {
 		patchVer, err = strconv.ParseInt(versionComponents[3], 10, 64)
 		if err != nil {

--- a/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -60,7 +60,7 @@ func internalLogger() *zap.SugaredLogger {
 	return log.Sugar()
 }
 
-//NewLogger generates a new logger, and tees ginkgo output to the search db
+// NewLogger generates a new logger, and tees ginkgo output to the search db
 func NewLogger(pkg string, ind string, paths ...string) (*zap.SugaredLogger, error) {
 	var messageKey = zapcore.OmitKey
 	if ind == TestLogIndex {
@@ -141,7 +141,7 @@ func configureLoggerWithJenkinsEnv(log *zap.SugaredLogger) *zap.SugaredLogger {
 	return log
 }
 
-//configureOutputs configures the search output path if it is available
+// configureOutputs configures the search output path if it is available
 func configureOutputs(ind string) ([]string, error) {
 	var outputs []string
 	searchWriter, err := SearchWriterFromEnv(ind)

--- a/pkg/test/framework/metrics/prometheus.go
+++ b/pkg/test/framework/metrics/prometheus.go
@@ -89,12 +89,6 @@ func NewPrometheusMetricsReceiver(cfg PrometheusMetricsReceiverConfig) (*Prometh
 	return &receiver, nil
 }
 
-// overridePusher overrides the Prometheus pusher used by this metrics receiver - tests may
-// use this function to mock the pusher
-func (rcvr *PrometheusMetricsReceiver) overridePusher(pusher push.Pusher) {
-	rcvr.promPusher = &pusher
-}
-
 func (rcvr *PrometheusMetricsReceiver) makeMetricName(name string) string {
 	if rcvr.Name != "" {
 		return rcvr.Name + "_" + name

--- a/pkg/yaml/replace_merge_test.go
+++ b/pkg/yaml/replace_merge_test.go
@@ -256,8 +256,6 @@ k2:
 // WHEN ReplacementMerge is called
 // THEN ensure that the result is correct.
 func TestReplaceMany(t *testing.T) {
-	const indent = 2
-
 	tests := []struct {
 		testName string
 		values   []string

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -42,7 +42,7 @@ type ComponentValidator interface {
 	ValidateUpdate(old *Verrazzano, new *Verrazzano) []error
 }
 
-var componentValidator ComponentValidator = nil
+var componentValidator ComponentValidator
 
 func SetComponentValidator(v ComponentValidator) {
 	componentValidator = v

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
@@ -42,7 +42,7 @@ type ComponentValidator interface {
 	ValidateUpdateV1Beta1(old *Verrazzano, new *Verrazzano) []error
 }
 
-var componentValidator ComponentValidator = nil
+var componentValidator ComponentValidator
 
 func SetComponentValidator(v ComponentValidator) {
 	componentValidator = v

--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -83,7 +83,7 @@ func CreateOrUpdateVMI(ctx spi.ComponentContext, updateFunc VMIMutateFunc) error
 	}
 	vmi := NewVMI()
 	_, err = controllerutil.CreateOrUpdate(context.TODO(), ctx.Client(), vmi, func() error {
-		var existingVMI *vmov1.VerrazzanoMonitoringInstance = nil
+		var existingVMI *vmov1.VerrazzanoMonitoringInstance
 		if len(vmi.Spec.SecretsName) > 0 {
 			existingVMI = vmi.DeepCopy()
 		}
@@ -327,7 +327,7 @@ func CheckIngressesAndCerts(ctx spi.ComponentContext, comp spi.Component) error 
 	return nil
 }
 
-//IsMultiNodeOpenSearch returns true if the VZ OpenSearch has more than 1 node.
+// IsMultiNodeOpenSearch returns true if the VZ OpenSearch has more than 1 node.
 func IsMultiNodeOpenSearch(vz *vzapi.Verrazzano) (bool, error) {
 	opensearch := vz.Spec.Components.Elasticsearch
 	var replicas int32
@@ -343,14 +343,14 @@ func IsMultiNodeOpenSearch(vz *vzapi.Verrazzano) (bool, error) {
 	return replicas > 1, nil
 }
 
-//addNodeGroupReplicas iterates through each OpenSearch node and sums the replicas
+// addNodeGroupReplicas iterates through each OpenSearch node and sums the replicas
 func addNodeGroupReplicas(os *vzapi.ElasticsearchComponent, replicas *int32) {
 	for _, node := range os.Nodes {
 		*replicas += node.Replicas
 	}
 }
 
-//addInstallArgReplicas sums the replicas from master, data, and ingest node install args.
+// addInstallArgReplicas sums the replicas from master, data, and ingest node install args.
 func addInstallArgReplicas(os *vzapi.ElasticsearchComponent, replicas *int32) error {
 	addStr := func(v string) error {
 		var val int32

--- a/platform-operator/controllers/verrazzano/component/istio/envoy_filter.go
+++ b/platform-operator/controllers/verrazzano/component/istio/envoy_filter.go
@@ -42,8 +42,6 @@ const specField = "spec"
 
 // Create the Envoy network filter
 func createEnvoyFilter(log vzlog.VerrazzanoLogger, client clipkg.Client) error {
-	const IstioEnvoyFilter = "server-header-filter"
-
 	// Unmarshal the YAML into an object
 	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	err := yaml.Unmarshal([]byte(filterYaml), u)

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
@@ -129,10 +129,9 @@ func testCR() *installv1alpha1.Verrazzano {
 }
 
 type fakeMonitor struct {
-	result          bool
-	istioctlSuccess bool
-	err             error
-	running         bool
+	result  bool
+	err     error
+	running bool
 }
 
 func (f *fakeMonitor) run(args installRoutineParams) {
@@ -142,13 +141,7 @@ func (f *fakeMonitor) checkResult() (bool, error) { return f.result, f.err }
 
 func (f *fakeMonitor) reset() {}
 
-func (f *fakeMonitor) init() {}
-
-func (f *fakeMonitor) sendResult(r bool) {}
-
 func (f *fakeMonitor) isRunning() bool { return f.running }
-
-func (f *fakeMonitor) isIstioctlSuccess() bool { return f.istioctlSuccess }
 
 var _ installMonitor = &fakeMonitor{}
 

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -154,23 +154,6 @@ func (c mysqlComponent) getInstallArgs(vz *vzapi.Verrazzano) []vzapi.InstallArgs
 	return nil
 }
 
-func (c mysqlComponent) getInstallOverridesV1beta1(object runtime.Object) []v1beta1.Overrides {
-	if vz, ok := object.(*vzapi.Verrazzano); ok {
-		if vz != nil && vz.Spec.Components.Keycloak != nil {
-			valueOverrides, err := vzapi.ConvertInstallOverridesWithArgsToV1Beta1(vz.Spec.Components.Keycloak.MySQL.MySQLInstallArgs, vz.Spec.Components.Keycloak.MySQL.InstallOverrides)
-			if err != nil {
-				return nil
-			}
-			return valueOverrides.ValueOverrides
-		}
-	}
-	vz := object.(*v1beta1.Verrazzano)
-	if vz != nil && vz.Spec.Components.Keycloak != nil {
-		return vz.Spec.Components.Keycloak.MySQL.InstallOverrides.ValueOverrides
-	}
-	return nil
-}
-
 // MonitorOverrides checks whether monitoring of install overrides is enabled or not
 func (c mysqlComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
 	if ctx.EffectiveCR().Spec.Components.Keycloak != nil {

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
@@ -115,7 +115,7 @@ func hasRole(roles []vmov1.NodeRole, roleToHave vmov1.NodeRole) bool {
 
 // findESReplicas searches the ES install args to find the correct resources to search for in isReady
 func findESReplicas(ctx spi.ComponentContext, nodeType vmov1.NodeRole) int32 {
-	var replicas int32 = 0
+	var replicas int32
 	if vzconfig.IsOpenSearchEnabled(ctx.EffectiveCR()) && ctx.EffectiveCR().Spec.Components.Elasticsearch != nil {
 		for _, node := range ctx.EffectiveCR().Spec.Components.Elasticsearch.Nodes {
 			for _, role := range node.Roles {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -75,7 +75,7 @@ func NewComponent() spi.Component {
 	}
 }
 
-//AppendOverrides set the Rancher overrides for Helm
+// AppendOverrides set the Rancher overrides for Helm
 func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	log := ctx.Log()
 	rancherHostName, err := getRancherHostname(ctx.Client(), ctx.EffectiveCR())
@@ -99,7 +99,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	return appendCAOverrides(log, kvs, ctx)
 }
 
-//appendRegistryOverrides appends overrides if a custom registry is being used
+// appendRegistryOverrides appends overrides if a custom registry is being used
 func appendRegistryOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 	// If using external registry, add registry overrides to Rancher
 	registry := os.Getenv(constants.RegistryOverrideEnvVar)
@@ -119,7 +119,7 @@ func appendRegistryOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 	return kvs
 }
 
-//appendCAOverrides sets overrides for CA Issuers, ACME or CA.
+// appendCAOverrides sets overrides for CA Issuers, ACME or CA.
 func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.ComponentContext) ([]bom.KeyValue, error) {
 	cm := ctx.EffectiveCR().Spec.Components.CertManager
 	if cm == nil {

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -45,8 +45,6 @@ const (
 // ComponentJSONName is the josn name of the verrazzano component in CRD
 const ComponentJSONName = "verrazzano"
 
-var getControllerRuntimeClient = getClient
-
 type verrazzanoComponent struct {
 	helm.HelmComponent
 }

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
@@ -42,6 +42,8 @@ var crEnabled = vzapi.Verrazzano{
 	},
 }
 
+var getControllerRuntimeClient = getClient
+
 // genericTestRunner is used to run generic OS commands with expected results
 type genericTestRunner struct {
 }

--- a/platform-operator/controllers/verrazzano/controller.go
+++ b/platform-operator/controllers/verrazzano/controller.go
@@ -552,11 +552,6 @@ func buildClusterRoleBindingName(namespace string, name string) string {
 	return fmt.Sprintf("verrazzano-install-%s-%s", namespace, name)
 }
 
-// buildInternalConfigMapName returns the name of the internal configmap associated with an install resource.
-func buildInternalConfigMapName(name string) string {
-	return fmt.Sprintf("verrazzano-install-%s-internal", name)
-}
-
 func isOperatorSameVersionAsCR(vzVersion string) bool {
 	bomVersion, currentVersion, ok := getVzAndOperatorVersions(vzVersion)
 	if ok {
@@ -864,17 +859,6 @@ func (r *Reconciler) setUninstallCondition(log vzlog.VerrazzanoLogger, vz *insta
 	return r.updateStatus(log, vz, msg, newCondition)
 }
 
-// getInternalConfigMap Convenience method for getting the saved install ConfigMap
-func (r *Reconciler) getInternalConfigMap(ctx context.Context, vz *installv1alpha1.Verrazzano) (installConfig *corev1.ConfigMap, err error) {
-	key := client.ObjectKey{
-		Namespace: getInstallNamespace(),
-		Name:      buildInternalConfigMapName(vz.Name),
-	}
-	installConfig = &corev1.ConfigMap{}
-	err = r.Get(ctx, key, installConfig)
-	return installConfig, err
-}
-
 // createVerrazzanoSystemNamespace creates the Verrazzano system namespace if it does not already exist
 func (r *Reconciler) createVerrazzanoSystemNamespace(ctx context.Context, cr *installv1alpha1.Verrazzano, log vzlog.VerrazzanoLogger) error {
 	// remove injection label if disabled
@@ -1114,22 +1098,6 @@ func (r *Reconciler) initForVzResource(vz *installv1alpha1.Verrazzano, log vzlog
 // This is needed for unit testing
 func initUnitTesing() {
 	unitTesting = true
-}
-
-func (r *Reconciler) updateVerrazzano(log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) error {
-	err := r.Update(context.TODO(), vz)
-	if err == nil {
-		return nil
-	}
-	if ctrlerrors.IsUpdateConflict(err) {
-		log.Info("Requeuing to get a new copy of the Verrazzano resource since the current one is outdated.")
-	} else if statusErr, ok := err.(*errors.StatusError); ok && strings.Contains(statusErr.Status().Message, "conversion webhook") {
-		log.Oncef("Timed out connecting to conversion webhook")
-	} else {
-		log.Errorf("Failed to update Verrazzano resource :v", err)
-	}
-	// Return error so that reconcile gets called again
-	return err
 }
 
 func (r *Reconciler) updateVerrazzanoStatus(log vzlog.VerrazzanoLogger, vz *installv1alpha1.Verrazzano) error {

--- a/platform-operator/controllers/verrazzano/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/upgrade_test.go
@@ -6,10 +6,8 @@ package verrazzano
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math/big"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -65,14 +63,6 @@ const jaegerURL = "jaeger." + dnsDomain
 
 var istioEnabled = false
 var jaegerEnabled = true
-
-// goodRunner is used to test helm success without actually running an OS exec command
-type goodRunner struct {
-}
-
-// badRunner is used to test helm failure without actually running an OS exec command
-type badRunner struct {
-}
 
 // TestUpgradeNoVersion tests the reconcileUpgrade method for the following use case
 // GIVEN a request to reconcile a verrazzano resource after install is completed
@@ -1543,14 +1533,6 @@ func TestIsLastConditionTrue(t *testing.T) {
 		},
 	}
 	asserts.True(isLastCondition(st, vzapi.CondInstallFailed), "isLastCondition should have returned true")
-}
-
-func (r goodRunner) Run(_ *exec.Cmd) (stdout []byte, stderr []byte, err error) {
-	return []byte("success"), []byte(""), nil
-}
-
-func (r badRunner) Run(_ *exec.Cmd) (stdout []byte, stderr []byte, err error) {
-	return []byte(""), []byte("failure"), errors.New("Helm Error")
 }
 
 // TestInstanceRestoreWithEmptyStatus tests the reconcileUpdate method for the following use case

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
@@ -37,7 +37,6 @@ func TestGetInstanceInfo(t *testing.T) {
 	const esURL = "elasticsearch." + dnsDomain
 	const promURL = "prometheus." + dnsDomain
 	const grafanaURL = "grafana." + dnsDomain
-	const kialiURL = "kiali." + dnsDomain
 	const kibanaURL = "kibana." + dnsDomain
 	const rancherURL = "rancher." + dnsDomain
 	const consoleURL = "verrazzano." + dnsDomain

--- a/tests/e2e/pkg/weblogic/weblogic.go
+++ b/tests/e2e/pkg/weblogic/weblogic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package weblogic
@@ -48,10 +48,6 @@ func GetDomainInCluster(namespace string, name string, kubeconfigPath string) (*
 
 // GetHealthOfServers returns a slice of strings, each item representing the health of a server in the domain
 func GetHealthOfServers(uDomain *unstructured.Unstructured) ([]string, error) {
-	// Separator for list of servers
-	const serverSep = ","
-	// Separator for server fields
-	const fieldSep = ":"
 	// jsonpath template used to extract the server info
 	const template = `{.status.servers[*].health}`
 

--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -117,13 +117,13 @@ var (
 	filesWithErrors map[string][]string
 
 	// numFilesAnalyzed Total number of files analyzed
-	numFilesAnalyzed uint = 0
+	numFilesAnalyzed uint
 
 	// numFilesSkipped Total number of files skipped
-	numFilesSkipped uint = 0
+	numFilesSkipped uint
 
 	// numDirectoriesSkipped Total number of directories skipped
-	numDirectoriesSkipped uint = 0
+	numDirectoriesSkipped uint
 
 	// filesToIgnore Files to ignore
 	filesToIgnore = []string{}
@@ -132,7 +132,7 @@ var (
 	directoriesToIgnore = []string{}
 
 	// enforceCurrentYear Enforce that the current year is present in the copyright string (for modified files checks)
-	enforceCurrentYear = false
+	enforceCurrentYear bool
 
 	// currentYear Holds the current year string if we are enforcing that
 	currentYear string

--- a/tools/eventually-checker/check_eventually.go
+++ b/tools/eventually-checker/check_eventually.go
@@ -228,7 +228,7 @@ func getEventuallyFuncName(pkg string, args []ast.Expr) (string, bool) {
 	case *ast.Ident:
 		return pkg + "." + x.Name, false
 	case *ast.SelectorExpr:
-		var p string = pkg + "."
+		var p = pkg + "."
 		if ident, ok := x.X.(*ast.Ident); ok {
 			p = ident.Name + "."
 		}

--- a/tools/fix-copyright/copyright.go
+++ b/tools/fix-copyright/copyright.go
@@ -364,7 +364,7 @@ func fixHeaders(args []string) error {
 			if err != nil {
 				return err
 			}
-			var replacement []byte = []byte{}
+			var replacement []byte
 			// if file already contains header, use the created year from that copyright header
 			firstBytes, createdYearFromHeader, updatedYearFromHeader := parseYearsFromHeader(fileContents)
 			modifyExistingHeader := true

--- a/tools/generate-profiles/generate.go
+++ b/tools/generate-profiles/generate.go
@@ -55,7 +55,7 @@ func main() {
 
 	parseFlags(defaultDir)
 	if help {
-		fmt.Println(info)
+		fmt.Print(info)
 		os.Exit(0)
 	}
 
@@ -105,7 +105,7 @@ func generateAndWrite(profileType string, outputLocation string, verrazzanoDir s
 		return err
 	}
 	defer file.Close()
-	err = os.WriteFile(fileLoc, crYAML, 0666)
+	err = os.WriteFile(fileLoc, crYAML, 0600)
 	if err != nil {
 		return err
 	}

--- a/tools/url_linter/invalid_url_linter.sh
+++ b/tools/url_linter/invalid_url_linter.sh
@@ -13,7 +13,11 @@ fi
 #creating a temporary arrangement for linter
 URL_LINTER_TEMPDIR=""
 function init_url_linter() {
-    export URL_LINTER_TEMPDIR=$(mktemp -d $WORKSPACE/url_linter_temp_XXX)
+    local _template=url_linter_temp_XXX
+    if [ -n "${WORKSPACE}" ] ; then
+        _template="${WORKSPACE}/${_template}"
+    fi
+    export URL_LINTER_TEMPDIR=$(mktemp -d ${_template})
     if [ -z $URL_LINTER_TEMPDIR ] || [ ! -d $URL_LINTER_TEMPDIR ]; then
         echo "Failed to initialize temporary directory"
         exit 1

--- a/tools/vz/cmd/cluster/cluster_get_kubeconfig.go
+++ b/tools/vz/cmd/cluster/cluster_get_kubeconfig.go
@@ -99,7 +99,7 @@ func runCmdClusterGetKubeconfig(helper helpers.VZHelper, cmd *cobra.Command, arg
 	message := "Wrote kubeconfig to file"
 	if existingKubeconfig {
 		// write new kubeconfig to temp file and merge with existing file
-		if err = os.WriteFile(newKubeconfigPath, []byte(kubeconfigContents), 0700); err != nil {
+		if err = os.WriteFile(newKubeconfigPath, []byte(kubeconfigContents), 0600); err != nil {
 			return err
 		}
 
@@ -113,7 +113,7 @@ func runCmdClusterGetKubeconfig(helper helpers.VZHelper, cmd *cobra.Command, arg
 			os.Remove(newKubeconfigPath)
 		}()
 	}
-	if err = os.WriteFile(filePath, []byte(kubeconfigContents), 0700); err != nil {
+	if err = os.WriteFile(filePath, []byte(kubeconfigContents), 0600); err != nil {
 		fmt.Fprintf(helper.GetOutputStream(), "Failed to write kubeconfig to file %s - %v\n", filePath, err)
 		return err
 	}


### PR DESCRIPTION
Upgrade golangci-lint to 1.47.3 and enforce the version in the makefile
Replace deprecated linters deadcode and golint with unused and revive 
Run golangci-lint from the root and fix all errors
