### PR TITLE
VZ-7524: disable TestRepairMySQLPodsWaitingReadinessGates

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -1945,6 +1945,7 @@ func TestDumpDatabaseWithExecErrors(t *testing.T) {
 // WHEN they are not all ready after a given time period
 // THEN recycle the mysql-operator
 func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
+	t.Skip("Temporarily disable due to intermittent failures")
 	mySQLOperatorPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mysqloperator.ComponentName,


### PR DESCRIPTION
Disable test because it is intermittently failing.
