### PR TITLE
VZ-7765: Wire up cluster label selector in cluster operator

### DIFF
--- a/cluster-operator/controllers/rancher/rancher_cluster_controller.go
+++ b/cluster-operator/controllers/rancher/rancher_cluster_controller.go
@@ -95,13 +95,17 @@ func (r *RancherClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	var l labels.Set = cluster.GetLabels()
-	selector, err := metav1.LabelSelectorAsSelector(r.ClusterSelector)
-	if err != nil {
-		r.Log.Errorf("Error parsing cluster label selector: %v", err)
-		return ctrl.Result{}, err
+	var selector labels.Selector
+
+	if r.ClusterSelector != nil {
+		selector, err = metav1.LabelSelectorAsSelector(r.ClusterSelector)
+		if err != nil {
+			r.Log.Errorf("Error parsing cluster label selector: %v", err)
+			return ctrl.Result{}, err
+		}
 	}
 
-	if selector.Matches(l) {
+	if selector == nil || selector.Matches(l) {
 		// ensure the VMC exists
 		if err = r.ensureVMC(cluster); err != nil {
 			return ctrl.Result{}, err

--- a/cluster-operator/controllers/rancher/rancher_cluster_controller.go
+++ b/cluster-operator/controllers/rancher/rancher_cluster_controller.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,8 +33,10 @@ const (
 
 type RancherClusterReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Log    *zap.SugaredLogger
+	Scheme             *runtime.Scheme
+	ClusterSyncEnabled bool
+	ClusterSelector    *metav1.LabelSelector
+	Log                *zap.SugaredLogger
 }
 
 var gvk = schema.GroupVersionKind{
@@ -86,9 +89,23 @@ func (r *RancherClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	// ensure the VMC exists
-	if err = r.ensureVMC(cluster); err != nil {
+	if !r.ClusterSyncEnabled {
+		r.Log.Debug("Cluster sync is disabled, skipping VMC creation")
+		return ctrl.Result{}, nil
+	}
+
+	var l labels.Set = cluster.GetLabels()
+	selector, err := metav1.LabelSelectorAsSelector(r.ClusterSelector)
+	if err != nil {
+		r.Log.Errorf("Error parsing cluster label selector: %v", err)
 		return ctrl.Result{}, err
+	}
+
+	if selector.Matches(l) {
+		// ensure the VMC exists
+		if err = r.ensureVMC(cluster); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/cluster-operator/controllers/rancher/rancher_cluster_controller_test.go
+++ b/cluster-operator/controllers/rancher/rancher_cluster_controller_test.go
@@ -189,9 +189,10 @@ func newRequest(name string) ctrl.Request {
 
 func newRancherClusterReconciler(c client.Client) RancherClusterReconciler {
 	return RancherClusterReconciler{
-		Client: c,
-		Scheme: newScheme(),
-		Log:    zap.S(),
+		Client:             c,
+		Scheme:             newScheme(),
+		ClusterSyncEnabled: true,
+		Log:                zap.S(),
 	}
 }
 

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Jeffail/gabs/v2"
+	gabs "github.com/Jeffail/gabs/v2"
 	cons "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -103,7 +103,7 @@ func registerManagedClusterWithRancher(rc *RancherConfig, clusterName string, ra
 	var err error
 	if clusterID == "" {
 		log.Oncef("Registering managed cluster in Rancher with name: %s", clusterName)
-		clusterID, err = ImportClusterToRancher(rc, clusterName, log)
+		clusterID, err = ImportClusterToRancher(rc, clusterName, nil, log)
 		if err != nil {
 			log.Errorf("Failed to import cluster to Rancher: %v", err)
 			return "", "", err
@@ -157,14 +157,11 @@ func newRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*RancherCo
 
 // ImportClusterToRancher uses the Rancher API to import the cluster. The cluster will show as "pending" until the registration
 // YAML is applied on the managed cluster.
-func ImportClusterToRancher(rc *RancherConfig, clusterName string, log vzlog.VerrazzanoLogger) (string, error) {
+func ImportClusterToRancher(rc *RancherConfig, clusterName string, labels map[string]string, log vzlog.VerrazzanoLogger) (string, error) {
 	action := http.MethodPost
-	payload := `{"type": "cluster",
-		"name":"` + clusterName + `",
-		"dockerRootDir": "/var/lib/docker",
-		"enableClusterAlerting": "false",
-		"enableClusterMonitoring": "false",
-		"enableNetworkPolicy": "false"}`
+
+	payload := makeClusterPayload(clusterName, labels)
+
 	reqURL := rc.BaseURL + clusterPath
 	headers := map[string]string{"Content-Type": "application/json"}
 	headers["Authorization"] = "Bearer " + rc.APIAccessToken
@@ -193,6 +190,44 @@ func ImportClusterToRancher(rc *RancherConfig, clusterName string, log vzlog.Ver
 	log.Oncef("Successfully registered managed cluster in Rancher with name: %s", clusterName)
 
 	return httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "id", "unable to find cluster id in Rancher response")
+}
+
+// makeClusterPayload returns the payload for Rancher cluster creation, given a cluster name
+// and labels to apply to it
+func makeClusterPayload(clusterName string, labels map[string]string) string {
+	labelsJSONString := makeLabelsJSONString(labels)
+
+	payload := `{"type": "cluster",
+		"name":"` + clusterName + `",
+		"dockerRootDir": "/var/lib/docker",
+		"enableClusterAlerting": "false",
+		"enableClusterMonitoring": "false",
+		"enableNetworkPolicy": "false"`
+
+	if len(labelsJSONString) > 0 {
+		payload = fmt.Sprintf(`%s, "labels": { %s } }`, payload, labelsJSONString)
+	} else {
+		payload = fmt.Sprintf("%s}", payload)
+	}
+	return payload
+}
+
+func makeLabelsJSONString(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+
+	labelsJSONString := ""
+	i := 0
+	for label, val := range labels {
+		commaIfNeeded := ","
+		if i == 0 {
+			commaIfNeeded = ""
+		}
+		i++
+		labelsJSONString = fmt.Sprintf(`%s%s "%s": "%s"`, labelsJSONString, commaIfNeeded, label, val)
+	}
+	return labelsJSONString
 }
 
 // DeleteClusterFromRancher uses the Rancher API to delete a cluster in Rancher.

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -218,7 +218,7 @@ func makeClusterPayload(clusterName string, labels map[string]string) (string, e
 }
 
 func makeLabelsJSONString(labels map[string]string) (string, error) {
-	if labels == nil || len(labels) == 0 {
+	if len(labels) == 0 {
 		return "", nil
 	}
 	labelsJSON, err := json.Marshal(labels)

--- a/cluster-operator/controllers/vmc/rancher_test.go
+++ b/cluster-operator/controllers/vmc/rancher_test.go
@@ -142,8 +142,8 @@ func Test_makeClusterPayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := makeClusterPayload(tt.clusterName, tt.labels)
-			fmt.Printf("%v\n", payload)
+			payload, err := makeClusterPayload(tt.clusterName, tt.labels)
+			asserts.NoError(t, err)
 			payloadParsed, err := gabs.ParseJSON([]byte(payload))
 			asserts.NoError(t, err)
 			asserts.Equal(t, tt.clusterName, payloadParsed.Path("name").Data())

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
 	"github.com/verrazzano/verrazzano/cluster-operator/internal/certificate"
@@ -24,10 +25,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/yaml"
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/cluster-operator/controllers/rancher"
 	// +kubebuilder:scaffold:imports
+)
+
+const (
+	clusterSelectorFilePath = "/var/syncRancherClusters/selector.yaml"
+	syncClustersEnvVarName  = "RANCHER_CLUSTER_SYNC_ENABLED"
 )
 
 var (
@@ -68,6 +75,12 @@ func main() {
 
 	ctrl.SetLogger(kzap.New(kzap.UseFlagOptions(&opts)))
 
+	syncEnabled, clusterSelector, err := shouldSyncRancherClusters(clusterSelectorFilePath)
+	if err != nil {
+		log.Error(err, "error processing cluster sync config")
+		os.Exit(1)
+	}
+
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -79,8 +92,8 @@ func main() {
 
 	// if the user has specified a label selector to filter Rancher clusters, create a custom cache that applies the selector
 	// Note: populate this from the selector provided by the user
-	var clusterSelector *metav1.LabelSelector
 	if clusterSelector != nil {
+		log.Debugf("Applying cluster label selector to controller cache: %+v", *clusterSelector)
 		options.NewCache = func(conf *rest.Config, opts cache.Options) (cache.Cache, error) {
 			if opts.SelectorsByObject == nil {
 				opts.SelectorsByObject = make(cache.SelectorsByObject)
@@ -102,13 +115,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&rancher.RancherClusterReconciler{
-		Client: mgr.GetClient(),
-		Log:    log,
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		log.Errorf("Failed to create IngressTrait controller: %v", err)
-		os.Exit(1)
+	if syncEnabled {
+		if err = (&rancher.RancherClusterReconciler{
+			Client: mgr.GetClient(),
+			Log:    log,
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			log.Errorf("Failed to create Rancher cluster controller: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		log.Info("Rancher cluster sync disabled, cluster reconciler not started")
 	}
 
 	// Set up the reconciler for VerrazzanoManagedCluster objects
@@ -172,4 +189,32 @@ func main() {
 		log.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// shouldSyncRancherClusters returns true if Rancher cluster synchronization is enabled. An optional
+// user-specified label selector can be used to filter the Rancher clusters. If sync is enabled and
+// the label selector is nil, we will sync all Rancher clusters.
+func shouldSyncRancherClusters(clusterSelectorFile string) (bool, *metav1.LabelSelector, error) {
+	enabled := os.Getenv(syncClustersEnvVarName)
+	if enabled == "" || strings.ToLower(enabled) != "true" {
+		return false, nil, nil
+	}
+
+	f, err := os.Stat(clusterSelectorFile)
+	if err != nil || f.Size() == 0 {
+		return true, nil, nil
+	}
+
+	b, err := os.ReadFile(clusterSelectorFile)
+	if err != nil {
+		return true, nil, err
+	}
+
+	selector := &metav1.LabelSelector{}
+	err = yaml.Unmarshal(b, selector)
+	if err != nil {
+		return true, nil, err
+	}
+
+	return true, selector, err
 }

--- a/cluster-operator/main_test.go
+++ b/cluster-operator/main_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestShouldSyncRancherClusters tests the shouldSyncRancherClusters function
+func TestShouldSyncRancherClusters(t *testing.T) {
+	asserts := assert.New(t)
+
+	// when this test is done, reset the cluster sync env var
+	envValue, envValueExists := os.LookupEnv(syncClustersEnvVarName)
+	defer func() {
+		if envValueExists {
+			os.Setenv(syncClustersEnvVarName, envValue)
+		} else {
+			os.Unsetenv(syncClustersEnvVarName)
+		}
+	}()
+
+	var tests = []struct {
+		testName              string
+		enabled               bool
+		clusterSelectorText   string
+		expectedLabelSelector *metav1.LabelSelector
+		expectedError         bool
+	}{
+		// GIVEN cluster sync is disabled
+		// WHEN  shouldSyncRancherClusters is called
+		// THEN  the call returns that cluster sync is disabled, a nil label selector, and no error
+		{
+			"Sync Rancher clusters is disabled",
+			false,
+			"",
+			nil,
+			false,
+		},
+		// GIVEN cluster sync is enabled and no label selector yaml is provided
+		// WHEN  shouldSyncRancherClusters is called
+		// THEN  the call returns that cluster sync is enabled, a nil label selector, and no error
+		{
+			"Sync Rancher clusters is enabled, no label selector specified",
+			true,
+			"",
+			nil,
+			false,
+		},
+		// GIVEN cluster sync is enabled and a label selector yaml is provided
+		// WHEN  shouldSyncRancherClusters is called
+		// THEN  the call returns that cluster sync is enabled, a populated label selector, and no error
+		{
+			"Sync Rancher clusters is enabled, simple label selector specified",
+			true,
+			"matchLabels:\n  foo: bar\n",
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			false,
+		},
+		// GIVEN cluster sync is enabled and a more complex label selector yaml is provided
+		// WHEN  shouldSyncRancherClusters is called
+		// THEN  the call returns that cluster sync is enabled, a populated label selector, and no error
+		{
+			"Sync Rancher clusters is enabled, complex label selector specified",
+			true,
+			"matchLabels:\n  foo: bar\nmatchExpressions:\n- key: clustertype\n  operator: In\n  values: [special, reallyspecial]",
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					metav1.LabelSelectorRequirement{
+						Key:      "clustertype",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"special", "reallyspecial"},
+					},
+				},
+			},
+			false,
+		},
+		// GIVEN cluster sync is enabled and malformed label selector yaml is provided
+		// WHEN  shouldSyncRancherClusters is called
+		// THEN  the call returns that cluster sync is enabled, a nil label selector, and an error
+		{
+			"Sync Rancher clusters is enabled, invalid label selector",
+			true,
+			"matchLabels:\n  bogus\n",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			// if cluster selector text is specified, write it to a temp file
+			var filename string
+			if len(tt.clusterSelectorText) > 0 {
+				var err error
+				filename, err = writeTempFile(tt.clusterSelectorText)
+				asserts.NoError(err)
+				defer os.Remove(filename)
+			}
+			os.Setenv(syncClustersEnvVarName, strconv.FormatBool(tt.enabled))
+
+			enabled, labelSelector, err := shouldSyncRancherClusters(filename)
+
+			if tt.expectedError {
+				asserts.Error(err, tt.testName)
+			} else {
+				asserts.NoError(err, tt.testName)
+			}
+			asserts.Equal(tt.enabled, enabled, tt.testName)
+			asserts.Equal(tt.expectedLabelSelector, labelSelector, tt.testName)
+		})
+	}
+}
+
+// writeTempFile creates a temp file with the specified string content. It returns the
+// file name.
+func writeTempFile(clusterSelectorText string) (string, error) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	f.Write([]byte(clusterSelectorText))
+	f.Close()
+	return f.Name(), nil
+}

--- a/cluster-operator/main_test.go
+++ b/cluster-operator/main_test.go
@@ -75,7 +75,7 @@ func TestShouldSyncRancherClusters(t *testing.T) {
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"foo": "bar"},
 				MatchExpressions: []metav1.LabelSelectorRequirement{
-					metav1.LabelSelectorRequirement{
+					{
 						Key:      "clustertype",
 						Operator: metav1.LabelSelectorOpIn,
 						Values:   []string{"special", "reallyspecial"},

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator_component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +43,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
-			Dependencies:              []string{networkpolicies.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, rancher.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -89,8 +89,6 @@ if [ $((MAJOR_VERSION)) -eq 1 ] && [ $((MINOR_VERSION)) -lt 4 ] ; then
   metadata:
     name: ${MANAGED_CLUSTER_NAME}
     namespace: verrazzano-mc
-    labels:
-      rancher-sync: enabled
   spec:
     description: "VerrazzanoManagedCluster object for ${MANAGED_CLUSTER_NAME}"
     caSecret: ca-secret-${MANAGED_CLUSTER_NAME}
@@ -111,8 +109,6 @@ else
   metadata:
     name: ${MANAGED_CLUSTER_NAME}
     namespace: verrazzano-mc
-    labels:
-      rancher-sync: enabled
   spec:
     description: "VerrazzanoManagedCluster object for ${MANAGED_CLUSTER_NAME}"
 EOF

--- a/tests/e2e/config/scripts/register_managed_cluster.sh
+++ b/tests/e2e/config/scripts/register_managed_cluster.sh
@@ -89,6 +89,8 @@ if [ $((MAJOR_VERSION)) -eq 1 ] && [ $((MINOR_VERSION)) -lt 4 ] ; then
   metadata:
     name: ${MANAGED_CLUSTER_NAME}
     namespace: verrazzano-mc
+    labels:
+      rancher-sync: enabled
   spec:
     description: "VerrazzanoManagedCluster object for ${MANAGED_CLUSTER_NAME}"
     caSecret: ca-secret-${MANAGED_CLUSTER_NAME}
@@ -109,6 +111,8 @@ else
   metadata:
     name: ${MANAGED_CLUSTER_NAME}
     namespace: verrazzano-mc
+    labels:
+      rancher-sync: enabled
   spec:
     description: "VerrazzanoManagedCluster object for ${MANAGED_CLUSTER_NAME}"
 EOF

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml
@@ -21,3 +21,13 @@ spec:
       enabled: true
     prometheusNodeExporter:
       enabled: true
+    clusterOperator:
+      overrides:
+        - values:
+            syncRancherClusters:
+              enabled: true
+              clusterSelector:
+                matchExpressions:
+                  - key: ranhcher-sync
+                    operator: In
+                    values: [ enabled ]

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml
@@ -28,6 +28,6 @@ spec:
               enabled: true
               clusterSelector:
                 matchExpressions:
-                  - key: ranhcher-sync
+                  - key: rancher-sync
                     operator: In
                     values: [ enabled ]

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml
@@ -36,6 +36,6 @@ spec:
               enabled: true
               clusterSelector:
                 matchExpressions:
-                  - key: vmc-sync
+                  - key: rancher-sync
                     operator: In
                     values: [ enabled ]

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml
@@ -29,3 +29,13 @@ spec:
       enabled: true
     prometheusNodeExporter:
       enabled: true
+    clusterOperator:
+      overrides:
+        - values:
+            syncRancherClusters:
+              enabled: true
+              clusterSelector:
+                matchExpressions:
+                  - key: vmc-sync
+                    operator: In
+                    values: [ enabled ]

--- a/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-upgrade.yaml
@@ -16,6 +16,16 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
+    clusterOperator:
+      overrides:
+        - values:
+            syncRancherClusters:
+              enabled: true
+              clusterSelector:
+                matchExpressions:
+                  - key: rancher-sync
+                    operator: In
+                    values: [ enabled ]
     # Prometheus Operator components are not included to account for upgrade tests
   volumeClaimSpecTemplates:
     - metadata:

--- a/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
+++ b/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
@@ -134,15 +134,16 @@ func initializeTestResources() (*versioned.Clientset, *vmc.RancherConfig) {
 	return client, rc
 }
 
-// testRancherClusterCreation tests a cluster created in Rancher
+// testRancherClusterCreation tests that a cluster created in Rancher with the right labels results in a VMC
 func testRancherClusterCreation(rc *vmc.RancherConfig, client *versioned.Clientset, clusterName string) string {
 	// GIVEN a Rancher cluster is created using Rancher API/UI
 	// WHEN the Rancher cluster is appropriately labeled
 	// THEN a VMC is auto-created for that cluster
 
-	// Create cluster in Rancher and label it (when labels are supported)
+	// Create cluster in Rancher and label it as specified in the VZ resource installed
 	var err error
-	clusterID, err := vmc.ImportClusterToRancher(rc, clusterName, vzlog.DefaultLogger())
+	rancherClusterLabels := map[string]string{"rancher-sync": "enabled"}
+	clusterID, err := vmc.ImportClusterToRancher(rc, clusterName, rancherClusterLabels, vzlog.DefaultLogger())
 	Expect(err).ShouldNot(HaveOccurred())
 	pkg.Log(pkg.Info, fmt.Sprintf("Got cluster id %s from Rancher\n", clusterID))
 

--- a/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
+++ b/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
@@ -38,13 +38,14 @@ var _ = t.AfterEach(func() {})
 
 var _ = t.AfterSuite(func() {})
 
+var rancherClusterLabels = map[string]string{"rancher-sync": "enabled"}
 var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.install"), func() {
 
-	// 1. Create the cluster in Rancher
+	// 1. Create clusters in Rancher with labels that match the selector configured in the Verrazzano resource
 	// 2. Delete the cluster in Rancher
 	// Verify that the VMC was created and deleted in sync
-	t.Context("When clusters are created and deleted in Rancher", func() {
-		const clusterName = "cluster1"
+	t.Context("When cluster is created and deleted in Rancher with the configured labels", func() {
+		const clusterName = "RancherCreateDelete"
 		var clusterID string
 
 		t.BeforeEach(func() {
@@ -52,7 +53,7 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 		})
 
 		t.It("a VMC is automatically created", func() {
-			clusterID = testRancherClusterCreation(rc, client, clusterName)
+			clusterID = testRancherClusterCreation(rc, client, clusterName, rancherClusterLabels, true)
 		})
 
 		t.It("a VMC is automatically deleted", func() {
@@ -60,11 +61,26 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 		})
 	})
 
+	// 1. Create clusters in Rancher with matching selector labels
+	// 2. Delete the cluster in Rancher
+	// Verify that the VMC was created and deleted in sync
+	t.Context("When cluster is created in Rancher without the configured labels", func() {
+		const clusterName = "RancherNoLabel"
+
+		t.BeforeEach(func() {
+			client, rc = initializeTestResources()
+		})
+
+		t.It("a VMC is NOT created", func() {
+			_ = testRancherClusterCreation(rc, client, clusterName, nil, false)
+		})
+	})
+
 	// 1. Create the VMC
 	// 2. Delete the VMC
 	// Verify the Rancher cluster was created and deleted in sync
 	t.Context("When VMCs are created and deleted", func() {
-		const clusterName = "cluster2"
+		const clusterName = "VMCCreateDelete"
 
 		t.BeforeEach(func() {
 			client, rc = initializeTestResources()
@@ -81,9 +97,9 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 
 	// 1. Create the VMC
 	// 2. Delete the cluster in Rancher
-	// Verify the Rancher cluster is created and the VMC is deleted
-	t.Context("When VMC is created and deleted in Rancher", func() {
-		const clusterName = "cluster3"
+	// Verify the Rancher cluster is created and then the VMC is deleted
+	t.Context("When VMC is created and the cluster is deleted in Rancher", func() {
+		const clusterName = "VMCCreateRancherDelete"
 		var clusterID string
 
 		t.BeforeEach(func() {
@@ -94,26 +110,26 @@ var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.ins
 			clusterID = testVMCCreation(rc, client, clusterName)
 		})
 
-		t.It("a VMC is automatically deleted", func() {
+		t.It("the VMC is automatically deleted", func() {
 			testRancherClusterDeletion(rc, client, clusterName, clusterID)
 		})
 	})
 
-	// 1. Create the cluster in Rancher
+	// 1. Create the cluster in Rancher with configured labels
 	// 2. Delete the VMC
-	// Verify the VMC is created and the Rancher cluster is deleted
-	t.Context("When VMC is created and deleted in Rancher", func() {
-		const clusterName = "cluster4"
+	// Verify the VMC is created and then the Rancher cluster is deleted
+	t.Context("When Rancher cluster is created with configured labels and then the VMC is deleted", func() {
+		const clusterName = "rancherCreateVMCDelete"
 
 		t.BeforeEach(func() {
 			client, rc = initializeTestResources()
 		})
 
 		t.It("a VMC is automatically created", func() {
-			testRancherClusterCreation(rc, client, clusterName)
+			testRancherClusterCreation(rc, client, clusterName, rancherClusterLabels, true)
 		})
 
-		t.It("a Rancher cluster is automatically deleted", func() {
+		t.It("the Rancher cluster is automatically deleted", func() {
 			testVMCDeletion(rc, client, clusterName)
 		})
 	})
@@ -135,24 +151,43 @@ func initializeTestResources() (*versioned.Clientset, *vmc.RancherConfig) {
 }
 
 // testRancherClusterCreation tests that a cluster created in Rancher with the right labels results in a VMC
-func testRancherClusterCreation(rc *vmc.RancherConfig, client *versioned.Clientset, clusterName string) string {
+func testRancherClusterCreation(rc *vmc.RancherConfig, client *versioned.Clientset, clusterName string, rancherClusterLabels map[string]string, vmcExpected bool) string {
 	// GIVEN a Rancher cluster is created using Rancher API/UI
 	// WHEN the Rancher cluster is appropriately labeled
 	// THEN a VMC is auto-created for that cluster
 
 	// Create cluster in Rancher and label it as specified in the VZ resource installed
 	var err error
-	rancherClusterLabels := map[string]string{"rancher-sync": "enabled"}
 	clusterID, err := vmc.ImportClusterToRancher(rc, clusterName, rancherClusterLabels, vzlog.DefaultLogger())
 	Expect(err).ShouldNot(HaveOccurred())
 	pkg.Log(pkg.Info, fmt.Sprintf("Got cluster id %s from Rancher\n", clusterID))
 
-	// Eventually, a VMC with that cluster name should be created
+	if vmcExpected {
+		// VMC is expected - assert that it is created
+		assertVMCEventuallyCreated(clusterName)
+	} else {
+		// VMC is not expected - assert that it is not created
+		assertVMCConsistentlyNotExists(clusterName, fmt.Sprintf("Making sure that no VMC is created for Rancher cluster %s ", clusterName))
+	}
+	return clusterID
+}
+
+// assertVMCConsistentlyNotExists asserts that consistently, a VMC with the given cluster name does NOT get created for some period of time
+func assertVMCConsistentlyNotExists(clusterName string, msg string) {
+	Consistently(func() bool {
+		pkg.Log(pkg.Info, msg)
+		_, err := client.ClustersV1alpha1().VerrazzanoManagedClusters(constants.VerrazzanoMultiClusterNamespace).Get(context.TODO(), clusterName, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}).WithPolling(pollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+}
+
+// assertVMCEventuallyCreated asserts that eventually, a VMC with the given cluster name exists
+func assertVMCEventuallyCreated(clusterName string) {
+	// Eventually, a VMC with the given cluster name should be created
 	Eventually(func() (*v1alpha1.VerrazzanoManagedCluster, error) {
 		pkg.Log(pkg.Info, "Waiting for VMC to be created")
 		return client.ClustersV1alpha1().VerrazzanoManagedClusters(constants.VerrazzanoMultiClusterNamespace).Get(context.TODO(), clusterName, metav1.GetOptions{})
 	}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeNil())
-	return clusterID
 }
 
 // testRancherClusterDeletion tests a cluster deleted in Rancher
@@ -178,11 +213,8 @@ func testRancherClusterDeletion(rc *vmc.RancherConfig, client *versioned.Clients
 		return errors.IsNotFound(err)
 	}).WithPolling(pollingInterval).WithTimeout(waitTimeout).Should(BeTrue())
 
-	Consistently(func() bool {
-		pkg.Log(pkg.Info, "Waiting for VMC to remain deleted")
-		_, err := client.ClustersV1alpha1().VerrazzanoManagedClusters(constants.VerrazzanoMultiClusterNamespace).Get(context.TODO(), clusterName, metav1.GetOptions{})
-		return errors.IsNotFound(err)
-	}).WithPolling(pollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
+	// make sure VMC doesn't get re-created, and remains deleted for some time.
+	assertVMCConsistentlyNotExists(clusterName, "Waiting for VMC to remain deleted")
 }
 
 // testVMCCreation tests a VMC created for a managed cluster


### PR DESCRIPTION
This PR wires up the cluster label selector in the cluster operator. We now auto create VMCs from Rancher clusters when:

1. Rancher cluster sync is enabled
2. Rancher cluster labels match the optional label selector configured in the Verrazzano CR. If sync is enabled and no cluster selector is specified, all Rancher clusters will be synchronized.

This PR also adds end-to-end tests for cluster selectors.