### PR TITLE
VZ-7504: End-to-end test of new Rancher cluster user

### DIFF
--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -250,24 +250,6 @@ func GetAllClustersInRancher(rc *rancherutil.RancherConfig, log vzlog.Verrazzano
 	return clusters, hash.Sum(nil), nil
 }
 
-func GetClusterKubeconfig(rc *RancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (string, error) {
-	action := http.MethodPost
-	reqURL := rc.BaseURL + clustersPath + "/" + clusterID + "?action=generateKubeconfig"
-	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken}
-
-	response, responseBody, err := sendRequest(action, reqURL, headers, "", rc, log)
-
-	if response != nil && response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed fetching cluster kubeconfig for cluster id %s, response code: %d", clusterID, response.StatusCode)
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	return httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "config", "")
-}
-
 // isManagedClusterActiveInRancher returns true if the managed cluster is active
 func isManagedClusterActiveInRancher(rc *rancherutil.RancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (bool, error) {
 	reqURL := rc.BaseURL + clustersPath + "/" + clusterID

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -250,6 +250,24 @@ func GetAllClustersInRancher(rc *rancherutil.RancherConfig, log vzlog.Verrazzano
 	return clusters, hash.Sum(nil), nil
 }
 
+func GetClusterKubeconfig(rc *RancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (string, error) {
+	action := http.MethodPost
+	reqURL := rc.BaseURL + clustersPath + "/" + clusterID + "?action=generateKubeconfig"
+	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken}
+
+	response, responseBody, err := sendRequest(action, reqURL, headers, "", rc, log)
+
+	if response != nil && response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed fetching cluster kubeconfig for cluster id %s, response code: %d", clusterID, response.StatusCode)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "config", "")
+}
+
 // isManagedClusterActiveInRancher returns true if the managed cluster is active
 func isManagedClusterActiveInRancher(rc *rancherutil.RancherConfig, clusterID string, log vzlog.VerrazzanoLogger) (bool, error) {
 	reqURL := rc.BaseURL + clustersPath + "/" + clusterID

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -405,7 +405,7 @@ var _ = t.Describe("Multi Cluster Verify Kubeconfig Permissions", Label("f:multi
 		t.It("should be able to list secrets", func() {
 			Eventually(func() (*v1.SecretList, error) {
 				return clientset.CoreV1().Secrets(constants.VerrazzanoSystemNamespace).List(context.TODO(), metav1.ListOptions{})
-			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeNil())
+			}).WithPolling(pollingInterval).WithTimeout(time.Minute).ShouldNot(BeNil())
 		})
 
 		t.It("should not be able to list pods", func() {

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	v1alpha12 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	covmc "github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 
@@ -16,18 +17,22 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 
 	oamv1alpha2 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,6 +47,7 @@ const permissionTest2Namespace = "permissions-test2-ns"
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+var rancherProxyKubeconfig string
 
 const vpTest1 = "permissions-test1"
 const vpTest2 = "permissions-test2"
@@ -51,6 +57,12 @@ var t = framework.NewTestFramework("permissions_test")
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	// Do set up for multi cluster tests
 	deployTestResources()
+
+	Eventually(func() error {
+		var err error
+		rancherProxyKubeconfig, err = getUserKubeconfigForManagedCluster()
+		return err
+	}).WithPolling(pollingInterval).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
 })
 
 var _ = BeforeSuite(beforeSuite)
@@ -379,6 +391,26 @@ var _ = t.Describe("Multi Cluster Verify Kubeconfig Permissions", Label("f:multi
 				}
 				return errors.IsForbidden(err), nil
 			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected to get a forbidden error")
+		})
+	})
+
+	t.When("the Rancher MC user accesses Kubernetes resources on the managed cluster", func() {
+		var clientset *kubernetes.Clientset
+		t.BeforeEach(func() {
+			var err error
+			clientset, err = pkg.GetKubernetesClientsetForCluster(rancherProxyKubeconfig)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		t.It("should be able to list secrets", func() {
+			Eventually(func() (*v1.SecretList, error) {
+				return clientset.CoreV1().Secrets(constants.VerrazzanoSystemNamespace).List(context.TODO(), metav1.ListOptions{})
+			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeNil())
+		})
+
+		t.It("should not be able to list pods", func() {
+			_, err := clientset.CoreV1().Pods(constants.VerrazzanoSystemNamespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(errors.IsForbidden(err)).To(BeTrue(), "Expected forbidden error", err)
 		})
 	})
 })
@@ -760,4 +792,49 @@ func isStatusAsExpected(status clustersv1alpha1.MultiClusterResourceStatus,
 		}
 	}
 	return matchingConditionCount >= 1 && matchingClusterStatusCount == 1
+}
+
+func getUserKubeconfigForManagedCluster() (string, error) {
+	// get the Rancher cluster id from the VMC status
+	client, err := pkg.GetClusterOperatorClientset(adminKubeconfig)
+	if err != nil {
+		return "", err
+	}
+	vmc, err := client.ClustersV1alpha1().VerrazzanoManagedClusters(constants.VerrazzanoMultiClusterNamespace).Get(context.TODO(), managedClusterName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if vmc.Status.RancherRegistration.ClusterID == "" {
+		return "", fmt.Errorf("Rancher status cluster id is empty")
+	}
+
+	// get the Verrazzano cluster user password from the secret and create a Rancher config with a bearer token for the user
+	secret, err := pkg.GetSecretInCluster(constants.VerrazzanoMultiClusterNamespace, "verrazzano-cluster-user", adminKubeconfig)
+	if err != nil {
+		return "", err
+	}
+	config, err := pkg.CreateNewRancherConfigForUser(t.Logs, adminKubeconfig, "verrazzanocluster", string(secret.Data["password"]))
+	if err != nil {
+		return "", err
+	}
+
+	// get the managed cluster kubeconfig configured for the user from Rancher
+	kubeconfig, err := covmc.GetClusterKubeconfig(config, vmc.Status.RancherRegistration.ClusterID, vzlog.DefaultLogger())
+	Expect(err).ShouldNot(HaveOccurred())
+	if err != nil {
+		return "", err
+	}
+
+	// write the kubeconfig contents to a temp file
+	tmpFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer tmpFile.Close()
+	_, err = tmpFile.WriteString(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpFile.Name(), nil
 }

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -817,11 +817,11 @@ func getUserKubeconfigForManagedCluster(httpClient *retryablehttp.Client) (strin
 	}
 
 	// get the Verrazzano cluster user password from the secret and create a Rancher config with a bearer token for the user
-	secret, err := pkg.GetSecretInCluster(constants.VerrazzanoMultiClusterNamespace, "verrazzano-cluster-user", adminKubeconfig)
+	secret, err := pkg.GetSecretInCluster(constants.VerrazzanoMultiClusterNamespace, constants.VerrazzanoClusterRancherName, adminKubeconfig)
 	if err != nil {
 		return "", err
 	}
-	config, err := pkg.CreateNewRancherConfigForUser(t.Logs, adminKubeconfig, "verrazzanocluster", string(secret.Data["password"]))
+	config, err := pkg.CreateNewRancherConfigForUser(t.Logs, adminKubeconfig, constants.VerrazzanoClusterRancherUsername, string(secret.Data["password"]))
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
+++ b/tests/e2e/multicluster/verify-permissions/verify_permissions_test.go
@@ -799,6 +799,9 @@ func isStatusAsExpected(status clustersv1alpha1.MultiClusterResourceStatus,
 	return matchingConditionCount >= 1 && matchingClusterStatusCount == 1
 }
 
+// getUserKubeconfigForManagedCluster calls the Rancher API and downloads a kubeconfig configured to access
+// the managed cluster using the Verrazzano cluster user. That user has a very limited set of roles (the roles
+// needed to push managed cluster resources). This function returns the file path to the kubeconfig file on success.
 func getUserKubeconfigForManagedCluster(httpClient *retryablehttp.Client) (string, error) {
 	// get the Rancher cluster id from the VMC status
 	client, err := pkg.GetClusterOperatorClientset(adminKubeconfig)
@@ -825,7 +828,6 @@ func getUserKubeconfigForManagedCluster(httpClient *retryablehttp.Client) (strin
 
 	// get the managed cluster kubeconfig configured for the user from Rancher
 	kubeconfig, err := pkg.GetClusterKubeconfig(t.Logs, httpClient, config, vmc.Status.RancherRegistration.ClusterID)
-	Expect(err).ShouldNot(HaveOccurred())
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/pkg/rancher.go
+++ b/tests/e2e/pkg/rancher.go
@@ -299,7 +299,7 @@ func CreateNewRancherConfigForUser(log *zap.SugaredLogger, kubeconfigPath string
 	return &rc, nil
 }
 
-func GetClusterKubeconfig(log *zap.SugaredLogger, httpClient *retryablehttp.Client, rc *vmc.RancherConfig, clusterID string) (string, error) {
+func GetClusterKubeconfig(log *zap.SugaredLogger, httpClient *retryablehttp.Client, rc *rancherutil.RancherConfig, clusterID string) (string, error) {
 	reqURL := rc.BaseURL + "/v3/clusters/" + clusterID + "?action=generateKubeconfig"
 	req, err := retryablehttp.NewRequest("POST", reqURL, nil)
 	if err != nil {

--- a/tests/e2e/pkg/rancher.go
+++ b/tests/e2e/pkg/rancher.go
@@ -57,7 +57,7 @@ func GetURLForIngress(log *zap.SugaredLogger, api *APIEndpoint, namespace string
 	return ingressURL, err
 }
 
-func GetRancherAdminToken(log *zap.SugaredLogger, httpClient *retryablehttp.Client, rancherURL string) string {
+func eventuallyGetRancherAdminPassword(log *zap.SugaredLogger) (string, error) {
 	var err error
 	var secret *corev1.Secret
 	gomega.Eventually(func() error {
@@ -68,25 +68,48 @@ func GetRancherAdminToken(log *zap.SugaredLogger, httpClient *retryablehttp.Clie
 		return err
 	}, waitTimeout, pollingInterval).Should(gomega.BeNil())
 
+	if secret == nil {
+		return "", fmt.Errorf("Unable to get rancher admin secret")
+	}
+
 	var rancherAdminPassword []byte
 	var ok bool
 	if rancherAdminPassword, ok = secret.Data["password"]; !ok {
-		log.Error(fmt.Sprintf("Error getting rancher admin credentials: %v", err))
+		return "", fmt.Errorf("Error getting rancher admin credentials")
+	}
+
+	return string(rancherAdminPassword), nil
+}
+
+func GetRancherAdminToken(log *zap.SugaredLogger, httpClient *retryablehttp.Client, rancherURL string) string {
+	rancherAdminPassword, err := eventuallyGetRancherAdminPassword(log)
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting rancher admin password: %v", err))
 		return ""
 	}
 
+	token, err := getRancherUserToken(log, httpClient, rancherURL, "admin", string(rancherAdminPassword))
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting user token from rancher: %v", err))
+		return ""
+	}
+
+	return token
+}
+
+func getRancherUserToken(log *zap.SugaredLogger, httpClient *retryablehttp.Client, rancherURL string, username string, password string) (string, error) {
 	rancherLoginURL := fmt.Sprintf("%s/%s", rancherURL, "v3-public/localProviders/local?action=login")
-	payload := `{"Username": "admin", "Password": "` + string(rancherAdminPassword) + `"}`
+	payload := `{"Username": "` + username + `", "Password": "` + password + `"}`
 	response, err := httpClient.Post(rancherLoginURL, "application/json", strings.NewReader(payload))
 	if err != nil {
 		log.Error(fmt.Sprintf("Error getting rancher admin token: %v", err))
-		return ""
+		return "", err
 	}
 
 	err = httputil.ValidateResponseCode(response, http.StatusCreated)
 	if err != nil {
 		log.Errorf("Invalid response code when fetching Rancher token: %v", err)
-		return ""
+		return "", err
 	}
 
 	defer response.Body.Close()
@@ -95,16 +118,16 @@ func GetRancherAdminToken(log *zap.SugaredLogger, httpClient *retryablehttp.Clie
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Errorf("Failed to read Rancher token response: %v", err)
-		return ""
+		return "", err
 	}
 
 	token, err := httputil.ExtractFieldFromResponseBodyOrReturnError(string(body), "token", "unable to find token in Rancher response")
 	if err != nil {
 		log.Errorf("Failed to extra token from Rancher response: %v", err)
-		return ""
+		return "", err
 	}
 
-	return token
+	return token, nil
 }
 
 // VerifyRancherAccess verifies that Rancher is accessible.
@@ -234,6 +257,14 @@ func EventuallyGetRancherHost(log *zap.SugaredLogger, api *APIEndpoint) (string,
 }
 
 func CreateNewRancherConfig(log *zap.SugaredLogger, kubeconfigPath string) (*rancherutil.RancherConfig, error) {
+	rancherAdminPassword, err := eventuallyGetRancherAdminPassword(log)
+	if err != nil {
+		return nil, err
+	}
+	return CreateNewRancherConfigForUser(log, kubeconfigPath, "admin", rancherAdminPassword)
+}
+
+func CreateNewRancherConfigForUser(log *zap.SugaredLogger, kubeconfigPath string, username string, password string) (*rancherutil.RancherConfig, error) {
 	apiEndpoint := EventuallyGetAPIEndpoint(kubeconfigPath)
 	rancherHost, err := EventuallyGetRancherHost(log, apiEndpoint)
 	if err != nil {
@@ -252,12 +283,16 @@ func CreateNewRancherConfig(log *zap.SugaredLogger, kubeconfigPath string) (*ran
 	if err != nil {
 		return nil, err
 	}
-	adminToken := GetRancherAdminToken(log, httpClient, rancherURL)
+	token, err := getRancherUserToken(log, httpClient, rancherURL, username, password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user token from Rancher: %v", err)
+	}
+
 	rc := rancherutil.RancherConfig{
 		// populate Rancher config from the functions available in this file,adding as necessary
 		BaseURL:                  rancherURL,
 		Host:                     rancherHost,
-		APIAccessToken:           adminToken,
+		APIAccessToken:           token,
 		CertificateAuthorityData: caCert,
 		AdditionalCA:             additionalCA,
 	}


### PR DESCRIPTION
This PR adds end-to-end testing of the new Rancher cluster user that has restricted permissions. The approach:

1. Log into Rancher API using the Rancher cluster user credentials, fetch the API token
2. Download the kubeconfig for the managed cluster via the Rancher API. This will use the Rancher proxy and permissions will be restricted to the role permissions that the Rancher cluster user is assigned.
3. Access the managed cluster using the kubeconfig
4. Test positive and negative resource access cases