### PR TITLE
Fix Rancher cluster sync logger

### DIFF
--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -39,7 +39,7 @@ type RancherClusterSyncer struct {
 func (r *RancherClusterSyncer) StartSyncing() {
 	// initialize logger - the AddCallerSkip is needed otherwise the caller in the log message always shows "vzlog.go"
 	l := r.Log.Desugar().WithOptions(zap.AddCallerSkip(2))
-	log := vzlog.EnsureContext("rancher_cluster_sync").EnsureLogger("syncer", l.Sugar(), zap.S()).SetFrequency(300)
+	log := vzlog.EnsureContext("rancher_cluster_sync").EnsureLogger("syncer", l.Sugar(), zap.S())
 
 	log.Info("Starting Rancher cluster synchronizing loop")
 

--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -33,11 +32,15 @@ var clustersResponseHash []byte
 
 type RancherClusterSyncer struct {
 	client.Client
+	Log *zap.SugaredLogger
 }
 
 // StartSyncing starts the Rancher cluster synchronization loop
 func (r *RancherClusterSyncer) StartSyncing() {
-	log := r.initLogger()
+	// initialize logger - the AddCallerSkip is needed otherwise the caller in the log message always shows "vzlog.go"
+	l := r.Log.Desugar().WithOptions(zap.AddCallerSkip(2))
+	log := vzlog.EnsureContext("rancher_cluster_sync").EnsureLogger("syncer", l.Sugar(), zap.S()).SetFrequency(300)
+
 	log.Info("Starting Rancher cluster synchronizing loop")
 
 	// prevent a panic from taking down the operator
@@ -51,17 +54,6 @@ func (r *RancherClusterSyncer) StartSyncing() {
 		r.syncRancherClusters(log)
 		time.Sleep(time.Minute)
 	}
-}
-
-// initLogger initializes the Verrazzano logger
-func (r *RancherClusterSyncer) initLogger() vzlog.VerrazzanoLogger {
-	zaplog, err := log.BuildZapInfoLogger(2)
-	if err != nil {
-		// failed so fall back to the basic zap sugared logger
-		zaplog = zap.S()
-	}
-	// set frequency on the logger so progress messages are logged once every 5 minutes
-	return vzlog.EnsureContext("rancher_cluster_sync").EnsureLogger("syncer", zaplog, zaplog).SetFrequency(300)
 }
 
 // syncRancherClusters gets the list of clusters from Rancher and creates and deletes VMC resources

--- a/platform-operator/controllers/clusters/sync_rancher_clusters.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters.go
@@ -65,7 +65,7 @@ func (r *RancherClusterSyncer) syncRancherClusters(log vzlog.VerrazzanoLogger) {
 		return
 	}
 
-	log.Progress("Synchronizing Rancher clusters and VMCs")
+	log.Debug("Synchronizing Rancher clusters and VMCs")
 
 	// call Rancher to get the list of clusters
 	rc, err := newRancherConfig(r.Client, log)

--- a/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
+++ b/platform-operator/controllers/clusters/sync_rancher_clusters_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/test/mockmatchers"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -76,7 +77,7 @@ func TestSyncRancherClusters(t *testing.T) {
 
 	// call the syncer
 	r := &RancherClusterSyncer{Client: k8sFake}
-	log := r.initLogger()
+	log := vzlog.DefaultLogger()
 	r.syncRancherClusters(log)
 
 	mocker.Finish()
@@ -134,7 +135,7 @@ func TestSyncRancherClustersWithPaging(t *testing.T) {
 
 	// call the syncer
 	r := &RancherClusterSyncer{Client: k8sFake}
-	log := r.initLogger()
+	log := vzlog.DefaultLogger()
 	r.syncRancherClusters(log)
 
 	mocker.Finish()
@@ -206,7 +207,7 @@ func TestEnsureVMCsWithError(t *testing.T) {
 
 	rancherClusters := []rancherCluster{{name: "test", id: "test"}}
 	r := &RancherClusterSyncer{Client: &erroringFakeClient{Client: k8sFake}}
-	log := r.initLogger()
+	log := vzlog.DefaultLogger()
 
 	// GIVEN a list of Rancher clusters fetched from the Rancher API
 	//  WHEN a call is made to ensureVMCs and the k8s client returns an error on a call to Create

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -362,6 +362,7 @@ func reconcilePlatformOperator(config internalconfig.OperatorConfig, log *zap.Su
 	// Start the goroutine to sync Rancher clusters and VerrazzanoManagedCluster objects
 	rancherClusterSyncer := &clusterscontroller.RancherClusterSyncer{
 		Client: mgr.GetClient(),
+		Log:    log,
 	}
 	go rancherClusterSyncer.StartSyncing()
 


### PR DESCRIPTION
The logger in the Rancher cluster sync code was not being set correctly. As a result the log level configured on the VPO (via command line switch) was not honored. I tested by setting the log level to debug on the VPO and confirmed that debug log message appear.

I also changed a Progress message to a Debug message.