### PR TITLE
VZ-7053: Rancher upgrade workaround (release-1.3)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -4,28 +4,34 @@
 package rancher
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"strings"
 
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// getDynamicClientFuncSig defines the signature for a function that returns a k8s dynamic client
+type getDynamicClientFuncSig func() (dynamic.Interface, error)
+
+// getDynamicClientFunc is the function for getting a k8s dynamic client - this allows us to override
+// the function for unit testing
+var getDynamicClientFunc getDynamicClientFuncSig = getDynamicClient
 
 // Constants for Kubernetes resource names
 const (
@@ -70,7 +76,27 @@ const (
 	SettingFirstLogin          = "first-login"
 )
 
+const (
+	rancherChartsClusterRepoName        = "rancher-charts"
+	rancherPartnerChartsClusterRepoName = "rancher-partner-charts"
+	rancherRke2ChartsClusterRepoName    = "rancher-rke2-charts"
+
+	chartDefaultBranchName = "chart-default-branch"
+)
+
 var GVKSetting = common.GetRancherMgmtAPIGVKForKind("Setting")
+
+var cattleSettingsGVR = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "settings",
+}
+
+var cattleClusterReposGVR = schema.GroupVersionResource{
+	Group:    "catalog.cattle.io",
+	Version:  "v1",
+	Resource: "clusterrepos",
+}
 
 func useAdditionalCAs(acme vzapi.Acme) bool {
 	return acme.Environment != "production"
@@ -90,13 +116,6 @@ func getRancherHostname(c client.Client, vz *vzapi.Verrazzano) (string, error) {
 func isRancherReady(ctx spi.ComponentContext) bool {
 	log := ctx.Log()
 	c := ctx.Client()
-
-	// Temporary work around for Rancher issue 36914
-	err := checkRancherUpgradeFailure(c, log)
-	if err != nil {
-		log.ErrorfThrottled("Error checking Rancher pod logs: %s", err.Error())
-		return false
-	}
 
 	deployments := []types.NamespacedName{
 		{
@@ -125,91 +144,58 @@ func isRancherReady(ctx spi.ComponentContext) bool {
 	return status.DeploymentsAreReady(log, c, deployments, 1, prefix)
 }
 
-// checkRancherUpgradeFailure - temporary work around for Rancher issue 36914. During an upgrade, the Rancher pods
-// are recycled.  When the leader pod is restarted, it is possible that a Rancher 2.5.9 pod could
-// acquire leader and recreate the downloaded helm charts it requires.
-//
-// If one of the Rancher pods is failing to find the rancher-webhook, recycle that pod.
-func checkRancherUpgradeFailure(c client.Client, log vzlog.VerrazzanoLogger) error {
-	ctx := context.TODO()
-
-	// Get the Rancher pods
-	podList := &corev1.PodList{}
-	err := c.List(ctx, podList, client.InNamespace(ComponentNamespace), client.MatchingLabels{"app": "rancher"})
-	if err != nil {
+// chartsNotUpdatedWorkaround - workaround for VZ-7053, where some of the Helm charts are not
+// getting updated after Rancher upgrade. This workaround will scale the Rancher deployment down
+// and then delete the ClusterRepo resources. This must be done in PreUpgrade. Scaling down is
+// necessary to prevent an old pod from updating the ClusterRepo with an old commit. When Rancher
+// is upgraded, new Rancher pods will start and create new ClusterRepo resources with the correct
+// chart data.
+func chartsNotUpdatedWorkaround(ctx spi.ComponentContext) error {
+	if err := scaleDownRancherDeployment(ctx.Client(), ctx.Log()); err != nil {
 		return err
 	}
-	if len(podList.Items) == 0 {
+	return deleteClusterRepos(ctx.Log())
+}
+
+// scaleDownRancherDeployment scales the Rancher deployment down to zero replicas
+func scaleDownRancherDeployment(c client.Client, log vzlog.VerrazzanoLogger) error {
+	deployment := appsv1.Deployment{}
+	namespacedName := types.NamespacedName{Name: common.RancherName, Namespace: common.CattleSystem}
+	if err := c.Get(context.TODO(), namespacedName, &deployment); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if deployment.Status.AvailableReplicas == 0 {
+		// deployment is scaled down, we're done
 		return nil
 	}
 
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas > 0 {
+		log.Infof("Scaling down Rancher deployment %v", namespacedName)
+		zero := int32(0)
+		deployment.Spec.Replicas = &zero
+		if err := c.Update(context.TODO(), &deployment); err != nil {
+			return log.ErrorfNewErr("Failed to scale Rancher deployment %v to zero replicas: %v", namespacedName, err)
+		}
+	}
+
+	// return RetryableError so we come back through this function again and check the replicas - repeat
+	// until there are no available replicas
+	log.Progressf("Waiting for Rancher deployment %v to scale down", namespacedName)
+	return ctrlerrors.RetryableError{Source: ComponentName}
+}
+
+// getDynamicClient returns a dynamic k8s client
+func getDynamicClient() (dynamic.Interface, error) {
 	config, err := ctrl.GetConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	clientSet, err := kubernetes.NewForConfig(config)
+	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	// Check the logs of each pod
-	podsRestarted := false
-	for i, pod := range podList.Items {
-		// Skip pods that are already being deleted
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
-
-		// Skip pods that are not ready, they will get checked again in another call to isReady.
-		if !isPodReady(pod) {
-			continue
-		}
-
-		// Get the pod log stream
-		logStream, err := clientSet.CoreV1().Pods(ComponentNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: "rancher"}).Stream(ctx)
-		if err != nil {
-			return err
-		}
-		defer logStream.Close()
-
-		// Search the stream for the expected text
-		restartPod := false
-		scanner := bufio.NewScanner(logStream)
-		for scanner.Scan() {
-			token := scanner.Text()
-			if strings.Contains(token, "[ERROR] available chart version") {
-				log.Infof("Rancher IsReady: Failed to find system chart for pod %s: %s", pod.Name, token)
-				restartPod = true
-				break
-			}
-		}
-
-		// If the pod is failing to find the system chart for rancher-webhook, the wrong helm charts are
-		// being used by the Rancher pod. Restart the pod. This will cause another Rancher pod to become the leader,
-		// and, if needed, will recreate the custom resources related to the helm charts.
-		if restartPod {
-			// Delete custom resources containing helm charts to use
-			err := deleteClusterRepos(log)
-			if err != nil {
-				return err
-			}
-			log.Infof("Rancher IsReady: Restarting pod %s", pod.Name)
-			err = c.Delete(ctx, &podList.Items[i])
-			if err != nil {
-				return err
-			}
-			podsRestarted = true
-		}
-	}
-
-	// If any pods were restarted, return an error so that the IsReady check will not continue
-	// any further.  Checks will resume again after the pod is ready again.
-	if podsRestarted {
-		return fmt.Errorf("Rancher IsReady: pods were restarted, waiting for them to be ready again")
-	}
-
-	return nil
+	return dynamicClient, nil
 }
 
 // deleteClusterRepos - temporary work around for Rancher issue 36914. On upgrade of Rancher
@@ -217,69 +203,48 @@ func checkRancherUpgradeFailure(c client.Client, log vzlog.VerrazzanoLogger) err
 // helm charts for the previous release of Rancher are used (instead of the charts on the Rancher
 // container image).
 func deleteClusterRepos(log vzlog.VerrazzanoLogger) error {
-
-	config, err := ctrl.GetConfig()
+	dynamicClient, err := getDynamicClientFunc()
 	if err != nil {
-		log.Debugf("Rancher IsReady: Failed getting config: %v", err)
+		log.Errorf("Rancher deleteClusterRepos: Failed creating dynamic client: %v", err)
 		return err
-	}
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		log.Debugf("Rancher IsReady: Failed creating dynamic client: %v", err)
-		return err
-	}
-
-	// Configure the GVR
-	gvr := schema.GroupVersionResource{
-		Group:    "management.cattle.io",
-		Version:  "v3",
-		Resource: "settings",
 	}
 
 	// Get the name of the default branch for the helm charts
-	name := "chart-default-branch"
-	chartDefaultBranch, err := dynamicClient.Resource(gvr).Get(context.TODO(), name, metav1.GetOptions{})
+	chartDefaultBranch, err := dynamicClient.Resource(cattleSettingsGVR).Get(context.TODO(), chartDefaultBranchName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
-		log.Debugf("Rancher IsReady: Failed getting settings.management.cattle.io %s: %v", name, err)
+		log.Errorf("Rancher deleteClusterRepos: Failed getting settings.management.cattle.io %s: %v", chartDefaultBranchName, err)
 		return err
 	}
 
 	// Obtain the name of the default branch from the custom resource
 	defaultBranch, _, err := unstructured.NestedString(chartDefaultBranch.Object, "default")
 	if err != nil {
-		log.Debugf("Rancher IsReady: Failed to find default branch value in settings.management.cattle.io %s: %v", name, err)
+		log.Errorf("Rancher deleteClusterRepos: Failed to find default branch value in settings.management.cattle.io %s: %v", chartDefaultBranchName, err)
 		return err
 	}
 
-	log.Infof("Rancher IsReady: The default release branch is currently set to %s", defaultBranch)
+	log.Infof("Rancher deleteClusterRepos: The default release branch is currently set to %s", defaultBranch)
 
 	// Delete settings.management.cattle.io chart-default-branch
-	err = dynamicClient.Resource(gvr).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err = dynamicClient.Resource(cattleSettingsGVR).Delete(context.TODO(), chartDefaultBranchName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
-		log.Debugf("Rancher IsReady: Failed deleting settings.management.cattle.io %s: %v", name, err)
+		log.Errorf("Rancher deleteClusterRepos: Failed deleting settings.management.cattle.io %s: %v", chartDefaultBranchName, err)
 		return err
 	}
-	log.Infof("Rancher IsReady: Deleted settings.management.cattle.io %s", name)
-
-	// Reconfigure the GVR
-	gvr = schema.GroupVersionResource{
-		Group:    "catalog.cattle.io",
-		Version:  "v1",
-		Resource: "clusterrepos",
-	}
+	log.Infof("Rancher deleteClusterRepos: Deleted settings.management.cattle.io %s", chartDefaultBranchName)
 
 	// List of clusterrepos to delete
-	names := []string{"rancher-charts", "rancher-rke2-charts", "rancher-partner-charts"}
+	names := []string{rancherChartsClusterRepoName, rancherPartnerChartsClusterRepoName, rancherRke2ChartsClusterRepoName}
 	for _, name := range names {
-		err = dynamicClient.Resource(gvr).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err = dynamicClient.Resource(cattleClusterReposGVR).Delete(context.TODO(), name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
-			log.Debugf("Rancher IsReady: Failed deleting clusterrepos.catalog.cattle.io %s: %v", name, err)
+			log.Errorf("Rancher deleteClusterRepos: Failed deleting clusterrepos.catalog.cattle.io %s: %v", name, err)
 			return err
 		}
-		log.Infof("Rancher IsReady: Deleted clusterrepos.catalog.cattle.io %s", name)
+		log.Infof("Rancher deleteClusterRepos: Deleted clusterrepos.catalog.cattle.io %s", name)
 	}
 
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -184,7 +184,15 @@ func (r rancherComponent) PreInstall(ctx spi.ComponentContext) error {
 	return nil
 }
 
-//Install
+// PreUpgrade
+/* Runs pre-upgrade steps
+- Scales down Rancher pods and deletes the ClusterRepo resources to work around Rancher upgrade issues (VZ-7053)
+*/
+func (r rancherComponent) PreUpgrade(ctx spi.ComponentContext) error {
+	return chartsNotUpdatedWorkaround(ctx)
+}
+
+// Install
 /* Installs the Helm chart, and patches the resulting objects
 - ensure Helm chart is installed
 - Patch Rancher deployment with MKNOD capability

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -253,7 +253,7 @@ func TestChartsNotUpdatedWorkaround(t *testing.T) {
 			},
 		},
 	).Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false)
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
 	err := chartsNotUpdatedWorkaround(ctx)
 	assert.Error(t, err)
 
@@ -279,7 +279,7 @@ func TestChartsNotUpdatedWorkaround(t *testing.T) {
 			},
 		},
 	).Build()
-	ctx = spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false)
+	ctx = spi.NewFakeContext(client, &vzapi.Verrazzano{}, false)
 	err = chartsNotUpdatedWorkaround(ctx)
 	assert.NoError(t, err)
 

--- a/platform-operator/controllers/verrazzano/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/upgrade_component.go
@@ -93,7 +93,6 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 		case compStatePreUpgrade:
 			compLog.Oncef("Component %s pre-upgrade running", compName)
 			if err := comp.PreUpgrade(compContext); err != nil {
-				compLog.Errorf("Failed pre-upgrading component %s: %v", compName, err)
 				return ctrl.Result{}, err
 			}
 			upgradeContext.state = compStateUpgrade


### PR DESCRIPTION
Backport of the Rancher upgrade workaround to the release-1.3 branch. This works around the problem where Rancher complains that the bundled chart version does not meet the minimum chart requirements, and Rancher fails to upgrade Fleet, Gitjob, etc.