### PR TITLE
Set authproxy strategy maxUnavailable to 0 

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -40,7 +40,7 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Update authproxy deployment strategy to set `maxUnavailable` to 0 to force create-before-delete on RollingUpdate.