### PR TITLE
VZ-7690. PSR smoke tests

### DIFF
--- a/ci/make/cleanup.mk
+++ b/ci/make/cleanup.mk
@@ -1,0 +1,19 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+include global-env.mk
+
+.PHONY: dumplogs
+dumplogs:
+	${CI_SCRIPTS_DIR}/dumpRunLogs.sh ${DUMP_ROOT_DIRECTORY}
+
+test-reports: export TEST_REPORT ?= "test-report.xml"
+test-reports: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
+.PHONY: test-reports
+test-reports:
+	# Copy the generated test reports to WORKSPACE to archive them
+	mkdir -p ${TEST_REPORT_DIR}
+	cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+	find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
+
+.PHONY: pipeline-artifacts
+pipeline-artifacts: dumplogs test-reports

--- a/ci/make/env-template.sh
+++ b/ci/make/env-template.sh
@@ -1,0 +1,63 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# Set WORKSPACE where you want all temporary test files to go, etc
+# - default is ${HOME}/verrazzano-workspace
+#export WORKSPACE=
+
+# Set this to true to enable script debugging
+#export VZ_TEST_DEBUG=true
+
+# Used for the Github packages repo creds for the image pull secret for private branch builds
+export DOCKER_CREDS_USR=my-github-user
+export DOCKER_CREDS_PSW=$(cat ~/.github_token)
+export DOCKER_REPO=ghcr.io
+
+# Set these variables to set the Oracle Container Registry (OCR) secrets, typically your Oracle SSO
+#export OCR_REPO=container-registry.oracle.com
+#export OCR_CREDS_USR=me@oracle.com
+#export OCR_CREDS_PSW=$(cat ~/.oracle_sso)
+
+# Override where the Kubeconfig for the cluster is stored
+#export KUBECONFIG= # Default is ${WORKSPACE}/test_kubeconfig
+
+#### Platform Operator Settings 
+#
+# The following env vars control how the Platform Operator manifest is obtained
+#
+# - OPERATOR_YAML             - Specify a local platform operator manifest to use
+# - VERRAZZANO_OPERATOR_IMAGE - Set this to use a specific operator image version, a manifest will be generated using this value
+# - OCI_OS_NAMESPACE          - This must be set to the build system's ObjectStore namespace for the manifest-download default case
+#
+# If VERRAZZANO_OPERATOR_IMAGE and OPERATOR_YAML are not specified, the default is to download the operator manifest from
+# the most recent, successful Jenkins build for the current branch
+#
+export OCI_OS_NAMESPACE=
+#export OPERATOR_YAML=/home/mcico/tmp/workspace/downloaded-operator.yaml
+#export VERRAZZANO_OPERATOR_IMAGE=ghcr.io/verrazzano/verrazzano-platform-operator-jenkins:1.4.0-20220607181222-af48cc1c
+if [ -z "${OCI_OS_NAMESPACE}" ] && [ -z "" ] && [ -z "" ]; then
+  echo "One of OCI_OS_NAMESPACE, OPERATOR_YAML, or VERRAZZANO_OPERATOR_IMAGE must be set in the local environment"
+fi
+
+### Cluster customizations
+# export KIND_NODE_COUNT=3 # Default is 1
+#export KUBERNETES_CLUSTER_VERSION=1.22 # default is 1.22
+
+### Common VZ Install customizations
+#
+# INSTALL_CONFIG_FILE_KIND    - the VZ install CR to use, default is ${TEST_SCRIPTS_DIR}/v1beta1/install-verrazzano-kind.yaml
+# INSTALL_PROFILE             - the install profile to use (default is "dev")
+# VZ_ENVIRONMENT_NAME         - environmentName to use
+# ENABLE_API_ENVOY_LOGGING    - enables debug in the Istio Envoy containers
+# WILDCARD_DNS_DOMAIN         - an override for a user-specified wildcard DNS domain to use
+#
+#export INSTALL_CONFIG_FILE_KIND=
+#export INSTALL_PROFILE=prod 
+
+# Set this to any value for Gingko dry runs
+#export DRY_RUN=true
+
+# Required Weblogic/MySQL passwords for examples tests
+#WEBLOGIC_PSW= # required by WebLogic application and console ingress test
+#DATABASE_PSW= # required by console ingress test
+

--- a/ci/make/env-template.sh
+++ b/ci/make/env-template.sh
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+# Template env vars file for running make commands locally
+
 # Set WORKSPACE where you want all temporary test files to go, etc
 # - default is ${HOME}/verrazzano-workspace
 #export WORKSPACE=
@@ -12,11 +14,6 @@
 export DOCKER_CREDS_USR=my-github-user
 export DOCKER_CREDS_PSW=$(cat ~/.github_token)
 export DOCKER_REPO=ghcr.io
-
-# Set these variables to set the Oracle Container Registry (OCR) secrets, typically your Oracle SSO
-#export OCR_REPO=container-registry.oracle.com
-#export OCR_CREDS_USR=me@oracle.com
-#export OCR_CREDS_PSW=$(cat ~/.oracle_sso)
 
 # Override where the Kubeconfig for the cluster is stored
 #export KUBECONFIG= # Default is ${WORKSPACE}/test_kubeconfig

--- a/ci/make/global-env.mk
+++ b/ci/make/global-env.mk
@@ -1,0 +1,23 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+export GOPATH ?= /home/opc/go
+export GO_REPO_PATH ?= ${GOPATH}/src/github.com/verrazzano
+
+export VZ_ROOT := ${GO_REPO_PATH}/verrazzano
+export CI_ROOT ?= ${VZ_ROOT}/ci
+export CI_SCRIPTS_DIR ?= ${CI_ROOT}/scripts
+
+export WORKSPACE ?= ${HOME}/verrazzano-workspace
+export KUBECONFIG ?= ${WORKSPACE}/test_kubeconfig
+
+export IMAGE_PULL_SECRET ?= verrazzano-container-registry
+export DOCKER_REPO ?= 'ghcr.io'
+export DOCKER_NAMESPACE ?= 'verrazzano'
+export TEST_ROOT ?= ${VZ_ROOT}/tests/e2e
+export TEST_SCRIPTS_DIR ?= ${TEST_ROOT}/config/scripts
+export DUMP_ROOT_DIRECTORY ?= ${WORKSPACE}/cluster-snapshots
+
+export OCI_OS_ARTIFACT_BUCKET=build-failure-artifacts
+export OCI_OS_COMMIT_BUCKET=verrazzano-builds-by-commit
+export OCI_CLI_PROFILE ?= DEFAULT

--- a/ci/make/install.mk
+++ b/ci/make/install.mk
@@ -1,0 +1,11 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+include global-env.mk
+
+install-verrazzano: export INSTALL_CONFIG_FILE_KIND ?= ${TEST_SCRIPTS_DIR}/v1beta1/install-verrazzano-kind.yaml
+install-verrazzano: export POST_INSTALL_DUMP ?= false
+.PHONY: install-verrazzano
+install-verrazzano:
+	@echo "Running KIND install"
+	${CI_SCRIPTS_DIR}/install_verrazzano.sh

--- a/ci/make/kind.mk
+++ b/ci/make/kind.mk
@@ -1,0 +1,27 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+include global-env.mk
+
+export CLUSTER_NAME ?= kind
+
+setup-kind: export INSTALL_CONFIG_FILE_KIND ?= ${TEST_SCRIPTS_DIR}/v1beta1/install-verrazzano-kind.yaml
+setup-kind: export CREATE_CLUSTER_USE_CALICO ?= false
+setup-kind: export TESTS_EXECUTED_FILE ?= ${WORKSPACE}/tests_executed_file.tmp
+setup-kind: export KUBERNETES_CLUSTER_VERSION ?= 1.24
+.PHONY: setup-kind
+setup-kind:
+	@echo "Setup KIND cluster"
+	${CI_SCRIPTS_DIR}/setup_kind.sh ${CREATE_CLUSTER_USE_CALICO}
+#	${CI_SCRIPTS_DIR}/prepare_jenkins_at_environment.sh ${CREATE_CLUSTER_USE_CALICO} ${WILDCARD_DNS_DOMAIN} ${USE_DB_FOR_GRAFANA}
+
+#clean-kind: export KUBECONFIG ?= "${WORKSPACE}/test_kubeconfig"
+.PHONY: clean-kind
+clean-kind:
+	@echo "Cleanup kind cluster ${CLUSTER_NAME}, KUBECONFIG=${KUBECONFIG}"
+	${CI_SCRIPTS_DIR}/cleanup_kind_clusters.sh ${CLUSTER_NAME} ${KUBECONFIG}
+
+.PHONY: clean-kind-all
+clean-kind-all:
+	@echo "Deleting all kind clusters"
+	kind delete clusters --all

--- a/ci/make/kind.mk
+++ b/ci/make/kind.mk
@@ -13,7 +13,6 @@ setup-kind: export KUBERNETES_CLUSTER_VERSION ?= 1.24
 setup-kind:
 	@echo "Setup KIND cluster"
 	${CI_SCRIPTS_DIR}/setup_kind.sh ${CREATE_CLUSTER_USE_CALICO}
-#	${CI_SCRIPTS_DIR}/prepare_jenkins_at_environment.sh ${CREATE_CLUSTER_USE_CALICO} ${WILDCARD_DNS_DOMAIN} ${USE_DB_FOR_GRAFANA}
 
 #clean-kind: export KUBECONFIG ?= "${WORKSPACE}/test_kubeconfig"
 .PHONY: clean-kind

--- a/ci/make/tests.mk
+++ b/ci/make/tests.mk
@@ -27,19 +27,4 @@ run-test: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
 run-test:
 	${CI_SCRIPTS_DIR}/run-ginkgo.sh
 
-#.PHONY: dumplogs
-#dumplogs:
-#	${CI_SCRIPTS_DIR}/dumpRunLogs.sh ${DUMP_ROOT_DIRECTORY}
-
-#test-reports: export TEST_REPORT ?= "test-report.xml"
-#test-reports: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
-#.PHONY: test-reports
-#test-reports:
-#	# Copy the generated test reports to WORKSPACE to archive them
-#	mkdir -p ${TEST_REPORT_DIR}
-#	cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-#	find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
-#
-##.PHONY: pipeline-artifacts
-##pipeline-artifacts: dumplogs test-reports
 

--- a/ci/make/tests.mk
+++ b/ci/make/tests.mk
@@ -1,0 +1,45 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+include global-env.mk
+
+export DUMP_ROOT_DIRECTORY ?= ${WORKSPACE}/cluster-snapshots
+export GINGKO_ARGS ?= -v --keep-going --no-color --junit-report=test-report.xml --keep-separate-reports=true
+
+run-test: export RANDOMIZE_TESTS ?= false
+run-test: export RUN_PARALLEL ?= true
+run-test: export TEST_REPORT ?= "test-report.xml"
+run-test: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
+.PHONY: run-test-parallel
+run-test-parallel:
+	${CI_SCRIPTS_DIR}/run-ginkgo.sh
+
+run-test: export RANDOMIZE_TESTS := false
+run-test: export RUN_PARALLEL := false
+.PHONY: run-sequential
+run-sequential: run-test
+
+run-test: export RANDOMIZE_TESTS ?= true
+run-test: export RUN_PARALLEL ?= true
+run-test: export TEST_REPORT ?= "test-report.xml"
+run-test: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
+.PHONY: run-test-randomize
+run-test:
+	${CI_SCRIPTS_DIR}/run-ginkgo.sh
+
+#.PHONY: dumplogs
+#dumplogs:
+#	${CI_SCRIPTS_DIR}/dumpRunLogs.sh ${DUMP_ROOT_DIRECTORY}
+
+#test-reports: export TEST_REPORT ?= "test-report.xml"
+#test-reports: export TEST_REPORT_DIR ?= "${WORKSPACE}/tests/e2e"
+#.PHONY: test-reports
+#test-reports:
+#	# Copy the generated test reports to WORKSPACE to archive them
+#	mkdir -p ${TEST_REPORT_DIR}
+#	cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+#	find . -name "${TEST_REPORT}" | cpio -pdm ${TEST_REPORT_DIR}
+#
+##.PHONY: pipeline-artifacts
+##pipeline-artifacts: dumplogs test-reports
+

--- a/ci/psr/Jenkinsfile
+++ b/ci/psr/Jenkinsfile
@@ -296,7 +296,7 @@ pipeline {
             }
         }
 
-        stage('Smoke Test') {
+        stage('Scenario Tests') {
             environment {
                 DOCKER_REPO="${env.DOCKER_REGISTRY}"
                 KIND_KUBERNETES_CLUSTER_VERSION="${params.KUBERNETES_CLUSTER_VERSION}"

--- a/ci/psr/Jenkinsfile
+++ b/ci/psr/Jenkinsfile
@@ -4,6 +4,7 @@
 def DOCKER_IMAGE_TAG
 def SUSPECT_LIST = ""
 def VERRAZZANO_DEV_VERSION = ""
+def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def tarfilePrefix=""
 def storeLocation=""
 
@@ -27,8 +28,22 @@ pipeline {
     }
 
     parameters {
-        booleanParam (description: 'Whether to perform a scan of the built images', name: 'PERFORM_SCAN', defaultValue: false)
-        booleanParam (description: 'Whether to emit metrics from the pipeline', name: 'EMIT_METRICS', defaultValue: false)
+        choice (name: 'KUBERNETES_CLUSTER_VERSION', description: 'Kubernetes Version for KinD Cluster', choices: [ "1.24", "1.23", "1.22", "1.21" ])
+        string (name: 'VZ_BRANCH_TO_USE', defaultValue: 'CURRENT', trim: true, description: 'This is the name of the Verrazzano product branch to use for testing the PSR tooling; CURRENT means using the working branch')
+        string (name: 'VERRAZZANO_OPERATOR_IMAGE', defaultValue: 'NONE', trim: true, description: 'Uses a specific Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the latest operator.yaml from related Verrazzano repo branch will be used to create Verrazzano platform operator manifest')
+        string (name: 'KIND_NODE_COUNT', defaultValue: '3', trim: true, description: 'Number of nodes for the KIND cluster for smoke testing')
+        booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
+        booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
+
+        booleanParam (name: 'PERFORM_SCAN', defaultValue: false, description: 'Whether to perform a scan of the built images')
+        booleanParam (name: 'EMIT_METRICS', defaultValue: false, description: 'Whether to emit metrics from the pipeline')
+        booleanParam (name: 'FAIL_IF_COVERAGE_DECREASED', defaultValue: false, description: 'Whether to fail build if UT coverage number decreases lower than its release-* coverage from object storage. This defaults to true, meaning Any non release-*/master branch will fail if its coverage is lower. This can be disabled so that jobs only WARN when coverage drops but not fail.')
+        booleanParam (name: 'UPLOAD_UNIT_TEST_COVERAGE', defaultValue: false, description: 'Whether to write the UT coverage number to object storage. This always occurs for release-*/master branches. Defaults to true, but it can be disabled to not always upload.')
+        booleanParam (name: 'SKIP_BUILD', defaultValue: false, description: "Skip the PSR tool and Worker builds")
+        booleanParam (name: 'VZ_TEST_DEBUG', defaultValue: true, description: "Enables debug of Verrazzano installation scripts")
+        string (name: 'TAGGED_TESTS', defaultValue: '', trim: true, description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:')
+        string (name: 'INCLUDED_TESTS', defaultValue: '.*', description: 'A regex matching any fully qualified test file that should be executed (e.g. examples/helidon/). Default: .*', trim: true)
+        string (name: 'EXCLUDED_TESTS', defaultValue: '_excluded_test', description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test', trim: true)
     }
 
     environment {
@@ -39,13 +54,14 @@ pipeline {
         DOCKER_PSR_BACKEND_IMAGE_NAME = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_PSR_BACKEND_PUBLISH_IMAGE_NAME : env.DOCKER_PSR_BRANCH_BACKEND_IMAGE_NAME}"
 
         GOPATH = '/home/opc/go'
-        GO_REPO_PATH = "${GOPATH}/src/github.com/verrazzano/verrazzano"
-        PSR_PATH = "${GO_REPO_PATH}/tools/psr"
+        GO_REPO_PATH = "${GOPATH}/src/github.com/verrazzano"
+        VZ_ROOT="${GO_REPO_PATH}/verrazzano"
+        PSR_PATH = "${VZ_ROOT}/tools/psr"
 
         DOCKER_CREDS = credentials('github-packages-credentials-rw')
         DOCKER_EMAIL = credentials('github-packages-email')
         DOCKER_REGISTRY = 'ghcr.io'
-        DOCKER_REPO = 'verrazzano'
+        DOCKER_REPO = "verrazzano"
         OCR_CREDS = credentials('ocr-pull-and-push-account')
         OCR_REPO = 'container-registry.oracle.com'
 
@@ -72,6 +88,23 @@ pipeline {
         OCIR_SCAN_REGISTRY = credentials('ocir-scan-registry')
         OCIR_SCAN_REPOSITORY_PATH = credentials('ocir-scan-repository-path')
         DOCKER_SCAN_CREDS = credentials('v8odev-ocir')
+
+        //VZ_TEST_BRANCH = "${params.VZ_BRANCH_TO_USE}"
+
+        // Environment variable for Verrazzano CLI executable
+        VZ_COMMAND="${WORKSPACE}/vz"
+
+        // used to generate Ginkgo test reports
+        TEST_REPORT = "test-report.xml"
+        GINKGO_REPORT_ARGS = "--junit-report=${TEST_REPORT} --keep-separate-reports=true"
+        TEST_REPORT_DIR = "${WORKSPACE}/tests/e2e"
+        TESTS_EXECUTED_FILE = "${WORKSPACE}/tests_executed_file.tmp"
+
+        KUBECONFIG = "${WORKSPACE}/test_kubeconfig"
+        VERRAZZANO_KUBECONFIG = "${KUBECONFIG}"
+        WILDCARD_DNS_DOMAIN = "nip.io"
+
+        PSR_COMMAND = "${VZ_ROOT}/psrctl"
     }
 
     stages {
@@ -110,6 +143,7 @@ pipeline {
                 moveContentToGoRepoPath()
 
                 script {
+                    EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = getEffectiveDumpOnSuccess()
                     // Create the image tag
                     def props = readProperties file: '.verrazzano-development-version'
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
@@ -120,6 +154,12 @@ pipeline {
                         env.VERRAZZANO_VERSION = "${env.VERRAZZANO_VERSION}-${env.BUILD_NUMBER}+${SHORT_COMMIT_HASH}"
                     }
                     DOCKER_IMAGE_TAG = "v${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
+
+                    env.VZ_TEST_BRANCH = params.VZ_BRANCH_TO_USE
+                    if (params.VZ_BRANCH_TO_USE == "CURRENT") {
+                        env.VZ_TEST_BRANCH = env.BRANCH_NAME
+                    }
+                    echo "VZ_TEST_BRANCH: ${env.VZ_TEST_BRANCH}"
 
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT
@@ -137,6 +177,9 @@ pipeline {
         stage('Parallel Build, Test, and Compliance') {
             parallel {
                 stage('Build PSR CLI and Save Binaries') {
+                    when {
+                        expression {params.SKIP_BUILD == false}
+                    }
                     environment {
                       DOCKER_REPO="${DOCKER_REPO}"
                       DOCKER_REGISTRY="${DOCKER_REGISTRY}"
@@ -159,7 +202,12 @@ pipeline {
                 }
 
                 stage('Build PSR Images and Save Generated Files') {
-                    when { not { buildingTag() } }
+                    when {
+                       allOf {
+                          not { buildingTag() }
+                          expression {params.SKIP_BUILD == false}
+                       }
+                    }
                     environment {
                       DOCKER_REPO="${DOCKER_REPO}"
                       DOCKER_REGISTRY="${DOCKER_REGISTRY}"
@@ -189,7 +237,12 @@ pipeline {
                 }
 
                 stage('Quality, Compliance Checks, and Unit Tests') {
-                    when { not { buildingTag() } }
+                    when {
+                       allOf {
+                          not { buildingTag() }
+                          expression {params.SKIP_BUILD == false}
+                       }
+                    }
                     steps {
                         sh """
                             cd ${PSR_PATH}
@@ -202,7 +255,7 @@ pipeline {
                                 cd ${PSR_PATH}
                                 cp coverage.html ${WORKSPACE}
                                 cp coverage.xml ${WORKSPACE}
-                                ${GO_REPO_PATH}/build/copy-junit-output.sh ${WORKSPACE}
+                                ${VZ_ROOT}/build/copy-junit-output.sh ${WORKSPACE}
                              """
                             cobertura(coberturaReportFile: 'coverage.xml',
                                     enableNewApi: true,
@@ -242,11 +295,51 @@ pipeline {
                }
             }
         }
+
+        stage('Smoke Test') {
+            environment {
+                DOCKER_REPO="${env.DOCKER_REGISTRY}"
+                KIND_KUBERNETES_CLUSTER_VERSION="${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_BUCKET="${env.OCI_OS_BUCKET}"
+                OCI_OS_LOCATION="${env.VZ_TEST_BRANCH}"
+                KIND_NODE_COUNT="${env.KIND_NODE_COUNT}"
+                PSR_COMMAND="${env.PSR_COMMAND}"
+            }
+            steps {
+                script {
+                    runMakeCommand("all")
+                }
+            }
+            post {
+                success {
+                    script {
+                        VZ_TEST_METRIC = metricJobName('psr-smoke-test')
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '1')
+                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
+                            dumpK8sCluster('psr-tests-success-cluster-snapshot')
+                        }
+                    }
+                }
+                failure {
+                    script {
+                        VZ_TEST_METRIC = metricJobName('psr-smoke-test')
+                        METRICS_PUSHED=metricTimerEnd("${VZ_TEST_METRIC}", '0')
+                        if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                            dumpK8sCluster('psr-tests-failure-cluster-snapshot')
+                        }
+                        postFailureProcessing()
+                    }
+                }
+                cleanup {
+                    runMakeCommand("cleanup")
+                }
+            }
+        }
     }
 
     post {
         always {
-            archiveArtifacts artifacts: '**/coverage.html,**/logs/**', allowEmptyArchive: true
+            archiveArtifacts artifacts: "**/scanning-report*.json,**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*full-cluster*/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: '**/*test-result.xml', allowEmptyResults: true
         }
         failure {
@@ -271,13 +364,20 @@ pipeline {
     }
 }
 
+def runMakeCommand(makeTarget) {
+    sh """
+       cd ${VZ_ROOT}/ci/psr
+       make -I ${VZ_ROOT}/ci/make ${makeTarget}
+    """
+}
+
 // Called in Stage CLI steps
 def buildCLI() {
     sh """
         cd ${PSR_PATH}
         make go-build-cli
-        ${GO_REPO_PATH}/ci/scripts/save_psr_tooling.sh ${env.BRANCH_NAME} ${SHORT_COMMIT_HASH}
-        #cp out/linux_amd64/psrctl ${GO_REPO_PATH}/psrctl
+        ${VZ_ROOT}/ci/scripts/save_psr_tooling.sh ${env.BRANCH_NAME} ${SHORT_COMMIT_HASH}
+        cp out/linux_amd64/psrctl ${PSR_COMMAND}
     """
 }
 
@@ -294,7 +394,7 @@ def buildImages(dockerImageTag) {
 // REVIEW: seems redundant with the save_psr_tooling script?
 def saveCLIExecutables() {
     sh """
-        cd ${GO_REPO_PATH}/tools/psr
+        cd ${VZ_ROOT}/tools/psr
         oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/psrctl-linux-amd64.tar.gz --file $WORKSPACE/psrctl-linux-amd64.tar.gz
         oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/psrctl-linux-amd64.tar.gz --file $WORKSPACE/psrctl-linux-amd64.tar.gz
         oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_BUCKET} --name ${env.BRANCH_NAME}/psrctl-linux-amd64.tar.gz.sha256 --file $WORKSPACE/psrctl-linux-amd64.tar.gz.sha256
@@ -306,8 +406,10 @@ def saveCLIExecutables() {
 def runGinkgoRandomize(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
-            cd ${GO_REPO_PATH}/tests/e2e
-            ginkgo -p --randomize-all -v --keep-going --no-color ${testSuitePath}/...
+            cd ${VZ_ROOT}/tests/e2e
+            if [ -d "${testSuitePath}" ]; then
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            fi
             ../../build/copy-junit-output.sh ${WORKSPACE}
         """
     }
@@ -317,11 +419,43 @@ def runGinkgoRandomize(testSuitePath) {
 def runGinkgo(testSuitePath) {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
-            cd ${GO_REPO_PATH}/tests/e2e
-            ginkgo -v --keep-going --no-color ${testSuitePath}/...
+            cd ${VZ_ROOT}/tests/e2e
+            ginkgo -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
             ../../build/copy-junit-output.sh ${WORKSPACE}
         """
     }
+}
+
+def dumpK8sCluster(dumpDirectory) {
+    sh """
+        ${VZ_ROOT}/ci/scripts/capture_cluster_snapshot.sh ${dumpDirectory}
+    """
+}
+
+def postFailureProcessing() {
+    sh """
+        curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o ${WORKSPACE}/build-console-output.log ${BUILD_URL}consoleText
+    """
+    archiveArtifacts artifacts: '**/build-console-output.log', allowEmptyArchive: true
+    sh """
+        curl -k -u ${JENKINS_READ_USR}:${JENKINS_READ_PSW} -o archive.zip ${BUILD_URL}artifact/*zip*/archive.zip
+        oci --region us-phoenix-1 os object put --force --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_ARTIFACT_BUCKET} --name ${env.JOB_NAME}/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/archive.zip --file archive.zip
+        rm archive.zip
+    """
+    script {
+        if (env.BRANCH_NAME == "master" || env.BRANCH_NAME ==~ "release-.*" || env.BRANCH_NAME ==~ "mark/*") {
+            slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
+        }
+    }
+}
+
+def getEffectiveDumpOnSuccess() {
+    def effectiveValue = params.DUMP_K8S_CLUSTER_ON_SUCCESS
+    if (FORCE_DUMP_K8S_CLUSTER_ON_SUCCESS.equals("true") && (env.BRANCH_NAME.equals("master"))) {
+        effectiveValue = true
+        echo "Forcing dump on success based on global override setting"
+    }
+    return effectiveValue
 }
 
 def isPagerDutyEnabled() {
@@ -336,9 +470,9 @@ def isPagerDutyEnabled() {
 // Called in Stage Clean workspace and checkout steps
 def moveContentToGoRepoPath() {
     sh """
-        rm -rf ${GO_REPO_PATH}
-        mkdir -p ${GO_REPO_PATH}
-        tar cf - . | (cd ${GO_REPO_PATH}/ ; tar xf -)
+        rm -rf ${VZ_ROOT}
+        mkdir -p ${VZ_ROOT}
+        tar cf - . | (cd ${VZ_ROOT}/ ; tar xf -)
     """
 }
 

--- a/ci/psr/Makefile
+++ b/ci/psr/Makefile
@@ -32,13 +32,6 @@ test: export IMAGE_PULL_SECRET ?= verrazzano-container-registry
 test: export DOCKER_REGISTRY ?= ghcr.io
 .PHONY: test
 test: run-test-parallel
-#	kubectl create ns ${TEST_NAMESPACE} || true
-#	kubectl label ns --overwrite=true ${TEST_NAMESPACE} verrazzano-managed=true istio-injection=enabled
-#	${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "${TEST_NAMESPACE}"
-#	${PSR_COMMAND} start -s ops-s2 -n psrtest
-#	sleep 120
-#	${PSR_COMMAND} stop -s ops-s2 -n psrtest
-#	@echo "Testing complete"
 
 # Executes an upgrade to a new Verrazzano version from the initially installed version
 .PHONY: cleanup

--- a/ci/psr/Makefile
+++ b/ci/psr/Makefile
@@ -4,6 +4,9 @@
 include ../make/kind.mk
 include ../make/install.mk
 include ../make/cleanup.mk
+include ../make/tests.mk
+
+export PSR_PATH ?= ${VZ_ROOT}/tools/psr
 
 .PHONY: all
 all: setup install test
@@ -21,19 +24,21 @@ install:
 	make install-verrazzano
 
 # Executes test suite(s) against the target Verrazzano install
-test: export TEST_SUITES ?= verify-install/...
+test: export TEST_ROOT = ${PSR_PATH}/tests
+test: export TEST_SUITES ?= opensearch/...
 test: export PSR_COMMAND ?= psrctl
 test: export TEST_NAMESPACE ?= psrtest
+test: export IMAGE_PULL_SECRET ?= verrazzano-container-registry
+test: export DOCKER_REGISTRY ?= ghcr.io
 .PHONY: test
-test:
-	@echo "Running tests ${TEST_SUITES}"
-	kubectl create ns ${TEST_NAMESPACE} || true
-	kubectl label ns --overwrite=true ${TEST_NAMESPACE} verrazzano-managed=true istio-injection=enabled
-	${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "${TEST_NAMESPACE}"
-	${PSR_COMMAND} start -s ops-s2 -n psrtest
-	sleep 120
-	${PSR_COMMAND} stop -s ops-s2 -n psrtest
-	@echo "Testing complete"
+test: run-test-parallel
+#	kubectl create ns ${TEST_NAMESPACE} || true
+#	kubectl label ns --overwrite=true ${TEST_NAMESPACE} verrazzano-managed=true istio-injection=enabled
+#	${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "${TEST_NAMESPACE}"
+#	${PSR_COMMAND} start -s ops-s2 -n psrtest
+#	sleep 120
+#	${PSR_COMMAND} stop -s ops-s2 -n psrtest
+#	@echo "Testing complete"
 
 # Executes an upgrade to a new Verrazzano version from the initially installed version
 .PHONY: cleanup

--- a/ci/psr/Makefile
+++ b/ci/psr/Makefile
@@ -1,0 +1,41 @@
+# Copyright (C) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+include ../make/kind.mk
+include ../make/install.mk
+include ../make/cleanup.mk
+
+.PHONY: all
+all: setup install test
+
+setup: export K8S_VERSION = 1.24
+.PHONY: setup
+setup:
+	@echo "Running test setup"
+	make setup-kind
+
+# Peforms an install of Verrazzano to the target system
+.PHONY: install
+install: 
+	@echo "Installing Verrazzano"
+	make install-verrazzano
+
+# Executes test suite(s) against the target Verrazzano install
+test: export TEST_SUITES ?= verify-install/...
+test: export PSR_COMMAND ?= psrctl
+test: export TEST_NAMESPACE ?= psrtest
+.PHONY: test
+test:
+	@echo "Running tests ${TEST_SUITES}"
+	kubectl create ns ${TEST_NAMESPACE} || true
+	kubectl label ns --overwrite=true ${TEST_NAMESPACE} verrazzano-managed=true istio-injection=enabled
+	${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "${TEST_NAMESPACE}"
+	${PSR_COMMAND} start -s ops-s2 -n psrtest
+	sleep 120
+	${PSR_COMMAND} stop -s ops-s2 -n psrtest
+	@echo "Testing complete"
+
+# Executes an upgrade to a new Verrazzano version from the initially installed version
+.PHONY: cleanup
+cleanup: pipeline-artifacts clean-kind
+	@echo "Running test cleanup"

--- a/ci/scripts/cleanup_kind_clusters.sh
+++ b/ci/scripts/cleanup_kind_clusters.sh
@@ -13,6 +13,20 @@ if [ -z "${KUBECONFIG}" ]; then
   exit 1
 fi
 
+# Set CLEANUP_KIND_CONTAINERS to true, while second cluster and onwards
+if [ "${CLEANUP_KIND_CONTAINERS}" == "true" ]; then
+  cd ${PLATFORM_OPERATOR_DIR}/build/scripts
+  ./cleanup.sh ${CLUSTER_NAME}
+else
+  echo "Delete the cluster and kube config in multi-cluster environment"
+  kind delete cluster --name ${CLUSTER_NAME}
+  if [ -f "${KUBECONFIG}" ]
+  then
+    echo "Deleting the kubeconfig '${KUBECONFIG}' ..."
+    rm ${KUBECONFIG}
+  fi
+fi
+
 echo "Delete the cluster and kube config in multi-cluster environment"
 kind delete cluster --name ${CLUSTER_NAME}
 if [ -f "${KUBECONFIG}" ]

--- a/ci/scripts/dumpRunLogs.sh
+++ b/ci/scripts/dumpRunLogs.sh
@@ -1,6 +1,14 @@
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+set -u
+
+POST_DUMP_FAILED_FILE="${POST_DUMP_FAILED_FILE:-${WORKSPACE}/post_dump_failed_file.tmp}"
+VZ_LOGS_ROOT="${VZ_LOGS_ROOT:-${WORKSPACE}/logs}"
+VERRAZZANO_INSTALL_LOGS_DIR="${VERRAZZANO_INSTALL_LOGS_DIR:-${VZ_LOGS_ROOT}}"
+VZ_COMMAND="${VZ_COMMAND:-${GOPATH}/bin/vz}"
+TESTS_EXECUTED_FILE="${TESTS_EXECUTED_FILE:-${WORKSPACE}/tests_executed_file.tmp}"
+
 dumpK8sCluster() {
   ANALYSIS_REPORT="analysis.report"
   dumpDirectory=$1
@@ -10,7 +18,7 @@ dumpK8sCluster() {
   # Create a bug-report and run analysis tool on the bug-report
   # Requires environment variable KUBECONFIG or $HOME/.kube/config
   BUG_REPORT_FILE="${dumpDirectory}/bug-report.tar.gz"
-  if [[ -x $GOPATH/bin/vz ]]; then
+  if [[ -x ${VZ_COMMAND} ]]; then
     $GOPATH/vz bug-report --report-file ${BUG_REPORT_FILE}
   else
     GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go bug-report --report-file ${BUG_REPORT_FILE}
@@ -23,8 +31,8 @@ dumpK8sCluster() {
     rm ${BUG_REPORT_FILE} || true
 
     # Run vz analyze on the extracted directory
-    if [[ -x $GOPATH/bin/vz ]]; then
-      $GOPATH/vz analyze --capture-dir ${dumpDirectory}/bug-report --report-format detailed --report-file ${dumpDirectory}/bug-report/${ANALYSIS_REPORT}
+    if [[ -x ${VZ_COMMAND} ]]; then
+      ${VZ_COMMAND} analyze --capture-dir ${dumpDirectory}/bug-report --report-format detailed --report-file ${dumpDirectory}/bug-report/${ANALYSIS_REPORT}
     else
       GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go analyze --capture-dir ${dumpDirectory}/bug-report --report-format detailed --report-file ${dumpDirectory}/bug-report/${ANALYSIS_REPORT}
     fi
@@ -33,35 +41,42 @@ dumpK8sCluster() {
 
 dumpVerrazzanoSystemPods() {
   cd ${GO_REPO_PATH}/verrazzano/platform-operator
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-system-pods.log"
+  local sysLogs=${VERRAZZANO_INSTALL_LOGS_DIR}/system
+  mkdir -p ${sysLogs}
+  export DIAGNOSTIC_LOG="${sysLogs}/verrazzano-system-pods.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -m "verrazzano system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-system-certs.log"
+  export DIAGNOSTIC_LOG="${sysLogs}/verrazzano-system-certs.log"
   ./scripts/install/k8s-dump-objects.sh -o cert -n verrazzano-system -m "verrazzano system certs" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-system-osd.log"
+  export DIAGNOSTIC_LOG="${sysLogs}/verrazzano-system-osd.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-osd-*" -m "verrazzano system opensearchdashboards log" -l -c osd || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-system-es-master.log"
-  ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-es-master-*" -m "verrazzano system opensearchdashboards log" -l -c es-master || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  export DIAGNOSTIC_LOG="${sysLogs}/verrazzano-system-os-master.log"
+  ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "vmi-system-os-master-*" -m "verrazzano system opensearchdashboards log" -l -c es-master || echo "failed" > ${POST_DUMP_FAILED_FILE}
 }
 
 dumpCattleSystemPods() {
   cd ${GO_REPO_PATH}/verrazzano/platform-operator
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/cattle-system-pods.log"
+  local rancherLogs=${VERRAZZANO_INSTALL_LOGS_DIR}/rancher
+  mkdir -p ${rancherLogs}
+  export DIAGNOSTIC_LOG="${rancherLogs}/cattle-system-pods.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -m "cattle system pods" || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/rancher.log"
+  export DIAGNOSTIC_LOG="${rancherLogs}/rancher.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n cattle-system -r "rancher-*" -m "Rancher logs" -c rancher -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
 }
 
 dumpNginxIngressControllerLogs() {
   cd ${GO_REPO_PATH}/verrazzano/platform-operator
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/nginx-ingress-controller.log"
+  local nginxLogs=${VERRAZZANO_INSTALL_LOGS_DIR}/nginx
+  mkdir -p ${nginxLogs}
+  export DIAGNOSTIC_LOG="${nginxLogs}/nginx-ingress-controller.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n ingress-nginx -r "nginx-ingress-controller-*" -m "Nginx Ingress Controller" -c controller -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
 }
 
 dumpVerrazzanoPlatformOperatorLogs() {
   ## dump out verrazzano-platform-operator logs
-  mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
-  kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  local vpoLogs=${VZ_LOGS_ROOT}/verrazzano-platform-operator
+  mkdir -p ${vpoLogs}
+  kubectl -n verrazzano-install logs --selector=app=verrazzano-platform-operator > ${vpoLogs}/verrazzano-platform-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  kubectl -n verrazzano-install describe pod --selector=app=verrazzano-platform-operator > ${vpoLogs}/verrazzano-platform-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
   echo "verrazzano-platform-operator logs dumped to verrazzano-platform-operator-pod.log"
   echo "verrazzano-platform-operator pod description dumped to verrazzano-platform-operator-pod.out"
   echo "------------------------------------------"
@@ -69,9 +84,10 @@ dumpVerrazzanoPlatformOperatorLogs() {
 
 dumpVerrazzanoApplicationOperatorLogs() {
   ## dump out verrazzano-application-operator logs
-  mkdir -p ${WORKSPACE}/verrazzano-application-operator/logs
-  kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${WORKSPACE}/verrazzano-application-operator/logs/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  local vaoLogs=${VZ_LOGS_ROOT}/verrazzano-application-operator
+  mkdir -p ${vaoLogs}
+  kubectl -n verrazzano-system logs --selector=app=verrazzano-application-operator > ${vaoLogs}/verrazzano-application-operator-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  kubectl -n verrazzano-system describe pod --selector=app=verrazzano-application-operator > ${vaoLogs}/verrazzano-application-operator-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
   echo "verrazzano-application-operator logs dumped to verrazzano-application-operator-pod.log"
   echo "verrazzano-application-operator pod description dumped to verrazzano-application-operator-pod.out"
   echo "------------------------------------------"
@@ -79,9 +95,10 @@ dumpVerrazzanoApplicationOperatorLogs() {
 
 dumpOamKubernetesRuntimeLogs() {
   ## dump out oam-kubernetes-runtime logs
-  mkdir -p ${WORKSPACE}/oam-kubernetes-runtime/logs
-  kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/oam-kubernetes-runtime/logs/oam-kubernetes-runtime-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
-  kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${WORKSPACE}/verrazzano-application-operator/logs/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  local oamLogs=${VZ_LOGS_ROOT}/oam-kubernetes-runtime
+  mkdir -p ${oamLogs}
+  kubectl -n verrazzano-system logs --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${oamLogs}/oam-kubernetes-runtime-pod.log --tail -1 || echo "failed" > ${POST_DUMP_FAILED_FILE}
+  kubectl -n verrazzano-system describe pod --selector=app.kubernetes.io/instance=oam-kubernetes-runtime > ${oamLogs}/oam-kubernetes-runtime-pod.out || echo "failed" > ${POST_DUMP_FAILED_FILE}
   echo "verrazzano-application-operator logs dumped to oam-kubernetes-runtime-pod.log"
   echo "verrazzano-application-operator pod description dumped to oam-kubernetes-runtime-pod.out"
   echo "------------------------------------------"
@@ -89,7 +106,9 @@ dumpOamKubernetesRuntimeLogs() {
 
 dumpVerrazzanoApiLogs() {
   cd ${GO_REPO_PATH}/verrazzano/platform-operator
-  export DIAGNOSTIC_LOG="${VERRAZZANO_INSTALL_LOGS_DIR}/verrazzano-authproxy.log"
+  local sysLogs=${VERRAZZANO_INSTALL_LOGS_DIR}/system
+  mkdir -p ${sysLogs}
+  export DIAGNOSTIC_LOG="${sysLogs}/verrazzano-authproxy.log"
   ./scripts/install/k8s-dump-objects.sh -o pods -n verrazzano-system -r "verrazzano-authproxy-*" -m "verrazzano api" -c verrazzano-authproxy -l || echo "failed" > ${POST_DUMP_FAILED_FILE}
 }
 

--- a/ci/scripts/run-ginkgo.sh
+++ b/ci/scripts/run-ginkgo.sh
@@ -10,6 +10,7 @@ if [ -z "${TEST_SUITES}" ]; then
   exit 0
 fi
 
+TEST_ROOT=${TEST_ROOT:-"${GOPATH}/src/github.com/verrazzano"}
 TEST_DUMP_ROOT=${TEST_DUMP_ROOT:-"."}
 SEQUENTIAL_SUITES=${SEQUENTIAL_SUITES:-false}
 

--- a/ci/scripts/setup_kind.sh
+++ b/ci/scripts/setup_kind.sh
@@ -53,9 +53,6 @@ BRANCH_NAME=${BRANCH_NAME:-$(git branch --show-current)}
 SHORT_COMMIT_HASH=${SHORT_COMMIT_HASH:-$(git rev-parse --short=8 HEAD)}
 OCI_OS_LOCATION=${OCI_OS_LOCATION:-ephemeral/${BRANCH_NAME}/${SHORT_COMMIT_HASH}}
 
-TEST_OVERRIDE_CONFIGMAP_FILE="${TEST_SCRIPTS_DIR}/pre-install-overrides/test-overrides-configmap.yaml"
-TEST_OVERRIDE_SECRET_FILE="${TEST_SCRIPTS_DIR}/pre-install-overrides/test-overrides-secret.yaml"
-
 KIND_CACHING=${KIND_CACHING:="false"}
 KIND_NODE_COUNT=${KIND_NODE_COUNT:-1}
 
@@ -86,70 +83,6 @@ echo "Listing pods in kube-system namespace ..."
 kubectl get pods -n kube-system
 
 echo "Install metallb"
-#cd ${GO_REPO_PATH}/verrazzano
 ${TEST_SCRIPTS_DIR}/install-metallb.sh
-
-echo "Create Image Pull Secrets"
-${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}"
-# REVIEW: Do we need github-packages still?
-${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh github-packages "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}"
-if [ -n "${OCR_REPO}" ] && [ -n "${OCR_CREDS_USR}" ] && [ -n "${OCR_CREDS_PSW}" ]; then
-  echo "Creating Oracle Container Registry pull secret"
-  ${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh ocr "${OCR_REPO}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}"
-fi
-
-if ! kubectl get cm test-overrides 2>&1 > /dev/null; then
-  echo "Creating Override ConfigMap"
-  kubectl create cm test-overrides --from-file=${TEST_OVERRIDE_CONFIGMAP_FILE}
-  if [ $? -ne 0 ]; then
-    echo "Could not create Override ConfigMap"
-    exit 1
-  fi
-fi
-
-if ! kubectl get secret test-overrides 2>&1 > /dev/null; then
-  echo "Creating Override Secret"
-  kubectl create secret generic test-overrides --from-file=${TEST_OVERRIDE_SECRET_FILE}
-  if [ $? -ne 0 ]; then
-    echo "Could not create Override Secret"
-    exit 1
-  fi
-fi
-
-# optionally create a cluster dump snapshot for verifying uninstalls
-if [ -n "${CLUSTER_SNAPSHOT_DIR}" ]; then
-  ${TEST_SCRIPTS_DIR}/looping-test/dump_cluster.sh ${CLUSTER_SNAPSHOT_DIR}
-fi
-
-echo "Install Platform Operator"
-if [ -z "$OPERATOR_YAML" ] && [ "" = "${OPERATOR_YAML}" ]; then
-  # Derive the name of the operator.yaml file, copy or generate the file, then install
-  if [ "NONE" = "${VERRAZZANO_OPERATOR_IMAGE}" ]; then
-      echo "Using operator.yaml from object storage location ${OCI_OS_LOCATION}"
-      curl -s -L https://objectstorage.us-phoenix-1.oraclecloud.com/n/${OCI_OS_NAMESPACE}/b/${OCI_OS_COMMIT_BUCKET}/o/${OCI_OS_LOCATION}/operator.yaml > ${WORKSPACE}/downloaded-operator.yaml
-      cp ${WORKSPACE}/downloaded-operator.yaml ${WORKSPACE}/acceptance-test-operator.yaml
-  else
-      echo "Generating operator.yaml based on image name provided: ${VERRAZZANO_OPERATOR_IMAGE}"
-      env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${VERRAZZANO_OPERATOR_IMAGE} ${VZ_ROOT}/tools/scripts/generate_operator_yaml.sh > ${WORKSPACE}/acceptance-test-operator.yaml
-  fi
-  kubectl apply -f ${WORKSPACE}/acceptance-test-operator.yaml
-else
-  # The operator.yaml filename was provided, install using that file.
-  echo "Using provided operator.yaml file: " ${OPERATOR_YAML}
-  kubectl apply -f ${OPERATOR_YAML}
-fi
-
-# make sure ns exists
-${TEST_SCRIPTS_DIR}/check_verrazzano_ns_exists.sh verrazzano-install
-
-# create secret in verrazzano-install ns
-${TEST_SCRIPTS_DIR}/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
-
-echo "Wait for Operator to be ready"
-kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-if [ $? -ne 0 ]; then
-  echo "Operator is not ready"
-  exit 1
-fi
 
 exit 0

--- a/tests/e2e/config/scripts/create_kind_cluster.sh
+++ b/tests/e2e/config/scripts/create_kind_cluster.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
-
+set -x
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 CLUSTER_NAME=$1
 PLATFORM_OPERATOR_DIR=$2
@@ -19,13 +19,13 @@ KIND_IMAGE=""
 CALICO_SUFFIX=""
 
 create_kind_cluster() {
-  if [ ${K8S_VERSION} == 1.21 ]; then
+  if [ "${K8S_VERSION}" == "1.21" ]; then
     KIND_IMAGE="v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207"
-  elif [ ${K8S_VERSION} == 1.22 ]; then
+  elif [ "${K8S_VERSION}" == "1.22" ]; then
     KIND_IMAGE="v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105"
-  elif [ ${K8S_VERSION} == 1.23 ]; then
+  elif [ "${K8S_VERSION}" == "1.23" ]; then
     KIND_IMAGE="v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
-  elif [ ${K8S_VERSION} == 1.24 ]; then
+  elif [ "${K8S_VERSION}" == "1.24" ]; then
     KIND_IMAGE="v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e"
   else
     echo "ERROR: Invalid value for Kubernetes Version ${K8S_VERSION}."

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -1007,6 +1007,44 @@ func CreateNamespace(name string, labels map[string]string) (*corev1.Namespace, 
 	return CreateNamespaceWithAnnotations(name, labels, nil)
 }
 
+// CreateOrUpdateNamespace creates or updates a namespace
+func CreateOrUpdateNamespace(name string, labels map[string]string, annotations map[string]string) (*corev1.Namespace, error) {
+	// Get the Kubernetes clientset
+	clientset, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	var ns *corev1.Namespace
+	if ns, err = clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+		return clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+			}, metav1.CreateOptions{})
+	}
+	ns.Labels = mergeMaps(ns.Labels, labels)
+	ns.Annotations = mergeMaps(ns.Annotations, annotations)
+	return clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+}
+
+func mergeMaps(m1 map[string]string, m2 map[string]string) map[string]string {
+	result := m1
+	if result == nil {
+		result = map[string]string{}
+	}
+	// merge keys from m2 into m1, overwriting existing keys of m1.
+	for k, v := range m2 {
+		result[k] = v
+	}
+	return result
+}
+
 func CreateNamespaceWithAnnotations(name string, labels map[string]string, annotations map[string]string) (*corev1.Namespace, error) {
 	// Get the Kubernetes clientset
 	clientset, err := k8sutil.GetKubernetesClientset()

--- a/tools/psr/Makefile
+++ b/tools/psr/Makefile
@@ -114,8 +114,8 @@ run-cli:
 # install the CLI
 #
 .PHONY: install-cli
-install-cli:
-	$(GO) install -ldflags "${CLI_GO_LDFLAGS}" ./...
+install-cli: docker-build
+	$(GO) install -ldflags "${CLI_GO_LDFLAGS}" ./psrctl/...
 
 .PHONY: unit-test
 unit-test:

--- a/tools/psr/Makefile
+++ b/tools/psr/Makefile
@@ -121,5 +121,7 @@ install-cli:
 unit-test:
 	$(GO) test -v  ${TEST_PATHS}
 
+psr-quality: export FAIL_IF_COVERAGE_DECREASED ?= false
+psr-quality: export UPLOAD_UNIT_TEST_COVERAGE ?= false
 .PHONY: psr-quality
 psr-quality: golangci-lint word-linter coverage

--- a/tools/psr/psrctl/cmd/constants/constants.go
+++ b/tools/psr/psrctl/cmd/constants/constants.go
@@ -35,6 +35,10 @@ const (
 	ImageNameKey        = "imageName"
 	ImagePullSecKey     = "imagePullSecrets[0].name"
 	ImagePullSecDefault = "verrazzano-container-registry"
+
+	OutputFormatName      = "output"
+	OutputFormatNameShort = "o"
+	OutputFormatHelp      = "Output format, can be one of \"json\" or \"text\", defaults to \"text\""
 )
 
 var defaultWorkerImage string

--- a/tools/psr/psrctl/cmd/list/list.go
+++ b/tools/psr/psrctl/cmd/list/list.go
@@ -4,6 +4,7 @@
 package list
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/cmd/constants"
@@ -26,6 +27,7 @@ psrctl list -n foo
 var scenarioID string
 var namespace string
 var allNamepaces bool
+var outputFormat string
 
 func NewCmdList(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd := cmdhelpers.NewCommand(vzHelper, CommandName, helpShort, helpLong)
@@ -38,6 +40,8 @@ func NewCmdList(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&scenarioID, constants.FlagScenario, constants.FlagsScenarioShort, "", constants.FlagScenarioHelp)
 	cmd.PersistentFlags().StringVarP(&namespace, constants.FlagNamespace, constants.FlagNamespaceShort, "default", constants.FlagNamespaceHelp)
 	cmd.PersistentFlags().BoolVarP(&allNamepaces, constants.FlagAll, constants.FlagAllShort, false, constants.FlagAllHelp)
+	cmd.PersistentFlags().StringVarP(&outputFormat, constants.OutputFormatName, constants.OutputFormatNameShort, "text", constants.OutputFormatHelp)
+	cmd.PersistentFlags().MarkHidden(constants.OutputFormatName)
 
 	return cmd
 }
@@ -63,6 +67,15 @@ func RunCmdList(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		} else {
 			fmt.Printf("There are no scenarios running in namespace %s\n", namespace)
 		}
+		return nil
+	}
+
+	if outputFormat == "json" {
+		jsonOut, err := json.Marshal(scenarios)
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(jsonOut))
 		return nil
 	}
 

--- a/tools/psr/tests/opensearch/s2/opensearch_s2_suite_test.go
+++ b/tools/psr/tests/opensearch/s2/opensearch_s2_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package s2
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+)
+
+var t = framework.NewTestFramework("psr_ops_s2")
+
+var skipStartScenario bool
+var skipStopScenario bool
+
+func init() {
+	flag.BoolVar(&skipStartScenario, "skipStartScenario", false, "skipStartScenario skips the call to start the scenario")
+	flag.BoolVar(&skipStopScenario, "skipStopScenario", false, "skipStopScenario skips the call to stop the scenario")
+}
+
+func TestOpenSearchScenarios(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Opensearch ops-s2 Suite")
+}

--- a/tools/psr/tests/opensearch/s2/opensearch_s2_test.go
+++ b/tools/psr/tests/opensearch/s2/opensearch_s2_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package s2
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/tools/psr/tests/pkg/constants"
+	"github.com/verrazzano/verrazzano/tools/psr/tests/pkg/psrctlcli"
+	"github.com/verrazzano/verrazzano/tools/psr/tests/pkg/secrets"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+
+	"github.com/hashicorp/go-retryablehttp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	longWaitTimeout     = 15 * time.Minute
+	longPollingInterval = 30 * time.Second
+
+	namespace  = "psrtest"
+	scenarioID = "ops-s2"
+)
+
+var (
+	vz             *v1beta1.Verrazzano
+	httpClient     *retryablehttp.Client
+	vmiCredentials *pkg.UsernamePassword
+
+	kubeconfig string
+
+	namespaceLabels = map[string]string{
+		"istio-injection":    "enabled",
+		"verrazzano-managed": "true",
+	}
+)
+
+var beforeSuite = t.BeforeSuiteFunc(func() {
+	var err error
+	vz, err = pkg.GetVerrazzanoV1beta1()
+	Expect(err).To(Not(HaveOccurred()))
+
+	kubeconfig, _ = k8sutil.GetKubeConfigLocation()
+
+	httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
+	vmiCredentials = pkg.EventuallyGetSystemVMICredentials()
+
+	if _, err = pkg.CreateOrUpdateNamespace(namespace, namespaceLabels, nil); err != nil {
+		t.Fail(fmt.Sprintf("Error creating or updating namespace %s: %s", namespace, err.Error()))
+		return
+	}
+
+	if err := secrets.CreateOrUpdatePipelineImagePullSecret(log, namespace, kubeconfig); err != nil {
+		t.Fail(fmt.Sprintf("Error creating creating image pull secret for tests suite: %s", err.Error()))
+		return
+	}
+
+	if !psrctlcli.IsScenarioRunning(log, scenarioID, namespace) {
+		_, stderr, err := psrctlcli.StartScenario(log, scenarioID, namespace)
+		if err != nil {
+			t.Fail(fmt.Sprintf("Error starting scenario: %s", err.Error()))
+			log.Error(string(stderr))
+			return
+		}
+	}
+})
+
+var afterSuite = t.AfterSuiteFunc(func() {
+	if psrctlcli.IsScenarioRunning(log, scenarioID, namespace) {
+		_, stderr, err := psrctlcli.StopScenario(log, scenarioID, namespace)
+		if err != nil {
+			log.Errorf("Error starting scenario: %s", err.Error())
+			log.Error(string(stderr))
+		}
+	}
+})
+
+var _ = BeforeSuite(beforeSuite)
+
+var _ = AfterSuite(afterSuite)
+
+var log = vzlog.DefaultLogger()
+
+var _ = t.Describe("ops-s2", Label("f:psr-ops-s2"), func() {
+	const (
+		waitTimeout     = 2 * time.Minute
+		pollingInterval = 5 * time.Second
+	)
+
+	// GIVEN a Verrazzano installation with a running PSR ops-s2 scenario
+	// WHEN  we wish to validate the PSR workers
+	// THEN  the scenario pods are running
+	t.DescribeTable("Scenario pods are deployed,",
+		func(name string, expected bool) {
+			Eventually(func() (bool, error) {
+				exists, err := pkg.DoesPodExist(namespace, name)
+				if exists {
+					t.Logs.Infof("Found pod %s/%s", namespace, name)
+				}
+				return exists, err
+			}, waitTimeout, pollingInterval).Should(Equal(expected))
+		},
+		t.Entry("PSR ops-s2 getlogs-0 pods running", "psr-ops-s2-ops-getlogs-0-ops-getlogs", true),
+		t.Entry("PSR ops-s2 getlogs-1 pods running", "psr-ops-s2-ops-getlogs-1-ops-getlogs", true),
+		t.Entry("PSR ops-s2 writelogs-1 pods running", "psr-ops-s2-ops-writelogs-2-ops-writelogs", true),
+	)
+
+	// GIVEN a Verrazzano installation
+	// WHEN  we wish to validate the PSR workers
+	// THEN  we can successfully access the prometheus endpoint
+	t.DescribeTable("Verify Prometheus Endpoint",
+		func(getURLFromVZStatus func() *string) {
+			url := getURLFromVZStatus()
+			if url != nil {
+				Eventually(func() (int, error) {
+					return httpGet(*url)
+				}).WithPolling(pollingInterval).WithTimeout(waitTimeout).Should(Equal(http.StatusOK))
+			}
+		},
+		Entry("Prometheus", func() *string { return vz.Status.VerrazzanoInstance.PrometheusURL }),
+	)
+
+	testfunc := func(getMetricName func() string) {
+		metricName := getMetricName()
+		Eventually(func() bool {
+			return pkg.MetricsExistInCluster(metricName, getMetricLabels(""), kubeconfig)
+		}, longWaitTimeout, longPollingInterval).Should(BeTrue(),
+			fmt.Sprintf("No metrics found for %s", metricName))
+	}
+
+	// GIVEN a Verrazzano installation
+	// WHEN  all opensearch PSR workers are running
+	// THEN  metrics can be found for all opensearch PSR workers
+	metrics := constants.GetOpsS2Metrics()
+	metricsTestTableEntries := []interface{}{testfunc}
+	for i := range metrics {
+		osWorkerMetric := metrics[i]
+		metricsTestTableEntries = append(metricsTestTableEntries,
+			Entry(fmt.Sprintf("Verify metric %s", osWorkerMetric), func() string {
+				return osWorkerMetric
+			}),
+		)
+	}
+	t.DescribeTable("Verify Opensearch Worker Metrics", metricsTestTableEntries...)
+})
+
+func getMetricLabels(_ string) map[string]string {
+	return map[string]string{
+		//"app_oam_dev_component": podName,
+		"verrazzano_cluster": "local",
+	}
+}
+
+// MetricsRangeExistsInCluster validates the availability of a given metric in the given cluster over an interval
+func MetricsRangeExistsInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
+	end := time.Now()
+	start := end.Add(time.Duration(-24) * time.Hour)
+	duration := int64(30)
+	metric, err := pkg.QueryMetricRange(metricsName, &start, &end, duration, kubeconfigPath)
+	if err != nil {
+		return false
+	}
+	metrics := pkg.JTq(metric, "data", "result").([]interface{})
+	if metrics != nil {
+		return pkg.FindMetric(metrics, keyMap)
+	}
+	return false
+}
+
+// httpGet issues an HTTP GET request with basic auth to the specified URL. httpGet returns the HTTP status code
+// and an error.
+func httpGet(url string) (int, error) {
+	req, err := retryablehttp.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.SetBasicAuth(vmiCredentials.Username, vmiCredentials.Password)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	return resp.StatusCode, nil
+}

--- a/tools/psr/tests/pkg/constants/opensearch_metrics.go
+++ b/tools/psr/tests/pkg/constants/opensearch_metrics.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package constants
+
+var OpensearchGetLogsMetrics = []string{
+	"psr_opensearch_getlogs_data_chars_total",
+	"psr_opensearch_getlogs_failure_count_total",
+	"psr_opensearch_getlogs_failure_latency_nanoseconds",
+	"psr_opensearch_getlogs_loop_count_total",
+	"psr_opensearch_getlogs_success_count_total",
+	"psr_opensearch_getlogs_success_latency_nanoseconds",
+	"psr_opensearch_getlogs_worker_last_loop_nanoseconds",
+	"psr_opensearch_getlogs_worker_running_seconds_total",
+	"psr_opensearch_getlogs_worker_thread_count_total",
+}
+
+var OpensearchPostLogsMetrics = []string{
+	"psr_opensearch_postlogs_data_chars_total",
+	"psr_opensearch_postlogs_failure_count_total",
+	"psr_opensearch_postlogs_failure_latency_nanoseconds",
+	"psr_opensearch_postlogs_loop_count_total",
+	"psr_opensearch_postlogs_success_count_total",
+	"psr_opensearch_postlogs_success_latency_nanoseconds",
+	"psr_opensearch_postlogs_worker_last_loop_nanoseconds",
+	"psr_opensearch_postlogs_worker_running_seconds_total",
+	"psr_opensearch_postlogs_worker_thread_count_total",
+}
+
+var OpensearchRestartMetrics = []string{
+	"psr_opensearch_restart_loop_count_total",
+	"psr_opensearch_restart_pod_restart_count",
+	"psr_opensearch_restart_pod_restart_time_nanoseconds",
+	"psr_opensearch_restart_worker_last_loop_nanoseconds",
+	"psr_opensearch_restart_worker_running_seconds_total",
+	"psr_opensearch_restart_worker_thread_count_total",
+}
+
+var OpensearchScalingMetrics = []string{
+	"psr_opensearch_scaling_loop_count_total",
+	"psr_opensearch_scaling_scale_in_count_total",
+	"psr_opensearch_scaling_scale_in_seconds",
+	"psr_opensearch_scaling_scale_out_count_total",
+	"psr_opensearch_scaling_scale_out_seconds",
+	"psr_opensearch_scaling_worker_last_loop_nanoseconds",
+	"psr_opensearch_scaling_worker_running_seconds_total",
+	"psr_opensearch_scaling_worker_thread_count_total",
+}
+
+var OpensearchWritelogsMetrics = []string{
+	"psr_opensearch_writelogs_logged_chars_total",
+	"psr_opensearch_writelogs_logged_lines_count_total",
+	"psr_opensearch_writelogs_loop_count_total",
+	"psr_opensearch_writelogs_worker_last_loop_nanoseconds",
+	"psr_opensearch_writelogs_worker_running_seconds_total",
+	"psr_opensearch_writelogs_worker_thread_count_total",
+}
+
+func GetOpsS2Metrics() []string {
+	metrics := OpensearchGetLogsMetrics
+	metrics = append(metrics, OpensearchWritelogsMetrics...)
+	return metrics
+}

--- a/tools/psr/tests/pkg/psrctlcli/psrctl_cli.go
+++ b/tools/psr/tests/pkg/psrctlcli/psrctl_cli.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package psrctlcli
+
+import (
+	"encoding/json"
+	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/scenario"
+	"os"
+	"os/exec"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	vzos "github.com/verrazzano/verrazzano/pkg/os"
+)
+
+// Debug is set from a platform-operator arg and sets the helm --debug flag
+var Debug bool
+
+// cmdRunner needed for unit tests
+var runner vzos.CmdRunner = vzos.DefaultRunner{}
+
+const PsrctlCmdKey = "PSR_COMMAND"
+
+// GetPsrctlCmd Returns the path to the psrctl command for the test run
+func GetPsrctlCmd() string {
+	psrcmd := os.Getenv(PsrctlCmdKey)
+	if psrcmd == "" {
+		psrcmd = "psrctl"
+	}
+	return psrcmd
+}
+
+// IsScenarioRunning Returns true if the named scenario is running
+func IsScenarioRunning(log vzlog.VerrazzanoLogger, scenarioName string, namespace string) bool {
+	_, found := FindScenario(log, scenarioName, namespace)
+	return found
+}
+
+// FindScenario Returns true if the named scenario is running
+func FindScenario(log vzlog.VerrazzanoLogger, scenarioID string, namespace string) (scenario.Scenario, bool) {
+	runningScenarios, err := ListScenarios(log, namespace)
+	if err != nil {
+		log.Errorf("Error listing scenarios: %s", err.Error())
+		return scenario.Scenario{}, false
+	}
+	for _, scenario := range runningScenarios {
+		if scenario.ScenarioManifest.ID == scenarioID {
+			return scenario, true
+		}
+	}
+	return scenario.Scenario{}, false
+}
+
+// ListScenarios Lists any running scenarios in the specified namespace
+func ListScenarios(log vzlog.VerrazzanoLogger, namespace string) ([]scenario.Scenario, error) {
+	// Helm get values command will get the current set values for the installed chart.
+	// The output will be used as input to the helm upgrade command.
+	args := []string{"list", "-o", "json"}
+	if namespace != "" {
+		args = append(args, "--namespace")
+		args = append(args, namespace)
+	}
+
+	psrctlCmd := GetPsrctlCmd()
+	log.Infof("psrctl: %s", psrctlCmd)
+	cmd := exec.Command(psrctlCmd, args...)
+	log.Debugf("Running command to list scenarios: %s", cmd.String())
+	stdout, stderr, err := runner.Run(cmd)
+	if err != nil {
+		log.Errorf("Failed to list scenarios for namespace %s: stderr %s", namespace, string(stderr))
+		return []scenario.Scenario{}, err
+	}
+
+	//  Log get values output
+	log.Debugf("Successfully listed scenarios in namespace %s: %v", namespace, string(stdout))
+	var scenarios []scenario.Scenario
+	if err := json.Unmarshal(stdout, &scenarios); err != nil {
+		return nil, err
+	}
+	return scenarios, nil
+}
+
+// StartScenario Starts a PSR scenario in the specified namespace.
+func StartScenario(log vzlog.VerrazzanoLogger, scenario string, namespace string, additionalArgs ...string) ([]byte, []byte, error) {
+	// Helm get values command will get the current set values for the installed chart.
+	// The output will be used as input to the helm upgrade command.
+	args := []string{"start", "-s", scenario, "-n", namespace}
+	args = append(args, additionalArgs...)
+
+	psrctlCmd := GetPsrctlCmd()
+	cmd := exec.Command(psrctlCmd, args...)
+	log.Debugf("Run scenario command: %s", cmd.String())
+	return runner.Run(cmd)
+}
+
+// StopScenario Starts a PSR scenario in the specified namespace.
+func StopScenario(log vzlog.VerrazzanoLogger, scenario string, namespace string, additionalArgs ...string) ([]byte, []byte, error) {
+	// Helm get values command will get the current set values for the installed chart.
+	// The output will be used as input to the helm upgrade command.
+	args := []string{"stop", "-s", scenario, "-n", namespace}
+	args = append(args, additionalArgs...)
+
+	psrctlCmd := GetPsrctlCmd()
+	cmd := exec.Command(psrctlCmd, args...)
+	log.Debugf("Run scenario command: %s", cmd.String())
+	return runner.Run(cmd)
+}

--- a/tools/psr/tests/pkg/secrets/pipeline_secrets.go
+++ b/tools/psr/tests/pkg/secrets/pipeline_secrets.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package secrets
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"os"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+)
+
+const (
+	//PipelineImagePullSecName Image pull secr env var name for pipeline
+	PipelineImagePullSecName = "IMAGE_PULL_SECRET"
+	//PipelineRegistryKey Docker registry env var name for pipeline
+	PipelineRegistryKey = "DOCKER_REGISTRY"
+	//PipelineDockerUserKey Docker user env var name for pipeline
+	PipelineDockerUserKey = "DOCKER_CREDS_USR"
+	//PipelineDockerPswKey Docker credential env var name for pipeline
+	PipelineDockerPswKey = "DOCKER_CREDS_PSW"
+
+	//DefaultImagePullSecName Default image pull sec name
+	DefaultImagePullSecName = "verrazzano-container-registry"
+)
+
+// CreateOrUpdatePipelineImagePullSecret Creates an image pull secret for a Pipeline test run if the variable
+// "IMAGE_PULL_SECRET" is defined.
+//
+// If IMAGE_PULL_SECRET is defined, the secret is created from the following env vars:
+// - DOCKER_REGISTRY (defaults to "ghcr.io")
+// - DOCKER_CREDS_USR
+// - DOCKER_CREDS_PSW
+func CreateOrUpdatePipelineImagePullSecret(log vzlog.VerrazzanoLogger, namespace string, kubeconfigPath string) error {
+	pullSecretName := os.Getenv(PipelineImagePullSecName)
+	if pullSecretName == "" {
+		log.Infof("Image pull secret not defined, skipping secret creation")
+		return nil
+	}
+	registryName := os.Getenv(PipelineRegistryKey)
+	if registryName == "" {
+		registryName = "ghcr.io"
+		log.Infof("Image registry not defined, using default %s", registryName)
+	}
+	registryUser := os.Getenv(PipelineDockerUserKey)
+	if registryName == "" {
+		return fmt.Errorf("registry user %s not defined", PipelineDockerUserKey)
+	}
+	registryPwd := os.Getenv(PipelineDockerPswKey)
+	if registryName == "" {
+		return fmt.Errorf("registry cred %s not defined", PipelineDockerPswKey)
+	}
+	_, err := pkg.CreateDockerSecretInCluster(namespace, pullSecretName, registryName, registryUser, registryPwd, kubeconfigPath)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}

--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -228,6 +228,7 @@ function dump_extra_details_per_namespace() {
         kubectl --insecure-skip-tls-verify get orders.acme.cert-manager.io -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/acme-orders.json || true
         kubectl --insecure-skip-tls-verify get statefulsets -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/statefulsets.json || true
         kubectl --insecure-skip-tls-verify get secrets -n $NAMESPACE -o json |jq 'del(.items[].data)' 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/secrets.json || true
+        kubectl --insecure-skip-tls-verify get serviceaccounts -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/serviceaccounts.json || true
         kubectl --insecure-skip-tls-verify get certificates -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/certificates.json || true
         kubectl --insecure-skip-tls-verify get MetricsTrait -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/metrics-traits.json || true
         kubectl --insecure-skip-tls-verify get servicemonitor -n $NAMESPACE -o json 2>/dev/null > $CAPTURE_DIR/cluster-snapshot/$NAMESPACE/service-monitors.json || true


### PR DESCRIPTION
VZ-7690.  Add OS scenario smoke tests to pipeline.

Modifies the PSR pipeline to run a smoke test of one of the existing Opensearch scenarios.   For now just the `ops-s2` scenario covered.

The initial PR will
- Create a KIND cluster with 3 nodes
- Create a namespace and label it
- Add the image pull secret defined by the pipeline
- Run the ops-s2 scenario, which checks for the running pods and scenario metrics to exists, then shuts it down

The impl uses a Make target to invoke all the test code, including cluster creation, test setup, test execution, and post-run cleanup.  This impl is derived from an POC that used Makefile targets for pipeline commands.

Other things of note:
- Creates a new `tests` package underneath `tools/psr`
- creates psrctl utility code to invoke the tool from ginkgo test code
- Some minor updates to shared `tests/e2e/pkg` code that we reuse here
- Adds a hidden `--output` option to the `psrctl list` command to be able to marshal running scenarios into the scenario structs 
