### PR TITLE
VZ-7792 Fix Jaeger service name used in E2E tests

### DIFF
--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -53,7 +53,7 @@ var (
 
 	// services that are common plus the ones unique to admin cluster
 	adminClusterSystemServiceNames = append(managedClusterSystemServiceNames,
-		"jaeger-operator-jaeger.verrazzano-monitoring",
+		"jaeger.verrazzano-monitoring",
 		"system-es-master.verrazzano-system")
 )
 


### PR DESCRIPTION
The Jaeger service name used for envoy traces of Jaeger pods is "jaeger.verrazzano-monitoring" but a wrong name "jaeger-operator-jaeger.verrazzano-monitoring" was used in the tests. The Jaeger Query/UI application traces use the name "jaeger-operator-jaeger.verrazzano-monitoring" and hence the tests were passing most of the times even though a wrong name was used.
