### PR TITLE
Fix preupgrade unit tests

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
@@ -485,6 +485,11 @@ func TestPreInstall(t *testing.T) {
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	tests := []struct {
 		name       string
 		client     clipkg.Client

--- a/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/fluentd_component_test.go
@@ -441,6 +441,11 @@ func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string,
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned. Otherwise, return error.
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../helm_config"

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_component_test.go
@@ -4,6 +4,7 @@ package kiali
 
 import (
 	"context"
+	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"testing"
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
@@ -327,6 +328,11 @@ func TestKialiPostUpgradeUpdateResources(t *testing.T) {
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../thirdparty"

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component_test.go
@@ -6,6 +6,7 @@ package mysqloperator
 import (
 	"context"
 	"fmt"
+	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"testing"
 
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
@@ -243,6 +244,11 @@ func TestPreInstall(t *testing.T) {
 // GIVEN a call to PreUpgrade
 // THEN return the expected error
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	fakeClient := fake.NewClientBuilder().Build()
 	erroringClient := &erroringFakeClient{fakeClient}
 

--- a/platform-operator/controllers/verrazzano/component/oam/oam_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam_component_test.go
@@ -5,6 +5,7 @@ package oam
 
 import (
 	"context"
+	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"testing"
 
@@ -139,6 +140,11 @@ func TestValidateUpdateV1Beta1(t *testing.T) {
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../thirdparty"

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -4,6 +4,7 @@
 package operator
 
 import (
+	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"testing"
 
@@ -311,6 +312,11 @@ func TestPreInstallcomponent(t *testing.T) {
 
 // test PreUpgrade for component class
 func TestPreUpgradecomponent(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	c := fake.NewClientBuilder().Build()
 	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, true)
 	assert.Nil(t, NewComponent().PreUpgrade(ctx))

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -211,6 +211,11 @@ func TestPreInstall(t *testing.T) {
 
 // TestPreUpgrade tests the PreUpgrade func call
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	asserts := assert.New(t)
 	three := int32(3)
 	// create a fake dynamic client to serve the Setting and ClusterRepo resources

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component_test.go
@@ -64,6 +64,11 @@ func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string,
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned
 func TestPreUpgrade(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
+	defer helmcli.SetDefaultChartStateFunction()
+
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../helm_config"

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo_component_test.go
@@ -194,6 +194,11 @@ func TestPostUpgrade(t *testing.T) {
 //	WHEN I call PreUpgrade with defaults
 //	THEN no error is returned
 func TestPreUpgrade(t *testing.T) {
+	helm.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helm.ChartStatusDeployed, nil
+	})
+	defer helm.SetDefaultChartStateFunction()
+
 	// The actual pre-upgrade testing is performed by the underlying unit tests, this just adds coverage
 	// for the Component interface hook
 	config.TestHelmConfigDir = "../../../../helm_config"


### PR DESCRIPTION
A recent change breaks a number of the component `PreUpgrade` unit tests, this is to stub out the Helm command calls that are making them fail when invoked from the prompt.