### PR TITLE
VZ-7423.  Fix use of image pull secret with OAM component, add psrctl hooks for secret

### DIFF
--- a/tools/psr/Makefile
+++ b/tools/psr/Makefile
@@ -29,6 +29,7 @@ DOCKER_IMAGE_FULLNAME := ${DOCKER_REGISTRY}/${DOCKER_IMAGE_FULLNAME}
 endif
 endif
 DOCKER_IMAGE_TAG ?= local-$(shell git rev-parse --short HEAD)
+DOCKER_IMAGE_FULL_PATH := ${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}
 
 GIT_COMMIT:=$(shell git rev-parse HEAD)
 BUILD_VERSION:=$(shell grep verrazzano-development-version ${MAKEFILE_DIR}/../../.verrazzano-development-version | cut -d= -f 2)
@@ -36,7 +37,7 @@ BUILD_DATE:=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 
 DIST_DIR:=dist
 GO=GO111MODULE=on GOPRIVATE=github.com/verrazzano/* CGO_ENABLED=0  go
-CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.cliVersion=${BUILD_VERSION}' -X '${CONSTANTS_DIR}.defaultWorkerImage=${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}'
+CLI_GO_LDFLAGS=-X '${VERSION_DIR}.gitCommit=${GIT_COMMIT}' -X '${VERSION_DIR}.buildDate=${BUILD_DATE}' -X '${VERSION_DIR}.cliVersion=${BUILD_VERSION}' -X '${CONSTANTS_DIR}.defaultWorkerImage=${DOCKER_IMAGE_FULL_PATH}'
 
 export TEST_PATHS ?= ./backend/...
 

--- a/tools/psr/manifests/charts/worker/templates/component.yaml
+++ b/tools/psr/manifests/charts/worker/templates/component.yaml
@@ -18,14 +18,13 @@ spec:
         app: psr-worker
         version: v1
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-      {{- end }}
       containers:
         - name: psr-backend
           image: {{  .Values.imageName }}
           imagePullPolicy: {{  .Values.imagePullPolicy }}
+          {{- with (first .Values.imagePullSecrets) }}
+          imagePullSecret: {{ .name }}
+          {{- end }}
           env:
             {{- range $key, $val := .Values.global.envVars }}
             - name: {{ $key }}

--- a/tools/psr/manifests/charts/worker/values.yaml
+++ b/tools/psr/manifests/charts/worker/values.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-imagePullSecrets: [ ]
-
-#imageName: ghcr.io/verrazzano/psr-backend:local-c10faf9
+#imageName:
+imagePullSecrets:
+  - name: verrazzano-container-registry
 imagePullPolicy: IfNotPresent
 
 replicas: 1
@@ -21,4 +21,3 @@ appType: oam
 # Each worker that has a subchart needs to override this property
 opensearch-authpol:
   enabled: false
-

--- a/tools/psr/psrctl/cmd/constants/constants.go
+++ b/tools/psr/psrctl/cmd/constants/constants.go
@@ -28,7 +28,12 @@ const (
 	WorkerImageNameShort = "w"
 	WorkerImageNameHelp  = `The full PSR image name and tag to use for executing scenarios`
 
-	ImageNameKey = "imageName"
+	ImagePullSecretName      = "pull-secret"
+	ImagePullSecretNameShort = "p"
+	ImagePullSecretNameHelp  = `The name of the imagePullSecret for the PSR worker image`
+
+	ImageNameKey    = "imageName"
+	ImagePullSecKey = "imagePullSecrets[0].name"
 )
 
 var defaultWorkerImage string

--- a/tools/psr/psrctl/cmd/list/list.go
+++ b/tools/psr/psrctl/cmd/list/list.go
@@ -47,7 +47,7 @@ func RunCmdList(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	if allNamepaces {
 		namespace = ""
 	}
-	m, err := scenario.NewManager(namespace, "", "")
+	m, err := scenario.NewManager(namespace, "")
 
 	if err != nil {
 		return fmt.Errorf("Failed to create scenario Manager %v", err)

--- a/tools/psr/psrctl/cmd/stop/stop.go
+++ b/tools/psr/psrctl/cmd/stop/stop.go
@@ -39,7 +39,7 @@ func NewCmdStop(vzHelper helpers.VZHelper) *cobra.Command {
 // RunCmdStop - Run the "psrctl Stop" command
 func RunCmdStop(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 
-	m, err := scenario.NewManager(namespace, "", "")
+	m, err := scenario.NewManager(namespace, "")
 	if err != nil {
 		return fmt.Errorf("Failed to create scenario Manager %v", err)
 	}

--- a/tools/psr/psrctl/pkg/scenario/manager.go
+++ b/tools/psr/psrctl/pkg/scenario/manager.go
@@ -5,9 +5,9 @@ package scenario
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/tools/psr/psrctl/cmd/constants"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/embedded"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -19,26 +19,23 @@ type Manager struct {
 	Manifest            embedded.PsrManifests
 	ExternalScenarioDir string
 	Namespace           string
-	WorkerImage         string
+	HelmOverrides       []helm.HelmOverrides
 	DryRun              bool
 	Verbose             bool
 }
 
 // NewManager returns a scenario Manager
-func NewManager(namespace string, externalScenarioDir string, imageName string) (Manager, error) {
+func NewManager(namespace string, externalScenarioDir string, helmOverrides ...helm.HelmOverrides) (Manager, error) {
 	client, err := k8sutil.GetCoreV1Client(vzlog.DefaultLogger())
 	if err != nil {
 		return Manager{}, fmt.Errorf("Failed to get CoreV1 client: %v", err)
-	}
-	if len(imageName) == 0 {
-		imageName = constants.GetDefaultWorkerImage()
 	}
 	m := Manager{
 		Namespace:           namespace,
 		Log:                 vzlog.DefaultLogger(),
 		Manifest:            *embedded.Manifests,
 		ExternalScenarioDir: externalScenarioDir,
-		WorkerImage:         imageName,
+		HelmOverrides:       helmOverrides,
 		Client:              client,
 		Verbose:             true,
 	}

--- a/tools/psr/psrctl/pkg/scenario/start.go
+++ b/tools/psr/psrctl/pkg/scenario/start.go
@@ -6,7 +6,6 @@ package scenario
 import (
 	"fmt"
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
-	"github.com/verrazzano/verrazzano/tools/psr/psrctl/cmd/constants"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"path/filepath"
@@ -42,10 +41,9 @@ func (m Manager) StartScenario(scman *ScenarioManifest) (string, error) {
 	// Helm install each use case
 	var i int
 	for _, uc := range scman.Usecases {
-		// Create the set of HelmOverrides, starting with the worker image
-		helmOverrides := []helmcli.HelmOverrides{
-			m.buildWorkerImageOverride(),
-		}
+		// Create the set of HelmOverrides, initialized from the manager settings
+		helmOverrides := m.HelmOverrides
+
 		// This is the usecase path, E.G. manifests/usecases/opensearch/getlogs/getlogs.yaml
 		ucOverride := filepath.Join(m.Manifest.UseCasesAbsDir, uc.UsecasePath)
 		helmOverrides = append(helmOverrides, helmcli.HelmOverrides{FileOverride: ucOverride})
@@ -104,8 +102,4 @@ func readWorkerType(ucOverride string) (string, error) {
 		return "nil", fmt.Errorf("Failed to find global.envVars.PSR_WORKER_TYPE in %s", ucOverride)
 	}
 	return wt.Global.EnvVars.WorkerType, nil
-}
-
-func (m Manager) buildWorkerImageOverride() helmcli.HelmOverrides {
-	return helmcli.HelmOverrides{SetOverrides: fmt.Sprintf("%s=%s", constants.ImageNameKey, m.WorkerImage)}
 }


### PR DESCRIPTION
Fix use of image pull secret with OAM component, add psrctl hooks for secret
- make `verrazzano-container-registry` the default pull secret, since the PSR repos are all private for now
- also, make the communication of additional HelmOverrides more general in the Manager impl

Example:

```
psrctl start -s ops-s1 -p mysecret -w "ghcr.io/verrazzano/psr-backend-jenkins:xxxxx"
```

assuming that `mysecret` is an existing pull secret and the credentials are valid.
