### PR TITLE
Check Effective CR for Rancher Keycloak integration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 Fixes:
 
 - Rancher upgrade intermittently fails with errors stating that the available chart version is less than the minimum chart version for Rancher system charts.
-- Fixed a bug related to when to integate Rancher with Keycloak auth
+- Fixed a bug related to Rancher/Keycloak auth integration for managed cluster profile
 
 ### v1.4.1
 Fixes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 Fixes:
 
 - Rancher upgrade intermittently fails with errors stating that the available chart version is less than the minimum chart version for Rancher system charts.
+- Fixed a bug related to when to integate Rancher with Keycloak auth
 
 ### v1.4.1
 Fixes:

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -74,7 +74,7 @@ func NewComponent() spi.Component {
 	}
 }
 
-//AppendOverrides set the Rancher overrides for Helm
+// AppendOverrides set the Rancher overrides for Helm
 func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	log := ctx.Log()
 	rancherHostName, err := getRancherHostname(ctx.Client(), ctx.EffectiveCR())
@@ -98,7 +98,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	return appendCAOverrides(log, kvs, ctx)
 }
 
-//appendRegistryOverrides appends overrides if a custom registry is being used
+// appendRegistryOverrides appends overrides if a custom registry is being used
 func appendRegistryOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 	// If using external registry, add registry overrides to Rancher
 	registry := os.Getenv(constants.RegistryOverrideEnvVar)
@@ -118,7 +118,7 @@ func appendRegistryOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 	return kvs
 }
 
-//appendCAOverrides sets overrides for CA Issuers, ACME or CA.
+// appendCAOverrides sets overrides for CA Issuers, ACME or CA.
 func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.ComponentContext) ([]bom.KeyValue, error) {
 	cm := ctx.EffectiveCR().Spec.Components.CertManager
 	if cm == nil {
@@ -364,7 +364,7 @@ func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
 // +enables or disables Keycloak Auth provider.
 func configureAuthProviders(ctx spi.ComponentContext) error {
 	log := ctx.Log()
-	if vzconfig.IsKeycloakEnabled(ctx.ActualCR()) && isKeycloakAuthEnabled(ctx.ActualCR()) {
+	if vzconfig.IsKeycloakEnabled(ctx.EffectiveCR()) && isKeycloakAuthEnabled(ctx.EffectiveCR()) {
 		if err := configureKeycloakOIDC(ctx); err != nil {
 			return log.ErrorfThrottledNewErr("failed configuring keycloak oidc provider: %s", err.Error())
 		}


### PR DESCRIPTION
In the Rancher code, there is a check if Keycloak is enabled before configuration the Keycloak Rancher integration. However, that only looks at the Actual CR. If the install were configured so that Rancher were enabled but Keycloak wasn't this would cause an error. This change that check to look at the effective CR.