### PR TITLE
VZ-6468: Delete Rancher cluster when VMC is deleted

### DIFF
--- a/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/platform-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -81,6 +81,7 @@ type RancherRegistrationStatus string
 const (
 	RegistrationCompleted RancherRegistrationStatus = "Completed"
 	RegistrationFailed    RancherRegistrationStatus = "Failed"
+	DeleteFailed          RancherRegistrationStatus = "DeleteFailed"
 )
 
 // RancherRegistration defines the Rancher registration state for a managed cluster.

--- a/platform-operator/controllers/clusters/vmc_controller.go
+++ b/platform-operator/controllers/clusters/vmc_controller.go
@@ -322,7 +322,35 @@ func (r *VerrazzanoManagedClusterReconciler) SetupWithManager(mgr ctrl.Manager) 
 
 // reconcileManagedClusterDelete performs all necessary cleanup during cluster deletion
 func (r *VerrazzanoManagedClusterReconciler) reconcileManagedClusterDelete(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-	return r.deleteClusterPrometheusConfiguration(ctx, vmc)
+	if err := r.deleteClusterPrometheusConfiguration(ctx, vmc); err != nil {
+		return err
+	}
+	return r.deleteClusterFromRancher(ctx, vmc)
+}
+
+// deleteClusterFromRancher calls the Rancher API to delete the cluster associated with the VMC if the VMC has a cluster id set in the status.
+func (r *VerrazzanoManagedClusterReconciler) deleteClusterFromRancher(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
+	clusterID := vmc.Status.RancherRegistration.ClusterID
+	if clusterID == "" {
+		r.log.Debugf("VMC %s/%s has no Rancher cluster id, skipping delete", vmc.Namespace, vmc.Name)
+		return nil
+	}
+
+	rc, err := newRancherConfig(r.Client, r.log)
+	if err != nil {
+		msg := "Failed to create Rancher API client"
+		r.updateRancherStatus(ctx, vmc, clustersv1alpha1.DeleteFailed, clusterID, msg)
+		r.log.Errorf("Unable to connect to Rancher API on admin cluster while attempting delete operation: %v", err)
+		return err
+	}
+	if _, err = DeleteClusterFromRancher(rc, clusterID, r.log); err != nil {
+		msg := "Failed deleting cluster"
+		r.updateRancherStatus(ctx, vmc, clustersv1alpha1.DeleteFailed, clusterID, msg)
+		r.log.Errorf("Unable to delete Rancher cluster %s/%s: %v", vmc.Namespace, vmc.Name, err)
+		return err
+	}
+
+	return nil
 }
 
 func (r *VerrazzanoManagedClusterReconciler) setStatusConditionManagedCARetrieved(vmc *clustersv1alpha1.VerrazzanoManagedCluster, value corev1.ConditionStatus, msg string) {

--- a/platform-operator/controllers/clusters/vmc_controller_test.go
+++ b/platform-operator/controllers/clusters/vmc_controller_test.go
@@ -779,96 +779,31 @@ func TestCreateVMCSyncRoleBindingFailed(t *testing.T) {
 // THEN ensure the object is not processed
 func TestDeleteVMC(t *testing.T) {
 	namespace := "verrazzano-install"
-	labels := map[string]string{"label1": "test"}
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	mockStatus := mocks.NewMockStatusWriter(mocker)
-	asserts.NotNil(mockStatus)
 
-	// Expect a call to get the VerrazzanoManagedCluster resource.
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: testManagedCluster}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, vmc *clustersapi.VerrazzanoManagedCluster) error {
-			vmc.TypeMeta = metav1.TypeMeta{
-				APIVersion: apiVersion,
-				Kind:       kind}
-			vmc.ObjectMeta = metav1.ObjectMeta{
-				Namespace:         name.Namespace,
-				Name:              name.Name,
-				DeletionTimestamp: &metav1.Time{Time: time.Now()},
-				Labels:            labels,
-				Finalizers:        []string{finalizerName}}
-			vmc.Status = clustersapi.VerrazzanoManagedClusterStatus{
-				PrometheusHost: getPrometheusHost(),
+	mockRequestSender := mocks.NewMockRequestSender(mocker)
+	savedRancherHTTPClient := rancherHTTPClient
+	defer func() {
+		rancherHTTPClient = savedRancherHTTPClient
+	}()
+	rancherHTTPClient = mockRequestSender
+
+	// Expect all of the calls when deleting a VMC
+	expectMockCallsForDelete(t, mock, namespace)
+	expectRancherGetAdminTokenHTTPCall(t, mockRequestSender)
+
+	// Expect an API call to delete the Rancher cluster
+	mockRequestSender.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURIMethod("DELETE", clustersPath+"/"+unitTestRancherClusterID)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			r := io.NopCloser(bytes.NewReader([]byte("")))
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       r,
 			}
-
-			return nil
-		})
-
-	jobs := `  - ` + constants.PrometheusJobNameKey + `: test
-    scrape_interval: 20s
-    scrape_timeout: 15s
-    scheme: http
-  - ` + constants.PrometheusJobNameKey + `: test2
-    scrape_interval: 20s
-    scrape_timeout: 15s
-    scheme: http`
-
-	// Expect a call to get the additional scrape config secret - return it configured with the two scrape jobs
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: constants.PromAdditionalScrapeConfigsSecretName}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				constants.PromAdditionalScrapeConfigsSecretKey: []byte(jobs),
-			}
-			return nil
-		})
-
-	// Expect a call to get the additional scrape config secret (we call controllerruntime.CreateOrUpdate so it fetches again) - return it
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: constants.PromAdditionalScrapeConfigsSecretName}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				constants.PromAdditionalScrapeConfigsSecretKey: []byte(jobs),
-			}
-			return nil
-		})
-
-	// Expect a call to update the additional scrape config secret
-	mock.EXPECT().
-		Update(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.UpdateOption) error {
-			// validate that the scrape config for the managed cluster is no longer present
-			scrapeConfigs, err := metricsutils.ParseScrapeConfig(string(secret.Data[constants.PromAdditionalScrapeConfigsSecretKey]))
-			if err != nil {
-				return err
-			}
-			asserts.Len(scrapeConfigs.Children(), 1, "Expected only one scrape config")
-			scrapeJobName := scrapeConfigs.Children()[0].Search(constants.PrometheusJobNameKey).Data()
-			asserts.Equal("test2", scrapeJobName)
-			return nil
-		})
-
-	// Expect a call to get the managed cluster TLS certs secret - return it configured with two managed cluster certs
-	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: vpoconstants.PromManagedClusterCACertsSecretName}, gomock.Not(gomock.Nil())).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				"ca-test":  []byte("ca-cert-1"),
-				"ca-test2": []byte("ca-cert-1"),
-			}
-			return nil
-		})
-
-	// Expect a call to update the managed cluster TLS certs secret
-	mock.EXPECT().
-		Update(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.UpdateOption) error {
-			// validate that the cert for the cluster being deleted is no longer present
-			asserts.Len(secret.Data, 1, "Expected only one managed cluster cert")
-			asserts.Contains(secret.Data, "ca-test2", "Expected to find cert for managed cluster not being deleted")
-			return nil
+			return resp, nil
 		})
 
 	// Expect a call to update the VerrazzanoManagedCluster finalizer
@@ -889,6 +824,110 @@ func TestDeleteVMC(t *testing.T) {
 	asserts.NoError(err)
 	asserts.Equal(false, result.Requeue)
 	asserts.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestDeleteVMCFailedDeletingRancherCluster tests deleting a VMC when there are errors attempting to
+// delete the Rancher cluster.
+func TestDeleteVMCFailedDeletingRancherCluster(t *testing.T) {
+	namespace := "verrazzano-install"
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	asserts.NotNil(mockStatus)
+
+	mockRequestSender := mocks.NewMockRequestSender(mocker)
+	savedRancherHTTPClient := rancherHTTPClient
+	defer func() {
+		rancherHTTPClient = savedRancherHTTPClient
+	}()
+	rancherHTTPClient = mockRequestSender
+
+	// GIVEN a VMC is being deleted
+	//  WHEN we fail creating a Rancher API client that will be used to delete the cluster in Rancher
+	//  THEN the appropriate status is set on the VMC and the finalizer is not removed
+
+	// Expect all of the calls when deleting a VMC
+	expectMockCallsForDelete(t, mock, namespace)
+
+	// Expect an HTTP request to fetch the admin token from Rancher - return an error
+	mockRequestSender.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(loginURIPath)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			asserts.Equal(loginQueryString, req.URL.RawQuery)
+
+			r := io.NopCloser(bytes.NewReader([]byte("")))
+			resp := &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodDelete},
+			}
+			return resp, nil
+		})
+
+	mock.EXPECT().Status().Return(mockStatus)
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.AssignableToTypeOf(&clustersapi.VerrazzanoManagedCluster{}), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, vmc *clustersapi.VerrazzanoManagedCluster, opts ...client.UpdateOption) error {
+			asserts.Equal(clustersapi.DeleteFailed, vmc.Status.RancherRegistration.Status)
+			asserts.Equal("Failed to create Rancher API client", vmc.Status.RancherRegistration.Message)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest(namespace, testManagedCluster)
+	reconciler := newVMCReconciler(mock)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(true, result.Requeue)
+
+	// GIVEN a VMC is being deleted
+	//  WHEN we fail attempting to delete the cluster in Rancher
+	//  THEN the appropriate status is set on the VMC and the finalizer is not removed
+
+	mock = mocks.NewMockClient(mocker)
+	mockStatus = mocks.NewMockStatusWriter(mocker)
+	mockRequestSender = mocks.NewMockRequestSender(mocker)
+	rancherHTTPClient = mockRequestSender
+
+	// Expect all of the calls when deleting a VMC
+	expectMockCallsForDelete(t, mock, namespace)
+	expectRancherGetAdminTokenHTTPCall(t, mockRequestSender)
+
+	// Expect an API call to delete the Rancher cluster - return an error
+	mockRequestSender.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURIMethod("DELETE", clustersPath+"/"+unitTestRancherClusterID)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			r := io.NopCloser(bytes.NewReader([]byte("")))
+			resp := &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodDelete},
+			}
+			return resp, nil
+		})
+
+	mock.EXPECT().Status().Return(mockStatus)
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.AssignableToTypeOf(&clustersapi.VerrazzanoManagedCluster{}), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, vmc *clustersapi.VerrazzanoManagedCluster, opts ...client.UpdateOption) error {
+			asserts.Equal(clustersapi.DeleteFailed, vmc.Status.RancherRegistration.Status)
+			asserts.Equal("Failed deleting cluster", vmc.Status.RancherRegistration.Message)
+			return nil
+		})
+
+	// Create and make the request
+	request = newRequest(namespace, testManagedCluster)
+	reconciler = newVMCReconciler(mock)
+	result, err = reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	asserts.NoError(err)
+	asserts.Equal(true, result.Requeue)
 }
 
 // TestSyncManifestSecretFailRancherRegistration tests syncing the manifest secret
@@ -2332,4 +2371,100 @@ func expectRancherConfigK8sCalls(t *testing.T, k8sMock *mocks.MockClient) {
 	k8sMock.EXPECT().
 		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: constants.AdditionalTLS}), gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: rancherNamespace, Resource: "Secret"}, constants.AdditionalTLS))
+}
+
+// expectMockCallsForDelete mocks expectations for the VMC deletion scenario. These are the common mock expectations across
+// tests that exercise delete functionality. Individual tests add mock expectations after these to test various scenarios.
+func expectMockCallsForDelete(t *testing.T, mock *mocks.MockClient, namespace string) {
+	asserts := assert.New(t)
+
+	// Expect a call to get the VerrazzanoManagedCluster resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: namespace, Name: testManagedCluster}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, vmc *clustersapi.VerrazzanoManagedCluster) error {
+			vmc.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       kind}
+			vmc.ObjectMeta = metav1.ObjectMeta{
+				Namespace:         name.Namespace,
+				Name:              name.Name,
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{finalizerName}}
+			vmc.Status = clustersapi.VerrazzanoManagedClusterStatus{
+				PrometheusHost: getPrometheusHost(),
+				RancherRegistration: clustersapi.RancherRegistration{
+					ClusterID: unitTestRancherClusterID,
+				},
+			}
+
+			return nil
+		})
+
+	jobs := `  - ` + constants.PrometheusJobNameKey + `: test
+    scrape_interval: 20s
+    scrape_timeout: 15s
+    scheme: http
+  - ` + constants.PrometheusJobNameKey + `: test2
+    scrape_interval: 20s
+    scrape_timeout: 15s
+    scheme: http`
+
+	// Expect a call to get the additional scrape config secret - return it configured with the two scrape jobs
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: constants.PromAdditionalScrapeConfigsSecretName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				constants.PromAdditionalScrapeConfigsSecretKey: []byte(jobs),
+			}
+			return nil
+		})
+
+	// Expect a call to get the additional scrape config secret (we call controllerruntime.CreateOrUpdate so it fetches again) - return it
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: constants.PromAdditionalScrapeConfigsSecretName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				constants.PromAdditionalScrapeConfigsSecretKey: []byte(jobs),
+			}
+			return nil
+		})
+
+	// Expect a call to update the additional scrape config secret
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.UpdateOption) error {
+			// validate that the scrape config for the managed cluster is no longer present
+			scrapeConfigs, err := metricsutils.ParseScrapeConfig(string(secret.Data[constants.PromAdditionalScrapeConfigsSecretKey]))
+			if err != nil {
+				return err
+			}
+			asserts.Len(scrapeConfigs.Children(), 1, "Expected only one scrape config")
+			scrapeJobName := scrapeConfigs.Children()[0].Search(constants.PrometheusJobNameKey).Data()
+			asserts.Equal("test2", scrapeJobName)
+			return nil
+		})
+
+	// Expect a call to get the managed cluster TLS certs secret - return it configured with two managed cluster certs
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: vpoconstants.VerrazzanoMonitoringNamespace, Name: vpoconstants.PromManagedClusterCACertsSecretName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret) error {
+			secret.Data = map[string][]byte{
+				"ca-test":  []byte("ca-cert-1"),
+				"ca-test2": []byte("ca-cert-1"),
+			}
+			return nil
+		})
+
+	// Expect a call to update the managed cluster TLS certs secret
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.UpdateOption) error {
+			// validate that the cert for the cluster being deleted is no longer present
+			asserts.Len(secret.Data, 1, "Expected only one managed cluster cert")
+			asserts.Contains(secret.Data, "ca-test2", "Expected to find cert for managed cluster not being deleted")
+			return nil
+		})
+
+	// Expect Rancher k8s calls to configure the API client
+	expectRancherConfigK8sCalls(t, mock)
 }

--- a/tests/e2e/config/scripts/deregister_managed_cluster.sh
+++ b/tests/e2e/config/scripts/deregister_managed_cluster.sh
@@ -23,26 +23,6 @@ echo ADMIN_KUBECONFIG: ${ADMIN_KUBECONFIG}
 echo MANAGED_CLUSTER_NAME: ${MANAGED_CLUSTER_NAME}
 echo MANAGED_KUBECONFIG: ${MANAGED_KUBECONFIG}
 
-function deleteRancherCluster() {
-      # get the admin user token from the Rancher API
-      RANCHER_URL=$(kubectl --kubeconfig ${ADMIN_KUBECONFIG} get vz -o jsonpath='{.items[0].status.instance.rancherUrl}')
-      echo "RANCHER_URL: ${RANCHER_URL}"
-      RANCHER_ADMIN_PASS=$(kubectl --kubeconfig ${ADMIN_KUBECONFIG} get secret -n cattle-system rancher-admin-secret -o jsonpath={.data.password} | base64 --decode)
-      RANCHER_TOKEN=$(curl -s -k -X POST -H 'Content-Type: application/json' "${RANCHER_URL}/v3-public/localProviders/local?action=login"  -d "{\"username\":\"admin\", \"password\":\"${RANCHER_ADMIN_PASS}\"}"| jq -r ".token")
-      if [ -z "${RANCHER_TOKEN}" ] ; then
-        echo "Rancher token for admin user not found"
-        exit 1
-      fi
-
-      # Use the token to retrieve Rancher cluster id and delete the cluster from Rancher
-      RANCHER_CLUSTER_ID=$(curl -s -k -X GET -H "Authorization: Bearer ${RANCHER_TOKEN}" "${RANCHER_URL}/v3/clusters?name=${MANAGED_CLUSTER_NAME}" | jq -r '.data[0].id')
-      echo "deleting RANCHER_CLUSTER_ID: ${RANCHER_CLUSTER_ID}"
-      curl -s -k -X DELETE -H "Authorization: Bearer ${RANCHER_TOKEN}" "${RANCHER_URL}/v3/clusters/${RANCHER_CLUSTER_ID}"
-}
-
-# Delete the Rancher cluster explicitly here until VMC delete auto-triggers Rancher cluster delete (VZ-6451).
-echo "Deleting Rancher cluster"
-deleteRancherCluster
 echo "Deleting VMC on admin cluster ${MANAGED_CLUSTER_NAME}"
 kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc delete vmc ${MANAGED_CLUSTER_NAME}
 echo "Deleting cluster registration secret on managed cluster"


### PR DESCRIPTION
This PR continues the work to make Rancher cluster synchronization fully bidirectional. When a VMC is deleted, if it has a Rancher cluster id set in the status, the VMC controller will call the Rancher API to delete the cluster.