### PR TITLE
VZ 7578: Work around omitempty replicas for node groups

### DIFF
--- a/platform-operator/apis/verrazzano/testdata/base/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/base/v1beta1.yaml
@@ -215,16 +215,6 @@ spec:
       enabled: true
     opensearch:
       enabled: true
-      nodes:
-        - name: es-master
-          roles:
-            - master
-        - name: es-data
-          roles:
-            - data
-        - name: es-ingest
-          roles:
-            - ingest
     opensearchDashboards:
       enabled: true
       replicas: 1

--- a/platform-operator/apis/verrazzano/testdata/dev/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/dev/v1beta1.yaml
@@ -10,12 +10,6 @@ spec:
   components:
     opensearch:
       nodes:
-        - name: es-data
-          roles:
-          - data
-        - name: es-ingest
-          roles:
-          - ingest
         - name: es-master
           replicas: 1
           resources:

--- a/platform-operator/apis/verrazzano/testdata/fromallcomps/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromallcomps/v1beta1.yaml
@@ -266,19 +266,6 @@ spec:
             frobber: frob
     opensearch:
       enabled: true
-      nodes:
-        - name: es-master
-          replicas: 0
-          roles:
-            - master
-        - name: es-data
-          replicas: 0
-          roles:
-            - data
-        - name: es-ingest
-          replicas: 0
-          roles:
-            - ingest
     opensearchDashboards:
       enabled: true
       replicas: 1

--- a/platform-operator/apis/verrazzano/testdata/fromha/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromha/v1beta1.yaml
@@ -78,12 +78,6 @@ spec:
               replicas: 2
     opensearch:
       nodes:
-        - name: es-master
-          roles:
-            - master
-        - name: es-data
-          roles:
-            - data
         - name: es-ingest
           replicas: 2
           roles:

--- a/platform-operator/apis/verrazzano/testdata/fromocneha/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromocneha/v1beta1.yaml
@@ -96,16 +96,10 @@ spec:
               replicas: 2
     opensearch:
       nodes:
-        - name: es-data
-          roles:
-            - data
         - name: es-ingest
           replicas: 2
           roles:
             - ingest
-        - name: es-master
-          roles:
-            - master
     opensearchDashboards:
       replicas: 2
     prometheusOperator:

--- a/platform-operator/apis/verrazzano/testdata/managed-cluster/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/managed-cluster/v1beta1.yaml
@@ -12,16 +12,6 @@ spec:
       enabled: false
     opensearch:
       enabled: false
-      nodes:
-        - name: es-data
-          roles:
-            - data
-        - name: es-ingest
-          roles:
-            - ingest
-        - name: es-master
-          roles:
-            - master
     grafana:
       enabled: false
     opensearchDashboards:

--- a/platform-operator/apis/verrazzano/v1alpha1/convert_to.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/convert_to.go
@@ -421,11 +421,16 @@ func convertInstallArgsToOSNodes(args []InstallArgs) (map[string]v1beta1.OpenSea
 		}
 	}
 
-	return map[string]v1beta1.OpenSearchNode{
-		masterNodeName: *masterNode,
-		dataNodeName:   *dataNode,
-		ingestNodeName: *ingestNode,
-	}, nil
+	nodes := map[string]v1beta1.OpenSearchNode{}
+	addNode := func(node *v1beta1.OpenSearchNode) {
+		if node.Replicas > 0 {
+			nodes[node.Name] = *node
+		}
+	}
+	addNode(masterNode)
+	addNode(dataNode)
+	addNode(ingestNode)
+	return nodes, nil
 }
 
 func convertFluentdToV1Beta1(src *FluentdComponent) *v1beta1.FluentdComponent {

--- a/platform-operator/apis/verrazzano/v1alpha1/convert_to_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/convert_to_test.go
@@ -134,16 +134,6 @@ func TestConvertInstallArgsToOSNodes(t *testing.T) {
 					Name:     masterNodeName,
 					Roles:    []vmov1.NodeRole{vmov1.MasterRole},
 				},
-				dataNodeName: {
-					Replicas: 0,
-					Name:     dataNodeName,
-					Roles:    []vmov1.NodeRole{vmov1.DataRole},
-				},
-				ingestNodeName: {
-					Replicas: 0,
-					Name:     ingestNodeName,
-					Roles:    []vmov1.NodeRole{vmov1.IngestRole},
-				},
 			},
 		},
 		{
@@ -217,23 +207,7 @@ func TestConvertInstallArgsToOSNodes(t *testing.T) {
 					Value: "0",
 				},
 			},
-			map[string]v1beta1.OpenSearchNode{
-				masterNodeName: {
-					Replicas: 0,
-					Name:     masterNodeName,
-					Roles:    []vmov1.NodeRole{vmov1.MasterRole},
-				},
-				dataNodeName: {
-					Replicas: 0,
-					Name:     dataNodeName,
-					Roles:    []vmov1.NodeRole{vmov1.DataRole},
-				},
-				ingestNodeName: {
-					Replicas: 0,
-					Name:     ingestNodeName,
-					Roles:    []vmov1.NodeRole{vmov1.IngestRole},
-				},
-			},
+			map[string]v1beta1.OpenSearchNode{},
 		},
 	}
 

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_permutations_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_permutations_test.go
@@ -3,6 +3,7 @@
 package spi
 
 import (
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -11,19 +12,20 @@ import (
 )
 
 const (
-	basicDevMerged                  = "testdata/basicDevMerged.yaml"
-	basicProdMerged                 = "testdata/basicProdMerged.yaml"
-	basicManagedClusterMerged       = "testdata/basicManagedClusterMerged.yaml"
-	devAllDisabledMerged            = "testdata/devAllDisabledMerged.yaml"
-	devOCIDNSOverrideMerged         = "testdata/devOCIOverrideMerged.yaml"
-	devCertManagerOverrideMerged    = "testdata/devCertManagerOverrideMerged.yaml"
-	devElasticSearchOveridesMerged  = "testdata/devESArgsStorageOverride.yaml"
-	devKeycloakOveridesMerged       = "testdata/devKeycloakInstallArgsStorageOverride.yaml"
-	prodElasticSearchOveridesMerged = "testdata/prodESOverridesMerged.yaml"
-	prodElasticSearchStorageMerged  = "testdata/prodESStorageArgsMerged.yaml"
-	prodIngressIstioOverridesMerged = "testdata/prodIngressIstioOverridesMerged.yaml"
-	prodFluentdOverridesMerged      = "testdata/prodFluentdOverridesMerged.yaml"
-	managedClusterEnableAllMerged   = "testdata/managedClusterEnableAllOverrideMerged.yaml"
+	basicDevMerged                   = "testdata/basicDevMerged.yaml"
+	basicProdMerged                  = "testdata/basicProdMerged.yaml"
+	basicManagedClusterMerged        = "testdata/basicManagedClusterMerged.yaml"
+	devAllDisabledMerged             = "testdata/devAllDisabledMerged.yaml"
+	devOCIDNSOverrideMerged          = "testdata/devOCIOverrideMerged.yaml"
+	devCertManagerOverrideMerged     = "testdata/devCertManagerOverrideMerged.yaml"
+	devElasticSearchOveridesMerged   = "testdata/devESArgsStorageOverride.yaml"
+	devKeycloakOveridesMerged        = "testdata/devKeycloakInstallArgsStorageOverride.yaml"
+	prodElasticSearchOveridesMerged  = "testdata/prodESOverridesMerged.yaml"
+	prodElasticSearchStorageMerged   = "testdata/prodESStorageArgsMerged.yaml"
+	prodIngressIstioOverridesMerged  = "testdata/prodIngressIstioOverridesMerged.yaml"
+	prodFluentdOverridesMerged       = "testdata/prodFluentdOverridesMerged.yaml"
+	managedClusterEnableAllMerged    = "testdata/managedClusterEnableAllOverrideMerged.yaml"
+	prodNoStorageOpenSearchOverrides = "testdata/prodNoStorageOpenSearchOverrides.yaml"
 )
 
 var falseValue = false
@@ -410,6 +412,46 @@ var managedClusterEnableAllOverride = v1alpha1.Verrazzano{
 			Kibana:        &v1alpha1.KibanaComponent{Enabled: &trueValue},
 			Prometheus:    &v1alpha1.PrometheusComponent{Enabled: &trueValue},
 			Rancher:       &v1alpha1.RancherComponent{Enabled: &trueValue},
+		},
+	},
+}
+
+var prodNoStorageOSOverrides = v1alpha1.Verrazzano{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "prod-no-storage-os-overrides",
+	},
+	Spec: v1alpha1.VerrazzanoSpec{
+		Profile: "prod",
+		DefaultVolumeSource: &corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+		Components: v1alpha1.ComponentSpec{
+			Elasticsearch: &v1alpha1.ElasticsearchComponent{
+				Enabled: &trueValue,
+				Nodes: []v1alpha1.OpenSearchNode{
+					{
+						Name:     "es-master",
+						Replicas: 0,
+					},
+					{
+						Name:     "es-data",
+						Replicas: 0,
+					},
+					{
+						Name:     "es-ingest",
+						Replicas: 0,
+					},
+					{
+						Name:     "custom",
+						Replicas: 3,
+						Roles: []vmov1.NodeRole{
+							vmov1.DataRole,
+							vmov1.IngestRole,
+							vmov1.MasterRole,
+						},
+					},
+				},
+			},
 		},
 	},
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
@@ -135,6 +135,12 @@ func TestContextProfilesMerge(t *testing.T) {
 			actualCR:     managedClusterEnableAllOverride,
 			expectedYAML: managedClusterEnableAllMerged,
 		},
+		{
+			name:         "TestProdNoStorageOpenSearchOverrides",
+			description:  "Test prod profile with no storage and OpenSearch overrides",
+			actualCR:     prodNoStorageOSOverrides,
+			expectedYAML: prodNoStorageOpenSearchOverrides,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
@@ -1,0 +1,306 @@
+metadata:
+  creationTimestamp: null
+  name: prod-no-storage-os-overrides
+spec:
+  components:
+    applicationOperator:
+      enabled: true
+    authProxy:
+      enabled: true
+      kubernetes:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - verrazzano-authproxy
+                  topologyKey: kubernetes.io/hostname
+                weight: 100
+        replicas: 1
+    certManager:
+      certificate:
+        acme:
+          provider: ""
+        ca:
+          clusterResourceNamespace: cert-manager
+          secretName: verrazzano-ca-certificate-secret
+      enabled: true
+      overrides:
+        - values:
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app: cert-manager
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
+            cainjector:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app: cainjector
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+              replicaCount: 1
+            replicaCount: 1
+            webhook:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app: webhook
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+              replicaCount: 1
+    coherenceOperator:
+      enabled: true
+    console:
+      enabled: true
+      overrides:
+        - values:
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app: verrazzano-console
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
+            replicas: 1
+    dns:
+      wildcard:
+        domain: nip.io
+    elasticsearch:
+      enabled: true
+      nodes:
+        - name: es-master
+          resources:
+            requests:
+              memory: 1503238553600m
+          roles:
+            - master
+          storage:
+            size: 50Gi
+        - name: es-data
+          resources:
+            requests:
+              memory: 5153960755200m
+          roles:
+            - data
+          storage:
+            size: 50Gi
+        - name: es-ingest
+          resources:
+            requests:
+              memory: 2560Mi
+          roles:
+            - ingest
+        - name: custom
+          replicas: 3
+          roles:
+            - data
+            - ingest
+            - master
+    fluentd:
+      elasticsearchSecret: verrazzano-es-internal
+      elasticsearchURL: http://verrazzano-authproxy-elasticsearch:8775
+      enabled: true
+    grafana:
+      enabled: true
+    ingress:
+      enabled: true
+      overrides:
+        - values:
+            controller:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: controller
+                            app.kubernetes.io/name: ingress-nginx
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+              autoscaling:
+                enabled: false
+                minReplicas: 1
+            defaultBackend:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: default-backend
+                            app.kubernetes.io/name: ingress-nginx
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+              replicaCount: 1
+      type: LoadBalancer
+    istio:
+      egress:
+        kubernetes:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - istio-egressgateway
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          replicas: 1
+      enabled: true
+      ingress:
+        kubernetes:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - istio-ingressgateway
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          replicas: 1
+      overrides:
+        - values:
+            apiVersion: install.istio.io/v1alpha1
+            kind: IstioOperator
+            spec:
+              components:
+                pilot:
+                  k8s:
+                    affinity:
+                      podAntiAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          - podAffinityTerm:
+                              labelSelector:
+                                matchLabels:
+                                  app: istiod
+                              topologyKey: kubernetes.io/hostname
+                            weight: 100
+    keycloak:
+      enabled: true
+      mysql:
+        overrides:
+          - values:
+              image:
+                pullPolicy: IfNotPresent
+                pullSecrets:
+                  enabled: false
+              podSpec:
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - podAffinityTerm:
+                          labelSelector:
+                            matchLabels:
+                              app.kubernetes.io/instance: mysql-innodbcluster-mysql-mysql-server
+                              app.kubernetes.io/name: mysql-innodbcluster-mysql-server
+                          topologyKey: kubernetes.io/hostname
+                        weight: 100
+              router:
+                podSpec:
+                  affinity:
+                    podAntiAffinity:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        - podAffinityTerm:
+                            labelSelector:
+                              matchLabels:
+                                app.kubernetes.io/instance: mysql-innodbcluster-mysql-router
+                                app.kubernetes.io/name: mysql-router
+                            topologyKey: kubernetes.io/hostname
+                          weight: 100
+              routerInstances: 1
+              serverInstances: 1
+      overrides:
+        - values:
+            affinity: |
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/instance: keycloak
+                          app.kubernetes.io/name: keycloak
+                      topologyKey: kubernetes.io/hostname
+            replicas: 1
+    kiali:
+      enabled: true
+      overrides:
+        - values:
+            deployment:
+              affinity:
+                pod_anti:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app: kiali
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+              replicas: 1
+    kibana:
+      enabled: true
+      replicas: 1
+    mySQLOperator:
+      enabled: true
+    oam:
+      enabled: true
+    prometheus:
+      enabled: true
+    prometheusOperator:
+      enabled: true
+      overrides:
+        - values:
+            prometheus:
+              prometheusSpec:
+                resources:
+                  requests:
+                    memory: 128Mi
+        - values:
+            prometheus:
+              prometheusSpec:
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - podAffinityTerm:
+                          labelSelector:
+                            matchLabels:
+                              app.kubernetes.io/name: prometheus
+                          topologyKey: kubernetes.io/hostname
+                        weight: 100
+                replicas: 1
+    rancher:
+      enabled: true
+    verrazzano:
+      enabled: true
+    weblogicOperator:
+      enabled: true
+  defaultVolumeSource:
+    emptyDir: {}
+  environmentName: default
+  profile: prod
+  security: {}
+status: {}

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 metadata:
   creationTimestamp: null
   name: prod-no-storage-os-overrides


### PR DESCRIPTION
Omit empty replicas for node groups was causing user defined `0` values to be ignored when creating the EffectiveCR.