### PR TITLE
VZ-6427: Enhance test by logging unhealthy scrape targets if metrics are not available.

### DIFF
--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -131,6 +131,8 @@ func findMetric(metrics []interface{}, keyMap map[string]string) bool {
 			return true
 		}
 	}
+	// if metric is not found, list unhealthy scrape targets if any for debugging
+	ListUnhealthyScrapeTargets()
 	return false
 }
 
@@ -147,6 +149,20 @@ func MetricsExist(metricsName, key, value string) bool {
 	m[key] = value
 
 	return MetricsExistInCluster(metricsName, m, kubeconfigPath)
+}
+
+// ListUnhealthyScrapeTargets lists all the scrape targets that are unhealthy
+func ListUnhealthyScrapeTargets() {
+	targets, err := ScrapeTargets()
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting scrape targets: %v", err))
+		return
+	}
+	for _, target := range targets {
+		if Jq(target, "health") != "up" {
+			Log(Info, fmt.Sprintf("target: %s is not ready", Jq(target, "scrapeUrl")))
+		}
+	}
 }
 
 // ScrapeTargets queries Prometheus API /api/v1/targets to list scrape targets


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.

This MR enhances a test by logging the unhealthy targets when metrics fetched are not available to get some insight.
