### PR TITLE
Add CONSOLE_REPO_BRANCH parameter that is referenced by the console t…

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -51,6 +51,10 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "v1beta1", "v1alpha1"])
 
+        string (name: 'CONSOLE_REPO_BRANCH',
+                defaultValue: '',
+                description: 'The branch to check out after cloning the console repository.',
+                trim: true)
         string (name: 'GIT_COMMIT_TO_USE',
                 defaultValue: 'NONE',
                 description: 'This is the full git commit hash from the source build to be used for all jobs',


### PR DESCRIPTION
The uninstall resiliency tests were referencing but not defining the CONSOLE_REPOR_BRANCH parameter. This caused the console tests to be failing to align the console sources at the commit for the image, and we were seeing failures (it looks like it was always using the tip of master and then started to fail
