### PR TITLE
VZ-7759 Add helm configmap to transfer install overrides to the VCO

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
@@ -13,4 +13,3 @@ data:
 {{ toYaml .Values.syncRancherClusters.clusterSelector | indent 4 }}
   {{- end -}}
 {{- end -}}
-

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+{{- if .Values.syncRancherClusters.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-selector
+  namespace: {{ .Values.namespace }}
+data:
+  {{- if .Values.syncRancherClusters.clusterSelector -}}
+  selector.yaml: {{ .Values.syncRancherClusters.clusterSelector }}
+  {{- end -}}
+{{- end -}}
+

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   {{- if .Values.syncRancherClusters.clusterSelector -}}
-  selector.yaml: {{ .Values.syncRancherClusters.clusterSelector }}
+  selector.yaml: {{ .Values.syncRancherClusters.clusterSelector | toString }}
   {{- end -}}
 {{- end -}}
 

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
@@ -1,14 +1,16 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 {{- if .Values.syncRancherClusters.enabled -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-selector
   namespace: {{ .Values.namespace }}
 data:
-  {{- if .Values.syncRancherClusters.clusterSelector -}}
-  selector.yaml: {{ .Values.syncRancherClusters.clusterSelector | toString }}
+  {{ if .Values.syncRancherClusters.clusterSelector -}}
+  selector.yaml: |
+{{ toYaml .Values.syncRancherClusters.clusterSelector | indent 4 }}
   {{- end -}}
 {{- end -}}
 

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/configmap.yaml
@@ -1,7 +1,5 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-{{- if .Values.syncRancherClusters.enabled -}}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,5 +9,9 @@ data:
   {{ if .Values.syncRancherClusters.clusterSelector -}}
   selector.yaml: |
 {{ toYaml .Values.syncRancherClusters.clusterSelector | indent 4 }}
-  {{- end -}}
-{{- end -}}
+  {{- end }}
+  {{ if .Values.syncRancherClusters.enabled -}}
+  enabled: "true"
+  {{ else -}}
+  enabled: "false"
+  {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -37,4 +37,5 @@ spec:
             name: {{ .Values.name }}-selector
             items:
             - key: selector.yaml
+              path: selector.yaml
             optional: true

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -28,5 +28,5 @@ spec:
       volumes:
         - name: clusterSelector
           configMap:
-            configMapName: {{ .Values.name }}-selector
+            name: {{ .Values.name }}-selector
             optional: true

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -21,4 +21,11 @@ spec:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        volumeMounts:
+          - name: clusterSelector
       serviceAccountName: {{ .Values.name }}
+      volumes:
+        - name: clusterSelector
+          configMap:
+            configMapName: {{ .Values.name }}-selector
+            optional: true

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         volumeMounts:
           - name: clusterSelector
+            mountPath: /var/selector
       serviceAccountName: {{ .Values.name }}
       volumes:
         - name: clusterSelector

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -22,11 +22,11 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         volumeMounts:
-          - name: clusterSelector
+          - name: cluster-selector
             mountPath: /var/selector
       serviceAccountName: {{ .Values.name }}
       volumes:
-        - name: clusterSelector
+        - name: cluster-selector
           configMap:
             name: {{ .Values.name }}-selector
             optional: true

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -22,14 +22,14 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
-        - name: CLUSTER_SYNC_ENABLED
+        - name: RANCHER_CLUSTER_SYNC_ENABLED
           valueFrom:
             configMapKeyRef:
               name: {{ .Values.name }}-selector
               key: enabled
         volumeMounts:
           - name: cluster-selector
-            mountPath: /var/selector
+            mountPath: /var/syncRancherClusters
       serviceAccountName: {{ .Values.name }}
       volumes:
         - name: cluster-selector

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
-          name: CLUSTER_SYNC_ENABLED
+        - name: CLUSTER_SYNC_ENABLED
           valueFrom:
             configMapKeyRef:
               name: {{ .Values.name }}-selector

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        env:
+          name: CLUSTER_SYNC_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.name }}-selector
+              key: enabled
         volumeMounts:
           - name: cluster-selector
             mountPath: /var/selector
@@ -29,4 +35,6 @@ spec:
         - name: cluster-selector
           configMap:
             name: {{ .Values.name }}-selector
+            items:
+            - key: selector.yaml
             optional: true

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
@@ -8,3 +8,7 @@ imagePullPolicy: IfNotPresent
 
 global:
   imagePullSecrets: []
+
+syncRancherClusters:
+  enabled: false
+  labelSelector: ""

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
@@ -11,4 +11,3 @@ global:
 
 syncRancherClusters:
   enabled: false
-  labelSelector: ""


### PR DESCRIPTION
The install overrides for the label selector need to be communicated to the VCO. Through this configmap, we can determine the state of the install overrides and correctly apply the label selector
