### PR TITLE
Add missing doc.go file for the verrazzano v1beta1 API

### DIFF
--- a/platform-operator/apis/verrazzano/v1beta1/doc.go
+++ b/platform-operator/apis/verrazzano/v1beta1/doc.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+// +groupGoName=Verrazzano
+// +groupName=install.verrazzano.io
+package v1beta1
+
+// Needed to generate correct API group for the clients

--- a/platform-operator/clientset/versioned/typed/verrazzano/v1beta1/fake/fake_verrazzano.go
+++ b/platform-operator/clientset/versioned/typed/verrazzano/v1beta1/fake/fake_verrazzano.go
@@ -23,9 +23,9 @@ type FakeVerrazzanos struct {
 	ns   string
 }
 
-var verrazzanosResource = schema.GroupVersionResource{Group: "verrazzano", Version: "v1beta1", Resource: "verrazzanos"}
+var verrazzanosResource = schema.GroupVersionResource{Group: "install.verrazzano.io", Version: "v1beta1", Resource: "verrazzanos"}
 
-var verrazzanosKind = schema.GroupVersionKind{Group: "verrazzano", Version: "v1beta1", Kind: "Verrazzano"}
+var verrazzanosKind = schema.GroupVersionKind{Group: "install.verrazzano.io", Version: "v1beta1", Kind: "Verrazzano"}
 
 // Get takes name of the verrazzano, and returns the corresponding verrazzano object, and an error if there is any.
 func (c *FakeVerrazzanos) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.Verrazzano, err error) {

--- a/platform-operator/clientset/versioned/typed/verrazzano/v1beta1/verrazzano_client.go
+++ b/platform-operator/clientset/versioned/typed/verrazzano/v1beta1/verrazzano_client.go
@@ -18,7 +18,7 @@ type VerrazzanoV1beta1Interface interface {
 	VerrazzanosGetter
 }
 
-// VerrazzanoV1beta1Client is used to interact with features provided by the verrazzano group.
+// VerrazzanoV1beta1Client is used to interact with features provided by the install.verrazzano.io group.
 type VerrazzanoV1beta1Client struct {
 	restClient rest.Interface
 }


### PR DESCRIPTION
This pull request adds a missing doc.go file for the verrazzano v1beta1 API.  Without this file, generating the v1beta1 API doc was skipped.