### PR TITLE
Add check for empty Rancher manifest YAML

### DIFF
--- a/platform-operator/controllers/clusters/sync_manifest_secret.go
+++ b/platform-operator/controllers/clusters/sync_manifest_secret.go
@@ -79,6 +79,11 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 				msg := fmt.Sprintf("Failed to register managed cluster with Rancher: %v", err)
 				r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, clusterID, msg)
 				r.log.Info("Failed to register managed cluster, manifest secret will not contain Rancher YAML")
+			} else if len(rancherYAML) == 0 {
+				// we successfully called the Rancher API but for some reason the returned registration manifest YAML is empty,
+				// set the status on the VMC and return an error so we reconcile again
+				r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, clusterID, "Empty Rancher manifest YAML")
+				return vzVMCWaitingForClusterID, r.log.ErrorNewErr("Failed retrieving Rancher manifest, YAML is an empty string")
 			} else {
 				msg := "Registration of managed cluster completed successfully"
 				r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationCompleted, clusterID, msg)


### PR DESCRIPTION
This PR adds a check for the case where we fetch the registration manifest from the Rancher API and the call returns success, but the manifest is empty. We have seen a few test pipeline failures where this appears to be the case, so this will help to identify the condition. Returning an error in this case also forces a re-reconcile and the manifest should eventually be non-empty.

I also added unit test coverage for an unrelated function, as it was the only function in the file that had very little coverage.