### PR TITLE
VZ 7476: Synchronize availability channels

### DIFF
--- a/platform-operator/controllers/verrazzano/health/availability.go
+++ b/platform-operator/controllers/verrazzano/health/availability.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health
@@ -9,6 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type componentAvailability struct {
@@ -18,25 +19,28 @@ type componentAvailability struct {
 }
 
 // updateAvailability updates the availability for a given set of components
-func (p *PlatformHealth) updateAvailability(components []spi.Component) (*Status, error) {
+func (p *PlatformHealth) updateAvailability(components []spi.Component) error {
 	// Get the Verrazzano resource
 	vz, err := p.getVerrazzanoResource()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get Verrazzano resource: %v", err)
+		return fmt.Errorf("Failed to get Verrazzano resource: %v", err)
 	}
 	if vz == nil {
-		return nil, nil
+		return nil
 	}
 	vzlogger, err := newLogger(vz)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get Verrazzano resource logger: %v", err)
+		return fmt.Errorf("Failed to get Verrazzano resource logger: %v", err)
 	}
 	// calculate a new availability status
 	status, err := p.newStatus(vzlogger, vz, components)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get new Verrazzano availability: %v", err)
+		return fmt.Errorf("Failed to get new Verrazzano availability: %v", err)
 	}
-	return status, nil
+	if err := p.sendStatus(status); err != nil {
+		return fmt.Errorf("Failed to update Verrazzano availability: %v", err)
+	}
+	return nil
 }
 
 // newStatus creates a new availability status based on the current state of the component set.
@@ -49,6 +53,7 @@ func (p *PlatformHealth) newStatus(log vzlog.VerrazzanoLogger, vz *vzapi.Verrazz
 	countEnabled := 0
 	countAvailable := 0
 	status := &Status{
+		Verrazzano: vz,
 		Components: map[string]bool{},
 	}
 	for _, component := range components {
@@ -73,6 +78,42 @@ func (p *PlatformHealth) newStatus(log vzlog.VerrazzanoLogger, vz *vzapi.Verrazz
 	status.Available = availabilityColumn
 	log.Debugf("Set component availability: %s", availabilityColumn)
 	return status, nil
+}
+
+func (p *PlatformHealth) sendStatus(status *Status) error {
+	p.status = status
+	// if cluster Verrazzano has identical status, don't send an update
+	if status != nil && !status.needsUpdate() {
+		return nil
+	}
+	select {
+	case <-p.ackChannel:
+		// if the last status has been ack'd, send a new status
+		p.statusChannel <- p.status
+	default:
+		// if no response, try to update the Verrazzano resource ourselves, so the channel
+		// does not block with message congestion.
+		// We may not get a response if:
+		// - Verrazzano reconciliation is taking a very long time
+		// - the VPO is inactive (no changes in the Verrazzano resource)
+		return p.updateVerrazzano()
+	}
+	return nil
+}
+
+func (p *PlatformHealth) updateVerrazzano() error {
+	if p.status == nil || p.status.Verrazzano == nil {
+		return nil
+	}
+	// If the Verrazzano is not Ready, don't update it.
+	if p.status.Verrazzano.Status.State == vzapi.VzStateReady {
+		p.status.merge(p.status.Verrazzano)
+		if err := p.client.Status().Update(context.TODO(), p.status.Verrazzano); err != nil && !apierrors.IsConflict(err) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func isEnabled(vz *vzapi.Verrazzano, component spi.Component) bool {

--- a/platform-operator/controllers/verrazzano/health/availability.go
+++ b/platform-operator/controllers/verrazzano/health/availability.go
@@ -1,4 +1,4 @@
-// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health

--- a/platform-operator/controllers/verrazzano/health/availability_test.go
+++ b/platform-operator/controllers/verrazzano/health/availability_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health
@@ -159,9 +159,9 @@ func TestUpdateAvailability(t *testing.T) {
 				p = newTestHealthCheck()
 			}
 
-			status, err := p.updateAvailability([]spi.Component{})
+			err := p.updateAvailability([]spi.Component{})
 			assert.NoError(t, err)
-			assert.Equal(t, status == nil, tt.vz == nil)
+			assert.Equal(t, p.status == nil, tt.vz == nil)
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/health/availability_test.go
+++ b/platform-operator/controllers/verrazzano/health/availability_test.go
@@ -1,4 +1,4 @@
-// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health

--- a/platform-operator/controllers/verrazzano/health/platform_health.go
+++ b/platform-operator/controllers/verrazzano/health/platform_health.go
@@ -1,4 +1,4 @@
-// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health

--- a/platform-operator/controllers/verrazzano/health/platform_health.go
+++ b/platform-operator/controllers/verrazzano/health/platform_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health
@@ -12,31 +12,36 @@ import (
 	"time"
 )
 
+const channelBufferSize = 10
+
 // PlatformHealth polls Verrazzano component availability every tickTime, and writes status updates to a secret
 // It is the job of the Verrazzano controller to read availability status from the secret when updating
 // Verrazzano status.
 // The secret containing status is used for synchronization - multiple goroutines writing to the same object
 // will cause performance degrading write conflicts.
 type PlatformHealth struct {
-	client   clipkg.Client
-	tickTime time.Duration
-	shutdown chan int // The channel on which shutdown signals are sent/received
-	logger   *zap.SugaredLogger
-	status   *Status      // Last known Status
-	c        chan *Status // The channel on which Status is sent/received
+	client        clipkg.Client
+	tickTime      time.Duration
+	logger        *zap.SugaredLogger
+	status        *Status      // Last known Status
+	statusChannel chan *Status // The channel on which Status is sent/received
+	shutdown      chan int     // The channel on which shutdown signals are sent/received
+	ackChannel    chan bool    // The channel on which acknowledgements are sent/received
 }
 
 type Status struct {
 	Components map[string]bool
 	Available  string
+	Verrazzano *vzapi.Verrazzano
 }
 
 func New(c clipkg.Client, tick time.Duration) *PlatformHealth {
 	return &PlatformHealth{
-		client:   c,
-		tickTime: tick,
-		logger:   zap.S().With(log.FieldController, "availability"),
-		c:        make(chan *Status),
+		client:        c,
+		tickTime:      tick,
+		logger:        zap.S().With(log.FieldController, "availability"),
+		statusChannel: make(chan *Status, channelBufferSize),
+		ackChannel:    make(chan bool, channelBufferSize),
 	}
 }
 
@@ -47,25 +52,20 @@ func (p *PlatformHealth) Start() {
 		// already running, so nothing to do
 		return
 	}
-	p.shutdown = make(chan int)
+	p.shutdown = make(chan int, channelBufferSize)
 
 	// goroutine updates availability every p.tickTime. If a shutdown signal is received (or channel is closed),
 	// the goroutine returns.
 	go func() {
 		ticker := time.NewTicker(p.tickTime)
+		p.ackChannel <- true
 		for {
 			select {
 			case <-ticker.C:
 				// timer event causes availability update
-				status, err := p.updateAvailability(registry.GetComponents())
+				err := p.updateAvailability(registry.GetComponents())
 				if err != nil {
 					p.logger.Errorf("%v", err)
-				} else {
-					// only send an update if status has changed
-					if p.status != status {
-						p.status = status
-						p.c <- p.status
-					}
 				}
 			case <-p.shutdown:
 				// shutdown event causes termination
@@ -87,18 +87,36 @@ func (p *PlatformHealth) Pause() {
 // SetAvailabilityStatus adds health check status to a Verrazzano resource, if it is available
 func (p *PlatformHealth) SetAvailabilityStatus(vz *vzapi.Verrazzano) {
 	select {
-	case status := <-p.c:
-		if status == nil {
-			return
+	case status := <-p.statusChannel:
+		if status != nil {
+			status.merge(vz)
 		}
-		for component := range status.Components {
-			if comp, ok := vz.Status.Components[component]; ok {
-				available := status.Components[component]
-				comp.Available = &available
-			}
-		}
-		vz.Status.Available = &status.Available
+		p.ackChannel <- true
 	default:
 		return
 	}
+}
+
+func (a *Status) merge(vz *vzapi.Verrazzano) {
+	for component := range a.Components {
+		if comp, ok := vz.Status.Components[component]; ok {
+			available := a.Components[component]
+			comp.Available = &available
+		}
+	}
+	vz.Status.Available = &a.Available
+}
+
+func (a *Status) needsUpdate() bool {
+	if a.Verrazzano == nil {
+		return true
+	}
+	for component := range a.Components {
+		if comp, ok := a.Verrazzano.Status.Components[component]; ok {
+			if comp.Available == nil || *comp.Available != a.Components[component] {
+				return true
+			}
+		}
+	}
+	return a.Verrazzano.Status.Available == nil || *a.Verrazzano.Status.Available != a.Available
 }

--- a/platform-operator/controllers/verrazzano/health/platform_health_test.go
+++ b/platform-operator/controllers/verrazzano/health/platform_health_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health

--- a/platform-operator/controllers/verrazzano/health/platform_health_test.go
+++ b/platform-operator/controllers/verrazzano/health/platform_health_test.go
@@ -1,4 +1,4 @@
-// Copyright (statusChannel) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package health

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - --zap-log-level=info
             - --enable-webhook-validation=true
-            - --health-check-period=0
+            - --health-check-period=60
           env:
             - name: VERRAZZANO_KUBECONFIG
               value: /home/verrazzano/kubeconfig


### PR DESCRIPTION
- Use bi-directional communication to prevent status channel from blocking
- Ensure updates are made to the VZ CR availability when main Verrazzano reconciler is idle