### PR TITLE
Fix VZ image helper script output

### DIFF
--- a/tools/scripts/vz-registry-image-helper.sh
+++ b/tools/scripts/vz-registry-image-helper.sh
@@ -104,7 +104,7 @@ function run_docker() {
     tmpfile=$(mktemp -t vz-helper-docker-err.XXXXXX)
     docker $* 2>${tmpfile}
     local result=$?
-    local denied=$(egrep -i "(Anonymous|permission_denied)" ${tmpfile})
+    local denied=$(egrep -i "(Anonymous|permission_denied|403.*forbidden)" ${tmpfile})
     if [ -n "$denied" ]; then
        echo """
 
@@ -116,7 +116,7 @@ Please log into the target registry and try again.
 
       """
       rm ${tmpfile}
-      usage 1
+      exit 1
     elif [ "${result}" != "0" ]; then
       echo "An error occurred running docker command:"
       cat ${tmpfile}

--- a/tools/scripts/vz-registry-image-helper.sh
+++ b/tools/scripts/vz-registry-image-helper.sh
@@ -100,6 +100,7 @@ function exit_trap() {
 trap exit_trap EXIT
 
 function run_docker() {
+  local fatal=false
   if [ "${DRY_RUN}" != "true" ]; then
     tmpfile=$(mktemp -t vz-helper-docker-err.XXXXXX)
     docker $* 2>${tmpfile}
@@ -115,14 +116,17 @@ $(cat ${tmpfile})
 Please log into the target registry and try again.
 
       """
-      rm ${tmpfile}
-      exit 1
+      fatal=true
     elif [ "${result}" != "0" ]; then
       echo "An error occurred running docker command:"
       cat ${tmpfile}
     fi
   fi
   rm ${tmpfile}
+  if [ "${fatal}" == "true" ]; then
+    # Fatal error occurred, exit immeditately
+    exit 1
+  fi
   return ${result}
 }
 


### PR DESCRIPTION
The VZ image helper script currently mangles the error output from docker commands; this helps make the errors clearer, and displays the normal docker stdout progress for feedback to the user.

Sample output with non-auth error:

```
$ ./vz-registry-image-helper.sh -t phx.ocir.io -r odsbuilddev/xxxx -i verrazzano-platform-operator -b ./verrazzano-bom.json 
Include component: verrazzano-platform-operator
Checking if docker is installed ...
Checking if jq is installed ...
Using image registry ./master-generated-verrazzano-bom.json
Components: verrazzano-platform-operator
Processing images for Verrazzano subcomponent verrazzano-platform-operator/verrazzano-platform-operator
Processing image ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1 to phx.ocir.io/odsbuilddev/mcico/dev/v8o/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
>> Pulling image: ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
v1.4.0-20220926143320-a4b799a1: Pulling from verrazzano/verrazzano-platform-operator
a2a00260331c: Extracting [==================================================>]   49.8MB/49.8MB
d295e1977af1: Download complete 
d681dfd65dda: Download complete 
50b0aa4ae62a: Download complete 
eb64b4ef40b1: Download complete 
cf5998e78f0e: Download complete 
fc0c7efc43a6: Download complete 
b8ad7d1a2ec2: Download complete 
caf5e46edd2b: Download complete 
dcdcaf050c92: Download complete 
5b8a3e1453e7: Download complete 
da9f23b5c7cf: Download complete 
339afb80ea15: Download complete 
0a14f1449416: Download complete 
An error occurred running docker command:
failed to register layer: Error processing tar file(exit status 1): write /usr/share/terminfo/s/screen.rxvt: no space left on device
```

Sample with auth error:

```
$ ./vz-registry-image-helper.sh -t phx.ocir.io -r odsbuilddev/xxxx -i verrazzano-platform-operator -b ./verrazzano-bom.json 
Include component: verrazzano-platform-operator
Checking if docker is installed ...
Checking if jq is installed ...
Using image registry ./master-generated-verrazzano-bom.json
Components: verrazzano-platform-operator
Processing images for Verrazzano subcomponent verrazzano-platform-operator/verrazzano-platform-operator
Processing image ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1 to phx.ocir.io/odsbuilddev/mcico/dev/v8o/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
>> Pulling image: ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
v1.4.0-20220926143320-a4b799a1: Pulling from verrazzano/verrazzano-platform-operator
Digest: sha256:369f182cd0e378555d5341b50f7a8d5c68224866ce68d032e5fa920ac31791c4
Status: Image is up to date for ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
>> Tagging image: ghcr.io/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1 to phx.ocir.io/odsbuilddev/mcico/dev/v8o/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
>> Pushing image: phx.ocir.io/odsbuilddev/mcico/dev/v8o/verrazzano/verrazzano-platform-operator:v1.4.0-20220926143320-a4b799a1
The push refers to repository [phx.ocir.io/odsbuilddev/mcico/dev/v8o/verrazzano/verrazzano-platform-operator]
9ff510727aad: Preparing 
9020c8cf0727: Preparing 
a6d05d20eacf: Preparing 
bd76292e0862: Preparing 
2f2ef0be824e: Preparing 
e0ef297b3821: Waiting 
6c624d828286: Waiting 
eb0fda14ee98: Waiting 
be0c91111429: Waiting 
7779ba07155a: Waiting 
8a329fd6662b: Waiting 
d819eb4a3d43: Waiting 
e0e8d25aae64: Waiting 
ac0d5e75f97f: Waiting 


Permission error from Docker:

denied: Anonymous users are only allowed read access on public repos

Please log into the target registry and try again.

      
Command [exit 1] exited with code [1]
```

