### PR TITLE
VZ-7564 Update PSR metrics port and path

### DIFF
--- a/tools/psr/backend/metrics/server.go
+++ b/tools/psr/backend/metrics/server.go
@@ -35,8 +35,7 @@ func StartMetricsServerOrDie(providers []spi.WorkerMetricsProvider) {
 	server := http.Server{
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
-		Addr:         "0.0.0.0:9090"}
-
+		Addr:         "0.0.0.0:8080"}
 	if err := server.ListenAndServe(); err != nil {
 		zap.S().Errorf("Failed to start metrics server: %v", err)
 		os.Exit(1)

--- a/tools/psr/manifests/charts/worker/templates/appconfig.yaml
+++ b/tools/psr/manifests/charts/worker/templates/appconfig.yaml
@@ -19,7 +19,7 @@ spec:
             kind: MetricsTrait
             spec:
               scraper: verrazzano-system/vmi-system-prometheus-0
-              path: "/actuator/prometheus"
+              path: "/metrics"
         - trait:
             apiVersion: core.oam.dev/v1alpha2
             kind: ManualScalerTrait


### PR DESCRIPTION
This change updates the metrics scrape port and path to pull the metrics into prometheus.