### PR TITLE
VZ-6775: Add validations to ignore analyzing a false cluster-snapshot directory

### DIFF
--- a/tools/vz/pkg/analysis/internal/util/cluster/analyzer_test.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/analyzer_test.go
@@ -42,9 +42,8 @@ func TestRunAnalysisBadArgs(t *testing.T) {
 // THEN no error is returned
 func TestRunAnalysisValidArgs(t *testing.T) {
 	logger := log.GetDebugEnabledLogger()
-	// Call runAnalysis with an analyzer that fails, it will NOT return an error here, we
-	// log them as errors and continue on
-	err = RunAnalysis(logger, "../../../test/cluster/cluster-snapshot")
+	// Call runAnalysis with an analyzer that passes, we log the info and continue
+	err := RunAnalysis(logger, "../../../test/cluster/cluster-snapshot")
 	assert.Nil(t, err)
 
 }

--- a/tools/vz/pkg/analysis/internal/util/cluster/analyzer_test.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/analyzer_test.go
@@ -36,6 +36,18 @@ func TestRunAnalysisBadArgs(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// TestRunAnalysisValidArgs Tests the main RunAnalysis function
+// GIVEN a call to RunAnalysis
+// WHEN with valid inputs
+// THEN no error is returned
+func TestRunAnalysisValidArgs(t *testing.T) {
+	logger := log.GetDebugEnabledLogger()
+	// Call runAnalysis with an analyzer that fails, it will NOT return an error here, we
+	// log them as errors and continue on
+	err = RunAnalysis(logger, "../../../test/cluster/cluster-snapshot")
+	assert.Nil(t, err)
+
+}
 func badTestAnalyzer(log *zap.SugaredLogger, clusterRoot string) (err error) {
 	return errors.New("test failure")
 }

--- a/tools/vz/pkg/analysis/test/cluster/cluster-snapshot/cluster-snapshot/test.json
+++ b/tools/vz/pkg/analysis/test/cluster/cluster-snapshot/cluster-snapshot/test.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "resourceVersion": "1"
+  },
+  "items": []
+}

--- a/tools/vz/pkg/analysis/test/cluster/cluster-snapshot/cluster-snapshot/test.json
+++ b/tools/vz/pkg/analysis/test/cluster/cluster-snapshot/cluster-snapshot/test.json
@@ -1,6 +1,9 @@
 {
+  "apiVersion": "v1",
+  "items": [],
+  "kind": "List",
   "metadata": {
-    "resourceVersion": "1"
-  },
-  "items": []
+    "resourceVersion": "",
+    "selfLink": ""
+  }
 }

--- a/tools/vz/pkg/analysis/test/cluster/image-pull-case1/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/image-pull-case1/cluster-snapshot/verrazzano-resources.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "resourceVersion": "1"
+  },
+  "items": []
+}

--- a/tools/vz/pkg/analysis/test/cluster/image-pull-case1/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/image-pull-case1/cluster-snapshot/verrazzano-resources.json
@@ -1,6 +1,9 @@
 {
+  "apiVersion": "v1",
+  "items": [],
+  "kind": "List",
   "metadata": {
-    "resourceVersion": "1"
-  },
-  "items": []
+    "resourceVersion": "",
+    "selfLink": ""
+  }
 }

--- a/tools/vz/pkg/analysis/test/cluster/insufficient-mem/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/insufficient-mem/cluster-snapshot/verrazzano-resources.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "resourceVersion": "1"
+  },
+  "items": []
+}

--- a/tools/vz/pkg/analysis/test/cluster/insufficient-mem/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/insufficient-mem/cluster-snapshot/verrazzano-resources.json
@@ -1,6 +1,9 @@
 {
+  "apiVersion": "v1",
+  "items": [],
+  "kind": "List",
   "metadata": {
-    "resourceVersion": "1"
-  },
-  "items": []
+    "resourceVersion": "",
+    "selfLink": ""
+  }
 }

--- a/tools/vz/pkg/analysis/test/cluster/pending-pods/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/pending-pods/cluster-snapshot/verrazzano-resources.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "resourceVersion": "1"
+  },
+  "items": []
+}

--- a/tools/vz/pkg/analysis/test/cluster/pending-pods/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/pending-pods/cluster-snapshot/verrazzano-resources.json
@@ -1,6 +1,9 @@
 {
+  "apiVersion": "v1",
+  "items": [],
+  "kind": "List",
   "metadata": {
-    "resourceVersion": "1"
-  },
-  "items": []
+    "resourceVersion": "",
+    "selfLink": ""
+  }
 }

--- a/tools/vz/pkg/analysis/test/cluster/problem-pods/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/problem-pods/cluster-snapshot/verrazzano-resources.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "resourceVersion": "1"
+  },
+  "items": []
+}

--- a/tools/vz/pkg/analysis/test/cluster/problem-pods/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/problem-pods/cluster-snapshot/verrazzano-resources.json
@@ -1,6 +1,9 @@
 {
+  "apiVersion": "v1",
+  "items": [],
+  "kind": "List",
   "metadata": {
-    "resourceVersion": "1"
-  },
-  "items": []
+    "resourceVersion": "",
+    "selfLink": ""
+  }
 }


### PR DESCRIPTION
Today if we have named a top-level directory as cluster-snapshot like test/cluster-snapshot/cluster-snapshot, and run vz analyze command on that, it will tend to analyze both the cluster-snapshot directories and provide results for both while the top one is just holding the real one. To avoid that, have added the validation to check if the directory containing **verrazzano-resources.json** since should be available as an output of bug-report command. If not present, we simply ignore that directory.




