### PR TITLE
VZ-7690.  Few minor fixes

### DIFF
--- a/ci/make/env-template.sh
+++ b/ci/make/env-template.sh
@@ -18,6 +18,10 @@ export DOCKER_REPO=ghcr.io
 # Override where the Kubeconfig for the cluster is stored
 #export KUBECONFIG= # Default is ${WORKSPACE}/test_kubeconfig
 
+#### Custom MetalLB settings
+#
+#METALLB_ADDRESS_RANGE=  # Set this to override the default MetalLB address rainge for KIND
+
 #### Platform Operator Settings 
 #
 # The following env vars control how the Platform Operator manifest is obtained

--- a/ci/scripts/setup_kind.sh
+++ b/ci/scripts/setup_kind.sh
@@ -83,6 +83,7 @@ echo "Listing pods in kube-system namespace ..."
 kubectl get pods -n kube-system
 
 echo "Install metallb"
-${TEST_SCRIPTS_DIR}/install-metallb.sh
+METALLB_ADDRESS_RANGE=${METALLB_ADDRESS_RANGE:-"172.18.0.230-172.18.0.254"}
+${TEST_SCRIPTS_DIR}/install-metallb.sh "${METALLB_ADDRESS_RANGE}"
 
 exit 0


### PR DESCRIPTION
Fixes for make-based install scripts
- Allow override of Metallb address range for when a custom range is needed
- Remove conditional creation of test overrides resources
