### PR TITLE
VZ-7524: temporarily disable TestRepairMySQLPodsWaitingReadinessGates

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -1945,6 +1945,7 @@ func TestDumpDatabaseWithExecErrors(t *testing.T) {
 // WHEN they are not all ready after a given time period
 // THEN recycle the mysql-operator
 func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
+	t.Skip("Temporarily skipping test due to intermittent failures")
 	mySQLOperatorPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mysqloperator.ComponentName,


### PR DESCRIPTION
The unit test TestRepairMySQLPodsWaitingReadinessGates is having occasional failures.  Temporarily disabling until the problem is resolved.