### PR TITLE
VZ-7294: Disable console tests during HA in place upgrade

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -454,6 +454,9 @@ pipeline {
                             }
                         }
                         stage ('console') {
+                            when {
+                                expression { false }
+                            }
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
                             }


### PR DESCRIPTION
Disable console tests during HA in place upgrade