### PR TITLE
Tvlatas/backend tests

### DIFF
--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -1,0 +1,494 @@
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+import groovy.transform.Field
+
+@Field
+def GIT_COMMIT_TO_USE = ""
+@Field
+def LAST_CLEAN_BACKEND_COMMIT = ""
+def agentLabel = env.JOB_NAME.contains('master') ? "phx-small" : "small"
+@Field
+def TESTS_FAILED = false
+@Field
+def storeLocation=""
+@Field
+def verrazzanoPrefix="verrazzano-"
+@Field
+def fullBundle=""
+@Field
+def liteBundle=""
+@Field
+def SUSPECT_LIST = ""
+@Field
+def COMPARISON_URL_ON_FAILURE = ""
+
+@Field
+def backendTestsUpToDate              = false // If true, indicates that the backend tests already passed at the latest commit
+
+// Non Fields
+def branchSpecificSchedule = getCronSchedule()
+
+// File containing the links to download the Verrazzano distributions
+@Field
+def verrazzanoDistributionsFile = "verrazzano_distributions.html"
+
+pipeline {
+    options {
+        timeout(time: 12, unit: 'HOURS')
+        skipDefaultCheckout true
+        disableConcurrentBuilds()
+        timestamps ()
+    }
+
+    agent {
+       docker {
+            image "${RUNNER_DOCKER_IMAGE}"
+            args "${RUNNER_DOCKER_ARGS}"
+            registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
+            registryCredentialsId 'ocir-pull-and-push-account'
+            label "${agentLabel}"
+        }
+    }
+
+    triggers {
+        cron(branchSpecificSchedule)
+    }
+
+    parameters {
+        booleanParam (description: 'Skip tests to private registry stage, useful for testing out private registry testing, support and push to OCIR', name: 'SKIP_TO_PRIVATE_REGISTRY', defaultValue: false)
+        string (name: 'TAGGED_TESTS',
+                defaultValue: '',
+                description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
+                trim: true)
+        string (name: 'INCLUDED_TESTS',
+                defaultValue: '.*',
+                description: 'A regex matching any fully qualified test file that should be executed (e.g. examples/helidon/). Default: .*',
+                trim: true)
+        string (name: 'EXCLUDED_TESTS',
+                defaultValue: '_excluded_test',
+                description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
+                trim: true)
+        booleanParam (description: 'Force execution of the tests even if up-to-date', name: 'FORCE', defaultValue: false)
+        booleanParam (description: 'Skip test execution (for debugging)', name: 'DRY_RUN', defaultValue: false)
+    }
+
+    environment {
+        IS_BACKEND_PIPELINE = "true"
+        OCIR_SCAN_COMPARTMENT = credentials('ocir-scan-compartment')
+        OCIR_SCAN_TARGET = credentials('ocir-scan-target')
+        OCIR_SCAN_REGISTRY = credentials('ocir-scan-registry')
+        OCIR_SCAN_REPOSITORY_PATH = credentials('ocir-scan-repository-path')
+        DOCKER_SCAN_CREDS = credentials('v8odev-ocir')
+        DOCKER_CREDS = credentials('github-packages-credentials-rw')
+        DOCKER_REPO = 'ghcr.io'
+
+        OCI_CLI_AUTH="instance_principal"
+        OCI_OS_NAMESPACE = credentials('oci-os-namespace')
+        OCI_OS_BUCKET="verrazzano-builds"
+        OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+        SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
+
+        STABLE_COMMIT_OS_LOCATION = "${CLEAN_BRANCH_NAME}/last-stable-commit.txt"
+        CLEAN_BACKEND_OS_LOCATION = "${CLEAN_BRANCH_NAME}-last-clean-backend-test/verrazzano_backend-commit.txt"
+
+        STABLE_COMMIT_LOCATION = "${WORKSPACE}/last-stable-commit.txt"
+        CLEAN_BACKEND_LOCATION = "${WORKSPACE}/last-clean-backend-commit.txt"
+
+        OCI_OS_REGION="us-phoenix-1"
+    }
+
+    // This job runs against the latest stable master commit. That is defined as the last clean master build and test run whose
+    // commit has been stored in object storage. This job will fetch that commit from master and run extended tests using that.
+    // This job is NOT currently setup to run extended tests from other branches, if you need to run those extended jobs you will
+    // need to run those against your branch individually.
+
+    stages {
+        stage('Check last clean backend') {
+            steps {
+                sh """
+                    oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${STABLE_COMMIT_OS_LOCATION} --file ${STABLE_COMMIT_LOCATION}
+                """
+
+                script {
+                    // Check if there is already a clean backend run at this commit already, and set the display name if
+                    // it already is tested, or if doing a special run type (dry run, etc...)
+                    preliminaryChecks()
+                }
+            }
+        }
+        stage('Clean workspace and checkout') {
+            when {
+                allOf {
+                    expression { return runTests() }
+                }
+            }
+            steps {
+                script {
+                    cleanWorkspaceAndCheckout()
+                }
+            }
+        }
+
+        stage ('Backend Test Suites') {
+            when {
+                allOf {
+                    expression { return runTests() }
+                }
+            }
+            parallel {
+                stage('Upgrade Path Minor Release Tests') {
+                    steps {
+                            script {
+                                build job: "/verrazzano-push-triggered-upgrade-minor-release-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'N_JOBS_FOR_EACH_BATCH', value: '6'),
+                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
+                                    ], wait: true
+                            }
+                    }
+                }
+            }
+        }
+
+        stage('Update Last Clean Backend Test') {
+            when {
+                allOf {
+                    expression { return runTests() }
+                    expression { TESTS_FAILED == false }
+                }
+            }
+            environment {
+                GIT_COMMIT_USED = "${env.GIT_COMMIT}"
+            }
+            steps {
+                script {
+                    sh """
+                        # Update the clean backend commit
+                        echo "git-commit=${GIT_COMMIT_USED}" > commit-that-passed.txt
+                        oci --region ${OCI_OS_REGION} os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BRANCH_NAME}-last-clean-backend-test/verrazzano_backend-commit.txt --file commit-that-passed.txt
+                    """
+                }
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: "**/prerelease_validation.out,**/release_status.out,**/${verrazzanoImagesFile},**/${verrazzanoDistributionsFile}", allowEmptyArchive: true
+        }
+        failure {
+            script {
+                if (isAlertingEnabled()) {
+                    if (isPagerDutyEnabled()) {
+                        pagerduty(resolve: false, serviceKey: "$SERVICE_KEY",
+                        incDescription: "Verrazzano Backend Tests: ${env.JOB_NAME} - Failed",
+                        incDetails: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}")
+                    }
+                    slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nSuspects:\n${SUSPECT_LIST}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}" )
+                    echo "done alerts"
+                }
+            }
+        }
+        cleanup {
+            deleteDir()
+        }
+    }
+}
+
+// Preliminary job checks and display updates
+def preliminaryChecks() {
+    // Get the last stable commit ID to pass the triggered tests
+    def stableCommitProps = readProperties file: "${STABLE_COMMIT_LOCATION}"
+    GIT_COMMIT_TO_USE = stableCommitProps['git-commit']
+    echo "Last stable commit: ${GIT_COMMIT_TO_USE}"
+
+    LAST_CLEAN_BACKEND_COMMIT=getLastCleanBackendCommit()
+    echo "Last clean backend commit: ${LAST_CLEAN_BACKEND_COMMIT}"
+
+    if (LAST_CLEAN_BACKEND_COMMIT == GIT_COMMIT_TO_USE) {
+        backendTestsUpToDate = true
+    }
+
+    echo "Up to date: ${backendTestsUpToDate}"
+    echo "Dry run: ${params.DRY_RUN}"
+    echo "Force run: ${params.FORCE}"
+    echo "Execute tests: " + runTests()
+
+    // Indicate in title if run is up-to-date or dry-run
+    if (params.DRY_RUN) {
+        currentBuild.displayName = "${currentBuild.displayName} : DRY-RUN"
+    }
+    if (backendTestsUpToDate) {
+        currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE"
+    }
+    if (params.FORCE) {
+        currentBuild.displayName = "${currentBuild.displayName} : FORCE"
+    }
+
+    if (runTests()) {
+        echo "Executing backend tests for commit ${GIT_COMMIT_TO_USE}"
+    }
+}
+
+def dockerLogins() {
+    try {
+        sh """
+            echo "${DOCKER_SCAN_CREDS_PSW}" | docker login ${env.OCIR_SCAN_REGISTRY} -u ${DOCKER_SCAN_CREDS_USR} --password-stdin
+        """
+    } catch(error) {
+        echo "docker login failed, retrying after sleep"
+        retry(4) {
+            sleep(30)
+            sh """
+            echo "${DOCKER_SCAN_CREDS_PSW}" | docker login ${env.OCIR_SCAN_REGISTRY} -u ${DOCKER_SCAN_CREDS_USR} --password-stdin
+            """
+        }
+    }
+    if (!(env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.startsWith("release-1."))) {
+        try {
+            sh """
+                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+            """
+        } catch(error) {
+            echo "docker login failed, retrying after sleep"
+            retry(4) {
+                sleep(30)
+                sh """
+                    echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                """
+            }
+        }
+    }
+}
+
+def scmCheckout() {
+    echo "${NODE_LABELS}"
+    echo "SCM checkout of ${GIT_COMMIT_TO_USE}"
+    def scmInfo = checkout([
+        $class: 'GitSCM',
+        branches: [[name: GIT_COMMIT_TO_USE]],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [],
+        submoduleCfg: [],
+        userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
+    env.GIT_COMMIT = scmInfo.GIT_COMMIT
+    env.GIT_BRANCH = scmInfo.GIT_BRANCH
+    echo "SCM checkout of ${env.GIT_BRANCH} at ${env.GIT_COMMIT}"
+    // If the commit we were handed is not what the SCM says we are using, fail
+    if (!env.GIT_COMMIT.equals(GIT_COMMIT_TO_USE)) {
+        error( "SCM didn't checkout the commit we expected. Expected: ${GIT_COMMIT_TO_USE}, Found: ${scmInfo.GIT_COMMIT}")
+    }
+
+    if (LAST_CLEAN_BACKEND_COMMIT != null) {
+        COMPARISON_URL_ON_FAILURE = "https://github.com/verrazzano/verrazzano/compare/${LAST_CLEAN_BACKEND_COMMIT}...${GIT_COMMIT_TO_USE}"
+        def lastClean = "${LAST_CLEAN_BACKEND_COMMIT}"
+        def currentStable = "${GIT_COMMIT_TO_USE}"
+        def commitList = getCommitListFromGitLog(lastClean, currentStable)
+        withCredentials([file(credentialsId: 'jenkins-to-slack-users', variable: 'JENKINS_TO_SLACK_JSON')]) {
+            def userMappings = readJSON file: JENKINS_TO_SLACK_JSON
+            SUSPECT_LIST = getSuspectList(commitList, userMappings)
+            echo "Suspect list: ${SUSPECT_LIST}"
+        }
+    }
+    echo "URL if fails: ${COMPARISON_URL_ON_FAILURE}"
+}
+
+def cleanWorkspaceAndCheckout() {
+    scmCheckout()
+    dockerLogins()
+    TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
+    SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
+    // update the description with some meaningful info
+    currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
+    storeLocation="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+}
+
+// Returns the last clean commit for the backends, or null if the commit file does not exist yet.
+// - fails the pipeline if any error other than 404 is returned by the OCI CLI
+def getLastCleanBackendCommit() {
+    lastBackendCommitCommandOutput = sh (
+        label: "Get last clean backend commit ID",
+        script: "oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${CLEAN_BACKEND_OS_LOCATION} --file ${CLEAN_BACKEND_LOCATION} 2>&1 || true",
+        returnStdout: true
+        ).trim()
+    echo "command out: ${lastBackendCommitCommandOutput}"
+    if (lastBackendCommitCommandOutput.length() > 0) {
+        // We can get warning messages here as well even when the command succeeded, so be more precise on the checking
+        if (lastBackendCommitCommandOutput =~ /(.*)status(.*)\d{1,4}(.*)/) {
+            // If we think we had a status: NNN, we ignore 404 and fail for others
+            assert lastBackendCommitCommandOutput =~ /(.*)status(.*)404(.*)/ : "An unexpected error occurred getting last backend commit from ObjectStore: ${lastBackendCommitCommandOutput}"
+        } else {
+            // If we got here, we have some message that may or may not be an error. If we don't see the file, we assume it was an error
+            sh """
+                if [ ! -f ${CLEAN_BACKEND_LOCATION} ]; then
+                    echo "An unexpected error occurred getting last backend commit from ObjectStore: ${lastBackendCommitCommandOutput}"
+                    exit 1
+                fi
+            """
+        }
+    }
+    // Get the commit ID for the last known clean pass of the Backend tests
+    def cleanBackendsCommitProps = readProperties file: "${CLEAN_BACKEND_LOCATION}"
+    return cleanBackendsCommitProps['git-commit']
+}
+
+// Checks all the conditions gating test execution and coallates the result
+def runTests() {
+  return params.FORCE || ( ! backendTestsUpToDate && ! params.DRY_RUN )
+}
+
+def isAlertingEnabled() {
+    // this controls whether any alerting happens for these tests
+    if (NOTIFY_BACKEND_FAILURES.equals("true") && (env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.startsWith("release-1."))) {
+        echo "Alert notifications enabled for ${env.BRANCH_NAME}"
+        return true
+    }
+    return false
+}
+
+def isPagerDutyEnabled() {
+    // this additionally controls whether PD alerts are enabled (note that you must also enable alerting in general as well if you want these)
+    if (NOTIFY_PAGERDUTY_BACKEND_FAILURES.equals("true")) {
+        echo "Pager-Duty notifications enabled via global override setting"
+        return true
+    }
+    return false
+}
+
+def getCronSchedule() {
+    if (env.BRANCH_NAME.equals("master")) {
+        return "@weekly"
+    } else if (env.BRANCH_NAME.startsWith("release-1")) {
+        return "@weekly"
+    }
+    return ""
+}
+
+// Called in Stage Clean workspace and checkout steps
+def getCommitListFromGitLog(lastClean, currentStable) {
+    echo "Checking for change sets"
+    def commitList = sh(returnStdout: true, script: "git log ${lastClean}...${currentStable} --oneline | cut -d \" \" -f 1").trim().split('\n')
+    for (int i = 0; i < commitList.size(); i++) {
+        echo "Found commit id: ${commitList[i]}"
+    }
+    return commitList
+}
+
+def trimIfGithubNoreplyUser(userIn) {
+    if (userIn == null) {
+        echo "Not a github noreply user, not trimming: ${userIn}"
+        return userIn
+    }
+    if (userIn.matches(".*\\+.*@users.noreply.github.com.*")) {
+        def userOut = userIn.substring(userIn.indexOf("+") + 1, userIn.indexOf("@"))
+        return userOut;
+    }
+    if (userIn.matches(".*<.*@users.noreply.github.com.*")) {
+        def userOut = userIn.substring(userIn.indexOf("<") + 1, userIn.indexOf("@"))
+        return userOut;
+    }
+    if (userIn.matches(".*@users.noreply.github.com")) {
+        def userOut = userIn.substring(0, userIn.indexOf("@"))
+        return userOut;
+    }
+    echo "Not a github noreply user, not trimming: ${userIn}"
+    return userIn
+}
+
+def getSuspectList(commitList, userMappings) {
+    def retValue = ""
+    def suspectList = []
+    if (commitList == null || commitList.size() == 0) {
+        echo "No commits to form suspect list"
+    } else {
+        for (int i = 0; i < commitList.size(); i++) {
+            def id = commitList[i]
+            try {
+                def gitAuthor = sh(
+                    script: "git log --format='%ae' '$id^!'",
+                    returnStdout: true
+                ).trim()
+                if (gitAuthor != null) {
+                    def author = trimIfGithubNoreplyUser(gitAuthor)
+                    echo "DEBUG: author: ${gitAuthor}, ${author}, id: ${id}"
+                    if (userMappings.containsKey(author)) {
+                        def slackUser = userMappings.get(author)
+                        if (!suspectList.contains(slackUser)) {
+                            echo "Added ${slackUser} as suspect"
+                            retValue += " ${slackUser}"
+                            suspectList.add(slackUser)
+                        }
+                    } else {
+                        // If we don't have a name mapping use the commit.author, at least we can easily tell if the mapping gets dated
+                        if (!suspectList.contains(author)) {
+                            echo "Added ${author} as suspect"
+                            retValue += " ${author}"
+                            suspectList.add(author)
+                        }
+                    }
+                } else {
+                    echo "No author returned from git"
+                }
+            } catch (Exception e) {
+                echo "INFO: Problem processing commit ${id}, skipping commit: " + e.toString()
+            }
+        }
+    }
+    def startedByUser = "";
+    def causes = currentBuild.getBuildCauses()
+    echo "causes: " + causes.toString()
+    for (cause in causes) {
+        def causeString = cause.toString()
+        echo "current cause: " + causeString
+        def causeInfo = readJSON text: causeString
+        if (causeInfo.userId != null) {
+            startedByUser = causeInfo.userId
+        }
+    }
+
+    if (startedByUser.length() > 0) {
+        echo "Build was started by a user, adding them to the suspect notification list: ${startedByUser}"
+        def author = trimIfGithubNoreplyUser(startedByUser)
+        echo "DEBUG: author: ${startedByUser}, ${author}"
+        if (userMappings.containsKey(author)) {
+            def slackUser = userMappings.get(author)
+            if (!suspectList.contains(slackUser)) {
+                echo "Added ${slackUser} as suspect"
+                retValue += " ${slackUser}"
+                suspectList.add(slackUser)
+            }
+        } else {
+            // If we don't have a name mapping use the commit.author, at least we can easily tell if the mapping gets dated
+            if (!suspectList.contains(author)) {
+               echo "Added ${author} as suspect"
+               retValue += " ${author}"
+               suspectList.add(author)
+            }
+        }
+    } else {
+        echo "Build not started by a user, not adding to notification list"
+    }
+    echo "returning suspect list: ${retValue}"
+    return retValue
+}
+
+@NonCPS
+List extractReleaseTags(final String fileContent) {
+    List releases = []
+    fileContent.eachLine { tag ->
+        releases << tag
+    }
+    return releases
+}
+
+def getLatestReleaseVersion() {
+    final String releaseTags = readFile(file: "${workspace}/tags.txt")
+    list gitTags = extractReleaseTags(releaseTags)
+    echo "gitTags = ${gitTags}"
+    return gitTags.pop()
+}

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -177,9 +177,6 @@ pipeline {
         }
     }
     post {
-        always {
-            archiveArtifacts artifacts: "**/prerelease_validation.out,**/release_status.out,**/${verrazzanoImagesFile},**/${verrazzanoDistributionsFile}", allowEmptyArchive: true
-        }
         failure {
             script {
                 if (isAlertingEnabled()) {

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -56,7 +56,6 @@ pipeline {
     }
 
     parameters {
-        booleanParam (description: 'Skip tests to private registry stage, useful for testing out private registry testing, support and push to OCIR', name: 'SKIP_TO_PRIVATE_REGISTRY', defaultValue: false)
         string (name: 'TAGGED_TESTS',
                 defaultValue: '',
                 description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -275,21 +275,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Upgrade Path Minor Release Tests') {
-                    steps {
-                            script {
-                                build job: "/verrazzano-push-triggered-upgrade-minor-release-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'N_JOBS_FOR_EACH_BATCH', value: '6'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
-                                    ], wait: true
-                            }
-                    }
-                }
                 stage('Upgrade Resiliency tests') {
                     steps {
                         script {


### PR DESCRIPTION
This creates a back-end test suite.

The backend test suite runs on a longer cadence than the periodic tests, but are required to be run and clean in order to release the product. The initial cadence will be weekly, this may change up as the testing story evolves. The trade-off here is resource usage vs early detection.

Initially this will include tests which are simply too expensive to run on the periodic test cadence. The Upgrade Path tests are being moved into this test suite, others may also be included (for example the new Kind OCI/DNS variant tests may be included here.

This change gets the test pipeline running, and moves the upgrade path tests into it and out of the periodic tests.

There will be more adjustments/followup related to the release candidate support. These are required for release as are the periodics, we will need to decide exactly how we align the pipelines there. Ie: the initial stake in the ground is that both periodics and the upgrade tests are picking up the latest stable commit, we may want to keep doing that, or we may want to have these pickup the latest clean periodic commit to use that when they start up (these days that is not very current, so I opted to start off having it pickup the latest stable commit). If we keep things at latest stable commit, the release candidate will be the latest commit that passed both tests. But that would be a follow-up change, not in this initial change
