### PR TITLE
Add latest code location to metrics

### DIFF
--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -21,6 +21,8 @@ const (
 	Status            = "status"
 	attempts          = "attempts"
 	test              = "test"
+	testFilename      = "file_name"
+	testLineNumber    = "line_number"
 	BuildURL          = "build_url"
 	JenkinsJob        = "jenkins_job"
 	BranchName        = "branch_name"
@@ -166,11 +168,21 @@ func Emit(log *zap.SugaredLogger) {
 	}
 	t := spec.FullText()
 	l := spec.Labels()
-
+	filename, linenumber := extractLastCodeLocation(spec)
 	log.With(attempts, spec.NumAttempts).
 		With(test, t).
+		With(testFilename, filename).
+		With(testLineNumber, linenumber).
 		With(Label, l).
 		Info()
+}
+
+func extractLastCodeLocation(spec ginkgo.SpecReport) (string, int) {
+	if len(spec.ContainerHierarchyLocations) < 1 {
+		return "", -1
+	}
+	location := spec.ContainerHierarchyLocations[len(spec.ContainerHierarchyLocations)-1]
+	return location.FileName, location.LineNumber
 }
 
 func DurationMillis() int64 {


### PR DESCRIPTION
Filename and line number will be added the test metrics. This can be used to isolate failing suites in their respective pipelines.