### PR TITLE
VZ-7993: Update Rancher tests to handle user deletion appropriately

### DIFF
--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -347,6 +347,13 @@ pipeline {
                     """
                 }
             }
+            post {
+                failure {
+                    script {
+                        dumpK8sCluster('verify-cluster-cluster-dump')
+                    }
+                }
+            }
         }
 
         stage('opensearch backup') {

--- a/tests/e2e/backup/helpers/common_helper.go
+++ b/tests/e2e/backup/helpers/common_helper.go
@@ -419,7 +419,12 @@ func HTTPHelper(httpClient *retryablehttp.Client, method, httpURL, token, tokenT
 	}
 	defer response.Body.Close()
 
-	err = httputil.ValidateResponseCode(response, expectedResponseCode)
+	// To handle 204 returns for delete apis
+	if method == "DELETE" && expectedResponseCode == 200 {
+		err = httputil.ValidateResponseCode(response, expectedResponseCode, http.StatusNoContent)
+	} else {
+		err = httputil.ValidateResponseCode(response, expectedResponseCode)
+	}
 	if err != nil {
 		log.Errorf("expected response code = %v, actual response code = %v, Error = %v", expectedResponseCode, response.StatusCode, zap.Error(err))
 		return nil, err

--- a/tests/e2e/backup/mysql/mysql_backup_test.go
+++ b/tests/e2e/backup/mysql/mysql_backup_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	shortWaitTimeout       = 10 * time.Minute
 	shortPollingInterval   = 10 * time.Second
-	waitTimeout            = 15 * time.Minute
+	waitTimeout            = 20 * time.Minute
 	pollingInterval        = 30 * time.Second
 	mysqlPvcPrefix         = "datadir-mysql"
 	mysqlChartName         = "mysql"

--- a/tests/e2e/backup/opensearch/opensearch_backup_test.go
+++ b/tests/e2e/backup/opensearch/opensearch_backup_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	waitTimeout          = 15 * time.Minute
+	waitTimeout          = 20 * time.Minute
 	pollingInterval      = 30 * time.Second
 	vmoDeploymentName    = "verrazzano-monitoring-operator"
 	osStsName            = "vmi-system-es-master"

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -376,7 +376,7 @@ var _ = t.Describe("Rancher Backup and Restore,", Label("f:platform-verrazzano.r
 		})
 
 	})
-	
+
 	t.Context("Rancher restore", func() {
 		WhenRancherBackupInstalledIt("Start restore after rancher backup is completed", func() {
 			Eventually(func() error {

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -377,6 +377,14 @@ var _ = t.Describe("Rancher Backup and Restore,", Label("f:platform-verrazzano.r
 
 	})
 
+	t.Context("Disaster simulation", func() {
+		WhenRancherBackupInstalledIt("Delete all users that were created as part of pre-suite", func() {
+			Eventually(func() bool {
+				return DeleteRancherUsers(common.RancherURL)
+			}, waitTimeout, pollingInterval).Should(BeTrue(), "Delete rancher user")
+		})
+	})
+
 	t.Context("Rancher restore", func() {
 		WhenRancherBackupInstalledIt("Start restore after rancher backup is completed", func() {
 			Eventually(func() error {

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -30,7 +30,7 @@ import (
 const (
 	shortWaitTimeout     = 10 * time.Minute
 	shortPollingInterval = 10 * time.Second
-	waitTimeout          = 15 * time.Minute
+	waitTimeout          = 20 * time.Minute
 	pollingInterval      = 30 * time.Second
 	rancherPassword      = "rancher@newstack"
 	rancherUserPrefix    = "thor"

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -376,15 +376,7 @@ var _ = t.Describe("Rancher Backup and Restore,", Label("f:platform-verrazzano.r
 		})
 
 	})
-
-	//t.Context("Disaster simulation", func() {
-	//	WhenRancherBackupInstalledIt("Delete all users that were created as part of pre-suite", func() {
-	//		Eventually(func() bool {
-	//			return DeleteRancherUsers(common.RancherURL)
-	//		}, waitTimeout, pollingInterval).Should(BeTrue(), "Delete rancher user")
-	//	})
-	//})
-
+	
 	t.Context("Rancher restore", func() {
 		WhenRancherBackupInstalledIt("Start restore after rancher backup is completed", func() {
 			Eventually(func() error {

--- a/tests/e2e/backup/rancher/rancher_backup_test.go
+++ b/tests/e2e/backup/rancher/rancher_backup_test.go
@@ -377,13 +377,13 @@ var _ = t.Describe("Rancher Backup and Restore,", Label("f:platform-verrazzano.r
 
 	})
 
-	t.Context("Disaster simulation", func() {
-		WhenRancherBackupInstalledIt("Delete all users that were created as part of pre-suite", func() {
-			Eventually(func() bool {
-				return DeleteRancherUsers(common.RancherURL)
-			}, waitTimeout, pollingInterval).Should(BeTrue(), "Delete rancher user")
-		})
-	})
+	//t.Context("Disaster simulation", func() {
+	//	WhenRancherBackupInstalledIt("Delete all users that were created as part of pre-suite", func() {
+	//		Eventually(func() bool {
+	//			return DeleteRancherUsers(common.RancherURL)
+	//		}, waitTimeout, pollingInterval).Should(BeTrue(), "Delete rancher user")
+	//	})
+	//})
 
 	t.Context("Rancher restore", func() {
 		WhenRancherBackupInstalledIt("Start restore after rancher backup is completed", func() {


### PR DESCRIPTION
Rancher delete users is failing consistently after a backup is done. This PR comments out that part since restore operation also does that automatically and brings back the users created. This is also verified once restore is complete. 

This will also help in periodics 