### PR TITLE
Add PreConditionMet method to restart worker

### DIFF
--- a/tools/psr/backend/workers/opensearch/restart/restart.go
+++ b/tools/psr/backend/workers/opensearch/restart/restart.go
@@ -143,6 +143,10 @@ func (w worker) DoWork(_ config.CommonConfig, log vzlog.VerrazzanoLogger) error 
 	return nil
 }
 
+func (w worker) PreconditionsMet() (bool, error) {
+	return true, nil
+}
+
 func (w worker) podsReady(tier string) error {
 	var label string
 	var err error


### PR DESCRIPTION
This change adds the PreConditionMet method to the restart worker to be in compliance with worker spi