### PR TITLE
VZ-7150: namespaceLabelKey renamed to VerrrazzanoManagedKey

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -224,3 +224,6 @@ const ResticDaemonSetName = "restic"
 
 // RancherBackupNamesSpace indicates the namespace to be used for Rancher Backup installation
 const RancherBackupNamesSpace = "cattle-resources-system"
+
+// VerrazzanoManagedKey indicates the label key to the Verrazzano managed namespaces
+const VerrazzanoManagedKey = "verrazzano.io/namespace"

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager.go
@@ -89,8 +89,6 @@ const (
 	// Uninstall resources
 	controllerConfigMap = "cert-manager-controller"
 	caInjectorConfigMap = "cert-manager-cainjector-leader-election"
-
-	vzNsLabel = "verrazzano.io/namespace"
 )
 
 type authenticationType string

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component.go
@@ -281,11 +281,14 @@ func checkExistingCertManager(vz runtime.Object) error {
 	if err != nil {
 		return err
 	}
-	ns, err := client.Namespaces().List(context.TODO(), metav1.ListOptions{})
-	if err != nil && !kerrs.IsNotFound(err) {
-		return err
+	ns, err := client.Namespaces().Get(context.TODO(), ComponentNamespace, metav1.GetOptions{})
+	if err != nil {
+		if !kerrs.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
-	if err = common.CheckExistingNamespace(ns.Items, func(namespace *v1.Namespace) bool {
+	if err = common.CheckExistingNamespace([]v1.Namespace{*ns}, func(namespace *v1.Namespace) bool {
 		if namespace.Name == ComponentNamespace || namespace.Namespace == ComponentNamespace {
 			return true
 		}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager_component_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
 	cmutil "github.com/jetstack/cert-manager/pkg/api/util"
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -46,13 +48,11 @@ const (
 
 var (
 	mockNamespaceCoreV1Client = common.MockGetCoreV1(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name:      ComponentName,
-		Namespace: ComponentNamespace,
-		Labels:    map[string]string{vzNsLabel: ComponentNamespace},
+		Name:   ComponentName,
+		Labels: map[string]string{constants.VerrazzanoManagedKey: ComponentNamespace},
 	}})
 	mockNamespaceWithoutLabelClient = common.MockGetCoreV1(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name:      ComponentName,
-		Namespace: ComponentNamespace,
+		Name: ComponentName,
 	}})
 )
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -52,7 +52,6 @@ const (
 	FleetSystemNamespace      = "cattle-fleet-system"
 	FleetLocalSystemNamespace = "cattle-fleet-local-system"
 	defaultSecretNamespace    = "cert-manager"
-	namespaceLabelKey         = "verrazzano.io/namespace"
 	rancherTLSSecretName      = "tls-ca"
 	defaultVerrazzanoName     = "verrazzano-ca-certificate-secret"
 	fleetAgentDeployment      = "fleet-agent"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -556,7 +556,7 @@ func TestValidateInstall(t *testing.T) {
 	labelledNamespace := &corev1.Namespace{}
 	labelledNamespace.Name = FleetSystemNamespace
 	labelledNamespace.Namespace = FleetSystemNamespace
-	labelledNamespace.Labels = map[string]string{namespaceLabelKey: FleetSystemNamespace}
+	labelledNamespace.Labels = map[string]string{constants.VerrazzanoManagedKey: FleetSystemNamespace}
 	vz := &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
 			Components: vzapi.ComponentSpec{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
@@ -6,6 +6,7 @@ package rancher
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"strings"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -158,8 +159,8 @@ func labelNamespace(c client.Client) error {
 		return err
 	}
 	for i := range nsList.Items {
-		if _, found := nsList.Items[i].Labels[namespaceLabelKey]; isRancherNamespace(&(nsList.Items[i])) && !found {
-			nsList.Items[i].Labels[namespaceLabelKey] = nsList.Items[i].Name
+		if _, found := nsList.Items[i].Labels[constants.VerrazzanoManagedKey]; isRancherNamespace(&(nsList.Items[i])) && !found {
+			nsList.Items[i].Labels[constants.VerrazzanoManagedKey] = nsList.Items[i].Name
 			c.Update(context.TODO(), &(nsList.Items[i]), &client.UpdateOptions{})
 		}
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -148,7 +150,7 @@ func TestLabelNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: FleetSystemNamespace,
 			Labels: map[string]string{
-				namespaceLabelKey: FleetSystemNamespace,
+				constants.VerrazzanoManagedKey: FleetSystemNamespace,
 			},
 		},
 	}
@@ -156,7 +158,7 @@ func TestLabelNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: FleetSystemNamespace,
 			Labels: map[string]string{
-				namespaceLabelKey: FleetSystemNamespace,
+				constants.VerrazzanoManagedKey: FleetSystemNamespace,
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
@@ -6,6 +6,8 @@ package rancher
 import (
 	"context"
 
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -25,11 +27,11 @@ func createCattleSystemNamespace(log vzlog.VerrazzanoLogger, c client.Client) er
 	}
 	log.Debugf("Creating %s namespace", common.CattleSystem)
 	if _, err := controllerruntime.CreateOrUpdate(context.TODO(), c, namespace, func() error {
-		log.Debugf("Ensuring %s label is present on %s namespace", namespaceLabelKey, common.CattleSystem)
+		log.Debugf("Ensuring %s label is present on %s namespace", constants.VerrazzanoManagedKey, common.CattleSystem)
 		if namespace.Labels == nil {
 			namespace.Labels = map[string]string{}
 		}
-		namespace.Labels[namespaceLabelKey] = common.RancherName
+		namespace.Labels[constants.VerrazzanoManagedKey] = common.RancherName
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
Following Review/comment fixed in this MR.
1. namespaceLabelKey renamed to verrrazzanoManagedKey
2.  In checkExistingCertManager function, single namespace is fetched instead of list of namespace.
