### PR TITLE
Ignore .DS_Store file within every directory being scanned for copyright and license year checks

### DIFF
--- a/tools/copyright/copyright.go
+++ b/tools/copyright/copyright.go
@@ -43,6 +43,7 @@ var (
 		"THIRD_PARTY_LICENSES.txt",
 		"coverage.html",
 		"clair-scanner",
+		".DS_Store",
 	}
 
 	// directoriesToShip is a list of well-known (sub)directories to skip while scanning, relative to the working


### PR DESCRIPTION
Ignore .DS_Store file within every directory being scanned for copyright and license year checks