### PR TITLE
VZ-7402: Backporting Bug fix to release-1.4: Opensearch Dashboards does not redirect to login on session

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -471,9 +471,9 @@ data:
             end
         end
         if backend_name == "kibana" then
-            if not (uri == "/" or uri:find("/app/kibana") == 1) then
-                able_to_redirect = false
-            end
+           if not (uri == "/" or uri:find("/app/") == 1) then
+               able_to_redirect = false
+           end
         end
         if able_to_redirect == true then
             me.debug("returning backend_name '"..backend_name.."', able_to_redirect is true")


### PR DESCRIPTION
In case, Opensearch URL has path/URI other than "/" and "home/kibana", authproxy was throwing unauthenticated error if cookies gets expired.
For example,
https://kibana.<url>.nip.io/ was getting redirected to keycloakwas getting redirected to keycloak
but
https://kibana.<url>.nip.io/app/management/opensearch-dashboards was getting 401 error.
In this MR, updated OSD redirecting check for Keycloak to /app/* instead of /app/kibana
