### PR TITLE
VZ-7796: Separate MySQL workaround code and tests into separate files

### DIFF
--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
@@ -200,88 +199,6 @@ func (c mysqlComponent) isMySQLReady(ctx spi.ComponentContext) bool {
 	}
 
 	return ready && checkDbMigrationJobCompletion(ctx) && isInnoDBClusterOnline(ctx)
-}
-
-// repairMySQLPodsWaitingReadinessGates - temporary workaround to repair issue were a MySQL pod
-// can be stuck waiting for its readiness gates to be met.
-func (c mysqlComponent) repairMySQLPodsWaitingReadinessGates(ctx spi.ComponentContext) error {
-	podsWaiting, err := c.mySQLPodsWaitingForReadinessGates(ctx)
-	if err != nil {
-		return err
-	}
-	if podsWaiting {
-		// Restart the mysql-operator to see if it will finish setting the readiness gates
-		ctx.Log().Info("Restarting the mysql-operator to see if it will repair MySQL pods stuck waiting for readiness gates")
-
-		operPod, err := getMySQLOperatorPod(ctx.Log(), ctx.Client())
-		if err != nil {
-			return fmt.Errorf("Failed restarting the mysql-operator to repair stuck MySQL pods: %v", err)
-		}
-
-		if err = ctx.Client().Delete(context.TODO(), operPod, &clipkg.DeleteOptions{}); err != nil {
-			return err
-		}
-
-		// Clear the timer
-		*c.LastTimeReadinessGateRepairStarted = time.Time{}
-	}
-	return nil
-}
-
-// mySQLPodsWaitingForReadinessGates - detect if there are MySQL pods stuck waiting for
-// their readiness gates to be true.
-func (c mysqlComponent) mySQLPodsWaitingForReadinessGates(ctx spi.ComponentContext) (bool, error) {
-	if c.LastTimeReadinessGateRepairStarted.IsZero() {
-		*c.LastTimeReadinessGateRepairStarted = time.Now()
-		return false, nil
-	}
-
-	// Initiate repair only if time to wait period has been exceeded
-	expiredTime := c.LastTimeReadinessGateRepairStarted.Add(5 * time.Minute)
-	if time.Now().After(expiredTime) {
-		// Check if the current not ready state is due to readiness gates not met
-		ctx.Log().Debug("Checking if MySQL not ready due to pods waiting for readiness gates")
-
-		selector := metav1.LabelSelectorRequirement{Key: mySQLComponentLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{mySQLDComponentName}}
-		podList := k8sready.GetPodsList(ctx.Log(), ctx.Client(), types.NamespacedName{Namespace: ComponentNamespace}, &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{selector}})
-		if podList == nil || len(podList.Items) == 0 {
-			return false, fmt.Errorf("Failed checking MySQL readiness gates, no pods found matching selector %s", selector.String())
-		}
-
-		for i := range podList.Items {
-			pod := podList.Items[i]
-			// Check if the readiness conditions have been met
-			conditions := pod.Status.Conditions
-			if len(conditions) == 0 {
-				return false, fmt.Errorf("Failed checking MySQL readiness gates, no status conditions found for pod %s/%s", pod.Namespace, pod.Name)
-			}
-			readyCount := 0
-			for _, condition := range conditions {
-				for _, gate := range pod.Spec.ReadinessGates {
-					if condition.Type == gate.ConditionType && condition.Status == v1.ConditionTrue {
-						readyCount++
-						continue
-					}
-				}
-			}
-
-			// All readiness gates must be true
-			if len(pod.Spec.ReadinessGates) != readyCount {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
-}
-
-// getMySQLOperatorPod - return the mysql-operator pod
-func getMySQLOperatorPod(log vzlog.VerrazzanoLogger, client clipkg.Client) (*v1.Pod, error) {
-	operSelector := metav1.LabelSelectorRequirement{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{mysqloperator.ComponentName}}
-	operPodList := k8sready.GetPodsList(log, client, types.NamespacedName{Namespace: mysqloperator.ComponentNamespace}, &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{operSelector}})
-	if operPodList == nil || len(operPodList.Items) != 1 {
-		return nil, fmt.Errorf("no pods found matching selector %s", operSelector.String())
-	}
-	return &operPodList.Items[0], nil
 }
 
 // isInnoDBClusterOnline returns true if the InnoDBCluster resource cluster status is online

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
@@ -1937,82 +1935,4 @@ func TestDumpDatabaseWithExecErrors(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, strings.Contains(err.Error(), weakPass))
 	assert.True(t, strings.Contains(err.Error(), "-p******"))
-}
-
-// TestRepairMySQLPodsWaitingReadinessGates tests the temporary workaround for MySQL
-// pods getting stuck during install waiting for all readiness gates to be true.
-// GIVEN a MySQL Pod with readiness gates defined
-// WHEN they are not all ready after a given time period
-// THEN recycle the mysql-operator
-func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
-	mySQLOperatorPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mysqloperator.ComponentName,
-			Namespace: mysqloperator.ComponentNamespace,
-			Labels: map[string]string{
-				"name": mysqloperator.ComponentName,
-			},
-		},
-	}
-
-	mySQLPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mysql-0",
-			Namespace: ComponentNamespace,
-			Labels: map[string]string{
-				mySQLComponentLabel: mySQLDComponentName,
-			},
-		},
-		Spec: v1.PodSpec{
-			ReadinessGates: []v1.PodReadinessGate{{ConditionType: "gate1"}, {ConditionType: "gate2"}},
-		},
-		Status: v1.PodStatus{
-			Conditions: []v1.PodCondition{
-				{Type: "gate1", Status: v1.ConditionTrue},
-				{Type: "gate2", Status: v1.ConditionTrue},
-			},
-		},
-	}
-
-	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
-	mysqlComp := NewComponent().(mysqlComponent)
-	mysqlComp.LastTimeReadinessGateRepairStarted = &time.Time{}
-	fakeCtx := spi.NewFakeContext(cli, nil, nil, false)
-
-	// First time calling, expect timer to get initialized
-	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
-	err := mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
-	assert.NoError(t, err)
-	assert.False(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
-
-	// Second time calling, expect no error and mysql-operator pod to still exist
-	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
-	assert.NoError(t, err)
-
-	pod := v1.Pod{}
-	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
-	assert.NoError(t, err)
-
-	// Third time calling, set the timer to exceed the expiration time which will force a check of the readiness gates.
-	// The readiness gates will be set to true going into the call, so the mysql-operator should not get recycled.
-	*mysqlComp.LastTimeReadinessGateRepairStarted = time.Now().Add(-time.Hour * 2)
-	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
-	assert.NoError(t, err)
-
-	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
-	assert.NoError(t, err)
-
-	// Fourth time calling, set one of the readiness gates to false.  This should force deletion of the mysql-operator pod.
-	// The timer should also get reset.
-	mySQLPod.Status.Conditions = []v1.PodCondition{{Type: "gate1", Status: v1.ConditionTrue}, {Type: "gate2", Status: v1.ConditionFalse}}
-	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
-	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	*mysqlComp.LastTimeReadinessGateRepairStarted = time.Now().Add(-time.Hour * 2)
-	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
-	assert.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
-	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
-
-	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
-	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err))
 }

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_workarounds.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_workarounds.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8sready "github.com/verrazzano/verrazzano/pkg/k8s/ready"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// repairMySQLPodsWaitingReadinessGates - temporary workaround to repair issue were a MySQL pod
+// can be stuck waiting for its readiness gates to be met.
+func (c mysqlComponent) repairMySQLPodsWaitingReadinessGates(ctx spi.ComponentContext) error {
+	podsWaiting, err := c.mySQLPodsWaitingForReadinessGates(ctx)
+	if err != nil {
+		return err
+	}
+	if podsWaiting {
+		// Restart the mysql-operator to see if it will finish setting the readiness gates
+		ctx.Log().Info("Restarting the mysql-operator to see if it will repair MySQL pods stuck waiting for readiness gates")
+
+		operPod, err := getMySQLOperatorPod(ctx.Log(), ctx.Client())
+		if err != nil {
+			return fmt.Errorf("Failed restarting the mysql-operator to repair stuck MySQL pods: %v", err)
+		}
+
+		if err = ctx.Client().Delete(context.TODO(), operPod, &clipkg.DeleteOptions{}); err != nil {
+			return err
+		}
+
+		// Clear the timer
+		*c.LastTimeReadinessGateRepairStarted = time.Time{}
+	}
+	return nil
+}
+
+// mySQLPodsWaitingForReadinessGates - detect if there are MySQL pods stuck waiting for
+// their readiness gates to be true.
+func (c mysqlComponent) mySQLPodsWaitingForReadinessGates(ctx spi.ComponentContext) (bool, error) {
+	if c.LastTimeReadinessGateRepairStarted.IsZero() {
+		*c.LastTimeReadinessGateRepairStarted = time.Now()
+		return false, nil
+	}
+
+	// Initiate repair only if time to wait period has been exceeded
+	expiredTime := c.LastTimeReadinessGateRepairStarted.Add(5 * time.Minute)
+	if time.Now().After(expiredTime) {
+		// Check if the current not ready state is due to readiness gates not met
+		ctx.Log().Debug("Checking if MySQL not ready due to pods waiting for readiness gates")
+
+		selector := metav1.LabelSelectorRequirement{Key: mySQLComponentLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{mySQLDComponentName}}
+		podList := k8sready.GetPodsList(ctx.Log(), ctx.Client(), types.NamespacedName{Namespace: ComponentNamespace}, &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{selector}})
+		if podList == nil || len(podList.Items) == 0 {
+			return false, fmt.Errorf("Failed checking MySQL readiness gates, no pods found matching selector %s", selector.String())
+		}
+
+		for i := range podList.Items {
+			pod := podList.Items[i]
+			// Check if the readiness conditions have been met
+			conditions := pod.Status.Conditions
+			if len(conditions) == 0 {
+				return false, fmt.Errorf("Failed checking MySQL readiness gates, no status conditions found for pod %s/%s", pod.Namespace, pod.Name)
+			}
+			readyCount := 0
+			for _, condition := range conditions {
+				for _, gate := range pod.Spec.ReadinessGates {
+					if condition.Type == gate.ConditionType && condition.Status == v1.ConditionTrue {
+						readyCount++
+						continue
+					}
+				}
+			}
+
+			// All readiness gates must be true
+			if len(pod.Spec.ReadinessGates) != readyCount {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// getMySQLOperatorPod - return the mysql-operator pod
+func getMySQLOperatorPod(log vzlog.VerrazzanoLogger, client clipkg.Client) (*v1.Pod, error) {
+	operSelector := metav1.LabelSelectorRequirement{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{mysqloperator.ComponentName}}
+	operPodList := k8sready.GetPodsList(log, client, types.NamespacedName{Namespace: mysqloperator.ComponentNamespace}, &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{operSelector}})
+	if operPodList == nil || len(operPodList.Items) != 1 {
+		return nil, fmt.Errorf("no pods found matching selector %s", operSelector.String())
+	}
+	return &operPodList.Items[0], nil
+}

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_workarounds_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_workarounds_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestRepairMySQLPodsWaitingReadinessGates tests the temporary workaround for MySQL
+// pods getting stuck during install waiting for all readiness gates to be true.
+// GIVEN a MySQL Pod with readiness gates defined
+// WHEN they are not all ready after a given time period
+// THEN recycle the mysql-operator
+func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
+	mySQLOperatorPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mysqloperator.ComponentName,
+			Namespace: mysqloperator.ComponentNamespace,
+			Labels: map[string]string{
+				"name": mysqloperator.ComponentName,
+			},
+		},
+	}
+
+	mySQLPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysql-0",
+			Namespace: ComponentNamespace,
+			Labels: map[string]string{
+				mySQLComponentLabel: mySQLDComponentName,
+			},
+		},
+		Spec: v1.PodSpec{
+			ReadinessGates: []v1.PodReadinessGate{{ConditionType: "gate1"}, {ConditionType: "gate2"}},
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{Type: "gate1", Status: v1.ConditionTrue},
+				{Type: "gate2", Status: v1.ConditionTrue},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
+	mysqlComp := NewComponent().(mysqlComponent)
+	mysqlComp.LastTimeReadinessGateRepairStarted = &time.Time{}
+	fakeCtx := spi.NewFakeContext(cli, nil, nil, false)
+
+	// First time calling, expect timer to get initialized
+	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
+	err := mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
+	assert.NoError(t, err)
+	assert.False(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
+
+	// Second time calling, expect no error and mysql-operator pod to still exist
+	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
+	assert.NoError(t, err)
+
+	pod := v1.Pod{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
+	assert.NoError(t, err)
+
+	// Third time calling, set the timer to exceed the expiration time which will force a check of the readiness gates.
+	// The readiness gates will be set to true going into the call, so the mysql-operator should not get recycled.
+	*mysqlComp.LastTimeReadinessGateRepairStarted = time.Now().Add(-time.Hour * 2)
+	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
+	assert.NoError(t, err)
+
+	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
+	assert.NoError(t, err)
+
+	// Fourth time calling, set one of the readiness gates to false.  This should force deletion of the mysql-operator pod.
+	// The timer should also get reset.
+	mySQLPod.Status.Conditions = []v1.PodCondition{{Type: "gate1", Status: v1.ConditionTrue}, {Type: "gate2", Status: v1.ConditionFalse}}
+	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
+	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
+	*mysqlComp.LastTimeReadinessGateRepairStarted = time.Now().Add(-time.Hour * 2)
+	err = mysqlComp.repairMySQLPodsWaitingReadinessGates(fakeCtx)
+	assert.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
+	assert.True(t, mysqlComp.LastTimeReadinessGateRepairStarted.IsZero())
+
+	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}


### PR DESCRIPTION
Separate out MySQL workaround code and tests, in preparation for additional workaround logic.