### PR TITLE
Fix the way registry is set for Rancher BFS images

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -247,9 +247,8 @@ func appendImageOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom.K
 		if registryOverride == "" {
 			registry = bomFile.ResolveRegistry(subcomponent, image) + "/"
 		}
-		repo := bomFile.ResolveRepo(subcomponent, image)
 
-		fullImageName := fmt.Sprintf("%s%s/%s", registry, repo, image.ImageName)
+		fullImageName := fmt.Sprintf("%s%s/%s", registry, subcomponent.Repository, image.ImageName)
 		// For the shell image, we need to combine to one env var
 		if image.ImageName == cattleShellImageName {
 			envList = append(envList, envVar{Name: imEnvVar, Value: fmt.Sprintf("%s:%s", fullImageName, image.ImageTag), SetString: false})

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -226,17 +226,11 @@ func appendImageOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom.K
 		return kvs, ctx.Log().ErrorfNewErr("Failed to get the bom file for the Rancher image overrides: %v", err)
 	}
 
-	// Set the Rancher default registry, if registry overrides are not present
-	registry := os.Getenv(constants.RegistryOverrideEnvVar)
-	if registry == "" {
-		kvs = append(kvs, bom.KeyValue{Key: systemDefaultRegistryKey, Value: bomFile.GetRegistry()})
-	}
-
+	registryOverride := os.Getenv(constants.RegistryOverrideEnvVar)
 	subcomponent, err := bomFile.GetSubcomponent(rancherImageSubcomponent)
 	if err != nil {
 		return kvs, ctx.Log().ErrorfNewErr("Failed to get the subcomponent %s from the bom: %v", rancherImageSubcomponent, err)
 	}
-	repo := subcomponent.Repository
 	images := subcomponent.Images
 
 	var envList []envVar
@@ -246,7 +240,16 @@ func appendImageOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom.K
 		if !ok {
 			continue
 		}
-		fullImageName := fmt.Sprintf("%s/%s", repo, image.ImageName)
+
+		// if there is a registry override set, it will be communicated to Rancher using the "systemDefaultRegistry" helm value,
+		// otherwise we prepend the image here with the registry value from the BOM
+		var registry = ""
+		if registryOverride == "" {
+			registry = bomFile.ResolveRegistry(subcomponent, image) + "/"
+		}
+		repo := bomFile.ResolveRepo(subcomponent, image)
+
+		fullImageName := fmt.Sprintf("%s%s/%s", registry, repo, image.ImageName)
 		// For the shell image, we need to combine to one env var
 		if image.ImageName == cattleShellImageName {
 			envList = append(envList, envVar{Name: imEnvVar, Value: fmt.Sprintf("%s:%s", fullImageName, image.ImageTag), SetString: false})


### PR DESCRIPTION
Prior to this change, if the private registry override is not specified in an environment variable, we set the Rancher registry to use ghcr.io so that Rancher would pull the Verrazzano Rancher BFS images. However, if the user attempts to run an operation that pulls another image that we do not BFS, Rancher will prepend the image with ghcr.io and the image will not be found. The specific use case that uncovered this was attempting to create an RKE2 cluster from Rancher, which uses a machine provisioning image that we do not BFS.

This PR fixes the images so we prepend only our BFS images with ghcr.io if the registry is not overridden. The Rancher registry setting is now only used for private registry scenarios.