### PR TITLE
VZ-7550: Update to Coherence Operator 3.2.9 release

### DIFF
--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -6,16 +6,3 @@
 defaultCoherenceImage: ghcr.io/oracle/coherence-ce:22.06.1
 
 replicas: 1
-
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          topologyKey: "kubernetes.io/hostname"
-          labelSelector:
-            matchLabels:
-              control-plane: coherence
-              app.kubernetes.io/name: coherence-operator
-              app.kubernetes.io/instance: coherence-operator-manager
-              app.kubernetes.io/version: "3.2.8"
-        weight: 100

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -5,8 +5,8 @@
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.2.8
-appVersion: 3.2.8
+version: 3.2.9
+appVersion: 3.2.9
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/version: "3.2.9"
     app.kubernetes.io/component: webhook
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -28,7 +28,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/version: "3.2.9"
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-rest
-    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/version: "3.2.9"
     app.kubernetes.io/component: rest
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -52,7 +52,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/version: "3.2.9"
     app.kubernetes.io/component: manager
 ---
 apiVersion: apps/v1
@@ -64,7 +64,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/version: "3.2.9"
     app.kubernetes.io/component: manager
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -80,7 +80,7 @@ spec:
         control-plane: coherence
         app.kubernetes.io/name: coherence-operator
         app.kubernetes.io/instance: coherence-operator-manager
-        app.kubernetes.io/version: "3.2.8"
+        app.kubernetes.io/version: "3.2.9"
         app.kubernetes.io/component: manager
         app.kubernetes.io/part-of: coherence-operator
         app.kubernetes.io/managed-by: helm
@@ -196,7 +196,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.8"
+                    app.kubernetes.io/version: "3.2.9"
               weight: 50
             - podAffinityTerm:
                 topologyKey: "oci.oraclecloud.com/fault-domain"
@@ -205,7 +205,16 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.8"
+                    app.kubernetes.io/version: "3.2.9"
+              weight: 10
+            - podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    control-plane: coherence
+                    app.kubernetes.io/name: coherence-operator
+                    app.kubernetes.io/instance: coherence-operator-manager
+                    app.kubernetes.io/version: "3.2.9"
               weight: 1
 {{- end }}
       volumes:

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -3,7 +3,7 @@
 # http://oss.oracle.com/licenses/upl.
 
 # image is the Coherence Operator image
-image: "ghcr.io/oracle/coherence-operator:3.2.8"
+image: "ghcr.io/oracle/coherence-operator:3.2.9"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
@@ -11,7 +11,7 @@ defaultCoherenceImage: "ghcr.io/oracle/coherence-ce:22.06.1"
 
 # defaultCoherenceUtilsImage is the Coherence Operator image that will be used when running
 # Coherence Pods. This image version should typically match the Operator version.
-defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.8"
+defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.9"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -337,7 +337,7 @@
     },
     {
       "name": "coherence-operator",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -345,7 +345,7 @@
           "images": [
             {
               "image": "coherence-operator",
-              "tag": "3.2.8",
+              "tag": "3.2.9",
               "helmFullImageKey": "image"
             }
           ]


### PR DESCRIPTION
Update Coherence Operator to [3.2.9](https://github.com/oracle/coherence-operator/releases/tag/v3.2.9)
