### PR TITLE
VZ-6767 store Kiali signing key as a secret

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -89,6 +89,8 @@ func GetValues(log vzlog.VerrazzanoLogger, releaseName string, namespace string)
 	if namespace != "" {
 		args = append(args, "--namespace")
 		args = append(args, namespace)
+		args = append(args, "-o")
+		args = append(args, "yaml")
 	}
 
 	cmd := exec.Command("helm", args...)

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -6,17 +6,14 @@ package kiali
 import (
 	"context"
 	"fmt"
+
+	"github.com/verrazzano/verrazzano/pkg/bom"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
+	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/security/password"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/verrazzano/verrazzano/pkg/bom"
-	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
@@ -26,9 +23,12 @@ import (
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -5,7 +5,6 @@ package kiali
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/security/password"
@@ -38,8 +37,7 @@ const (
 	kialiServicePort      = "20001"
 	kialiMetricsPort      = "9090"
 	webFQDNKey            = "server.web_fqdn"
-	configMapKey          = "config.yaml"
-	kialiSigningKeySecret = "kiali-signing-key"
+	kialiSigningKeySecret = "kiali-signing-key" //nolint:gosec //#gosec G101
 	signingKey            = "signing-key"
 	signingKeyPath        = "login_token.signing_key"
 )
@@ -245,7 +243,7 @@ func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
 	}
 	signingKeyData, ok := secret.Data[signingKey]
 	if !ok {
-		return "", errors.New(fmt.Sprintf("Error retrieving signing key from secret %s", kialiSigningKeySecret))
+		return "", fmt.Errorf(fmt.Sprintf("Error retrieving signing key from secret %s", kialiSigningKeySecret))
 	}
 	return string(signingKeyData), nil
 }

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -74,8 +74,9 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		return kvs, err
 	}
 	kvs = append(kvs, bom.KeyValue{
-		Key:   signingKeyPath,
-		Value: signingKey,
+		Key:       signingKeyPath,
+		Value:     signingKey,
+		SetString: true,
 	})
 	return kvs, nil
 }

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -217,6 +217,7 @@ func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
 			Name:      kialiSigningKeySecret,
 			Namespace: globalconst.VerrazzanoSystemNamespace,
 		},
+		Data: map[string][]byte{},
 	}
 	err := ctx.Client().Get(context.TODO(), clipkg.ObjectKey{
 		Namespace: constants.VerrazzanoSystemNamespace,

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -74,9 +74,8 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		return kvs, err
 	}
 	kvs = append(kvs, bom.KeyValue{
-		Key:       signingKeyPath,
-		Value:     signingKey,
-		SetString: true,
+		Key:   signingKeyPath,
+		Value: signingKey,
 	})
 	return kvs, nil
 }

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -225,7 +225,7 @@ func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
 	}, &secret)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return "", ctx.Log().ErrorfThrottledNewErr("Unexpected error getting secre %s, : %V", kialiSigningKeySecret, err)
+			return "", ctx.Log().ErrorfThrottledNewErr("Unexpected error getting secret %s, : %V", kialiSigningKeySecret, err)
 		}
 		pw, err := password.GeneratePassword(16)
 		if err != nil {

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -210,6 +210,7 @@ func buildKialiHostnameForDomain(dnsDomain string) string {
 
 // getKialiSigningKey this secret holds the data for the Kiali signing key
 func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
+
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kialiSigningKeySecret,
@@ -231,10 +232,6 @@ func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
 		}
 		_, err = controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &secret, func() error {
 			if secret.Data[signingKey] == nil {
-				pw, err := password.GeneratePassword(16)
-				if err != nil {
-					return err
-				}
 				secret.Data[signingKey] = []byte(pw)
 			}
 			return nil

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -5,11 +5,15 @@ package kiali
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
+	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/security/password"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
@@ -19,7 +23,9 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	istiov1beta1 "istio.io/api/type/v1beta1"
+
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,11 +33,15 @@ import (
 )
 
 const (
-	kialiHostName    = "kiali.vmi.system"
-	kialiSystemName  = "vmi-system-kiali"
-	kialiServicePort = "20001"
-	kialiMetricsPort = "9090"
-	webFQDNKey       = "server.web_fqdn"
+	kialiHostName         = "kiali.vmi.system"
+	kialiSystemName       = "vmi-system-kiali"
+	kialiServicePort      = "20001"
+	kialiMetricsPort      = "9090"
+	webFQDNKey            = "server.web_fqdn"
+	configMapKey          = "config.yaml"
+	kialiSigningKeySecret = "kiali-signing-key"
+	signingKey            = "signing-key"
+	signingKeyPath        = "login_token.signing_key"
 )
 
 // isKialiReady checks if the Kiali deployment is ready
@@ -59,6 +69,14 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 			Value: hostName,
 		})
 	}
+	signingKey, err := getKialiSigningKey(ctx)
+	if err != nil {
+		return kvs, err
+	}
+	kvs = append(kvs, bom.KeyValue{
+		Key:   signingKeyPath,
+		Value: signingKey,
+	})
 	return kvs, nil
 }
 
@@ -190,6 +208,45 @@ func getKialiHostName(context spi.ComponentContext) (string, error) {
 
 func buildKialiHostnameForDomain(dnsDomain string) string {
 	return fmt.Sprintf("%s.%s", kialiHostName, dnsDomain)
+}
+
+// getKialiSigningKey this secret holds the data for the Kiali signing key
+func getKialiSigningKey(ctx spi.ComponentContext) (string, error) {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kialiSigningKeySecret,
+			Namespace: globalconst.VerrazzanoSystemNamespace,
+		},
+	}
+	err := ctx.Client().Get(context.TODO(), clipkg.ObjectKey{
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      kialiSigningKeySecret,
+	}, &secret)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return "", ctx.Log().ErrorfThrottledNewErr("Unexpected error getting secre %s, : %V", kialiSigningKeySecret, err)
+		}
+		pw, err := password.GeneratePassword(16)
+		if err != nil {
+			return "", err
+		}
+		_, err = controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &secret, func() error {
+			if secret.Data[signingKey] == nil {
+				pw, err := password.GeneratePassword(16)
+				if err != nil {
+					return err
+				}
+				secret.Data[signingKey] = []byte(pw)
+			}
+			return nil
+		})
+		return pw, err
+	}
+	signingKeyData, ok := secret.Data[signingKey]
+	if !ok {
+		return "", errors.New(fmt.Sprintf("Error retrieving signing key from secret %s", kialiSigningKeySecret))
+	}
+	return string(signingKeyData), nil
 }
 
 // GetOverrides returns the Kiali specific install overrides from v1beta1.Verrazzano CR

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_test.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_test.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_test.go
@@ -37,9 +37,10 @@ func TestAppendOverrides(t *testing.T) {
 	}
 	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, vz, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
 	assert.Nil(t, err)
-	assert.Len(t, kvs, 2)
+	assert.Len(t, kvs, 3)
 	assert.Equal(t, bom.KeyValue{Key: "key1", Value: "value1"}, kvs[0])
 	assert.Equal(t, bom.KeyValue{Key: webFQDNKey, Value: fmt.Sprintf("%s.default.mydomain.com", kialiHostName)}, kvs[1])
+	assert.Equal(t, signingKeyPath, kvs[2].Key)
 }
 
 // TestIsKialiReady tests the isKialiReady function


### PR DESCRIPTION
This change generates a random string to use as the Kiali signing key and stores it in the secret. This will prevent the Kiali pod from bouncing after every upgrade. It also modifies the GetValues function to include -o yaml as an argument. This fixes a bug where helm CLI output was getting included in the values file.