### PR TITLE
VZ-7875: Use helper to get the list of repository URLs

### DIFF
--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -46,6 +46,7 @@ pipeline {
         REPO_URLS_PROPS = "vzsource_repo_urls.properties"
         REPO_URLS1_PROPS = "vzsource_repo_urls_1.properties"
         REPO_URLS2_PROPS = "vzsource_repo_urls_2.properties"
+        REPO_URLS3_PROPS = "vzsource_repo_urls_3.properties
     }
 
     stages {
@@ -103,9 +104,18 @@ pipeline {
                         oci --region ${OCI_REGION} os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
                         chmod uog+x ${WORKSPACE}/verrazzano-helper
 
-                        # Redirect the output of verrazzano-helper get repo-urls to a file
-                        ${WORKSPACE}/verrazzano-helper get repo-urls > ${WORKSPACE}/${REPO_URLS_PROPS}
+                        # Redirect the output of verrazzano-helper get repo-urls to files
+                        ${WORKSPACE}/verrazzano-helper get repo-urls all > ${WORKSPACE}/${REPO_URLS_PROPS}
                         echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS_PROPS}
+
+                        ${WORKSPACE}/verrazzano-helper get repo-urls public_repos > ${WORKSPACE}/${REPO_URLS1_PROPS}
+                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS1_PROPS}
+
+                        ${WORKSPACE}/verrazzano-helper get repo-urls internal_repos > ${WORKSPACE}/${REPO_URLS2_PROPS}
+                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS2_PROPS}
+
+                        ${WORKSPACE}/verrazzano-helper get repo-urls additional_repos > ${WORKSPACE}/${REPO_URLS3_PROPS}
+                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS3_PROPS}
                     """
                 }
             }
@@ -130,7 +140,7 @@ pipeline {
                 script {
                     sh """
                         # Dry run to ensure REPO_URLS_PROPS contains the URLs for all the images listed in verrazzano-images.txt
-                        ${WORKSPACE}/release/scripts/download_source_prt.sh ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt ${WORKSPACE}/${REPO_URLS_PROPS} ${WORKSPACE}/downloaded_source true
+                        ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS_PROPS} -s ${WORKSPACE}/downloaded_source -d true
                     """
                 }
             }
@@ -139,26 +149,32 @@ pipeline {
         stage('Download Source') {
             steps {
                 script {
-                    sh """
-                        mkdir -p ${WORKSPACE}/downloaded_source
-                        grep -v ${GITLAB_URL_PREFIX} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS1_PROPS}
-                        grep -F -x -v -f ${WORKSPACE}/${REPO_URLS1_PROPS} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS2_PROPS}
-                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS2_PROPS}
-                    """
-
                     withCredentials([gitUsernamePassword(credentialsId: 'gitlab_rw', gitToolName: 'git-tool')]) {
                         sh """
-                            ${WORKSPACE}/release/scripts/download_source_prt.sh ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt ${WORKSPACE}/${REPO_URLS2_PROPS} ${WORKSPACE}/downloaded_source
+                            ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS2_PROPS} -s ${WORKSPACE}/downloaded_source -c true
+                            ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS3_PROPS} -s ${WORKSPACE}/downloaded_source
                         """
                     }
 
                     withCredentials([gitUsernamePassword(credentialsId: 'github_rw', gitToolName: 'git-tool')]) {
                         sh """
-                            ${WORKSPACE}/release/scripts/download_source_prt.sh ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt ${WORKSPACE}/${REPO_URLS1_PROPS} ${WORKSPACE}/downloaded_source
+                            ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS1_PROPS} -s ${WORKSPACE}/downloaded_source
                             mkdir -p ${WORKSPACE}/archive_dir
                             ${WORKSPACE}/release/scripts/archive_source_prt.sh ${WORKSPACE}/downloaded_source ${WORKSPACE}/archive_dir ${params.RELEASE_VERSION}
                         """
                     }
+                }
+            }
+        }
+        stage('Create Source Archive') {
+            steps {
+                script {
+                    sh """
+                        mkdir -p ${WORKSPACE}/archive_dir
+                        ${WORKSPACE}/release/scripts/archive_source_prt.sh ${WORKSPACE}/downloaded_source ${WORKSPACE}/archive_dir ${params.RELEASE_VERSION}
+                        ls ${WORKSPACE}/archive_dir
+                        ls ${WORKSPACE}/downloaded_source
+                    """
                 }
             }
         }

--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -21,12 +21,17 @@ pipeline {
         string (description: 'The release branch', name: 'RELEASE_BRANCH', defaultValue: 'NONE', trim: true)
         string (description: 'The source commit for the release (required for full release)', name: 'COMMIT_TO_USE', defaultValue: 'NONE', trim: true )
         string (description: 'The release version (major.minor.patch format, e.g. 1.5.0)', name: 'RELEASE_VERSION', defaultValue: 'NONE', trim: true)
+        string (description: 'verrazzano-helper branch, user branch name is used when testing verrazzano-helper changes', name: 'VERRAZZANO_HELPER_BRANCH',
+                defaultValue: 'master', trim: true)
+        string (description: 'verrazzano-examples branch, user branch name is used for testing purpose only', name: 'VERRAZZANO_EXAMPLES_BRANCH',
+                defaultValue: 'master', trim: true)
     }
 
     environment {
         OBJECT_STORAGE_NS = credentials('oci-os-namespace')
         OBJECT_STORAGE_BUCKET="verrazzano-builds"
         OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
+        OCI_OS_SHARED_BUCKET="build-shared-files"
         OCI_REGION="us-phoenix-1"
         OCI_CLI_AUTH="api_key"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -83,17 +88,49 @@ pipeline {
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.COMMIT_TO_USE
                 }
+
             }
         }
 
-        stage('Download Scripts') {
+        stage('Download Repo URLs') {
+            environment {
+                GITHUB_AUTH_TOKEN = credentials('github-api-token-release-process')
+            }
+            steps {
+                script {
+                    sh """
+                        echo "Downloading verrazzano-helper from object storage"
+                        oci --region ${OCI_REGION} os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
+                        chmod uog+x ${WORKSPACE}/verrazzano-helper
+
+                        # Redirect the output of verrazzano-helper get repo-urls to a file
+                        ${WORKSPACE}/verrazzano-helper get repo-urls > ${WORKSPACE}/${REPO_URLS_PROPS}
+                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS_PROPS}
+                    """
+                }
+            }
+        }
+
+        stage('Download Image List') {
             steps {
                 script {
                     sh """
                         cd ${WORKSPACE}
                         echo "Downloading verrazzano_images.txt from object storage"
-                        oci --region us-phoenix-1 os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OBJECT_STORAGE_BUCKET} --name master/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt --file ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt
-                        oci --region us-phoenix-1 os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OBJECT_STORAGE_BUCKET} --name ${env.BRANCH_NAME}/${REPO_URLS_PROPS} --file ${WORKSPACE}/${REPO_URLS_PROPS}
+
+                        # Get from master only for non-release branches
+                        oci --region ${OCI_REGION} os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OBJECT_STORAGE_BUCKET} --name ${params.VERRAZZANO_EXAMPLES_BRANCH}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt --file ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt
+                    """
+                }
+            }
+        }
+
+        stage('Validate Repo URLs') {
+            steps {
+                script {
+                    sh """
+                        # Dry run to ensure REPO_URLS_PROPS contains the URLs for all the images listed in verrazzano-images.txt
+                        ${WORKSPACE}/release/scripts/download_source_prt.sh ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt ${WORKSPACE}/${REPO_URLS_PROPS} ${WORKSPACE}/downloaded_source true
                     """
                 }
             }
@@ -103,10 +140,10 @@ pipeline {
             steps {
                 script {
                     sh """
-                            mkdir -p ${WORKSPACE}/downloaded_source
-                            grep -v ${GITLAB_URL_PREFIX} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS1_PROPS}
-                            grep -F -x -v -f ${WORKSPACE}/${REPO_URLS1_PROPS} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS2_PROPS}
-                            echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS2_PROPS}
+                        mkdir -p ${WORKSPACE}/downloaded_source
+                        grep -v ${GITLAB_URL_PREFIX} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS1_PROPS}
+                        grep -F -x -v -f ${WORKSPACE}/${REPO_URLS1_PROPS} ${WORKSPACE}/${REPO_URLS_PROPS} > ${WORKSPACE}/${REPO_URLS2_PROPS}
+                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS2_PROPS}
                     """
 
                     withCredentials([gitUsernamePassword(credentialsId: 'gitlab_rw', gitToolName: 'git-tool')]) {

--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -159,8 +159,6 @@ pipeline {
                     sh """
                         mkdir -p ${WORKSPACE}/archive_dir
                         ${WORKSPACE}/release/scripts/archive_source_prt.sh ${WORKSPACE}/downloaded_source ${WORKSPACE}/archive_dir ${params.RELEASE_VERSION}
-                        ls ${WORKSPACE}/archive_dir
-                        ls ${WORKSPACE}/downloaded_source
                     """
                 }
             }

--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -165,6 +165,9 @@ pipeline {
         }
     }
     post {
+        always {
+            archiveArtifacts artifacts: "**/vzsource*.properties,**/verrazzano_*.txt", allowEmptyArchive: true
+        }
         cleanup {
             deleteDir()
         }

--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -100,22 +100,14 @@ pipeline {
             steps {
                 script {
                     sh """
-                        echo "Downloading verrazzano-helper from object storage"
                         oci --region ${OCI_REGION} os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OCI_OS_SHARED_BUCKET} --name ${params.VERRAZZANO_HELPER_BRANCH}/verrazzano-helper --file ${WORKSPACE}/verrazzano-helper
                         chmod uog+x ${WORKSPACE}/verrazzano-helper
 
                         # Redirect the output of verrazzano-helper get repo-urls to files
                         ${WORKSPACE}/verrazzano-helper get repo-urls all > ${WORKSPACE}/${REPO_URLS_PROPS}
-                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS_PROPS}
-
                         ${WORKSPACE}/verrazzano-helper get repo-urls public_repos > ${WORKSPACE}/${REPO_URLS1_PROPS}
-                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS1_PROPS}
-
                         ${WORKSPACE}/verrazzano-helper get repo-urls internal_repos > ${WORKSPACE}/${REPO_URLS2_PROPS}
-                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS2_PROPS}
-
                         ${WORKSPACE}/verrazzano-helper get repo-urls additional_repos > ${WORKSPACE}/${REPO_URLS3_PROPS}
-                        echo "# URLs end here" >> ${WORKSPACE}/${REPO_URLS3_PROPS}
                     """
                 }
             }
@@ -126,9 +118,6 @@ pipeline {
                 script {
                     sh """
                         cd ${WORKSPACE}
-                        echo "Downloading verrazzano_images.txt from object storage"
-
-                        # Get from master only for non-release branches
                         oci --region ${OCI_REGION} os object get --namespace ${OBJECT_STORAGE_NS} -bn ${OBJECT_STORAGE_BUCKET} --name ${params.VERRAZZANO_EXAMPLES_BRANCH}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt --file ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt
                     """
                 }
@@ -152,15 +141,13 @@ pipeline {
                     withCredentials([gitUsernamePassword(credentialsId: 'gitlab_rw', gitToolName: 'git-tool')]) {
                         sh """
                             ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS2_PROPS} -s ${WORKSPACE}/downloaded_source -c true
-                            ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS3_PROPS} -s ${WORKSPACE}/downloaded_source
+                            ${WORKSPACE}/release/scripts/download_source_prt.sh -a ${WORKSPACE}/${REPO_URLS3_PROPS} -s ${WORKSPACE}/downloaded_source
                         """
                     }
 
                     withCredentials([gitUsernamePassword(credentialsId: 'github_rw', gitToolName: 'git-tool')]) {
                         sh """
                             ${WORKSPACE}/release/scripts/download_source_prt.sh -i ${WORKSPACE}/verrazzano_${VERRAZZANO_DEV_VERSION}-images.txt -r ${WORKSPACE}/${REPO_URLS1_PROPS} -s ${WORKSPACE}/downloaded_source
-                            mkdir -p ${WORKSPACE}/archive_dir
-                            ${WORKSPACE}/release/scripts/archive_source_prt.sh ${WORKSPACE}/downloaded_source ${WORKSPACE}/archive_dir ${params.RELEASE_VERSION}
                         """
                     }
                 }

--- a/release/builds/JenkinsfileSourceArchive
+++ b/release/builds/JenkinsfileSourceArchive
@@ -46,7 +46,7 @@ pipeline {
         REPO_URLS_PROPS = "vzsource_repo_urls.properties"
         REPO_URLS1_PROPS = "vzsource_repo_urls_1.properties"
         REPO_URLS2_PROPS = "vzsource_repo_urls_2.properties"
-        REPO_URLS3_PROPS = "vzsource_repo_urls_3.properties
+        REPO_URLS3_PROPS = "vzsource_repo_urls_3.properties"
     }
 
     stages {

--- a/release/scripts/download_source_prt.sh
+++ b/release/scripts/download_source_prt.sh
@@ -150,9 +150,6 @@ function downloadSourceCode() {
 
   # Remove git history and other files
   rm -rf .git .gitignore .github .gitattributes
-  echo "------------------------------------------"
-  ls -a
-  echo "------------------------------------------"
   printf "\n"
 }
 
@@ -166,6 +163,10 @@ function downloadSourceExamples() {
     return
   fi
   cd "${SAVE_DIR}"
+  if [ -d "${SAVE_DIR}/examples" ]; then
+    continue
+  fi
+
   git clone "${repoUrl}"
   cd examples
   # Remove git history and other files
@@ -198,7 +199,6 @@ function downloadAdditionalSource() {
        ''|\#*) continue ;;
       esac
       key=$(echo $key | tr '.' '_')
-
       url=$(echo "${value}"|cut -d':' -f2-)
       branchInfo=$(echo "${value}"|cut -d':' -f1)
       downloadSourceCode "$key" ${branchInfo} "${url}"

--- a/release/scripts/download_source_prt.sh
+++ b/release/scripts/download_source_prt.sh
@@ -5,32 +5,83 @@
 #
 # A script to download the source code for the images build from source.
 
-set -e
+set -o pipefail
+set -o errtrace
 
-SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
-
-if [ -z "$1" ]; then
-  echo "Specify the file containing the list of images"
-  exit 1
-fi
-
-if [ -z "$2" ]; then
-  echo "Specify the file containing the repository URLs"
-  exit 1
-fi
-
-if [ -z "$3" ]; then
-  echo "Specify an existing directory to download the source code from various repositories"
-  exit 1
-fi
-
-IMAGES_TO_PUBLISH=$1
-REPO_URL_PROPS=$2
-SAVE_DIR=$3
-DRY_RUN=${4:-false}
+# variables
+IMAGES_TO_PUBLISH=
+REPO_URL_PROPS=
+ADDITIONAL_REPO_URLS=
+SAVE_DIR=
+DRY_RUN=false
+CLEAN_SAVE_DIR=false
 
 # Verrazzano repository, which is prefix for each of the entries in IMAGES_TO_PUBLISH
 VZ_REPO_PREFIX="verrazzano/"
+
+function exit_trap() {
+  local rc=$?
+  local lc="$BASH_COMMAND"
+
+  if [[ $rc -ne 0 ]]; then
+    echo "Command exited with code [$rc]"
+  fi
+}
+
+trap exit_trap EXIT
+
+function usage() {
+  ec=${1:-0}
+  echo """
+A script to download the source code for the images used by Verrazzano..
+
+Options:
+-i Verrazzano image list
+-r File containing the repository URLs to download the source
+-a Addition source repository URLs
+-s Directory to download the source
+-d Dry run to ensure file specified by -r flag contains the URLs for all the images listed in the file specified by -i flag
+-c Clean the directory to download the source
+
+Examples:
+  # Download source to /tmp/source_dir by reading the components from mydir/verrazzano_images.txt and repository URLs from mydir/repo_url.properties
+  $0 -i mydir/verrazzano_images.txt -r mydir/repo_url.properties -s mydir/source_dir
+
+"""
+  exit ${ec}
+}
+
+# Validate the input flags
+function validateFlags() {
+  if [ -z "${ADDITIONAL_REPO_URLS}" ] || [ "${ADDITIONAL_REPO_URLS}" == "" ]; then
+    if [ "${REPO_URL_PROPS}" == "" ]; then
+      echo "The file containing the repository URLs to download the source is required, but not specified by flag -r"
+      usage 1
+    fi
+    if [[ ! -f "${REPO_URL_PROPS}" ]]; then
+      echo "The file containing the repository URLs specified by flag -r doesn't exist"
+      usage 1
+    fi
+  fi
+
+  if [ "${SAVE_DIR}" == "" ]; then
+    echo "The directory to save the source is required, but not specified by flag -s"
+    usage 1
+  fi
+}
+
+# Initialize the source download
+function initDownload() {
+  # Create SAVE_DIR, if it doesn't exist
+  if [[ ! -d "${SAVE_DIR}" ]] && [[ "$DRY_RUN" == false ]]; then
+    mkdir -p ${SAVE_DIR}
+  fi
+
+  # Clean SAVE_DIR when $CLEAN_SAVE_DIR is true
+  if [[ "$CLEAN_SAVE_DIR" == true ]] && [[ "$DRY_RUN" == false ]]; then
+    rm -rf ${SAVE_DIR}/*
+  fi
+}
 
 # Read the components from IMAGES_TO_PUBLISH file and download the source from the corresponding repositories
 function processImagesToPublish() {
@@ -59,26 +110,17 @@ function processImagesToPublish() {
 # Download source using git clone,
 function downloadSourceCode() {
   local compKey=$1
-  local shortCommit=$2
-  local repoUrl=""
-  local keyFound=false
-  while IFS='=' read -r key value
-  do
-    key=$(echo $key | tr '.' '_')
-    if [ "${compKey}" = "${key}" ]; then
-      repoUrl=${value}
-      keyFound=true
-      break
-    fi
-  done < "${REPO_URL_PROPS}"
-
-  # Fail when the property for the component is not defined in REPO_URL_PROPS
-  if [ "${keyFound}" == false ]; then
-    if [ "$DRY_RUN" == true ]; then
-      echo "The repository URL for the component ${compKey} is missing from file ${REPO_URL_PROPS}"
-      exit 1
-    else
-      continue
+  local commitOrBranch=$2
+  local repoUrl=$3
+  if [ "${repoUrl}" = "" ]; then
+    repoUrl=$(getRepoUrl "${key}")
+    if [ "${repoUrl}" = "" ]; then
+      if [ "$DRY_RUN" == true ]; then
+        echo "The repository URL for the component ${compKey} is missing from file ${REPO_URL_PROPS}"
+        exit 1
+      else
+        continue
+      fi
     fi
   fi
 
@@ -88,24 +130,23 @@ function downloadSourceCode() {
   fi
 
   # Consider the value SKIP_CLONE for a property, to ignore cloning the repository
-  # Also skip when there is no property defined for the compKey.
-  if [ "${repoUrl}" = "SKIP_CLONE" ] || [ "${repoUrl}" = "" ]; then
+  if [ "${repoUrl}" = "SKIP_CLONE" ]; then
     continue
   fi
 
   cd "${SAVE_DIR}"
+  changeDir=$(getChangeDir "${repoUrl}")
+  if [ -d "${SAVE_DIR}/${changeDir}" ]; then
+    echo "Directory ${SAVE_DIR}/${changeDir} exists, continue"
+    continue
+  fi
 
   # Create a blobless clone, downloads all reachable commits and trees while fetching blobs on-demand.
-  git clone --filter=blob:none "${value}"
-
-  # In most of the cases, we should be able to cd ${key}, find change dir only when previous cd fails
-  # Something like cd "${key}" || { changeDir=$(getChangeDir "${value}") cd "${changeDir} }
-  # But need to find a way to avoid the error message when cd "${key}" fails
-  changeDir=$(getChangeDir "${value}")
+  git clone --filter=blob:none "${repoUrl}"
   cd "${changeDir}"
 
   # -c advice.detachedHead=false is used to avoid the Git message for the detached HEAD
-  git -c advice.detachedHead=false checkout "${shortCommit}"
+  git -c advice.detachedHead=false checkout "${commitOrBranch}"
 
   # Remove git history and other files
   rm -rf .git .gitignore .github .gitattributes
@@ -145,18 +186,65 @@ function getChangeDir() {
   echo "${repoUrl%%.git}"
 }
 
-# If SAVE_DIR exists, fail if it has files / directories
-if [[ ! -d "${SAVE_DIR}" ]] && [[ "$DRY_RUN" == false ]]; then
-  mkdir -p ${SAVE_DIR}
-fi
+# Download additional source for the component, which is not part of verrazzano-bom.json
+function downloadAdditionalSource() {
+  local additionalSource=$1
+  if [ -f "${additionalSource}" ];
+  then
+    while IFS='=' read -r key value
+    do
+      # Skip empty lines and comments starting with #
+      case $key in
+       ''|\#*) continue ;;
+      esac
+      key=$(echo $key | tr '.' '_')
 
-if [[ ! -f "${REPO_URL_PROPS}" ]]; then
-  echo "Input file ${REPO_URL_PROPS} doesn't exist"
-  exit 1
-fi
+      url=$(echo "${value}"|cut -d':' -f2-)
+      branchInfo=$(echo "${value}"|cut -d':' -f1)
+      downloadSourceCode "$key" ${branchInfo} "${url}"
+    done < "${additionalSource}"
+  else
+    echo "$additionalSource here not found."
+  fi
+}
 
-processImagesToPublish "${IMAGES_TO_PUBLISH}"
-downloadSourceExamples
+# Read input flags
+while getopts 'a:i:r:s:d:c:' flag; do
+  case $flag in
+  a)
+    ADDITIONAL_REPO_URLS=$OPTARG
+    ;;
+  i)
+    IMAGES_TO_PUBLISH=$OPTARG
+    ;;
+  r)
+    REPO_URL_PROPS=$OPTARG
+    ;;
+  s)
+    SAVE_DIR=$OPTARG
+    ;;
+  d)
+    DRY_RUN=true
+    ;;
+  c)
+    CLEAN_SAVE_DIR=true
+    ;;
+  h | ?)
+    usage
+    ;;
+  esac
+done
+
+# Validate the command line flags
+validateFlags
+initDownload
+
+if [ "${ADDITIONAL_REPO_URLS}" == "" ]; then
+  processImagesToPublish "${IMAGES_TO_PUBLISH}"
+  downloadSourceExamples
+else
+  downloadAdditionalSource "${ADDITIONAL_REPO_URLS}"
+fi
 
 if [ "$DRY_RUN" == true ] ; then
    echo "Completed running the script with DRY_RUN = true"

--- a/release/scripts/download_source_prt.sh
+++ b/release/scripts/download_source_prt.sh
@@ -109,6 +109,9 @@ function downloadSourceCode() {
 
   # Remove git history and other files
   rm -rf .git .gitignore .github .gitattributes
+  echo "------------------------------------------"
+  ls -a
+  echo "------------------------------------------"
   printf "\n"
 }
 

--- a/release/scripts/download_source_prt.sh
+++ b/release/scripts/download_source_prt.sh
@@ -137,7 +137,6 @@ function downloadSourceCode() {
   cd "${SAVE_DIR}"
   changeDir=$(getChangeDir "${repoUrl}")
   if [ -d "${SAVE_DIR}/${changeDir}" ]; then
-    echo "Directory ${SAVE_DIR}/${changeDir} exists, continue"
     continue
   fi
 


### PR DESCRIPTION
This change gets the list of source repositories from the Verrazzano helper in the build pipeline. The script to download the source code is updated to allow additional repositories.
