### PR TITLE
VZ-7616: Increase unit test coverage for mysqloperator component

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
@@ -4,20 +4,23 @@
 package mysqloperator
 
 import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/pkg/helm"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	appsv1 "k8s.io/api/apps/v1"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 var testScheme = runtime.NewScheme()
@@ -25,32 +28,6 @@ var testScheme = runtime.NewScheme()
 func init() {
 	_ = scheme.AddToScheme(testScheme)
 	_ = vzapi.AddToScheme(testScheme)
-}
-
-// TestGetInstallOverrides tests the GetInstallOverrides function
-// GIVEN a call to GetInstallOverrides
-// WHEN there is a valid MySQL Operator configuration
-// THEN the correct Helm overrides are returned
-func TestGetInstallOverrides(t *testing.T) {
-	vz := &vzapi.Verrazzano{
-		Spec: vzapi.VerrazzanoSpec{
-			Components: vzapi.ComponentSpec{
-				MySQLOperator: &vzapi.MySQLOperatorComponent{
-					InstallOverrides: vzapi.InstallOverrides{
-						ValueOverrides: []vzapi.Overrides{
-							{Values: &apiextensionsv1.JSON{
-								Raw: []byte("{\"key1\": \"value1\"}")},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	comp := NewComponent()
-	overrides := comp.GetOverrides(vz).([]vzapi.Overrides)
-	assert.Equal(t, []byte("{\"key1\": \"value1\"}"), overrides[0].Values.Raw)
 }
 
 // TestIsEnabled tests the IsEnabled function
@@ -112,111 +89,6 @@ func TestIsEnabled(t *testing.T) {
 			assert.Equal(t, tt.want, c)
 		})
 	}
-}
-
-// TestIsMySQLOperatorReady tests the isReady function
-// GIVEN a call to isReady
-// WHEN the deployment object has enough replicas available
-// THEN true is returned
-func TestIsMySQLOperatorReady(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      ComponentName,
-				Labels:    map[string]string{"app": ComponentName},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": ComponentName},
-				},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				Replicas:          1,
-				UpdatedReplicas:   1,
-			},
-		},
-		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   ComponentNamespace,
-				Name:        ComponentName + "-95d8c5d96",
-				Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-			},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      ComponentName + "-95d8c5d96-m6mbr",
-				Labels: map[string]string{
-					"pod-template-hash": "95d8c5d96",
-					"app":               ComponentName,
-				},
-			},
-		},
-	).Build()
-
-	mysqlOperator := NewComponent().(mysqlOperatorComponent)
-	assert.True(t, mysqlOperator.isReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
-}
-
-// TestIsMySQLOperatorNotReady tests the isReady function
-// GIVEN a call to isReady
-// WHEN the deployment object does NOT have enough replicas available
-// THEN false is returned
-func TestIsMySQLOperatorNotReady(t *testing.T) {
-	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
-		return helm.ChartStatusDeployed, nil
-	})
-	defer helm.SetDefaultChartStatusFunction()
-
-	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ComponentNamespace,
-			Name:      ComponentNamespace,
-		},
-		Status: appsv1.DeploymentStatus{
-			AvailableReplicas: 1,
-			Replicas:          1,
-			UpdatedReplicas:   0,
-		},
-	}).Build()
-	mysqlOperator := NewComponent().(mysqlOperatorComponent)
-	assert.False(t, mysqlOperator.isReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
-}
-
-// TestIsInstalled tests the isInstalled function
-// GIVEN a call to isInstalled
-// WHEN the deployment object exists
-// THEN true is returned
-func TestIsInstalled(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ComponentNamespace,
-				Name:      ComponentName,
-				Labels:    map[string]string{"app": ComponentName},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": ComponentName},
-				},
-			},
-		},
-	).Build()
-
-	mysqlOperator := NewComponent().(mysqlOperatorComponent)
-	assert.True(t, mysqlOperator.isInstalled(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
-}
-
-// TestIsInstalledFalse tests the isInstalled function
-// GIVEN a call to isInstalled
-// WHEN the deployment object does not exist
-// THEN false is returned
-func TestIsInstalledFalse(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
-	mysqlOperator := NewComponent().(mysqlOperatorComponent)
-	assert.False(t, mysqlOperator.isInstalled(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
 }
 
 // TestValidateInstall tests the ValidateInstall function
@@ -282,6 +154,11 @@ func TestValidateInstall(t *testing.T) {
 					Components: vzapi.ComponentSpec{}}},
 			expectError: false,
 		},
+		{
+			name:        "Nil vz resource",
+			vz:          nil,
+			expectError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -295,34 +172,336 @@ func TestValidateInstall(t *testing.T) {
 	}
 }
 
-// TestAppendOverrides tests the AppendOverrides function
-// GIVEN a call to AppendOverrides
-// WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
-// THEN the correct Helm overrides are returned
-func TestAppendOverrides(t *testing.T) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ComponentNamespace,
-			Name:      constants.GlobalImagePullSecName,
+// TestPreInstall tests the PreInstall function of mysqloperator
+// GIVEN a call to PreInstall with different vz CR
+// THEN return the expected error
+func TestPreInstall(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	enabled := true
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: ComponentNamespace}, gomock.Not(gomock.Nil())).
+		Return(fmt.Errorf("server error"))
+
+	tests := []struct {
+		name string
+		ctx  spi.ComponentContext
+		err  error
+	}{
+		{
+			name: "PreInstallNoError",
+			ctx:  spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false),
+			err:  nil,
+		},
+		{
+			name: "PreInstallWithIstioEnabled",
+			ctx: spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Istio: &vzapi.IstioComponent{
+							Enabled:          &enabled,
+							InjectionEnabled: &enabled,
+						},
+					},
+				},
+			}, nil, false),
+			err: nil,
+		},
+		{
+			name: "PreInstallServerError",
+			ctx:  spi.NewFakeContext(mockClient, &vzapi.Verrazzano{}, nil, false),
+			err:  fmt.Errorf("Failed to create or update the mysql-operator namespace: server error"),
 		},
 	}
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secret).Build()
 
-	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
-	assert.Nil(t, err)
-	assert.Len(t, kvs, 2)
-	assert.Equal(t, bom.KeyValue{Key: "key1", Value: "value1"}, kvs[0])
-	assert.Equal(t, bom.KeyValue{Key: "image.pullSecrets.enabled", Value: "true"}, kvs[1])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().PreInstall(tt.ctx)
+			assert.Equal(t, tt.err, err)
+		})
+	}
 }
 
-// TestAppendOverridesNoSecret tests the AppendOverrides function
-// GIVEN a call to AppendOverrides
-// WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
-// THEN the correct Helm overrides are returned
-func TestAppendOverridesNoSecret(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
-	assert.Nil(t, err)
-	assert.Len(t, kvs, 1)
-	assert.Equal(t, bom.KeyValue{Key: "key1", Value: "value1"}, kvs[0])
+// TestPreUpgrade tests the PreUpgrade function of mysqloperator
+// GIVEN a call to PreUpgrade
+// THEN return the expected error
+func TestPreUpgrade(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+
+	mockClient.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Name: ComponentName, Namespace: ComponentNamespace}, gomock.Not(gomock.Nil())).
+		Return(fmt.Errorf("server error"))
+
+	tests := []struct {
+		name string
+		ctx  spi.ComponentContext
+		err  error
+	}{
+		{
+			// If the mysql-operator deployment is found, update and return no error
+			name: "PreUpgradeNoError",
+			ctx:  spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false),
+			err:  nil,
+		},
+		{
+			// If the mysql-operator deployment is not found for any reason, return a retryable error
+			name: "PreUpgradeServerError",
+			ctx:  spi.NewFakeContext(mockClient, &vzapi.Verrazzano{}, nil, false),
+			err:  ctrlerrors.RetryableError{Source: ComponentName, Cause: fmt.Errorf("server error")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().PreUpgrade(tt.ctx)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}
+
+// TestPreUninstall tests the PreUninstall function of mysqloperator
+// GIVEN a call to PreUninstall
+// THEN return a retryable error
+// WHEN mysql pods are still present in the keycloak ns
+func TestPreUninstall(t *testing.T) {
+	label := make(map[string]string)
+	label["mysql.oracle.com/cluster"] = "mysql"
+
+	fakeClient := fake.NewClientBuilder().WithLists(
+		&corev1.PodList{
+			TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: constants.KeycloakNamespace,
+						Labels:    label,
+					},
+				},
+			},
+		},
+	).Build()
+
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+
+	mockClient.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		Return(fmt.Errorf("server error"))
+
+	tests := []struct {
+		name string
+		ctx  spi.ComponentContext
+		err  error
+	}{
+		{
+			name: "PreUninstallNoError",
+			ctx:  spi.NewFakeContext(fake.NewClientBuilder().Build(), nil, nil, false),
+			err:  nil,
+		},
+		{
+			name: "PreUninstallRetryableError",
+			ctx:  spi.NewFakeContext(fakeClient, nil, nil, false),
+			err:  ctrlerrors.RetryableError{Source: ComponentName},
+		},
+		{
+			name: "PreUninstallServerError",
+			ctx:  spi.NewFakeContext(mockClient, nil, nil, false),
+			err:  fmt.Errorf("server error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().PreUninstall(tt.ctx)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}
+
+// TestValidateUpdate tests ValidateUpdate function
+// GIVEN an old and a new vz resource
+// THEN return an error
+// WHEN mysqloperator is getting disabled during update
+func TestValidateUpdate(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name        string
+		oldvz       *vzapi.Verrazzano
+		newvz       *vzapi.Verrazzano
+		expectError bool
+	}{
+		{
+			name:        "MySQL Operator enabled in both new and old vz",
+			oldvz:       getVZWithMySQLOperatorComp(&trueValue),
+			newvz:       getVZWithMySQLOperatorComp(&trueValue),
+			expectError: false,
+		},
+		{
+			name:        "MySQL Operator enabled in old vz and disabled in new vz",
+			oldvz:       getVZWithMySQLOperatorComp(&trueValue),
+			newvz:       getVZWithMySQLOperatorComp(&falseValue),
+			expectError: true,
+		},
+		{
+			name:        "MySQL Operator component nil in both new and old vz",
+			oldvz:       getVZWithMySQLOperatorComp(nil),
+			newvz:       getVZWithMySQLOperatorComp(nil),
+			expectError: false,
+		},
+		{
+			name:        "MySQL Operator component nil in old and disabled in new",
+			oldvz:       getVZWithMySQLOperatorComp(nil),
+			newvz:       getVZWithMySQLOperatorComp(&falseValue),
+			expectError: true,
+		},
+		{
+			name:        "New vz is nil",
+			oldvz:       getVZWithMySQLOperatorComp(&trueValue),
+			newvz:       nil,
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().ValidateUpdate(tt.oldvz, tt.newvz)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateInstallV1Beta1 tests ValidateInstallV1Beta1 function
+// GIVEN a v1beta1 vz resource
+// THEN return the expected error
+func TestValidateInstallV1Beta1(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name        string
+		vz          *installv1beta1.Verrazzano
+		expectError bool
+	}{
+		{
+			name: "MySQL Operator explicitly enabled, Keycloak disabled",
+			vz: &installv1beta1.Verrazzano{
+				Spec: installv1beta1.VerrazzanoSpec{
+					Components: installv1beta1.ComponentSpec{
+						MySQLOperator: &installv1beta1.MySQLOperatorComponent{
+							Enabled: &trueValue},
+						Keycloak: &installv1beta1.KeycloakComponent{
+							Enabled: &falseValue}}}},
+			expectError: false,
+		},
+		{
+			// MySQL Operator must be enabled if keycloak is enabled
+			name: "MySQL Operator explicitly disabled, Keycloak enabled",
+			vz: &installv1beta1.Verrazzano{
+				Spec: installv1beta1.VerrazzanoSpec{
+					Components: installv1beta1.ComponentSpec{
+						MySQLOperator: &installv1beta1.MySQLOperatorComponent{
+							Enabled: &falseValue},
+						Keycloak: &installv1beta1.KeycloakComponent{
+							Enabled: &trueValue}}}},
+			expectError: true,
+		},
+		{
+			name: "MySQL Operator and Keycloak explicitly disabled",
+			vz: &installv1beta1.Verrazzano{
+				Spec: installv1beta1.VerrazzanoSpec{
+					Components: installv1beta1.ComponentSpec{
+						MySQLOperator: &installv1beta1.MySQLOperatorComponent{
+							Enabled: &falseValue},
+						Keycloak: &installv1beta1.KeycloakComponent{
+							Enabled: &falseValue}}}},
+			expectError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().ValidateInstallV1Beta1(tt.vz)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateUpdate tests ValidateUpdate function
+// GIVEN an old and a new v1beta1 vz resource
+// THEN return an error
+// WHEN mysqloperator is getting disabled during update
+func TestValidateUpdateV1Beta1(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name        string
+		oldvz       *installv1beta1.Verrazzano
+		newvz       *installv1beta1.Verrazzano
+		expectError bool
+	}{
+		{
+			name:        "MySQL Operator enabled in both new and old vz",
+			oldvz:       getv1beta1VZWithMySQLOperatorComp(&trueValue),
+			newvz:       getv1beta1VZWithMySQLOperatorComp(&trueValue),
+			expectError: false,
+		},
+		{
+			name:        "MySQL Operator enabled in old vz and disabled in new vz",
+			oldvz:       getv1beta1VZWithMySQLOperatorComp(&trueValue),
+			newvz:       getv1beta1VZWithMySQLOperatorComp(&falseValue),
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewComponent().ValidateUpdateV1Beta1(tt.oldvz, tt.newvz)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// getVZWithMySQLOperatorComp return a v1alpha1 vz resource with mysql-operator enabled, disabled or nil
+func getVZWithMySQLOperatorComp(enabled *bool) *vzapi.Verrazzano {
+	if enabled == nil {
+		return &vzapi.Verrazzano{
+			Spec: vzapi.VerrazzanoSpec{
+				Components: vzapi.ComponentSpec{
+					MySQLOperator: nil,
+				}}}
+	}
+	return &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				MySQLOperator: &vzapi.MySQLOperatorComponent{
+					Enabled: enabled,
+				},
+			}}}
+}
+
+// getv1beta1VZWithMySQLOperatorComp return a v1beta1 vz resource with mysql-operator enabled or disabled
+func getv1beta1VZWithMySQLOperatorComp(enabled *bool) *installv1beta1.Verrazzano {
+	return &installv1beta1.Verrazzano{
+		Spec: installv1beta1.VerrazzanoSpec{
+			Components: installv1beta1.ComponentSpec{
+				MySQLOperator: &installv1beta1.MySQLOperatorComponent{
+					Enabled: enabled,
+				},
+			}}}
 }

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_test.go
@@ -6,13 +6,14 @@ package mysqloperator
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -26,6 +27,7 @@ import (
 // WHEN there is a valid MySQL Operator configuration
 // THEN the correct Helm overrides are returned
 func TestGetInstallOverrides(t *testing.T) {
+	overridesValue := []byte("{\"key1\": \"value1\"}")
 	vz := &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
 			Components: vzapi.ComponentSpec{
@@ -33,7 +35,7 @@ func TestGetInstallOverrides(t *testing.T) {
 					InstallOverrides: vzapi.InstallOverrides{
 						ValueOverrides: []vzapi.Overrides{
 							{Values: &apiextensionsv1.JSON{
-								Raw: []byte("{\"key1\": \"value1\"}")},
+								Raw: overridesValue},
 							},
 						},
 					},
@@ -44,7 +46,7 @@ func TestGetInstallOverrides(t *testing.T) {
 
 	comp := NewComponent()
 	overrides := comp.GetOverrides(vz).([]vzapi.Overrides)
-	assert.Equal(t, []byte("{\"key1\": \"value1\"}"), overrides[0].Values.Raw)
+	assert.Equal(t, overridesValue, overrides[0].Values.Raw)
 
 	vz = &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{
@@ -64,7 +66,7 @@ func TestGetInstallOverrides(t *testing.T) {
 					InstallOverrides: v1beta1.InstallOverrides{
 						ValueOverrides: []v1beta1.Overrides{
 							{Values: &apiextensionsv1.JSON{
-								Raw: []byte("{\"key1\": \"value1\"}")},
+								Raw: overridesValue},
 							},
 						},
 					},
@@ -74,7 +76,7 @@ func TestGetInstallOverrides(t *testing.T) {
 	}
 
 	overrides2 := comp.GetOverrides(beta1vz).([]v1beta1.Overrides)
-	assert.Equal(t, []byte("{\"key1\": \"value1\"}"), overrides2[0].Values.Raw)
+	assert.Equal(t, overridesValue, overrides2[0].Values.Raw)
 }
 
 // TestIsMySQLOperatorReady tests the isReady function

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysqloperator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/pkg/helm"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestGetInstallOverrides tests the GetInstallOverrides function
+// GIVEN a call to GetInstallOverrides
+// WHEN there is a valid MySQL Operator configuration
+// THEN the correct Helm overrides are returned
+func TestGetInstallOverrides(t *testing.T) {
+	vz := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				MySQLOperator: &vzapi.MySQLOperatorComponent{
+					InstallOverrides: vzapi.InstallOverrides{
+						ValueOverrides: []vzapi.Overrides{
+							{Values: &apiextensionsv1.JSON{
+								Raw: []byte("{\"key1\": \"value1\"}")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	comp := NewComponent()
+	overrides := comp.GetOverrides(vz).([]vzapi.Overrides)
+	assert.Equal(t, []byte("{\"key1\": \"value1\"}"), overrides[0].Values.Raw)
+
+	vz = &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				MySQLOperator: nil,
+			},
+		},
+	}
+
+	overrides = comp.GetOverrides(vz).([]vzapi.Overrides)
+	assert.Equal(t, []vzapi.Overrides{}, overrides)
+
+	beta1vz := &v1beta1.Verrazzano{
+		Spec: v1beta1.VerrazzanoSpec{
+			Components: v1beta1.ComponentSpec{
+				MySQLOperator: &v1beta1.MySQLOperatorComponent{
+					InstallOverrides: v1beta1.InstallOverrides{
+						ValueOverrides: []v1beta1.Overrides{
+							{Values: &apiextensionsv1.JSON{
+								Raw: []byte("{\"key1\": \"value1\"}")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	overrides2 := comp.GetOverrides(beta1vz).([]v1beta1.Overrides)
+	assert.Equal(t, []byte("{\"key1\": \"value1\"}"), overrides2[0].Values.Raw)
+}
+
+// TestIsMySQLOperatorReady tests the isReady function
+// GIVEN a call to isReady
+// WHEN the deployment object has enough replicas available
+// THEN true is returned
+func TestIsMySQLOperatorReady(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ComponentNamespace,
+				Name:      ComponentName,
+				Labels:    map[string]string{"app": ComponentName},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": ComponentName},
+				},
+			},
+			Status: appsv1.DeploymentStatus{
+				AvailableReplicas: 1,
+				Replicas:          1,
+				UpdatedReplicas:   1,
+			},
+		},
+		&appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   ComponentNamespace,
+				Name:        ComponentName + "-95d8c5d96",
+				Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ComponentNamespace,
+				Name:      ComponentName + "-95d8c5d96-m6mbr",
+				Labels: map[string]string{
+					"pod-template-hash": "95d8c5d96",
+					"app":               ComponentName,
+				},
+			},
+		},
+	).Build()
+
+	mysqlOperator := NewComponent().(mysqlOperatorComponent)
+	assert.True(t, mysqlOperator.isReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
+}
+
+// TestIsMySQLOperatorNotReady tests the isReady function
+// GIVEN a call to isReady
+// WHEN the deployment object does NOT have enough replicas available
+// THEN false is returned
+func TestIsMySQLOperatorNotReady(t *testing.T) {
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStatusFunction()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ComponentNamespace,
+			Name:      ComponentNamespace,
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: 1,
+			Replicas:          1,
+			UpdatedReplicas:   0,
+		},
+	}).Build()
+	mysqlOperator := NewComponent().(mysqlOperatorComponent)
+	assert.False(t, mysqlOperator.isReady(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
+}
+
+// TestIsInstalled tests the isInstalled function
+// GIVEN a call to isInstalled
+// WHEN the deployment object exists
+// THEN true is returned
+func TestIsInstalled(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ComponentNamespace,
+				Name:      ComponentName,
+				Labels:    map[string]string{"app": ComponentName},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": ComponentName},
+				},
+			},
+		},
+	).Build()
+
+	mysqlOperator := NewComponent().(mysqlOperatorComponent)
+	assert.True(t, mysqlOperator.isInstalled(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
+}
+
+// TestIsInstalledFalse tests the isInstalled function
+// GIVEN a call to isInstalled
+// WHEN the deployment object does not exist
+// THEN false is returned
+func TestIsInstalledFalse(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
+	mysqlOperator := NewComponent().(mysqlOperatorComponent)
+	assert.False(t, mysqlOperator.isInstalled(spi.NewFakeContext(fakeClient, &vzapi.Verrazzano{}, nil, false)))
+}
+
+// TestAppendOverrides tests the AppendOverrides function
+// GIVEN a call to AppendOverrides
+// WHEN the verrazzano-container-registry secret exists in the mysql-operator namespace
+// THEN the correct Helm overrides are returned
+func TestAppendOverrides(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ComponentNamespace,
+			Name:      constants.GlobalImagePullSecName,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secret).Build()
+
+	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
+	assert.Nil(t, err)
+	assert.Len(t, kvs, 2)
+	assert.Equal(t, bom.KeyValue{Key: "key1", Value: "value1"}, kvs[0])
+	assert.Equal(t, bom.KeyValue{Key: "image.pullSecrets.enabled", Value: "true"}, kvs[1])
+}
+
+// TestAppendOverridesNoSecret tests the AppendOverrides function
+// GIVEN a call to AppendOverrides
+// WHEN the verrazzano-container-registry secret does not exist in the mysql-operator namespace
+// THEN the correct Helm overrides are returned
+func TestAppendOverridesNoSecret(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	kvs, err := AppendOverrides(spi.NewFakeContext(fakeClient, nil, nil, false), "", "", "", []bom.KeyValue{{Key: "key1", Value: "value1"}})
+	assert.Nil(t, err)
+	assert.Len(t, kvs, 1)
+	assert.Equal(t, bom.KeyValue{Key: "key1", Value: "value1"}, kvs[0])
+}


### PR DESCRIPTION
Increased coverage from 28.57% to 90.5%

The tests for both mysqloperator.go and mysqloperator_component.go were in the same test file so separated them into mysqloperator_test.go and mysqloperator_component_test.go as well.
