### PR TITLE
VZ-7770: Added USE_V8O_DOC_STAGE  for vz tool

### DIFF
--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -201,6 +201,7 @@ pipeline {
         // OCI_COMPARTMENT_ID=credentials('oci-tiburon-dev-compartment-ocid')
         // OCI_TELEMETRY_URL=credentials('oci-telemetry-url')
         VZ_CLI_TARGZ="vz-linux-amd64.tar.gz"
+        USE_V8O_DOC_STAGE = "${env.BRANCH_NAME == 'master' ? 'true' : 'false'}"
 
         // used to emit metrics
         PROMETHEUS_GW_URL=credentials('prometheus-dev-url')


### PR DESCRIPTION
In ocne CI tests, whenever we have failures and we run vz tools against the same, in that scenario it will show non-release version doc, as a consequence developer can't verify the things.
There was a keyword which is used to determine the same, added that keyword in CI definition will resolve the things.