### PR TITLE
WIP: VZ-7456: Change all calls to GetVerrazzanoVersion to use eventually

### DIFF
--- a/tests/e2e/backup/mysql/mysql_backup_test.go
+++ b/tests/e2e/backup/mysql/mysql_backup_test.go
@@ -7,23 +7,23 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-	"go.uber.org/zap"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"strings"
 	"text/template"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+	"go.uber.org/zap"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -330,7 +330,7 @@ func WhenMySQLOpInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version 1.4.0: %s", err.Error()))

--- a/tests/e2e/backup/opensearch/opensearch_backup_test.go
+++ b/tests/e2e/backup/opensearch/opensearch_backup_test.go
@@ -7,12 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-	"go.uber.org/zap"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"text/template"
 	"time"
@@ -20,8 +14,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+	"go.uber.org/zap"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -248,7 +248,7 @@ func WhenVeleroInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version 1.4.0: %s", err.Error()))

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -7,24 +7,24 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/verrazzano/verrazzano/pkg/constants"
-	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	common "github.com/verrazzano/verrazzano/tests/e2e/backup/helpers"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -282,7 +282,7 @@ func WhenRancherBackupInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version 1.4.0: %s", err.Error()))

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -12,14 +12,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 const (
@@ -121,7 +119,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			if err != nil {
 				Skip(skipVerifications)
 			}
-			if ok, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeConfig); !ok {
+			if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeConfig); !ok {
 				Skip(skipVerifications)
 			}
 			Eventually(func() bool {

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -7,23 +7,20 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -275,7 +272,7 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 			Expect(err).To(BeNil(), fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		}
 		// Coherence metric fix available only from 1.3.0
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
+		if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath); ok {
 			t.It("Retrieve Prometheus scraped metrics", func() {
 				if getVariant() == "helidon" {
 					pkg.Concurrently(

--- a/tests/e2e/grafana-db/grafana_test.go
+++ b/tests/e2e/grafana-db/grafana_test.go
@@ -7,18 +7,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -99,7 +99,7 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 	// GIVEN a running grafana instance
 	// WHEN a call is made to Grafana Dashboard with UID corresponding to OpenSearch Summary Dashboard
 	// THEN the dashboard metadata of the corresponding dashboard is returned
-	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
+	if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath); ok {
 		t.It("Get details of the OpenSearch Grafana Dashboard", func() {
 			pkg.TestOpenSearchGrafanaDashBoard(pollingInterval, waitTimeout)
 		})
@@ -163,7 +163,7 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 	// GIVEN a running grafana instance
 	// WHEN a call is made to Grafana Dashboard with UID corresponding to OpenSearch Summary Dashboard
 	// THEN the dashboard metadata of the corresponding dashboard is returned
-	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
+	if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath); ok {
 		t.It("Get details of the OpenSearch Grafana Dashboard", func() {
 			pkg.TestOpenSearchGrafanaDashBoard(pollingInterval, waitTimeout)
 		})

--- a/tests/e2e/logging/opensearch/opensearch_mappings_test.go
+++ b/tests/e2e/logging/opensearch/opensearch_mappings_test.go
@@ -44,7 +44,7 @@ var _ = t.Describe("OpenSearch field mappings", Label("f:observability.logging.e
 				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			})
 		}
-		supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+		supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 		if err != nil {
 			t.It(description, func() {
 				Fail(err.Error())
@@ -85,7 +85,7 @@ var _ = t.Describe("OpenSearch field mappings", Label("f:observability.logging.e
 				pkg.Log(pkg.Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 				return false
 			}
-			supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+			supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 			if err != nil {
 				pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 				return false

--- a/tests/e2e/logging/opensearch/opensearch_retention_policy_test.go
+++ b/tests/e2e/logging/opensearch/opensearch_retention_policy_test.go
@@ -5,11 +5,12 @@ package opensearch
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"time"
 )
 
 var _ = t.Describe("Opensearch Retention Policies Suite", Label("f:observability.logging.es"), func() {
@@ -21,7 +22,7 @@ var _ = t.Describe("Opensearch Retention Policies Suite", Label("f:observability
 				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			})
 		}
-		supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+		supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 		if err != nil {
 			t.It(description, func() {
 				Fail(err.Error())

--- a/tests/e2e/logging/opensearch/opensearch_rollover_policy_test.go
+++ b/tests/e2e/logging/opensearch/opensearch_rollover_policy_test.go
@@ -5,13 +5,14 @@ package opensearch
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"sort"
-	"strconv"
-	"time"
 )
 
 const (
@@ -27,7 +28,7 @@ var _ = t.Describe("Opensearch Rollover Policies Suite", Label("f:observability.
 				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			})
 		}
-		supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+		supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 		if err != nil {
 			t.It(description, func() {
 				Fail(err.Error())

--- a/tests/e2e/logging/system/system_logging_test.go
+++ b/tests/e2e/logging/system/system_logging_test.go
@@ -6,13 +6,13 @@ package system
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"regexp"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -96,7 +96,7 @@ var _ = t.Describe("Elasticsearch system component data", Label("f:observability
 		valid = validateWeblogicOperatorLogs() && valid
 		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 		Expect(err).To(BeNil())
-		isJaegerSupported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeConfigPath)
+		isJaegerSupported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeConfigPath)
 		Expect(err).To(BeNil())
 		if isJaegerSupported {
 			valid = validateJaegerCollectorLogs() && valid

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -9,11 +9,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
@@ -72,7 +71,7 @@ var _ = clusterDump.BeforeSuite(func() {
 
 	// Create a service in VZ versions 1.4.0 and greater, so that a servicemonitor will be generated
 	// by Verrazzano for Prometheus Operator
-	isVzMinVer14, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+	isVzMinVer14, _ := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfig)
 	if isVzMinVer14 {
 		Eventually(func() error {
 			promJobName, err := getPromJobName()
@@ -208,7 +207,7 @@ var _ = t.Describe("DeployMetrics Application test", Label("f:app-lcm.oam"), fun
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			isVzMinVer14, _ := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+			isVzMinVer14, _ := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfig)
 			if isVzMinVer14 {
 				serviceName, err := getPromJobName()
 				if err != nil {
@@ -273,7 +272,7 @@ func getClusterNameForPromQuery() (string, error) {
 	if err != nil {
 		return kubeConfigPath, err
 	}
-	isMinVersion110, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeConfigPath)
+	isMinVersion110, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeConfigPath)
 	if err != nil {
 		return "", err
 	}
@@ -309,7 +308,7 @@ func getPromJobName() (string, error) {
 	if err != nil {
 		return kubeconfig, err
 	}
-	usesServiceMonitor, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+	usesServiceMonitor, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfig)
 	if err != nil {
 		return kubeconfig, err
 	}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -9,12 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
 
 const (
@@ -117,7 +116,7 @@ var _ = t.BeforeSuite(func() {
 		}
 	}
 
-	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeConfig)
+	isMinVersion110, err = pkg.IsVerrazzanoMinVersionEventually("1.1.0", adminKubeConfig)
 	if err != nil {
 		Fail(err.Error())
 	}
@@ -218,7 +217,7 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 						job: pilot,
 					}
 
-					minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", adminKubeConfig)
+					minVer14, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", adminKubeConfig)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf(failedVerifyVersionMsg, err))
 						return false
@@ -240,7 +239,7 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 					job: oldPrometheus,
 				}
 
-				minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", adminKubeConfig)
+				minVer14, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", adminKubeConfig)
 				if err != nil {
 					pkg.Log(pkg.Error, fmt.Sprintf(failedVerifyVersionMsg, err))
 					return false

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -9,13 +9,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 )
 
 const (
@@ -164,7 +163,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 	t.Context("for Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
 
 		// Coherence metric fix available only from 1.3.0
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", adminKubeconfig); ok {
+		if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", adminKubeconfig); ok {
 			t.It("Verify base_jvm_uptime_seconds metrics exist for managed cluster", func() {
 				clusterNameMetricsLabel, _ := pkg.GetClusterNameMetricLabel(adminKubeconfig)
 				Eventually(func() bool {

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -9,13 +9,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vmcv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/clusters/v1alpha1"
 	vmcClient "github.com/verrazzano/verrazzano/platform-operator/clientset/versioned"
@@ -87,7 +86,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 					Fail(err.Error())
 				}
 			}
-			curAdminVersion14, err := pkg.IsVerrazzanoMinVersion("1.4.0", adminKubeconfig)
+			curAdminVersion14, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -128,7 +127,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 			if minimalVerification {
 				Skip("Skipping since not part of minimal verification")
 			}
-			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeconfig)
+			supported, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -145,7 +144,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 			if minimalVerification {
 				Skip("Skipping since not part of minimal verification")
 			}
-			supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", adminKubeconfig)
+			supported, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}
@@ -253,7 +252,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 			if minimalVerification {
 				Skip("Skipping since not part of minimal verification")
 			}
-			supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", adminKubeconfig)
+			supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", adminKubeconfig)
 			if err != nil {
 				Fail(err.Error())
 			}

--- a/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
+++ b/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
@@ -298,7 +298,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 
 	t.Context("for Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
 		// Coherence metric fix available only from 1.3.0
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", adminKubeconfig); ok {
+		if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", adminKubeconfig); ok {
 			t.It("Retrieve application Prometheus scraped metrics", func() {
 				if skipVerify {
 					Skip(skipVerifications)

--- a/tests/e2e/opensearch/topology/topology_test.go
+++ b/tests/e2e/opensearch/topology/topology_test.go
@@ -51,7 +51,7 @@ var _ = clusterDump.BeforeSuite(func() {
 	Expect(err).To(BeNil())
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 	Expect(err).To(BeNil())
-	isMinVersion140, err = pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	isMinVersion140, err = pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	Expect(err).To(BeNil())
 
 	Eventually(func() bool {

--- a/tests/e2e/pkg/conditional_spec.go
+++ b/tests/e2e/pkg/conditional_spec.go
@@ -34,6 +34,6 @@ func MinVersionSpec(description string, minVersion string, specFunc interface{})
 			Log(Error, fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			return false, err
 		}
-		return IsVerrazzanoMinVersion(minVersion, kubeconfigPath)
+		return IsVerrazzanoMinVersionEventually(minVersion, kubeconfigPath)
 	}, specFunc)
 }

--- a/tests/e2e/pkg/elasticsearch.go
+++ b/tests/e2e/pkg/elasticsearch.go
@@ -8,9 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/gomega"
-	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"html/template"
 	"net/http"
 	url2 "net/url"
@@ -19,6 +16,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/onsi/gomega"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/onsi/ginkgo/v2"
@@ -291,7 +292,7 @@ func isUsingDataStreams(kubeconfigPath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return IsVerrazzanoMinVersion("1.3.0", kubeConfig)
+	return IsVerrazzanoMinVersionEventually("1.3.0", kubeConfig)
 }
 
 func UseExternalElasticsearch() bool {

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -13,10 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/gomega"
-
 	"github.com/google/uuid"
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/onsi/gomega"
 	vaoClient "github.com/verrazzano/verrazzano/application-operator/clientset/versioned"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/semver"
@@ -627,7 +626,7 @@ func IsVerrazzanoMinVersionEventually(minVersion string, kubeconfigPath string) 
 	var isMinVersion bool
 	var err error
 	gomega.Eventually(func() error {
-		isMinVersion, err = IsVerrazzanoMinVersion(minVersion, kubeconfigPath)
+		isMinVersion, err = IsVerrazzanoMinVersionEventually(minVersion, kubeconfigPath)
 		return err
 	}, waitTimeout, pollingInterval).Should(gomega.BeNil())
 	return isMinVersion, err

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onsi/gomega"
+
 	"github.com/google/uuid"
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	vaoClient "github.com/verrazzano/verrazzano/application-operator/clientset/versioned"
@@ -618,6 +620,17 @@ func IsVerrazzanoMinVersion(minVersion string, kubeconfigPath string) (bool, err
 		return false, nil
 	}
 	return IsMinVersion(vzVersion, minVersion)
+}
+
+// IsVerrazzanoMinVersionEventually returns true if the installed Verrazzano version >= minVersion
+func IsVerrazzanoMinVersionEventually(minVersion string, kubeconfigPath string) (bool, error) {
+	var isMinVersion bool
+	var err error
+	gomega.Eventually(func() error {
+		isMinVersion, err = IsVerrazzanoMinVersion(minVersion, kubeconfigPath)
+		return err
+	}, waitTimeout, pollingInterval).Should(gomega.BeNil())
+	return isMinVersion, err
 }
 
 // IsMinVersion returns true if the given version >= minVersion

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -92,7 +92,7 @@ func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubecon
 // GetClusterNameMetricLabel returns the label name used for labeling metrics with the Verrazzano cluster
 // This is different in pre-1.1 VZ releases versus later releases
 func GetClusterNameMetricLabel(kubeconfigPath string) (string, error) {
-	isVz11OrGreater, err := IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	isVz11OrGreater, err := IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error checking Verrazzano min version == 1.1: %t", err))
 		return "verrazzano_cluster", err // callers can choose to ignore the error

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -5,14 +5,14 @@ package framework
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-	"go.uber.org/zap"
 	"os"
 	"reflect"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+	"go.uber.org/zap"
 )
 
 type TestFramework struct {
@@ -104,7 +104,7 @@ func (t *TestFramework) It(text string, args ...interface{}) bool {
 }
 
 func (t *TestFramework) ItMinimumVersion(text string, version string, kubeconfigPath string, args ...interface{}) bool {
-	supported, err := pkg.IsVerrazzanoMinVersion(version, kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually(version, kubeconfigPath)
 	if err != nil {
 		t.Logs.Errorf("Error getting Verrazzano version: %v", err)
 		return false

--- a/tests/e2e/pkg/vmi/elastic.go
+++ b/tests/e2e/pkg/vmi/elastic.go
@@ -161,7 +161,7 @@ func (e *Elastic) CheckTLSSecret() bool {
 // CheckHealth checks the health status of Opensearch cluster
 // Returns true if the health status is green otherwise false
 func (e *Elastic) CheckHealth(kubeconfigPath string) bool {
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 		return false
@@ -196,7 +196,7 @@ func (e *Elastic) CheckHealth(kubeconfigPath string) bool {
 // CheckIndicesHealth checks the health status of indices in a cluster
 // Returns true if the health status of all the indices is green otherwise false
 func (e *Elastic) CheckIndicesHealth(kubeconfigPath string) bool {
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Error getting Verrazzano version: %v", err))
 		return false

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -10,12 +10,11 @@ import (
 	"strings"
 	"time"
 
-	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -138,7 +137,7 @@ func isConsoleIngressHost(ingressHost string) bool {
 // isConsoleURLExpected - Returns true in VZ < 1.1.1. For VZ >= 1.1.1, returns false only if explicitly disabled
 // in the CR or when managed cluster profile is used
 func isConsoleURLExpected(kubeconfigPath string) (bool, error) {
-	isAtleastVz111, err := pkg.IsVerrazzanoMinVersion("1.1.1", kubeconfigPath)
+	isAtleastVz111, err := pkg.IsVerrazzanoMinVersionEventually("1.1.1", kubeconfigPath)
 	if err != nil {
 		return false, err
 	}

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -203,7 +203,7 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 				t.Logs.Info("Test mysql ingress rules")
 				kubeconfigPath, _ := k8sutil.GetKubeConfigLocation()
 				label := "app"
-				if ok, _ := pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath); ok {
+				if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath); ok {
 					label = "tier"
 				}
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: "prometheus"}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{label: "mysql"}}, "keycloak", envoyStatsMetricsPort, false, true)

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -5,11 +5,11 @@ package grafana
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -57,7 +57,7 @@ var _ = t.Describe("Post Upgrade Grafana Dashboard", Label("f:observability.logg
 	// GIVEN a running grafana instance
 	// WHEN a call is made to Grafana Dashboard with UID corresponding to OpenSearch Summary Dashboard
 	// THEN the dashboard metadata of the corresponding dashboard is returned
-	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
+	if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath); ok {
 		t.It("Get details of the OpenSearch Grafana Dashboard", func() {
 			pkg.TestOpenSearchGrafanaDashBoard(pollingInterval, waitTimeout)
 		})

--- a/tests/e2e/upgrade/post-upgrade/metricsbinding/metrics_binding_test.go
+++ b/tests/e2e/upgrade/post-upgrade/metricsbinding/metrics_binding_test.go
@@ -51,7 +51,7 @@ func WhenMetricsBindingInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version less than 1.4.0: %s", err.Error()))

--- a/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_dashboards_test.go
+++ b/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_dashboards_test.go
@@ -6,12 +6,13 @@ package opensearch
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
-	"os"
-	"strings"
 )
 
 const (
@@ -28,7 +29,7 @@ var _ = t.Describe("Index Patterns", Label("f:observability.logging.kibana"), fu
 				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			})
 		}
-		supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+		supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 		if err != nil {
 			t.It(description, func() {
 				Fail(err.Error())
@@ -48,7 +49,7 @@ var _ = t.Describe("Index Patterns", Label("f:observability.logging.kibana"), fu
 		Eventually(func() bool {
 			kubeConfigPath, _ := k8sutil.GetKubeConfigLocation()
 			if pkg.IsOpenSearchDashboardsEnabled(kubeConfigPath) {
-				isVersionAbove1_3_0, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeConfigPath)
+				isVersionAbove1_3_0, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeConfigPath)
 				if err != nil {
 					pkg.Log(pkg.Error, fmt.Sprintf("failed to find the verrazzano version: %v", err))
 					return false

--- a/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_test.go
+++ b/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_test.go
@@ -6,9 +6,10 @@ package opensearch
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"os"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +35,7 @@ var _ = t.Describe("Post upgrade OpenSearch", Label("f:observability.logging.es"
 				Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			})
 		}
-		supported, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath)
+		supported, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath)
 		if err != nil {
 			t.It(description, func() {
 				Fail(err.Error())

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -166,7 +165,7 @@ var _ = t.Describe("Checking if Verrazzano system components are ready, post-upg
 						t.Logs.Infof("Skipping disabled component %s", componentName)
 						return true
 					}
-					isVersionAbove1_4_0, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+					isVersionAbove1_4_0, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf("failed to find the verrazzano version: %v", err))
 						return false
@@ -264,7 +263,7 @@ var _ = t.Describe("Checking if Verrazzano system components are ready, post-upg
 						t.Logs.Infof("Skipping disabled component %s", componentName)
 						return true
 					}
-					isVersionAbove1_4_0, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+					isVersionAbove1_4_0, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 					if err != nil {
 						pkg.Log(pkg.Error, fmt.Sprintf("failed to find the verrazzano version: %v", err))
 						return false

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -6,13 +6,13 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"net/http"
 	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -94,7 +94,7 @@ var _ = t.Describe("Pre Upgrade Grafana Dashboard", Label("f:observability.loggi
 	// GIVEN a running grafana instance
 	// WHEN a call is made to Grafana Dashboard with UID corresponding to OpenSearch Summary Dashboard
 	// THEN the dashboard metadata of the corresponding dashboard is returned
-	if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
+	if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeconfigPath); ok {
 		t.It("Get details of the OpenSearch Grafana Dashboard", func() {
 			pkg.TestOpenSearchGrafanaDashBoard(pollingInterval, waitTimeout)
 		})

--- a/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_test.go
@@ -53,14 +53,14 @@ func WhenMetricsBindingInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	vz14OrLater, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	vz14OrLater, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version less than 1.4.0: %s", err.Error()))
 		})
 	}
 	below14 := !vz14OrLater
-	above12, err := pkg.IsVerrazzanoMinVersion("1.2.0", kubeconfigPath)
+	above12, err := pkg.IsVerrazzanoMinVersionEventually("1.2.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version at or above 1.2.0: %s", err.Error()))

--- a/tests/e2e/upgrade/pre-upgrade/opensearch-dashboards/opensearch_dashboards_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/opensearch-dashboards/opensearch_dashboards_test.go
@@ -6,13 +6,13 @@ package dashboards
 import (
 	"bufio"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"os"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -34,7 +34,7 @@ var _ = t.Describe("Pre Upgrade OpenSearch Dashboards Setup", Label("f:observabi
 		Eventually(func() bool {
 			kubeConfigPath, _ := k8sutil.GetKubeConfigLocation()
 			if pkg.IsOpenSearchDashboardsEnabled(kubeConfigPath) {
-				isVersionAbove1_3_0, err := pkg.IsVerrazzanoMinVersion("1.3.0", kubeConfigPath)
+				isVersionAbove1_3_0, err := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeConfigPath)
 				if err != nil {
 					pkg.Log(pkg.Error, fmt.Sprintf("failed to find the verrazzano version: %v", err))
 					return false

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -10,14 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -76,7 +75,7 @@ var _ = t.Describe("rancher", Label("f:infra-lcm",
 				}, waitTimeout, pollingInterval).Should(Equal(true), "rancher local cluster not in active state")
 				metrics.Emit(t.Metrics.With("get_cluster_state_elapsed_time", time.Since(start).Milliseconds()))
 
-				minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+				minVer14, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 				Expect(err).ToNot(HaveOccurred())
 
 				start = time.Now()
@@ -224,7 +223,7 @@ var _ = t.Describe("rancher", Label("f:infra-lcm",
 
 				}
 
-				minVer15, err := pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath)
+				minVer15, err := pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath)
 				Expect(err).ToNot(HaveOccurred())
 				if minVer15 {
 					verifySettingValue(rancher.SettingUIPrimaryColor, rancher.SettingUIPrimaryColorValue, k8sClient)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -333,7 +333,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 		size = override.Spec.Resources.Requests.Storage().String()
 	}
 
-	minVer14, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfig)
+	minVer14, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfig)
 	Expect(err).ToNot(HaveOccurred())
 
 	expectedPromReplicas, err := getExpectedPrometheusReplicaCount(kubeconfig)

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -124,7 +124,7 @@ var _ = t.BeforeSuite(func() {
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	isKeycloakEnabled = pkg.IsKeycloakEnabled(kubeconfigPath)
-	isMinVersion140, err = pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	isMinVersion140, err = pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}
@@ -159,7 +159,7 @@ var _ = t.Describe("Verify", Label("f:platform-lcm.install"), func() {
 		kubeconfigPath, _ := k8sutil.GetKubeConfigLocation()
 
 		size := "8Gi" // based on values set in platform-operator/thirdparty/charts/mysql
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath); ok {
+		if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath); ok {
 			size = "2Gi"
 		}
 		override, _ := pkg.GetEffectiveKeyCloakPersistenceOverride(kubeconfigPath)
@@ -168,13 +168,13 @@ var _ = t.Describe("Verify", Label("f:platform-lcm.install"), func() {
 		}
 
 		claimName := "mysql"
-		if ok, _ := pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath); ok {
+		if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath); ok {
 			claimName = "datadir-mysql-0"
 		}
 
 		if pkg.IsDevProfile() {
 			expectedKeyCloakPVCs := 0
-			is15, _ := pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath)
+			is15, _ := pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath)
 			if is15 {
 				expectedKeyCloakPVCs = 1
 			}

--- a/tests/e2e/verify-install/kiali/kiali_test.go
+++ b/tests/e2e/verify-install/kiali/kiali_test.go
@@ -5,17 +5,17 @@ package kiali
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/kiali"
-	corev1 "k8s.io/api/core/v1"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/kiali"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -45,7 +45,7 @@ func WhenKialiInstalledIt(description string, f interface{}) {
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -182,7 +182,7 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 		t.DescribeTable("VMI components that don't exist in older versions are deployed,",
 			func(name string, expected bool) {
 				Eventually(func() (bool, error) {
-					ok, _ := pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+					ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 					if !ok {
 						// skip test
 						fmt.Printf("Skipping Kiali check since version < 1.1.0")

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -152,7 +152,7 @@ var _ = t.BeforeSuite(func() {
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
-	isMinVersion140, err = pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	isMinVersion140, err = pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/verify-install/rancherbackup/rancher_backup_test.go
+++ b/tests/e2e/verify-install/rancherbackup/rancher_backup_test.go
@@ -47,7 +47,7 @@ func WhenRancherBackupInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version 1.4.0: %s", err.Error()))

--- a/tests/e2e/verify-install/velero/velero_test.go
+++ b/tests/e2e/verify-install/velero/velero_test.go
@@ -60,7 +60,7 @@ func WhenVeleroInstalledIt(description string, f func()) {
 			Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 		})
 	}
-	supported, err := pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	supported, err := pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		t.It(description, func() {
 			Fail(fmt.Sprintf("Failed to check Verrazzano version 1.4.0: %s", err.Error()))

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -8,12 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,19 +44,19 @@ var _ = t.BeforeSuite(func() {
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
-	isMinVersion110, err = pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	isMinVersion110, err = pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}
-	isMinVersion120, err = pkg.IsVerrazzanoMinVersion("1.2.0", kubeconfigPath)
+	isMinVersion120, err = pkg.IsVerrazzanoMinVersionEventually("1.2.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}
-	isMinVersion140, err = pkg.IsVerrazzanoMinVersion("1.4.0", kubeconfigPath)
+	isMinVersion140, err = pkg.IsVerrazzanoMinVersionEventually("1.4.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}
-	isMinVersion150, err = pkg.IsVerrazzanoMinVersion("1.5.0", kubeconfigPath)
+	isMinVersion150, err = pkg.IsVerrazzanoMinVersionEventually("1.5.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/verify-install/web/web_test.go
+++ b/tests/e2e/verify-install/web/web_test.go
@@ -59,7 +59,7 @@ var _ = t.BeforeSuite(func() {
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
-	isTestSupported, err = pkg.IsVerrazzanoMinVersion("1.1.0", kubeconfigPath)
+	isTestSupported, err = pkg.IsVerrazzanoMinVersionEventually("1.1.0", kubeconfigPath)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/workloads/coherence/coherence_workload_test.go
+++ b/tests/e2e/workloads/coherence/coherence_workload_test.go
@@ -161,7 +161,7 @@ var _ = t.Describe("Validate deployment of VerrazzanoCoherenceWorkload", Label("
 				Expect(err).To(BeNil(), fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 			}
 			// Coherence metric fix available only from 1.3.0
-			if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeConfig); ok {
+			if ok, _ := pkg.IsVerrazzanoMinVersionEventually("1.3.0", kubeConfig); ok {
 				Eventually(func() bool {
 					return pkg.MetricsExist("vendor:coherence_service_messages_local", "role", "HelloCoherenceRole")
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue())


### PR DESCRIPTION
Sometimes the API server fails a request to get the Verrazzano resource.  Added a function to use eventually block and updated all test references.  This change should benefit many tests from this intermittent issue.