### PR TITLE
Add verrazzano-cluster-operator to list of pods that do not have an istio sidecar

### DIFF
--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -219,5 +219,5 @@ func GetInjectedSystemNamespaces() []string {
 }
 
 func GetNoInjectionComponents() []string {
-	return []string{"coherence-operator", "oam-kubernetes-runtime", "verrazzano-application-operator"}
+	return []string{"coherence-operator", "oam-kubernetes-runtime", "verrazzano-application-operator", "verrazzano-cluster-operator"}
 }

--- a/platform-operator/internal/config/config_test.go
+++ b/platform-operator/internal/config/config_test.go
@@ -54,7 +54,7 @@ func TestConfigDefaults(t *testing.T) {
 func TestSetConfig(t *testing.T) {
 	asserts := assert.New(t)
 	vzsystemNamespace := []string{"verrazzano-system", "verrazzano-monitoring", "ingress-nginx", "keycloak"}
-	vznonsystemNamespace := []string{"coherence-operator", "oam-kubernetes-runtime", "verrazzano-application-operator"}
+	vznonsystemNamespace := []string{"coherence-operator", "oam-kubernetes-runtime", "verrazzano-application-operator", "verrazzano-cluster-operator"}
 	TestHelmConfigDir = "/etc/verrazzano/helm_config"
 	TestProfilesDir = "/etc/verrazzano/profile"
 	bomFilePathOverride = "/etc/verrazzano/bom.json"


### PR DESCRIPTION
Prior to this change, when updating the VZ CR the verrazzano-cluster-operator pod would get restarted, but it has no istio sidecar so it should not be restarted.