### PR TITLE
JIRA:VZ-7591 update rancher user lists as users are deleted

### DIFF
--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -199,16 +199,34 @@ func DeleteRancherUsers(rancherURL string) bool {
 		return false
 	}
 	httpClient := pkg.EventuallyVerrazzanoRetryableHTTPClient()
+	rancherDeletedIds := make([]int, 0)
 	for i := 0; i < len(common.RancherUserNameList); i++ {
 		rancherUserDeleteURL := fmt.Sprintf("%s/v3/users/%s", rancherURL, common.RancherUserIDList[i])
 		_, err := common.HTTPHelper(httpClient, "DELETE", rancherUserDeleteURL, token, "Bearer", http.StatusOK, nil, t.Logs)
 		if err != nil {
 			t.Logs.Errorf("Error while retrieving http data %v", zap.Error(err))
+			updatedUserLists(rancherDeletedIds)
 			return false
 		}
 		t.Logs.Infof("Successfully deleted rancher user '%v' with id '%v' ", common.RancherUserNameList[i], common.RancherUserIDList[i])
+		rancherDeletedIds = append(rancherDeletedIds, i)
 	}
 	return true
+}
+
+// updateUserLists updates the rancher user lists by removing those users that have already been deleted
+func updatedUserLists(ids []int) {
+	for _, id := range ids {
+		common.RancherUserNameList = removeItem(common.RancherUserNameList, id)
+		common.RancherUserIDList = removeItem(common.RancherUserIDList, id)
+	}
+}
+
+// removeItem returns a slice with the item specified by the index removed
+func removeItem(s []string, index int) []string {
+	ret := make([]string, 0)
+	ret = append(ret, s[:index]...)
+	return append(ret, s[index+1:]...)
 }
 
 // VerifyRancherUsers gets an existing rancher user

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -205,7 +205,7 @@ func DeleteRancherUsers(rancherURL string) bool {
 		_, err := common.HTTPHelper(httpClient, "DELETE", rancherUserDeleteURL, token, "Bearer", http.StatusOK, nil, t.Logs)
 		if err != nil {
 			t.Logs.Errorf("Error while retrieving http data %v", zap.Error(err))
-			updatedUserLists(rancherDeletedIds)
+			updateUserLists(rancherDeletedIds)
 			return false
 		}
 		t.Logs.Infof("Successfully deleted rancher user '%v' with id '%v' ", common.RancherUserNameList[i], common.RancherUserIDList[i])
@@ -215,7 +215,7 @@ func DeleteRancherUsers(rancherURL string) bool {
 }
 
 // updateUserLists updates the rancher user lists by removing those users that have already been deleted
-func updatedUserLists(ids []int) {
+func updateUserLists(ids []int) {
 	for _, id := range ids {
 		common.RancherUserNameList = removeItem(common.RancherUserNameList, id)
 		common.RancherUserIDList = removeItem(common.RancherUserIDList, id)


### PR DESCRIPTION
If there is an issue while deleting the rancher users during the test the user deletion will be re-attempted.  There is a need to remove the deleted users from the list being provided to the deletion method to avoid 404 responses for deletion of users already deleted and the build ultimately failing.