### PR TITLE
Allow OAM clusterrole to be not found during uninstall (#4908)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/oam/oam.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam.go
@@ -9,16 +9,17 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/status"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -144,7 +145,9 @@ func deleteOAMClusterRoles(client client.Client, log vzlog.VerrazzanoLogger) err
 	for _, role := range clusterRoles {
 		log.Progressf("Deleting OAM clusterrole %s", role.Name)
 		if err := client.Delete(ctx, role); err != nil {
-			return err
+			if !errors.IsNotFound(err) {
+				return err
+			}
 		}
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/oam/oam_test.go
+++ b/platform-operator/controllers/verrazzano/component/oam/oam_test.go
@@ -4,9 +4,11 @@ package oam
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	appsv1 "k8s.io/api/apps/v1"
@@ -183,4 +185,37 @@ func TestEnsureClusterRoles(t *testing.T) {
 	assert.Equal(t, 1, len(clusterRole.Rules))
 	assert.Equal(t, 1, len(clusterRole.Rules[0].Resources))
 	assert.Equal(t, "persistentvolumeclaims", clusterRole.Rules[0].Resources[0])
+}
+
+// TestDeleteOAMClusterRoles tests the deleteOAMClusterRoles function
+// GIVEN a call to deleteOAMClusterRoles
+//
+//	WHEN the OAM ClusterRoles are found and deleted
+//	THEN no error is returned and all OAM ClusterRoles are deleted
+func TestDeleteOAMClusterRoles(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, nil, nil, false)
+	ensureClusterRoles(ctx)
+
+	err := deleteOAMClusterRoles(client, vzlog.DefaultLogger())
+	assert.NoError(t, err)
+	var clusterRole rbacv1.ClusterRole
+	err = client.Get(context.TODO(), types.NamespacedName{Name: pvcClusterRoleName}, &clusterRole)
+	assert.True(t, errors.IsNotFound(err))
+	err = client.Get(context.TODO(), types.NamespacedName{Name: istioClusterRoleName}, &clusterRole)
+	assert.True(t, errors.IsNotFound(err))
+	err = client.Get(context.TODO(), types.NamespacedName{Name: certClusterRoleName}, &clusterRole)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+// TestDeleteOAMClusterRolesNotFound tests the deleteOAMClusterRoles function
+// GIVEN a call to deleteOAMClusterRoles
+//
+//	WHEN the OAM ClusterRoles are not found
+//	THEN no error is returned
+func TestDeleteOAMClusterRolesNotFound(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+	err := deleteOAMClusterRoles(client, vzlog.DefaultLogger())
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Backport fix so that uninstall does not fail when OAM clusterrole is not found.