### PR TITLE
VZ-7389 Post release tasks - Update BOM file to consume images from 1.3.7 version

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -197,7 +197,7 @@
             },
             {
               "image": "console",
-              "tag": "1.3.6-20220913175624-85e75ff",
+              "tag": "1.3.7-20221013201924-0b59987",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },
@@ -220,7 +220,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "1.3.6-20221005180712-77b6cfc",
+              "tag": "1.3.7-20221013201626-04f2fec",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
VZ-7389 Post release tasks - Update BOM file to consume images from 1.3.7 version
