### PR TITLE
Exclude PSR from code coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ precommit-check: check check-tests copyright-check
 precommit-build:
 	go build ./...
 
-unit-test-coverage: export COVERAGE_EXCLUSIONS="(tests/e2e|tools/psr)"
+unit-test-coverage: export COVERAGE_EXCLUSIONS ?= tests/e2e|tools/psr
 .PHONY: unit-test-coverage
 unit-test-coverage:
 	${SCRIPT_DIR}/coverage.sh html

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ precommit-check: check check-tests copyright-check
 precommit-build:
 	go build ./...
 
+unit-test-coverage: export COVERAGE_EXCLUSIONS="(tests/e2e|tools/psr)"
 .PHONY: unit-test-coverage
 unit-test-coverage:
 	${SCRIPT_DIR}/coverage.sh html

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -5,7 +5,7 @@
 #
 # Code coverage generation
 TEST_PATHS=${TEST_PATHS:-"./..."}
-go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev /tests/e2e)
+go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "(/tests/e2e|/tools/psr)")
 TEST_STATUS=$?
 
 # Remove specific files from coverage report

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -4,12 +4,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Code coverage generation
-TEST_PATHS=${TEST_PATHS:-"./..."}
+set -x
+TEST_PATHS=${TEST_PATHS:-./...}
 # Coverage exclusions regex
-COVERAGE_EXCLUSIONS=${COVERAGE_EXCLUSIONS:-"tests/e2e"}
+COVERAGE_EXCLUSIONS=${COVERAGE_EXCLUSIONS:-/tests/e2e}
 
-go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "${COVERAGE_EXCLUSIONS}")
+go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "(${COVERAGE_EXCLUSIONS})")
 TEST_STATUS=$?
+set +x
 
 # Remove specific files from coverage report
 cat ./coverage.raw.cov |\

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -5,7 +5,10 @@
 #
 # Code coverage generation
 TEST_PATHS=${TEST_PATHS:-"./..."}
-go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "(/tests/e2e|/tools/psr)")
+# Coverage exclusions regex
+COVERAGE_EXCLUSIONS=${COVERAGE_EXCLUSIONS:-"tests/e2e"}
+
+go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "${COVERAGE_EXCLUSIONS}")
 TEST_STATUS=$?
 
 # Remove specific files from coverage report

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -4,14 +4,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Code coverage generation
-set -x
 TEST_PATHS=${TEST_PATHS:-./...}
 # Coverage exclusions regex
 COVERAGE_EXCLUSIONS=${COVERAGE_EXCLUSIONS:-/tests/e2e}
 
 go test -coverprofile ./coverage.raw.cov $(go list ${TEST_PATHS} | grep -Ev "(${COVERAGE_EXCLUSIONS})")
 TEST_STATUS=$?
-set +x
 
 # Remove specific files from coverage report
 cat ./coverage.raw.cov |\


### PR DESCRIPTION
The PSR tooling code is used internally, and should not be included in code coverage reporting for the product.