### PR TITLE
VZ 7330:Misspelled words corrected

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -1242,7 +1242,7 @@ func TestFailureToGetWorkloadDefinition(t *testing.T) {
 	assert.GreaterOrEqual(result.RequeueAfter.Milliseconds(), time.Duration(0).Milliseconds())
 }
 
-// TestFailureToUpdateStatus tests tje Reconcile method for the following use case
+// TestFailureToUpdateStatus tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an ingress trait resource
 // WHEN the request to update the trait status fails
 // THEN ensure an error is returned
@@ -1789,7 +1789,7 @@ func TestBuildAppHostNameNodePortExternalIP(t *testing.T) {
 	assert.Equal(testExternalDomainName, domainName)
 }
 
-// TestGetTraitFailurePropagated tests tje Reconcile method for the following use case
+// TestGetTraitFailurePropagated tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an ingress trait resource
 // WHEN a failure occurs getting the ingress trait resource
 // THEN the error is propagated

--- a/application-operator/controllers/namespace/namespace_controller_test.go
+++ b/application-operator/controllers/namespace/namespace_controller_test.go
@@ -609,7 +609,7 @@ func runAddOCILoggingTest(t *testing.T, addLoggingResult bool) {
 		})
 
 	// if the result from adding logging returns true (meaning the Fluentd configmap was updated), then
-	// mock expections for restarting Fluentd
+	// mock exceptions for restarting Fluentd
 	if addLoggingResult {
 		mockFluentdRestart(mock, asserts)
 	}
@@ -704,7 +704,7 @@ func Test_reconcileOCILoggingAddOCILoggingAddFailed(t *testing.T) {
 	asserts.Len(ns.Finalizers, 2)
 }
 
-// mockFluentdRestart - Mock expections for Fluentd daemonset restart
+// mockFluentdRestart - Mock exceptions for Fluentd daemonset restart
 func mockFluentdRestart(mock *mocks.MockClient, asserts *assert.Assertions) {
 	// Expect a call to get the Fleuntd Daemonset and another to update it with a restart time annotation
 	mock.EXPECT().

--- a/application-operator/controllers/webhooks/metrics-binding-updater-workload_test.go
+++ b/application-operator/controllers/webhooks/metrics-binding-updater-workload_test.go
@@ -1003,7 +1003,7 @@ func TestHandleNamespaceAnnotation(t *testing.T) {
 // uses the legacy VMI Prometheus ConfigMap
 // GIVEN an existing metrics binding which uses the legacy VMI Prometheus ConfigMap
 // WHEN the webhook Handle is called
-// THEN the metrics binding should be modified to use the Pormetheus Operator additionalScrapeConfigs secret instead
+// THEN the metrics binding should be modified to use the Prometheus Operator additionalScrapeConfigs secret instead
 func TestExistingMetricsBindingVmiConfigMap(t *testing.T) {
 
 	v := newGeneratorWorkloadWebhook()

--- a/application-operator/mcagent/mcagent_project.go
+++ b/application-operator/mcagent/mcagent_project.go
@@ -42,7 +42,7 @@ func (s *Syncer) syncVerrazzanoProjects() error {
 				vpLocal := clustersv1alpha1.VerrazzanoProject{}
 				err := s.LocalClient.Get(s.Context, types.NamespacedName{Namespace: vp.Namespace, Name: vp.Name}, &vpLocal)
 				if err == nil {
-					s.Log.Debugf("Deleting VerrazzanoProject %q from namespace %q because it is no longer targetted at this cluster", vp.Name, vp.Namespace)
+					s.Log.Debugf("Deleting VerrazzanoProject %q from namespace %q because it is no longer targeted at this cluster", vp.Name, vp.Namespace)
 					err2 := s.LocalClient.Delete(s.Context, &vpLocal)
 					if err2 != nil {
 						s.Log.Errorf("failed to delete VerrazzanoProject with name %q and namespace %q: %v", vp.Name, vp.Namespace, err2)

--- a/application-operator/metricsexporter/metricsexporter_utils.go
+++ b/application-operator/metricsexporter/metricsexporter_utils.go
@@ -66,7 +66,7 @@ func init() {
 	RegisterMetrics()
 }
 
-// RequiredInitialization initalizes the metrics object, but does not register the metrics
+// RequiredInitialization initializes the metrics object, but does not register the metrics
 func RequiredInitialization() {
 	MetricsExp = metricsExporter{
 		internalConfig: initConfiguration(),
@@ -83,7 +83,7 @@ func RegisterMetrics() {
 	go registerMetricsHandlers(zap.S())
 }
 
-// InitializeAllMetricsArray initalizes the allMetrics array
+// InitializeAllMetricsArray initializes the allMetrics array
 func InitializeAllMetricsArray() {
 	// Loop through all metrics declarations in metric maps
 	for _, value := range MetricsExp.internalData.simpleCounterMetricMap {
@@ -95,7 +95,7 @@ func InitializeAllMetricsArray() {
 
 }
 
-// initCounterMetricMap initalizes the simpleCounterMetricMap for the metricsExporter object
+// initCounterMetricMap initializes the simpleCounterMetricMap for the metricsExporter object
 func initCounterMetricMap() map[metricName]*SimpleCounterMetric {
 	return map[metricName]*SimpleCounterMetric{
 		AppconfigReconcileCounter: {
@@ -233,7 +233,7 @@ func initCounterMetricMap() map[metricName]*SimpleCounterMetric {
 	}
 }
 
-// initDurationMetricMap initalizes the DurationMetricMap for the metricsExporter object
+// initDurationMetricMap initializes the DurationMetricMap for the metricsExporter object
 func initDurationMetricMap() map[metricName]*DurationMetrics {
 	return map[metricName]*DurationMetrics{
 		AppconfigReconcileDuration: {
@@ -347,7 +347,7 @@ func registerMetricsHandlers(log *zap.SugaredLogger) {
 	}
 }
 
-// initializeFailedMetricsArray initalizes the failedMetrics array
+// initializeFailedMetricsArray initializes the failedMetrics array
 func initializeFailedMetricsArray() {
 	for i, metric := range MetricsExp.internalConfig.allMetrics {
 		MetricsExp.internalConfig.failedMetrics[metric] = i

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -9,7 +9,7 @@ import (
 	platformOperatorConstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 )
 
-// RestartVersionAnnotation - the annotation used by user to tell Verrazzano applicaton to restart its components
+// RestartVersionAnnotation - the annotation used by user to tell Verrazzano application to restart its components
 const RestartVersionAnnotation = "verrazzano.io/restart-version"
 
 // VerrazzanoRestartAnnotation is the annotation used to restart platform workloads

--- a/pkg/log/vzlog/doc.go
+++ b/pkg/log/vzlog/doc.go
@@ -21,7 +21,7 @@ package vzlog
 // then we delete the logging context. So, if you changed the resource foo an hour later,
 // and the same code path is executed, then the message will be displayed once, for the new reconcile session.
 //
-// The main purpose of this package is to provide logging during Kubernetes resource reconcilation.  For that
+// The main purpose of this package is to provide logging during Kubernetes resource reconciliation.  For that
 // use case, use the EnsureResourceLogger method as follows.  See the function descrition for more details.
 //
 //   	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
@@ -36,7 +36,7 @@ package vzlog
 // as described here. The logger is initialized with the zap.SugaredLogger and then used instead of the zap logger directly.
 // The same SugaredLogger calls can be made: Debug, Debugf, Info, Infof, Error, and Errorf.  The
 // two new calls are Progress and Progressf. The S() method will return the underlying SugaredLogger.
-// The following psuedo-code shows how this should be used:
+// The following pseudo-code shows how this should be used:
 //
 //   log := vzlog.EnsureContext(key).EnsureLogger("default", zaplog, zaplog)
 //

--- a/pkg/yaml/expand_test.go
+++ b/pkg/yaml/expand_test.go
@@ -94,7 +94,7 @@ const expanded11 = `aa:
     val_11`
 
 // TestExpand tests the Expand function
-// GIVEN a set of dot seperated names
+// GIVEN a set of dot separated names
 // WHEN Expand is called
 // THEN ensure that the expanded result is correct.
 func TestExpand(t *testing.T) {
@@ -201,7 +201,7 @@ const lmExpanded4 = `    aa:
         - val_4c`
 
 // TestLeftMargin tests the Expand function
-// GIVEN a set of dot seperated names
+// GIVEN a set of dot separated names
 // WHEN Expand is called with a non-zero left margin
 // THEN ensure that the expanded result is correct.
 func TestLeftMargin(t *testing.T) {

--- a/pkg/yaml/helm_test.go
+++ b/pkg/yaml/helm_test.go
@@ -41,7 +41,7 @@ const hyphenName = `name:
 `
 
 // TestExpand tests the Expand function
-// GIVEN a set of dot seperated names
+// GIVEN a set of dot separated names
 // WHEN Expand is called
 // THEN ensure that the expanded result is correct.
 func TestHelmValueFileConstructor(t *testing.T) {

--- a/platform-operator/apis/verrazzano/validators/validate.go
+++ b/platform-operator/apis/verrazzano/validators/validate.go
@@ -136,7 +136,7 @@ func ValidateNewVersion(currStatusVerString string, currSpecVerString string, ne
 	// - use case is, user rolls back to an earlier version of the platform operator and requests the older BOM version
 	currentStatusVersion, err := semver.NewSemVersion(strings.TrimSpace(currStatusVerString))
 	if err != nil {
-		// for this path we should alwyas have a status version
+		// for this path we should always have a status version
 		return err
 	}
 	if newSpecVer.IsLessThan(currentStatusVersion) {

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
@@ -303,7 +303,7 @@ func TestRemoveResourcePolicyAnnotation(t *testing.T) {
 // TestUninstallResources tests the Fluentd Uninstall call
 // GIVEN a Fluentd component
 //  WHEN I call Uninstall with the Fluentd helm chart not installed
-//  THEN ensure that all Fluentd resources are explicity deleted
+//  THEN ensure that all Fluentd resources are explicitly deleted
 func TestUninstallResources(t *testing.T) {
 	helmcli.SetCmdRunner(vzos.GenericTestRunner{
 		StdOut: []byte(""),

--- a/platform-operator/controllers/verrazzano/component/common/compare_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/compare_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCompareInstallArgs(t *testing.T) {
-	const exception = `test-execption`
+	const exception = `test-exception`
 	tests := []struct {
 		name    string
 		old     []vzapi.InstallArgs

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
@@ -575,7 +575,7 @@ func TestUninstallHelmChartNotInstalled(t *testing.T) {
 // TestUninstallResources tests the Fluentd Uninstall call
 // GIVEN a Fluentd component
 //  WHEN I call Uninstall with the Fluentd helm chart not installed
-//  THEN ensure that all Fluentd resources are explicity deleted
+//  THEN ensure that all Fluentd resources are explicitly deleted
 func TestUninstallResources(t *testing.T) {
 	helmcli.SetCmdRunner(os.GenericTestRunner{
 		StdOut: []byte(""),

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -90,7 +90,7 @@ func TestUpgrade(t *testing.T) {
 		PreUpgradeFunc:          fakePreUpgrade,
 	}
 
-	// This string is built from the Key:Value arrary returned by the bom.buildImageOverrides() function
+	// This string is built from the Key:Value array returned by the bom.buildImageOverrides() function
 	fakeOverrides = []string{
 		"rancherImage=ghcr.io/verrazzano/rancher",
 		"rancherImageTag=v2.5.7-20210407205410-1c7b39d0c",
@@ -193,7 +193,7 @@ func TestUpgradeWithEnvOverrides(t *testing.T) {
 	_ = os.Setenv(constants.ImageRepoOverrideEnvVar, "myrepo")
 	defer func() { _ = os.Unsetenv(constants.ImageRepoOverrideEnvVar) }()
 
-	// This string is built from the Key:Value arrary returned by the bom.buildImageOverrides() function
+	// This string is built from the Key:Value array returned by the bom.buildImageOverrides() function
 	fakeOverrides = []string{
 		"rancherImage=myreg.io/myrepo/verrazzano/rancher",
 		"rancherImageTag=v2.5.7-20210407205410-1c7b39d0c",
@@ -231,7 +231,7 @@ func TestInstall(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
-	// This string is built from the Key:Value arrary returned by the bom.buildImageOverrides() function
+	// This string is built from the Key:Value array returned by the bom.buildImageOverrides() function
 	fakeOverrides = []string{
 		"rancherImage=ghcr.io/verrazzano/rancher",
 		"rancherImageTag=v2.5.7-20210407205410-1c7b39d0c",
@@ -279,7 +279,7 @@ func TestInstallWithAllOverride(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
-	// This string is built from the Key:Value arrary returned by the bom.buildImageOverrides() function
+	// This string is built from the Key:Value array returned by the bom.buildImageOverrides() function
 	fakeOverrides = []string{
 		"rancherImage=ghcr.io/verrazzano/rancher",
 		"rancherImageTag=v2.5.7-20210407205410-1c7b39d0c",
@@ -325,7 +325,7 @@ func TestInstallPreviousFailure(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 
-	// This string is built from the Key:Value arrary returned by the bom.buildImageOverrides() function
+	// This string is built from the Key:Value array returned by the bom.buildImageOverrides() function
 	fakeOverrides = []string{
 		"rancherImage=ghcr.io/verrazzano/rancher",
 		"rancherImageTag=v2.5.7-20210407205410-1c7b39d0c",

--- a/platform-operator/controllers/verrazzano/controller_test.go
+++ b/platform-operator/controllers/verrazzano/controller_test.go
@@ -569,7 +569,7 @@ func TestUninstallComplete(t *testing.T) {
 // TestUninstallStarted tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an Verrazzano resource
 // WHEN a Verrazzano resource has been deleted
-// THEN ensure an unisntall job is started
+// THEN ensure an uninstall job is started
 func TestUninstallStarted(t *testing.T) {
 	unitTesting = true
 	namespace := "verrazzano"

--- a/platform-operator/controllers/verrazzano/install_test.go
+++ b/platform-operator/controllers/verrazzano/install_test.go
@@ -192,7 +192,7 @@ func testUpdate(t *testing.T,
 			verrazzano.Status.Components = compStatusMap
 			return nil
 		})
-	// The mocks are added to accomodate the expected calls to List instance when component is Ready
+	// The mocks are added to accommodate the expected calls to List instance when component is Ready
 	mock.EXPECT().
 		List(gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList, options ...client.UpdateOption) error {

--- a/platform-operator/controllers/verrazzano/uninstall.go
+++ b/platform-operator/controllers/verrazzano/uninstall.go
@@ -291,9 +291,9 @@ func (r *Reconciler) uninstallCleanup(ctx spi.ComponentContext) (ctrl.Result, er
 		return ctrl.Result{}, err
 	}
 
-	// Run Rancher Post Uninstall explicilty to delete any remaining Rancher resources; this may be needed in case
+	// Run Rancher Post Uninstall explicitly to delete any remaining Rancher resources; this may be needed in case
 	// the uninstall was interrupted during uninstall, or if the cluster is a managed cluster where Rancher is not
-	// installed explicilty.
+	// installed explicitly.
 	if err := r.runRancherPostInstall(ctx); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/platform-operator/internal/vzconfig/enabled.go
+++ b/platform-operator/internal/vzconfig/enabled.go
@@ -66,7 +66,7 @@ func IsIstioEnabled(cr runtime.Object) bool {
 	return true
 }
 
-// IsCertManagerEnabled - Returns false only if CertManager is explictly disabled by the user
+// IsCertManagerEnabled - Returns false only if CertManager is explicitly disabled by the user
 func IsCertManagerEnabled(cr runtime.Object) bool {
 	if vzv1alpha1, ok := cr.(*vzapi.Verrazzano); ok {
 		if vzv1alpha1 != nil && vzv1alpha1.Spec.Components.CertManager != nil && vzv1alpha1.Spec.Components.CertManager.Enabled != nil {

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -89,7 +89,7 @@ func init() {
 	RegisterMetrics(zap.S())
 }
 
-// This function initalizes the metrics object, but does not register the metrics
+// This function initializes the metrics object, but does not register the metrics
 func RequiredInitialization() {
 	MetricsExp = MetricsExporter{
 		internalConfig: initConfiguration(),
@@ -128,7 +128,7 @@ func newMetricsComponent(name string) *MetricsComponent {
 	}
 }
 
-//This function initalizes the simpleCounterMetricMap for the metricsExporter object
+//This function initializes the simpleCounterMetricMap for the metricsExporter object
 func initSimpleCounterMetricMap() map[metricName]*SimpleCounterMetric {
 	return map[metricName]*SimpleCounterMetric{
 		ReconcileCounter: {
@@ -146,7 +146,7 @@ func initSimpleCounterMetricMap() map[metricName]*SimpleCounterMetric {
 	}
 }
 
-// This function initalizes the metricComponentMap for the metricsExporter object
+// This function initializes the metricComponentMap for the metricsExporter object
 func initMetricComponentMap() map[metricName]*MetricsComponent {
 	return map[metricName]*MetricsComponent{
 		authproxyMetricName:            newMetricsComponent("authproxy"),
@@ -180,12 +180,12 @@ func initMetricComponentMap() map[metricName]*MetricsComponent {
 	}
 }
 
-// This function initalizes the simpleGaugeMetricMap for the metricsExporter object
+// This function initializes the simpleGaugeMetricMap for the metricsExporter object
 func initSimpleGaugeMetricMap() map[metricName]*SimpleGaugeMetric {
 	return map[metricName]*SimpleGaugeMetric{}
 }
 
-// This function initalizes the durationMetricMap for the metricsExporter object
+// This function initializes the durationMetricMap for the metricsExporter object
 func initDurationMetricMap() map[metricName]*DurationMetric {
 	return map[metricName]*DurationMetric{
 		ReconcileDuration: {
@@ -264,7 +264,7 @@ func registerMetricsHandlers(log *zap.SugaredLogger) {
 	}
 }
 
-// This function initalizes the failedMetrics array
+// This function initializes the failedMetrics array
 func initializeFailedMetricsArray() {
 	for i, metric := range MetricsExp.internalConfig.allMetrics {
 		MetricsExp.internalConfig.failedMetrics[metric] = i
@@ -313,7 +313,7 @@ func AnalyzeVerrazzanoResourceMetrics(log vzlog.VerrazzanoLogger, cr vzapi.Verra
 	}
 }
 
-// This function initalizes the allMetrics array
+// This function initializes the allMetrics array
 func InitializeAllMetricsArray() {
 	//loop through all metrics declarations in metric maps
 	for _, value := range MetricsExp.internalData.simpleCounterMetricMap {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -228,7 +228,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.4.1-20221007061008-20da125",
+              "tag": "v1.4.1-20221014102648-b2093df",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -185,7 +185,7 @@ func PopulateRancherUsers(rancherURL string, n int) error {
 			return err
 		}
 		common.RancherUserNameList = append(common.RancherUserNameList, userName)
-		t.Logs.Infof("Sucessfully created rancher user %v", userName)
+		t.Logs.Infof("Successfully created rancher user %v", userName)
 	}
 
 	return nil
@@ -206,7 +206,7 @@ func DeleteRancherUsers(rancherURL string) bool {
 			t.Logs.Errorf("Error while retrieving http data %v", zap.Error(err))
 			return false
 		}
-		t.Logs.Infof("Sucessfully deleted rancher user '%v' with id '%v' ", common.RancherUserNameList[i], common.RancherUserIDList[i])
+		t.Logs.Infof("Successfully deleted rancher user '%v' with id '%v' ", common.RancherUserNameList[i], common.RancherUserIDList[i])
 	}
 	return true
 }

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -34,7 +34,7 @@ const (
 	vmoFunctionMetric              = "vmo_reconcile_total"
 	vmoCounterMetric               = "vmo_deployment_update_total"
 	vmoGaugeMetric                 = "vmo_work_queue_size"
-	vmoTimestampMetric             = "vmo_configmap_last_succesful_timestamp"
+	vmoTimestampMetric             = "vmo_configmap_last_successful_timestamp"
 	vaoSuccessCountMetric          = "vao_appconfig_successful_reconcile_total"
 	vaoFailCountMetric             = "vao_appconfig_error_reconcile_total"
 	vaoDurationCountMetric         = "vao_appconfig_reconcile_duration_count"

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -70,7 +70,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 		// This test is part of the minimal verification.
 		t.It("has the expected VerrazzanoManagedCluster", func() {
 			var client *vmcClient.Clientset
-			// If registration happend in VZ versions 1.4 and above on admin cluster, check the ManagedCARetrieved condition as well
+			// If registration happened in VZ versions 1.4 and above on admin cluster, check the ManagedCARetrieved condition as well
 			adminVersionAtRegistration := os.Getenv("ADMIN_VZ_VERSION_AT_REGISTRATION")
 			pkg.Log(pkg.Info, fmt.Sprintf("Admin cluster VZ version at registration is '%s'", adminVersionAtRegistration))
 			regVersion14 := false

--- a/tests/e2e/pkg/elasticsearch.go
+++ b/tests/e2e/pkg/elasticsearch.go
@@ -105,7 +105,7 @@ type Action struct {
 	} `json:"delete,omitempty"`
 }
 
-// Transistion defined in ISM policy
+// Transition defined in ISM policy
 type Transition struct {
 	StateName  string            `json:"state_name"`
 	Conditions map[string]string `json:"conditions"`

--- a/tests/e2e/update/updater.go
+++ b/tests/e2e/update/updater.go
@@ -232,10 +232,10 @@ func IsCRReadyAfterUpdate(cr *vzapi.Verrazzano, updatedTime time.Time) bool {
 		pkg.Log(pkg.Info, fmt.Sprintf("Checking if condition of type '%s', transitioned at '%s' is for the expected update",
 			condition.Type, condition.LastTransitionTime))
 		if (condition.Type == vzapi.CondInstallComplete || condition.Type == vzapi.CondUpgradeComplete) && condition.Status == corev1.ConditionTrue {
-			// check if the transistion time is post the time of update
+			// check if the transition time is post the time of update
 			transitionTime, err := time.Parse(time.RFC3339, condition.LastTransitionTime)
 			if err != nil {
-				pkg.Log(pkg.Error, "Unable to parse the transistion time '"+condition.LastTransitionTime+"'")
+				pkg.Log(pkg.Error, "Unable to parse the transition time '"+condition.LastTransitionTime+"'")
 				return false
 			}
 			if transitionTime.After(updatedTime) {

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -317,7 +317,7 @@ var _ = t.Describe("In Verrazzano", Label("f:platform-lcm.install"), func() {
 			Expect(crb.RoleRef.Name == "admin").To(BeTrue(),
 				"the roleRef.name should be admin")
 			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
-				"the roleRef.kind shoudl be ClusterRole")
+				"the roleRef.kind should be ClusterRole")
 
 			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")
@@ -345,7 +345,7 @@ var _ = t.Describe("In Verrazzano", Label("f:platform-lcm.install"), func() {
 			Expect(crb.RoleRef.Name == "verrazzano-monitor").To(BeTrue(),
 				"the roleRef.name should be verrazzano-monitor")
 			Expect(crb.RoleRef.Kind == "ClusterRole").To(BeTrue(),
-				"the roleRef.kind shoudl be ClusterRole")
+				"the roleRef.kind should be ClusterRole")
 
 			Expect(len(crb.Subjects) == 1).To(BeTrue(),
 				"there should be one subject")

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -133,7 +133,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	if existingvz != nil {
 		// Allow install command to continue if an install is in progress and the same version is specified.
 		// For example, control-C was entered and the install command is run again.
-		// Note: "Installing" is a state that was used in pre 1.4.0 installs and replaced wih "Reconciling".
+		// Note: "Installing" is a state that was used in pre 1.4.0 installs and replaced with "Reconciling".
 		if existingvz.Status.State != v1beta1.VzStateReconciling && existingvz.Status.State != "Installing" {
 			return fmt.Errorf("Only one install of Verrazzano is allowed")
 		}

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -52,7 +52,7 @@ const v1beta1MinVersion = "1.4.0"
 
 func NewVerrazzanoForVZVersion(version string) (schema.GroupVersion, client.Object, error) {
 	if version == "" {
-		// default to a v1alpha1 compatible verison if not specified
+		// default to a v1alpha1 compatible version if not specified
 		version = "1.3.0"
 	}
 	actualVersion, err := semver.NewSemVersion(version)


### PR DESCRIPTION
Words that were misspelled when misspell linter was enabled have been corrected and VMO image tag has been updated.
