### PR TITLE
VZ-7575: update proxyv2 and pilot images and test refactoring

### DIFF
--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -127,14 +127,8 @@ func NewBom(bomPath string) (Bom, error) {
 	if err != nil {
 		return Bom{}, err
 	}
-	bom := Bom{
-		subComponentMap: make(map[string]*BomSubComponent),
-	}
-	err = bom.init(string(jsonBom))
-	if err != nil {
-		return Bom{}, err
-	}
-	return bom, nil
+
+	return ParseBom(string(jsonBom))
 }
 
 // Initialize the BomInfo.  Load the Bom from the JSON file and build
@@ -342,4 +336,16 @@ func FindKV(kvs []KeyValue, key string) string {
 		}
 	}
 	return ""
+}
+
+// ParseBom - create a new bom from a JSON string
+func ParseBom(bomJson string) (Bom, error) {
+	bom := Bom{
+		subComponentMap: make(map[string]*BomSubComponent),
+	}
+	err := bom.init(bomJson)
+	if err != nil {
+		return Bom{}, err
+	}
+	return bom, nil
 }

--- a/pkg/bom/bom.go
+++ b/pkg/bom/bom.go
@@ -339,11 +339,11 @@ func FindKV(kvs []KeyValue, key string) string {
 }
 
 // ParseBom - create a new bom from a JSON string
-func ParseBom(bomJson string) (Bom, error) {
+func ParseBom(bomJSON string) (Bom, error) {
 	bom := Bom{
 		subComponentMap: make(map[string]*BomSubComponent),
 	}
-	err := bom.init(bomJson)
+	err := bom.init(bomJSON)
 	if err != nil {
 		return Bom{}, err
 	}

--- a/pkg/bom/bom_test.go
+++ b/pkg/bom/bom_test.go
@@ -271,12 +271,12 @@ func TestBomImageOverrides(t *testing.T) {
 // THEN the correct Verrazzano bom is returned when json is valid, else an error is returned
 func TestParseBom(t *testing.T) {
 	assert := assert.New(t)
-	bom, err := ParseBom("invalid")
+	_, err := ParseBom("invalid")
 	assert.Error(err, "should have returned error parsing invalid bom")
 
 	jsonBom, err := ioutil.ReadFile(realBomFilePath)
 	assert.NoError(err, "error while reading bom file")
-	bom, err = ParseBom(string(jsonBom))
+	bom, err := ParseBom(string(jsonBom))
 	assert.NoError(err, "error parsing valid bom")
 	assert.Equal("ghcr.io", bom.bomDoc.Registry, "Wrong registry name")
 	assert.Len(bom.bomDoc.Components, 14, "incorrect number of Bom components")

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -101,13 +101,13 @@
           "name": "istiod",
           "images": [
             {
-              "image": "pilot",
-              "tag": "1.13.5",
+              "image": "pilot-jenkins",
+              "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "values.pilot.image"
             },
             {
-              "image": "proxyv2",
-              "tag": "1.13.5",
+              "image": "proxyv2-jenkins",
+              "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -186,8 +186,8 @@
               "helmTagKey": "nodeExporter.imageVersion"
             },
             {
-              "image": "proxyv2",
-              "tag": "1.13.5",
+              "image": "proxyv2-jenkins",
+              "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -225,8 +225,8 @@
               "helmTagKey": "monitoringOperator.imageVersion"
             },
             {
-              "image": "proxyv2",
-              "tag": "1.13.5",
+              "image": "proxyv2-jenkins",
+              "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -101,12 +101,12 @@
           "name": "istiod",
           "images": [
             {
-              "image": "pilot-jenkins",
+              "image": "pilot",
               "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "values.pilot.image"
             },
             {
-              "image": "proxyv2-jenkins",
+              "image": "proxyv2",
               "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
@@ -186,7 +186,7 @@
               "helmTagKey": "nodeExporter.imageVersion"
             },
             {
-              "image": "proxyv2-jenkins",
+              "image": "proxyv2",
               "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
@@ -225,7 +225,7 @@
               "helmTagKey": "monitoringOperator.imageVersion"
             },
             {
-              "image": "proxyv2-jenkins",
+              "image": "proxyv2",
               "tag": "1.13.5-1-20221103131708-70a481e9",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -5,6 +5,7 @@ package verify
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,7 +41,6 @@ const (
 	fiveMinutes = 5 * time.Minute
 
 	pollingInterval = 10 * time.Second
-	envoyImage      = "proxyv2:1.13.5"
 	minimumVersion  = "1.1.0"
 )
 
@@ -48,6 +48,7 @@ var t = framework.NewTestFramework("verify")
 
 var vzcr *vzapi.Verrazzano
 var kubeconfigPath string
+var envoyImage string
 
 var _ = t.BeforeSuite(func() {
 	var err error
@@ -65,6 +66,16 @@ var _ = t.BeforeSuite(func() {
 		}
 		return err
 	}, oneMinute, pollingInterval).Should(BeNil(), "Expected to get Verrazzano CR")
+
+	// Get the envoy proxy image name and tag
+	Eventually(func() error {
+		var err error
+		envoyImage, err = getEnvoyProxyImageRef()
+		if err != nil {
+			return err
+		}
+		return err
+	}, oneMinute, pollingInterval).Should(BeNil(), "Expected to get envoy proxy image name and tag")
 })
 var _ = t.AfterSuite(func() {})
 var _ = t.AfterEach(func() {})
@@ -330,4 +341,32 @@ func isDisabled(componentName string) bool {
 		return comp.State == vzapi.CompStateDisabled
 	}
 	return true
+}
+
+// getEnvoyProxyImageRef gets the envoy proxy image and its tag from bom in verrazzano-platform-operator pod running in cluster
+func getEnvoyProxyImageRef() (string, error) {
+	bom, err := pkg.GetBOM()
+	if err != nil {
+		return "", fmt.Errorf("error getting bom, %s", err.Error())
+	}
+
+	istiodSubComponent := "istiod"
+	images, err := bom.GetSubcomponentImages(istiodSubComponent)
+	if err != nil {
+		return "", fmt.Errorf("error getting images for %s, %s", istiodSubComponent, err.Error())
+	}
+
+	envoyProxyImageName := "proxyv2"
+	envoyProxyImageRef := ""
+	for _, image := range images {
+		if strings.HasPrefix(image.ImageName, envoyProxyImageName) {
+			envoyProxyImageRef = fmt.Sprintf("%s:%s", image.ImageName, image.ImageTag)
+		}
+	}
+
+	if envoyProxyImageRef == "" {
+		return "", fmt.Errorf("envoy proxy image %s not defined in subcomponent %s in bom", envoyProxyImageName, istiodSubComponent)
+	}
+
+	return envoyProxyImageRef, nil
 }

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -117,7 +117,7 @@ var _ = t.Describe("Application pods post-upgrade", Label("f:platform-lcm.upgrad
 		springbootNamespace   = "springboot"
 		todoListNamespace     = "todo-list"
 	)
-	t.DescribeTable("should contain Envoy sidecar 1.13.5",
+	t.DescribeTable("should contain Envoy sidecar with image "+envoyImage,
 		func(namespace string, timeout time.Duration) {
 			exists, err := pkg.DoesNamespaceExist(namespace)
 			if err != nil {


### PR DESCRIPTION
1. updates proxyv2 and pilot images
2. refactoring for removing hardcoded proxyv2 image reference from verify_restart_test 
- created a function `ParseBom` to be able to construct bom struct from a json string
- added `GetBOM` func to test package to get the bom from verrazzano-platform-operator pod in cluster
- and refactored the test to get the envoy image from the bom  
