### PR TITLE
VZ-7554: Stop logging large stack traces while components are waiting

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -42,6 +42,12 @@ func (r RetryableError) Error() string {
 	return builder.String()
 }
 
+// IsRetryableError returns true if the error is a RetryableError.
+func IsRetryableError(err error) bool {
+	_, ok := err.(RetryableError)
+	return ok
+}
+
 // IsUpdateConflict returns true if the error is an update conflict error. This is occurs when the controller-runtime cache
 // is out of sync with the etc database
 func IsUpdateConflict(err error) bool {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -190,6 +190,7 @@ func (i istioComponent) Install(compContext spi.ComponentContext) error {
 		succeeded, err := i.monitor.checkResult()
 		if err != nil {
 			// Not finished yet, requeue
+			compContext.Log().Progress("Component Istio waiting to finish installing in the background")
 			return err
 		}
 		// reset on success or failure

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -150,7 +150,11 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			// If component is not installed,install it
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
-				compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
+				// Only log this error if this is not a RetryableError
+				if _, ok := err.(spi2.RetryableError); !ok {
+					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
+				}
+
 				return ctrl.Result{Requeue: true}
 			}
 

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -136,8 +136,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			}
 			compLog.Progressf("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
-				// Only log this error if this is not a RetryableError
-				if _, ok := err.(ctrlerrors.RetryableError); !ok {
+				if !ctrlerrors.IsRetryableError(err) {
 					compLog.ErrorfThrottled("Error running PreInstall for component %s: %v", compName, err)
 				}
 
@@ -150,8 +149,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			// If component is not installed,install it
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
-				// Only log this error if this is not a RetryableError
-				if _, ok := err.(ctrlerrors.RetryableError); !ok {
+				if !ctrlerrors.IsRetryableError(err) {
 					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
 				}
 
@@ -172,8 +170,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 		case compStatePostInstall:
 			compLog.Oncef("Component %s post-install running", compName)
 			if err := comp.PostInstall(compContext); err != nil {
-				// Only log this error if this is not a RetryableError
-				if _, ok := err.(ctrlerrors.RetryableError); !ok {
+				if !ctrlerrors.IsRetryableError(err) {
 					compLog.ErrorfThrottled("Error running PostInstall for component %s: %v", compName, err)
 				}
 

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -4,7 +4,7 @@
 package reconcile
 
 import (
-	spi2 "github.com/verrazzano/verrazzano/pkg/controller/errors"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -137,7 +137,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			compLog.Progressf("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
 				// Only log this error if this is not a RetryableError
-				if _, ok := err.(spi2.RetryableError); !ok {
+				if _, ok := err.(ctrlerrors.RetryableError); !ok {
 					compLog.ErrorfThrottled("Error running PreInstall for component %s: %v", compName, err)
 				}
 
@@ -151,7 +151,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
 				// Only log this error if this is not a RetryableError
-				if _, ok := err.(spi2.RetryableError); !ok {
+				if _, ok := err.(ctrlerrors.RetryableError); !ok {
 					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
 				}
 
@@ -173,7 +173,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 			compLog.Oncef("Component %s post-install running", compName)
 			if err := comp.PostInstall(compContext); err != nil {
 				// Only log this error if this is not a RetryableError
-				if _, ok := err.(spi2.RetryableError); !ok {
+				if _, ok := err.(ctrlerrors.RetryableError); !ok {
 					compLog.ErrorfThrottled("Error running PostInstall for component %s: %v", compName, err)
 				}
 


### PR DESCRIPTION
Fluentd logs a large stack trace while waiting for the creation of the `verrazzano-es-internal` secret during preinstall. Jaeger Operator and Istio also log large stack traces while waiting, but they are during postinstall and install, respectively. This PR aims to prevent these stack traces from filling up the main log.

Fluentd and Jaeger Operator already have progress logs when waiting in these scenarios. Istio did not, so this PR also adds a progress log for when Istio returns a `RetryableError` due to needing to wait.