### PR TITLE
VZ-7362: Move workload readiness check code to a common pkg

### DIFF
--- a/pkg/k8s/ready/certificates.go
+++ b/pkg/k8s/ready/certificates.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,9 +27,11 @@ func CertificatesAreReady(client clipkg.Client, log vzlog.VerrazzanoLogger, vz *
 		return true, []types.NamespacedName{}
 	}
 
-	if !vzconfig.IsCertManagerEnabled(vz) {
-		log.Oncef("Cert-Manager disabled, skipping certificates check")
-		return true, []types.NamespacedName{}
+	if vz != nil && vz.Spec.Components.CertManager != nil && vz.Spec.Components.CertManager.Enabled != nil {
+		if !*vz.Spec.Components.CertManager.Enabled {
+			log.Oncef("Cert-Manager disabled, skipping certificates check")
+			return true, []types.NamespacedName{}
+		}
 	}
 
 	log.Oncef("Checking certificates status for %v", certificates)

--- a/pkg/k8s/ready/certificates_test.go
+++ b/pkg/k8s/ready/certificates_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"

--- a/pkg/k8s/ready/daemonset_ready.go
+++ b/pkg/k8s/ready/daemonset_ready.go
@@ -1,12 +1,11 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package status
+package ready
 
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	appsv1 "k8s.io/api/apps/v1"
@@ -66,7 +65,7 @@ func DaemonSetsAreReady(log vzlog.VerrazzanoLogger, client client.Client, namesp
 // running and ready
 func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client client.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedNodes int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := status.GetPodsList(log, client, namespacedName, selector)
+	pods := GetPodsList(log, client, namespacedName, selector)
 	if pods == nil {
 		return false
 	}
@@ -111,7 +110,7 @@ func podsReadyDaemonSet(log vzlog.VerrazzanoLogger, client client.Client, namesp
 	}
 
 	// Make sure pods using the latest controllerRevision resource are ready.
-	podsReady, success := status.EnsurePodsAreReady(log, savedPods, expectedNodes, prefix)
+	podsReady, success := EnsurePodsAreReady(log, savedPods, expectedNodes, prefix)
 	if !success {
 		return false
 	}

--- a/pkg/k8s/ready/daemonset_ready_test.go
+++ b/pkg/k8s/ready/daemonset_ready_test.go
@@ -1,7 +1,7 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package status
+package ready
 
 import (
 	"testing"
@@ -17,63 +17,63 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestStatefulsetReady(t *testing.T) {
+func TestDaemonSetsReady(t *testing.T) {
 
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": "foo",
 		},
 	}
-	enoughReplicas := &appsv1.StatefulSet{
+	enoughReplicas := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
 		},
-		Spec: appsv1.StatefulSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 		},
-		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas:   1,
-			UpdatedReplicas: 1,
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        1,
+			UpdatedNumberScheduled: 1,
 		},
 	}
-	enoughReplicasMultiple := &appsv1.StatefulSet{
+	enoughReplicasMultiple := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
 		},
-		Spec: appsv1.StatefulSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 		},
-		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas:   2,
-			UpdatedReplicas: 2,
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        2,
+			UpdatedNumberScheduled: 2,
 		},
 	}
-	notEnoughReadyReplicas := &appsv1.StatefulSet{
+	notEnoughReadyReplicas := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
 		},
-		Spec: appsv1.StatefulSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 		},
-		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas:   0,
-			UpdatedReplicas: 1,
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        0,
+			UpdatedNumberScheduled: 1,
 		},
 	}
-	notEnoughUpdatedReplicas := &appsv1.StatefulSet{
+	notEnoughUpdatedReplicas := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "bar",
 		},
-		Spec: appsv1.StatefulSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 		},
-		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas:   1,
-			UpdatedReplicas: 0,
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        1,
+			UpdatedNumberScheduled: 0,
 		},
 	}
 
@@ -82,7 +82,7 @@ func TestStatefulsetReady(t *testing.T) {
 			Name:      "foo-95d8c5d96-m6mbr",
 			Namespace: "bar",
 			Labels: map[string]string{
-				controllerRevisionHashLabel: "foo-95d8c5d96",
+				controllerRevisionHashLabel: "95d8c5d96",
 				"app":                       "foo",
 			},
 		},
@@ -99,7 +99,7 @@ func TestStatefulsetReady(t *testing.T) {
 			Name:      "foo-95d8c5d96-m6y76",
 			Namespace: "bar",
 			Labels: map[string]string{
-				controllerRevisionHashLabel: "foo-95d8c5d96",
+				controllerRevisionHashLabel: "95d8c5d96",
 				"app":                       "foo",
 			},
 		},
@@ -116,7 +116,7 @@ func TestStatefulsetReady(t *testing.T) {
 			Name:      "foo-95d8c5d96-m6mbr",
 			Namespace: "bar",
 			Labels: map[string]string{
-				controllerRevisionHashLabel: "foo-95d8c5d96",
+				controllerRevisionHashLabel: "95d8c5d96",
 				"app":                       "foo",
 			},
 		},
@@ -168,14 +168,14 @@ func TestStatefulsetReady(t *testing.T) {
 		expected int32
 	}{
 		{
-			"should be ready when statefulset has enough replicas and pod is ready",
+			"should be ready when daemonset has enough replicas and pod is ready",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(enoughReplicas, readyPod, controllerRevision).Build(),
 			namespacedName,
 			true,
 			1,
 		},
 		{
-			"should be ready when statefulset has enough replicas and one pod of two pods is ready",
+			"should be ready when daemonset has enough replicas and one pod of two pods is ready",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(enoughReplicasMultiple, notReadyContainerPod, readyPod, controllerRevision).Build(),
 			namespacedName,
 			true,
@@ -189,28 +189,28 @@ func TestStatefulsetReady(t *testing.T) {
 			2,
 		},
 		{
-			"should be not ready when statefulset has enough replicas but pod init container pods is not ready",
+			"should be not ready when daemonset has enough replicas but pod init container pods is not ready",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(enoughReplicas, notReadyInitContainerPod, controllerRevision).Build(),
 			namespacedName,
 			false,
 			1,
 		},
 		{
-			"should be not ready when statefulset has enough replicas but pod container pods is not ready",
+			"should be not ready when daemonset has enough replicas but pod container pods is not ready",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(enoughReplicas, notReadyContainerPod, controllerRevision).Build(),
 			namespacedName,
 			false,
 			1,
 		},
 		{
-			"should be not ready when pod not found for statefulset",
+			"should be not ready when pod not found for daemonset",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(enoughReplicas).Build(),
 			namespacedName,
 			false,
 			1,
 		},
 		{
-			"should be not ready when statefulset not found",
+			"should be not ready when daemonset not found",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build(),
 			namespacedName,
 			false,
@@ -231,14 +231,14 @@ func TestStatefulsetReady(t *testing.T) {
 			1,
 		},
 		{
-			"should be not ready when statefulset doesn't have enough ready replicas",
+			"should be not ready when daemonset doesn't have enough ready replicas",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(notEnoughReadyReplicas).Build(),
 			namespacedName,
 			false,
 			1,
 		},
 		{
-			"should be not ready when statefulset doesn't have enough updated replicas",
+			"should be not ready when daemonset doesn't have enough updated replicas",
 			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(notEnoughUpdatedReplicas).Build(),
 			namespacedName,
 			false,
@@ -255,7 +255,7 @@ func TestStatefulsetReady(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.ready, StatefulSetsAreReady(vzlog.DefaultLogger(), tt.c, tt.n, tt.expected, ""))
+			assert.Equal(t, tt.ready, DaemonSetsAreReady(vzlog.DefaultLogger(), tt.c, tt.n, tt.expected, ""))
 		})
 	}
 }

--- a/pkg/k8s/ready/deployment_ready.go
+++ b/pkg/k8s/ready/deployment_ready.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	"context"

--- a/pkg/k8s/ready/deployment_ready_test.go
+++ b/pkg/k8s/ready/deployment_ready_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/k8s/ready/ingresses_present.go
+++ b/pkg/k8s/ready/ingresses_present.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	"context"

--- a/pkg/k8s/ready/ingresses_present_test.go
+++ b/pkg/k8s/ready/ingresses_present_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-package status
+package ready
 
 import (
 	"testing"

--- a/pkg/k8s/ready/pod_ready.go
+++ b/pkg/k8s/ready/pod_ready.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package status
+package ready
 
 import (
 	"context"

--- a/pkg/k8s/ready/statefulset_ready.go
+++ b/pkg/k8s/ready/statefulset_ready.go
@@ -1,12 +1,11 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package status
+package ready
 
 import (
 	"context"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -70,7 +69,7 @@ func DoStatefulSetsExist(log vzlog.VerrazzanoLogger, client client.Client, names
 // running and ready
 func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client client.Client, namespacedName types.NamespacedName, selector *metav1.LabelSelector, expectedReplicas int32, prefix string) bool {
 	// Get a list of pods for a given namespace and labels selector
-	pods := status.GetPodsList(log, client, namespacedName, selector)
+	pods := GetPodsList(log, client, namespacedName, selector)
 	if pods == nil {
 		return false
 	}
@@ -114,7 +113,7 @@ func podsReadyStatefulSet(log vzlog.VerrazzanoLogger, client client.Client, name
 	}
 
 	// Make sure pods using the latest controllerRevision resource are ready.
-	podsReady, success := status.EnsurePodsAreReady(log, savedPods, expectedReplicas, prefix)
+	podsReady, success := EnsurePodsAreReady(log, savedPods, expectedReplicas, prefix)
 	if !success {
 		return false
 	}

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator.go
@@ -13,7 +13,7 @@ import (
 
 	oamv1alpha2 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -112,7 +112,7 @@ func isApplicationOperatorReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // Add label/annotations required by Helm to the Verrazzano installed trait definitions.  Originally, the

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -5,6 +5,7 @@ package authproxy
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"io/fs"
 	"os"
 
@@ -12,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -53,7 +53,7 @@ func isAuthProxyReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // AppendOverrides builds the set of verrazzano-authproxy overrides for the helm install

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -27,8 +27,8 @@ import (
 	certv1client "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzresource "github.com/verrazzano/verrazzano/pkg/k8s/resource"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/security/password"
@@ -407,7 +407,7 @@ func isCertManagerReady(context spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())
-	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 }
 
 // writeCRD writes out CertManager CRD manifests with OCI DNS specifications added

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence.go
@@ -9,7 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -23,7 +23,7 @@ func isCoherenceOperatorReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // GetOverrides gets the install overrides

--- a/platform-operator/controllers/verrazzano/component/console/console.go
+++ b/platform-operator/controllers/verrazzano/component/console/console.go
@@ -6,7 +6,7 @@ package console
 import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -67,7 +67,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 }
 
 func isConsoleReady(ctx spi.ComponentContext) bool {
-	return status.DeploymentsAreReady(
+	return ready.DeploymentsAreReady(
 		ctx.Log(),
 		ctx.Client(),
 		[]types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/helm"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -120,7 +120,7 @@ func isExternalDNSReady(compContext spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", compContext.GetComponent())
-	return status.DeploymentsAreReady(compContext.Log(), compContext.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(compContext.Log(), compContext.Client(), deployments, 1, prefix)
 }
 
 // AppendOverrides builds the set of external-dns overrides for the helm install

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd.go
@@ -9,11 +9,11 @@ import (
 
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +89,7 @@ func isFluentdReady(ctx spi.ComponentContext) bool {
 				Name:      ComponentName,
 				Namespace: ComponentNamespace,
 			})
-		return status.DaemonSetsAreReady(ctx.Log(), ctx.Client(), daemonsets, 1, prefix)
+		return ready.DaemonSetsAreReady(ctx.Log(), ctx.Client(), daemonsets, 1, prefix)
 	}
 	return false
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana.go
@@ -6,7 +6,7 @@ package grafana
 import (
 	"fmt"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,7 +18,7 @@ const grafanaDeployment = "vmi-system-grafana"
 func isGrafanaInstalled(ctx spi.ComponentContext) bool {
 	prefix := newPrefix(ctx.GetComponent())
 	deployments := newDeployments()
-	return status.DoDeploymentsExist(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DoDeploymentsExist(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // isGrafanaReady checks that the deployment has the minimum number of replicas available and
@@ -26,7 +26,7 @@ func isGrafanaInstalled(ctx spi.ComponentContext) bool {
 func isGrafanaReady(ctx spi.ComponentContext) bool {
 	prefix := newPrefix(ctx.GetComponent())
 	deployments := newDeployments()
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix) && common.IsGrafanaAdminSecretReady(ctx)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix) && common.IsGrafanaAdminSecretReady(ctx)
 }
 
 // newPrefix creates a component prefix string

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/helm"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzos "github.com/verrazzano/verrazzano/pkg/os"
 	"github.com/verrazzano/verrazzano/pkg/yaml"
@@ -23,7 +24,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -326,14 +326,14 @@ func (h HelmComponent) PostInstall(context spi.ComponentContext) error {
 
 	// If the component has any ingresses associated, those should be present
 	prefix := fmt.Sprintf("Component %s", h.Name())
-	if !status.IngressesPresent(context.Log(), context.Client(), h.GetIngressNames(context), prefix) {
+	if !ready.IngressesPresent(context.Log(), context.Client(), h.GetIngressNames(context), prefix) {
 		return ctrlerrors.RetryableError{
 			Source:    h.ReleaseName,
 			Operation: "Check if Ingresses are present",
 		}
 	}
 
-	if readyStatus, certsNotReady := status.CertificatesAreReady(context.Client(), context.Log(), context.EffectiveCR(), h.Certificates); !readyStatus {
+	if readyStatus, certsNotReady := ready.CertificatesAreReady(context.Client(), context.Log(), context.EffectiveCR(), h.Certificates); !readyStatus {
 		context.Log().Progressf("Certificates not ready for component %s: %v", h.ReleaseName, certsNotReady)
 		return ctrlerrors.RetryableError{
 			Source:    h.ReleaseName,

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -14,8 +14,8 @@ import (
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/istio"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/pkg/k8s/webhook"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -397,7 +397,7 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 			Namespace: IstioNamespace,
 		},
 	}
-	ready := status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	ready := ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 	if !ready {
 		return false
 	}

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator.go
@@ -15,7 +15,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -135,13 +135,13 @@ func isJaegerOperatorReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf(componentPrefixFmt, ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // isDefaultJaegerInstanceReady checks if the deployments of default Jaeger instance managed by VZ are in ready state
 func isDefaultJaegerInstanceReady(ctx spi.ComponentContext) bool {
 	prefix := fmt.Sprintf(componentPrefixFmt, ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), getJaegerComponentDeployments(), 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), getJaegerComponentDeployments(), 1, prefix)
 }
 
 // PreInstall implementation for the Jaeger Operator Component
@@ -544,7 +544,7 @@ func ReassociateResources(cli clipkg.Client) error {
 
 func doDefaultJaegerInstanceDeploymentsExists(ctx spi.ComponentContext) bool {
 	prefix := fmt.Sprintf(componentPrefixFmt, ctx.GetComponent())
-	return status.DoDeploymentsExist(ctx.Log(), ctx.Client(), getJaegerComponentDeployments(), 1, prefix)
+	return ready.DoDeploymentsExist(ctx.Log(), ctx.Client(), getJaegerComponentDeployments(), 1, prefix)
 }
 
 // removeMutatingWebhookConfig removes the  jaeger-operator-mutating-webhook-configuration resource during the pre-upgrade

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzpassword "github.com/verrazzano/verrazzano/pkg/security/password"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -22,7 +23,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1323,7 +1323,7 @@ func isKeycloakReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulset, 1, prefix)
+	return ready.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulset, 1, prefix)
 }
 
 // isPodReady determines if the pod is running by checking for a Ready condition with Status equal True

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -10,7 +10,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/security/password"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -51,7 +51,7 @@ func isKialiReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // AppendOverrides Build the set of Kiali overrides for the helm install

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	k8sstatus "github.com/verrazzano/verrazzano/pkg/k8s/status"
+	k8sready "github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzpassword "github.com/verrazzano/verrazzano/pkg/security/password"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -21,7 +21,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -174,9 +173,9 @@ func isMySQLReady(ctx spi.ComponentContext) bool {
 			routerReplicas = int(value.(float64))
 		}
 	}
-	ready := status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulset, int32(serverReplicas), prefix)
+	ready := k8sready.StatefulSetsAreReady(ctx.Log(), ctx.Client(), statefulset, int32(serverReplicas), prefix)
 	if ready && routerReplicas > 0 {
-		ready = k8sstatus.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployment, int32(routerReplicas), prefix)
+		ready = k8sready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployment, int32(routerReplicas), prefix)
 	}
 
 	return ready && checkDbMigrationJobCompletion(ctx) && isInnoDBClusterOnline(ctx)

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -56,12 +56,12 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 
 // isReady - component specific checks for being ready
 func isReady(ctx spi.ComponentContext) bool {
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), getDeploymentList(), 1, getPrefix(ctx))
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), getDeploymentList(), 1, getPrefix(ctx))
 }
 
 // isInstalled checks that the deployment exists
 func isInstalled(ctx spi.ComponentContext) bool {
-	return status.DoDeploymentsExist(ctx.Log(), ctx.Client(), getDeploymentList(), 1, getPrefix(ctx))
+	return ready.DoDeploymentsExist(ctx.Log(), ctx.Client(), getDeploymentList(), 1, getPrefix(ctx))
 }
 
 func getPrefix(ctx spi.ComponentContext) string {

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconst "github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -50,7 +50,7 @@ func isNginxReady(context spi.ComponentContext) bool {
 	if err != nil && context.GetComponent() == ComponentName {
 		context.Log().Progressf("Ingress external IP pending for component %s: %s", ComponentName, err.Error())
 	}
-	return err == nil && status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	return err == nil && ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 }
 
 func AppendOverrides(context spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {

--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -37,7 +37,7 @@ func isOAMReady(context spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())
-	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 }
 
 // ensureClusterRoles creates or updates additional OAM cluster roles during install and upgrade

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"fmt"
 	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
-	pkgstatus "github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +46,7 @@ func doesOSExist(ctx spi.ComponentContext) bool {
 		Name:      esMasterStatefulset,
 		Namespace: ComponentNamespace,
 	}}
-	return status.DoStatefulSetsExist(ctx.Log(), ctx.Client(), sts, 1, prefix)
+	return ready.DoStatefulSetsExist(ctx.Log(), ctx.Client(), sts, 1, prefix)
 }
 
 // IsSingleDataNodeCluster returns true if there is exactly 1 or 0 data nodes
@@ -77,7 +76,7 @@ func isOSNodeReady(ctx spi.ComponentContext, node vzapi.OpenSearchNode, prefix s
 
 	// If a node has the master role, it is a statefulset
 	if hasRole(node.Roles, vmov1.MasterRole) {
-		return status.StatefulSetsAreReady(ctx.Log(), ctx.Client(), []types.NamespacedName{{
+		return ready.StatefulSetsAreReady(ctx.Log(), ctx.Client(), []types.NamespacedName{{
 			Name:      nodeControllerName,
 			Namespace: ComponentNamespace,
 		}}, node.Replicas, prefix)
@@ -94,11 +93,11 @@ func isOSNodeReady(ctx spi.ComponentContext, node vzapi.OpenSearchNode, prefix s
 				Namespace: ComponentNamespace,
 			})
 		}
-		return pkgstatus.DeploymentsAreReady(ctx.Log(), ctx.Client(), dataDeployments, 1, prefix)
+		return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), dataDeployments, 1, prefix)
 	}
 
 	// Ingest nodes can be handled like normal deployments
-	return pkgstatus.DeploymentsAreReady(ctx.Log(), ctx.Client(), []types.NamespacedName{{
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), []types.NamespacedName{{
 		Name:      nodeControllerName,
 		Namespace: ComponentNamespace,
 	}}, node.Replicas, prefix)

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards.go
@@ -5,7 +5,7 @@ package opensearchdashboards
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
@@ -28,7 +28,7 @@ func isOSDReady(ctx spi.ComponentContext) bool {
 			})
 	}
 
-	if !status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix) {
+	if !ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix) {
 		return false
 	}
 
@@ -42,5 +42,5 @@ func doesOSDExist(ctx spi.ComponentContext) bool {
 		Name:      kibanaDeployment,
 		Namespace: ComponentNamespace,
 	}}
-	return status.DoDeploymentsExist(ctx.Log(), ctx.Client(), deploy, 1, prefix)
+	return ready.DoDeploymentsExist(ctx.Log(), ctx.Client(), deploy, 1, prefix)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter.go
@@ -9,7 +9,7 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -26,7 +26,7 @@ func isPrometheusAdapterReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // PreInstall implementation for the Prometheus Adapter Component

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics.go
@@ -9,7 +9,7 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -28,7 +28,7 @@ func isDeploymentReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // PreInstall implementation for the Kube State Metrics Component

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter.go
@@ -12,8 +12,8 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ func isPrometheusNodeExporterReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DaemonSetsAreReady(ctx.Log(), ctx.Client(), sets, 1, prefix)
+	return ready.DaemonSetsAreReady(ctx.Log(), ctx.Client(), sets, 1, prefix)
 }
 
 // PreInstall implementation for the Prometheus Node-Exporter Component

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -17,7 +17,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -68,7 +68,7 @@ func isPrometheusOperatorReady(ctx spi.ComponentContext) bool {
 		ctx.Log().Errorf("Failed to create selector for %s: %v", ComponentName, err)
 		return false
 	}
-	return status.DeploymentsReadyBySelectors(ctx.Log(), ctx.Client(), 1, prefix, &client.ListOptions{
+	return ready.DeploymentsReadyBySelectors(ctx.Log(), ctx.Client(), 1, prefix, &client.ListOptions{
 		Namespace:     ComponentNamespace,
 		LabelSelector: selector,
 	})

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway.go
@@ -9,7 +9,7 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -28,7 +28,7 @@ func isPushgatewayReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // PreInstall implementation for the Prometheus Pushgateway Component

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -14,7 +14,7 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -262,7 +262,7 @@ func isRancherReady(ctx spi.ComponentContext) bool {
 	}
 
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(log, c, deployments, 1, prefix)
+	return ready.DeploymentsAreReady(log, c, deployments, 1, prefix)
 }
 
 // checkRancherUpgradeFailure - temporary work around for Rancher issue 36914. During an upgrade, the Rancher pods

--- a/platform-operator/controllers/verrazzano/component/rancherbackup/rancher_backup.go
+++ b/platform-operator/controllers/verrazzano/component/rancherbackup/rancher_backup.go
@@ -6,7 +6,7 @@ package rancherbackup
 import (
 	"context"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -27,7 +27,7 @@ const (
 
 // isRancherBackupOperatorReady checks if the Rancher Backup deployment is ready
 func isRancherBackupOperatorReady(context spi.ComponentContext) bool {
-	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, componentPrefix)
+	return ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, componentPrefix)
 }
 
 // GetOverrides gets the install overrides

--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
@@ -6,11 +6,10 @@ package velero
 import (
 	"context"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	pkgstatus "github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,8 +24,8 @@ const (
 
 // isVeleroOperatorReady checks if the Velero deployment is ready
 func isVeleroOperatorReady(context spi.ComponentContext) bool {
-	return pkgstatus.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, componentPrefix) &&
-		status.DaemonSetsAreReady(context.Log(), context.Client(), daemonSets, 1, componentPrefix)
+	return ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, componentPrefix) &&
+		ready.DaemonSetsAreReady(context.Log(), context.Client(), daemonSets, 1, componentPrefix)
 }
 
 // AppendOverrides appends Helm value overrides for the Velero component's Helm chart

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -27,7 +27,7 @@ func isVMOReady(context spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", context.GetComponent())
-	return status.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(context.Log(), context.Client(), deployments, 1, prefix)
 }
 
 // appendVMOOverrides appends overrides for the VMO component

--- a/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
+++ b/platform-operator/controllers/verrazzano/component/weblogic/weblogic_operator.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -82,7 +82,7 @@ func isWeblogicOperatorReady(ctx spi.ComponentContext) bool {
 		},
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return status.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
 }
 
 // GetOverrides returns install overrides for a component

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/k8s/status"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -365,7 +365,7 @@ func vpoIsReady(client clipkg.Client) (bool, error) {
 		return false, nil
 	}
 
-	if !status.PodsReadyDeployment(nil, client, namespacedName, deployment.Spec.Selector, expectedReplicas, constants.VerrazzanoPlatformOperator) {
+	if !ready.PodsReadyDeployment(nil, client, namespacedName, deployment.Spec.Selector, expectedReplicas, constants.VerrazzanoPlatformOperator) {
 		return false, nil
 	}
 


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

This MR moves the readiness-related code to a common package, Currently, all the readiness code is scattered in two different packages. 
