### PR TITLE
VZ-7871: Update NGINX prometheus exporter image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -201,7 +201,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20221129133859-b29d89bb",
+              "tag": "v0.10.0-20221130224901-85fea23b",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -201,7 +201,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "0.10.0-20221129133859-b29d89bb",
+              "tag": "v0.10.0-20221129133859-b29d89bb",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -201,7 +201,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "0.10.0",
+              "tag": "0.10.0-20221129133859-b29d89bb",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }


### PR DESCRIPTION
Updates the NGINX prometheus exporter image, where the image tag includes the date and short commit