### PR TITLE
Fix deploymetrics test service creation to tolerate service already existing. The pre-upgrade run of this test creates the service for VZ >= 1.4.0, and the post upgrade run should tolerate that.

### DIFF
--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -79,7 +79,9 @@ var _ = clusterDump.BeforeSuite(func() {
 			}
 			serviceName := promJobName
 			err = createService(serviceName)
-			if err != nil {
+			// if this is running post upgrade, we may have already run this test pre-upgrade and
+			// created the service. It is not an error if the service already exists.
+			if err != nil && !errors.IsAlreadyExists(err) {
 				pkg.Log(pkg.Error, fmt.Sprintf("Failed to create the Service for the Service Monitor: %v", err))
 				return err
 			}


### PR DESCRIPTION


Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
