### PR TITLE
VZ-7360: Mutating webhook for mysql backup jobs

### DIFF
--- a/application-operator/controllers/webhooks/mysql_backup.go
+++ b/application-operator/controllers/webhooks/mysql_backup.go
@@ -26,22 +26,23 @@ import (
 )
 
 const (
-	// MySQLBackupPath specifies the path of Istio defaulter webhook
+	// MySQLBackupPath specifies the path of Istio defaulter webhook.
 	MySQLBackupPath = "/mysql-backup"
 
-	// MySQLOperatorJobLabel and MySQLOperatorJobLabelValue is the label key,value applied to the job by mysql-operator
+	// MySQLOperatorJobLabel and MySQLOperatorJobLabelValue are the label key,value pair
+	// that are applied to the job by mysql-operator.
 
 	MySQLOperatorJobLabel      = "app.kubernetes.io/created-by"
 	MySQLOperatorJobLabelValue = "mysql-operator"
 
-	// MySQLOperatorJobPodSpecAnnotationKey and MySQLOperatorJobPodSpecAnnotationValue applied to the job spec
-	// so that it can talk to the k8s api server
+	// MySQLOperatorJobPodSpecAnnotationKey and MySQLOperatorJobPodSpecAnnotationValue are
+	// applied to the job spec so that it can talk to the k8s api server.
 
 	MySQLOperatorJobPodSpecAnnotationKey   = "traffic.sidecar.istio.io/excludeOutboundPorts"
 	MySQLOperatorJobPodSpecAnnotationValue = "443"
 )
 
-// MySQLBackupJobWebhook type for istio defaulter webhook
+// MySQLBackupJobWebhook type for Verrazzano mysql backup webhook
 type MySQLBackupJobWebhook struct {
 	client.Client
 	IstioClient   istioversionedclient.Interface
@@ -54,7 +55,7 @@ type MySQLBackupJobWebhook struct {
 // This function is called for any jobs that are created in a namespace with the label istio-injection=enabled.
 func (m *MySQLBackupJobWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 
-	counterMetricObject, errorCounterMetricObject, handleDurationMetricObject, zapLogForMetrics, err := metricsexporter.ExposeControllerMetrics("MySQlHa", metricsexporter.MysqlHaHandleCounter, metricsexporter.MysqlHaHandleError, metricsexporter.MysqlHaHandleDuration)
+	counterMetricObject, errorCounterMetricObject, handleDurationMetricObject, zapLogForMetrics, err := metricsexporter.ExposeControllerMetrics("MySQlBackup", metricsexporter.MysqlHaHandleCounter, metricsexporter.MysqlHaHandleError, metricsexporter.MysqlHaHandleDuration)
 	if err != nil {
 		return admission.Response{}
 	}
@@ -78,6 +79,7 @@ func (m *MySQLBackupJobWebhook) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
+// processJob processes the job request and applies the necessary annotations based on Job ownership and labels
 func (m *MySQLBackupJobWebhook) processJob(counterMetricObject, errorCounterMetricObject *metricsexporter.SimpleCounterMetric, req admission.Request, job *batchv1.Job, log, metricsLog *zap.SugaredLogger) admission.Response {
 
 	var mysqlOperatorOwnerReferencePresent, mysqlOperatorLabelPresent bool
@@ -206,7 +208,7 @@ func (m *MySQLBackupJobWebhook) isCronJobCreatedByMysqlOperator(errorCounterMetr
 	}
 
 	if mysqlOperatorOwnerReferencePresent && mysqlOperatorLabelPresent {
-		// This is a litmus test that the cronjob was created bt mysql-operator
+		// This is a litmus test that the cronjob was created by mysql-operator
 		return true, nil
 	}
 

--- a/application-operator/controllers/webhooks/mysql_backup_test.go
+++ b/application-operator/controllers/webhooks/mysql_backup_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/verrazzano/verrazzano/application-operator/metricsexporter"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// TestHandleBadRequest tests handling an invalid admission.Request
+// GIVEN an MysqlBackupJobWebhook and an admission.Request
+// WHEN Handle is called with an invalid admission.Request containing no content
+// THEN Handle should return an error with http.StatusBadRequest
+func TestHandleBadRequestMySQL(t *testing.T) {
+
+	decoder := decoder()
+	defaulter := &MySQLBackupJobWebhook{}
+	err := defaulter.InjectDecoder(decoder)
+	assert.NoError(t, err, "Unexpected error injecting decoder")
+	req := admission.Request{}
+	res := defaulter.Handle(context.TODO(), req)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, int32(http.StatusBadRequest), res.Result.Code)
+}
+
+// TestHandleIstioDisabledMysqlBackupJob tests handling an admission.Request
+// GIVEN a MysqlBackupJobWebhook and an admission.Request
+// WHEN Handle is called with an admission.Request containing a job resource with MysqlHA disabled
+// THEN Handle should return an Allowed response with no action required
+func TestHandleIstioDisabledMysqlBackupJob(t *testing.T) {
+
+	defaulter := &MySQLBackupJobWebhook{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		KubeClient:    fake.NewSimpleClientset(),
+		IstioClient:   istiofake.NewSimpleClientset(),
+	}
+	// Create a job with Istio injection disabled
+	p := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-disabled",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"sidecar.istio.io/inject": "false",
+			},
+		},
+	}
+
+	job, err := defaulter.KubeClient.BatchV1().Jobs("default").Create(context.TODO(), p, metav1.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error creating job")
+
+	decoder := decoder()
+	err = defaulter.InjectDecoder(decoder)
+	assert.NoError(t, err, "Unexpected error injecting decoder")
+	req := admission.Request{}
+	req.Namespace = "default"
+	marshaledJob, err := json.Marshal(job)
+	assert.NoError(t, err, "Unexpected error marshaling job")
+	req.Object = runtime.RawExtension{Raw: marshaledJob}
+	res := defaulter.Handle(context.TODO(), req)
+	assert.True(t, res.Allowed)
+	assert.Equal(t, metav1.StatusReason("No action required, job labeled with sidecar.istio.io/inject: false"), res.Result.Reason)
+}
+
+// TestHandleSkipAnnotateMysqlBackupJob tests handling an admission.Request
+// GIVEN a MysqlBackupJobWebhook and an admission.Request
+// WHEN Handle is called with an admission.Request containing job not created by mysql-operator
+// THEN Handle should return an Allowed response with no action required
+func TestHandleSkipAnnotateMysqlBackupJob(t *testing.T) {
+
+	defaulter := &MySQLBackupJobWebhook{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		KubeClient:    fake.NewSimpleClientset(),
+		IstioClient:   istiofake.NewSimpleClientset(),
+	}
+	// Create a job with Istio injection disabled
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "random-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	job, err := defaulter.KubeClient.BatchV1().Jobs("default").Create(context.TODO(), job, metav1.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error creating job")
+
+	decoder := decoder()
+	err = defaulter.InjectDecoder(decoder)
+	assert.NoError(t, err, "Unexpected error injecting decoder")
+	req := admission.Request{}
+	req.Namespace = "default"
+	marshaledJob, err := json.Marshal(job)
+	assert.NoError(t, err, "Unexpected error marshaling job")
+	req.Object = runtime.RawExtension{Raw: marshaledJob}
+	res := defaulter.Handle(context.TODO(), req)
+	assert.True(t, res.Allowed)
+	assert.Equal(t, metav1.StatusReason("No action required, job not labelled with app.kubernetes.io/created-by: mysql-operator"), res.Result.Reason)
+}
+
+// TestHandleAnnotateMysqlBackupJob tests handling an admission.Request
+// GIVEN a MysqlBackupJobWebhook and an admission.Request
+// WHEN Handle is called with an admission.Request containing job created by mysql-operator
+// THEN Handle should return an Allowed response with no action required
+func TestHandleAnnotateMysqlBackupJob(t *testing.T) {
+
+	defaulter := &MySQLBackupJobWebhook{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		KubeClient:    fake.NewSimpleClientset(),
+		IstioClient:   istiofake.NewSimpleClientset(),
+	}
+	// Create a job with Istio injection disabled
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backup-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/created-by": "mysql-operator",
+			},
+		},
+	}
+
+	job, err := defaulter.KubeClient.BatchV1().Jobs("default").Create(context.TODO(), job, metav1.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error creating job")
+
+	decoder := decoder()
+	err = defaulter.InjectDecoder(decoder)
+	assert.NoError(t, err, "Unexpected error injecting decoder")
+	req := admission.Request{}
+	req.Namespace = "default"
+	marshaledJob, err := json.Marshal(job)
+	assert.NoError(t, err, "Unexpected error marshaling job")
+	req.Object = runtime.RawExtension{Raw: marshaledJob}
+	res := defaulter.Handle(context.TODO(), req)
+	assert.True(t, res.Allowed)
+	assert.NoError(t, err, "Unexpected error marshaling job")
+}
+
+// TestHandleAnnotateMysqlBackupCronJob tests handling an admission.Request
+// GIVEN a MysqlBackupJobWebhook and an admission.Request
+// WHEN Handle is called with an admission.Request containing job created by mysql-operator
+// THEN Handle should return an Allowed response with no action required
+//func TestHandleAnnotateMysqlBackupCronJob(t *testing.T) {
+//
+//	defaulter := &MySQLBackupJobWebhook{
+//		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+//		KubeClient:    fake.NewSimpleClientset(),
+//		IstioClient:   istiofake.NewSimpleClientset(),
+//	}
+//	// Create a job with Cronjob owner refernce
+//	job := &batchv1.Job{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name:      "backup-job",
+//			Namespace: "default",
+//			//Labels: map[string]string{
+//			//	"app.kubernetes.io/created-by": "mysql-operator",
+//			//},
+//			OwnerReferences: []metav1.OwnerReference{
+//				metav1.OwnerReference{
+//					Kind: "CronJob",
+//					Name: "BackupFoo",
+//				},
+//			},
+//		},
+//	}
+//
+//	cjob := &batchv1.CronJob{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Labels: map[string]string{
+//				"app.kubernetes.io/created-by": "mysql-operator",
+//			},
+//			OwnerReferences: []metav1.OwnerReference{
+//				metav1.OwnerReference{
+//					Kind: "InnoDBCluster",
+//					Name: "mysql",
+//				},
+//			},
+//			Name: "BackupFoo",
+//		},
+//		//Spec: batchv1.CronJobSpec{
+//		//	JobTemplate: batchv1.JobTemplateSpec{
+//		//		Spec: job,
+//		//	}
+//		//},
+//	}
+//
+//	job, err := defaulter.KubeClient.BatchV1().Jobs("default").Create(context.TODO(), job, metav1.CreateOptions{})
+//	_, err = defaulter.KubeClient.BatchV1().CronJobs("default").Create(context.TODO(), cjob, metav1.CreateOptions{})
+//	assert.NoError(t, err, "Unexpected error creating job")
+//
+//	decoder := decoder()
+//	err = defaulter.InjectDecoder(decoder)
+//	assert.NoError(t, err, "Unexpected error injecting decoder")
+//	req := admission.Request{}
+//	req.Namespace = "default"
+//	marshaledJob, err := json.Marshal(job)
+//	assert.NoError(t, err, "Unexpected error marshaling job")
+//	req.Object = runtime.RawExtension{Raw: marshaledJob}
+//	res := defaulter.Handle(context.TODO(), req)
+//	assert.True(t, res.Allowed)
+//	assert.NoError(t, err, "Unexpected error marshaling job")
+//}
+
+// TestIstioMysqlBackupHandleFailed tests to make sure the failure metric is being exposed
+func TestIstioMysqlBackupHandleFailed(t *testing.T) {
+
+	assert := assert.New(t)
+	// Create a request and decode(Handle) it
+	decoder := decoder()
+	defaulter := &IstioWebhook{}
+	_ = defaulter.InjectDecoder(decoder)
+	req := admission.Request{}
+	defaulter.Handle(context.TODO(), req)
+	reconcileerrorCounterObject, err := metricsexporter.GetSimpleCounterMetric(metricsexporter.MysqlHaHandleError)
+	assert.NoError(err)
+	// Expect a call to fetch the error
+	reconcileFailedCounterBefore := testutil.ToFloat64(reconcileerrorCounterObject.Get())
+	reconcileerrorCounterObject.Get().Inc()
+	reconcileFailedCounterAfter := testutil.ToFloat64(reconcileerrorCounterObject.Get())
+	assert.Equal(reconcileFailedCounterBefore, reconcileFailedCounterAfter-1)
+}

--- a/application-operator/internal/certificates/certificates.go
+++ b/application-operator/internal/certificates/certificates.go
@@ -44,7 +44,7 @@ const (
 	MultiClusterConfigMapName = "verrazzano-application-multiclusterconfigmap"
 	// MultiClusterSecretName is the resource name for the MultiClusterSecret ValidatingWebhook
 	MultiClusterSecretName = "verrazzano-application-multiclustersecret" //nolint:gosec //#gosec G101
-	// MysqlMutatingWebhookName is the resource name for the Verrazzano MutatingWebhook for Istio pods
+	// MysqlMutatingWebhookName is the resource name for the Verrazzano MutatingWebhook for MySQL backup pods
 	MysqlMutatingWebhookName = "verrazzano-mysql-backup"
 )
 

--- a/application-operator/internal/certificates/certificates.go
+++ b/application-operator/internal/certificates/certificates.go
@@ -44,6 +44,8 @@ const (
 	MultiClusterConfigMapName = "verrazzano-application-multiclusterconfigmap"
 	// MultiClusterSecretName is the resource name for the MultiClusterSecret ValidatingWebhook
 	MultiClusterSecretName = "verrazzano-application-multiclustersecret" //nolint:gosec //#gosec G101
+	// MysqlMutatingWebhookName is the resource name for the Verrazzano MutatingWebhook for Istio pods
+	MysqlMutatingWebhookName = "verrazzano-mysql-backup"
 )
 
 // SetupCertificates creates the needed certificates for the validating webhook

--- a/application-operator/metricsexporter/metricsexporter_utils.go
+++ b/application-operator/metricsexporter/metricsexporter_utils.go
@@ -59,6 +59,9 @@ const (
 	VzProjHandleCounter                    metricName = "VzProj handle counter"
 	VzProjHandleError                      metricName = "VzProj handle error"
 	VzProjHandleDuration                   metricName = "VzProj hanlde duration"
+	MysqlHaHandleCounter                   metricName = "mysqlha handle counter"
+	MysqlHaHandleError                     metricName = "mysqlha handle error"
+	MysqlHaHandleDuration                  metricName = "mysqlha handle duration"
 )
 
 func init() {
@@ -230,6 +233,16 @@ func initCounterMetricMap() map[metricName]*SimpleCounterMetric {
 				Name: "vao_vzproj_error_handle_total",
 				Help: "Tracks how many times a the helidonworkload reconcile process has failed"}),
 		},
+		MysqlHaHandleCounter: {
+			metric: prometheus.NewCounter(prometheus.CounterOpts{
+				Name: "vao_mysql_ha_handle_total",
+				Help: "Tracks how many times the mysql ha jobs reconcile process has been successful"}),
+		},
+		MysqlHaHandleError: {
+			metric: prometheus.NewCounter(prometheus.CounterOpts{
+				Name: "vao_mysql_ha_error_handle_total",
+				Help: "Tracks how many times the mysql ha jobs reconcile process has failed"}),
+		},
 	}
 }
 
@@ -312,6 +325,12 @@ func initDurationMetricMap() map[metricName]*DurationMetrics {
 			metric: prometheus.NewSummary(prometheus.SummaryOpts{
 				Name: "vao_bindingupdater_handle_duration",
 				Help: "The duration in seconds of vao Ingresstrait reconcile process",
+			}),
+		},
+		MysqlHaHandleDuration: {
+			metric: prometheus.NewSummary(prometheus.SummaryOpts{
+				Name: "vao_mysql_ha_handle_duration",
+				Help: "The duration in seconds of mysql ha jobs handle process",
 			}),
 		},
 	}

--- a/application-operator/metricsexporter/metricsexporter_utils.go
+++ b/application-operator/metricsexporter/metricsexporter_utils.go
@@ -59,9 +59,9 @@ const (
 	VzProjHandleCounter                    metricName = "VzProj handle counter"
 	VzProjHandleError                      metricName = "VzProj handle error"
 	VzProjHandleDuration                   metricName = "VzProj hanlde duration"
-	MysqlHaHandleCounter                   metricName = "mysqlha handle counter"
-	MysqlHaHandleError                     metricName = "mysqlha handle error"
-	MysqlHaHandleDuration                  metricName = "mysqlha handle duration"
+	MysqlHaHandleCounter                   metricName = "mysql backup handle counter"
+	MysqlHaHandleError                     metricName = "mysql backup handle error"
+	MysqlHaHandleDuration                  metricName = "mysql backup handle duration"
 )
 
 func init() {

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -65,6 +65,7 @@ rules:
       - batch
     resources:
       - jobs
+      - cronjobs
     verbs:
       - get
       - list
@@ -307,6 +308,27 @@ rules:
       - get
       - list
       - update
+  - apiGroups:
+      - mysql.oracle.com
+    resources:
+      - mysqlbackups
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - mysql.oracle.com
+    resources:
+      - mysqlbackups/status
+    verbs:
+      - get
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -360,7 +382,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          imagePullPolicy: Always
           ports:
             - containerPort: 9443
               name: https-webhook
@@ -496,6 +518,42 @@ webhooks:
           - CREATE
         resources:
           - pods
+    sideEffects: None
+    failurePolicy: Fail
+    matchPolicy: Exact
+    timeoutSeconds: 30
+    admissionReviewVersions:
+      - v1beta1
+      - v1
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: verrazzano-mysql-backup
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+webhooks:
+  - name: verrazzano-mysql-backup.verrazzano.io
+    namespaceSelector:
+      matchExpressions:
+        - {key: istio-injection, operator: In, values: [enabled]}
+        - {key: verrazzano.io/namespace, operator: NotIn, values: [verrazzano-system, kube-system, verrazzano-monitoring]}
+    clientConfig:
+      service:
+        name: {{ .Values.name }}
+        namespace: {{ .Values.namespace }}
+        path: "/mysql-backup"
+    rules:
+      - apiGroups:
+          - batch
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - jobs
     sideEffects: None
     failurePolicy: Fail
     matchPolicy: Exact

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/verrazzano-application-operator.yaml
@@ -382,7 +382,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: 9443
               name: https-webhook


### PR DESCRIPTION
Develop a mutating webhook which adds istio-annotations to backup job when it is invoked by mysql-operator so that the job can communicate to etcd. This also applies to cronjobs

