### PR TITLE
 VZ-7797: Custom fail method for test framework

### DIFF
--- a/tests/e2e/backup/mysql/mysql_backup_suite_test.go
+++ b/tests/e2e/backup/mysql/mysql_backup_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMySQLOperatorBackup(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "MySQL Operator Backup Suite")
+func TestMySQLOperatorBackup(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "MySQL Operator Backup Suite")
 }

--- a/tests/e2e/backup/opensearch/opensearch_backup_suite_test.go
+++ b/tests/e2e/backup/opensearch/opensearch_backup_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestOpensearchBackup(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Opensearch Backup Suite")
+func TestOpensearchBackup(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Opensearch Backup Suite")
 }

--- a/tests/e2e/backup/rancher/rancher_backup_suite_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestRancherBackup(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Rancher Backup Suite")
+func TestRancherBackup(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Rancher Backup Suite")
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -13,5 +13,5 @@ func RunE2ETests(t *testing.T) {
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
-	ginkgo.RunSpecs(t, "Verrazzano e2e tests")
+	ginkgo.RunSpecs(test, "Verrazzano e2e tests")
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -10,8 +10,6 @@ import (
 )
 
 func RunE2ETests(t *testing.T) {
-
 	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(test, "Verrazzano e2e tests")
+	ginkgo.RunSpecs(t, "Verrazzano e2e tests")
 }

--- a/tests/e2e/examples/bobsbooks/bobs_books_suite_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestBobsBooksExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Bobs Books Example Test Suite")
+func TestBobsBooksExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Bobs Books Example Test Suite")
 }

--- a/tests/e2e/examples/helidon/helidon_example_suite_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -28,7 +27,7 @@ func init() {
 
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Hello Helidon Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Hello Helidon Suite")
 }

--- a/tests/e2e/examples/helidonconfig/helidon_config_suite_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Helidon Config Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Helidon Config Suite")
 }

--- a/tests/e2e/examples/helidonmetrics/helidon_metrics_suite_test.go
+++ b/tests/e2e/examples/helidonmetrics/helidon_metrics_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Helidon Metrics Config Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Helidon Metrics Config Suite")
 }

--- a/tests/e2e/examples/socks/sock_shop_example_suite_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_suite_test.go
@@ -6,7 +6,7 @@ package socks
 import (
 	"flag"
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
@@ -20,7 +20,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
 }
 
-func TestSockShopApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Sock Shop Suite")
+func TestSockShopApplication(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Sock Shop Suite")
 }

--- a/tests/e2e/examples/springboot/springboot_suite_test.go
+++ b/tests/e2e/examples/springboot/springboot_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestSpringBootExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Spring Boot Suite")
+func TestSpringBootExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Spring Boot Suite")
 }

--- a/tests/e2e/examples/todo/todo_list_suite_test.go
+++ b/tests/e2e/examples/todo/todo_list_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -24,7 +23,7 @@ func init() {
 }
 
 // TestToDoListExample tests the ToDoList example
-func TestToDoListExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "ToDo List Example Test Suite")
+func TestToDoListExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "ToDo List Example Test Suite")
 }

--- a/tests/e2e/grafana-db/grafana_suite_test.go
+++ b/tests/e2e/grafana-db/grafana_suite_test.go
@@ -5,11 +5,10 @@ package grafanadb
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"testing"
 )
 
-func TestGrafanaDashboardPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "DB Backed Grafana Dashboard Suite")
+func TestGrafanaDashboardPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "DB Backed Grafana Dashboard Suite")
 }

--- a/tests/e2e/ha/helidon/helidon_example_suite_test.go
+++ b/tests/e2e/ha/helidon/helidon_example_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "ha-hello-helidon", "namespace is the app namespace")
 }
 
-func TestHAHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "HA Hello Helidon Suite")
+func TestHAHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "HA Hello Helidon Suite")
 }

--- a/tests/e2e/ha/inplaceupgrade/in_place_upgrade_suite_test.go
+++ b/tests/e2e/ha/inplaceupgrade/in_place_upgrade_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestInPlaceUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "OKE in-place cluster upgrade")
+func TestInPlaceUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "OKE in-place cluster upgrade")
 }

--- a/tests/e2e/ha/monitor/monitor_suite_test.go
+++ b/tests/e2e/ha/monitor/monitor_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
 
@@ -19,7 +18,7 @@ func init() {
 	flag.BoolVar(&runContinuous, "runContinuous", true, "run monitors continuously if set")
 }
 
-func TestHAMonitor(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "HA Monitoring Suite")
+func TestHAMonitor(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "HA Monitoring Suite")
 }

--- a/tests/e2e/ingress/console/console_ingress_suite_test.go
+++ b/tests/e2e/ingress/console/console_ingress_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var istioInjection string
@@ -18,7 +17,7 @@ func init() {
 }
 
 // TestConsoleIngress tests an ingress trait setup for console access.
-func TestConsoleIngress(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Console Ingress Test Suite")
+func TestConsoleIngress(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Console Ingress Test Suite")
 }

--- a/tests/e2e/istio/authz/authpolicy_suite_test.go
+++ b/tests/e2e/istio/authz/authpolicy_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var istioInjection string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestAuthPolicyExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Istio AuthorizationPolicy Suite")
+func TestAuthPolicyExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Istio AuthorizationPolicy Suite")
 }

--- a/tests/e2e/jaeger/helidon/jaeger_helidon_suite_test.go
+++ b/tests/e2e/jaeger/helidon/jaeger_helidon_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
 }
 
-func TestJaegerHelidonTracing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger Tracing Suite")
+func TestJaegerHelidonTracing(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger Tracing Suite")
 }

--- a/tests/e2e/jaeger/hotrod/jaeger_hotrod_suite_test.go
+++ b/tests/e2e/jaeger/hotrod/jaeger_hotrod_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
 }
 
-func TestJaegerHotrodTracing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger Hotrod Application Tracing Suite")
+func TestJaegerHotrodTracing(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger Hotrod Application Tracing Suite")
 }

--- a/tests/e2e/jaeger/system/jaeger_system_suite_test.go
+++ b/tests/e2e/jaeger/system/jaeger_system_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerSystemTracing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger System Tracing Suite")
+func TestJaegerSystemTracing(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger System Tracing Suite")
 }

--- a/tests/e2e/jobmetrics/jobmetrics_suite_test.go
+++ b/tests/e2e/jobmetrics/jobmetrics_suite_test.go
@@ -5,11 +5,10 @@ package jobmetrics
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"testing"
 )
 
-func TestJobMetics(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Job Metrics Suite")
+func TestJobMetics(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Job Metrics Suite")
 }

--- a/tests/e2e/jwt/helidon-svc/helidon_example_suite_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -25,7 +24,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Hello Helidon Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Hello Helidon Suite")
 }

--- a/tests/e2e/jwt/helidon/helidon_example_suite_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -25,7 +24,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Hello Helidon Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Hello Helidon Suite")
 }

--- a/tests/e2e/logging/helidon/helidon_logging_suite_test.go
+++ b/tests/e2e/logging/helidon/helidon_logging_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -19,7 +18,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Helidon Logging Suite")
+func TestHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Helidon Logging Suite")
 }

--- a/tests/e2e/logging/opensearch/opensearch_suite_test.go
+++ b/tests/e2e/logging/opensearch/opensearch_suite_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 // TestOpenSearchLogging tests the logging to Verrazzano indices in OpenSearch.
-func TestOpenSearchLogging(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "OpenSearch Logging Suite")
+func TestOpenSearchLogging(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "OpenSearch Logging Suite")
 }

--- a/tests/e2e/logging/system/system_logging_suite_test.go
+++ b/tests/e2e/logging/system/system_logging_suite_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 // TestSystemLogging tests the logging from Verrazzano system components.
-func TestSystemLogging(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "System Logging Suite")
+func TestSystemLogging(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "System Logging Suite")
 }

--- a/tests/e2e/logging/weblogic/weblogic_logging_suite_test.go
+++ b/tests/e2e/logging/weblogic/weblogic_logging_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -19,7 +18,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestWebLogicLogging(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "WebLogic Logging Suite")
+func TestWebLogicLogging(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "WebLogic Logging Suite")
 }

--- a/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/coherenceworkload/coherence_loggingtrait_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -20,7 +19,7 @@ func init() {
 }
 
 // TestCoherenceLoggingTrait tests an ingress trait setup for console access.
-func TestCoherenceLoggingTrait(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Coherence Logging Trait Test Suite")
+func TestCoherenceLoggingTrait(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Coherence Logging Trait Test Suite")
 }

--- a/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/helidonworkload/helidon_loggingtrait_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -20,7 +19,7 @@ func init() {
 }
 
 // TestHelidonLoggingTrait tests an ingress trait setup for console access.
-func TestHelidonLoggingTrait(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Helidon Logging Trait Test Suite")
+func TestHelidonLoggingTrait(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Helidon Logging Trait Test Suite")
 }

--- a/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_suite_test.go
+++ b/tests/e2e/loggingtrait/weblogicworkload/weblogic_loggingtrait_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -20,7 +19,7 @@ func init() {
 }
 
 // TestWebLogicLoggingTrait tests an ingress trait setup for console access.
-func TestWebLogicLoggingTrait(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "WebLogic Logging Trait Test Suite")
+func TestWebLogicLoggingTrait(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "WebLogic Logging Trait Test Suite")
 }

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -25,7 +24,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestDeploymentMetrics(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Deployment Metrics Suite")
+func TestDeploymentMetrics(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Deployment Metrics Suite")
 }

--- a/tests/e2e/metrics/syscomponents/metrics_suite_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var istioInjection string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestSystemComponentMetrics(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "System Component Metrics Suite")
+func TestSystemComponentMetrics(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "System Component Metrics Suite")
 }

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMultiClusterHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster Hello Helidon Suite")
+func TestMultiClusterHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster Hello Helidon Suite")
 }

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mchelidon

--- a/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMultiClusterHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster Hello Helidon NS Ops Suite")
+func TestMultiClusterHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster Hello Helidon NS Ops Suite")
 }

--- a/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/helidon-ns-ops/helidon_example_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mcnshelidon

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -21,7 +20,7 @@ func init() {
 	flag.BoolVar(&skipVerify, "skipVerify", false, "skipVerify skips the post deployment app validations")
 }
 
-func TestMultiClusterHelidonExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster Hello Helidon Suite")
+func TestMultiClusterHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster Hello Helidon Suite")
 }

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMultiClusterSockShopExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster Sock Shop Suite")
+func TestMultiClusterSockShopExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster Sock Shop Suite")
 }

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package sock_shop

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package todo_list

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_suite_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMultiClusterTodoListExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster Todo List Suite")
+func TestMultiClusterTodoListExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster Todo List Suite")
 }

--- a/tests/e2e/multicluster/verify-api/verify_api_suite_test.go
+++ b/tests/e2e/multicluster/verify-api/verify_api_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package api_test

--- a/tests/e2e/multicluster/verify-api/verify_api_suite_test.go
+++ b/tests/e2e/multicluster/verify-api/verify_api_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyRegister(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Multi-cluster api test Suite")
+func TestVerifyRegister(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Multi-cluster api test Suite")
 }

--- a/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_suite_test.go
+++ b/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestClusterSync(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Default Rancher Cluster Sync Suite")
+func TestClusterSync(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Default Rancher Cluster Sync Suite")
 }

--- a/tests/e2e/multicluster/verify-deregister/verify_deregister_suite_test.go
+++ b/tests/e2e/multicluster/verify-deregister/verify_deregister_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyDeregister(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verify Deregister Managed Cluster multi-cluster Suite")
+func TestVerifyDeregister(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verify Deregister Managed Cluster multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-deregister/verify_deregister_suite_test.go
+++ b/tests/e2e/multicluster/verify-deregister/verify_deregister_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package deregister_test

--- a/tests/e2e/multicluster/verify-install/defaultresource_suite_test.go
+++ b/tests/e2e/multicluster/verify-install/defaultresource_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestKubernetes(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Default Resource multi-cluster Suite")
+func TestKubernetes(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Default Resource multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-install/defaultresource_suite_test.go
+++ b/tests/e2e/multicluster/verify-install/defaultresource_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package defaultresource_test

--- a/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_suite_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/helidon/jaeger_helidon_mc_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerHelidonMCTracing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger Hello Helidon multi cluster app Tracing Suite")
+func TestJaegerHelidonMCTracing(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger Hello Helidon multi cluster app Tracing Suite")
 }

--- a/tests/e2e/multicluster/verify-jaeger/hotrod/jaeger_hotrod_mc_suite_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/hotrod/jaeger_hotrod_mc_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerHotrodMCTracing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger Hotrod multi cluster app Tracing Suite")
+func TestJaegerHotrodMCTracing(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger Hotrod multi cluster app Tracing Suite")
 }

--- a/tests/e2e/multicluster/verify-jaeger/install/jaeger_install_suite_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/install/jaeger_install_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerInstallMultiCluster(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Default Jaeger install multi-cluster Suite")
+func TestJaegerInstallMultiCluster(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Default Jaeger install multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_suite_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerSystemTracesMultiCluster(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Default Jaeger system traces multi-cluster Suite")
+func TestJaegerSystemTracesMultiCluster(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Default Jaeger system traces multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_suite_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_suite_test.go
@@ -4,11 +4,11 @@ package permissions_test
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestVerifyPermissions(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verify kubeconfig permissions multi-cluster Suite")
+func TestVerifyPermissions(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verify kubeconfig permissions multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_suite_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package permissions_test
 

--- a/tests/e2e/multicluster/verify-rancher/rancher_suite_test.go
+++ b/tests/e2e/multicluster/verify-rancher/rancher_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestKubernetes(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Default Rancher multi-cluster Suite")
+func TestKubernetes(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Default Rancher multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-register/verify_register_suite_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var minimalVerification bool
@@ -17,7 +16,7 @@ func init() {
 	flag.BoolVar(&minimalVerification, "minimalVerification", false, "minimalVerification to perform minimal verification")
 }
 
-func TestVerifyRegister(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Register Managed Cluster multi-cluster Suite")
+func TestVerifyRegister(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Register Managed Cluster multi-cluster Suite")
 }

--- a/tests/e2e/multicluster/verify-resources/verify_resources_suite_test.go
+++ b/tests/e2e/multicluster/verify-resources/verify_resources_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyResources(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Register multi-cluster resource verification Suite")
+func TestVerifyResources(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Register multi-cluster resource verification Suite")
 }

--- a/tests/e2e/multicluster/verify-resources/verify_resources_suite_test.go
+++ b/tests/e2e/multicluster/verify-resources/verify_resources_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package resources_test

--- a/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_suite_test.go
+++ b/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_suite_test.go
@@ -6,7 +6,7 @@ package mccoherence
 import (
 	"flag"
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
@@ -20,7 +20,7 @@ func init() {
 	flag.BoolVar(&skipVerify, "skipVerify", false, "skipVerify skips the post deployment app validations")
 }
 
-func TestMultiClusterCoherenceApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Test Suite to validate the support for VerrazzanoCoherenceWorkload in multi-cluster environment")
+func TestMultiClusterCoherenceApplication(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Test Suite to validate the support for VerrazzanoCoherenceWorkload in multi-cluster environment")
 }

--- a/tests/e2e/multicluster/workloads/mcweblogic/weblogic_workload_mc_suite_test.go
+++ b/tests/e2e/multicluster/workloads/mcweblogic/weblogic_workload_mc_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestMultiClusterWebLogicApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Test Suite to validate the support for VerrazzanoWebLogicWorkload in multi-cluster environment")
+func TestMultiClusterWebLogicApplication(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Test Suite to validate the support for VerrazzanoWebLogicWorkload in multi-cluster environment")
 }

--- a/tests/e2e/oci/logging/ocilogging_suite_test.go
+++ b/tests/e2e/oci/logging/ocilogging_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var istioInjection string
@@ -17,7 +16,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestOCILogging(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "OCI Logging Suite")
+func TestOCILogging(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "OCI Logging Suite")
 }

--- a/tests/e2e/opensearch/topology/topology_suite_test.go
+++ b/tests/e2e/opensearch/topology/topology_suite_test.go
@@ -5,11 +5,11 @@ package topology
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestTopology(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "OpenSearch Topology Suite")
+func TestTopology(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "OpenSearch Topology Suite")
 }

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -55,7 +55,7 @@ func (t *TestFramework) AfterEach(args ...interface{}) bool {
 	}
 
 	f := func() {
-		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
+		metrics.EmitStatus(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	}
 	args[0] = f

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -32,16 +32,7 @@ func NewTestFramework(pkg string) *TestFramework {
 }
 
 func (t *TestFramework) RegisterFailHandler() {
-	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
-		// Recover only to emit a fail, then re-panic
-		defer func() {
-			if p := recover(); p != nil {
-				metrics.EmitFail(t.Metrics)
-				panic(p)
-			}
-		}()
-		ginkgo.Fail(message, callerSkip...)
-	})
+	gomega.RegisterFailHandler(t.Fail)
 }
 
 // initDumpDirectoryIfNecessary - sets the DUMP_DIRECTORY env variable to a default if not set externally
@@ -206,6 +197,13 @@ func (t *TestFramework) Entry(description interface{}, args ...interface{}) gink
 
 // Fail - wrapper function for Ginkgo Fail
 func (t *TestFramework) Fail(message string, callerSkip ...int) {
+	// Recover only to emit a fail, then re-panic
+	defer func() {
+		if p := recover(); p != nil {
+			metrics.EmitFail(t.Metrics)
+			panic(p)
+		}
+	}()
 	ginkgo.Fail(message, callerSkip...)
 }
 

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"fmt"
+	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 	"go.uber.org/zap"
@@ -28,6 +29,19 @@ func NewTestFramework(pkg string) *TestFramework {
 	t.Logs, _ = metrics.NewLogger(pkg, metrics.TestLogIndex, "stdout")
 	t.initDumpDirectoryIfNecessary()
 	return t
+}
+
+func (t *TestFramework) RegisterFailHandler() {
+	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
+		// Recover only to emit a fail, then re-panic
+		defer func() {
+			if p := recover(); p != nil {
+				metrics.EmitFail(t.Metrics)
+				panic(p)
+			}
+		}()
+		ginkgo.Fail(message, callerSkip...)
+	})
 }
 
 // initDumpDirectoryIfNecessary - sets the DUMP_DIRECTORY env variable to a default if not set externally
@@ -55,7 +69,7 @@ func (t *TestFramework) AfterEach(args ...interface{}) bool {
 	}
 
 	f := func() {
-		metrics.EmitStatus(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
+		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 		reflect.ValueOf(body).Call([]reflect.Value{})
 	}
 	args[0] = f

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -157,11 +157,20 @@ func configureOutputs(ind string) ([]string, error) {
 	return outputs, nil
 }
 
-func Emit(log *zap.SugaredLogger) {
+func EmitStatus(log *zap.SugaredLogger) {
 	spec := ginkgo.CurrentSpecReport()
 	if spec.State != types.SpecStateInvalid {
 		log = log.With(Status, spec.State)
 	}
+	emitInternal(log, spec)
+}
+
+func Emit(log *zap.SugaredLogger) {
+	spec := ginkgo.CurrentSpecReport()
+	emitInternal(log, spec)
+}
+
+func emitInternal(log *zap.SugaredLogger, spec ginkgo.SpecReport) {
 	t := spec.FullText()
 	l := spec.Labels()
 	log = withCodeLocation(log, spec)

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -157,7 +157,7 @@ func configureOutputs(ind string) ([]string, error) {
 	return outputs, nil
 }
 
-func EmitStatus(log *zap.SugaredLogger) {
+func EmitFail(log *zap.SugaredLogger) {
 	spec := ginkgo.CurrentSpecReport()
 	if spec.State != types.SpecStateInvalid {
 		log = log.With(Status, spec.State)
@@ -167,6 +167,9 @@ func EmitStatus(log *zap.SugaredLogger) {
 
 func Emit(log *zap.SugaredLogger) {
 	spec := ginkgo.CurrentSpecReport()
+	if spec.State == types.SpecStatePassed {
+		log = log.With(Status, spec.State)
+	}
 	emitInternal(log, spec)
 }
 

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -159,9 +159,7 @@ func configureOutputs(ind string) ([]string, error) {
 
 func EmitFail(log *zap.SugaredLogger) {
 	spec := ginkgo.CurrentSpecReport()
-	if spec.State != types.SpecStateInvalid {
-		log = log.With(Status, spec.State)
-	}
+	log = log.With(Status, types.SpecStateFailed)
 	emitInternal(log, spec)
 }
 

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics_suite_test.go
@@ -5,11 +5,10 @@ package metrics_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"testing"
 )
 
-func TestWriter(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Metrics Suite")
+func TestWriter(test *testing.T) {
+	t.RegisterFailHandler()
+	RunSpecs(test, "Metrics Suite")
 }

--- a/tests/e2e/registry/registry_suite_test.go
+++ b/tests/e2e/registry/registry_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestKubernetes(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Registry Suite")
+func TestKubernetes(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Registry Suite")
 }

--- a/tests/e2e/scripts/install/install_suite_test.go
+++ b/tests/e2e/scripts/install/install_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestPrometheus(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Install Script Suite")
+func TestPrometheus(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Install Script Suite")
 }

--- a/tests/e2e/security/netpol/network_policy_suite_test.go
+++ b/tests/e2e/security/netpol/network_policy_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var namespace string
@@ -25,11 +24,11 @@ func isUsingCalico() bool {
 	return usingCalico == "true"
 }
 
-func TestSecurityNetworkPolicies(t *testing.T) {
+func TestSecurityNetworkPolicies(test *testing.T) {
 	if !isUsingCalico() {
-		t.Skip("Calico not enabled, skipping test")
+		test.Skip("Calico not enabled, skipping test")
 		return
 	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verrazzano Network Policy Suite")
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verrazzano Network Policy Suite")
 }

--- a/tests/e2e/security/rbac/rbac_suite_test.go
+++ b/tests/e2e/security/rbac/rbac_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestSecurityRBACExample(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verrazzano Role Based Access Suite")
+func TestSecurityRBACExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verrazzano Role Based Access Suite")
 }

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyCRDs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verify CRDs After Uninstall Suite")
+func TestVerifyCRDs(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verify CRDs After Uninstall Suite")
 }

--- a/tests/e2e/update/apiconversion/apiconversion_suite_test.go
+++ b/tests/e2e/update/apiconversion/apiconversion_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestApiconversion(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Apiconversion Suite")
+func TestApiconversion(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Apiconversion Suite")
 }

--- a/tests/e2e/update/authproxy/authproxy_update_suite_test.go
+++ b/tests/e2e/update/authproxy/authproxy_update_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestAuthProxyUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update authProxy Suite")
+func TestAuthProxyUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update authProxy Suite")
 }

--- a/tests/e2e/update/availability/availability_suite_test.go
+++ b/tests/e2e/update/availability/availability_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestAvailability(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Availability Suite")
+func TestAvailability(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Availability Suite")
 }

--- a/tests/e2e/update/certac/certac_suite_test.go
+++ b/tests/e2e/update/certac/certac_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestAdminClusterCertManagerUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Admin-Cluster Cert-Manager Suite")
+func TestAdminClusterCertManagerUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Admin-Cluster Cert-Manager Suite")
 }

--- a/tests/e2e/update/certmc/certmc_suite_test.go
+++ b/tests/e2e/update/certmc/certmc_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestManagedClusterCertManagerUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Managed-Cluster Cert-Manager Suite")
+func TestManagedClusterCertManagerUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Managed-Cluster Cert-Manager Suite")
 }

--- a/tests/e2e/update/dnsac/dnsac_suite_test.go
+++ b/tests/e2e/update/dnsac/dnsac_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestAdminClusterDNSUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Admin-Cluster DNS Suite")
+func TestAdminClusterDNSUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Admin-Cluster DNS Suite")
 }

--- a/tests/e2e/update/dnsmc/dnsmc_suite_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestManagedClusterDNSUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Managed-Cluster DNS Suite")
+func TestManagedClusterDNSUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Managed-Cluster DNS Suite")
 }

--- a/tests/e2e/update/env-dns-cm/env_dns_cert_update_suite_test.go
+++ b/tests/e2e/update/env-dns-cm/env_dns_cert_update_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-func TestEnvironmentNameDNSCertManagerUpdate(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Update env-dns-cm Suite")
+func TestEnvironmentNameDNSCertManagerUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	RunSpecs(test, "Update env-dns-cm Suite")
 }

--- a/tests/e2e/update/fluentd/fluentd_update_suite_test.go
+++ b/tests/e2e/update/fluentd/fluentd_update_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestFluentdUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Fluentd Suite")
+func TestFluentdUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Fluentd Suite")
 }

--- a/tests/e2e/update/fluentdextes/fluentdextes_suite_test.go
+++ b/tests/e2e/update/fluentdextes/fluentdextes_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestFluentdUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update Fluentd External ES Suite")
+func TestFluentdUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update Fluentd External ES Suite")
 }

--- a/tests/e2e/update/jaeger/jaeger_update_suite_test.go
+++ b/tests/e2e/update/jaeger/jaeger_update_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerPostInstallUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Post Install Update of Jaeger Operator Suite")
+func TestJaegerPostInstallUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Post Install Update of Jaeger Operator Suite")
 }

--- a/tests/e2e/update/nginxistio/nginxistio_suite_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestNginxIstioUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Update nginx-istio Suite")
+func TestNginxIstioUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Update nginx-istio Suite")
 }

--- a/tests/e2e/update/opensearch/opensearch_update_suite_test.go
+++ b/tests/e2e/update/opensearch/opensearch_update_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestOpenSearchPostInstallUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Post Install Update Opensearch Suite")
+func TestOpenSearchPostInstallUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Post Install Update Opensearch Suite")
 }

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_suite_test.go
@@ -5,11 +5,11 @@ package grafana
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestGrafanaDashboardPostUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Post Upgrade Grafana Dashboard Suite")
+func TestGrafanaDashboardPostUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Post Upgrade Grafana Dashboard Suite")
 }

--- a/tests/e2e/upgrade/post-upgrade/keycloak/keycloak_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/keycloak/keycloak_suite_test.go
@@ -5,11 +5,11 @@ package keycloak
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestKeycloakPostUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Post Upgrade Keycloak Suite")
+func TestKeycloakPostUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Post Upgrade Keycloak Suite")
 }

--- a/tests/e2e/upgrade/post-upgrade/metricsbinding/metrics_binding_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/metricsbinding/metrics_binding_suite_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 // TestMetricsBindingPostUpgrade tests the Metrics Binding status after an upgrade
-func TestMetricsBindingPostUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Metrics Binding Post-Upgrade Test Suite")
+func TestMetricsBindingPostUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Metrics Binding Post-Upgrade Test Suite")
 }

--- a/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/opensearch/opensearch_suite_test.go
@@ -5,11 +5,11 @@ package opensearch
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestVerifyOpenSearchPostUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Post Upgrade Verify OpenSearch Suite")
+func TestVerifyOpenSearchPostUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Post Upgrade Verify OpenSearch Suite")
 }

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verify

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_suite_test.go
@@ -5,11 +5,11 @@ package verify
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestVerifyAppRestart(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Upgrade Verify App Restart Suite")
+func TestVerifyAppRestart(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Upgrade Verify App Restart Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_suite_test.go
@@ -5,11 +5,11 @@ package grafana
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestGrafanaDashboardPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Pre Upgrade Grafana Dashboard Suite")
+func TestGrafanaDashboardPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Pre Upgrade Grafana Dashboard Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/keycloak/keycloak_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/keycloak/keycloak_suite_test.go
@@ -5,11 +5,11 @@ package keycloak
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestKeycloakPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Pre Upgrade Keycloak Suite")
+func TestKeycloakPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Pre Upgrade Keycloak Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/metricsbinding/metrics_binding_suite_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 // TestMetricsBindingPreUpgrade tests the deployment of resources before upgrade to verify the Metrics Binding upgrade
-func TestMetricsBindingPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Metrics Binding Pre-Upgrade Test Suite")
+func TestMetricsBindingPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Metrics Binding Pre-Upgrade Test Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/opensearch-dashboards/opensearch_dashboards_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/opensearch-dashboards/opensearch_dashboards_suite_test.go
@@ -5,11 +5,11 @@ package dashboards
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestOpenSearchDashboardPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Upgrade OpenSearch Dashboards Setup Suite")
+func TestOpenSearchDashboardPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Upgrade OpenSearch Dashboards Setup Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/opensearch/opensearch_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/opensearch/opensearch_suite_test.go
@@ -5,11 +5,11 @@ package opensearch
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestOpenSearchPreUpgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Pre Upgrade OpenSearch Suite")
+func TestOpenSearchPreUpgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Pre Upgrade OpenSearch Suite")
 }

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyUpgradeRequiredWithUpdate(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verify upgrade required checks.")
+func TestVerifyUpgradeRequiredWithUpdate(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verify upgrade required checks.")
 }

--- a/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_suite_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyPreupgrade(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Pre-upgrade verification.")
+func TestVerifyPreupgrade(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Pre-upgrade verification.")
 }

--- a/tests/e2e/verify-distribution/verifydistribution/verify_distribution_suite_test.go
+++ b/tests/e2e/verify-distribution/verifydistribution/verify_distribution_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerifyDistribution(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verify Verrazzano Distribution Suite")
+func TestVerifyDistribution(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verify Verrazzano Distribution Suite")
 }

--- a/tests/e2e/verify-infra/oam/oam_suite_test.go
+++ b/tests/e2e/verify-infra/oam/oam_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestOAMInfra(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "OAM Infra Test Suite")
+func TestOAMInfra(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "OAM Infra Test Suite")
 }

--- a/tests/e2e/verify-infra/oam/oam_suite_test.go
+++ b/tests/e2e/verify-infra/oam/oam_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oam

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -287,8 +287,7 @@ func verifyUILogoSetting(settingName string, logoPath string, dynamicClient dyna
 			return false, err
 		}
 
-		fmt.Println(logoSVG)
-		if stdout != "foobar" {
+		if stdout != logoSVG {
 			t.Logs.Errorf("Got %s for Rancher UI logo path, expected %s", stdout, logoSVG)
 			return false, nil
 		}

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -287,7 +287,8 @@ func verifyUILogoSetting(settingName string, logoPath string, dynamicClient dyna
 			return false, err
 		}
 
-		if stdout != logoSVG {
+		fmt.Println(logoSVG)
+		if stdout != "foobar" {
 			t.Logs.Errorf("Got %s for Rancher UI logo path, expected %s", stdout, logoSVG)
 			return false, nil
 		}

--- a/tests/e2e/verify-infra/restapi/rest_api_suite_test.go
+++ b/tests/e2e/verify-infra/restapi/rest_api_suite_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
 
 var t = framework.NewTestFramework("restapi_test")
 
-func TestRestApi(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "REST API Suite")
+func TestRestApi(t2 *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(t2, "REST API Suite")
 }

--- a/tests/e2e/verify-infra/restapi/rest_api_suite_test.go
+++ b/tests/e2e/verify-infra/restapi/rest_api_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 var t = framework.NewTestFramework("restapi_test")
 
-func TestRestApi(t2 *testing.T) {
+func TestRestApi(test *testing.T) {
 	t.RegisterFailHandler()
-	ginkgo.RunSpecs(t2, "REST API Suite")
+	ginkgo.RunSpecs(test, "REST API Suite")
 }

--- a/tests/e2e/verify-infra/vmi/vmi_suite_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVmi(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "VMI Suite")
+func TestVmi(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "VMI Suite")
 }

--- a/tests/e2e/verify-infra/vmi/vmi_suite_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmi_test

--- a/tests/e2e/verify-install/bom-validator/bom_validator_suite_test.go
+++ b/tests/e2e/verify-install/bom-validator/bom_validator_suite_test.go
@@ -5,11 +5,11 @@ package bomvalidator
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestBOMValidator(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "BOM Validator Suite")
+func TestBOMValidator(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "BOM Validator Suite")
 }

--- a/tests/e2e/verify-install/istio/istio_suite_test.go
+++ b/tests/e2e/verify-install/istio/istio_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestIstio(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Istio Suite")
+func TestIstio(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Istio Suite")
 }

--- a/tests/e2e/verify-install/jaeger-operator/jaeger_operator_suite_test.go
+++ b/tests/e2e/verify-install/jaeger-operator/jaeger_operator_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestJaegerOperator(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Jaeger Operator Suite")
+func TestJaegerOperator(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Jaeger Operator Suite")
 }

--- a/tests/e2e/verify-install/keycloak/keycloak_suite_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestKeycloak(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Keycloak Suite")
+func TestKeycloak(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Keycloak Suite")
 }

--- a/tests/e2e/verify-install/kiali/kiali_suite_test.go
+++ b/tests/e2e/verify-install/kiali/kiali_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kiali

--- a/tests/e2e/verify-install/kiali/kiali_suite_test.go
+++ b/tests/e2e/verify-install/kiali/kiali_suite_test.go
@@ -5,11 +5,11 @@ package kiali
 
 import (
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+
 	"testing"
 )
 
-func TestKiali(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Kiali Test Suite")
+func TestKiali(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Kiali Test Suite")
 }

--- a/tests/e2e/verify-install/kubernetes/kubernetes_suite_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestKubernetes(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Kubernetes Suite")
+func TestKubernetes(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Kubernetes Suite")
 }

--- a/tests/e2e/verify-install/kubernetes/kubernetes_suite_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kubernetes_test

--- a/tests/e2e/verify-install/promstack/promstack_suite_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestPrometheusStack(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Prometheus Stack Suite")
+func TestPrometheusStack(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Prometheus Stack Suite")
 }

--- a/tests/e2e/verify-install/rancherbackup/rancher_backup_suite_test.go
+++ b/tests/e2e/verify-install/rancherbackup/rancher_backup_suite_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVelero(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Rancher Backup Suite")
+func TestVelero(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Rancher Backup Suite")
 }

--- a/tests/e2e/verify-install/validators/validators_suite_test.go
+++ b/tests/e2e/verify-install/validators/validators_suite_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-func TestValidators(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Verrazzano Validators Suite")
+func TestValidators(test *testing.T) {
+	t.RegisterFailHandler()
+	RunSpecs(test, "Verrazzano Validators Suite")
 }

--- a/tests/e2e/verify-install/velero/velero_suite_test.go
+++ b/tests/e2e/verify-install/velero/velero_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVelero(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Velero Suite")
+func TestVelero(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Velero Suite")
 }

--- a/tests/e2e/verify-install/verrazzano/verrazzano_suite_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verrazzano_test

--- a/tests/e2e/verify-install/verrazzano/verrazzano_suite_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestVerrazzano(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Verrazzano Suite")
+func TestVerrazzano(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Verrazzano Suite")
 }

--- a/tests/e2e/verify-install/web/web_suite_test.go
+++ b/tests/e2e/verify-install/web/web_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package web_test

--- a/tests/e2e/verify-install/web/web_suite_test.go
+++ b/tests/e2e/verify-install/web/web_suite_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-func TestWeb(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Web Suite")
+func TestWeb(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Web Suite")
 }

--- a/tests/e2e/workloads/coherence/coherence_workload_suite_test.go
+++ b/tests/e2e/workloads/coherence/coherence_workload_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", generatedNamespace, "namespace is the app namespace")
 }
 
-func TestCoherenceApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Test Suite to validate the support for VerrazzanoCoherenceWorkload")
+func TestCoherenceApplication(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Test Suite to validate the support for VerrazzanoCoherenceWorkload")
 }

--- a/tests/e2e/workloads/oam/oam_workload_suite_test.go
+++ b/tests/e2e/workloads/oam/oam_workload_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 }
 
 // TestOAMWorkloads runs the OAM workload test suite that tests various OAM workload types
-func TestOAMWorkloads(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Test Suite to validate the support for OAM workloads")
+func TestOAMWorkloads(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Test Suite to validate the support for OAM workloads")
 }

--- a/tests/e2e/workloads/weblogic/weblogic_workload_suite_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var skipDeploy bool
@@ -23,7 +22,7 @@ func init() {
 	flag.StringVar(&istioInjection, "istioInjection", "enabled", "istioInjection enables the injection of istio side cars")
 }
 
-func TestWebLogicApplication(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Test Suite to validate the support for VerrazzanoWebLogicWorkload")
+func TestWebLogicApplication(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Test Suite to validate the support for VerrazzanoWebLogicWorkload")
 }


### PR DESCRIPTION
Implement a custom fail method that emits failure metrics. This will ensure that only one "failed" metric is pushed per test. Main changes are in ginkgo_wrapper.go and ginkgo_metrics.go. The rest is boilerplate changes to use the new fail method.