### PR TITLE
VZ-7568: Add unit tests to increase coverage for pkg/controller and pkg/security

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package spi
 
 import (
@@ -31,7 +32,7 @@ var _ error = RetryableError{}
 // Error implements the basic Go error contract
 func (r RetryableError) Error() string {
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("Retryable error, source: %s, operation: %s", r.Operation, r.Source))
+	builder.WriteString(fmt.Sprintf("Retryable error, source: %s, operation: %s", r.Source, r.Operation))
 	if r.Cause != nil {
 		builder.WriteString(fmt.Sprintf(", cause %s", r.Cause))
 	}
@@ -41,7 +42,7 @@ func (r RetryableError) Error() string {
 	return builder.String()
 }
 
-// IsUpdateConflict returns true if the error is an update confict error.  This is occurs when the controller-runtime cache
+// IsUpdateConflict returns true if the error is an update conflict error. This is occurs when the controller-runtime cache
 // is out of sync with the etc database
 func IsUpdateConflict(err error) bool {
 	return strings.Contains(err.Error(), "the object has been modified; please apply your changes to the latest version")

--- a/pkg/controller/errors/errors_test.go
+++ b/pkg/controller/errors/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package spi
 

--- a/pkg/controller/errors/errors_test.go
+++ b/pkg/controller/errors/errors_test.go
@@ -4,10 +4,11 @@ package spi
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 // TestRetryableError Tests RetryableError
@@ -83,4 +84,17 @@ func TestRetryableError(t *testing.T) {
 			assert.False(err.HasCause(), "HasCause should return false")
 		}
 	}
+}
+
+// TestShouldLogKubenetesAPIError tests ShouldLogKubernetesAPIError
+// Given an error
+// Check whether it should be logged ot not
+func TestShouldLogKubenetesAPIError(t *testing.T) {
+	asserts := assert.New(t)
+	err := fmt.Errorf("some kubernetes API error")
+
+	asserts.True(ShouldLogKubenetesAPIError(err))
+
+	err = fmt.Errorf(`operation cannot be fulfilled on configmaps "test": the object has been modified; please apply your changes to the latest version and try again`)
+	asserts.False(ShouldLogKubenetesAPIError(err))
 }

--- a/pkg/controller/requeue_test.go
+++ b/pkg/controller/requeue_test.go
@@ -3,9 +3,10 @@
 package controller
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestNewRequeueWithDelay tests the NewRequeueWithDelay func for the following use case
@@ -17,18 +18,21 @@ func TestNewRequeueWithDelay(t *testing.T) {
 	requeueWithDelay := NewRequeueWithDelay(3, 5, time.Second)
 	t.Logf("Requeue result: %v", requeueWithDelay)
 	asserts.True(requeueWithDelay.Requeue)
+	asserts.True(ShouldRequeue(requeueWithDelay))
 	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Second).Seconds())
 	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Second).Seconds())
 
 	requeueWithDelay = NewRequeueWithDelay(3, 5, time.Second)
 	t.Logf("Requeue result: %v", requeueWithDelay)
 	asserts.True(requeueWithDelay.Requeue)
+	asserts.True(ShouldRequeue(requeueWithDelay))
 	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Second).Seconds())
 	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Second).Seconds())
 
 	requeueWithDelay = NewRequeueWithDelay(3, 5, time.Minute)
 	t.Logf("Requeue result: %v", requeueWithDelay)
 	asserts.True(requeueWithDelay.Requeue)
+	asserts.True(ShouldRequeue(requeueWithDelay))
 	asserts.GreaterOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(3) * time.Minute).Seconds())
 	asserts.LessOrEqual(requeueWithDelay.RequeueAfter.Seconds(), (time.Duration(5) * time.Minute).Seconds())
 }

--- a/pkg/security/password/password_test.go
+++ b/pkg/security/password/password_test.go
@@ -4,9 +4,10 @@
 package password
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestGeneratePassword tests generating random passwords
@@ -72,6 +73,32 @@ func TestMaskFunction(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			res := f(tt.input)
 			assert.Equal(t, tt.output, res)
+		})
+	}
+}
+
+// TestGenerateRandomAlphaLower tests GenerateRandomAlphaLower
+func TestGenerateRandomAlphaLower(t *testing.T) {
+	var tests = []struct {
+		length   int
+		hasError bool
+	}{
+		{-1, true},
+		{0, true},
+		{15, false},
+		{31, false},
+		{66, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.length), func(t *testing.T) {
+			pw, err := GenerateRandomAlphaLower(tt.length)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.length, len(pw))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Added a few simple unit tests to increase coverage for pkg/controller and pkg/security.

Currently the coverage is:
    pkg/controller - 61.11%  --> 94.4%
    pkg/security - 74.29% --> 88.6%

