### PR TITLE
Fix keycloak-mysql network policy after upgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
@@ -25,12 +25,12 @@
 package networkpolicies
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -110,6 +110,12 @@ func (c networkPoliciesComponent) PreUpgrade(ctx spi.ComponentContext) error {
 // PostUpgrade performs post-upgrade actions
 func (c networkPoliciesComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	cleanTempFiles(ctx)
+
+	// remove the old podSelector label matcher from the keycloak-mysql network policy
+	if err := fixKeycloakMySQLNetPolicy(ctx); err != nil {
+		return err
+	}
+
 	return c.HelmComponent.PostUpgrade(ctx)
 }
 


### PR DESCRIPTION
When upgrading to 1.4, we update network policies, including the keycloak-mysql policy. The old policy has a podSelector that matches on the `app=mysql` label. The new policy matches on `tier=mysql` (for the new mysql-operator managed mysql). When the new network policy is installed via helm, the podSelector matchLabels are combined, and since the new mysql pod does not have an `app` label, the network policy is not applied correctly and the upgrade hangs.

Since we cannot add labels to the new mysql pods, this fix is implemented in the verrazzano-network-policies install component, in the `PostUpgrade` step. In `PostUpgrade`, we remove the `app` podSelector label matcher so that only the `tier=mysql` label is matched.

I tested this manually in a kind cluster with Calico by installing 1.3.5 and upgrading to the version on this branch. The podSelector gets updated properly and the upgrade completes as expected.