### PR TITLE
Disable a Rancher test

### DIFF
--- a/tests/e2e/multicluster/verify-rancher/rancher_test.go
+++ b/tests/e2e/multicluster/verify-rancher/rancher_test.go
@@ -46,7 +46,7 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 	t.It("Rancher log records do not contain any websocket bad handshake messages", func() {
 		// GIVEN existing system logs
 		// WHEN the Elasticsearch index for the cattle-system namespace is retrieved
-		// THEN is has a limited number of bad socket messages
+		// THEN it has a limited number of bad socket messages
 		adminKubeconfig := os.Getenv("ADMIN_KUBECONFIG")
 		indexName, err := pkg.GetOpenSearchSystemIndexWithKC(cattleSystemNamespace, adminKubeconfig)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -54,7 +54,9 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 			return pkg.LogIndexFound(indexName)
 		}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to find Elasticsearch index cattle-system")
 
-		Expect(getNumBadSocketMessages()).To(BeNumerically("<", 25))
+		// the presence of bad socket messages does not necessarily indicate that anything is wrong with Rancher
+		// from a user's perspective, so just log the number of bad socket messages for informational purposes
+		getNumBadSocketMessages()
 	})
 
 	t.Context("When the VMC is updated to the status of the managed cluster", func() {


### PR DESCRIPTION
This test does not seem to be useful. When this test detects an abnormal number of "bad socket" messages in the Rancher pod logs, there aren't any other test failures. The presence of these log messages does not seem to negatively impact the user's experience.

Temporarily disabling until I can collect more information before completely removing the test and associated code.