### PR TITLE
VZ-7407: Uptake latest Rancher image with pinned system charts

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -130,14 +130,14 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.8-20221006171647-46df1b595",
+              "tag": "20221012210346-f860af518",
               "dashboard": "v2.6.8-20221006170612-d84a9cbf",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.8-20221006171647-46df1b595"
+              "tag": "20221012210346-f860af518"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -130,14 +130,14 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20221012210346-f860af518",
+              "tag": "v2.6.8-20221013131607-2087c7430",
               "dashboard": "v2.6.8-20221006170612-d84a9cbf",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20221012210346-f860af518"
+              "tag": "v2.6.8-20221013131607-2087c7430"
             }
           ]
         },


### PR DESCRIPTION
Uptake the latest Rancher image that pins the Rancher charts to specific commits so that the Rancher image builds are reproducible.