### PR TITLE
Jaeger update test typo

### DIFF
--- a/tests/e2e/update/jaeger/jaeger_update_test.go
+++ b/tests/e2e/update/jaeger/jaeger_update_test.go
@@ -113,6 +113,6 @@ var _ = t.Describe("Update Jaeger", Label("f:platform-lcm.update"), func() {
 			err := update.UpdateCR(m)
 			foundExpectedErr := err != nil && strings.Contains(err.Error(), disableErrorMsg)
 			return foundExpectedErr
-		}).Should(BeTrue(), pollingInterval, waitTimeout)
+		}).WithPolling(pollingInterval).WithTimeout(waitTimeout).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
.Should(...) contained the wait timeout and polling interval. This could sometimes cause the test to fail