### PR TITLE
VZ 7470: Component Availability helpers

### DIFF
--- a/pkg/k8s/ready/available.go
+++ b/pkg/k8s/ready/available.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ready
+
+import (
+	"context"
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	typeDeployment  = "deployment"
+	typeStatefulset = "statefulset"
+	typeDaemonset   = "daemonset"
+	typeIngress     = "ingress"
+)
+
+type (
+	isObjectReadySig    func(client clipkg.Client, nsn types.NamespacedName) error
+	AvailabilityObjects struct {
+		StatefulsetNames []types.NamespacedName
+		DeploymentNames  []types.NamespacedName
+		DaemonsetNames   []types.NamespacedName
+		Ingresses        []types.NamespacedName
+	}
+)
+
+func (c *AvailabilityObjects) IsAvailable(log vzlog.VerrazzanoLogger, client clipkg.Client) (string, bool) {
+	if err := DeploymentsAreAvailable(client, c.DeploymentNames); err != nil {
+		return handleNotAvailableError(log, err)
+	}
+	if err := StatefulsetsAreAvailable(client, c.StatefulsetNames); err != nil {
+		return handleNotAvailableError(log, err)
+	}
+	if err := DaemonsetsAreAvailable(client, c.DaemonsetNames); err != nil {
+		return handleNotAvailableError(log, err)
+	}
+	if err := IngressesAreAvailable(client, c.Ingresses); err != nil {
+		return handleNotAvailableError(log, err)
+	}
+	return "", true
+}
+
+func handleNotAvailableError(log vzlog.VerrazzanoLogger, err error) (string, bool) {
+	log.Progressf(err.Error())
+	return err.Error(), false
+}
+
+// DeploymentsAreAvailable a list of deployments is available when the expected replicas is equal to the ready replicas
+func DeploymentsAreAvailable(client clipkg.Client, deployments []types.NamespacedName) error {
+	return objectsAreAvailable(client, deployments, isDeploymentAvailable)
+}
+
+// StatefulsetsAreAvailable a list of statefulsets is available when the expected replicas is equal to the ready replicas
+func StatefulsetsAreAvailable(client clipkg.Client, statefulsets []types.NamespacedName) error {
+	return objectsAreAvailable(client, statefulsets, isStatefulsetAvailable)
+}
+
+// DaemonsetsAreAvailable a list of daemonsets is available when the expected replicas is equal to the ready replicas
+func DaemonsetsAreAvailable(client clipkg.Client, daemonsets []types.NamespacedName) error {
+	return objectsAreAvailable(client, daemonsets, isDaemonsetAvailable)
+}
+
+func IngressesAreAvailable(client clipkg.Client, ingresses []types.NamespacedName) error {
+	return objectsAreAvailable(client, ingresses, isIngressAvailable)
+}
+
+func objectsAreAvailable(client clipkg.Client, objectKeys []types.NamespacedName, objectReadyFunc isObjectReadySig) error {
+	for _, nsn := range objectKeys {
+		if err := objectReadyFunc(client, nsn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isDeploymentAvailable(client clipkg.Client, nsn types.NamespacedName) error {
+	deploy := &appsv1.Deployment{}
+	if err := client.Get(context.TODO(), nsn, deploy); err != nil {
+		return handleGetError(err, nsn, typeDeployment)
+	}
+	return handleReplicasNotReady(deploy.Status.ReadyReplicas, deploy.Status.Replicas, nsn, typeDeployment)
+}
+
+func isStatefulsetAvailable(client clipkg.Client, nsn types.NamespacedName) error {
+	sts := &appsv1.StatefulSet{}
+	if err := client.Get(context.TODO(), nsn, sts); err != nil {
+		return handleGetError(err, nsn, typeStatefulset)
+	}
+	return handleReplicasNotReady(sts.Status.ReadyReplicas, sts.Status.Replicas, nsn, typeStatefulset)
+}
+
+func isDaemonsetAvailable(client clipkg.Client, nsn types.NamespacedName) error {
+	ds := &appsv1.DaemonSet{}
+	if err := client.Get(context.TODO(), nsn, ds); err != nil {
+		return handleGetError(err, nsn, typeDaemonset)
+	}
+	return handleReplicasNotReady(ds.Status.NumberReady, ds.Status.DesiredNumberScheduled, nsn, typeDaemonset)
+}
+
+func isIngressAvailable(client clipkg.Client, nsn types.NamespacedName) error {
+	ing := networkingv1.Ingress{}
+	if err := client.Get(context.TODO(), nsn, &ing); err != nil {
+		return handleGetError(err, nsn, typeIngress)
+	}
+	return nil
+}
+
+func handleGetError(err error, nsn types.NamespacedName, objectType string) error {
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("waiting for %s %v to exist", objectType, nsn)
+	}
+	return fmt.Errorf("failed getting %s %v: %v", objectType, nsn, err)
+}
+
+func handleReplicasNotReady(ready, expected int32, nsn types.NamespacedName, objectType string) error {
+	if ready != expected {
+		return fmt.Errorf("%s %v not available: %d/%d replicas ready", objectType, nsn, ready, expected)
+	}
+	return nil
+}

--- a/pkg/k8s/ready/available_test.go
+++ b/pkg/k8s/ready/available_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ready
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestIsComponentAvailable(t *testing.T) {
+	const (
+		zeroReplicas = 0
+		oneReplica   = 1
+		name         = "foo"
+		namespace    = "bar"
+	)
+	emptyClient := fake.NewClientBuilder().WithScheme(getScheme()).Build()
+	nsn := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+	objectMeta := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+	readyAndAvailableClient := fake.NewClientBuilder().WithScheme(getScheme()).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: objectMeta,
+			Status: appsv1.DeploymentStatus{
+				Replicas:      oneReplica,
+				ReadyReplicas: oneReplica,
+			},
+		}, &appsv1.StatefulSet{
+			ObjectMeta: objectMeta,
+			Status: appsv1.StatefulSetStatus{
+				Replicas:      oneReplica,
+				ReadyReplicas: oneReplica,
+			},
+		}, &appsv1.DaemonSet{
+			ObjectMeta: objectMeta,
+			Status: appsv1.DaemonSetStatus{
+				NumberReady:            oneReplica,
+				DesiredNumberScheduled: oneReplica,
+			},
+		}, &networkingv1.Ingress{
+			ObjectMeta: objectMeta,
+		}).Build()
+	unreadyClient := fake.NewClientBuilder().WithScheme(getScheme()).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: objectMeta,
+			Status: appsv1.DeploymentStatus{
+				Replicas:      oneReplica,
+				ReadyReplicas: zeroReplicas,
+			},
+		}, &appsv1.StatefulSet{
+			ObjectMeta: objectMeta,
+			Status: appsv1.StatefulSetStatus{
+				Replicas:      oneReplica,
+				ReadyReplicas: zeroReplicas,
+			},
+		}, &appsv1.DaemonSet{
+			ObjectMeta: objectMeta,
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: oneReplica,
+				NumberReady:            zeroReplicas,
+			},
+		}, &networkingv1.Ingress{
+			ObjectMeta: objectMeta,
+		}).Build()
+	var tests = []struct {
+		name      string
+		ao        *AvailabilityObjects
+		client    clipkg.Client
+		available bool
+	}{
+		{
+			"available when no objects",
+			&AvailabilityObjects{},
+			emptyClient,
+			true,
+		},
+		{
+			"unavailable when deploy not present",
+			&AvailabilityObjects{
+				DeploymentNames: []types.NamespacedName{nsn},
+			},
+			emptyClient,
+			false,
+		},
+		{
+			"unavailable when sts not present",
+			&AvailabilityObjects{
+				StatefulsetNames: []types.NamespacedName{nsn},
+			},
+			emptyClient,
+			false,
+		},
+		{
+			"unavailable when ds not present",
+			&AvailabilityObjects{
+				DaemonsetNames: []types.NamespacedName{nsn},
+			},
+			emptyClient,
+			false,
+		},
+		{
+			"unavailable when ing not present",
+			&AvailabilityObjects{
+				Ingresses: []types.NamespacedName{nsn},
+			},
+			emptyClient,
+			false,
+		},
+		{
+			"unavailable when deploy replicas not ready",
+			&AvailabilityObjects{
+				DeploymentNames: []types.NamespacedName{nsn},
+			},
+			unreadyClient,
+			false,
+		},
+		{
+			"unavailable when sts replicas not ready",
+			&AvailabilityObjects{
+				StatefulsetNames: []types.NamespacedName{nsn},
+			},
+			unreadyClient,
+			false,
+		},
+		{
+			"unavailable when ds replicas not ready",
+			&AvailabilityObjects{
+				DaemonsetNames: []types.NamespacedName{nsn},
+			},
+			unreadyClient,
+			false,
+		},
+		{
+			"available when all objects present",
+			&AvailabilityObjects{
+				DeploymentNames:  []types.NamespacedName{nsn},
+				StatefulsetNames: []types.NamespacedName{nsn},
+				DaemonsetNames:   []types.NamespacedName{nsn},
+				Ingresses:        []types.NamespacedName{nsn},
+			},
+			readyAndAvailableClient,
+			true,
+		},
+	}
+
+	log := vzlog.DefaultLogger()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, available := tt.ao.IsAvailable(log, tt.client)
+			assert.Equal(t, tt.available, available)
+		})
+	}
+}

--- a/pkg/k8s/ready/available_test.go
+++ b/pkg/k8s/ready/available_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,8 +49,6 @@ func TestIsComponentAvailable(t *testing.T) {
 				NumberReady:            oneReplica,
 				DesiredNumberScheduled: oneReplica,
 			},
-		}, &networkingv1.Ingress{
-			ObjectMeta: objectMeta,
 		}).Build()
 	unreadyClient := fake.NewClientBuilder().WithScheme(getScheme()).
 		WithObjects(&appsv1.Deployment{
@@ -72,8 +69,6 @@ func TestIsComponentAvailable(t *testing.T) {
 				DesiredNumberScheduled: oneReplica,
 				NumberReady:            zeroReplicas,
 			},
-		}, &networkingv1.Ingress{
-			ObjectMeta: objectMeta,
 		}).Build()
 	var tests = []struct {
 		name      string
@@ -112,14 +107,6 @@ func TestIsComponentAvailable(t *testing.T) {
 			false,
 		},
 		{
-			"unavailable when ing not present",
-			&AvailabilityObjects{
-				Ingresses: []types.NamespacedName{nsn},
-			},
-			emptyClient,
-			false,
-		},
-		{
 			"unavailable when deploy replicas not ready",
 			&AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{nsn},
@@ -149,7 +136,6 @@ func TestIsComponentAvailable(t *testing.T) {
 				DeploymentNames:  []types.NamespacedName{nsn},
 				StatefulsetNames: []types.NamespacedName{nsn},
 				DaemonsetNames:   []types.NamespacedName{nsn},
-				Ingresses:        []types.NamespacedName{nsn},
 			},
 			readyAndAvailableClient,
 			true,

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -6,6 +6,7 @@ package appoper
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
@@ -53,7 +54,7 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			Dependencies:              []string{networkpolicies.ComponentName, oam.ComponentName, istio.ComponentName},
 			GetInstallOverridesFunc:   GetOverrides,
-			AvailabilityObjects: &common.ComponentAvailabilityObjects{
+			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{
 						Name:      ComponentName,

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -53,6 +53,14 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			Dependencies:              []string{networkpolicies.ComponentName, oam.ComponentName, istio.ComponentName},
 			GetInstallOverridesFunc:   GetOverrides,
+			AvailabilityObjects: &common.ComponentAvailabilityObjects{
+				DeploymentNames: []types.NamespacedName{
+					{
+						Name:      ComponentName,
+						Namespace: ComponentNamespace,
+					},
+				},
+			},
 		},
 	}
 }
@@ -63,14 +71,6 @@ func (c applicationOperatorComponent) IsReady(context spi.ComponentContext) bool
 		return isApplicationOperatorReady(context)
 	}
 	return false
-}
-
-func (c applicationOperatorComponent) IsAvailable(context spi.ComponentContext) (reason string, available bool) {
-	available = c.IsReady(context)
-	if available {
-		return fmt.Sprintf("%s is available", c.Name()), true
-	}
-	return fmt.Sprintf("%s is unavailable: failed readiness checks", c.Name()), false
 }
 
 // PreUpgrade processing for the application-operator

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -108,7 +108,7 @@ type HelmComponent struct {
 	// Certificates associated with the component
 	Certificates []types.NamespacedName
 
-	AvailabilityObjects *common.ComponentAvailabilityObjects
+	AvailabilityObjects *ready.AvailabilityObjects
 }
 
 // Verify that HelmComponent implements Component
@@ -224,7 +224,7 @@ func (h HelmComponent) IsInstalled(context spi.ComponentContext) (bool, error) {
 // if the check fails.
 func (h HelmComponent) IsAvailable(context spi.ComponentContext) (reason string, available bool) {
 	if h.AvailabilityObjects != nil {
-		return h.AvailabilityObjects.IsAvailable(context)
+		return h.AvailabilityObjects.IsAvailable(context.Log(), context.Client())
 	}
 	return "", true
 }

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -107,6 +107,8 @@ type HelmComponent struct {
 
 	// Certificates associated with the component
 	Certificates []types.NamespacedName
+
+	AvailabilityObjects *common.ComponentAvailabilityObjects
 }
 
 // Verify that HelmComponent implements Component
@@ -221,11 +223,10 @@ func (h HelmComponent) IsInstalled(context spi.ComponentContext) (bool, error) {
 // Components should implement comprehensive availability checks, supplying an appropriate reason
 // if the check fails.
 func (h HelmComponent) IsAvailable(context spi.ComponentContext) (reason string, available bool) {
-	available = h.IsReady(context)
-	if available {
-		return fmt.Sprintf("%s is available", h.Name()), true
+	if h.AvailabilityObjects != nil {
+		return h.AvailabilityObjects.IsAvailable(context)
 	}
-	return fmt.Sprintf("%s is unavailable: failed readiness checks", h.Name()), false
+	return "", true
 }
 
 // IsReady Indicates whether a component is available and ready


### PR DESCRIPTION
Implement component availability helpers, if component owned deploy, sts, ds, ing objects are 'available', the component is available. Availability attempts to make use of existing pod readiness gates to keep things simple - ideally a pod's readiness gate should correspond with its availability.

Will follow up with implementations for remaining components, so where will be some minor changes. App operator is implemented as an example.