### PR TITLE
VZ-7478 Add prerequisite validator webhook (#4698)

### DIFF
--- a/pkg/k8s/node/node.go
+++ b/pkg/k8s/node/node.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package node
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetK8sNodeList returns a list of Kubernetes nodes
+func GetK8sNodeList(k8sClient client.Client) (*v1.NodeList, error) {
+	nodeList := &v1.NodeList{}
+	err := k8sClient.List(
+		context.TODO(),
+		nodeList,
+		&client.ListOptions{},
+	)
+	return nodeList, err
+}

--- a/pkg/k8s/node/node_test.go
+++ b/pkg/k8s/node/node_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package node
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+// TestGetK8sNodeList tests getting a list of Kubernetes nodes
+func TestGetK8sNodeList(t *testing.T) {
+	asserts := assert.New(t)
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+		&v1.Node{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+			},
+		}, &v1.Node{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+			},
+		}).Build()
+	nodeList, err := GetK8sNodeList(client)
+	asserts.NoError(err)
+	asserts.Equal(2, len(nodeList.Items))
+	asserts.Equal("node1", nodeList.Items[0].Name)
+	asserts.Equal("node2", nodeList.Items[1].Name)
+}

--- a/pkg/vzchecks/precheck.go
+++ b/pkg/vzchecks/precheck.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzchecks
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8s/node"
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+)
+
+// PrerequisiteCheck checks the prerequisites before applying the Verrazzano CR
+func PrerequisiteCheck(client clipkg.Client, profile ProfileType) []error {
+	return preCheck(client, profile)
+}
+
+func preCheck(client clipkg.Client, profile ProfileType) []error {
+	var errs []error
+	vzReq := getVZRequirement(profile)
+	if vzReq == (VZRequirement{}) {
+		return errs
+	}
+	nodeList, err := node.GetK8sNodeList(client)
+	if err != nil {
+		return []error{err}
+	}
+	if len(nodeList.Items) < vzReq.nodeCount {
+		errs = append(errs, fmt.Errorf(nodeCountReqMsg, vzReq.nodeCount, len(nodeList.Items)))
+	}
+
+	for _, node := range nodeList.Items {
+		var cpuAllocatable = node.Status.Allocatable[k8score.ResourceCPU]
+		var memoryAllocatable = node.Status.Allocatable[k8score.ResourceMemory]
+		var storageAllocatable = node.Status.Allocatable[k8score.ResourceEphemeralStorage]
+		if cpuAllocatable.MilliValue() < vzReq.cpu.allocatable.MilliValue() {
+			errs = append(errs, fmt.Errorf(cpuReqMsg, vzReq.cpu.allocatable.Value(),
+				node.Name, cpuAllocatable.Value()))
+		}
+		if memoryAllocatable.MilliValue() < vzReq.memory.allocatable.MilliValue() {
+			errs = append(errs, fmt.Errorf(memoryReqMsg, convertQuantityToString(vzReq.memory.allocatable),
+				node.Name, convertQuantityToString(memoryAllocatable)))
+		}
+		if storageAllocatable.MilliValue() < vzReq.ephemeralStorage.allocatable.MilliValue() {
+			errs = append(errs, fmt.Errorf(storageReqMsg, convertQuantityToString(vzReq.ephemeralStorage.allocatable),
+				node.Name, convertQuantityToString(storageAllocatable)))
+		}
+	}
+	return errs
+}
+
+// convertQuantityToString converts the given quantity value to a Gigabyte value
+func convertQuantityToString(quantity resource.Quantity) string {
+	gigabyteFormat := resource.MustParse("1G")
+	m := float64(quantity.Value()) / float64(gigabyteFormat.Value())
+	return strconv.FormatFloat(m, 'g', -1, 64)
+}

--- a/pkg/vzchecks/precheck_test.go
+++ b/pkg/vzchecks/precheck_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzchecks
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	client2 "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+var (
+	allNotMet              = []string{nodeCountReqMsg, cpuReqMsg, memoryReqMsg, storageReqMsg}
+	onlyStorageMet         = []string{nodeCountReqMsg, cpuReqMsg, memoryReqMsg}
+	onlyMemoryMet          = []string{nodeCountReqMsg, cpuReqMsg, storageReqMsg}
+	onlyCPUMet             = []string{nodeCountReqMsg, memoryReqMsg, storageReqMsg}
+	onlyNodeCountMet       = []string{cpuReqMsg, memoryReqMsg, storageReqMsg}
+	storageAndMemoryMet    = []string{nodeCountReqMsg, cpuReqMsg}
+	storageAndCPUMet       = []string{nodeCountReqMsg, memoryReqMsg}
+	storageAndNodeCountMet = []string{memoryReqMsg, cpuReqMsg}
+	memoryAndCPUMet        = []string{nodeCountReqMsg, storageReqMsg}
+	memoryAndNodeCountMet  = []string{cpuReqMsg, storageReqMsg}
+	nodeCountAndCPUMet     = []string{memoryReqMsg, storageReqMsg}
+	memoryNotMet           = []string{memoryReqMsg}
+	nodeNotMet             = []string{nodeCountReqMsg}
+	allMet                 = []string{}
+)
+
+type testData = struct {
+	profile   ProfileType
+	nodeCount int
+	cpu       string
+	memory    string
+	storage   string
+}
+
+// TestPrerequisiteCheck tests prerequisite checks for various profiles
+func TestPrerequisiteCheck(t *testing.T) {
+	var tests = []struct {
+		data     testData
+		errCount int
+		errTypes []string
+	}{
+		{testData{Prod, 2, "1", "423Ki", "50G"}, 7, allNotMet},
+		{testData{Prod, 3, "1", "12G", "50G"}, 9, onlyNodeCountMet},
+		{testData{Prod, 2, "1", "12G", "100G"}, 5, onlyStorageMet},
+		{testData{Prod, 2, "4", "12G", "50G"}, 5, onlyCPUMet},
+		{testData{Prod, 2, "1", "32G", "50G"}, 5, onlyMemoryMet},
+		{testData{Prod, 1, "6", "35G", "50G"}, 2, memoryAndCPUMet},
+		{testData{Prod, 2, "5", "12G", "100G"}, 3, storageAndCPUMet},
+		{testData{Prod, 2, "3", "32G", "100G"}, 3, storageAndMemoryMet},
+		{testData{Prod, 5, "6", "32G", "500G"}, 0, allMet},
+		{testData{Dev, 0, "1", "10G", "50G"}, 1, allNotMet},
+		{testData{Dev, 1, "1", "12G", "50G"}, 3, onlyNodeCountMet},
+		{testData{ManagedCluster, 2, "1", "12G", "100G"}, 4, storageAndNodeCountMet},
+		{testData{ManagedCluster, 2, "4", "12G", "50G"}, 4, nodeCountAndCPUMet},
+		{testData{Dev, 2, "2", "2G", "50G"}, 4, nodeCountAndCPUMet},
+		{testData{Dev, 1, "1", "5G", "100G"}, 2, storageAndNodeCountMet},
+		{testData{ManagedCluster, 2, "5", "12G", "100G"}, 2, memoryNotMet},
+		{testData{Dev, 1, "1", "32G", "10G"}, 2, memoryAndNodeCountMet},
+		{testData{Dev, 0, "", "", ""}, 1, nodeNotMet},
+		{testData{"unspecified", 1, "2", "24G", "50G"}, 0, allMet},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.data.profile), func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+				getNodes(tt.data)...).Build()
+			errs := PrerequisiteCheck(client, tt.data.profile)
+			assert.Equal(t, tt.errCount, len(errs))
+			vzReq := getVZRequirement(tt.data.profile)
+			for _, errMsg := range tt.errTypes {
+				for i := 1; i <= tt.data.nodeCount; i++ {
+					nodeName := fmt.Sprintf("node%d", i)
+					expectedMsg := getExpectedMessage(errMsg, nodeName, vzReq, tt.data)
+					assert.Equal(t, true, errorSliceContainsMessage(errs, expectedMsg),
+						"Expected error message \"%s\" not found", expectedMsg)
+				}
+			}
+		})
+	}
+}
+
+// errorSliceContainsMessage checks for a error message in a slice of errors
+// errs is the error slice to search. May be nil.
+// msg is the string to search for in the errs.
+// Returns true if the string is found in the slice and false otherwise.
+func errorSliceContainsMessage(errs []error, msg string) bool {
+	for _, err := range errs {
+		if err.Error() == msg {
+			return true
+		}
+	}
+	return false
+}
+
+func getNodes(data testData) []client2.Object {
+	var nodes []client2.Object
+	for i := 1; i <= data.nodeCount; i++ {
+		nodes = append(nodes, &v1.Node{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node%d", i),
+			},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					"cpu":               resource.MustParse(data.cpu),
+					"memory":            resource.MustParse(data.memory),
+					"ephemeral-storage": resource.MustParse(data.storage),
+				},
+			},
+		})
+	}
+	return nodes
+}
+
+func getExpectedMessage(errMsg string, nodeName string, vzReq VZRequirement, data testData) string {
+	expectedMsg := ""
+	switch errMsg {
+	case nodeCountReqMsg:
+		expectedMsg = fmt.Sprintf(errMsg, vzReq.nodeCount, data.nodeCount)
+	case cpuReqMsg:
+		expectedMsg = fmt.Sprintf(errMsg, vzReq.cpu.allocatable.Value(),
+			nodeName, data.cpu)
+	case memoryReqMsg:
+		expectedMsg = fmt.Sprintf(errMsg, convertQuantityToString(vzReq.memory.allocatable),
+			nodeName, convertQuantityToString(resource.MustParse(data.memory)))
+	case storageReqMsg:
+		expectedMsg = fmt.Sprintf(errMsg, convertQuantityToString(vzReq.ephemeralStorage.allocatable),
+			nodeName, convertQuantityToString(resource.MustParse(data.storage)))
+	}
+	return expectedMsg
+}

--- a/pkg/vzchecks/requirement.go
+++ b/pkg/vzchecks/requirement.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzchecks
+
+import (
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ProfileType is the type of installation profile.
+type ProfileType string
+
+type ResourceType string
+
+type VZRequirement struct {
+	nodeCount        int
+	cpu              *resourceInfo
+	memory           *resourceInfo
+	ephemeralStorage *resourceInfo
+}
+
+type resourceInfo struct {
+	resourceType ResourceType
+	allocatable  resource.Quantity
+}
+
+const (
+	// Dev identifies the development install profile
+	Dev ProfileType = "dev"
+	// Prod identifies the production install profile
+	Prod ProfileType = "prod"
+	// ManagedCluster identifies the production managed-cluster install profile
+	ManagedCluster ProfileType = "managed-cluster"
+)
+
+const (
+	CPU              = ResourceType(k8score.ResourceCPU)
+	Memory           = ResourceType(k8score.ResourceMemory)
+	EphemeralStorage = ResourceType(k8score.ResourceEphemeralStorage)
+)
+
+const (
+	nodeCountReqMsg = "minimum required number of worker nodes is %d but the available number of worker nodes is %d"
+	cpuReqMsg       = "minimum required CPUs is %v but the CPUs on node %s is %v"
+	memoryReqMsg    = "minimum required memory is %sG but the memory on node %s is %sG"
+	storageReqMsg   = "minimum required ephemeral storage is %sG but the ephemeral storage on node %s is %sG"
+)
+
+var (
+	DevReq = VZRequirement{
+		nodeCount:        1,
+		cpu:              &resourceInfo{resourceType: CPU, allocatable: resource.MustParse("2")},
+		memory:           &resourceInfo{resourceType: Memory, allocatable: resource.MustParse("16G")},
+		ephemeralStorage: &resourceInfo{resourceType: EphemeralStorage, allocatable: resource.MustParse("100G")},
+	}
+	ProdReq = VZRequirement{
+		nodeCount:        3,
+		cpu:              &resourceInfo{resourceType: CPU, allocatable: resource.MustParse("4")},
+		memory:           &resourceInfo{resourceType: Memory, allocatable: resource.MustParse("32G")},
+		ephemeralStorage: &resourceInfo{resourceType: EphemeralStorage, allocatable: resource.MustParse("100G")},
+	}
+	ManagedReq = VZRequirement{
+		nodeCount:        1,
+		cpu:              &resourceInfo{resourceType: CPU, allocatable: resource.MustParse("4")},
+		memory:           &resourceInfo{resourceType: Memory, allocatable: resource.MustParse("32G")},
+		ephemeralStorage: &resourceInfo{resourceType: EphemeralStorage, allocatable: resource.MustParse("100G")},
+	}
+	profileMap = map[ProfileType]VZRequirement{
+		Dev:            DevReq,
+		Prod:           ProdReq,
+		ManagedCluster: ManagedReq,
+	}
+)
+
+// getVZRequirement gets the VZRequirement based on the profile passed
+func getVZRequirement(requestedProfile ProfileType) VZRequirement {
+	if len(requestedProfile) == 0 {
+		// Default profile is Prod
+		requestedProfile = Prod
+	}
+	if val, ok := profileMap[requestedProfile]; ok {
+		return val
+	}
+	return VZRequirement{}
+}

--- a/pkg/vzchecks/requirement_test.go
+++ b/pkg/vzchecks/requirement_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vzchecks
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestGetVZRequirement tests getting Verrazzano requirement for various profiles
+func TestGetVZRequirement(t *testing.T) {
+	var tests = []struct {
+		profile   ProfileType
+		nodeCount int
+		cpu       string
+		memory    string
+		storage   string
+	}{
+		{Dev, 1, "2", "16G", "100G"},
+		{Prod, 3, "4", "32G", "100G"},
+		{ManagedCluster, 1, "4", "32G", "100G"},
+		{"", 3, "4", "32G", "100G"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.profile), func(t *testing.T) {
+			vzReq := getVZRequirement(tt.profile)
+			assert.Equal(t, tt.nodeCount, vzReq.nodeCount)
+			assert.Equal(t, tt.cpu, vzReq.cpu.allocatable.String())
+			assert.Equal(t, tt.memory, vzReq.memory.allocatable.String())
+			assert.Equal(t, tt.storage, vzReq.ephemeralStorage.allocatable.String())
+		})
+	}
+}
+
+// TestUnspecifiedProfileRequirement tests getting Verrazzano requirement for unspecified profile
+func TestUnspecifiedProfileRequirement(t *testing.T) {
+	vzReq := getVZRequirement("unspecified")
+	assert.Equal(t, vzReq, VZRequirement{})
+}

--- a/platform-operator/apis/verrazzano/webhooks/common.go
+++ b/platform-operator/apis/verrazzano/webhooks/common.go
@@ -13,6 +13,9 @@ const (
 	MysqlInstallValuesWebhook      = "verrazzano-platform-mysqlinstalloverrides"
 	MysqlInstallValuesV1beta1path  = "/v1beta1-validate-mysql-install-override-values"
 	MysqlInstallValuesV1alpha1path = "/v1alpha1-validate-mysql-install-override-values"
+	RequirementsWebhook            = "verrazzano-platform-requirements-validator"
+	RequirementsV1beta1Path        = "/v1beta1-validate-requirements"
+	RequirementsV1alpha1Path       = "/v1alpha1-validate-requirements"
 )
 
 // isMinVersion indicates whether the provide version is greater than the min version provided

--- a/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1alpha1.go
+++ b/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1alpha1.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	vzlog "github.com/verrazzano/verrazzano/pkg/log"
+	"github.com/verrazzano/verrazzano/pkg/vzchecks"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"go.uber.org/zap"
+	k8sadmission "k8s.io/api/admission/v1"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// RequirementsValidatorV1alpha1 is a struct holding objects used during validation.
+type RequirementsValidatorV1alpha1 struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// InjectClient injects the client.
+func (v *RequirementsValidatorV1alpha1) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// InjectDecoder injects the decoder.
+func (v *RequirementsValidatorV1alpha1) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// Handle performs validation of the Verrazzano prerequisites based on the profiled used.
+func (v *RequirementsValidatorV1alpha1) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var log = zap.S().With(vzlog.FieldResourceNamespace, req.Namespace, vzlog.FieldResourceName, req.Name, vzlog.FieldWebhook, RequirementsWebhook)
+
+	log.Infof("Processing requirements validator webhook")
+	vz := &v1alpha1.Verrazzano{}
+	err := v.decoder.Decode(req, vz)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if vz.ObjectMeta.DeletionTimestamp.IsZero() {
+		switch req.Operation {
+		case k8sadmission.Create, k8sadmission.Update:
+			return validateRequirementsV1alpha1(log, v.client, vz)
+		}
+	}
+	return admission.Allowed("")
+}
+
+// validateRequirementsV1alpha1 presents the user with a warning if the prerequisite checks are not met.
+func validateRequirementsV1alpha1(log *zap.SugaredLogger, client client.Client, vz *v1alpha1.Verrazzano) admission.Response {
+	response := admission.Allowed("")
+	if errs := vzchecks.PrerequisiteCheck(client, vzchecks.ProfileType(vz.Spec.Profile)); len(errs) > 0 {
+		var warnings []string
+		for _, err := range errs {
+			log.Warnf(err.Error())
+			warnings = append(warnings, err.Error())
+		}
+		return admission.Allowed("").WithWarnings(warnings...)
+	}
+	return response
+}

--- a/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1alpha1_test.go
+++ b/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1alpha1_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+)
+
+// newRequirementsValidatorV1alpha1 creates a new MultiClusterConfigmapValidator
+func newRequirementsValidatorV1alpha1(objects []client.Object) RequirementsValidatorV1alpha1 {
+	scheme := newV1alpha1Scheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	decoder, _ := admission.NewDecoder(scheme)
+	v := RequirementsValidatorV1alpha1{client: client, decoder: decoder}
+	return v
+}
+
+// TestPrerequisiteValidationWarningForV1alpha1 tests presenting a user warning
+// GIVEN a call to validate a Verrazzano resource
+// WHEN the nodes do not meet the prerequisites
+// THEN the admission request should be allowed but with a warning.
+func TestPrerequisiteValidationWarningForV1alpha1(t *testing.T) {
+	asrt := assert.New(t)
+	var nodes []client.Object
+	nodes = append(nodes, node("node1", "1", "32G", "40G"))
+	m := newRequirementsValidatorV1alpha1(nodes)
+	vz := &v1alpha1.Verrazzano{Spec: v1alpha1.VerrazzanoSpec{Profile: v1alpha1.Dev}}
+	req := newAdmissionRequest(admissionv1.Update, vz, vz)
+	res := m.Handle(context.TODO(), req)
+	asrt.True(res.Allowed, allowedFailureMessage)
+	asrt.Len(res.Warnings, 2, expectedWarningFailureMessage)
+	asrt.Contains(res.Warnings[0], "minimum required CPUs is 2 but the CPUs on node node1 is 1")
+	asrt.Contains(res.Warnings[1], "minimum required ephemeral storage is 100G but the ephemeral storage on node node1 is 40G")
+}
+
+// TestPrerequisiteValidationNoWarningForV1alpha1 tests presenting a user with no warning
+// GIVEN a call to validate a Verrazzano resource
+// WHEN the nodes meet the prerequisites
+// THEN the admission request should be allowed without a warning.
+func TestPrerequisiteValidationNoWarningForV1alpha1(t *testing.T) {
+	asrt := assert.New(t)
+	var nodes []client.Object
+	nodes = append(nodes, node("node1", "4", "32G", "140G"), node("node2", "5", "32G", "140G"), node("node3", "6", "32G", "140G"))
+	m := newRequirementsValidatorV1alpha1(nodes)
+	vz := &v1alpha1.Verrazzano{Spec: v1alpha1.VerrazzanoSpec{Profile: v1alpha1.Prod}}
+	req := newAdmissionRequest(admissionv1.Update, vz, vz)
+	res := m.Handle(context.TODO(), req)
+	asrt.True(res.Allowed, allowedFailureMessage)
+	asrt.Len(res.Warnings, 0, noWarningsFailureMessage)
+}
+
+func node(name string, cpu string, memory string, ephemeralStorage string) *v1.Node {
+	return &v1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				"cpu":               resource.MustParse(cpu),
+				"memory":            resource.MustParse(memory),
+				"ephemeral-storage": resource.MustParse(ephemeralStorage),
+			},
+		},
+	}
+}

--- a/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1beta1.go
+++ b/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1beta1.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	vzlog "github.com/verrazzano/verrazzano/pkg/log"
+	"github.com/verrazzano/verrazzano/pkg/vzchecks"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"go.uber.org/zap"
+	k8sadmission "k8s.io/api/admission/v1"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// RequirementsValidatorV1beta1 is a struct holding objects used during validation.
+type RequirementsValidatorV1beta1 struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// InjectClient injects the client.
+func (v *RequirementsValidatorV1beta1) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// InjectDecoder injects the decoder.
+func (v *RequirementsValidatorV1beta1) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// Handle performs validation of the Verrazzano prerequisites based on the profiled used.
+func (v *RequirementsValidatorV1beta1) Handle(ctx context.Context, req admission.Request) admission.Response {
+	var log = zap.S().With(vzlog.FieldResourceNamespace, req.Namespace, vzlog.FieldResourceName, req.Name, vzlog.FieldWebhook, RequirementsWebhook)
+
+	log.Infof("Processing Requirements validator webhook")
+	vz := &v1beta1.Verrazzano{}
+	err := v.decoder.Decode(req, vz)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if vz.ObjectMeta.DeletionTimestamp.IsZero() {
+		switch req.Operation {
+		case k8sadmission.Create, k8sadmission.Update:
+			return validateRequirementsV1beta1(log, v.client, vz)
+		}
+	}
+	return admission.Allowed("")
+}
+
+// validateRequirementsV1alpha1 presents the user with a warning if the prerequisite checks are not met.
+func validateRequirementsV1beta1(log *zap.SugaredLogger, client client.Client, vz *v1beta1.Verrazzano) admission.Response {
+	response := admission.Allowed("")
+	if errs := vzchecks.PrerequisiteCheck(client, vzchecks.ProfileType(vz.Spec.Profile)); len(errs) > 0 {
+		var warnings []string
+		for _, err := range errs {
+			log.Warnf(err.Error())
+			warnings = append(warnings, err.Error())
+		}
+		return admission.Allowed("").WithWarnings(warnings...)
+	}
+
+	return response
+}

--- a/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1beta1_test.go
+++ b/platform-operator/apis/verrazzano/webhooks/requirements_webhook_v1beta1_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhooks
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+)
+
+// newRequirementsValidatorV1beta1 creates a new RequirementsValidatorV1beta1
+func newRequirementsValidatorV1beta1(objects []client.Object) RequirementsValidatorV1beta1 {
+	scheme := newScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	decoder, _ := admission.NewDecoder(scheme)
+	v := RequirementsValidatorV1beta1{client: c, decoder: decoder}
+	return v
+}
+
+// TestPrerequisiteValidationWarningForV1beta1 tests presenting a user warning
+// GIVEN a call to validate a Verrazzano resource
+// WHEN the nodes do not meet the prerequisites
+// THEN the admission request should be allowed but with a warning.
+func TestPrerequisiteValidationWarningForV1beta1(t *testing.T) {
+	asrt := assert.New(t)
+	var nodes []client.Object
+	nodes = append(nodes, node("node1", "3", "16G", "400G"))
+	m := newRequirementsValidatorV1beta1(nodes)
+	vz := &v1beta1.Verrazzano{Spec: v1beta1.VerrazzanoSpec{Profile: v1beta1.Prod}}
+	req := newAdmissionRequest(admissionv1.Update, vz, vz)
+	res := m.Handle(context.TODO(), req)
+	asrt.True(res.Allowed, allowedFailureMessage)
+	asrt.Len(res.Warnings, 3, expectedWarningFailureMessage)
+	asrt.Contains(res.Warnings[0], "minimum required number of worker nodes is 3 but the available number of worker nodes is 1")
+	asrt.Contains(res.Warnings[1], "minimum required CPUs is 4 but the CPUs on node node1 is 3")
+	asrt.Contains(res.Warnings[2], "minimum required memory is 32G but the memory on node node1 is 16G")
+}
+
+// TestPrerequisiteValidationNoWarningForV1beta1 tests presenting a user with no warning
+// GIVEN a call to validate a Verrazzano resource
+// WHEN the nodes meet the prerequisites
+// THEN the admission request should be allowed without a warning.
+func TestPrerequisiteValidationNoWarningForV1beta1(t *testing.T) {
+	asrt := assert.New(t)
+	var nodes []client.Object
+	nodes = append(nodes, node("node1", "3", "16G", "100G"), node("node2", "5", "32G", "140G"))
+	m := newRequirementsValidatorV1beta1(nodes)
+	vz := &v1beta1.Verrazzano{Spec: v1beta1.VerrazzanoSpec{Profile: v1beta1.Dev}}
+	req := newAdmissionRequest(admissionv1.Update, vz, vz)
+	res := m.Handle(context.TODO(), req)
+	asrt.True(res.Allowed, allowedFailureMessage)
+	asrt.Len(res.Warnings, 0, noWarningsFailureMessage)
+}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/validatingwebhookconfiguration.yaml
@@ -118,3 +118,64 @@ webhooks:
     admissionReviewVersions:
       - v1beta1
       - v1
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: verrazzano-platform-requirements-validator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+webhooks:
+  - name: v1beta1-platform-requirements-validator.verrazzano.io.v1beta1
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
+    clientConfig:
+      service:
+        name: {{ .Values.name }}-webhook
+        namespace: {{ .Values.namespace }}
+        path: /v1beta1-validate-requirements
+    rules:
+      - apiGroups:
+          - install.verrazzano.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - verrazzanos
+    sideEffects: None
+    failurePolicy: Fail
+    matchPolicy: Exact
+    timeoutSeconds: 30
+    admissionReviewVersions:
+      - v1beta1
+      - v1
+  - name: v1alpha1-platform-requirements-validator.verrazzano.io.v1alpha1
+    namespaceSelector:
+      matchExpressions:
+        - { key: verrazzano.io/namespace, operator: NotIn, values: [ kube-system ] }
+    clientConfig:
+      service:
+        name: {{ .Values.name }}-webhook
+        namespace: {{ .Values.namespace }}
+        path: /v1alpha1-validate-requirements
+    rules:
+      - apiGroups:
+          - install.verrazzano.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - verrazzanos
+    sideEffects: None
+    failurePolicy: Fail
+    matchPolicy: Exact
+    timeoutSeconds: 30
+    admissionReviewVersions:
+      - v1beta1
+      - v1

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -183,6 +183,11 @@ func cleanupResources(client client.Client, vzHelper helpers.VZHelper) {
 		_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), err.Error()+"\n")
 	}
 
+	err = deleteWebhookConfiguration(client, constants.VerrazzanoRequirementsValidatorWebhook)
+	if err != nil {
+		_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), err.Error()+"\n")
+	}
+
 	err = deleteMutatingWebhookConfiguration(client, constants.MysqlBackupMutatingWebhookName)
 	if err != nil {
 		_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), err.Error()+"\n")

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -68,6 +68,8 @@ const VerrazzanoPlatformOperatorWebhook = "verrazzano-platform-operator-webhook"
 
 const VerrazzanoMysqlInstallValuesWebhook = "verrazzano-platform-mysqlinstalloverrides"
 
+const VerrazzanoRequirementsValidatorWebhook = "verrazzano-platform-requirements-validator"
+
 const VerrazzanoApplicationOperator = "verrazzano-application-operator"
 
 const VerrazzanoMonitoringOperator = "verrazzano-monitoring-operator"


### PR DESCRIPTION
A webhook has been added to check the Verrazzano prerequisites and
present an appropriate warning to the user while applying the
Verrazzano custom resource. 

This PR is same as #4698 with one additional commit to cleanup the newly added webhook.