### PR TITLE
VZ-7482: Increase HA pipeline timeout to 4 hours

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -431,17 +431,17 @@ pipeline {
                                 OKE_CLUSTER_ID="${OKE_CLUSTER_ID}"
                             }
                             steps {
-                                runGinkgoFailFast('ha/inplaceupgrade', "--timeout=90m")
+                                runGinkgoFailFast('ha/inplaceupgrade')
                             }
                         }
                         stage('HA Tests') {
                             steps {
-                                runGinkgoRandomize('ha/monitor', "--timeout=90m")
+                                runGinkgoRandomize('ha/monitor')
                             }
                         }
                         stage('Access Hello Helidon') {
                             steps {
-                                runGinkgo("ha/helidon", "--timeout=90m --namespace=${HELIDON_TEST_NAMESPACE}")
+                                runGinkgo("ha/helidon", "--namespace=${HELIDON_TEST_NAMESPACE}")
                             }
                         }
                         stage ('console') {
@@ -552,12 +552,12 @@ pipeline {
     }
 }
 
-def runGinkgoRandomize(testSuitePath, arguments = '') {
+def runGinkgoRandomize(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p $arguments --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+                ginkgo --timeout=90m -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
             fi
         """
     }
@@ -567,7 +567,7 @@ def runGinkgo(testSuitePath, arguments = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v -keep-going $arguments --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            ginkgo --timeout=90m -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
         """
     }
 }
@@ -576,7 +576,7 @@ def runGinkgoFailFast(testSuitePath, arguments = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --fail-fast $arguments --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            ginkgo --timeout=90m -v --fail-fast --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
         """
     }
 }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -557,7 +557,7 @@ def runGinkgoRandomize(testSuitePath, arguments = '') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
+                ginkgo -p $arguments --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
             fi
         """
     }
@@ -567,7 +567,7 @@ def runGinkgo(testSuitePath, arguments = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
+            ginkgo -v -keep-going $arguments --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }
@@ -576,7 +576,7 @@ def runGinkgoFailFast(testSuitePath, arguments = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --fail-fast --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
+            ginkgo -v --fail-fast $arguments --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -424,36 +424,24 @@ pipeline {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/ha-tests"
                     }
-                    options {
-                        timeout(time: 90, unit: "MINUTES")
-                    }
                     parallel {
                         stage('K8s In-place Upgrade') {
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/inplaceupgrade"
                                 OKE_CLUSTER_ID="${OKE_CLUSTER_ID}"
                             }
-                            options {
-                                timeout(time: 90, unit: "MINUTES")
-                            }
                             steps {
-                                runGinkgoFailFast('ha/inplaceupgrade')
+                                runGinkgoFailFast('ha/inplaceupgrade', "--timeout=90m")
                             }
                         }
                         stage('HA Tests') {
-                            options {
-                                timeout(time: 90, unit: "MINUTES")
-                            }
                             steps {
-                                runGinkgoRandomize('ha/monitor')
+                                runGinkgoRandomize('ha/monitor', "--timeout=90m")
                             }
                         }
                         stage('Access Hello Helidon') {
-                            options {
-                                timeout(time: 90, unit: "MINUTES")
-                            }
                             steps {
-                                runGinkgo("ha/helidon", "--namespace=${HELIDON_TEST_NAMESPACE}")
+                                runGinkgo("ha/helidon", "--timeout=90m --namespace=${HELIDON_TEST_NAMESPACE}")
                             }
                         }
                         stage ('console') {
@@ -462,9 +450,6 @@ pipeline {
                             }
                             environment {
                                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
-                            }
-                            options {
-                                timeout(time: 90, unit: "MINUTES")
                             }
                             steps {
                                 sh "CONSOLE_REPO_BRANCH=${params.CONSOLE_REPO_BRANCH} ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh"
@@ -567,12 +552,12 @@ pipeline {
     }
 }
 
-def runGinkgoRandomize(testSuitePath) {
+def runGinkgoRandomize(testSuitePath, arguments = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- $arguments
             fi
         """
     }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -14,7 +14,7 @@ Collections.shuffle(availableRegions)
 
 pipeline {
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         skipDefaultCheckout true
         timestamps ()
     }
@@ -423,6 +423,9 @@ pipeline {
                     }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/ha-tests"
+                    }
+                    options {
+                        timeout(time: 90, unit: "MINUTES")
                     }
                     parallel {
                         stage('K8s In-place Upgrade') {


### PR DESCRIPTION
Increase HA pipeline timeout, and extend ginkgo tests to timeout after 90m (default is 1 hour)