### PR TITLE
VZ-7533 PSR add base chart for worker

### DIFF
--- a/ignore_copyright_check.txt
+++ b/ignore_copyright_check.txt
@@ -12,7 +12,7 @@ platform-operator/helm_config/charts/verrazzano-monitoring-operator/NOTES.txt
 platform-operator/helm_config/charts/verrazzano-network-policies/NOTES.txt
 
 tools/psr/manifests/charts/worker/NOTES.txt
-tools/psr/manifests/charts/worker/chars/getlogs/NOTES.txt
+tools/psr/manifests/charts/worker/charts/getlogs/NOTES.txt
 
 LICENSES-OLCNE.pdf
 coverage.xml

--- a/ignore_copyright_check.txt
+++ b/ignore_copyright_check.txt
@@ -12,6 +12,7 @@ platform-operator/helm_config/charts/verrazzano-monitoring-operator/NOTES.txt
 platform-operator/helm_config/charts/verrazzano-network-policies/NOTES.txt
 
 tools/psr/manifests/charts/worker/NOTES.txt
+tools/psr/manifests/charts/worker/chars/getlogs/NOTES.txt
 
 LICENSES-OLCNE.pdf
 coverage.xml

--- a/tools/psr/backend/workers/opensearch/getlogs/getlogs.go
+++ b/tools/psr/backend/workers/opensearch/getlogs/getlogs.go
@@ -47,7 +47,6 @@ type getLogs struct {
 	spi.Worker
 	metricDescList []prometheus.Desc
 	*getLogsMetrics
-	lastGetReturnedError bool
 }
 
 var _ spi.Worker = getLogs{}
@@ -160,15 +159,7 @@ func (w getLogs) DoWork(conf config.CommonConfig, log vzlog.VerrazzanoLogger) er
 	respBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		w.lastGetReturnedError = true
 		return fmt.Errorf("Error reading response body: %v", err)
-	} else {
-		// If we had a failure on the prev call then log success so you can tell
-		// get is working just be looking at the pod log
-		if w.lastGetReturnedError {
-			log.Info("GET to OpenSearch successful after previous GET failed", err)
-		}
-		w.lastGetReturnedError = false
 	}
 	atomic.AddInt64(&w.getLogsMetrics.openSearchGetDataTotalChars.Val, int64(len(respBody)))
 	return nil

--- a/tools/psr/backend/workers/opensearch/getlogs/getlogs.go
+++ b/tools/psr/backend/workers/opensearch/getlogs/getlogs.go
@@ -47,6 +47,7 @@ type getLogs struct {
 	spi.Worker
 	metricDescList []prometheus.Desc
 	*getLogsMetrics
+	lastGetReturnedError bool
 }
 
 var _ spi.Worker = getLogs{}
@@ -159,7 +160,15 @@ func (w getLogs) DoWork(conf config.CommonConfig, log vzlog.VerrazzanoLogger) er
 	respBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
+		w.lastGetReturnedError = true
 		return fmt.Errorf("Error reading response body: %v", err)
+	} else {
+		// If we had a failure on the prev call then log success so you can tell
+		// get is working just be looking at the pod log
+		if w.lastGetReturnedError {
+			log.Info("GET to OpenSearch successful after previous GET failed", err)
+		}
+		w.lastGetReturnedError = false
 	}
 	atomic.AddInt64(&w.getLogsMetrics.openSearchGetDataTotalChars.Val, int64(len(respBody)))
 	return nil

--- a/tools/psr/backend/workmanager/runner.go
+++ b/tools/psr/backend/workmanager/runner.go
@@ -134,6 +134,9 @@ func (r runner) RunWorker(conf config.CommonConfig, log vzlog.VerrazzanoLogger) 
 				// get is working just be looking at the pod log.
 				log.Info("Next call to DoWork from runner successful after previous DoWork failed")
 			}
+			if loopCount == 1 {
+				log.Info("First call to DoWork succeeded")
+			}
 			r.prevWorkFailed = false
 		}
 		log.GetZapLogger().Sync()

--- a/tools/psr/manifests/charts/worker/Chart.yaml
+++ b/tools/psr/manifests/charts/worker/Chart.yaml
@@ -5,3 +5,8 @@ description: A Helm chart for the PSR Worker using Kubernetes resources
 name: psr-backend-k8s
 version: 0.1.0
 appVersion: 0.1.0
+dependencies:
+  - name: getlogs
+    repository: file://../getlogs
+    version: 0.1.0
+    condition: getlogs.enabled

--- a/tools/psr/manifests/charts/worker/charts/getlogs/.helmignore
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/.helmignore
@@ -1,10 +1,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-global:
-  envVars:
-    PSR_WORKER_TYPE: getlogs
-
-# activate subchart
-getlogs:
-  enabled: true
+test
+*.txt
+.gitignore
+.idea
+.git

--- a/tools/psr/manifests/charts/worker/charts/getlogs/Chart.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/Chart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-{{- if eq .Values.appType "k8s" }}
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "worker.fullName" .}}
-  namespace: {{ .Release.Namespace }}
-{{- end }}
+description: A Helm chart for the PSR getlogs worker
+name: getlogs
+version: 0.1.0
+appVersion: 0.1.0

--- a/tools/psr/manifests/charts/worker/charts/getlogs/NOTES.txt
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/NOTES.txt
@@ -1,0 +1,1 @@
+The PSR getlogs worker Helm chart has been installed!

--- a/tools/psr/manifests/charts/worker/charts/getlogs/templates/ingestauthorizationpolicy.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/templates/ingestauthorizationpolicy.yaml
@@ -1,11 +1,10 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-{{- if .Values.istio.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Namespace }}-ingest-authzpol
+  name: {{ template "worker.fullName" .}}-ingest-authzpol
   namespace: verrazzano-system
 spec:
   selector:
@@ -16,8 +15,7 @@ spec:
     - from:
         - source:
             namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Release.Name }}"]
+            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "worker.fullName" .}}"]
       to:
         - operation:
             ports: ["9200"]
-{{- end }}

--- a/tools/psr/manifests/charts/worker/charts/getlogs/templates/ingestauthorizationpolicy.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/templates/ingestauthorizationpolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: {{ template "worker.fullName" .}}-ingest-authzpol
+  name: {{ template "worker.fullName" .}}-{{ .Release.Namespace }}-ingest-authzpol
   namespace: verrazzano-system
 spec:
   selector:

--- a/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: {{ template "worker.fullName" .}}-master-authzpol
+  name: {{ template "worker.fullName" .}}-{{ .Release.Namespace }}--master-authzpol
   namespace: verrazzano-system
 spec:
   selector:

--- a/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
@@ -1,11 +1,10 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-{{- if .Values.istio.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Namespace }}-master-authzpol
+  name: {{ template "worker.fullName" .}}-master-authzpol
   namespace: verrazzano-system
 spec:
   selector:
@@ -16,8 +15,7 @@ spec:
     - from:
         - source:
             namespaces: ["{{ .Release.Namespace }}"]
-            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Release.Name }}"]
+            principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ template "worker.fullName" .}}"]
       to:
         - operation:
             ports: ["9200"]
-{{- end }}

--- a/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/templates/masterauthorizationpolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: {{ template "worker.fullName" .}}-{{ .Release.Namespace }}--master-authzpol
+  name: {{ template "worker.fullName" .}}-{{ .Release.Namespace }}-master-authzpol
   namespace: verrazzano-system
 spec:
   selector:

--- a/tools/psr/manifests/charts/worker/charts/getlogs/values.yaml
+++ b/tools/psr/manifests/charts/worker/charts/getlogs/values.yaml
@@ -1,10 +1,2 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-global:
-  envVars:
-    PSR_WORKER_TYPE: getlogs
-
-# activate subchart
-getlogs:
-  enabled: true

--- a/tools/psr/manifests/charts/worker/templates/_helpers.tpl
+++ b/tools/psr/manifests/charts/worker/templates/_helpers.tpl
@@ -1,10 +1,8 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-global:
-  envVars:
-    PSR_WORKER_TYPE: getlogs
+{{- define "worker.fullName" -}}
+{{- print .Release.Name "-" .Values.global.envVars.PSR_WORKER_TYPE -}}
+{{- end -}}
 
-# activate subchart
-getlogs:
-  enabled: true
+

--- a/tools/psr/manifests/charts/worker/templates/appconfig.yaml
+++ b/tools/psr/manifests/charts/worker/templates/appconfig.yaml
@@ -5,14 +5,14 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-  name: {{ .Release.Name}}
+  name: {{ template "worker.fullName" .}}
   namespace: {{ .Release.Namespace }}
   annotations:
     version: v1.0.0
     description: "PSR backend application"
 spec:
   components:
-    - componentName: {{ .Release.Name}}
+    - componentName: {{ template "worker.fullName" .}}
       traits:
         - trait:
             apiVersion: oam.verrazzano.io/v1alpha1

--- a/tools/psr/manifests/charts/worker/templates/component.yaml
+++ b/tools/psr/manifests/charts/worker/templates/component.yaml
@@ -5,14 +5,14 @@
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
-  name: {{ .Release.Name}}
+  name: {{ template "worker.fullName" .}}
   namespace: {{ .Release.Namespace }}
 spec:
   workload:
     apiVersion: core.oam.dev/v1alpha2
     kind: ContainerizedWorkload
     metadata:
-      name: {{ .Release.Name}}-{{ .Values.envVars.PSR_WORKER_TYPE }}
+      name: {{ template "worker.fullName" .}}
       namespace: {{ .Release.Namespace }}
       labels:
         app: psr-worker
@@ -27,7 +27,7 @@ spec:
           image: {{  .Values.imageName }}
           imagePullPolicy: {{  .Values.imagePullPolicy }}
           env:
-            {{- range $key, $val := .Values.envVars }}
+            {{- range $key, $val := .Values.global.envVars }}
             - name: {{ $key }}
               value: {{ $val }}
               {{- end }}

--- a/tools/psr/manifests/charts/worker/templates/deployment.yaml
+++ b/tools/psr/manifests/charts/worker/templates/deployment.yaml
@@ -1,25 +1,22 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# This manifest is used for testing without OAM by native Kubernetes resources only
-#
-
 {{- if eq .Values.appType "k8s" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name}}-{{ .Values.envVars.PSR_WORKER_TYPE }}
+  name: {{ template "worker.fullName" .}}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      psr.verrazzano.io/worker: {{ .Release.Name}}-{{ .Values.envVars.PSR_WORKER_TYPE }}
+      psr.verrazzano.io/worker: {{ template "worker.fullName" .}}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:
-        psr.verrazzano.io/worker: {{ .Release.Name}}-{{ .Values.envVars.PSR_WORKER_TYPE }}
-        app: psr-{{ .Values.envVars.PSR_WORKER_TYPE }}
+        psr.verrazzano.io/worker: {{ template "worker.fullName" .}}
+        app: psr-{{ .Values.global.envVars.PSR_WORKER_TYPE }}
         version: v1
     spec:
       serviceAccountName: {{ .Release.Name}}
@@ -28,11 +25,11 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
       containers:
-        - name: {{ .Release.Name}}-{{ .Values.envVars.PSR_WORKER_TYPE }}
+        - name: {{ .Release.Name}}-{{ .Values.global.envVars.PSR_WORKER_TYPE }}
           image: {{  .Values.imageName }}
           imagePullPolicy: {{  .Values.imagePullPolicy }}
           env:
-            {{- range $key, $val := .Values.envVars }}
+            {{- range $key, $val := .Values.global.envVars }}
             - name: {{ $key }}
               value: {{ $val }}
               {{- end }}

--- a/tools/psr/manifests/charts/worker/templates/deployment.yaml
+++ b/tools/psr/manifests/charts/worker/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: psr-{{ .Values.global.envVars.PSR_WORKER_TYPE }}
         version: v1
     spec:
-      serviceAccountName: {{ .Release.Name}}
+      serviceAccountName: {{ template "worker.fullName" .}}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/tools/psr/manifests/charts/worker/values.yaml
+++ b/tools/psr/manifests/charts/worker/values.yaml
@@ -9,12 +9,15 @@ imagePullPolicy: IfNotPresent
 replicas: 1
 
 # envVars contains default worker type and ENV vars common to all workers
-envVars:
-  PSR_WORKER_TYPE: example
-  PSR_ITERATION_SLEEP: 1s
-
-istio:
-  enabled: false
+global:
+  envVars:
+    PSR_WORKER_TYPE: example
+    PSR_ITERATION_SLEEP: 1s
 
 # appType can be either oam or k8s, which are just Kubernetes deployments
 appType: oam
+
+# Each worker that has a subchart needs to override this property
+getlogs:
+  enabled: false
+

--- a/tools/psr/manifests/usecases/opensearch/loggen.yaml
+++ b/tools/psr/manifests/usecases/opensearch/loggen.yaml
@@ -1,5 +1,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-envVars:
-  PSR_WORKER_TYPE: loggen
+
+global:
+  envVars:
+    PSR_WORKER_TYPE: loggen


### PR DESCRIPTION
Add base chart for worker so that worker specific charts are isolated. 
Added logging for runner so that we know a worker had a successful DoWork call.
Make some name changes to resources so that they are consistently named.