### PR TITLE
VZ-6427: Check test metrics only if scrape targets are up.

### DIFF
--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -56,15 +56,6 @@ func QueryMetric(metricsName string, kubeconfigPath string) (string, error) {
 		return "", fmt.Errorf("error retrieving metric %s, status %d", metricsName, resp.StatusCode)
 	}
 	Log(Info, fmt.Sprintf("metric: %s", resp.Body))
-	targetURL := fmt.Sprintf("https://%s/api/v1/targets?state=active", GetPrometheusIngressHost(kubeconfigPath))
-	resp1, err1 := GetWebPageWithBasicAuth(targetURL, "", "verrazzano", password, kubeconfigPath)
-	if err1 != nil {
-		return "", err1
-	}
-	if resp1.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error retrieving target, status %d", resp.StatusCode)
-	}
-	Log(Info, fmt.Sprintf("target: %s", resp1.Body))
 	return string(resp.Body), nil
 }
 
@@ -93,7 +84,6 @@ func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubecon
 	}
 	metrics := JTq(metric, "data", "result").([]interface{})
 	if metrics != nil {
-		Log(Info, fmt.Sprintf("Debug: Metrics: %v", metrics))
 		return findMetric(metrics, keyMap)
 	}
 	return false
@@ -172,9 +162,9 @@ func ScrapeTargetsUp() bool {
 	}
 	allUp := true
 	for _, target := range targets {
-		// allUp only remains true if all targets status is success
+		// allUp only remains true if all targets health is up
 		if Jq(target, "health") != "up" {
-			Log(Info, fmt.Sprintf("target: %s is not up yet", target))
+			Log(Info, fmt.Sprintf("target: %v is not up yet", target))
 			allUp = false
 		}
 	}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -164,7 +164,7 @@ func ScrapeTargetsUp() bool {
 	for _, target := range targets {
 		// allUp only remains true if all targets health is up
 		if Jq(target, "health") != "up" {
-			Log(Info, fmt.Sprintf("target: %v is not up yet", target))
+			Log(Info, fmt.Sprintf("target: %s is not up yet", Jq(target, "scrapeUrl")))
 			allUp = false
 		}
 	}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -178,10 +178,7 @@ func ScrapeTargetsUp() bool {
 			allUp = false
 		}
 	}
-	if allUp {
-		return true
-	}
-	return false
+	return allUp
 }
 
 // ScrapeTargets queries Prometheus API /api/v1/targets to list scrape targets

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -80,12 +80,15 @@ func GetPrometheusIngressHost(kubeconfigPath string) string {
 func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
 	metric, err := QueryMetric(metricsName, kubeconfigPath)
 	if err != nil {
+		Log(Error, fmt.Sprintf("Quering metrics was false."))
 		return false
 	}
 	metrics := JTq(metric, "data", "result").([]interface{})
 	if metrics != nil {
+		Log(Info, fmt.Sprintf("Debug: Metrics: %v", metrics))
 		return findMetric(metrics, keyMap)
 	}
+	Log(Info, fmt.Sprintf("Metrics is nil"))
 	return false
 }
 


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
This MR improves the test to check and parse the metrics only if Prometheus scrape targets are up and healthy. This will avoid repeatedly fetching metrics responses and then parsing and checking if the metric is there or not.
