### PR TITLE
Fix prometheus-pushgateway image name

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -553,7 +553,7 @@
           "name": "prometheus-pushgateway",
           "images": [
             {
-              "image": "pushgateway",
+              "image": "prometheus-pushgateway",
               "tag": "v1.4.2-20221012144616-8c52681c",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
Fix the prometheus-gateway image name so it's back to what it was previously in released Verrazzano versions.