### PR TITLE
Don't check for recent log records for Helidon app if running from LRE

### DIFF
--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -180,14 +181,16 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			Eventually(func() bool {
-				return pkg.FindLog(indexName,
-					[]pkg.Match{
-						{Key: "kubernetes.labels.app_oam_dev\\/component", Value: "hello-helidon-component"},
-						{Key: "kubernetes.labels.app_oam_dev\\/name", Value: helloHelidon},
-						{Key: "kubernetes.container_name", Value: "hello-helidon-container"}},
-					[]pkg.Match{})
-			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
+			if os.Getenv("TEST_ENV") != "LRE" {
+				Eventually(func() bool {
+					return pkg.FindLog(indexName,
+						[]pkg.Match{
+							{Key: "kubernetes.labels.app_oam_dev\\/component", Value: "hello-helidon-component"},
+							{Key: "kubernetes.labels.app_oam_dev\\/name", Value: helloHelidon},
+							{Key: "kubernetes.container_name", Value: "hello-helidon-container"}},
+						[]pkg.Match{})
+				}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
+			}
 		})
 	})
 


### PR DESCRIPTION
This pull request includes a  change to not check for recent log records for the Helidon app if running from LRE