### PR TITLE
VZ-6602 - Sync agent secret from admin cluster and always use Rancher URL in managed cluster kubeconfig when Rancher is enabled (remove rancherBasedKubeconfig feature flag)

### DIFF
--- a/application-operator/mcagent/mcagent_cluster_secrets.go
+++ b/application-operator/mcagent/mcagent_cluster_secrets.go
@@ -130,11 +130,6 @@ func (s *Syncer) syncRegistrationFromAdminCluster() (controllerutil.OperationRes
 	return opResult, nil
 }
 
-func agentSecretsEqual(agentSecret1 corev1.Secret, agentSecret2 corev1.Secret) bool {
-	return byteSlicesEqualTrimmedWhitespace(agentSecret1.Data[mcconstants.KubeconfigKey], agentSecret2.Data[mcconstants.KubeconfigKey]) &&
-		byteSlicesEqualTrimmedWhitespace(agentSecret1.Data[mcconstants.ManagedClusterNameKey], agentSecret2.Data[mcconstants.ManagedClusterNameKey])
-}
-
 func registrationInfoEqual(regSecret1 corev1.Secret, regSecret2 corev1.Secret) bool {
 	return byteSlicesEqualTrimmedWhitespace(regSecret1.Data[mcconstants.ESURLKey],
 		regSecret2.Data[mcconstants.ESURLKey]) &&

--- a/application-operator/mcagent/mcagent_cluster_secrets.go
+++ b/application-operator/mcagent/mcagent_cluster_secrets.go
@@ -53,12 +53,9 @@ func (s *Syncer) syncAgentSecretFromAdminCluster() (controllerutil.OperationResu
 	agentSecret.Name = constants.MCAgentSecret
 	agentSecret.Namespace = constants.VerrazzanoSystemNamespace
 	return controllerutil.CreateOrUpdate(s.Context, s.LocalClient, &agentSecret, func() error {
-		// Update the local cluster agent secret if the admin-kubeconfig or managed-cluster-name have changed
-		if !agentSecretsEqual(agentSecret, adminAgentSecret) {
-			// Get info from admin agent secret
-			agentSecret.Data[mcconstants.KubeconfigKey] = adminAgentSecret.Data[mcconstants.KubeconfigKey]
-			agentSecret.Data[mcconstants.ManagedClusterNameKey] = adminAgentSecret.Data[mcconstants.ManagedClusterNameKey]
-		}
+		// Set info from admin agent secret
+		agentSecret.Data[mcconstants.KubeconfigKey] = adminAgentSecret.Data[mcconstants.KubeconfigKey]
+		agentSecret.Data[mcconstants.ManagedClusterNameKey] = adminAgentSecret.Data[mcconstants.ManagedClusterNameKey]
 		return nil
 	})
 }

--- a/application-operator/mcagent/mcagent_cluster_secrets_test.go
+++ b/application-operator/mcagent/mcagent_cluster_secrets_test.go
@@ -13,6 +13,7 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
+	constants2 "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -31,6 +32,8 @@ const (
 	adminRegNewSecretPath      = "testdata/clusterca-adminregsecret-new.yaml"
 	clusterCAAdminSecretPath   = "testdata/clusterca-admincasecret.yaml"
 	mcCASecretPath             = "testdata/clusterca-mccasecret.yaml"
+	adminAgentSecretPath       = "testdata/admin-agent-secret.yaml"
+	adminAgentNewSecretPath    = "testdata/admin-agent-secret-new.yaml"
 	vzTLSSecretPathNew         = "testdata/clusterca-mctlssecret-new.yaml"
 	vzTLSSecretPath            = "testdata/clusterca-mctlssecret.yaml"
 	vmcPath                    = "testdata/clusterca-vmc.yaml"
@@ -42,6 +45,7 @@ const (
 	sampleVMCReadErrMsg        = "failed to read sample VMC"
 	regSecChangedErrMsg        = "registration secret was changed"
 	mcCASecChangedErrMsg       = "MC CA secret was changed"
+	sampleAdminAgentReadErrMsg = "failed to read sample Admin agent Secret"
 )
 
 // TestSyncAdminCANoDifference tests the synchronization method for the following use case.
@@ -356,8 +360,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.ESURLKey: "new OS url",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -366,8 +370,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.ESCaBundleKey: "new CA bundle",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -376,8 +380,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.RegistrationUsernameKey: "new user",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -386,8 +390,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.RegistrationPasswordKey: "new password",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -396,8 +400,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.KeycloakURLKey: "new keycloak url",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -406,8 +410,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSURLKey: "new value",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -416,8 +420,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSUsernameKey: "newuser",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -426,8 +430,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSPasswordKey: "newpassword",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -436,8 +440,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSCAKey: "newCAKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -446,8 +450,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSCertKey: "newTLSCertKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -456,26 +460,26 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSKey: "newTLSKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
 		{
 			"Admin CA bundle is different in managed cluster",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
 			createSecretWithOverrides(clusterRegSecretPath, map[string]string{
 				mcconstants.AdminCaBundleKey: "new CA bundle",
-			}),
+			}, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
 		{
 			"All values are in sync between admin and managed1 cluster",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			nil,
 		},
@@ -483,14 +487,14 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			"When registration secret is missing in admin cluster, then it should return error",
 			&testAdminCASecret,
 			nil,
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-cluster-managed1-registration\" not found"),
 		},
 		{
 			"When registration secret is missing in local cluster, then it should return error",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
 			nil,
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-cluster-registration\" not found"),
@@ -498,8 +502,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 		{
 			"When CA cert secret is missing in admin cluster, then it should return error",
 			nil,
-			createSecretWithOverrides(adminRegSecretPath, nil),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-local-ca-bundle\" not found"),
 		},
@@ -551,6 +555,104 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 	}
 }
 
+// TestSyncAgentSecretFromAdminCluster tests the synchronization method for the following use case.
+// GIVEN a request to sync Admin agent secret
+// WHEN the agent secret info is different in either admin-kubeconfig or managed-cluster-name
+// THEN ensure that managed cluster agent secret is updated, but not otherwise.
+func TestSyncAgentSecretFromAdminCluster(t *testing.T) {
+	testAdminAgentSecret := createSecretWithOverrides(adminAgentSecretPath, nil, "", getAgentSecretName(testClusterName))
+	testUnchangedLocalAgentSecret := createSecretWithOverrides(adminAgentSecretPath, nil, constants.VerrazzanoSystemNamespace, constants2.MCAgentSecret)
+	testNewAdminAgentSecret := createSecretWithOverrides(adminAgentNewSecretPath, nil, "", getAgentSecretName(testClusterName))
+	log := zap.S().With("test")
+	tests := []struct {
+		name                 string
+		testAdminAgentSecret *corev1.Secret
+		localAgentSecret     *corev1.Secret
+		otherAdminSecret     *corev1.Secret // some other unrelated secret present on admin cluster
+		expectedOperation    controllerutil.OperationResult
+		expectedError        error
+	}{
+		{
+			"admin agent secret identical to managed",
+			testAdminAgentSecret,
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultNone,
+			nil,
+		},
+		{
+			"admin agent secret kubeconfig changed",
+			testNewAdminAgentSecret,
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultUpdated,
+			nil,
+		},
+		{
+			"admin agent secret cluster name changed",
+			testAdminAgentSecret,
+			createSecretWithOverrides(adminAgentSecretPath, map[string]string{
+				mcconstants.ManagedClusterNameKey: "newmanagedclustername",
+			}, constants.VerrazzanoSystemNamespace, constants2.MCAgentSecret),
+			nil,
+			controllerutil.OperationResultUpdated,
+			nil,
+		},
+		{
+			"admin agent secret some unused field added",
+			createSecretWithOverrides(adminAgentSecretPath, map[string]string{
+				"somekeynotused": "somevalue",
+			}, "", getAgentSecretName(testClusterName)),
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultNone,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adminRuntimeObjects := []runtime.Object{}
+			if tt.testAdminAgentSecret != nil {
+				adminRuntimeObjects = append(adminRuntimeObjects, tt.testAdminAgentSecret)
+			}
+			adminClient := fake.NewClientBuilder().
+				WithScheme(newClusterCAScheme()).
+				WithRuntimeObjects(adminRuntimeObjects...).
+				Build()
+
+			localRuntimeObjects := []runtime.Object{}
+			if tt.localAgentSecret != nil {
+				localRuntimeObjects = append(localRuntimeObjects, tt.localAgentSecret)
+			}
+			localClient := fake.NewClientBuilder().
+				WithScheme(newClusterCAScheme()).
+				WithRuntimeObjects(localRuntimeObjects...).
+				Build()
+
+			s := &Syncer{
+				AdminClient:        adminClient,
+				LocalClient:        localClient,
+				Log:                log,
+				ManagedClusterName: testClusterName,
+				Context:            context.TODO(),
+			}
+			actualOperationResult, err := s.syncAgentSecretFromAdminCluster()
+			if tt.expectedError != nil {
+				asserts.Equal(t, err.Error(), tt.expectedError.Error())
+				return
+			}
+			asserts.NoError(t, err)
+			asserts.Equal(t, tt.expectedOperation, actualOperationResult)
+			// post sync call both the secrets should have the same values of registration secrets
+			// and calling sync again should be a no-op (unchanged).
+			reSyncOperationResult, err := s.syncAgentSecretFromAdminCluster()
+			asserts.NoError(t, err)
+			asserts.Equal(t, controllerutil.OperationResultNone, reSyncOperationResult)
+
+		})
+	}
+}
+
 // getSampleClusterCAVMC creates and returns a sample VMC
 func getSampleClusterCAVMC(filePath string) (platformopclusters.VerrazzanoManagedCluster, error) {
 	vmc := platformopclusters.VerrazzanoManagedCluster{}
@@ -589,7 +691,7 @@ func assertRegistrationInfoEqual(t *testing.T, regSecret1 *corev1.Secret, regSec
 	asserts.Equal(t, regSecret1.Data[mcconstants.JaegerOSTLSKey], regSecret2.Data[mcconstants.JaegerOSTLSKey], "Jaeger OS TLS Key is different")
 }
 
-func createSecretWithOverrides(filepath string, overrides map[string]string) *corev1.Secret {
+func createSecretWithOverrides(filepath string, overrides map[string]string, newNamespace string, newName string) *corev1.Secret {
 	secret, err := getSampleSecret(filepath)
 	if err != nil {
 		pkg.Log(pkg.Error, err.Error())
@@ -597,6 +699,12 @@ func createSecretWithOverrides(filepath string, overrides map[string]string) *co
 	}
 	for key, value := range overrides {
 		secret.Data[key] = []byte(value)
+	}
+	if newName != "" {
+		secret.Name = newName
+	}
+	if newNamespace != "" {
+		secret.Namespace = newNamespace
 	}
 	return &secret
 }

--- a/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  # a simple kubeconfig with server address https://admin-kubeconfig-new:6443 and ca data of "somecadata", user mcAgent with token "sometoken"
+  admin-kubeconfig: Y2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBzb21lY2FkYXRhIAogICAgc2VydmVyOiBodHRwczovL2FkbWluLWt1YmVjb25maWctbmV3OjY0NDMKICBuYW1lOiBhZG1pbgpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWRtaW4KICAgIHVzZXI6IG1jQWdlbnQKICBuYW1lOiBkZWZhdWx0Q29udGV4dApjdXJyZW50LWNvbnRleHQ6IGRlZmF1bHRDb250ZXh0CnVzZXJzOgotIG5hbWU6IG1jQWdlbnQKICB1c2VyOgogICAgdG9rZW46IHNvbWV0b2tlbgo=
+  managed-cluster-name: c29tZW1hbmFnZWQxCg== #somemanaged1
+kind: Secret
+metadata:
+  creationTimestamp: "2022-10-25T18:03:32Z"
+  name: verrazzano-cluster-managed1-agent
+  namespace: verrazzano-mc
+  ownerReferences:
+    - apiVersion: clusters.verrazzano.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: VerrazzanoManagedCluster
+      name: managed1
+      uid: 794564ed-1b85-4c90-ac95-6a65fb266036
+  resourceVersion: "11040"
+  uid: 3d4882e4-ec8a-43ff-a823-86ea086116b3
+type: Opaque

--- a/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: v1
 data:
   # a simple kubeconfig with server address https://admin-kubeconfig-new:6443 and ca data of "somecadata", user mcAgent with token "sometoken"

--- a/application-operator/mcagent/testdata/admin-agent-secret.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: v1
 data:
   # a simple kubeconfig with server address https://admin-kubeconfig1:6443 and ca data of "somecadata", user mcAgent with token "sometoken"

--- a/application-operator/mcagent/testdata/admin-agent-secret.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  # a simple kubeconfig with server address https://admin-kubeconfig1:6443 and ca data of "somecadata", user mcAgent with token "sometoken"
+  admin-kubeconfig: Y2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBzb21lY2FkYXRhIAogICAgc2VydmVyOiBodHRwczovL2FkbWluLWt1YmVjb25maWcxOjY0NDMKICBuYW1lOiBhZG1pbgpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWRtaW4KICAgIHVzZXI6IG1jQWdlbnQKICBuYW1lOiBkZWZhdWx0Q29udGV4dApjdXJyZW50LWNvbnRleHQ6IGRlZmF1bHRDb250ZXh0CnVzZXJzOgotIG5hbWU6IG1jQWdlbnQKICB1c2VyOgogICAgdG9rZW46IHNvbWV0b2tlbgo=
+  managed-cluster-name: c29tZW1hbmFnZWQxCg== #somemanaged1
+kind: Secret
+metadata:
+  creationTimestamp: "2022-10-25T18:03:32Z"
+  name: verrazzano-cluster-agent
+  namespace: verrazzano-mc
+  ownerReferences:
+    - apiVersion: clusters.verrazzano.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: VerrazzanoManagedCluster
+      name: managed1
+      uid: 794564ed-1b85-4c90-ac95-6a65fb266036
+  resourceVersion: "11040"
+  uid: 3d4882e4-ec8a-43ff-a823-86ea086116b3
+type: Opaque

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1973,7 +1973,7 @@ def setInitValues() {
         DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
         // update the description with some meaningful info
         setDisplayName()
-        currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+        currentBuild.description = "from ${params.VERSION_FOR_INSTALL}\n${SHORT_COMMIT_HASH} : ${env.GIT_COMMIT} : ${params.GIT_COMMIT_TO_USE}"
         if (params.TEST_ENV != "KIND") {
             // derive the prefix for the OKE cluster
             OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -32,7 +32,7 @@ func setConfigFunc(f func() (*rest.Config, error)) {
 // rancherBasedKubeConfigEnabled - feature flag for whether we support
 // Rancher based Kubeconfig - introduced for VZ-6448 Populate VMC with managed cluster data
 // Should be removed and enabled by default when story VZ-6449
-var rancherBasedKubeConfigEnabled = false
+var rancherBasedKubeConfigEnabled = true
 
 // Create an agent secret with a kubeconfig that has a token allowing access to the managed cluster
 // with restricted access as defined in the verrazzano-managed-cluster role.

--- a/platform-operator/controllers/clusters/sync_agent_secret.go
+++ b/platform-operator/controllers/clusters/sync_agent_secret.go
@@ -29,11 +29,6 @@ func setConfigFunc(f func() (*rest.Config, error)) {
 	getConfigFunc = f
 }
 
-// rancherBasedKubeConfigEnabled - feature flag for whether we support
-// Rancher based Kubeconfig - introduced for VZ-6448 Populate VMC with managed cluster data
-// Should be removed and enabled by default when story VZ-6449
-var rancherBasedKubeConfigEnabled = true
-
 // Create an agent secret with a kubeconfig that has a token allowing access to the managed cluster
 // with restricted access as defined in the verrazzano-managed-cluster role.
 // The code does the following:
@@ -81,12 +76,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	// Build the kubeconfig
 	var err error
 	var kc *vzk8s.KubeConfig
-	// Check feature flag before building kubeconfig from Rancher - feature flag was introduced in
-	// VZ-6448, to be removed when VZ-6449 is completed
-	if rancherBasedKubeConfigEnabled {
-		kc, err = r.buildKubeConfigUsingRancherURL(serviceAccountSecret)
-	}
-	if err != nil || !rancherBasedKubeConfigEnabled {
+
+	// Try to use Rancher URL in the kubeconfig - this will fail if Rancher is not enabled
+	kc, err = r.buildKubeConfigUsingRancherURL(serviceAccountSecret)
+	if err != nil {
 		r.log.Oncef("Failed to build admin kubeconfig using Rancher URL: %v", err)
 		kc, err = r.buildKubeConfigUsingAdminConfigMap(serviceAccountSecret)
 	}


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
