### PR TITLE
VZ-7502 Create a Rancher user and Role for multicluster interactions

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -94,6 +94,9 @@ const (
 	ClusterLocal                      = "local"
 	AuthConfigLocal                   = "local"
 	UserVerrazzano                    = "u-verrazzano"
+	UserVZMulticluster                = "u-verrazzano-multicluster"
+	UserVZMulticlusterUsername        = "verrazzanomc"
+	UserVZMulticlusterDescription     = "Verrazzano Multicluster"
 	UserVerrazzanoDescription         = "Verrazzano Admin"
 	GlobalRoleBindingVerrazzanoPrefix = "grb-"
 	SettingUIPL                       = "ui-pl"
@@ -523,6 +526,19 @@ func createOrUpdateRancherVerrazzanoUser(ctx spi.ComponentContext, vzUser *keycl
 	data[UserAttributeDisplayName] = caser.String(vzUser.Username)
 	data[UserAttributeDescription] = caser.String(UserVerrazzanoDescription)
 	data[UserAttributePrincipalIDs] = []interface{}{UserPrincipalKeycloakPrefix + vzUser.ID, UserPrincipalLocalPrefix + rancherUsername}
+
+	return createOrUpdateResource(ctx, nsn, GVKUser, data)
+}
+
+// createOrUpdateRancherVerrazzanoUser creates or updates the verrazzano multicluster user in Rancher
+func createOrUpdateVZMulticlusterUser(ctx spi.ComponentContext, username string, rancherUsername string) error {
+	nsn := types.NamespacedName{Name: rancherUsername}
+	data := map[string]interface{}{}
+	data[UserAttributeUserName] = username
+	caser := cases.Title(language.English)
+	data[UserAttributeDisplayName] = caser.String(username)
+	data[UserAttributeDescription] = caser.String(UserVZMulticlusterDescription)
+	data[UserAttributePrincipalIDs] = []interface{}{UserPrincipalLocalPrefix + rancherUsername}
 
 	return createOrUpdateResource(ctx, nsn, GVKUser, data)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -149,15 +149,16 @@ const (
 
 // roles and groups
 const (
-	AdminRoleName               = "admin"
-	VerrazzanoAdminRoleName     = "verrazzano-admin"
-	ViewRoleName                = "view"
-	VerrazzanoMonitorRoleName   = "verrazzano-monitor"
-	ClusterMemberRoleName       = "cluster-member"
-	VerrazzanoAdminsGroupName   = "verrazzano-admins"
-	VerrazzanoMonitorsGroupName = "verrazzano-monitors"
-	GroupKey                    = "group"
-	ClusterRoleKey              = "clusterRole"
+	AdminRoleName                 = "admin"
+	VerrazzanoAdminRoleName       = "verrazzano-admin"
+	ViewRoleName                  = "view"
+	VerrazzanoMonitorRoleName     = "verrazzano-monitor"
+	VerrazzanoClusterUserRoleName = "verrazzano-cluster-user"
+	ClusterMemberRoleName         = "cluster-member"
+	VerrazzanoAdminsGroupName     = "verrazzano-admins"
+	VerrazzanoMonitorsGroupName   = "verrazzano-monitors"
+	GroupKey                      = "group"
+	ClusterRoleKey                = "clusterRole"
 )
 
 // prefixes
@@ -531,14 +532,14 @@ func createOrUpdateRancherVerrazzanoUser(ctx spi.ComponentContext, vzUser *keycl
 }
 
 // createOrUpdateVZMulticlusterUser creates or updates the Verrazzano Multicluster user in Rancher
-func createOrUpdateVZMulticlusterUser(ctx spi.ComponentContext, username string, rancherUsername string) error {
-	nsn := types.NamespacedName{Name: rancherUsername}
+func createOrUpdateVZMulticlusterUser(ctx spi.ComponentContext) error {
+	nsn := types.NamespacedName{Name: UserVZMulticluster}
 	data := map[string]interface{}{}
-	data[UserAttributeUserName] = username
+	data[UserAttributeUserName] = UserVZMulticlusterUsername
 	caser := cases.Title(language.English)
-	data[UserAttributeDisplayName] = caser.String(username)
+	data[UserAttributeDisplayName] = caser.String(UserVZMulticlusterUsername)
 	data[UserAttributeDescription] = caser.String(UserVZMulticlusterDescription)
-	data[UserAttributePrincipalIDs] = []interface{}{UserPrincipalLocalPrefix + rancherUsername}
+	data[UserAttributePrincipalIDs] = []interface{}{UserPrincipalLocalPrefix + UserVZMulticluster}
 
 	return createOrUpdateResource(ctx, nsn, GVKUser, data)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -530,7 +530,7 @@ func createOrUpdateRancherVerrazzanoUser(ctx spi.ComponentContext, vzUser *keycl
 	return createOrUpdateResource(ctx, nsn, GVKUser, data)
 }
 
-// createOrUpdateRancherVerrazzanoUser creates or updates the verrazzano multicluster user in Rancher
+// createOrUpdateVZMulticlusterUser creates or updates the Verrazzano Multicluster user in Rancher
 func createOrUpdateVZMulticlusterUser(ctx spi.ComponentContext, username string, rancherUsername string) error {
 	nsn := types.NamespacedName{Name: rancherUsername}
 	data := map[string]interface{}{}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -153,7 +153,7 @@ const (
 	VerrazzanoAdminRoleName       = "verrazzano-admin"
 	ViewRoleName                  = "view"
 	VerrazzanoMonitorRoleName     = "verrazzano-monitor"
-	VerrazzanoClusterUserRoleName = "verrazzano-cluster-user"
+	VerrazzanoClusterUserRoleName = "verrazzano-cluster-rancher-user"
 	ClusterMemberRoleName         = "cluster-member"
 	VerrazzanoAdminsGroupName     = "verrazzano-admins"
 	VerrazzanoMonitorsGroupName   = "verrazzano-monitors"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -514,6 +514,10 @@ func ConfigureAuthProviders(ctx spi.ComponentContext) error {
 			return err
 		}
 
+		if err := createOrUpdateRancherVZMulticlusterUser(ctx); err != nil {
+			return err
+		}
+
 		if err := createOrUpdateRoleTemplates(ctx); err != nil {
 			return err
 		}
@@ -624,4 +628,8 @@ func createOrUpdateRancherUser(ctx spi.ComponentContext) error {
 		return err
 	}
 	return nil
+}
+
+func createOrUpdateRancherVZMulticlusterUser(ctx spi.ComponentContext) error {
+	return createOrUpdateVZMulticlusterUser(ctx, UserVZMulticlusterUsername, UserVZMulticluster)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -514,7 +514,7 @@ func ConfigureAuthProviders(ctx spi.ComponentContext) error {
 			return err
 		}
 
-		if err := createOrUpdateVZMulticlusterUser(ctx, UserVZMulticlusterUsername, UserVZMulticluster); err != nil {
+		if err := createOrUpdateVZMulticlusterUser(ctx); err != nil {
 			return err
 		}
 
@@ -533,13 +533,17 @@ func ConfigureAuthProviders(ctx spi.ComponentContext) error {
 	return nil
 }
 
-// createOrUpdateRoleTemplates creates or updates the verrazzano-admin and verrazzano-monitor RoleTemplates
+// createOrUpdateRoleTemplates creates or updates the verrazzano-admin, verrazzano-monitor, and verrazzano-cluster-user RoleTemplates
 func createOrUpdateRoleTemplates(ctx spi.ComponentContext) error {
 	if err := createOrUpdateRoleTemplate(ctx, VerrazzanoAdminRoleName); err != nil {
 		return err
 	}
 
-	return createOrUpdateRoleTemplate(ctx, VerrazzanoMonitorRoleName)
+	if err := createOrUpdateRoleTemplate(ctx, VerrazzanoMonitorRoleName); err != nil {
+		return err
+	}
+
+	return createOrUpdateRoleTemplate(ctx, VerrazzanoClusterUserRoleName)
 }
 
 // createOrUpdateClusterRoleTemplateBindings creates or updates the CRTBs for the verrazzano-admins and verrazzano-monitors groups

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -514,7 +514,7 @@ func ConfigureAuthProviders(ctx spi.ComponentContext) error {
 			return err
 		}
 
-		if err := createOrUpdateRancherVZMulticlusterUser(ctx); err != nil {
+		if err := createOrUpdateVZMulticlusterUser(ctx, UserVZMulticlusterUsername, UserVZMulticluster); err != nil {
 			return err
 		}
 
@@ -628,8 +628,4 @@ func createOrUpdateRancherUser(ctx spi.ComponentContext) error {
 		return err
 	}
 	return nil
-}
-
-func createOrUpdateRancherVZMulticlusterUser(ctx spi.ComponentContext) error {
-	return createOrUpdateVZMulticlusterUser(ctx, UserVZMulticlusterUsername, UserVZMulticluster)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -497,6 +497,7 @@ func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
 // ConfigureAuthProviders
 // +configures Keycloak as OIDC provider for Rancher.
 // +creates or updates default user verrazzano.
+// +creates or updated the verrazzano cluster user
 // +creates or updates admin clusterRole binding for  user verrazzano.
 // +disables first login setting to disable prompting for password on first login.
 // +enables or disables Keycloak Auth provider.

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -373,10 +373,13 @@ func testUpdate(t *testing.T,
 	kcIngress := createIngress(constants.KeycloakNamespace, constants.KeycloakIngress, constants.KeycloakIngress)
 	verrazzanoAdminClusterRole := createClusterRoles(rancher.VerrazzanoAdminRoleName)
 	verrazzanoMonitorClusterRole := createClusterRoles(rancher.VerrazzanoMonitorRoleName)
+	verrazzanoClusterUserRole := createClusterRoles(rancher.VerrazzanoClusterUserRoleName)
 	jobList := createJobsList()
 	addExec()
 
-	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(vz, sa, crb, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole).WithLists(&ingressList, &jobList).Build()
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
+		WithObjects(vz, sa, crb, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, &verrazzanoClusterUserRole).
+		WithLists(&ingressList, &jobList).Build()
 
 	ctx := spi.NewFakeContext(c, vz, nil, false)
 	// Sample bom file for version validation functions

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
@@ -554,6 +554,7 @@ func TestUpgradeCompleted(t *testing.T) {
 	kcIngress := createIngress(constants.KeycloakNamespace, constants.KeycloakIngress, constants.KeycloakIngress)
 	verrazzanoAdminClusterRole := createClusterRoles(rancher.VerrazzanoAdminRoleName)
 	verrazzanoMonitorClusterRole := createClusterRoles(rancher.VerrazzanoMonitorRoleName)
+	verrazzanoClusterUserRole := createClusterRoles(rancher.VerrazzanoClusterUserRoleName)
 	addExec()
 
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
@@ -576,7 +577,7 @@ func TestUpgradeCompleted(t *testing.T) {
 		rbac.NewServiceAccount(namespace, name, []string{}, nil),
 		rbac.NewClusterRoleBinding(&verrazzanoToUse, name, getInstallNamespace(), buildServiceAccountName(name)),
 		&rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting,
-		&verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole,
+		&verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, &verrazzanoClusterUserRole,
 	).Build()
 
 	config.TestProfilesDir = relativeProfilesDir
@@ -651,6 +652,7 @@ func TestUpgradeCompletedMultipleReconcile(t *testing.T) {
 	kcIngress := createIngress(constants.KeycloakNamespace, constants.KeycloakIngress, constants.KeycloakIngress)
 	verrazzanoAdminClusterRole := createClusterRoles(rancher.VerrazzanoAdminRoleName)
 	verrazzanoMonitorClusterRole := createClusterRoles(rancher.VerrazzanoMonitorRoleName)
+	verrazzanoClusterUserRole := createClusterRoles(rancher.VerrazzanoClusterUserRoleName)
 	addExec()
 
 	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
@@ -673,7 +675,7 @@ func TestUpgradeCompletedMultipleReconcile(t *testing.T) {
 		rbac.NewServiceAccount(namespace, name, []string{}, nil),
 		rbac.NewClusterRoleBinding(&verrazzanoToUse, name, getInstallNamespace(), buildServiceAccountName(name)),
 		&rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting,
-		&verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole,
+		&verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, &verrazzanoClusterUserRole,
 	).Build()
 
 	config.TestProfilesDir = relativeProfilesDir
@@ -910,6 +912,7 @@ func TestUpgradeComponent(t *testing.T) {
 	kcIngress := createIngress(constants.KeycloakNamespace, constants.KeycloakIngress, constants.KeycloakIngress)
 	verrazzanoAdminClusterRole := createClusterRoles(rancher.VerrazzanoAdminRoleName)
 	verrazzanoMonitorClusterRole := createClusterRoles(rancher.VerrazzanoMonitorRoleName)
+	verrazzanoClusterUserRole := createClusterRoles(rancher.VerrazzanoClusterUserRoleName)
 	addExec()
 
 	appConfigList := oamapi.ApplicationConfigurationList{Items: []oamapi.ApplicationConfiguration{}}
@@ -917,7 +920,9 @@ func TestUpgradeComponent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "keycloak", Name: "dump-claim"},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(&vz, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, kcPVC).WithLists(&ingressList, &appConfigList).Build()
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
+		WithObjects(&vz, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, &verrazzanoClusterUserRole, kcPVC).
+		WithLists(&ingressList, &appConfigList).Build()
 
 	// Reconcile upgrade until state is done.  Put guard to prevent infinite loop
 	reconciler := newVerrazzanoReconciler(c)
@@ -1119,6 +1124,7 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 	kcIngress := createIngress(constants.KeycloakNamespace, constants.KeycloakIngress, constants.KeycloakIngress)
 	verrazzanoAdminClusterRole := createClusterRoles(rancher.VerrazzanoAdminRoleName)
 	verrazzanoMonitorClusterRole := createClusterRoles(rancher.VerrazzanoMonitorRoleName)
+	verrazzanoClusterUserRole := createClusterRoles(rancher.VerrazzanoClusterUserRoleName)
 	addExec()
 
 	appConfigList := oamapi.ApplicationConfigurationList{Items: []oamapi.ApplicationConfiguration{}}
@@ -1126,7 +1132,9 @@ func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "keycloak", Name: "dump-claim"},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(&vz, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, kcPVC).WithLists(&ingressList, &appConfigList).Build()
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
+		WithObjects(&vz, &rancherIngress, &kcIngress, &authConfig, &kcSecret, &localAuthConfig, &firstLoginSetting, &verrazzanoAdminClusterRole, &verrazzanoMonitorClusterRole, &verrazzanoClusterUserRole, kcPVC).
+		WithLists(&ingressList, &appConfigList).Build()
 
 	// Reconcile upgrade until state is done.  Put guard to prevent infinite loop
 	reconciler := newVerrazzanoReconciler(c)

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -74,3 +74,19 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-cluster-rancher-user
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch

--- a/tools/vz/pkg/analysis/internal/util/report/report
+++ b/tools/vz/pkg/analysis/internal/util/report/report
@@ -1,0 +1,3 @@
+
+
+Verrazzano analysis CLI did not detect any issue in the cluster

--- a/tools/vz/pkg/analysis/internal/util/report/report
+++ b/tools/vz/pkg/analysis/internal/util/report/report
@@ -1,3 +1,0 @@
-
-
-Verrazzano analysis CLI did not detect any issue in the cluster


### PR DESCRIPTION
To provide some security for VPO operations on managed clusters, we can create this new user with limited multicluster permissions.