### PR TITLE
elimiated duplicate test runs on k8 verisons

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
             }
         }
 
-        stage('Kind Acceptance Tests on 1.22') {
+        stage('Kind Acceptance Tests on 1.24') {
             when {
                 allOf {
                     not { buildingTag() }
@@ -385,7 +385,7 @@ pipeline {
                     script {
                         build job: "verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                             parameters: [
-                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.22'),
+                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
                                 string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                 string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
                                 string(name: 'CRD_API_VERSION', value: params.CRD_API_VERSION),

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -321,23 +321,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.24') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                        parameters: [
-                                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
-                                                string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                                string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                                string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                                string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                                booleanParam(name: 'ENABLE_JWT_TESTING', value: true)
-                                        ], wait: true
-                            }
-                        }
-                    }
-                }
                 stage('Upgrade Path Minor Release Tests') {
                     steps {
                             script {

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -230,66 +230,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.24') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                    ], wait: true
-                            }
-                        }
-                    }
-                }
-                stage('Kind Acceptance Tests on 1.23') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.23'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                    ], wait: true
-                            }
-                        }
-                    }
-                }
-                stage('Kind Acceptance Tests on 1.21') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.21'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                    ], wait: true
-                            }
-                        }
-                    }
-                }
                 stage('Kind No Istio Injection Tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

For https://build.verrazzano.io/job/verrazzano/job/master/ the Kind job should always track the latest K8s version as this is the most likely to have issues and what we would prefer our customers to use.  Currently this pipeline should test 1.24

For https://build.verrazzano.io/job/verrazzano-push-triggered-acceptance-tests/job/master/ the pipeline should not do any Kind K8s version tests as the likelihood of regression not caught by the latest Kind/K8s version tests is low.

For https://build.verrazzano.io/job/verrazzano-periodic-triggered-tests/job/master/ this should test the supported Kind/K8s versions that are not covered by the main pipeline.  Currently this means K8s 1.21, 1.22, 1.23.

