### PR TITLE
VZ-7274 The refactoring that moved RELEASE_VERSION from a param missed a spot

### DIFF
--- a/release/scripts/create_github_release.sh
+++ b/release/scripts/create_github_release.sh
@@ -40,7 +40,7 @@ TEST_RUN=${3:-true}
 VERSION=${RELEASE_VERSION}
 
 if [[ $VERSION != v* ]] ; then
-  VERSION="v${1}"
+  VERSION="v${RELEASE_VERSION}"
 fi
 
 function verify_release_binaries_exist() {


### PR DESCRIPTION

The distribution work refactoring moved the RELEASE_VERSION from a script param to the environment. One spot was missed though were it added the "v" prefix, that still was using ${1} which is now the full commit hash