### PR TITLE
Add timestamps to the upgrade test pipeline

### DIFF
--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -8,6 +8,7 @@ def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 pipeline {
     options {
         skipDefaultCheckout true
+        timestamps ()
     }
 
     agent {


### PR DESCRIPTION
Add timestamps to the upgrade test pipeline so we get them in the build console output
