### PR TITLE
VZ-7188.  Upgrade Keycloak/InnoDB cluster on upgrade, fix private registry scenario

### DIFF
--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -186,6 +186,17 @@ func (b *Bom) GetComponent(componentName string) (*BomComponent, error) {
 	return nil, errors.New("unknown component " + componentName)
 }
 
+func (b *Bom) GetComponentVersion(componentName string) (string, error) {
+	component, err := b.GetComponent(componentName)
+	if err != nil {
+		return "", err
+	}
+	if len(component.Version) == 0 {
+		return "", fmt.Errorf("Did not find valid version for component %s: %s", component, component.Version)
+	}
+	return component.Version, nil
+}
+
 // GetSubcomponent gets the bom subcomponent
 func (b *Bom) GetSubcomponent(subComponentName string) (*BomSubComponent, error) {
 	sc, ok := b.subComponentMap[subComponentName]
@@ -202,6 +213,15 @@ func (b *Bom) GetSubcomponentImages(subComponentName string) ([]BomImage, error)
 		return nil, err
 	}
 	return sc.Images, nil
+}
+
+func (b *Bom) FindImage(sc *BomSubComponent, imageName string) (BomImage, error) {
+	for _, image := range sc.Images {
+		if image.ImageName == imageName {
+			return image, nil
+		}
+	}
+	return BomImage{}, fmt.Errorf("Image %s not found for sub-component %s", imageName, sc.Name)
 }
 
 // GetSubcomponentImageCount returns the number of subcomponent images

--- a/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/legacydb.go
@@ -120,9 +120,9 @@ func isLegacyDatabaseUpgrade(compContext spi.ComponentContext) bool {
 }
 
 // appendLegacyUpgradePersistenceValues appends the helm values necessary to support a legacy persistent database upgrade
-func appendLegacyUpgradePersistenceValues(kvs []bom.KeyValue) ([]bom.KeyValue, error) {
+func appendLegacyUpgradePersistenceValues(bomFile *bom.Bom, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	var err error
-	kvs, err = appendCustomImageOverrides(kvs)
+	kvs, err = appendCustomImageOverrides(bomFile, kvs)
 	if err != nil {
 		return kvs, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 	}

--- a/platform-operator/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/controllers/verrazzano/testdata/test_bom.json
@@ -377,6 +377,25 @@
       ]
     },
     {
+      "name": "mysql-operator",
+      "version": "8.0.30",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "mysql-operator",
+          "images": [
+            {
+              "image": "mysql-operator",
+              "tag": "8.0.30-2.0.6",
+              "helmRegKey": "image.registry",
+              "helmRepoKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "keycloak",
       "subcomponents": [
         {

--- a/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
@@ -24,6 +24,10 @@ spec:
 {{- end }}
   secretName: {{ .Release.Name }}-cluster-secret
   imagePullPolicy : {{ required "image.pullPolicy is required" .Values.image.pullPolicy }}
+{{- $repositoryPath := .Values.image.repository }}
+{{- if $repositoryPath }}
+  imageRepository: {{ $repositoryPath }}
+{{- end }}
   baseServerId: {{ required "baseServerId is required" .Values.baseServerId }}
   version: {{ .Values.serverVersion | default .Chart.AppVersion }}
   serviceAccountName: {{ .Release.Name }}-sa

--- a/platform-operator/thirdparty/charts/mysql/values.yaml
+++ b/platform-operator/thirdparty/charts/mysql/values.yaml
@@ -1,5 +1,7 @@
 image:
   pullPolicy: IfNotPresent
+  # The repository setting indicates where the images will be pulled
+  #repository:
   pullSecrets:
     enabled: false
     secretName:


### PR DESCRIPTION
Upgrade Keycloak/InnoDB cluster on upgrade, fix private registry scenario
- Add mysql-operator version parameter to helm values during mysql install
- Add BOM method to get comp version, use MySQL component version for IC upgrade
- Set the image repository value on the MySQL/ic resource during install/upgrade
- Add hooks to MySQL chart to allow setting the image repository on the IC resource
- Add mysql-operator to test BOM, use constants where appropriate
- Add unit tests where appropriate
