### PR TITLE
Revert "Set authproxy strategy maxUnavailable to 0"

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -40,7 +40,7 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION

This reverts commit 9284dffb35fe1f8ba5580845336824125266579c.

Causing failures in the authproxy dynamic update tests.