### PR TITLE
Update the network policies component to better allow conditional installation of network policies

### DIFF
--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol.go
@@ -120,6 +120,15 @@ func generateOverridesFile(ctx spi.ComponentContext, overrides *chartValues) (st
 func appendVerrazzanoValues(ctx spi.ComponentContext, overrides *chartValues) error {
 	effectiveCR := ctx.EffectiveCR()
 
+	overrides.AuthProxy = &authproxyValues{Enabled: vzcr.IsAuthProxyEnabled(effectiveCR)}
+	overrides.ConsoleValues = &consoleValues{Enabled: vzcr.IsConsoleEnabled(effectiveCR)}
+	overrides.ApplicationOperator = &appOperatorValues{Enabled: vzcr.IsApplicationOperatorEnabled(effectiveCR)}
+	overrides.OAM = &oamValues{Enabled: vzcr.IsOAMEnabled(effectiveCR)}
+	overrides.WeblogicOperator = &weblogicOperatorValues{Enabled: vzcr.IsWebLogicOperatorEnabled(effectiveCR)}
+	overrides.CoherenceOperator = &coherenceOperatorValues{Enabled: vzcr.IsCoherenceOperatorEnabled(effectiveCR)}
+	overrides.ClusterOperator = &clusterOperatorValues{Enabled: vzcr.IsClusterOperatorEnabled(effectiveCR)}
+	overrides.CertManager = &certManagerValues{Enabled: vzcr.IsCertManagerEnabled(effectiveCR)}
+	overrides.NGINX = &nginxValues{Enabled: vzcr.IsNGINXEnabled(effectiveCR)}
 	overrides.ElasticSearch = &elasticsearchValues{Enabled: vzcr.IsOpenSearchEnabled(effectiveCR)}
 	overrides.Externaldns = &externalDNSValues{Enabled: vzcr.IsExternalDNSEnabled(effectiveCR)}
 	overrides.Grafana = &grafanaValues{Enabled: vzcr.IsGrafanaEnabled(effectiveCR)}

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_values.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_values.go
@@ -8,16 +8,49 @@ package networkpolicies
 // This is only needed for the enabled/disable field for various components
 // used by the network policies helm charts
 type chartValues struct {
-	Name           string                `json:"name,omitempty"`
-	ElasticSearch  *elasticsearchValues  `json:"elasticSearch,omitempty"`
-	Externaldns    *externalDNSValues    `json:"externaldns,omitempty"`
-	Grafana        *grafanaValues        `json:"grafana,omitempty"`
-	Istio          *istioValues          `json:"istio,omitempty"`
-	JaegerOperator *jaegerOperatorValues `json:"jaegerOperator,omitempty"`
-	Keycloak       *keycloakValues       `json:"keycloak,omitempty"`
-	Prometheus     *prometheusValues     `json:"prometheus,omitempty"`
-	Rancher        *rancherValues        `json:"rancher,omitempty"`
-	Velero         *veleroValues         `json:"velero,omitempty"`
+	Name                string                   `json:"name,omitempty"`
+	ApplicationOperator *appOperatorValues       `json:"applicationOperator,omitempty"`
+	AuthProxy           *authproxyValues         `json:"authproxy,omitempty"`
+	CertManager         *certManagerValues       `json:"certManager,omitempty"`
+	ConsoleValues       *consoleValues           `json:"console,omitempty"`
+	ClusterOperator     *clusterOperatorValues   `json:"clusterOperator,omitempty"`
+	CoherenceOperator   *coherenceOperatorValues `json:"coherenceOperator,omitempty"`
+	WeblogicOperator    *weblogicOperatorValues  `json:"weblogicOperator,omitempty"`
+	ElasticSearch       *elasticsearchValues     `json:"elasticSearch,omitempty"`
+	Externaldns         *externalDNSValues       `json:"externaldns,omitempty"`
+	Grafana             *grafanaValues           `json:"grafana,omitempty"`
+	NGINX               *nginxValues             `json:"ingressNGINX,omitempty"`
+	OAM                 *oamValues               `json:"oam,omitempty"`
+	Istio               *istioValues             `json:"istio,omitempty"`
+	JaegerOperator      *jaegerOperatorValues    `json:"jaegerOperator,omitempty"`
+	Keycloak            *keycloakValues          `json:"keycloak,omitempty"`
+	Prometheus          *prometheusValues        `json:"prometheus,omitempty"`
+	Rancher             *rancherValues           `json:"rancher,omitempty"`
+	Velero              *veleroValues            `json:"velero,omitempty"`
+}
+
+type authproxyValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type appOperatorValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type oamValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type certManagerValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type consoleValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type nginxValues struct {
+	Enabled bool `json:"enabled"` // Always write
 }
 
 type elasticsearchValues struct {
@@ -49,6 +82,18 @@ type externalDNSValues struct {
 }
 
 type jaegerOperatorValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type clusterOperatorValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type coherenceOperatorValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type weblogicOperatorValues struct {
 	Enabled bool `json:"enabled"` // Always write
 }
 

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+{{- if .Values.authproxy.enabled }}
 # Network policy for Verrazzano API Proxy
 # Ingress: allow nginx-ingress-controller to connect to port 8775
 #          allow connect from Prometheus to scrape Envoy stats on port 15090
@@ -61,6 +62,7 @@ spec:
           protocol: TCP
         - port: 9113
           protocol: TCP
+{{- end }}
 {{- if .Values.console.enabled }}
 ---
 # Network policy for Verrazzano console
@@ -100,6 +102,7 @@ spec:
         - port: 15090
           protocol: TCP
 {{- end }}
+{{- if .Values.applicationOperator.enabled }}
 ---
 # Network policy for Verrazzano application operator
 # Ingress: allow access from Kubernetes API server for webhook port 9443
@@ -129,6 +132,8 @@ spec:
       ports:    
         - port: 9100
           protocol: TCP
+{{- end }}
+{{- if .Values.oam.enabled }}
 ---
 # Network policy for OAM Kubernetes Runtime operator
 # Ingress: deny all
@@ -144,6 +149,7 @@ spec:
       app.kubernetes.io/name: oam-kubernetes-runtime
   policyTypes:
     - Ingress
+{{- end }}
 {{- if .Values.jaegerOperator.enabled }}
 ---
 # Network policy for Jaeger Collector
@@ -227,6 +233,7 @@ spec:
         - port: 16686
           protocol: TCP
 {{- end }}
+{{- if .Values.clusterOperator.enabled }}
 ---
 # Network policy for Verrazzano cluster operator
 # Ingress: allow access from Prometheus to scrape metrics on port 8080
@@ -253,3 +260,4 @@ spec:
       ports:
         - port: 8080
           protocol: TCP
+{{- end }}

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+{{- if .Values.weblogicOperator.enabled }}
 ---
 # Network policy for WebLogic operator
 # Ingress: allow from istio-system
@@ -31,6 +32,8 @@ spec:
       ports:
         - port: 15090
           protocol: TCP
+{{- end }}
+{{- if .Values.coherenceOperator.enabled }}
 ---
 # Network policy for Coherence Operator
 # Ingress: allow connect from Kubernetes API server to validating webhook port 9443
@@ -52,6 +55,7 @@ spec:
           protocol: TCP
         - port: 8000
           protocol: TCP
+{{- end }}
 {{- if .Values.grafana.enabled}}
 ---
 # Network policy for VMI System Grafana
@@ -91,6 +95,7 @@ spec:
         - port: 15090
           protocol: TCP
 {{- end }}
+{{- if .Values.certManager.enabled }}
 ---
 # Network policy for Cert Manager
 # Ingress: allow connect from Prometheus for scraping metrics
@@ -118,6 +123,7 @@ spec:
       ports:
         - port: 9402
           protocol: TCP
+{{- end }}
 {{- if .Values.externaldns.enabled }}
 ---
 # Network policy for External DNS
@@ -289,6 +295,7 @@ spec:
           protocol: TCP
 
 {{- end }}
+{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher cluster agent
 # Ingress: deny all
@@ -304,7 +311,6 @@ spec:
       app: cattle-cluster-agent
   policyTypes:
     - Ingress
-{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher UI/API
 # Ingress: allow nginx ingress
@@ -357,6 +363,7 @@ spec:
         - port: 9443
           protocol: TCP
 {{- end }}
+{{- if .Values.ingressNGINX.enabled }}
 ---
 # Network policy for NGINX Ingress controller
 # Egress: allow all
@@ -431,6 +438,7 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
+{{- end }}
 {{- if .Values.istio.enabled}}
 ---
 # Network policy for istio-system pod communication

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/values.yaml
@@ -13,6 +13,12 @@ prometheus:
 grafana:
   enabled: true
 
+certManager:
+  enabled: true
+
+ingressNGINX:
+  enabled: true
+
 istio:
   enabled: true
 
@@ -28,6 +34,24 @@ externaldns:
 jaegerOperator:
   enabled: false
   namespace: verrazzano-monitoring
+
+weblogicOperator:
+  enabled: true
+
+coherenceOperator:
+  enabled: true
+
+authproxy:
+  enabled: true
+
+applicationOperator:
+  enabled: true
+
+oam:
+  enabled: true
+
+clusterOperator:
+  enabled: true
 
 console:
   enabled: true


### PR DESCRIPTION
The network-policies chart doesn't fully conditionalize all the resources based on the related-component's `enabled` setting.  This adds conditional wrappers around these resources accordingly.

Discovered this during manual testing with some components disabled.

Related components:

- console
- certManager
- ingressNGINX
- weblogicOperator
- coherenceOperator
- authproxy
- applicationOperator
- oam
- clusterOperator
