### PR TITLE
Make older version of k8s the default to ensure k8s upgrade

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -32,8 +32,8 @@ pipeline {
     parameters {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
-                // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5"])
+                // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
+                choices: [ "v1.23.4", "v1.22.5", "v1.21.5", "v1.24.1" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value


### PR DESCRIPTION
Make an older version of k8s the default for the HA pipeline, to ensure the cluster upgrade will occur.