### PR TITLE
VZ-7171: Fix Jaeger PodsRunning test running on LRE

### DIFF
--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -417,7 +417,7 @@ func isReadyAndRunning(pod v1.Pod) bool {
 		}
 		return true
 	}
-	// Jaeger has ES index cleaner pods that with a Succeeded phase. Return true for these type of pods.
+	// Jaeger Operator has index cleaner pods with a Succeeded status phase. Return true for these type of pods.
 	if pod.Status.Phase == v1.PodSucceeded {
 		return true
 	}

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -417,6 +417,10 @@ func isReadyAndRunning(pod v1.Pod) bool {
 		}
 		return true
 	}
+	// Jaeger has ES index cleaner pods that with a Succeeded phase. Return true for these type of pods.
+	if pod.Status.Phase == v1.PodSucceeded {
+		return true
+	}
 	if pod.Status.Reason == "Evicted" && len(pod.Status.ContainerStatuses) == 0 {
 		Log(Info, fmt.Sprintf("Pod %v was Evicted", pod.Name))
 		return true // ignore this evicted pod


### PR DESCRIPTION
This pull request fixes the Jaeger pods running test on the dev LRE to allow for jaeger operator pods that have completed and have a status phase of Succeeded.