### PR TITLE
VZ-7173.  Backport to release-1.3

### DIFF
--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/appoper"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"

--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -87,19 +87,27 @@ func getComponents() []spi.Component {
 	return componentsRegistry
 }
 
-func FindComponent(releaseName string) (bool, spi.Component) {
+func FindComponent(componentName string) (bool, spi.Component) {
 	for _, comp := range GetComponents() {
-		if comp.Name() == releaseName {
+		if comp.Name() == componentName {
 			return true, comp
 		}
 	}
 	return false, nil
 }
 
-// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available
+// ComponentDependenciesMet Checks if the declared dependencies for the component are ready and available; this is
+// a shallow check of the direct dependencies, with the expectation that any indirect dependencies will be implicitly
+// handled.
+//
+// For now, a dependency is soft; that is, we only care if it's Ready if it's enabled; if not we pass the dependency check
+// so as not to block the dependent.  This would theoretically allow, for example, components that depend on Istio
+// to continue to deploy if it's not enabled.  In the long run, the dependency mechanism should likely go away and
+// allow components to individually make those decisions.
+//
 func ComponentDependenciesMet(c spi.Component, context spi.ComponentContext) bool {
 	log := context.Log()
-	trace, err := checkDependencies(c, context, make(map[string]bool), make(map[string]bool))
+	trace, err := checkDirectDependenciesReady(c, context, make(map[string]bool))
 	if err != nil {
 		log.Error(err.Error())
 		return false
@@ -118,14 +126,10 @@ func ComponentDependenciesMet(c spi.Component, context spi.ComponentContext) boo
 }
 
 // checkDependencies Check the ready state of any dependencies and check for cycles
-func checkDependencies(c spi.Component, context spi.ComponentContext, visited map[string]bool, stateMap map[string]bool) (map[string]bool, error) {
+func checkDirectDependenciesReady(c spi.Component, context spi.ComponentContext, stateMap map[string]bool) (map[string]bool, error) {
 	compName := c.Name()
 	log := context.Log()
 	log.Debugf("Checking %s dependencies", compName)
-	if _, wasVisited := visited[compName]; wasVisited {
-		return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
-	}
-	visited[compName] = true
 	for _, dependencyName := range c.GetDependencies() {
 		if compName == dependencyName {
 			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, dependency cycle found for %s", c.Name())
@@ -139,15 +143,30 @@ func checkDependencies(c spi.Component, context spi.ComponentContext, visited ma
 		if !found {
 			return stateMap, context.Log().ErrorfNewErr("Failed, illegal state, declared dependency not found for %s: %s", c.Name(), dependencyName)
 		}
-		if trace, err := checkDependencies(dependency, context, visited, stateMap); err != nil {
-			return trace, err
-		}
 		// Only check if dependency is ready when the dependency is enabled
-		if dependency.IsEnabled(context.EffectiveCR()) && !dependency.IsReady(context) {
-			stateMap[dependencyName] = false // dependency is not ready
-			continue
-		}
-		stateMap[dependencyName] = true // dependency is ready
+		stateMap[dependencyName] = isDependencyReady(dependency, context) // dependency is ready
 	}
 	return stateMap, nil
+}
+
+// isDependencyReady Returns true if the component is disabled, is already in the Ready state, or if it's isReady() check is true
+func isDependencyReady(dependency spi.Component, context spi.ComponentContext) bool {
+	if !dependency.IsEnabled(context.EffectiveCR()) {
+		return true
+	}
+	if isInReadyState(context, dependency) {
+		// CR component status indicates ready
+		return true
+	}
+	return dependency.IsReady(context)
+}
+
+func isInReadyState(context spi.ComponentContext, comp spi.Component) bool {
+	if dependencyStatus, ok := context.ActualCR().Status.Components[comp.Name()]; ok {
+		// We've already reported Ready status for this component
+		if dependencyStatus.State == vzapi.CompStateReady {
+			return true
+		}
+	}
+	return false
 }

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -692,7 +692,7 @@ func (f fakeComponent) GetDependencies() []string {
 }
 
 func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
-	return true
+	return f.ready
 }
 
 func (f fakeComponent) IsEnabled(effectiveCR *v1alpha1.Verrazzano) bool {


### PR DESCRIPTION
Backport VZ-7173. Simplify VPO component dependency checks to just check the immediate dependencies of a component (#4229) (#4242)

- Check Enabled status before Ready checks, to short-circuit if a component is disabled
- Remove recursive dependency checks from ComponentDependenciesMet
- Remove the dependency cycle check hooks from ComponentDependenciesMet, move cycle checks to unit tests only
- Other unit test updates to properly set the fakeComponent instance ready/enabled states accordingly
- With this change, we should implicitly still wait on indirect dependencies via the controller sequence, and the direct dependencies' Ready checks.
