### PR TITLE
VZ-6916: Re-enable grafana test that was disabled.

### DIFF
--- a/tests/e2e/grafana-db/grafana_test.go
+++ b/tests/e2e/grafana-db/grafana_test.go
@@ -195,30 +195,30 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 	// GIVEN a running Grafana instance,
 	// WHEN a search is made for the dashboard using its title,
 	// THEN the dashboard metadata is returned.
-	/*
-		It("Search the test Grafana Dashboard using its title", func() {
-			Eventually(func() bool {
-				resp, err := pkg.SearchGrafanaDashboard(map[string]string{"query": testDashboardTitle})
-				if err != nil {
-					pkg.Log(pkg.Error, err.Error())
-					return false
-				}
-				if resp.StatusCode != http.StatusOK {
-					pkg.Log(pkg.Error, fmt.Sprintf("Failed to GET Grafana testDashboard: status=%d: body=%s", resp.StatusCode, string(resp.Body)))
-					return false
-				}
-				var body []map[string]string
-				json.Unmarshal(resp.Body, &body)
-				for _, dashboard := range body {
-					if dashboard["title"] == testDashboardTitle {
-						return true
-					}
-				}
+	It("Search the test Grafana Dashboard using its title", func() {
+		Eventually(func() bool {
+			resp, err := pkg.SearchGrafanaDashboard(map[string]string{"query": testDashboardTitle})
+			if err != nil {
+				pkg.Log(pkg.Error, err.Error())
 				return false
+			}
+			if resp.StatusCode != http.StatusOK {
+				pkg.Log(pkg.Error, fmt.Sprintf("Failed to GET Grafana testDashboard: status=%d: body=%s", resp.StatusCode, string(resp.Body)))
+				return false
+			}
+			var body []map[string]string
+			json.Unmarshal(resp.Body, &body)
 
-			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).Should(BeTrue())
-		})
-	*/
+			for _, dashboard := range body {
+				pkg.Log(pkg.Info, "Debug: "+dashboard["title"])
+				if dashboard["title"] == testDashboardTitle {
+					return true
+				}
+			}
+			return false
+
+		}).WithPolling(pollingInterval).WithTimeout(waitTimeout).Should(BeTrue())
+	})
 
 	// GIVEN a running grafana instance,
 	// WHEN a GET call is made  to Grafana with the UID of the system dashboard,

--- a/tests/e2e/grafana-db/grafana_test.go
+++ b/tests/e2e/grafana-db/grafana_test.go
@@ -210,7 +210,6 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 			json.Unmarshal(resp.Body, &body)
 
 			for _, dashboard := range body {
-				pkg.Log(pkg.Info, "Debug: "+dashboard["title"])
 				if dashboard["title"] == testDashboardTitle {
 					return true
 				}


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

This PR re-enables a grafana test that was disabled due to consistent failure. During debugging it was found that the underlying issue must have been addressed, and the test now passes consistently and hence enabling it back. Tried 5 runs straight to make sure there is no intermittent failure.
