### PR TITLE
VZ-7524: Fix intermittent unit test failure in TestRepairMySQLPodsWaitingReadinessGates

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -2006,6 +2006,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	mySQLPod.Status.Conditions = []v1.PodCondition{{Type: "gate1", Status: v1.ConditionTrue}, {Type: "gate2", Status: v1.ConditionFalse}}
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
+	*mysqlComp.LastTimeReadinessGateRepairStarted = mysqlComp.LastTimeReadinessGateRepairStarted.Truncate(2 * time.Hour)
 	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
 	assert.NoError(t, err)
 	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())


### PR DESCRIPTION
The test TestRepairMySQLPodsWaitingReadinessGates would sometimes fail with this:

11:00:48  --- FAIL: TestRepairMySQLPodsWaitingReadinessGates (0.00s)
11:00:48      mysql_test.go:2011: 
11:00:48          	Error Trace:	mysql_test.go:2011
11:00:48          	Error:      	Should be true
11:00:48          	Test:       	TestRepairMySQLPodsWaitingReadinessGates
11:00:48      mysql_test.go:2014: 
11:00:48          	Error Trace:	mysql_test.go:2014
11:00:48          	Error:      	An error is expected but got nil.
11:00:48          	Test:       	TestRepairMySQLPodsWaitingReadinessGates
11:00:48      mysql_test.go:2015: 
11:00:48          	Error Trace:	mysql_test.go:2015
11:00:48          	Error:      	Should be true
11:00:48          	Test:       	TestRepairMySQLPodsWaitingReadinessGates
