### PR TITLE
No Bug.  Fix keycloak component to use effective CR when updating Rancher authconfig

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -762,7 +762,7 @@ func configureKeycloakRealms(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	if vzcr.IsRancherEnabled(ctx.ActualCR()) {
+	if vzcr.IsRancherEnabled(ctx.EffectiveCR()) {
 		// Creating rancher client
 		err = createOrUpdateClient(ctx, cfg, cli, "rancher", rancherClientTmpl, rancherClientUrisTemplate, true)
 		if err != nil {


### PR DESCRIPTION
Fix keycloak to use the effective CR when checking if Rancher is enabled in order to update the Keycloak authconfig for SSO.