### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/application-operator/internal/certificates/certificates_test.go
+++ b/application-operator/internal/certificates/certificates_test.go
@@ -26,11 +26,7 @@ import (
 func TestSetupCertificates(t *testing.T) {
 	a := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "certs")
-	if err != nil {
-		a.Nil(err, "error should not be returned creating temporary directory")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	caBundle, err := SetupCertificates(dir)
 	a.Nil(err, "error should not be returned setting up certificates")
 	a.NotNil(caBundle, "CA bundle should be returned")

--- a/platform-operator/internal/k8s/certificate/certificate_test.go
+++ b/platform-operator/internal/k8s/certificate/certificate_test.go
@@ -31,17 +31,9 @@ func TestCreateWebhookCertificates(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// create temp dir for certs
-	tempDir, err := os.MkdirTemp("", "certs")
-	t.Logf("Using temp dir %s", tempDir)
-	defer func() {
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			t.Logf("Error removing tempdir %s", tempDir)
-		}
-	}()
-	asserts.Nil(err)
+	tempDir := t.TempDir()
 
-	err = CreateWebhookCertificates(zap.S(), client, tempDir)
+	err := CreateWebhookCertificates(zap.S(), client, tempDir)
 	asserts.Nil(err)
 
 	// Verify generated certs
@@ -57,15 +49,7 @@ func TestCreateWebhookCertificates(t *testing.T) {
 	asserts.NotEmpty(string(secret.Data[CertKey]))
 
 	// create temp dir for certs
-	tempDir2, err := os.MkdirTemp("", "certs")
-	t.Logf("Using temp dir %s", tempDir2)
-	defer func() {
-		err := os.RemoveAll(tempDir2)
-		if err != nil {
-			t.Logf("Error removing tempdir %s", tempDir2)
-		}
-	}()
-	asserts.Nil(err)
+	tempDir2 := t.TempDir()
 
 	// Call it again, should create new certs in location with identical contents
 	err = CreateWebhookCertificates(zap.S(), client, tempDir2)
@@ -110,15 +94,7 @@ func TestCreateWebhookCertificatesRaceCondition(t *testing.T) {
 	asserts.Nil(err)
 
 	// create temp dir for certs
-	tempDir, err := os.MkdirTemp("", "certs")
-	t.Logf("Using temp dir %s", tempDir)
-	defer func() {
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			t.Logf("Error removing tempdir %s", tempDir)
-		}
-	}()
-	asserts.Nil(err)
+	tempDir := t.TempDir()
 
 	// Simulate the race condition where the secrets do not exist when CreateWebhookCertificates is called
 	// but do exist when it attempts to create them later in the routine.

--- a/tools/generate-profiles/generate_test.go
+++ b/tools/generate-profiles/generate_test.go
@@ -4,12 +4,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 var vzDir = "../.."
@@ -21,10 +22,8 @@ var vzDir = "../.."
 func TestRun(t *testing.T) {
 	assert := assert.New(t)
 	os.Setenv(VzRootDir, vzDir)
-	dir, err := os.MkdirTemp("", "temp")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
-	err = run("prod", dir)
+	dir := t.TempDir()
+	err := run("prod", dir)
 	assert.NoError(err)
 	_, err = os.Stat(dir + "/" + "prod.yaml")
 	assert.NoError(err)

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -61,8 +61,7 @@ func TestBugReportExistingReportFile(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	// Define and create the bug report file
 	reportFile := "bug-report.tgz"
@@ -90,8 +89,7 @@ func TestBugReportExistingDir(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
 	if err := os.Mkdir(reportDir, os.ModePerm); err != nil {
@@ -116,8 +114,7 @@ func TestBugReportNonExistingFileDir(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
 	reportFile := reportDir + string(os.PathSeparator) + string(os.PathSeparator) + "bug-report.tgz"
@@ -140,8 +137,7 @@ func TestBugReportFileNoPermission(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	reportDir := tmpDir + string(os.PathSeparator) + "test-report"
 	// Create a directory with only read permission
@@ -175,8 +171,7 @@ func TestBugReportSuccess(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
 	assert.NoError(t, err)
@@ -272,8 +267,7 @@ func TestBugReportNoVerrazzano(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
 	err := cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
@@ -300,8 +294,7 @@ func TestBugReportFailureUsingInvalidClient(t *testing.T) {
 	cmd := NewCmdBugReport(rc)
 	assert.NotNil(t, cmd)
 
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
 	err := cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
@@ -399,13 +392,6 @@ func getInvalidClient() client.WithWatch {
 		},
 	}
 	return fake.NewClientBuilder().WithScheme(pkghelper.NewScheme()).WithObjects(testObj, deployment).Build()
-}
-
-// cleanupTempDir cleans up the given temp directory after the test run
-func cleanupTempDir(t *testing.T, dirName string) {
-	if err := os.RemoveAll(dirName); err != nil {
-		t.Fatalf("Remove directory failed: %v", err)
-	}
 }
 
 // cleanupTempDir cleans up the given temp file after the test run

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -32,8 +32,7 @@ import (
 //	WHEN I call function CreateReportArchive with a report file
 //	THEN expect it to create the report file
 func TestCreateReportArchive(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "bug-report")
-	defer cleanupTempDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	captureDir := tmpDir + string(os.PathSeparator) + "test-report"
 	if err := os.Mkdir(captureDir, os.ModePerm); err != nil {
@@ -101,13 +100,11 @@ func TestGroupVersionResource(t *testing.T) {
 //	THEN expect it to not throw any error
 func TestCaptureK8SResources(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset()
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
-	err = CaptureK8SResources(k8sClient, constants.VerrazzanoInstall, captureDir, rc)
+	err := CaptureK8SResources(k8sClient, constants.VerrazzanoInstall, captureDir, rc)
 	assert.NoError(t, err)
 }
 
@@ -122,9 +119,7 @@ func TestCaptureMultiClusterResources(t *testing.T) {
 	_ = appclusterv1alpha1.AddToScheme(scheme)
 
 	dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme)
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
@@ -145,9 +140,7 @@ func TestCaptureOAMResources(t *testing.T) {
 	_ = core.AddToScheme(scheme)
 
 	dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme)
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
@@ -157,13 +150,11 @@ func TestCaptureOAMResources(t *testing.T) {
 // TestCapturePodLog tests the functionality to capture the logs of a given pod.
 func TestCapturePodLog(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset()
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
-	err = CapturePodLog(k8sClient, corev1.Pod{}, constants.VerrazzanoInstall, captureDir, rc)
+	err := CapturePodLog(k8sClient, corev1.Pod{}, constants.VerrazzanoInstall, captureDir, rc)
 	assert.NoError(t, err)
 
 	//  GIVENT and empty k8s cluster,
@@ -228,9 +219,7 @@ func TestGetPodList(t *testing.T) {
 
 // TestCaptureVZResource tests the functionality to capture the Verrazzano resource.
 func TestCaptureVZResource(t *testing.T) {
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
@@ -329,25 +318,15 @@ func TestCreateFile(t *testing.T) {
 	//  GIVEN a k8s cluster with a VPO pod,
 	//	WHEN I call functions to create a JSON file for the pod,
 	//	THEN expect it to write to the provided resource file, the JSON contents of the pod and no error should be returned.
-	captureDir, err := os.MkdirTemp("", "testcapture")
-	defer cleanupTempDir(t, captureDir)
-	assert.NoError(t, err)
-	defer cleanupTempDir(t, captureDir)
+	captureDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
-	err = createFile(corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+	err := createFile(corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:      constants.VerrazzanoPlatformOperator,
 		Namespace: constants.VerrazzanoInstall,
 	}}, constants.VerrazzanoInstall, "test-file", captureDir, rc)
 	assert.NoError(t, err)
-}
-
-// cleanupTempDir cleans up the given temp directory after the test run
-func cleanupTempDir(t *testing.T, dirName string) {
-	if err := os.RemoveAll(dirName); err != nil {
-		t.Fatalf("RemoveAll failed: %v", err)
-	}
 }
 
 // cleanupTempDir cleans up the given temp file after the test run


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatalf("unexpected error %v", err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```