### PR TITLE
Re-introduce authproxy strategy to set maxUnavailable to 0 to force create-before-delete on RollingUpdates

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -40,7 +40,7 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package authproxy

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -140,7 +140,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		Fail(err.Error())
 	}
-	t.Logs.Info("Schedulable nodes: %v", nodeCount)
+	t.Logs.Infof("Schedulable nodes: %v", nodeCount)
 })
 
 var _ = BeforeSuite(beforeSuite)
@@ -174,11 +174,11 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 			m := AuthProxyPodPerNodeAffintyModifier{}
 			update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 
+			// Because the authproxy rollout strategy requires maxUnavailable == 0, k8s tries to spin
+			// up a new pod after the edit to the deployment which gets stuck in pending, regardless of the number
+			// of nodes
 			expectedRunning := nodeCount
 			expectedPending := true
-			if nodeCount == 1 {
-				expectedPending = false
-			}
 			t.Logs.Debugf("Expected running: %v, expected pending %v", expectedRunning, expectedPending)
 			update.ValidatePods(authProxyLabelValue, authProxyLabelKey, constants.VerrazzanoSystemNamespace, expectedRunning, expectedPending)
 		})

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -136,10 +136,11 @@ var nodeCount uint32
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	var err error
-	nodeCount, err = pkg.GetNodeCount()
+	nodeCount, err = pkg.GetSchedulableNodeCount()
 	if err != nil {
 		Fail(err.Error())
 	}
+	t.Logs.Info("Schedulable nodes: %v", nodeCount)
 })
 
 var _ = BeforeSuite(beforeSuite)
@@ -160,7 +161,7 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 	})
 
 	t.Describe("verrazzano-authproxy update replicas", Label("f:platform-lcm.authproxy-update-replicas"), func() {
-		t.It("authproxy explicit replicas", func() {
+		t.It("authproxy explicit replicas v1alpha1", func() {
 			m := AuthProxyReplicasModifier{replicas: nodeCount}
 			update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 			expectedRunning := nodeCount
@@ -169,22 +170,22 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 	})
 
 	t.Describe("verrazzano-authproxy update affinity", Label("f:platform-lcm.authproxy-update-affinity"), func() {
-		t.It("authproxy explicit affinity", func() {
+		t.It("authproxy explicit affinity v1alpha1", func() {
 			m := AuthProxyPodPerNodeAffintyModifier{}
 			update.UpdateCRWithRetries(m, pollingInterval, waitTimeout)
 
-			expectedRunning := nodeCount - 1
+			expectedRunning := nodeCount
 			expectedPending := true
 			if nodeCount == 1 {
-				expectedRunning = nodeCount
 				expectedPending = false
 			}
+			t.Logs.Debugf("Expected running: %v, expected pending %v", expectedRunning, expectedPending)
 			update.ValidatePods(authProxyLabelValue, authProxyLabelKey, constants.VerrazzanoSystemNamespace, expectedRunning, expectedPending)
 		})
 	})
 
 	t.Describe("verrazzano-authproxy update replicas with v1beta1 client", Label("f:platform-lcm.authproxy-update-replicas"), func() {
-		t.It("authproxy explicit replicas", func() {
+		t.It("authproxy explicit replicas v1beta1", func() {
 			m := AuthProxyReplicasModifierV1beta1{replicas: explicitReplicas}
 			update.UpdateCRV1beta1WithRetries(m, pollingInterval, waitTimeout)
 			expectedRunning := explicitReplicas
@@ -193,7 +194,7 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 	})
 
 	t.Describe("verrazzano-authproxy update affinity using v1beta1 client", Label("f:platform-lcm.authproxy-update-affinity"), func() {
-		t.It("authproxy explicit affinity", func() {
+		t.It("authproxy explicit affinity v1beta1", func() {
 			m := AuthProxyPodPerNodeAffintyModifierV1beta1{}
 			update.UpdateCRV1beta1WithRetries(m, pollingInterval, waitTimeout)
 			expectedRunning := explicitReplicas

--- a/tests/e2e/update/authproxy/authproxy_update_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_test.go
@@ -25,6 +25,8 @@ const (
 	explicitReplicas    = uint32(3)
 	waitTimeout         = 20 * time.Minute
 	pollingInterval     = 10 * time.Second
+
+	verrazzanoAuthproxyDeployment = "verrazzano-authproxy"
 )
 
 type AuthProxyReplicasModifier struct {
@@ -159,7 +161,7 @@ var _ = t.Describe("Update authProxy", Label("f:platform-lcm.update"), func() {
 			cr := update.GetCR()
 
 			expectedRunning := int32(1)
-			deployment, err := pkg.GetDeployment(constants.VerrazzanoSystemNamespace, constants.VerrazzanoAuthproxy)
+			deployment, err := pkg.GetDeployment(constants.VerrazzanoSystemNamespace, verrazzanoAuthproxyDeployment)
 			gomega.Expect(err).To(gomega.BeNil())
 			if deployment.Spec.Replicas != nil {
 				expectedRunning = *deployment.Spec.Replicas


### PR DESCRIPTION
Re-introduce change to set authproxy strategy maxUnavailable to 0 to force create-before-delete semantics on RollingUpdate.

This also changes the authproxy update tests to account for maxSurge during rolling update; the tests were not filtering out unschedulable nodes, and when the behavior changed to spin up new pods before deleting any existing ones it was throwing off the counts.  