### PR TITLE
VZ-7676: Cluster operator Rancher cluster controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docker-push: ## build and push all images
 
 .PHONY: create-test-deploy
 create-test-deploy: docker-push
-	(cd platform-operator; make create-test-deploy VZ_DEV_IMAGE=${VERRAZZANO_PLATFORM_OPERATOR_IMAGE} VZ_APP_OP_IMAGE=${VERRAZZANO_APPLICATION_OPERATOR_IMAGE})
+	(cd platform-operator; make create-test-deploy VZ_DEV_IMAGE=${VERRAZZANO_PLATFORM_OPERATOR_IMAGE} VZ_APP_OP_IMAGE=${VERRAZZANO_APPLICATION_OPERATOR_IMAGE} VZ_CLUSTER_OP_IMAGE=${VERRAZZANO_CLUSTER_OPERATOR_IMAGE})
 
 .PHONY: test-platform-operator-install
 test-platform-operator-install:

--- a/cluster-operator/controllers/rancher/rancher_cluster_controller.go
+++ b/cluster-operator/controllers/rancher/rancher_cluster_controller.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rancher
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+)
+
+const (
+	createdByLabel      = "app.kubernetes.io/created-by"
+	createdByVerrazzano = "verrazzano"
+	localClusterName    = "local"
+)
+
+type RancherClusterReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Log    *zap.SugaredLogger
+}
+
+var gvk = schema.GroupVersionKind{
+	Group:   "management.cattle.io",
+	Version: "v3",
+	Kind:    "Cluster",
+}
+
+func CattleClusterClientObject() client.Object {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	return obj
+}
+
+// SetupWithManager creates a new controller and adds it to the manager
+func (r *RancherClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(CattleClusterClientObject()).
+		Complete(r)
+}
+
+// Reconcile is the main controller reconcile function
+func (r *RancherClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Debugf("Reconciling Rancher cluster: %v", req.NamespacedName)
+
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	err := r.Client.Get(context.TODO(), req.NamespacedName, cluster)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	if errors.IsNotFound(err) {
+		r.Log.Debugf("Rancher cluster %v not found, nothing to do", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// if the deletion timestamp is set, delete the corresponding VMC
+	if cluster.GetDeletionTimestamp() != nil {
+		if err := r.deleteVMC(cluster); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// ensure the VMC exists
+	if err = r.ensureVMC(cluster); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// getClusterDisplayName returns the displayName spec field from the Rancher cluster resource
+func (r *RancherClusterReconciler) getClusterDisplayName(cluster *unstructured.Unstructured) (string, error) {
+	displayName, ok, err := unstructured.NestedString(cluster.Object, "spec", "displayName")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("Could not find spec displayName field in Cattle Cluster resource: %s", cluster.GetName())
+	}
+	return displayName, nil
+}
+
+// ensureVMC ensures that a VMC exists for the Rancher cluster. It will also set the Rancher cluster id in the VMC status
+// if it is not already set.
+func (r *RancherClusterReconciler) ensureVMC(cluster *unstructured.Unstructured) error {
+	displayName, err := r.getClusterDisplayName(cluster)
+	if err != nil {
+		return err
+	}
+
+	// ignore the "local" cluster
+	if displayName == localClusterName {
+		return nil
+	}
+
+	// attempt to create the VMC, if it already exists we just ignore the error
+	vmc := newVMC(displayName)
+	if err := r.Create(context.TODO(), vmc); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			r.Log.Errorf("Unable to create VMC with name %s: %v", displayName, err)
+			return err
+		}
+		r.Log.Debugf("VMC %s already exists", displayName)
+	} else {
+		r.Log.Infof("Created VMC for discovered Rancher cluster with name: %s", displayName)
+	}
+
+	// read back the VMC and if the cluster id isn't set in the status, set it
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: displayName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc); err != nil {
+		r.Log.Errorf("Unable to get VMC with name: %s", displayName)
+		return err
+	}
+	if vmc.Status.RancherRegistration.ClusterID == "" {
+		// Rancher cattle cluster resource name is also the Rancher cluster id
+		r.Log.Debugf("Updating VMC %s status with cluster id: %s", displayName, cluster.GetName())
+		vmc.Status.RancherRegistration.ClusterID = cluster.GetName()
+		if err := r.Status().Update(context.TODO(), vmc); err != nil {
+			r.Log.Errorf("Unable to update VMC %s status: %v", displayName, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteVMC deletes the VMC associated with a Rancher cluster
+func (r *RancherClusterReconciler) deleteVMC(cluster *unstructured.Unstructured) error {
+	displayName, err := r.getClusterDisplayName(cluster)
+	if err != nil {
+		return err
+	}
+
+	// ignore the "local" cluster
+	if displayName == localClusterName {
+		return nil
+	}
+
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: displayName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc); err != nil {
+		if errors.IsNotFound(err) {
+			r.Log.Debugf("VMC %s does not exist, nothing to do", displayName)
+			return nil
+		}
+		return err
+	}
+
+	// if the VMC has a cluster id in the status, delete the VMC
+	if len(vmc.Status.RancherRegistration.ClusterID) > 0 {
+		r.Log.Infof("Deleting VMC %s because it is no longer in Rancher", vmc.Name)
+		if err := r.Delete(context.TODO(), vmc); err != nil {
+			r.Log.Errorf("Unable to delete VMC %s: %v", vmc.Name, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// newVMC returns a minimally populated VMC object
+func newVMC(name string) *clustersv1alpha1.VerrazzanoManagedCluster {
+	return &clustersv1alpha1.VerrazzanoManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: vzconst.VerrazzanoMultiClusterNamespace,
+			Labels: map[string]string{
+				createdByLabel:                    createdByVerrazzano,
+				vzconst.VerrazzanoManagedLabelKey: "true",
+			},
+		},
+	}
+}

--- a/cluster-operator/controllers/rancher/rancher_cluster_controller_test.go
+++ b/cluster-operator/controllers/rancher/rancher_cluster_controller_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rancher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+)
+
+const (
+	clusterName = "c-m-hcknpvs7"
+	displayName = "unit-test-cluster"
+)
+
+// GIVEN a Rancher cluster resource is created
+// WHEN  the reconciler runs
+// THEN  a VMC is created and the cluster id is set in the status
+func TestReconcileCreateVMC(t *testing.T) {
+	asserts := assert.New(t)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(newCattleCluster(clusterName, displayName)).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	// expect that a VMC was created and that the cluster id is set in the status
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: displayName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc)
+	asserts.NoError(err)
+	asserts.Equal(clusterName, vmc.Status.RancherRegistration.ClusterID)
+}
+
+// GIVEN a Rancher cluster resource is created and a VMC already exists for the cluster
+// WHEN  the reconciler runs
+// THEN  the VMC is updated and the cluster id is set in the status
+func TestReconcileCreateVMCAlreadyExists(t *testing.T) {
+	asserts := assert.New(t)
+
+	vmc := newVMC(displayName)
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(newCattleCluster(clusterName, displayName), vmc).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	// expect the VMC still exists and that the cluster id is set in the status
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: displayName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc)
+	asserts.NoError(err)
+	asserts.Equal(clusterName, vmc.Status.RancherRegistration.ClusterID)
+}
+
+// GIVEN a Rancher cluster resource is being deleted
+// WHEN  the reconciler runs
+// THEN  the corresponding VMC is deleted
+func TestReconcileDeleteVMC(t *testing.T) {
+	asserts := assert.New(t)
+
+	cluster := newCattleCluster(clusterName, displayName)
+	now := metav1.Now()
+	cluster.SetDeletionTimestamp(&now)
+	vmc := newVMC(displayName)
+	vmc.Status.RancherRegistration.ClusterID = clusterName
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cluster, vmc).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	// expect that the VMC was deleted
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: displayName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc)
+	asserts.Error(err)
+	asserts.True(errors.IsNotFound(err))
+}
+
+// GIVEN a Rancher cluster resource is being deleted and the VMC does not exist
+// WHEN  the reconciler runs
+// THEN  no error is returned
+func TestReconcileDeleteVMCNotFound(t *testing.T) {
+	asserts := assert.New(t)
+
+	cluster := newCattleCluster(clusterName, displayName)
+	now := metav1.Now()
+	cluster.SetDeletionTimestamp(&now)
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cluster).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+}
+
+// GIVEN a Rancher cluster resource has been deleted
+// WHEN  the reconciler runs
+// THEN  no error is returned
+func TestReconcileClusterGone(t *testing.T) {
+	asserts := assert.New(t)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+}
+
+// GIVEN the local Rancher cluster resource is being reconciled
+// WHEN  the reconciler runs
+// THEN  no VMC is created
+func TestReconcileLocalCluster(t *testing.T) {
+	asserts := assert.New(t)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(newCattleCluster(clusterName, localClusterName)).Build()
+	reconciler := newRancherClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	// expect no VMC created for the local cluster
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: localClusterName, Namespace: vzconst.VerrazzanoMultiClusterNamespace}, vmc)
+	asserts.True(errors.IsNotFound(err))
+}
+
+// GIVEN a GVK exists for cattle clusters resources
+// WHEN  we fetch the client object for the cattle clusters GVK
+// THEN  the returned client object is not nil
+func TestCattleClusterClientObject(t *testing.T) {
+	asserts := assert.New(t)
+	obj := CattleClusterClientObject()
+	asserts.NotNil(obj)
+}
+
+func TestParseClusterErrorCases(t *testing.T) {
+	// GIVEN a cluster resource with no spec displayName field set
+	// WHEN  we attempt to get the displayName from the cluster object
+	// THEN  the expected error is returned
+	asserts := assert.New(t)
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	reconciler := newRancherClusterReconciler(nil)
+	_, err := reconciler.getClusterDisplayName(cluster)
+	asserts.ErrorContains(err, "Could not find spec displayName field")
+
+	// GIVEN a cluster resource with a bad type for the spec field
+	// WHEN  we attempt to get the displayName from the cluster object
+	// THEN  the expected error is returned
+	unstructured.SetNestedField(cluster.Object, true, "spec")
+	_, err = reconciler.getClusterDisplayName(cluster)
+	asserts.ErrorContains(err, ".spec.displayName accessor error")
+}
+
+func newRequest(name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: name,
+		},
+	}
+}
+
+func newRancherClusterReconciler(c client.Client) RancherClusterReconciler {
+	return RancherClusterReconciler{
+		Client: c,
+		Scheme: newScheme(),
+		Log:    zap.S(),
+	}
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+	clustersv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+func newCattleCluster(name, displayName string) *unstructured.Unstructured {
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	cluster.SetName(name)
+	unstructured.SetNestedField(cluster.Object, displayName, "spec", "displayName")
+	return cluster
+}

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -70,7 +70,7 @@ func main() {
 	}
 
 	// if the user has specified a label selector to filter Rancher clusters, create a custom cache that applies the selector
-	// TODO populate this from the selector provided by the user
+	// Note: populate this from the selector provided by the user
 	var clusterSelector *metav1.LabelSelector
 	if clusterSelector != nil {
 		options.NewCache = func(conf *rest.Config, opts cache.Options) (cache.Cache, error) {

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -9,14 +9,20 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	clustersverrazzanoiov1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/v1alpha1"
+	"github.com/verrazzano/verrazzano/cluster-operator/controllers/rancher"
+	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -41,24 +47,59 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
+	opts := kzap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	kzap.UseFlagOptions(&opts)
+	vzlog.InitLogs(opts)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	log := zap.S()
+
+	ctrl.SetLogger(kzap.New(kzap.UseFlagOptions(&opts)))
+
+	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "42d5ea87.verrazzano.io",
-	})
+	}
+
+	// if the user has specified a label selector to filter Rancher clusters, create a custom cache that applies the selector
+	// TODO populate this from the selector provided by the user
+	var clusterSelector *metav1.LabelSelector
+	if clusterSelector != nil {
+		options.NewCache = func(conf *rest.Config, opts cache.Options) (cache.Cache, error) {
+			if opts.SelectorsByObject == nil {
+				opts.SelectorsByObject = make(cache.SelectorsByObject)
+			}
+			selector, err := metav1.LabelSelectorAsSelector(clusterSelector)
+			if err != nil {
+				return nil, err
+			}
+			opts.SelectorsByObject[rancher.CattleClusterClientObject()] = cache.ObjectSelector{
+				Label: selector,
+			}
+			return cache.New(conf, opts)
+		}
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err = (&rancher.RancherClusterReconciler{
+		Client: mgr.GetClient(),
+		Log:    log,
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		log.Errorf("Failed to create IngressTrait controller: %v", err)
 		os.Exit(1)
 	}
 

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -211,7 +211,7 @@ create-test-deploy:
 	if [ -n "${VZ_DEV_IMAGE}" ]; then \
 		IMAGE=$$(echo $${VZ_DEV_IMAGE} | cut -f 1 -d :) ; \
 		IMAGE_TAG=$$(echo $${VZ_DEV_IMAGE} | cut -f 2 -d :) ; \
-		DOCKER_IMAGE_FULLNAME=$${IMAGE} DOCKER_IMAGE_TAG=$${IMAGE_TAG} VERRAZZANO_APPLICATION_OPERATOR_IMAGE=$${VZ_APP_OP_IMAGE} $(MAKE) generate-operator-yaml ; \
+		DOCKER_IMAGE_FULLNAME=$${IMAGE} DOCKER_IMAGE_TAG=$${IMAGE_TAG} VERRAZZANO_APPLICATION_OPERATOR_IMAGE=$${VZ_APP_OP_IMAGE} VERRAZZANO_CLUSTER_OPERATOR_IMAGE=$${VZ_CLUSTER_OP_IMAGE} $(MAKE) generate-operator-yaml ; \
 	else \
 		echo "VZ_DEV_IMAGE not defined, please set it to a valid image name/tag"; \
 	fi

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -56,6 +56,9 @@ const ImageRepoOverrideEnvVar = "IMAGE_REPO"
 // VerrazzanoAppOperatorImageEnvVar is the environment variable used to override the Verrazzano Application Operator image
 const VerrazzanoAppOperatorImageEnvVar = "APP_OPERATOR_IMAGE"
 
+// VerrazzanoClusterOperatorImageEnvVar is the environment variable used to override the Verrazzano Cluster Operator image
+const VerrazzanoClusterOperatorImageEnvVar = "CLUSTER_OPERATOR_IMAGE"
+
 // The Kubernetes default namespace
 const DefaultNamespace = "default"
 

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
@@ -5,13 +5,29 @@ package clusteroperator
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// AppendOverrides appends any additional overrides needed by the Cluster Operator component
+func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
+	envImageOverride := os.Getenv(constants.VerrazzanoClusterOperatorImageEnvVar)
+	if len(envImageOverride) > 0 {
+		kvs = append(kvs, bom.KeyValue{
+			Key:   "image",
+			Value: envImageOverride,
+		})
+	}
+
+	return kvs, nil
+}
 
 // isClusterOperatorReady checks if the cluster operator deployment is ready
 func (c clusterOperatorComponent) isClusterOperatorReady(ctx spi.ComponentContext) bool {

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_component.go
@@ -42,6 +42,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			Dependencies:              []string{networkpolicies.ComponentName},
+			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_test.go
@@ -5,11 +5,13 @@ package clusteroperator
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -75,4 +77,19 @@ func TestGetOverrides(t *testing.T) {
 			asserts.Equal(t, tt.expB1Overrides, NewComponent().GetOverrides(spi.NewFakeContext(nil, tt.verrazzanoA1, tt.verrazzanoB1, false, profilesRelativePath).EffectiveCRV1Beta1()))
 		})
 	}
+}
+
+// GIVEN a call to AppendOverrides
+// WHEN  the env var for the cluster operator image is set
+// THEN  the returned key/value pairs contains the image override
+func TestAppendOverrides(t *testing.T) {
+	customImage := "myreg.io/myrepo/v8o/verrazzano-cluster-operator-dev:local-20210707002801-b7449154"
+	os.Setenv(constants.VerrazzanoClusterOperatorImageEnvVar, customImage)
+	defer func() { os.Unsetenv(constants.VerrazzanoClusterOperatorImageEnvVar) }()
+
+	kvs, err := AppendOverrides(nil, "", "", "", nil)
+	asserts.NoError(t, err)
+	asserts.Len(t, kvs, 1)
+	asserts.Equal(t, "image", kvs[0].Key)
+	asserts.Equal(t, customImage, kvs[0].Value)
 }

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -1,0 +1,28 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-cluster-operator
+rules:
+  - apiGroups:
+      - management.cattle.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - clusters.verrazzano.io
+    resources:
+      - verrazzanomanagedclusters
+      - verrazzanomanagedclusters/status
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - patch
+      - watch

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
     resources:
       - clusters
     verbs:
+      - update
       - get
       - list
       - watch

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrolebinding.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: verrazzano-cluster-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Values.namespace }}

--- a/platform-operator/internal/operatorinit/run_operator.go
+++ b/platform-operator/internal/operatorinit/run_operator.go
@@ -61,11 +61,11 @@ func StartPlatformOperator(config config.OperatorConfig, log *zap.SugaredLogger,
 	}
 
 	// Start the goroutine to sync Rancher clusters and VerrazzanoManagedCluster objects
-	rancherClusterSyncer := &clusters.RancherClusterSyncer{
-		Client: mgr.GetClient(),
-		Log:    log,
-	}
-	go rancherClusterSyncer.StartSyncing()
+	//rancherClusterSyncer := &clusters.RancherClusterSyncer{
+	//	Client: mgr.GetClient(),
+	//	Log:    log,
+	//}
+	//go rancherClusterSyncer.StartSyncing()
 
 	// Setup secrets reconciler
 	if err = (&secrets.VerrazzanoSecretsReconciler{

--- a/platform-operator/internal/operatorinit/run_operator.go
+++ b/platform-operator/internal/operatorinit/run_operator.go
@@ -60,13 +60,6 @@ func StartPlatformOperator(config config.OperatorConfig, log *zap.SugaredLogger,
 		return errors.Wrap(err, "Failed to setup controller VerrazzanoManagedCluster")
 	}
 
-	// Start the goroutine to sync Rancher clusters and VerrazzanoManagedCluster objects
-	//rancherClusterSyncer := &clusters.RancherClusterSyncer{
-	//	Client: mgr.GetClient(),
-	//	Log:    log,
-	//}
-	//go rancherClusterSyncer.StartSyncing()
-
 	// Setup secrets reconciler
 	if err = (&secrets.VerrazzanoSecretsReconciler{
 		Client:        mgr.GetClient(),


### PR DESCRIPTION
This PR adds the implementation of the Rancher cluster controller to the Verrazzano Cluster Operator. The controller watches Rancher cluster resources and creates and deletes VMCs accordingly.

This PR also fixes problems related to overriding the cluster operator image when installing from a private registry and also adds clusterrole and clusterrolebinding to the VCO helm chart.

Notes:

1. The controller is set up to take a label selector that will be used to filter Rancher clusters. It's not currently being set and will sync all clusters. A separate PR will wire up the label selector that the user provides in the VZ CR.
2. The code that was doing this in the VPO has been disabled but not removed. It will be removed in a PR that @desagar is working on.