### PR TITLE
VZ-7481: Add undocumented install/upgrade option to override timeout for VPO

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -302,7 +302,7 @@ pipeline {
                             fi
 
                             echo "Installing Verrazzano"
-                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/platform-operator.yaml --timeout 45m
+                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/platform-operator.yaml --timeout 45m --platform-operator-timeout 10m
                        """
                     }
                     post {

--- a/tools/vz/cmd/helpers/command.go
+++ b/tools/vz/cmd/helpers/command.go
@@ -31,14 +31,14 @@ func NewCommand(vzHelper helpers.VZHelper, use string, short string, long string
 }
 
 // GetWaitTimeout returns the time to wait for a command to complete
-func GetWaitTimeout(cmd *cobra.Command) (time.Duration, error) {
+func GetWaitTimeout(cmd *cobra.Command, timeoutFlag string) (time.Duration, error) {
 	// Get the wait value from the command line
 	wait, err := cmd.PersistentFlags().GetBool(constants.WaitFlag)
 	if err != nil {
 		return time.Duration(0), err
 	}
 	if wait {
-		timeout, err := cmd.PersistentFlags().GetDuration(constants.TimeoutFlag)
+		timeout, err := cmd.PersistentFlags().GetDuration(timeoutFlag)
 		if err != nil {
 			return time.Duration(0), err
 		}

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -7,6 +7,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/spf13/cobra"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -15,7 +22,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
-	"io"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -24,24 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"net/http"
-	"os"
-	"regexp"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 const VpoSimpleLogFormatRegexp = `"level":"(.*?)","@timestamp":"(.*?)",(.*?)"message":"(.*?)",`
-
-// Number of retries after waiting a second for VPO to be ready
-const vpoDefaultWaitRetries = 60 * 5
-
-var vpoWaitRetries = vpoDefaultWaitRetries
-
-// Used with unit testing
-func SetVpoWaitRetries(retries int) { vpoWaitRetries = retries }
-func ResetVpoWaitRetries()          { vpoWaitRetries = vpoDefaultWaitRetries }
 
 // deleteLeftoverPlatformOperatorSig is a function needed for unit test override
 type deleteLeftoverPlatformOperatorSig func(client clipkg.Client) error
@@ -158,7 +150,7 @@ func ApplyPlatformOperatorYaml(cmd *cobra.Command, client clipkg.Client, vzHelpe
 }
 
 // WaitForPlatformOperator waits for the verrazzano-platform-operator to be ready
-func WaitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper, condType v1beta1.ConditionType) (string, error) {
+func WaitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper, condType v1beta1.ConditionType, timeout time.Duration) (string, error) {
 	// Provide the user with feedback while waiting for the verrazzano-platform-operator to be ready
 	feedbackChan := make(chan bool)
 	defer close(feedbackChan)
@@ -180,6 +172,7 @@ func WaitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper, co
 	// Wait for the verrazzano-platform-operator pod to be found
 	seconds := 0
 	retryCount := 0
+	retryMax := int(timeout.Seconds())
 	for {
 		ready, err := vpoIsReady(client)
 		if ready {
@@ -187,7 +180,7 @@ func WaitForPlatformOperator(client clipkg.Client, vzHelper helpers.VZHelper, co
 		}
 
 		retryCount++
-		if retryCount > vpoWaitRetries {
+		if retryCount > retryMax {
 			feedbackChan <- true
 			return "", fmt.Errorf("Waiting for %s pod in namespace %s: %v", constants.VerrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace, err)
 		}

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -6,19 +6,19 @@ package install
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/semver"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/pkg/semver"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"helm.sh/helm/v3/pkg/strvals"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,6 +66,7 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 
 	cmd.PersistentFlags().Bool(constants.WaitFlag, constants.WaitFlagDefault, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
+	cmd.PersistentFlags().Duration(constants.VPOTimeoutFlag, time.Minute*5, constants.VPOTimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, constants.VersionFlagDefault, constants.VersionFlagInstallHelp)
 	cmd.PersistentFlags().StringSliceP(constants.FilenameFlag, constants.FilenameFlagShorthand, []string{}, constants.FilenameFlagHelp)
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogFormatFlag, constants.LogFormatHelp)
@@ -80,6 +81,9 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an install.")
 	cmd.PersistentFlags().MarkHidden(constants.DryRunFlag)
 
+	// Hide the flag for overriding the default wait timeout for the platform-operator
+	cmd.PersistentFlags().MarkHidden(constants.VPOTimeoutFlag)
+
 	return cmd
 }
 
@@ -91,7 +95,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	}
 
 	// Get the timeout value for the install command
-	timeout, err := cmdhelpers.GetWaitTimeout(cmd)
+	timeout, err := cmdhelpers.GetWaitTimeout(cmd, constants.TimeoutFlag)
 	if err != nil {
 		return err
 	}
@@ -181,8 +185,14 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			return err
 		}
 
+		// Get the VPO timeout
+		vpoTimeout, err := cmdhelpers.GetWaitTimeout(cmd, constants.VPOTimeoutFlag)
+		if err != nil {
+			return err
+		}
+
 		// Wait for the platform operator to be ready before we create the Verrazzano resource.
-		vpoPodName, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete)
+		vpoPodName, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
 		if err != nil {
 			return err
 		}

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -7,11 +7,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"io"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"regexp"
 	"time"
+
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/spf13/cobra"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
@@ -114,7 +115,7 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	}
 
 	// Get the timeout value for the uninstall command.
-	timeout, err := cmdhelpers.GetWaitTimeout(cmd)
+	timeout, err := cmdhelpers.GetWaitTimeout(cmd, constants.TimeoutFlag)
 	if err != nil {
 		return err
 	}

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -5,13 +5,13 @@ package upgrade
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/verrazzano/verrazzano/pkg/semver"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +43,7 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 
 	cmd.PersistentFlags().Bool(constants.WaitFlag, constants.WaitFlagDefault, constants.WaitFlagHelp)
 	cmd.PersistentFlags().Duration(constants.TimeoutFlag, time.Minute*30, constants.TimeoutFlagHelp)
+	cmd.PersistentFlags().Duration(constants.VPOTimeoutFlag, time.Minute*5, constants.VPOTimeoutFlagHelp)
 	cmd.PersistentFlags().String(constants.VersionFlag, constants.VersionFlagDefault, constants.VersionFlagUpgradeHelp)
 	cmd.PersistentFlags().Var(&logsEnum, constants.LogFormatFlag, constants.LogFormatHelp)
 
@@ -54,6 +55,9 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	// Dry run flag is still being discussed - keep hidden for now
 	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an upgrade.")
 	cmd.PersistentFlags().MarkHidden(constants.DryRunFlag)
+
+	// Hide the flag for overriding the default wait timeout for the platform-operator
+	cmd.PersistentFlags().MarkHidden(constants.VPOTimeoutFlag)
 
 	return cmd
 }
@@ -112,7 +116,7 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Upgrading Verrazzano to version %s\n", version))
 
 	// Get the timeout value for the upgrade command
-	timeout, err := cmdhelpers.GetWaitTimeout(cmd)
+	timeout, err := cmdhelpers.GetWaitTimeout(cmd, constants.TimeoutFlag)
 	if err != nil {
 		return err
 	}
@@ -143,8 +147,14 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 			return err
 		}
 
+		// Get the VPO timeout
+		vpoTimeout, err := cmdhelpers.GetWaitTimeout(cmd, constants.VPOTimeoutFlag)
+		if err != nil {
+			return err
+		}
+
 		// Wait for the platform operator to be ready before we update the verrazzano install resource
-		vpoPodName, err := cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondUpgradeComplete)
+		vpoPodName, err := cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondUpgradeComplete, vpoTimeout)
 		if err != nil {
 			return err
 		}

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -6,6 +6,9 @@ package upgrade
 import (
 	"bytes"
 	"context"
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	cmdHelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
@@ -16,9 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 // TestUpgradeCmdDefaultNoWait
@@ -94,9 +95,8 @@ func TestUpgradeCmdDefaultNoVPO(t *testing.T) {
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
 
 	// Run upgrade command
-	cmdHelpers.SetVpoWaitRetries(1) // override for unit testing
+	cmd.PersistentFlags().Set(constants.VPOTimeoutFlag, "1s")
 	err := cmd.Execute()
-	cmdHelpers.ResetVpoWaitRetries()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
@@ -123,9 +123,8 @@ func TestUpgradeCmdDefaultMultipleVPO(t *testing.T) {
 	defer cmdHelpers.SetDefaultDeleteFunc()
 
 	// Run upgrade command
-	cmdHelpers.SetVpoWaitRetries(1) // override for unit testing
+	cmd.PersistentFlags().Set(constants.VPOTimeoutFlag, "1s")
 	err := cmd.Execute()
-	cmdHelpers.ResetVpoWaitRetries()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -23,6 +23,9 @@ const (
 	TimeoutFlag     = "timeout"
 	TimeoutFlagHelp = "Limits the amount of time a command will wait to complete"
 
+	VPOTimeoutFlag     = "platform-operator-timeout"
+	VPOTimeoutFlagHelp = "Limits the amount of time the CLI will wait for the Verrazzano Platform Operator to be ready"
+
 	VersionFlag            = "version"
 	VersionFlagDefault     = "latest"
 	VersionFlagInstallHelp = "The version of Verrazzano to install"

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	TimeoutFlagHelp = "Limits the amount of time a command will wait to complete"
 
 	VPOTimeoutFlag     = "platform-operator-timeout"
-	VPOTimeoutFlagHelp = "Limits the amount of time the CLI will wait for the Verrazzano Platform Operator to be ready"
+	VPOTimeoutFlagHelp = "Limits the amount of time a command will wait for the Verrazzano Platform Operator to be ready"
 
 	VersionFlag            = "version"
 	VersionFlagDefault     = "latest"


### PR DESCRIPTION
Add a VZ command line option to override the hard coded value of 5 minutes that the CLI waits for VPO to start.

Updated the HA test pipeline to use a longer wait timeout.