### PR TITLE
Update mysql to 8.0.31 in grafana-mysql.yaml

### DIFF
--- a/tests/testdata/grafana/grafana-mysql.yaml
+++ b/tests/testdata/grafana/grafana-mysql.yaml
@@ -82,7 +82,7 @@ spec:
               name: data
       containers:
         - name: mysql
-          image: "ghcr.io/verrazzano/mysql-server:8.0.30"
+          image: "ghcr.io/verrazzano/mysql-server:8.0.31"
           imagePullPolicy: "IfNotPresent"
           resources:
             requests:


### PR DESCRIPTION
Updates a test file used by tests with database for Grafana persistence, to use mysql-server:8.0.31 which is same as the one used in the verrazzano-bom.json. This change will help to get a clean run from BOM validator suite, although there is a potential enhancement that can be made for the BOM validator suite to consider the images defined in the BOM and use only the corresponding namespaces.
