### PR TITLE
VZ-7731 Set warning handler for VZ CLI client

### DIFF
--- a/tools/vz/cmd/helpers/cmd_context.go
+++ b/tools/vz/cmd/helpers/cmd_context.go
@@ -44,7 +44,8 @@ func (rc *RootCmdContext) GetClient(cmd *cobra.Command) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	// Set warning handler to output warnings to the error stream
+	config.WarningHandler = getWarningHandler(rc.GetErrorStream())
 	return client.New(config, client.Options{Scheme: helpers.NewScheme()})
 }
 

--- a/tools/vz/cmd/helpers/warning.go
+++ b/tools/vz/cmd/helpers/warning.go
@@ -22,7 +22,6 @@ func getWarningHandler(w io.Writer) rest.WarningHandler {
 
 // allowsColorOutput returns true if the specified writer is a terminal and
 // the process environment indicates color output is supported and desired.
-// Copied from k8s.io/kubectl/pkg/util/term.AllowsColorOutput.
 func allowsColorOutput(w io.Writer) bool {
 	if !isTerminal(w) {
 		return false

--- a/tools/vz/cmd/helpers/warning.go
+++ b/tools/vz/cmd/helpers/warning.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helpers
+
+import (
+	"github.com/mattn/go-isatty"
+	"io"
+	"k8s.io/client-go/rest"
+	"os"
+	"runtime"
+)
+
+// getWarningHandler returns an implementation of WarningHandler that outputs code 299 warnings to the specified writer.
+func getWarningHandler(w io.Writer) rest.WarningHandler {
+	// deduplicate and attempt color warnings when running from a terminal
+	return rest.NewWarningWriter(w, rest.WarningWriterOptions{
+		Deduplicate: true,
+		Color:       allowsColorOutput(w),
+	})
+}
+
+// allowsColorOutput returns true if the specified writer is a terminal and
+// the process environment indicates color output is supported and desired.
+// Copied from k8s.io/kubectl/pkg/util/term.AllowsColorOutput.
+func allowsColorOutput(w io.Writer) bool {
+	if !isTerminal(w) {
+		return false
+	}
+
+	// https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	// https://no-color.org/
+	if _, nocolor := os.LookupEnv("NO_COLOR"); nocolor {
+		return false
+	}
+
+	// On Windows WT_SESSION is set by the modern terminal component.
+	// Older terminals have poor support for UTF-8, VT escape codes, etc.
+	if runtime.GOOS == "windows" && os.Getenv("WT_SESSION") == "" {
+		return false
+	}
+
+	return true
+}
+
+func isTerminal(w io.Writer) bool {
+	if w, ok := w.(*os.File); ok && isatty.IsTerminal(w.Fd()) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
A warning handler has been added to VZ CLI client to output VPO webhook warning messages in the VZ CLI output.
