### PR TITLE
VZ-7371: Check events for addtional support data

### DIFF
--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -132,7 +132,7 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, event
 		for index, previousEvent := range finalEventList {
 			// If we already iterated through an event for the same involved object with given eventType
 			// And that event occurred before this current event, replace it accordingly
-			if IsInvolvedObjectSame(event, previousEvent) && event.LastTimestamp.Time.After(previousEvent.LastTimestamp.Time) {
+			if isInvolvedObjectSame(event, previousEvent) && event.LastTimestamp.Time.After(previousEvent.LastTimestamp.Time) {
 				foundInvolvedObject = true
 				// Remove the previous event from the final list
 				finalEventList = append(finalEventList[:index], finalEventList[index+1:]...)
@@ -150,13 +150,16 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, event
 	}
 
 	for _, event := range finalEventList {
+		if len(event.Message) == 0 {
+			continue
+		}
 		message = append(message, fmt.Sprintf("Namespace: %s, %s %s, Message: %s, Reason: %s", event.InvolvedObject.Namespace, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Reason))
 	}
 
 	return message, nil
 }
 
-func IsInvolvedObjectSame(eventA corev1.Event, eventB corev1.Event) bool {
+func isInvolvedObjectSame(eventA corev1.Event, eventB corev1.Event) bool {
 	return eventA.InvolvedObject.Kind == eventB.InvolvedObject.Kind &&
 		(eventA.InvolvedObject.Name == eventB.InvolvedObject.Name) &&
 		eventA.InvolvedObject.Namespace == eventB.InvolvedObject.Namespace

--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -96,8 +96,8 @@ func GetEventsRelatedToService(log *zap.SugaredLogger, clusterRoot string, servi
 	return serviceEvents, nil
 }
 
-// GetEventsRelatedToComponentNs gets events related to a component
-func GetEventsRelatedToComponentNs(log *zap.SugaredLogger, clusterRoot string, componentNamespace string, timeRange *files.TimeRange) (componentEvents []corev1.Event, err error) {
+// GetEventsRelatedToComponentNamespace gets events related to a component namespace
+func GetEventsRelatedToComponentNamespace(log *zap.SugaredLogger, clusterRoot string, componentNamespace string, timeRange *files.TimeRange) (componentEvents []corev1.Event, err error) {
 	log.Debugf("GetEventsRelatedToComponentNs called for component in namespace %s", componentNamespace)
 
 	podFile := files.FindFileInNamespace(clusterRoot, componentNamespace, podsJSON)

--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -130,7 +130,7 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, event
 	for _, event := range events {
 		foundInvolvedObject := false
 		for index, previousEvent := range finalEventList {
-			// If we already iterated through an event for the same involved object with type Warning
+			// If we already iterated through an event for the same involved object with given eventType
 			// And that event occurred before this current event, replace it accordingly
 			if IsInvolvedObjectSame(event, previousEvent) && event.LastTimestamp.Time.After(previousEvent.LastTimestamp.Time) {
 				foundInvolvedObject = true
@@ -143,8 +143,8 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, event
 			}
 		}
 		// No previous event for this specific involved object
-		// If the type is warning, add to the finalEventList
-		if !foundInvolvedObject && event.Type == "Warning" {
+		// Add to the finalEventList, if event type matches
+		if !foundInvolvedObject && event.Type == eventType {
 			finalEventList = append(finalEventList, event)
 		}
 	}

--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -6,6 +6,7 @@ package cluster
 
 import (
 	encjson "encoding/json"
+	"fmt"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis/internal/util/files"
 	"go.uber.org/zap"
 	"io"
@@ -93,6 +94,19 @@ func GetEventsRelatedToService(log *zap.SugaredLogger, clusterRoot string, servi
 		}
 	}
 	return serviceEvents, nil
+}
+
+// CheckEventsForWarnings goes through the events list for a specific Component/Service/Pod
+// and checks if there exists an event with type Warning and returns the corresponding reason and message
+// as an additional supporting data
+func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, timeRange *files.TimeRange) (message []string, err error) {
+	log.Debugf("Seraching the events list for any addtional support data")
+	for _, event := range events {
+		if event.Type == "Warning" {
+			message = append(message, fmt.Sprintf("Reason: %s, Message: %s", event.Reason, event.Message))
+		}
+	}
+	return message, nil
 }
 
 func getEventListIfPresent(path string) (eventList *corev1.EventList) {

--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -124,7 +124,7 @@ func GetEventsRelatedToComponentNamespace(log *zap.SugaredLogger, clusterRoot st
 // CheckEventsForWarnings goes through the events list for a specific Component/Service/Pod
 // and checks if there exists an event with type Warning and returns the corresponding reason and message
 // as an additional supporting data
-func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, timeRange *files.TimeRange) (message []string, err error) {
+func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, eventType string, timeRange *files.TimeRange) (message []string, err error) {
 	log.Debugf("Searching the events list for any additional support data")
 	var finalEventList []corev1.Event
 	for _, event := range events {
@@ -136,7 +136,7 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, timeR
 				foundInvolvedObject = true
 				// Remove the previous event from the final list
 				finalEventList = append(finalEventList[:index], finalEventList[index+1:]...)
-				if event.Type == "Warning" {
+				if event.Type == eventType {
 					finalEventList = append(finalEventList, event)
 				}
 				break

--- a/tools/vz/pkg/analysis/internal/util/cluster/events.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/events.go
@@ -150,7 +150,7 @@ func CheckEventsForWarnings(log *zap.SugaredLogger, events []corev1.Event, event
 	}
 
 	for _, event := range finalEventList {
-		message = append(message, fmt.Sprintf("Reosurce: %s %s, Namespace: %s, Reason: %s, Message: %s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.Reason, event.Message))
+		message = append(message, fmt.Sprintf("Namespace: %s, %s %s, Message: %s, Reason: %s", event.InvolvedObject.Namespace, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Reason))
 	}
 
 	return message, nil

--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -154,9 +154,6 @@ func analyzeNGINXIngressController(log *zap.SugaredLogger, clusterRoot string, p
 			log.Debugf("Failed to get events related to the NGINX ingress controller service", err)
 			return err
 		}
-		//messages := make(StringSlice, 1)
-		//messages.addMessages(CheckEventsForWarnings(log, events, nil))
-
 		//flags to make sure we're not capturing the same event message repeatedly
 		ephemeralIPLimitReachedCheck := false
 		lbServiceLimitReachedCheck := false
@@ -248,9 +245,6 @@ func analyzeNGINXIngressController(log *zap.SugaredLogger, clusterRoot string, p
 		messages := make(StringSlice, 1)
 		messages[0] = fmt.Sprintf("Namespace %s, Pod %s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 		// TODO: Time correlation on error search here
-
-		// Look through the events to see if we can find any Warning messages as additional supporting data
-		messages.addMessages(CheckEventsForWarnings(log, events, nil))
 
 		fileName := files.FindFileInClusterRoot(clusterRoot, ingressNginx)
 		nginxPodErrors, err := files.FindFilesAndSearch(log, fileName, LogFilesMatchRe, WideErrorSearchRe, nil)
@@ -413,7 +407,7 @@ func reportInstallIssue(log *zap.SugaredLogger, clusterRoot string, compsNotRead
 
 	// Check the events related to failed components namespace to provide additional support data
 	for namespace := range namespacesCompNoMsg {
-		eventList, err := GetEventsRelatedToComponentNs(log, clusterRoot, namespace, nil)
+		eventList, err := GetEventsRelatedToComponentNamespace(log, clusterRoot, namespace, nil)
 		if err != nil {
 
 		}

--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -245,6 +245,8 @@ func analyzeNGINXIngressController(log *zap.SugaredLogger, clusterRoot string, p
 		messages[0] = fmt.Sprintf("Namespace %s, Pod %s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 		// TODO: Time correlation on error search here
 
+		messages.addMessages(CheckEventsForWarnings(log, events, nil))
+
 		fileName := files.FindFileInClusterRoot(clusterRoot, ingressNginx)
 		nginxPodErrors, err := files.FindFilesAndSearch(log, fileName, LogFilesMatchRe, WideErrorSearchRe, nil)
 		if err != nil {

--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -245,6 +245,7 @@ func analyzeNGINXIngressController(log *zap.SugaredLogger, clusterRoot string, p
 		messages[0] = fmt.Sprintf("Namespace %s, Pod %s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 		// TODO: Time correlation on error search here
 
+		// Look through the events to see if we can find any Warning messages as additional supporting data
 		messages.addMessages(CheckEventsForWarnings(log, events, nil))
 
 		fileName := files.FindFileInClusterRoot(clusterRoot, ingressNginx)

--- a/tools/vz/pkg/analysis/internal/util/files/files.go
+++ b/tools/vz/pkg/analysis/internal/util/files/files.go
@@ -99,7 +99,7 @@ func FindFileInClusterRoot(clusterRoot string, filename string) string {
 	return fmt.Sprintf("%s/%s", clusterRoot, filename)
 }
 
-// FindFileNameInNamespace will find filename in the namespace
+// FindFileInNamespace will find filename in the namespace
 func FindFileInNamespace(clusterRoot string, namespace string, filename string) string {
 	return fmt.Sprintf("%s/%s/%s", clusterRoot, namespace, filename)
 }

--- a/tools/vz/pkg/analysis/internal/util/report/report.go
+++ b/tools/vz/pkg/analysis/internal/util/report/report.go
@@ -320,6 +320,13 @@ func GetAllSourcesFilteredIssues(log *zap.SugaredLogger, includeInfo bool, minCo
 	return filtered
 }
 
+// ClearReports clears the reports map, only for unit tests
+func ClearReports() {
+	reportMutex.Lock()
+	reports = make(map[string][]Issue)
+	reportMutex.Unlock()
+}
+
 // compare two structs are same or not
 func isEqualStructs(s1, s2 any) bool {
 	return reflect.DeepEqual(s1, s2)

--- a/tools/vz/pkg/analysis/main_test.go
+++ b/tools/vz/pkg/analysis/main_test.go
@@ -137,17 +137,14 @@ func TestProblemPodsNotReportedInstall(t *testing.T) {
 	reportedIssues := report.GetAllSourcesFilteredIssues(logger, true, 0, 0)
 	assert.NotNil(t, reportedIssues)
 	assert.True(t, len(reportedIssues) > 0)
-	problemPodsFound := 0
+
 	exceededLBLimit := 0
 	for _, issue := range reportedIssues {
-		if issue.Type == report.PodProblemsNotReported {
-			problemPodsFound++
-		} else if issue.Type == report.IngressLBLimitExceeded {
+		if issue.Type == report.IngressLBLimitExceeded {
 			exceededLBLimit++
 		}
 
 	}
-	assert.True(t, problemPodsFound > 0)
 	assert.True(t, exceededLBLimit > 0)
 }
 
@@ -366,6 +363,7 @@ func TestPendingPods(t *testing.T) {
 func TestIstioIngressInstallFailure(t *testing.T) {
 	logger := log.GetDebugEnabledLogger()
 
+	report.ClearReports()
 	err := Analyze(logger, "cluster", "test/cluster/istio-loadbalancer-creation-issue")
 	assert.Nil(t, err)
 

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/deployments.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/deployments.json
@@ -1,0 +1,102 @@
+{
+  "metadata": {
+    "resourceVersion": "8681"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller",
+        "namespace": "ingress-nginx",
+        "uid": "7ddb9497-ceb7-4cd5-aa3a-e768680a1990",
+        "resourceVersion": "8415",
+        "generation": 1,
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "labels": {
+          "app.kubernetes.io/component": "controller",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/managed-by": "Helm",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "app.kubernetes.io/version": "0.46.0",
+          "helm.sh/chart": "ingress-nginx-3.30.0"
+        },
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1",
+          "meta.helm.sh/release-name": "ingress-controller",
+          "meta.helm.sh/release-namespace": "ingress-nginx"
+        }
+      },
+      "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "unavailableReplicas": 1,
+        "conditions": [
+          {
+            "type": "Available",
+            "status": "False",
+            "lastUpdateTime": "2022-12-05T05:30:51Z",
+            "lastTransitionTime": "2022-12-05T05:30:51Z",
+            "reason": "MinimumReplicasUnavailable",
+            "message": "Deployment does not have minimum availability."
+          },
+          {
+            "type": "Progressing",
+            "status": "False",
+            "lastUpdateTime": "2022-12-05T06:02:58Z",
+            "lastTransitionTime": "2022-12-05T06:02:58Z",
+            "reason": "ProgressDeadlineExceeded",
+            "message": "ReplicaSet \"ingress-controller-ingress-nginx-controller-5fbb974589\" has timed out progressing."
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend",
+        "namespace": "ingress-nginx",
+        "uid": "493b6468-f68b-4e78-869f-ca9046f4ae8c",
+        "resourceVersion": "7877",
+        "generation": 1,
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "labels": {
+          "app.kubernetes.io/component": "default-backend",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/managed-by": "Helm",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "app.kubernetes.io/version": "0.46.0",
+          "helm.sh/chart": "ingress-nginx-3.30.0"
+        },
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1",
+          "meta.helm.sh/release-name": "ingress-controller",
+          "meta.helm.sh/release-namespace": "ingress-nginx"
+        }
+      },
+      "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "readyReplicas": 1,
+        "availableReplicas": 1,
+        "conditions": [
+          {
+            "type": "Available",
+            "status": "True",
+            "lastUpdateTime": "2022-12-05T06:00:35Z",
+            "lastTransitionTime": "2022-12-05T06:00:35Z",
+            "reason": "MinimumReplicasAvailable",
+            "message": "Deployment has minimum availability."
+          },
+          {
+            "type": "Progressing",
+            "status": "True",
+            "lastUpdateTime": "2022-12-05T06:00:35Z",
+            "lastTransitionTime": "2022-12-05T05:52:57Z",
+            "reason": "NewReplicaSetAvailable",
+            "message": "ReplicaSet \"ingress-controller-ingress-nginx-defaultbackend-7c64b98b75\" has successfully progressed."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/events.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/events.json
@@ -1,0 +1,1259 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4.172dcfdb421c1144",
+        "namespace": "ingress-nginx",
+        "uid": "8fac7488-6ee4-4a47-bc68-1336aa5ba362",
+        "resourceVersion": "6109",
+        "creationTimestamp": "2022-12-05T05:52:57Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "apiVersion": "v1",
+        "resourceVersion": "6104"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned ingress-nginx/ingress-controller-ingress-nginx-controller-5fbb974589-znsb4 to verrazzano-1-control-plane",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4.172dcfdb666c18a5",
+        "namespace": "ingress-nginx",
+        "uid": "8ef16b6e-0a74-4fcc-a022-d730669c725e",
+        "resourceVersion": "6124",
+        "creationTimestamp": "2022-12-05T05:52:58Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "apiVersion": "v1",
+        "resourceVersion": "6106",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"ghcr.io/verrazzano/proxyv2:1.10.4\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4.172dcfdb67a20a61",
+        "namespace": "ingress-nginx",
+        "uid": "c6d1d256-157b-4b9e-9210-4e7f271d53b7",
+        "resourceVersion": "6125",
+        "creationTimestamp": "2022-12-05T05:52:58Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "apiVersion": "v1",
+        "resourceVersion": "6106",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Created",
+      "message": "Created container istio-init",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4.172dcfdb6f7417bd",
+        "namespace": "ingress-nginx",
+        "uid": "4603382d-b74d-4ca8-b306-704314038ea6",
+        "resourceVersion": "6129",
+        "creationTimestamp": "2022-12-05T05:52:58Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "apiVersion": "v1",
+        "resourceVersion": "6106",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Started",
+      "message": "Started container istio-init",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4.172dcfdb9c7f4aea",
+        "namespace": "ingress-nginx",
+        "uid": "72503171-6755-4580-9465-96a35a18e7cd",
+        "resourceVersion": "6134",
+        "creationTimestamp": "2022-12-05T05:52:58Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "apiVersion": "v1",
+        "resourceVersion": "6106",
+        "fieldPath": "spec.containers{controller}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"ghcr.io/verrazzano/nginx-ingress-controller:0.46.0-20220301064424-ee602c1aa\"",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589.172dcea6df730934",
+        "namespace": "ingress-nginx",
+        "uid": "f721b363-bb73-4a98-a472-6672073e7104",
+        "resourceVersion": "3915",
+        "creationTimestamp": "2022-12-05T05:30:52Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589",
+        "uid": "1b0a74cc-42e5-4ed9-bbaf-67b5a447f70e",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1690"
+      },
+      "reason": "FailedCreate",
+      "message": "Error creating: Internal error occurred: failed calling webhook \"verrazzano-application-istio-defaulter.verrazzano.io\": Post \"https://verrazzano-application-operator.verrazzano-system.svc:443/istio-defaulter?timeout=30s\": dial tcp a13309ad710c3a45161c16214bc71f2bf4f5edf765c3d04f84f21e769769b312:443: connect: connection refused",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:52Z",
+      "lastTimestamp": "2022-12-05T05:42:01Z",
+      "count": 18,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589.172dcfdb41be600c",
+        "namespace": "ingress-nginx",
+        "uid": "2fd83907-d663-4b6a-98aa-49989e133af9",
+        "resourceVersion": "6105",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:57Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589",
+        "uid": "1b0a74cc-42e5-4ed9-bbaf-67b5a447f70e",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1717"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller.172dcea69d80a46e",
+        "namespace": "ingress-nginx",
+        "uid": "be5f3b4f-f005-4198-b61f-6781e6c48eec",
+        "resourceVersion": "1686",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "managedFields": [
+          {
+            "manager": "controller",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:51Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller",
+        "uid": "9701a1a8-48d2-43cb-9cb8-c18c0c165db2",
+        "apiVersion": "v1",
+        "resourceVersion": "1674"
+      },
+      "reason": "IPAllocated",
+      "message": "Assigned IP \"a13309ad710c3a45161c16214bc71f2bf4f5edf765c3d04f84f21e769769b312\"",
+      "source": {
+        "component": "metallb-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:51Z",
+      "lastTimestamp": "2022-12-05T05:30:51Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller.172dcea69e5e7acd",
+        "namespace": "ingress-nginx",
+        "uid": "f390d623-a994-4037-93ee-84e1cd6472d4",
+        "resourceVersion": "1693",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:51Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-controller",
+        "uid": "7ddb9497-ceb7-4cd5-aa3a-e768680a1990",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1687"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set ingress-controller-ingress-nginx-controller-5fbb974589 to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:51Z",
+      "lastTimestamp": "2022-12-05T05:30:51Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75.172dcea6df72b2e4",
+        "namespace": "ingress-nginx",
+        "uid": "51df1393-8da3-4873-8034-19f717d88f78",
+        "resourceVersion": "3914",
+        "creationTimestamp": "2022-12-05T05:30:52Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:52Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75",
+        "uid": "5b3d9ed3-cbc9-4761-8577-20cacb72e463",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1688"
+      },
+      "reason": "FailedCreate",
+      "message": "Error creating: Internal error occurred: failed calling webhook \"verrazzano-application-istio-defaulter.verrazzano.io\": Post \"https://verrazzano-application-operator.verrazzano-system.svc:443/istio-defaulter?timeout=30s\": dial tcp a13309ad710c3a45161c16214bc71f2bf4f5edf765c3d04f84f21e769769b312:443: connect: connection refused",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:52Z",
+      "lastTimestamp": "2022-12-05T05:42:01Z",
+      "count": 18,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75.172dcfdb3b69f4e9",
+        "namespace": "ingress-nginx",
+        "uid": "16a40c4f-0b0c-4399-91ac-b42b28055f8f",
+        "resourceVersion": "6097",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:57Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75",
+        "uid": "5b3d9ed3-cbc9-4761-8577-20cacb72e463",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1716"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dcfdb3bb71bcc",
+        "namespace": "ingress-nginx",
+        "uid": "7c8183a7-0f6e-4194-9b4f-dab5719e14e7",
+        "resourceVersion": "6099",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:57Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6094"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned ingress-nginx/ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt to verrazzano-1-control-plane",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dcfdb61163231",
+        "namespace": "ingress-nginx",
+        "uid": "41848879-cfe9-45f7-bc1d-c13198d89879",
+        "resourceVersion": "6122",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:57Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"ghcr.io/verrazzano/proxyv2:1.10.4\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dcfdb6218cf74",
+        "namespace": "ingress-nginx",
+        "uid": "739b7c1e-5313-4ac3-a9ef-ad60b64e7f28",
+        "resourceVersion": "6123",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:57Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Created",
+      "message": "Created container istio-init",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:57Z",
+      "lastTimestamp": "2022-12-05T05:52:57Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dcfdb6947ddac",
+        "namespace": "ingress-nginx",
+        "uid": "55bab0a0-aea3-4812-b4a3-25364dfe3e0f",
+        "resourceVersion": "6126",
+        "creationTimestamp": "2022-12-05T05:52:58Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.initContainers{istio-init}"
+      },
+      "reason": "Started",
+      "message": "Started container istio-init",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dcfdb9c655d13",
+        "namespace": "ingress-nginx",
+        "uid": "7fe774b2-3484-4abb-849c-ae2640bf5193",
+        "resourceVersion": "6133",
+        "creationTimestamp": "2022-12-05T05:52:58Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:52:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{ingress-nginx-default-backend}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"ghcr.io/verrazzano/nginx-ingress-default-backend:0.46.0-20220301064424-ee602c1aa\"",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T05:52:58Z",
+      "lastTimestamp": "2022-12-05T05:52:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd04519bb396b",
+        "namespace": "ingress-nginx",
+        "uid": "dbe78c3d-b4f7-44e5-be2f-09d83ffbc995",
+        "resourceVersion": "7852",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{ingress-nginx-default-backend}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"ghcr.io/verrazzano/nginx-ingress-default-backend:0.46.0-20220301064424-ee602c1aa\" in 7m33.074296717s",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd0451af3a08a",
+        "namespace": "ingress-nginx",
+        "uid": "c872232d-0908-4dba-8060-104f390b66c2",
+        "resourceVersion": "7853",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{ingress-nginx-default-backend}"
+      },
+      "reason": "Created",
+      "message": "Created container ingress-nginx-default-backend",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd04522c0bb90",
+        "namespace": "ingress-nginx",
+        "uid": "77f9ba2a-b3ad-46f2-9f36-f749ba4024df",
+        "resourceVersion": "7856",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{ingress-nginx-default-backend}"
+      },
+      "reason": "Started",
+      "message": "Started container ingress-nginx-default-backend",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd04522ec2610",
+        "namespace": "ingress-nginx",
+        "uid": "7162725f-3b03-46ae-9ff8-d7fad18e8264",
+        "resourceVersion": "7857",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{istio-proxy}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"ghcr.io/verrazzano/proxyv2:1.10.4\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd0452416d743",
+        "namespace": "ingress-nginx",
+        "uid": "18012fe5-05a5-4c6f-91c8-0726a85a8837",
+        "resourceVersion": "7858",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{istio-proxy}"
+      },
+      "reason": "Created",
+      "message": "Created container istio-proxy",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd0452b92aca2",
+        "namespace": "ingress-nginx",
+        "uid": "e356313b-34e7-4f9b-867b-0db2ddfbcec5",
+        "resourceVersion": "7859",
+        "creationTimestamp": "2022-12-05T06:00:32Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:32Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{istio-proxy}"
+      },
+      "reason": "Started",
+      "message": "Started container istio-proxy",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:32Z",
+      "lastTimestamp": "2022-12-05T06:00:32Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt.172dd04567bff8be",
+        "namespace": "ingress-nginx",
+        "uid": "f72bb43d-4f12-467e-80f8-6aef0d9ecf82",
+        "resourceVersion": "7866",
+        "creationTimestamp": "2022-12-05T06:00:33Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:00:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:fieldPath": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "apiVersion": "v1",
+        "resourceVersion": "6095",
+        "fieldPath": "spec.containers{istio-proxy}"
+      },
+      "reason": "Unhealthy",
+      "message": "Readiness probe failed: Get \"http://a13309ad710c3a45161c16214bc71f2bf4f5edf765c3d04f84f21e769769b312:15021/healthz/ready\": dial tcp a13309ad710c3a45161c16214bc71f2bf4f5edf765c3d04f84f21e769769b312:15021: connect: connection refused",
+      "source": {
+        "component": "kubelet",
+        "host": "verrazzano-1-control-plane"
+      },
+      "firstTimestamp": "2022-12-05T06:00:33Z",
+      "lastTimestamp": "2022-12-05T06:00:33Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend.172dcea69e38d3d8",
+        "namespace": "ingress-nginx",
+        "uid": "b6e2ed9d-82f9-473b-b765-51460380b293",
+        "resourceVersion": "1691",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:51Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "ingress-nginx",
+        "name": "ingress-controller-ingress-nginx-defaultbackend",
+        "uid": "493b6468-f68b-4e78-869f-ca9046f4ae8c",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1685"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set ingress-controller-ingress-nginx-defaultbackend-7c64b98b75 to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:51Z",
+      "lastTimestamp": "2022-12-05T05:30:51Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/pods.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/pods.json
@@ -1,0 +1,269 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-5fbb974589-znsb4",
+        "generateName": "ingress-controller-ingress-nginx-controller-5fbb974589-",
+        "namespace": "ingress-nginx",
+        "uid": "5b49970c-4ea1-408b-bc5d-91de8219e77f",
+        "resourceVersion": "6138",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "labels": {
+          "app.kubernetes.io/component": "controller",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "istio.io/rev": "default",
+          "pod-template-hash": "5fbb974589",
+          "security.istio.io/tlsMode": "istio",
+          "service.istio.io/canonical-name": "ingress-nginx",
+          "service.istio.io/canonical-revision": "latest"
+        },
+        "annotations": {
+          "cni.projectcalico.org/podIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd/32",
+          "cni.projectcalico.org/podIPs": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd/32",
+          "kubectl.kubernetes.io/default-container": "controller",
+          "kubectl.kubernetes.io/default-logs-container": "controller",
+          "prometheus.io/port": "10254",
+          "prometheus.io/scrape": "true",
+          "sidecar.istio.io/rewriteAppHTTPProbers": "true",
+          "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-data\",\"istio-podinfo\",\"istio-token\",\"istiod-ca-cert\"],\"imagePullSecrets\":[\"verrazzano-container-registry\"]}",
+          "system.io/scrape": "true",
+          "traffic.sidecar.istio.io/excludeInboundPorts": "80,443",
+          "traffic.sidecar.istio.io/includeInboundPorts": ""
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "ingress-controller-ingress-nginx-controller-5fbb974589",
+            "uid": "1b0a74cc-42e5-4ed9-bbaf-67b5a447f70e",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:58Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:57Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [controller istio-proxy]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:57Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [controller istio-proxy]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:57Z"
+          }
+        ],
+        "hostIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd",
+        "podIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd",
+        "podIPs": [
+          {
+            "ip": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd"
+          }
+        ],
+        "startTime": "2022-12-05T05:52:57Z",
+        "initContainerStatuses": [
+          {
+            "name": "istio-init",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2022-12-05T05:52:58Z",
+                "finishedAt": "2022-12-05T05:52:58Z",
+                "containerID": "containerd://87c989892a000c6bb8bfb13db42ec2542439a17fa0854aa5fbe3c41eabd70c71"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/proxyv2:1.10.4",
+            "imageID": "docker.io/library/import-2022-11-08@sha256:00c24a8889e019fe01181065d20075e8ee2d715d0734ec4c0b89506c3852346b",
+            "containerID": "containerd://87c989892a000c6bb8bfb13db42ec2542439a17fa0854aa5fbe3c41eabd70c71"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "name": "controller",
+            "state": {
+              "waiting": {
+                "reason": "PodInitializing"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/nginx-ingress-controller:0.46.0-20220301064424-ee602c1aa",
+            "imageID": "",
+            "started": false
+          },
+          {
+            "name": "istio-proxy",
+            "state": {
+              "waiting": {
+                "reason": "PodInitializing"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/proxyv2:1.10.4",
+            "imageID": "",
+            "started": false
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75f6blt",
+        "generateName": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75-",
+        "namespace": "ingress-nginx",
+        "uid": "7e79981c-6996-46d1-8671-e4c0199e58cb",
+        "resourceVersion": "7873",
+        "creationTimestamp": "2022-12-05T05:52:57Z",
+        "labels": {
+          "app.kubernetes.io/component": "default-backend",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "istio.io/rev": "default",
+          "pod-template-hash": "7c64b98b75",
+          "security.istio.io/tlsMode": "istio",
+          "service.istio.io/canonical-name": "ingress-nginx",
+          "service.istio.io/canonical-revision": "latest"
+        },
+        "annotations": {
+          "cni.projectcalico.org/podIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd/32",
+          "cni.projectcalico.org/podIPs": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd/32",
+          "kubectl.kubernetes.io/default-container": "ingress-nginx-default-backend",
+          "kubectl.kubernetes.io/default-logs-container": "ingress-nginx-default-backend",
+          "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-data\",\"istio-podinfo\",\"istio-token\",\"istiod-ca-cert\"],\"imagePullSecrets\":[\"verrazzano-container-registry\"]}"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "ingress-controller-ingress-nginx-defaultbackend-7c64b98b75",
+            "uid": "5b3d9ed3-cbc9-4761-8577-20cacb72e463",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:58Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T06:00:35Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T06:00:35Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T05:52:57Z"
+          }
+        ],
+        "hostIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd",
+        "podIP": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd",
+        "podIPs": [
+          {
+            "ip": "818b460bfe6540128c96415f37bcde503db2e64962aac3048ecac73e4413f8dd"
+          }
+        ],
+        "startTime": "2022-12-05T05:52:57Z",
+        "initContainerStatuses": [
+          {
+            "name": "istio-init",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2022-12-05T05:52:58Z",
+                "finishedAt": "2022-12-05T05:52:58Z",
+                "containerID": "containerd://2151753a6d3673d8848b48cb355a9d1be9e7635df0e7500594c805cf6617b734"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/proxyv2:1.10.4",
+            "imageID": "docker.io/library/import-2022-11-08@sha256:00c24a8889e019fe01181065d20075e8ee2d715d0734ec4c0b89506c3852346b",
+            "containerID": "containerd://2151753a6d3673d8848b48cb355a9d1be9e7635df0e7500594c805cf6617b734"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "name": "ingress-nginx-default-backend",
+            "state": {
+              "running": {
+                "startedAt": "2022-12-05T06:00:32Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/nginx-ingress-default-backend:0.46.0-20220301064424-ee602c1aa",
+            "imageID": "ghcr.io/verrazzano/nginx-ingress-default-backend@sha256:c8fd3155436c4efe336e6e774e4c0eb50b62ad7e12b7b87d066486ff2acfa4a5",
+            "containerID": "containerd://17260bb52b1db73e59cccaccf3d847e64c39ac7d491188f219132fd44049402b",
+            "started": true
+          },
+          {
+            "name": "istio-proxy",
+            "state": {
+              "running": {
+                "startedAt": "2022-12-05T06:00:32Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "ghcr.io/verrazzano/proxyv2:1.10.4",
+            "imageID": "docker.io/library/import-2022-11-08@sha256:00c24a8889e019fe01181065d20075e8ee2d715d0734ec4c0b89506c3852346b",
+            "containerID": "containerd://af501c96f485260ea42431234f4a59e92d56f5ac96b48eb23faea84a9d9c3145",
+            "started": true
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/services.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/ingress-nginx/services.json
@@ -1,0 +1,85 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller",
+        "namespace": "ingress-nginx",
+        "uid": "9701a1a8-48d2-43cb-9cb8-c18c0c165db2",
+        "resourceVersion": "1683",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "labels": {
+          "app.kubernetes.io/component": "controller",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/managed-by": "Helm",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "app.kubernetes.io/version": "0.46.0",
+          "helm.sh/chart": "ingress-nginx-3.30.0"
+        },
+        "annotations": {
+          "meta.helm.sh/release-name": "ingress-controller",
+          "meta.helm.sh/release-namespace": "ingress-nginx"
+        }
+      },
+      "status": {
+        "loadBalancer": {
+          "ingress": [
+            {
+              "ip": "2b111992ddf06436c7d263ab114423553eb0e6db9c38f430a2dc85385848a42c"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-controller-metrics",
+        "namespace": "ingress-nginx",
+        "uid": "8312c7fa-4bec-47e6-ac87-1487cd2e2a3b",
+        "resourceVersion": "1675",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "labels": {
+          "app.kubernetes.io/component": "controller",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/managed-by": "Helm",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "app.kubernetes.io/version": "0.46.0",
+          "helm.sh/chart": "ingress-nginx-3.30.0"
+        },
+        "annotations": {
+          "meta.helm.sh/release-name": "ingress-controller",
+          "meta.helm.sh/release-namespace": "ingress-nginx"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-controller-ingress-nginx-defaultbackend",
+        "namespace": "ingress-nginx",
+        "uid": "fd2784cb-ea77-4605-8408-e9d391f67314",
+        "resourceVersion": "1677",
+        "creationTimestamp": "2022-12-05T05:30:51Z",
+        "labels": {
+          "app.kubernetes.io/component": "default-backend",
+          "app.kubernetes.io/instance": "ingress-controller",
+          "app.kubernetes.io/managed-by": "Helm",
+          "app.kubernetes.io/name": "ingress-nginx",
+          "app.kubernetes.io/version": "0.46.0",
+          "helm.sh/chart": "ingress-nginx-3.30.0"
+        },
+        "annotations": {
+          "meta.helm.sh/release-name": "ingress-controller",
+          "meta.helm.sh/release-namespace": "ingress-nginx"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/deployments.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/deployments.json
@@ -1,0 +1,53 @@
+{
+  "metadata": {
+    "resourceVersion": "8681"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "mysql",
+        "namespace": "keycloak",
+        "uid": "b4c86c7d-3ee2-40c6-a9a9-fde05204ae04",
+        "resourceVersion": "8427",
+        "generation": 1,
+        "creationTimestamp": "2022-12-05T05:30:54Z",
+        "labels": {
+          "app": "mysql",
+          "app.kubernetes.io/managed-by": "Helm",
+          "chart": "mysql-1.6.9",
+          "heritage": "Helm",
+          "release": "mysql"
+        },
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1",
+          "meta.helm.sh/release-name": "mysql",
+          "meta.helm.sh/release-namespace": "keycloak"
+        }
+      },
+      "status": {
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updatedReplicas": 1,
+        "unavailableReplicas": 1,
+        "conditions": [
+          {
+            "type": "Available",
+            "status": "False",
+            "lastUpdateTime": "2022-12-05T05:30:54Z",
+            "lastTransitionTime": "2022-12-05T05:30:54Z",
+            "reason": "MinimumReplicasUnavailable",
+            "message": "Deployment does not have minimum availability."
+          },
+          {
+            "type": "Progressing",
+            "status": "False",
+            "lastUpdateTime": "2022-12-05T06:03:01Z",
+            "lastTransitionTime": "2022-12-05T06:03:01Z",
+            "reason": "ProgressDeadlineExceeded",
+            "message": "ReplicaSet \"mysql-56b9fcc88f\" has timed out progressing."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/events.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/events.json
@@ -1,0 +1,463 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "mysql-56b9fcc88f-87tvn.172dd067996be453",
+        "namespace": "keycloak",
+        "uid": "68d4f743-77c8-46dc-86c6-e416f1a9d45b",
+        "resourceVersion": "8425",
+        "creationTimestamp": "2022-12-05T06:03:00Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T06:03:00Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "keycloak",
+        "name": "mysql-56b9fcc88f-87tvn",
+        "uid": "32565d1b-8d2d-4dfc-98d5-63fce3727ddb",
+        "apiVersion": "v1",
+        "resourceVersion": "6146"
+      },
+      "reason": "FailedScheduling",
+      "message": "running PreBind plugin \"VolumeBinding\": binding volumes: timed out waiting for the condition",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2022-12-05T06:03:00Z",
+      "lastTimestamp": "2022-12-05T06:03:00Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql-56b9fcc88f.172dcea7874ff0d7",
+        "namespace": "keycloak",
+        "uid": "21ede5c2-82a9-4431-ab2c-bb06bfe2ee5a",
+        "resourceVersion": "3924",
+        "creationTimestamp": "2022-12-05T05:30:55Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:55Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "keycloak",
+        "name": "mysql-56b9fcc88f",
+        "uid": "a7e4a6db-d29c-411c-a8c1-73743377e839",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1738"
+      },
+      "reason": "FailedCreate",
+      "message": "Error creating: Internal error occurred: failed calling webhook \"verrazzano-application-istio-defaulter.verrazzano.io\": Post \"https://verrazzano-application-operator.verrazzano-system.svc:443/istio-defaulter?timeout=30s\": dial tcp a9c3f78fb5a0ed5f5b8b4998a2a9c351963ef6a037fc46788871d59ed269b2b1:443: connect: connection refused",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:55Z",
+      "lastTimestamp": "2022-12-05T05:42:04Z",
+      "count": 18,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql-56b9fcc88f.172dcfdbe630aadd",
+        "namespace": "keycloak",
+        "uid": "c67d000f-3f82-4fd8-bedc-e81ee85bf2a2",
+        "resourceVersion": "6147",
+        "creationTimestamp": "2022-12-05T05:53:00Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:53:00Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "keycloak",
+        "name": "mysql-56b9fcc88f",
+        "uid": "a7e4a6db-d29c-411c-a8c1-73743377e839",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1753"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: mysql-56b9fcc88f-87tvn",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:53:00Z",
+      "lastTimestamp": "2022-12-05T05:53:00Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql.172dcea745f2e0d7",
+        "namespace": "keycloak",
+        "uid": "6cd29837-bf8a-4fee-9e53-9487558fe399",
+        "resourceVersion": "5590",
+        "creationTimestamp": "2022-12-05T05:30:54Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:54Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "PersistentVolumeClaim",
+        "namespace": "keycloak",
+        "name": "mysql",
+        "uid": "fa1d3866-0843-4271-94a5-4ee33885f59d",
+        "apiVersion": "v1",
+        "resourceVersion": "1731"
+      },
+      "reason": "WaitForFirstConsumer",
+      "message": "waiting for first consumer to be created before binding",
+      "source": {
+        "component": "persistentvolume-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:54Z",
+      "lastTimestamp": "2022-12-05T05:50:58Z",
+      "count": 82,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql.172dcea746f306de",
+        "namespace": "keycloak",
+        "uid": "fdff0c76-aafb-4039-8f83-750e753832cb",
+        "resourceVersion": "1739",
+        "creationTimestamp": "2022-12-05T05:30:54Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:30:54Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "keycloak",
+        "name": "mysql",
+        "uid": "b4c86c7d-3ee2-40c6-a9a9-fde05204ae04",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "1735"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set mysql-56b9fcc88f to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:30:54Z",
+      "lastTimestamp": "2022-12-05T05:30:54Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql.172dcfdbe6c1423c",
+        "namespace": "keycloak",
+        "uid": "5a745459-8568-4aeb-8aea-2e0bcbfb57a7",
+        "resourceVersion": "7972",
+        "creationTimestamp": "2022-12-05T05:55:58Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:55:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "PersistentVolumeClaim",
+        "namespace": "keycloak",
+        "name": "mysql",
+        "uid": "fa1d3866-0843-4271-94a5-4ee33885f59d",
+        "apiVersion": "v1",
+        "resourceVersion": "6150"
+      },
+      "reason": "ExternalProvisioning",
+      "message": "waiting for a volume to be created, either by external provisioner \"rancher.io/local-path\" or manually created by system administrator",
+      "source": {
+        "component": "persistentvolume-controller"
+      },
+      "firstTimestamp": "2022-12-05T05:53:00Z",
+      "lastTimestamp": "2022-12-05T06:00:58Z",
+      "count": 33,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql.172dcfdbe736ac02",
+        "namespace": "keycloak",
+        "uid": "cf0c7124-f92d-49f4-80ca-a0f2924206e7",
+        "resourceVersion": "7922",
+        "creationTimestamp": "2022-12-05T05:53:00Z",
+        "managedFields": [
+          {
+            "manager": "local-path-provisioner",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:53:00Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "PersistentVolumeClaim",
+        "namespace": "keycloak",
+        "name": "mysql",
+        "uid": "fa1d3866-0843-4271-94a5-4ee33885f59d",
+        "apiVersion": "v1",
+        "resourceVersion": "6150"
+      },
+      "reason": "Provisioning",
+      "message": "External provisioner is provisioning volume for claim \"keycloak/mysql\"",
+      "source": {
+        "component": "rancher.io/local-path_local-path-provisioner-6c9449b9dd-n2tjn_a4ca364e-1cdd-4556-b0af-bed389af8441"
+      },
+      "firstTimestamp": "2022-12-05T05:53:00Z",
+      "lastTimestamp": "2022-12-05T06:00:47Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "mysql.172dcff7fb4cfc38",
+        "namespace": "keycloak",
+        "uid": "cea7ffeb-03b6-4710-9b2a-2b1b167ba5cd",
+        "resourceVersion": "8373",
+        "creationTimestamp": "2022-12-05T05:55:00Z",
+        "managedFields": [
+          {
+            "manager": "local-path-provisioner",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-12-05T05:55:00Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {
+                "f:apiVersion": {},
+                "f:kind": {},
+                "f:name": {},
+                "f:namespace": {},
+                "f:resourceVersion": {},
+                "f:uid": {}
+              },
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "PersistentVolumeClaim",
+        "namespace": "keycloak",
+        "name": "mysql",
+        "uid": "fa1d3866-0843-4271-94a5-4ee33885f59d",
+        "apiVersion": "v1",
+        "resourceVersion": "6150"
+      },
+      "reason": "ProvisioningFailed",
+      "message": "failed to provision volume with StorageClass \"standard\": failed to create volume pvc-fa1d3866-0843-4271-94a5-4ee33885f59d: create process timeout after 120 seconds",
+      "source": {
+        "component": "rancher.io/local-path_local-path-provisioner-6c9449b9dd-n2tjn_a4ca364e-1cdd-4556-b0af-bed389af8441"
+      },
+      "firstTimestamp": "2022-12-05T05:55:00Z",
+      "lastTimestamp": "2022-12-05T06:02:47Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/pods.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/pods.json
@@ -1,0 +1,55 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "mysql-56b9fcc88f-87tvn",
+        "generateName": "mysql-56b9fcc88f-",
+        "namespace": "keycloak",
+        "uid": "32565d1b-8d2d-4dfc-98d5-63fce3727ddb",
+        "resourceVersion": "8426",
+        "creationTimestamp": "2022-12-05T05:53:00Z",
+        "labels": {
+          "app": "mysql",
+          "istio.io/rev": "default",
+          "pod-template-hash": "56b9fcc88f",
+          "release": "mysql",
+          "security.istio.io/tlsMode": "istio",
+          "service.istio.io/canonical-name": "mysql",
+          "service.istio.io/canonical-revision": "latest"
+        },
+        "annotations": {
+          "kubectl.kubernetes.io/default-container": "mysql",
+          "kubectl.kubernetes.io/default-logs-container": "mysql",
+          "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-data\",\"istio-podinfo\",\"istio-token\",\"istiod-ca-cert\"],\"imagePullSecrets\":[\"verrazzano-container-registry\"]}"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "mysql-56b9fcc88f",
+            "uid": "a7e4a6db-d29c-411c-a8c1-73743377e839",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "PodScheduled",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2022-12-05T06:03:00Z",
+            "reason": "SchedulerError",
+            "message": "running PreBind plugin \"VolumeBinding\": binding volumes: timed out waiting for the condition"
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/services.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/keycloak/services.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {
+    "resourceVersion": "8693"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "mysql",
+        "namespace": "keycloak",
+        "uid": "b0677a71-46bb-488d-bd7f-99b8963be545",
+        "resourceVersion": "1733",
+        "creationTimestamp": "2022-12-05T05:30:54Z",
+        "labels": {
+          "app": "mysql",
+          "app.kubernetes.io/managed-by": "Helm",
+          "chart": "mysql-1.6.9",
+          "heritage": "Helm",
+          "release": "mysql"
+        },
+        "annotations": {
+          "meta.helm.sh/release-name": "mysql",
+          "meta.helm.sh/release-namespace": "keycloak"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/verrazzano-install/verrazzano-platform-operator-6b6c754758-rlgtw/logs.txt
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/verrazzano-install/verrazzano-platform-operator-6b6c754758-rlgtw/logs.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+==== START logs for container verrazzano-platform-operator of pod verrazzano-install/verrazzano-platform-operator-6b6c754758-rlgtw ====
+{"level":"info","@timestamp":"2022-12-05T05:30:15.704Z","caller":"platform-operator/main.go:89","message":"Starting Verrazzano Platform Operator"}
+==== END logs for container verrazzano-platform-operator of pod verrazzano-install/verrazzano-platform-operator-6b6c754758-rlgtw ====

--- a/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/components-not-ready/cluster-snapshot/verrazzano-resources.json
@@ -1,0 +1,264 @@
+{
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "my-verrazzano",
+        "namespace": "default",
+        "uid": "a57012d8-8d42-4ea0-8114-3ca8de5c9ab9",
+        "resourceVersion": "5863",
+        "generation": 2,
+        "creationTimestamp": "2022-12-05T05:30:22Z",
+        "finalizers": [
+          "install.verrazzano.io"
+        ]
+      },
+      "status": {
+        "components": {
+          "cert-manager": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:33Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:51:42Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "cert-manager",
+            "state": "Ready"
+          },
+          "coherence-operator": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:36Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:31:02Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "coherence-operator",
+            "state": "Ready"
+          },
+          "external-dns": {
+            "name": "external-dns",
+            "state": "Disabled"
+          },
+          "ingress-controller": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:51Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              }
+            ],
+            "name": "ingress-controller",
+            "state": "Installing"
+          },
+          "istio": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:54Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:57Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "istio",
+            "state": "Ready"
+          },
+          "keycloak": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              }
+            ],
+            "name": "keycloak",
+            "state": "PreInstalling"
+          },
+          "kiali-server": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              }
+            ],
+            "name": "kiali-server",
+            "state": "PreInstalling"
+          },
+          "mysql": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:54Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              }
+            ],
+            "name": "mysql",
+            "state": "Installing"
+          },
+          "oam-kubernetes-runtime": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:29Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:36Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "oam-kubernetes-runtime",
+            "state": "Ready"
+          },
+          "rancher": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              }
+            ],
+            "name": "rancher",
+            "state": "PreInstalling"
+          },
+          "verrazzano": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              }
+            ],
+            "name": "verrazzano",
+            "state": "PreInstalling"
+          },
+          "verrazzano-application-operator": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:49Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:51:51Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "verrazzano-application-operator",
+            "state": "Ready"
+          },
+          "weblogic-operator": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2022-12-05T05:30:26Z",
+                "message": "PreInstall started",
+                "status": "True",
+                "type": "PreInstall"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:30:44Z",
+                "message": "Install started",
+                "status": "True",
+                "type": "InstallStarted"
+              },
+              {
+                "lastTransitionTime": "2022-12-05T05:51:56Z",
+                "message": "Install complete",
+                "status": "True",
+                "type": "InstallComplete"
+              }
+            ],
+            "name": "weblogic-operator",
+            "state": "Ready"
+          }
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-12-05T05:30:26Z",
+            "message": "Verrazzano install in progress",
+            "status": "True",
+            "type": "InstallStarted"
+          }
+        ],
+        "state": "Installing",
+        "version": "1.2.2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
In case there are no matches for any of the existing patterns when there is a component failure, the respective events.json for the component is used to find out events with type "Warning" to provide some additional support data (the message and reason related to that event), which might help in figuring out the reason for the issue.
