### PR TITLE
Alternate approach to generated overrides for psrctl 

### DIFF
--- a/tools/psr/Makefile
+++ b/tools/psr/Makefile
@@ -53,11 +53,15 @@ go-build:
 		-o out/linux_amd64/psr-backend \
 		${BACKEND_DIR}/main.go
 
+.PHONY: generate-overrides
+generate-overrides:
+	mkdir -p out
+	@echo "imageName: ${DOCKER_IMAGE_FULL_PATH}" > out/defaults.yaml
 #
 # Go build cli related tasks
 #
 .PHONY: go-build-cli
-go-build-cli:
+go-build-cli: generate-overrides
 	GOOS=darwin GOARCH=amd64 $(GO) build \
 		-ldflags "${CLI_GO_LDFLAGS}" \
 		-o out/darwin_amd64/psrctl \
@@ -107,14 +111,14 @@ run-example-k8s: kind-load-image
 # run the CLI
 #
 .PHONY: run-cli
-run-cli:
+run-cli: generate-overrides
 	$(GO) run ${GOPATH}/src/${CLI_DIR}/main.go
 
 #
 # install the CLI
 #
 .PHONY: install-cli
-install-cli:
+install-cli: generate-overrides
 	$(GO) install -ldflags "${CLI_GO_LDFLAGS}" ./...
 
 .PHONY: unit-test

--- a/tools/psr/Makefile
+++ b/tools/psr/Makefile
@@ -53,10 +53,15 @@ go-build:
 		-o out/linux_amd64/psr-backend \
 		${BACKEND_DIR}/main.go
 
+#
+# Generate Helm overrides containing the chart defaults, including the generated worker image
+# - the out/overrides dir will embedded in psrctl and applied when run
+#
 .PHONY: generate-overrides
 generate-overrides:
-	mkdir -p out
-	@echo "imageName: ${DOCKER_IMAGE_FULL_PATH}" > out/defaults.yaml
+	mkdir -p out/overrides
+	@echo "imageName: ${DOCKER_IMAGE_FULL_PATH}" > out/overrides/defaults.yaml
+
 #
 # Go build cli related tasks
 #

--- a/tools/psr/embed.go
+++ b/tools/psr/embed.go
@@ -13,7 +13,7 @@ import (
 //go:embed manifests
 var manifests embed.FS
 
-//go:embed out/*.yaml
+//go:embed out/overrides
 var overrides embed.FS
 
 // GetEmbeddedManifests returns the embedded manifests
@@ -21,7 +21,7 @@ func GetEmbeddedManifests() embed.FS {
 	return manifests
 }
 
-// GetGeneratedChartDefaults returns the set of generated defaults during the build
-func GetGeneratedChartDefaults() embed.FS {
+// GetGeneratedChartOverrides returns the set of generated defaults during the build
+func GetGeneratedChartOverrides() embed.FS {
 	return overrides
 }

--- a/tools/psr/embed.go
+++ b/tools/psr/embed.go
@@ -13,7 +13,15 @@ import (
 //go:embed manifests
 var manifests embed.FS
 
+//go:embed out/*.yaml
+var overrides embed.FS
+
 // GetEmbeddedManifests returns the embedded manifests
 func GetEmbeddedManifests() embed.FS {
 	return manifests
+}
+
+// GetGeneratedChartDefaults returns the set of generated defaults during the build
+func GetGeneratedChartDefaults() embed.FS {
+	return overrides
 }

--- a/tools/psr/psrctl/cmd/start/start.go
+++ b/tools/psr/psrctl/cmd/start/start.go
@@ -75,7 +75,7 @@ func RunCmdStart(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 
 func buildHelmOverrides() []helmcli.HelmOverrides {
 	return []helmcli.HelmOverrides{
-		{SetOverrides: fmt.Sprintf("%s=%s", constants.ImageNameKey, workerImage)},
+		//{SetOverrides: fmt.Sprintf("%s=%s", constants.ImageNameKey, workerImage)},
 		{SetOverrides: fmt.Sprintf("%s=%s", constants.ImagePullSecKey, imagePullSecret)},
 	}
 }

--- a/tools/psr/psrctl/pkg/embedded/extract.go
+++ b/tools/psr/psrctl/pkg/embedded/extract.go
@@ -87,7 +87,7 @@ func copyManifestsDir(rootDir string) error {
 	if err != nil {
 		return err
 	}
-	if err := writeDirDeep(filepath.Join(rootDir, "overrides"), "out", psr.GetGeneratedChartDefaults()); err != nil {
+	if err := writeDirDeep(rootDir, "out", psr.GetGeneratedChartOverrides()); err != nil {
 		return err
 	}
 	return nil

--- a/tools/psr/psrctl/pkg/scenario/start.go
+++ b/tools/psr/psrctl/pkg/scenario/start.go
@@ -69,7 +69,7 @@ func (m Manager) StartScenario(scman *ScenarioManifest) (string, error) {
 
 		if m.Verbose {
 			fmt.Printf("Installing use case %s as Helm release %s/%s\n", uc.UsecasePath, m.Namespace, relname)
-			fmt.Printf("Helm overrides: %v", helmOverrides)
+			fmt.Printf("Helm overrides: %v\n", helmOverrides)
 		}
 		_, stderr, err := helmcli.Upgrade(m.Log, relname, m.Namespace, m.Manifest.WorkerChartAbsDir, true, m.DryRun, helmOverrides)
 		if err != nil {


### PR DESCRIPTION
POC of alternate approach to the generated image name default, using embed
- during the build, dump the image path to a generated YAML file in `out/overrides`
- use the `embed` package store the `out/overrides` dir in the CLI binary (like the `manifests` dir)
- extract it to the PSR temp dir at runtime to an overrides dir
- append all YAMLs  in the overrides dir as helm file overrides
