### PR TITLE
Register all test panics as failed tests

### DIFF
--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -195,7 +195,6 @@ func (t *TestFramework) Entry(description interface{}, args ...interface{}) gink
 
 // Fail - wrapper function for Ginkgo Fail
 func (t *TestFramework) Fail(message string, callerSkip ...int) {
-	defer t.panicHandler()
 	ginkgo.Fail(message, callerSkip...)
 }
 

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -32,7 +32,7 @@ func NewTestFramework(pkg string) *TestFramework {
 }
 
 func (t *TestFramework) RegisterFailHandler() {
-	gomega.RegisterFailHandler(t.Fail)
+	gomega.RegisterFailHandler(ginkgo.Fail)
 }
 
 // initDumpDirectoryIfNecessary - sets the DUMP_DIRECTORY env variable to a default if not set externally
@@ -61,7 +61,7 @@ func (t *TestFramework) AfterEach(args ...interface{}) bool {
 
 	f := func() {
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
-		reflect.ValueOf(body).Call([]reflect.Value{})
+		t.invoke(body)
 	}
 	args[0] = f
 
@@ -80,9 +80,7 @@ func (t *TestFramework) BeforeEach(args ...interface{}) bool {
 	}
 
 	f := func() {
-
-		reflect.ValueOf(body).Call([]reflect.Value{})
-
+		t.invoke(body)
 	}
 	args[0] = f
 
@@ -100,7 +98,7 @@ func (t *TestFramework) It(text string, args ...interface{}) bool {
 	}
 	f := func() {
 		metrics.Emit(t.Metrics) // Starting point metric
-		reflect.ValueOf(body).Call([]reflect.Value{})
+		t.invoke(body)
 	}
 
 	args[len(args)-1] = ginkgo.Offset(1)
@@ -132,7 +130,7 @@ func (t *TestFramework) Describe(text string, args ...interface{}) bool {
 	}
 	f := func() {
 		metrics.Emit(t.Metrics)
-		reflect.ValueOf(body).Call([]reflect.Value{})
+		t.invoke(body)
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 	}
 	args[len(args)-1] = ginkgo.Offset(1)
@@ -152,7 +150,7 @@ func (t *TestFramework) DescribeTable(text string, args ...interface{}) bool {
 	funcType := reflect.TypeOf(body)
 	f := reflect.MakeFunc(funcType, func(args []reflect.Value) (results []reflect.Value) {
 		metrics.Emit(t.Metrics)
-		rv := reflect.ValueOf(body).Call(args)
+		rv := t.invoke(body)
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
 		return rv
 	})
@@ -168,7 +166,7 @@ func (t *TestFramework) BeforeSuite(body func()) bool {
 
 	f := func() {
 		metrics.Emit(t.Metrics)
-		reflect.ValueOf(body).Call([]reflect.Value{})
+		t.invoke(body)
 	}
 	return ginkgo.BeforeSuite(f)
 }
@@ -181,7 +179,7 @@ func (t *TestFramework) AfterSuite(body func()) bool {
 
 	f := func() {
 		metrics.Emit(t.Metrics.With(metrics.Duration, metrics.DurationMillis()))
-		reflect.ValueOf(body).Call([]reflect.Value{})
+		t.invoke(body)
 	}
 	return ginkgo.AfterSuite(f)
 }
@@ -197,14 +195,23 @@ func (t *TestFramework) Entry(description interface{}, args ...interface{}) gink
 
 // Fail - wrapper function for Ginkgo Fail
 func (t *TestFramework) Fail(message string, callerSkip ...int) {
-	// Recover only to emit a fail, then re-panic
-	defer func() {
-		if p := recover(); p != nil {
-			metrics.EmitFail(t.Metrics)
-			panic(p)
-		}
-	}()
+	defer t.panicHandler()
 	ginkgo.Fail(message, callerSkip...)
+}
+
+// panicHandler is used with defer to emit a failed status metric when a panic occurs
+func (t *TestFramework) panicHandler() {
+	// Recover only to emit a fail, then re-panic
+	if p := recover(); p != nil {
+		metrics.EmitFail(t.Metrics)
+		panic(p)
+	}
+}
+
+// invoke calls body as a function, wrapped with the panicHandler
+func (t *TestFramework) invoke(body interface{}) []reflect.Value {
+	defer t.panicHandler()
+	return reflect.ValueOf(body).Call([]reflect.Value{})
 }
 
 // Context - wrapper function for Ginkgo Context


### PR DESCRIPTION
Adds failure metrics for tests that panic outside of gomega fail handlers. Previously we would miss these metrics. 