### PR TITLE
NO JIRA: only build/save CLI linux amd64 binary with feature branches

### DIFF
--- a/ci/scripts/save_tooling.sh
+++ b/ci/scripts/save_tooling.sh
@@ -23,28 +23,28 @@ fi
 
 cd out
 tar -czf ${WORKSPACE}/vz-linux-amd64.tar.gz -C linux_amd64 .
-tar -czf ${WORKSPACE}/vz-linux-arm64.tar.gz -C linux_arm64 .
-tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
-tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
+#tar -czf ${WORKSPACE}/vz-linux-arm64.tar.gz -C linux_arm64 .
+#tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
+#tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
 
 cd ${WORKSPACE}
 sha256sum vz-linux-amd64.tar.gz > vz-linux-amd64.tar.gz.sha256
-sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
+#sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
 sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
-sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
+#sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
-oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256

--- a/ci/scripts/save_tooling.sh
+++ b/ci/scripts/save_tooling.sh
@@ -23,28 +23,33 @@ fi
 
 cd out
 tar -czf ${WORKSPACE}/vz-linux-amd64.tar.gz -C linux_amd64 .
-#tar -czf ${WORKSPACE}/vz-linux-arm64.tar.gz -C linux_arm64 .
-#tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
-#tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
+if [ "CURRENT_BRANCH_NAME" == "master" ] || [[ "CURRENT_BRANCH_NAME" == "release-*" ]]; then
+  tar -czf ${WORKSPACE}/vz-linux-arm64.tar.gz -C linux_arm64 .
+  tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
+  tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
+fi
 
 cd ${WORKSPACE}
 sha256sum vz-linux-amd64.tar.gz > vz-linux-amd64.tar.gz.sha256
-#sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
-#sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
-#sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
-#oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
+
+if [ "CURRENT_BRANCH_NAME" == "master" ] || [[ "CURRENT_BRANCH_NAME" == "release-*" ]]; then
+  sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
+  sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
+  sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz --file vz-linux-arm64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-arm64.tar.gz.sha256 --file vz-linux-arm64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz --file vz-darwin-amd64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-amd64.tar.gz.sha256 --file vz-darwin-amd64.tar.gz.sha256
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz --file vz-darwin-arm64.tar.gz
+  oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-darwin-arm64.tar.gz.sha256 --file vz-darwin-arm64.tar.gz.sha256
+fi

--- a/ci/scripts/save_tooling.sh
+++ b/ci/scripts/save_tooling.sh
@@ -30,7 +30,7 @@ tar -czf ${WORKSPACE}/vz-linux-amd64.tar.gz -C linux_amd64 .
 cd ${WORKSPACE}
 sha256sum vz-linux-amd64.tar.gz > vz-linux-amd64.tar.gz.sha256
 #sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
-sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
+#sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
 #sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CURRENT_BRANCH_NAME}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256

--- a/ci/scripts/save_tooling.sh
+++ b/ci/scripts/save_tooling.sh
@@ -23,7 +23,7 @@ fi
 
 cd out
 tar -czf ${WORKSPACE}/vz-linux-amd64.tar.gz -C linux_amd64 .
-if [ "CURRENT_BRANCH_NAME" == "master" ] || [[ "CURRENT_BRANCH_NAME" == "release-*" ]]; then
+if [[ $CURRENT_BRANCH_NAME == master ]] || [[ $CURRENT_BRANCH_NAME == release-* ]]; then
   tar -czf ${WORKSPACE}/vz-linux-arm64.tar.gz -C linux_arm64 .
   tar -czf ${WORKSPACE}/vz-darwin-amd64.tar.gz -C darwin_amd64 .
   tar -czf ${WORKSPACE}/vz-darwin-arm64.tar.gz -C darwin_arm64 .
@@ -36,7 +36,7 @@ oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} 
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz --file vz-linux-amd64.tar.gz
 oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${CURRENT_BRANCH_NAME}/${SHORT_COMMIT_HASH_ENV}/vz-linux-amd64.tar.gz.sha256 --file vz-linux-amd64.tar.gz.sha256
 
-if [ "CURRENT_BRANCH_NAME" == "master" ] || [[ "CURRENT_BRANCH_NAME" == "release-*" ]]; then
+if [[ $CURRENT_BRANCH_NAME == master ]] || [[ $CURRENT_BRANCH_NAME == release-* ]]; then
   sha256sum vz-linux-arm64.tar.gz > vz-linux-arm64.tar.gz.sha256
   sha256sum vz-darwin-amd64.tar.gz > vz-darwin-amd64.tar.gz.sha256
   sha256sum vz-darwin-arm64.tar.gz > vz-darwin-arm64.tar.gz.sha256

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -14,8 +14,8 @@ BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}
 endif
-ifndef RELEASE_BRANCH
-	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+ifndef BRANCH-NAME
+	BRANCH-NAME==$(shell git rev-parse --abbrev-ref HEAD)
 endif
 
 DIST_DIR:=dist
@@ -34,22 +34,24 @@ run:
 #
 .PHONY: go-build
 go-build:
-#	GOOS=darwin GOARCH=amd64 $(GO) build \
-#		-ldflags "${CLI_GO_LDFLAGS}" \
-#		-o out/darwin_amd64/vz \
-#		${GOPATH}/src/${VZ_DIR}/main.go
-#	GOOS=darwin GOARCH=arm64 $(GO) build \
-#		-ldflags "${CLI_GO_LDFLAGS}" \
-#		-o out/darwin_arm64/vz \
-#		${GOPATH}/src/${VZ_DIR}/main.go
 	GOOS=linux GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/linux_amd64/vz \
 		${GOPATH}/src/${VZ_DIR}/main.go
-#	GOOS=linux GOARCH=arm64 $(GO) build \
-#		-ldflags "${CLI_GO_LDFLAGS}" \
-#		-o out/linux_arm64/vz \
-#		${GOPATH}/src/${VZ_DIR}/main.go
+ifeq ($(BRANCH-NAME),$(filter $(BRANCH-NAME),master release-*))
+	GOOS=darwin GOARCH=amd64 $(GO) build \
+		-ldflags "${CLI_GO_LDFLAGS}" \
+		-o out/darwin_amd64/vz \
+		${GOPATH}/src/${VZ_DIR}/main.go
+	GOOS=darwin GOARCH=arm64 $(GO) build \
+		-ldflags "${CLI_GO_LDFLAGS}" \
+		-o out/darwin_arm64/vz \
+		${GOPATH}/src/${VZ_DIR}/main.go
+	GOOS=linux GOARCH=arm64 $(GO) build \
+		-ldflags "${CLI_GO_LDFLAGS}" \
+		-o out/linux_arm64/vz \
+		${GOPATH}/src/${VZ_DIR}/main.go
+endif
 
 .PHONY: cli
 cli: ## build the CLI

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -38,18 +38,18 @@ go-build:
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_amd64/vz \
 		${GOPATH}/src/${VZ_DIR}/main.go
-	GOOS=darwin GOARCH=arm64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS}" \
-		-o out/darwin_arm64/vz \
-		${GOPATH}/src/${VZ_DIR}/main.go
-	GOOS=linux GOARCH=amd64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS}" \
-		-o out/linux_amd64/vz \
-		${GOPATH}/src/${VZ_DIR}/main.go
-	GOOS=linux GOARCH=arm64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS}" \
-		-o out/linux_arm64/vz \
-		${GOPATH}/src/${VZ_DIR}/main.go
+#	GOOS=darwin GOARCH=arm64 $(GO) build \
+#		-ldflags "${CLI_GO_LDFLAGS}" \
+#		-o out/darwin_arm64/vz \
+#		${GOPATH}/src/${VZ_DIR}/main.go
+#	GOOS=linux GOARCH=amd64 $(GO) build \
+#		-ldflags "${CLI_GO_LDFLAGS}" \
+#		-o out/linux_amd64/vz \
+#		${GOPATH}/src/${VZ_DIR}/main.go
+#	GOOS=linux GOARCH=arm64 $(GO) build \
+#		-ldflags "${CLI_GO_LDFLAGS}" \
+#		-o out/linux_arm64/vz \
+#		${GOPATH}/src/${VZ_DIR}/main.go
 
 .PHONY: cli
 cli: ## build the CLI

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -34,18 +34,18 @@ run:
 #
 .PHONY: go-build
 go-build:
-	GOOS=darwin GOARCH=amd64 $(GO) build \
-		-ldflags "${CLI_GO_LDFLAGS}" \
-		-o out/darwin_amd64/vz \
-		${GOPATH}/src/${VZ_DIR}/main.go
+#	GOOS=darwin GOARCH=amd64 $(GO) build \
+#		-ldflags "${CLI_GO_LDFLAGS}" \
+#		-o out/darwin_amd64/vz \
+#		${GOPATH}/src/${VZ_DIR}/main.go
 #	GOOS=darwin GOARCH=arm64 $(GO) build \
 #		-ldflags "${CLI_GO_LDFLAGS}" \
 #		-o out/darwin_arm64/vz \
 #		${GOPATH}/src/${VZ_DIR}/main.go
-#	GOOS=linux GOARCH=amd64 $(GO) build \
-#		-ldflags "${CLI_GO_LDFLAGS}" \
-#		-o out/linux_amd64/vz \
-#		${GOPATH}/src/${VZ_DIR}/main.go
+	GOOS=linux GOARCH=amd64 $(GO) build \
+		-ldflags "${CLI_GO_LDFLAGS}" \
+		-o out/linux_amd64/vz \
+		${GOPATH}/src/${VZ_DIR}/main.go
 #	GOOS=linux GOARCH=arm64 $(GO) build \
 #		-ldflags "${CLI_GO_LDFLAGS}" \
 #		-o out/linux_arm64/vz \

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -15,7 +15,8 @@ ifdef RELEASE_VERSION
 	CLI_VERSION=${RELEASE_VERSION}
 endif
 ifndef BRANCH-NAME
-	BRANCH-NAME==$(shell git rev-parse --abbrev-ref HEAD)
+	BRANCH-NAME=$(shell git rev-parse --abbrev-ref HEAD)
+	SUBST-BRANCH-NAME:=$(BRANCH-NAME:release-%=release)
 endif
 
 DIST_DIR:=dist
@@ -38,7 +39,7 @@ go-build:
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/linux_amd64/vz \
 		${GOPATH}/src/${VZ_DIR}/main.go
-ifeq ($(BRANCH-NAME),$(filter $(BRANCH-NAME),master release-*))
+ifeq ($(SUBST-BRANCH-NAME),$(filter $(SUBST-BRANCH-NAME),master release))
 	GOOS=darwin GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_amd64/vz \


### PR DESCRIPTION
This pull request includes a change to only build the vz CLI binary for Linux amd64 with feature branches.  For master and release branches the build will be for all VZ cli platforms.