### PR TITLE
VZ-7793 - New OS image that has changes for OS context fetch during retry

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -240,7 +240,7 @@
             },
             {
               "image": "opensearch",
-              "tag": "1.2.3-20220810140719-c1dbc115d8a",
+              "tag": "1.2.3-20221123073048-b9a03fdef55",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -240,7 +240,7 @@
             },
             {
               "image": "opensearch",
-              "tag": "1.2.3-20221123073048-b9a03fdef55",
+              "tag": "1.2.3-20221123112624-b9a03fdef55",
               "helmFullImageKey": "monitoringOperator.esImage"
             },
             {


### PR DESCRIPTION
When kubecontext is fetched too soon after pod bringup, it errors out . As a result a retry is needed. The retry logic was not setting a specific flag hence even after retry the wait loop kept going and ultimately failed after max tries