### PR TITLE
Add deployment ports back in for PSR

### DIFF
--- a/tools/psr/manifests/charts/worker/templates/component.yaml
+++ b/tools/psr/manifests/charts/worker/templates/component.yaml
@@ -35,4 +35,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              name: backend
 {{- end }}

--- a/tools/psr/manifests/charts/worker/templates/deployment.yaml
+++ b/tools/psr/manifests/charts/worker/templates/deployment.yaml
@@ -37,4 +37,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              name: backend
 {{- end }}


### PR DESCRIPTION
This were removed because we thought they weren't needed. Turns out it breaks metrics so adding them back in.