### PR TITLE
VZ-7102. Cleanup legacy DB PV when upgrade is fully complete

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
@@ -192,7 +192,7 @@ func handleLegacyDatabasePreUpgrade(ctx spi.ComponentContext) error {
 		}
 	}
 	ctx.Log().Debugf("Updating PV/PVC %v", mysqlPVC)
-	if err := common.UpdateExistingVolumeClaims(ctx, mysqlPVC, StatefulsetPersistentVolumeClaim, ComponentName); err != nil {
+	if err := common.UpdateExistingVolumeClaims(ctx, mysqlPVC, legacyDBDumpClaim, ComponentName); err != nil {
 		ctx.Log().Debugf("Unable to update PV/PVC")
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
@@ -6,6 +6,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -9,12 +9,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	k8sstatus "github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzpassword "github.com/verrazzano/verrazzano/pkg/security/password"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -33,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -46,7 +46,7 @@ const (
 	secretKey             = "mysql-password"
 	mySQLUsername         = "keycloak"
 	rootPasswordKey       = "mysql-root-password" //nolint:gosec //#gosec G101
-	statefulsetClaimName  = "dump-claim"
+	legacyDBDumpClaim     = "dump-claim"
 	mySQLInitFilePrefix   = "init-mysql-"
 	dbLoadJobName         = "load-dump"
 	dbLoadContainerName   = "mysqlsh-load-dump"
@@ -498,7 +498,7 @@ func PostUpgradeCleanup(log vzlog.VerrazzanoLogger, client clipkg.Client) error 
 	log.Progressf("MySQL post-upgrade cleanup")
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      statefulsetClaimName,
+			Name:      legacyDBDumpClaim,
 			Namespace: ComponentNamespace,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
-
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -16,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -5,8 +5,9 @@ package mysql
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"path/filepath"
+
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -35,9 +35,6 @@ const ComponentNamespace = vzconst.KeycloakNamespace
 // DeploymentPersistentVolumeClaim is the name of a volume claim associated with a MySQL deployment
 const DeploymentPersistentVolumeClaim = "mysql"
 
-// StatefulsetPersistentVolumeClaim is the name of a volume claim associated with a MySQL statefulset
-const StatefulsetPersistentVolumeClaim = "dump-claim"
-
 // ComponentJSONName is the josn name of the verrazzano component in CRD
 const ComponentJSONName = "keycloak.mysql"
 

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -8,11 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"

--- a/platform-operator/controllers/verrazzano/upgrade.go
+++ b/platform-operator/controllers/verrazzano/upgrade.go
@@ -7,27 +7,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
-
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
-
-	"k8s.io/apimachinery/pkg/selection"
-
-	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	kblabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -180,10 +180,8 @@ var _ = t.Describe("Verify", Label("f:platform-lcm.install"), func() {
 				mysqlStatefulSet, err := pkg.GetStatefulSet("keycloak", "mysql")
 				Expect(err).ShouldNot(HaveOccurred(), "Unexpected error obtaining MySQL statefulset")
 				expectedClaims := int(mysqlStatefulSet.Status.Replicas)
-				if expectedClaims == 1 {
-					Expect(len(volumeClaims)).To(Equal(expectedClaims))
-					assertPersistentVolume(claimName, size)
-				}
+				Expect(len(volumeClaims)).To(Equal(expectedClaims))
+				assertPersistentVolume(claimName, size)
 			})
 		}
 	})


### PR DESCRIPTION
Delete the legacy DB PVC/PV once upgrade is completed.
- Add unit tests, and remove/rename legacy PVC constant
