### PR TITLE
WIP: VZ-7524: Resolve issue of TestRepairMySQLPodsWaitingReadinessGates failing

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -156,7 +156,7 @@ var (
 )
 
 // isMySQLReady checks to see if the MySQL component is in ready state
-func (c mysqlComponent) isMySQLReady(ctx spi.ComponentContext) bool {
+func (c *mysqlComponent) isMySQLReady(ctx spi.ComponentContext) bool {
 	deployment := []types.NamespacedName{
 		{
 			Name:      fmt.Sprintf("%s-router", ComponentName),
@@ -204,7 +204,7 @@ func (c mysqlComponent) isMySQLReady(ctx spi.ComponentContext) bool {
 
 // repairMySQLPodsWaitingReadinessGates - temporary workaround to repair issue were a MySQL pod
 // can be stuck waiting for its readiness gates to be met.
-func (c mysqlComponent) repairMySQLPodsWaitingReadinessGates(ctx spi.ComponentContext) error {
+func (c *mysqlComponent) repairMySQLPodsWaitingReadinessGates(ctx spi.ComponentContext) error {
 	podsWaiting, err := c.mySQLPodsWaitingForReadinessGates(ctx)
 	if err != nil {
 		return err
@@ -223,16 +223,16 @@ func (c mysqlComponent) repairMySQLPodsWaitingReadinessGates(ctx spi.ComponentCo
 		}
 
 		// Clear the timer
-		*c.LastTimeReadinessGateRepairStarted = time.Time{}
+		c.LastTimeReadinessGateRepairStarted = time.Time{}
 	}
 	return nil
 }
 
 // mySQLPodsWaitingForReadinessGates - detect if there are MySQL pods stuck waiting for
 // their readiness gates to be true.
-func (c mysqlComponent) mySQLPodsWaitingForReadinessGates(ctx spi.ComponentContext) (bool, error) {
+func (c *mysqlComponent) mySQLPodsWaitingForReadinessGates(ctx spi.ComponentContext) (bool, error) {
 	if c.LastTimeReadinessGateRepairStarted.IsZero() {
-		*c.LastTimeReadinessGateRepairStarted = time.Now()
+		c.LastTimeReadinessGateRepairStarted = time.Now()
 		return false, nil
 	}
 

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -1179,7 +1179,7 @@ func TestIsMySQLReady(t *testing.T) {
 			},
 		},
 	}
-	mysql := NewComponent().(mysqlComponent)
+	mysql := NewComponent().(*mysqlComponent)
 	assert.True(t, mysql.isMySQLReady(spi.NewFakeContext(fakeClient, vz, nil, false)))
 }
 
@@ -1288,7 +1288,7 @@ func TestIsMySQLNotReady(t *testing.T) {
 			},
 		},
 	}
-	mysql := NewComponent().(mysqlComponent)
+	mysql := NewComponent().(*mysqlComponent)
 	assert.False(t, mysql.isMySQLReady(spi.NewFakeContext(fakeClient, vz, nil, false)))
 }
 
@@ -1399,7 +1399,7 @@ func TestIsMySQLReadyInnoDBClusterNotOnline(t *testing.T) {
 			},
 		},
 	}
-	mysql := NewComponent().(mysqlComponent)
+	mysql := NewComponent().(*mysqlComponent)
 	assert.False(t, mysql.isMySQLReady(spi.NewFakeContext(fakeClient, vz, nil, false)))
 }
 
@@ -1975,7 +1975,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
-	mysqlComp := NewComponent().(mysqlComponent)
+	mysqlComp := NewComponent().(*mysqlComponent)
 	fakeCtx := spi.NewFakeContext(cli, nil, nil, false)
 
 	// First time calling, expect timer to get initialized
@@ -1994,7 +1994,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 
 	// Third time calling, set the timer to exceed the expiration time which will force a check of the readiness gates.
 	// The readiness gates will be set to true going into the call, so the mysql-operator should not get recycled.
-	*mysqlComp.LastTimeReadinessGateRepairStarted = mysqlComp.LastTimeReadinessGateRepairStarted.Truncate(2 * time.Hour)
+	mysqlComp.LastTimeReadinessGateRepairStarted = mysqlComp.LastTimeReadinessGateRepairStarted.Truncate(2 * time.Hour)
 	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
 	assert.NoError(t, err)
 
@@ -2006,7 +2006,6 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	mySQLPod.Status.Conditions = []v1.PodCondition{{Type: "gate1", Status: v1.ConditionTrue}, {Type: "gate2", Status: v1.ConditionFalse}}
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	*mysqlComp.LastTimeReadinessGateRepairStarted = mysqlComp.LastTimeReadinessGateRepairStarted.Truncate(2 * time.Hour)
 	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
 	assert.NoError(t, err)
 	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -1945,7 +1945,6 @@ func TestDumpDatabaseWithExecErrors(t *testing.T) {
 // WHEN they are not all ready after a given time period
 // THEN recycle the mysql-operator
 func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
-	t.Skip("Temporarily skipping test due to intermittent failures")
 	mySQLOperatorPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mysqloperator.ComponentName,


### PR DESCRIPTION
Change context for mysql component to be writeable and contain the timestamp for determining if mysql is stuck waiting for readiness gates.  The timestamp use to be in a local variable.
