### PR TITLE
CRD check before starting Rancher cluster sync controller

### DIFF
--- a/cluster-operator/main_test.go
+++ b/cluster-operator/main_test.go
@@ -181,6 +181,20 @@ func TestWatchCattleClustersCRD(t *testing.T) {
 	asserts.False(open)
 }
 
+// TestHandleFlags tests the handleFlags function
+func TestHandleFlags(t *testing.T) {
+	asserts := assert.New(t)
+
+	// GIVEN command line arguments
+	// WHEN  the handleFlags function is called
+	// THEN  the command line flags are parsed correctly
+	const testCertDir = "/tmp/unit-test"
+	os.Args = []string{"cmd", "--cert-dir=" + testCertDir}
+	handleFlags()
+
+	asserts.Equal(testCertDir, certDir)
+}
+
 // writeTempFile creates a temp file with the specified string content. It returns the
 // file name.
 func writeTempFile(clusterSelectorText string) (string, error) {

--- a/cluster-operator/main_test.go
+++ b/cluster-operator/main_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -119,6 +121,32 @@ func TestShouldSyncRancherClusters(t *testing.T) {
 			asserts.Equal(tt.expectedLabelSelector, labelSelector, tt.testName)
 		})
 	}
+}
+
+// TestIsCattleClustersCRDInstalled tests the isCattleClustersCRDInstalled function
+func TestIsCattleClustersCRDInstalled(t *testing.T) {
+	asserts := assert.New(t)
+
+	// GIVEN a cluster that does not have the cattle clusters CRD installed
+	// WHEN  a call is made to isCattleClustersCRDInstalled
+	// THEN  the function returns false
+	client := fake.NewSimpleClientset().ApiextensionsV1()
+	isInstalled, err := isCattleClustersCRDInstalled(client)
+	asserts.NoError(err)
+	asserts.False(isInstalled)
+
+	// GIVEN a cluster that does have the cattle clusters CRD installed
+	// WHEN  a call is made to isCattleClustersCRDInstalled
+	// THEN  the function returns true
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cattleClustersCRDName,
+		},
+	}
+	client = fake.NewSimpleClientset(crd).ApiextensionsV1()
+	isInstalled, err = isCattleClustersCRDInstalled(client)
+	asserts.NoError(err)
+	asserts.True(isInstalled)
 }
 
 // writeTempFile creates a temp file with the specified string content. It returns the

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -74,6 +74,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Without this check, if the cattle clusters CRD is not present in the cluster (because Rancher is not installed, for example), the verrazzano-cluster-operator goes into CrashLoopBackoff.