### PR TITLE
No Bug.  Use throttled messages for transient Rancher login errors

### DIFF
--- a/platform-operator/controllers/clusters/rancher.go
+++ b/platform-operator/controllers/clusters/rancher.go
@@ -122,7 +122,7 @@ func newRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*rancherCo
 	log.Debug("Getting Rancher TLS root CA")
 	caCert, err := common.GetRootCA(rdr)
 	if err != nil {
-		log.Errorf("Failed to get Rancher TLS root CA: %v", err)
+		log.ErrorfThrottled("Failed to get Rancher TLS root CA: %v", err)
 		return nil, err
 	}
 	rc.certificateAuthorityData = caCert
@@ -133,7 +133,7 @@ func newRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*rancherCo
 	log.Once("Getting admin token from Rancher")
 	adminToken, err := getAdminTokenFromRancher(rdr, rc, log)
 	if err != nil {
-		log.Errorf("Failed to get admin token from Rancher: %v", err)
+		log.ErrorfThrottled("Failed to get admin token from Rancher: %v", err)
 		return nil, err
 	}
 	rc.apiAccessToken = adminToken

--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -60,7 +60,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	if err != nil {
 		msg := fmt.Sprintf("Failed to create Rancher API client: %v", err)
 		r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, "", msg)
-		r.log.Infof("Unable to connect to Rancher API on admin cluster, manifest secret will not contain Rancher YAML: %v", err)
+		r.log.Progressf("Unable to connect to Rancher API on admin cluster, manifest secret will not contain Rancher YAML: %v", err)
 	} else {
 		var rancherYAML string
 		rancherYAML, clusterID, err = registerManagedClusterWithRancher(rc, vmc.Name, vmc.Status.RancherRegistration.ClusterID, r.log)


### PR DESCRIPTION
Use throttled error/info messages to cut down on transient Rancher login errors during install and upgrade like these:

```
[2022-10-17T18:39:54.454Z] 2022-10-17T18:39:54.316Z error Failed to get admin token from Rancher: expected response code 201 from POST but got 400: &{400 Bad Request 400 HTTP/1.1 1 1 map[Connection:[keep-alive] Date:[Mon, 17 Oct 2022 18:39:54 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]] 0xc005190080 -1 [chunked] false false map[] 0xc0048f4600 0xc0000afb80}

[2022-10-17T18:39:54.454Z] 2022-10-17T18:39:54.330Z info Unable to connect to Rancher API on admin cluster, manifest secret will not contain Rancher YAML: expected response code 201 from POST but got 400: &{400 Bad Request 400 HTTP/1.1 1 1 map[Connection:[keep-alive] Date:[Mon, 17 Oct 2022 18:39:54 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]] 0xc005190080 -1 [chunked] false false map[] 0xc0048f4600 0xc0000afb80}

[2022-10-17T18:39:54.454Z] 2022-10-17T18:39:54.431Z error Failed to get admin token from Rancher: expected response code 201 from POST but got 400: &{400 Bad Request 400 HTTP/1.1 1 1 map[Connection:[keep-alive] Date:[Mon, 17 Oct 2022 18:39:54 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]] 0xc0047cfb20 -1 [chunked] false false map[] 0xc002245400 0xc001d18580}

[2022-10-17T18:39:54.715Z] 2022-10-17T18:39:54.458Z info Unable to connect to Rancher API on admin cluster, manifest secret will not contain Rancher YAML: expected response code 201 from POST but got 400: &{400 Bad Request 400 HTTP/1.1 1 1 map[Connection:[keep-alive] Date:[Mon, 17 Oct 2022 18:39:54 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]] 0xc0047cfb20 -1 [chunked] false false map[] 0xc002245400 0xc001d18580}

[2022-10-17T18:39:54.715Z] 2022-10-17T18:39:54.514Z error Failed to get admin token from Rancher: expected response code 201 from POST but got 400: &{400 Bad Request 400 HTTP/1.1 1 1 map[Connection:[keep-alive] Date:[Mon, 17 Oct 2022 18:39:54 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]] 0xc0034a88a0 -1 [chunked] false false map[] 0xc0001a4500 0xc0043de0b0}
```

These just repeat a few dozen times until Rancher is ready.