### PR TITLE
JIRA: VZ-7343 make user db password idempotent

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -250,7 +250,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 	}
 
 	if compContext.Init(ComponentName).GetOperation() == vzconst.InstallOperation {
-		userPwd, err := createKeycloakDBUserPasswordIfNeeded(compContext)
+		userPwd, err := getOrCreateDBUserPassword(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 		}
@@ -582,8 +582,8 @@ func createMySQLInitFile(ctx spi.ComponentContext, userPwd []byte) (string, erro
 	return file.Name(), nil
 }
 
-// createKeycloakDBUserPasswordIfNeeded creates or updates a secret containing the password used by keycloak to access the DB
-func createKeycloakDBUserPasswordIfNeeded(compContext spi.ComponentContext) (string, error) {
+// getOrCreateDBUserPassword creates or updates a secret containing the password used by keycloak to access the DB
+func getOrCreateDBUserPassword(compContext spi.ComponentContext) (string, error) {
 	secretName := types.NamespacedName{
 		Namespace: ComponentNamespace,
 		Name:      rootSec,

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -590,12 +590,15 @@ func getOrCreateDBUserPassword(compContext spi.ComponentContext) (string, error)
 	}
 	dbSecret := &v1.Secret{}
 	err := compContext.Client().Get(context.TODO(), secretName, dbSecret)
-	if err != nil && errors.IsNotFound(err) {
-		password, err := vzpassword.GeneratePassword(12)
-		if err != nil {
-			return "", err
+	if err != nil {
+		if errors.IsNotFound(err) {
+			password, err := vzpassword.GeneratePassword(12)
+			if err != nil {
+				return "", err
+			}
+			return password, nil
 		}
-		return password, nil
+		return "", err
 	}
 	return string(dbSecret.Data[mySQLUserKey]), nil
 }

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -41,6 +41,7 @@ const (
 	helmUserName          = "credentials.user.name"     //nolint:gosec //#gosec G101
 	mysqlUpgradeSubComp   = "mysql-upgrade"
 	mySQLRootKey          = "rootPassword"
+	mySQLUserKey          = "userPassword"
 	secretName            = "mysql"
 	secretKey             = "mysql-password"
 	mySQLUsername         = "keycloak"
@@ -249,7 +250,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 	}
 
 	if compContext.Init(ComponentName).GetOperation() == vzconst.InstallOperation {
-		userPwd, err := createKeycloakDBSecret()
+		userPwd, err := createKeycloakDBUserPasswordIfNeeded(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
 		}
@@ -581,13 +582,22 @@ func createMySQLInitFile(ctx spi.ComponentContext, userPwd []byte) (string, erro
 	return file.Name(), nil
 }
 
-// createKeycloakDBSecret creates or updates a secret containing the password used by keycloak to access the DB
-func createKeycloakDBSecret() (string, error) {
-	password, err := vzpassword.GeneratePassword(12)
-	if err != nil {
-		return "", err
+// createKeycloakDBUserPasswordIfNeeded creates or updates a secret containing the password used by keycloak to access the DB
+func createKeycloakDBUserPasswordIfNeeded(compContext spi.ComponentContext) (string, error) {
+	secretName := types.NamespacedName{
+		Namespace: ComponentNamespace,
+		Name:      rootSec,
 	}
-	return password, nil
+	dbSecret := &v1.Secret{}
+	err := compContext.Client().Get(context.TODO(), secretName, dbSecret)
+	if err != nil && errors.IsNotFound(err) {
+		password, err := vzpassword.GeneratePassword(12)
+		if err != nil {
+			return "", err
+		}
+		return password, nil
+	}
+	return string(dbSecret.Data[mySQLUserKey]), nil
 }
 
 func appendDatabaseInitializationValues(compContext spi.ComponentContext, userPwd []byte, kvs []bom.KeyValue) ([]bom.KeyValue, error) {


### PR DESCRIPTION
Changes to ensure that the user password creation or access is idempotent across installations and upgrades.
