### PR TITLE
VZ 7769: Ignore evicted pods during E2E tests

### DIFF
--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -421,7 +421,7 @@ func isReadyAndRunning(pod v1.Pod) bool {
 	if pod.Status.Phase == v1.PodSucceeded {
 		return true
 	}
-	if pod.Status.Reason == "Evicted" && len(pod.Status.ContainerStatuses) == 0 {
+	if pod.Status.Reason == "Evicted" {
 		Log(Info, fmt.Sprintf("Pod %v was Evicted", pod.Name))
 		return true // ignore this evicted pod
 	}


### PR DESCRIPTION
Updated the evicted pods check to remove the pod status conditions. This had been failing the verrazzano-ocne pipelines fairly consistently with an evicted rancher pod (old rancher pod got evicted due to resource contention).