### PR TITLE
VZ-7637 - Enable use of Rancher proxy URL in kubeconfig used by managed clusters to connect to admin cluster.

### DIFF
--- a/application-operator/mcagent/mcagent_cluster_secrets_test.go
+++ b/application-operator/mcagent/mcagent_cluster_secrets_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
+	constants2 "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -31,6 +32,8 @@ const (
 	adminRegNewSecretPath      = "testdata/clusterca-adminregsecret-new.yaml"
 	clusterCAAdminSecretPath   = "testdata/clusterca-admincasecret.yaml"
 	mcCASecretPath             = "testdata/clusterca-mccasecret.yaml"
+	adminAgentSecretPath       = "testdata/admin-agent-secret.yaml"
+	adminAgentNewSecretPath    = "testdata/admin-agent-secret-new.yaml"
 	vzTLSSecretPathNew         = "testdata/clusterca-mctlssecret-new.yaml"
 	vzTLSSecretPath            = "testdata/clusterca-mctlssecret.yaml"
 	vmcPath                    = "testdata/clusterca-vmc.yaml"
@@ -42,6 +45,7 @@ const (
 	sampleVMCReadErrMsg        = "failed to read sample VMC"
 	regSecChangedErrMsg        = "registration secret was changed"
 	mcCASecChangedErrMsg       = "MC CA secret was changed"
+	sampleAdminAgentReadErrMsg = "failed to read sample Admin agent Secret"
 )
 
 // TestSyncAdminCANoDifference tests the synchronization method for the following use case.
@@ -356,8 +360,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.ESURLKey: "new OS url",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -366,8 +370,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.ESCaBundleKey: "new CA bundle",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -376,8 +380,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.RegistrationUsernameKey: "new user",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -386,8 +390,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.RegistrationPasswordKey: "new password",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -396,8 +400,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.KeycloakURLKey: "new keycloak url",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -406,8 +410,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSURLKey: "new value",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -416,8 +420,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSUsernameKey: "newuser",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -426,8 +430,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSPasswordKey: "newpassword",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -436,8 +440,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSCAKey: "newCAKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -446,8 +450,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSCertKey: "newTLSCertKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
@@ -456,26 +460,26 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			&testAdminCASecret,
 			createSecretWithOverrides(adminRegSecretPath, map[string]string{
 				mcconstants.JaegerOSTLSKey: "newTLSKey",
-			}),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			}, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
 		{
 			"Admin CA bundle is different in managed cluster",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
 			createSecretWithOverrides(clusterRegSecretPath, map[string]string{
 				mcconstants.AdminCaBundleKey: "new CA bundle",
-			}),
+			}, "", ""),
 			controllerutil.OperationResultUpdated,
 			nil,
 		},
 		{
 			"All values are in sync between admin and managed1 cluster",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			nil,
 		},
@@ -483,14 +487,14 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 			"When registration secret is missing in admin cluster, then it should return error",
 			&testAdminCASecret,
 			nil,
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-cluster-managed1-registration\" not found"),
 		},
 		{
 			"When registration secret is missing in local cluster, then it should return error",
 			&testAdminCASecret,
-			createSecretWithOverrides(adminRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
 			nil,
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-cluster-registration\" not found"),
@@ -498,8 +502,8 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 		{
 			"When CA cert secret is missing in admin cluster, then it should return error",
 			nil,
-			createSecretWithOverrides(adminRegSecretPath, nil),
-			createSecretWithOverrides(clusterRegSecretPath, nil),
+			createSecretWithOverrides(adminRegSecretPath, nil, "", ""),
+			createSecretWithOverrides(clusterRegSecretPath, nil, "", ""),
 			controllerutil.OperationResultNone,
 			fmt.Errorf("secrets \"verrazzano-local-ca-bundle\" not found"),
 		},
@@ -551,6 +555,104 @@ func TestSyncRegistrationFromAdminCluster(t *testing.T) {
 	}
 }
 
+// TestSyncAgentSecretFromAdminCluster tests the synchronization method for the following use case.
+// GIVEN a request to sync Admin agent secret
+// WHEN the agent secret info is different in either admin-kubeconfig or managed-cluster-name
+// THEN ensure that managed cluster agent secret is updated, but not otherwise.
+func TestSyncAgentSecretFromAdminCluster(t *testing.T) {
+	testAdminAgentSecret := createSecretWithOverrides(adminAgentSecretPath, nil, "", getAgentSecretName(testClusterName))
+	testUnchangedLocalAgentSecret := createSecretWithOverrides(adminAgentSecretPath, nil, constants.VerrazzanoSystemNamespace, constants2.MCAgentSecret)
+	testNewAdminAgentSecret := createSecretWithOverrides(adminAgentNewSecretPath, nil, "", getAgentSecretName(testClusterName))
+	log := zap.S().With("test")
+	tests := []struct {
+		name                 string
+		testAdminAgentSecret *corev1.Secret
+		localAgentSecret     *corev1.Secret
+		otherAdminSecret     *corev1.Secret // some other unrelated secret present on admin cluster
+		expectedOperation    controllerutil.OperationResult
+		expectedError        error
+	}{
+		{
+			"admin agent secret identical to managed",
+			testAdminAgentSecret,
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultNone,
+			nil,
+		},
+		{
+			"admin agent secret kubeconfig changed",
+			testNewAdminAgentSecret,
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultUpdated,
+			nil,
+		},
+		{
+			"admin agent secret cluster name changed",
+			testAdminAgentSecret,
+			createSecretWithOverrides(adminAgentSecretPath, map[string]string{
+				mcconstants.ManagedClusterNameKey: "newmanagedclustername",
+			}, constants.VerrazzanoSystemNamespace, constants2.MCAgentSecret),
+			nil,
+			controllerutil.OperationResultUpdated,
+			nil,
+		},
+		{
+			"admin agent secret some unused field added",
+			createSecretWithOverrides(adminAgentSecretPath, map[string]string{
+				"somekeynotused": "somevalue",
+			}, "", getAgentSecretName(testClusterName)),
+			testUnchangedLocalAgentSecret,
+			nil,
+			controllerutil.OperationResultNone,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adminRuntimeObjects := []runtime.Object{}
+			if tt.testAdminAgentSecret != nil {
+				adminRuntimeObjects = append(adminRuntimeObjects, tt.testAdminAgentSecret)
+			}
+			adminClient := fake.NewClientBuilder().
+				WithScheme(newClusterCAScheme()).
+				WithRuntimeObjects(adminRuntimeObjects...).
+				Build()
+
+			localRuntimeObjects := []runtime.Object{}
+			if tt.localAgentSecret != nil {
+				localRuntimeObjects = append(localRuntimeObjects, tt.localAgentSecret)
+			}
+			localClient := fake.NewClientBuilder().
+				WithScheme(newClusterCAScheme()).
+				WithRuntimeObjects(localRuntimeObjects...).
+				Build()
+
+			s := &Syncer{
+				AdminClient:        adminClient,
+				LocalClient:        localClient,
+				Log:                log,
+				ManagedClusterName: testClusterName,
+				Context:            context.TODO(),
+			}
+			actualOperationResult, err := s.syncAgentSecretFromAdminCluster()
+			if tt.expectedError != nil {
+				asserts.Equal(t, err.Error(), tt.expectedError.Error())
+				return
+			}
+			asserts.NoError(t, err)
+			asserts.Equal(t, tt.expectedOperation, actualOperationResult)
+			// post sync call both the secrets should have the same values of registration secrets
+			// and calling sync again should be a no-op (unchanged).
+			reSyncOperationResult, err := s.syncAgentSecretFromAdminCluster()
+			asserts.NoError(t, err)
+			asserts.Equal(t, controllerutil.OperationResultNone, reSyncOperationResult)
+
+		})
+	}
+}
+
 // getSampleClusterCAVMC creates and returns a sample VMC
 func getSampleClusterCAVMC(filePath string) (v1alpha1.VerrazzanoManagedCluster, error) {
 	vmc := v1alpha1.VerrazzanoManagedCluster{}
@@ -589,7 +691,7 @@ func assertRegistrationInfoEqual(t *testing.T, regSecret1 *corev1.Secret, regSec
 	asserts.Equal(t, regSecret1.Data[mcconstants.JaegerOSTLSKey], regSecret2.Data[mcconstants.JaegerOSTLSKey], "Jaeger OS TLS Key is different")
 }
 
-func createSecretWithOverrides(filepath string, overrides map[string]string) *corev1.Secret {
+func createSecretWithOverrides(filepath string, overrides map[string]string, newNamespace string, newName string) *corev1.Secret {
 	secret, err := getSampleSecret(filepath)
 	if err != nil {
 		pkg.Log(pkg.Error, err.Error())
@@ -597,6 +699,12 @@ func createSecretWithOverrides(filepath string, overrides map[string]string) *co
 	}
 	for key, value := range overrides {
 		secret.Data[key] = []byte(value)
+	}
+	if newName != "" {
+		secret.Name = newName
+	}
+	if newNamespace != "" {
+		secret.Namespace = newNamespace
 	}
 	return &secret
 }

--- a/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret-new.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+data:
+  # a simple kubeconfig with server address https://admin-kubeconfig-new:6443 and ca data of "somecadata", user mcAgent with token "sometoken"
+  admin-kubeconfig: Y2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBzb21lY2FkYXRhIAogICAgc2VydmVyOiBodHRwczovL2FkbWluLWt1YmVjb25maWctbmV3OjY0NDMKICBuYW1lOiBhZG1pbgpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWRtaW4KICAgIHVzZXI6IG1jQWdlbnQKICBuYW1lOiBkZWZhdWx0Q29udGV4dApjdXJyZW50LWNvbnRleHQ6IGRlZmF1bHRDb250ZXh0CnVzZXJzOgotIG5hbWU6IG1jQWdlbnQKICB1c2VyOgogICAgdG9rZW46IHNvbWV0b2tlbgo=
+  managed-cluster-name: c29tZW1hbmFnZWQxCg== #somemanaged1
+kind: Secret
+metadata:
+  creationTimestamp: "2022-10-25T18:03:32Z"
+  name: verrazzano-cluster-managed1-agent
+  namespace: verrazzano-mc
+  ownerReferences:
+    - apiVersion: clusters.verrazzano.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: VerrazzanoManagedCluster
+      name: managed1
+      uid: 794564ed-1b85-4c90-ac95-6a65fb266036
+  resourceVersion: "11040"
+  uid: 3d4882e4-ec8a-43ff-a823-86ea086116b3
+type: Opaque

--- a/application-operator/mcagent/testdata/admin-agent-secret.yaml
+++ b/application-operator/mcagent/testdata/admin-agent-secret.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+data:
+  # a simple kubeconfig with server address https://admin-kubeconfig1:6443 and ca data of "somecadata", user mcAgent with token "sometoken"
+  admin-kubeconfig: Y2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBzb21lY2FkYXRhIAogICAgc2VydmVyOiBodHRwczovL2FkbWluLWt1YmVjb25maWcxOjY0NDMKICBuYW1lOiBhZG1pbgpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWRtaW4KICAgIHVzZXI6IG1jQWdlbnQKICBuYW1lOiBkZWZhdWx0Q29udGV4dApjdXJyZW50LWNvbnRleHQ6IGRlZmF1bHRDb250ZXh0CnVzZXJzOgotIG5hbWU6IG1jQWdlbnQKICB1c2VyOgogICAgdG9rZW46IHNvbWV0b2tlbgo=
+  managed-cluster-name: c29tZW1hbmFnZWQxCg== #somemanaged1
+kind: Secret
+metadata:
+  creationTimestamp: "2022-10-25T18:03:32Z"
+  name: verrazzano-cluster-agent
+  namespace: verrazzano-mc
+  ownerReferences:
+    - apiVersion: clusters.verrazzano.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: VerrazzanoManagedCluster
+      name: managed1
+      uid: 794564ed-1b85-4c90-ac95-6a65fb266036
+  resourceVersion: "11040"
+  uid: 3d4882e4-ec8a-43ff-a823-86ea086116b3
+type: Opaque

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1977,7 +1977,7 @@ def setInitValues() {
         DOCKER_IMAGE_TAG = "${VERRAZZANO_DEV_VERSION}-${TIMESTAMP}-${SHORT_COMMIT_HASH}"
         // update the description with some meaningful info
         setDisplayName()
-        currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+        currentBuild.description = "from ${params.VERSION_FOR_INSTALL}\n${SHORT_COMMIT_HASH} : ${env.GIT_COMMIT} : ${params.GIT_COMMIT_TO_USE}"
         if (params.TEST_ENV != "KIND") {
             // derive the prefix for the OKE cluster
             OKE_CLUSTER_PREFIX = sh(returnStdout: true, script: "${GO_REPO_PATH}/verrazzano/ci/scripts/derive_oke_cluster_name.sh").trim()

--- a/cluster-operator/controllers/vmc/sync_agent_secret.go
+++ b/cluster-operator/controllers/vmc/sync_agent_secret.go
@@ -29,11 +29,6 @@ func setConfigFunc(f func() (*rest.Config, error)) {
 	getConfigFunc = f
 }
 
-// rancherBasedKubeConfigEnabled - feature flag for whether we support
-// Rancher based Kubeconfig - introduced for VZ-6448 Populate VMC with managed cluster data
-// Should be removed and enabled by default when story VZ-6449
-var rancherBasedKubeConfigEnabled = false
-
 // Create an agent secret with a kubeconfig that has a token allowing access to the managed cluster
 // with restricted access as defined in the verrazzano-managed-cluster role.
 // The code does the following:
@@ -81,12 +76,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncAgentSecret(vmc *clusterapi.Ver
 	// Build the kubeconfig
 	var err error
 	var kc *vzk8s.KubeConfig
-	// Check feature flag before building kubeconfig from Rancher - feature flag was introduced in
-	// VZ-6448, to be removed when VZ-6449 is completed
-	if rancherBasedKubeConfigEnabled {
-		kc, err = r.buildKubeConfigUsingRancherURL(serviceAccountSecret)
-	}
-	if err != nil || !rancherBasedKubeConfigEnabled {
+
+	// Try to use Rancher URL in the kubeconfig - this will fail if Rancher is not enabled
+	kc, err = r.buildKubeConfigUsingRancherURL(serviceAccountSecret)
+	if err != nil {
 		r.log.Oncef("Failed to build admin kubeconfig using Rancher URL: %v", err)
 		kc, err = r.buildKubeConfigUsingAdminConfigMap(serviceAccountSecret)
 	}

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -80,14 +80,9 @@ type secretAssertFn func(secret *corev1.Secret) error
 // TestCreateVMC tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an VerrazzanoManagedCluster resource
 // WHEN a VerrazzanoManagedCluster resource has been applied in a cluster where Rancher is enabled
-// THEN ensure all the objects are created correctly (USES feature flag rancherBasedKubeconfigEnabled)
+// THEN ensure all the objects are created correctly
 func TestCreateVMCRancherEnabled(t *testing.T) {
 	// with feature flag disabled (which triggers different asserts/mocks from enabled)
-	doTestCreateVMC(t, true)
-
-	// with feature flag enabled
-	rancherBasedKubeConfigEnabled = true
-	defer func() { rancherBasedKubeConfigEnabled = false }()
 	doTestCreateVMC(t, true)
 }
 
@@ -1713,26 +1708,25 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 			})
 	}
 
-	// ONLY if the rancherBasedKubeconfig feature flag is enabled - Expect a call to list Verrazzanos
-	// and return a Verrazzano that has Rancher URL in status only if rancherEnabled is true
-	if rancherBasedKubeConfigEnabled {
-		mock.EXPECT().
-			List(gomock.Any(), &v1beta1.VerrazzanoList{}, gomock.Not(gomock.Nil())).
-			DoAndReturn(func(ctx context.Context, list *v1beta1.VerrazzanoList, opts ...client.ListOption) error {
-				var status v1beta1.VerrazzanoStatus
-				if rancherEnabled {
-					status = v1beta1.VerrazzanoStatus{
-						VerrazzanoInstance: &v1beta1.InstanceInfo{RancherURL: &rancherURL},
-					}
+	// Expect a call to list Verrazzanos and return a Verrazzano that has Rancher URL in status only
+	// if rancherEnabled is true
+	mock.EXPECT().
+		List(gomock.Any(), &v1beta1.VerrazzanoList{}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, list *v1beta1.VerrazzanoList, opts ...client.ListOption) error {
+			var status v1beta1.VerrazzanoStatus
+			if rancherEnabled {
+				status = v1beta1.VerrazzanoStatus{
+					VerrazzanoInstance: &v1beta1.InstanceInfo{RancherURL: &rancherURL},
 				}
-				vz := v1beta1.Verrazzano{
-					Spec:   v1beta1.VerrazzanoSpec{},
-					Status: status,
-				}
-				list.Items = append(list.Items, vz)
-				return nil
-			})
-	}
+			}
+			vz := v1beta1.Verrazzano{
+				Spec:   v1beta1.VerrazzanoSpec{},
+				Status: status,
+			}
+			list.Items = append(list.Items, vz)
+			return nil
+		})
+
 	// Expect a call to get the service token secret, return the secret with the token
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoMultiClusterNamespace, Name: saSecretName}, gomock.Not(gomock.Nil())).
@@ -1743,7 +1737,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 			return nil
 		})
 
-	if rancherEnabled && rancherBasedKubeConfigEnabled {
+	if rancherEnabled {
 		// Expect a call to get the tls-ca-additional secret, return the secret as not found
 		mock.EXPECT().
 			Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: constants.AdditionalTLS}, gomock.Not(gomock.Nil())).
@@ -1780,7 +1774,7 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, secret *corev1.Secret, opts ...client.CreateOption) error {
 			adminKubeconfig := string(secret.Data[mcconstants.KubeconfigKey])
-			if rancherEnabled && rancherBasedKubeConfigEnabled {
+			if rancherEnabled {
 				assert.Contains(t, adminKubeconfig, "server: "+rancherURL)
 			} else {
 				assert.Contains(t, adminKubeconfig, "server: "+userAPIServerURL)

--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -9,13 +9,14 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"io"
+
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentd"
 	jaegeroperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/jaeger/operator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysqloperator"
 	vzstatus "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/status"
-	"io"
 	kblabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -11,7 +11,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	vzcontext "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/context"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -136,6 +135,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			return ctrl.Result{Requeue: true}, nil
 
 		case vzStateInstallComponents:
+			r.beforeInstallComponents(spiCtx)
 			res, err := r.installComponents(spiCtx, tracker, preUpgrade)
 			if err != nil || res.Requeue {
 				return res, err
@@ -190,4 +190,8 @@ func (r *Reconciler) reconcileWatchedComponents(spiCtx spi.ComponentContext) err
 		}
 	}
 	return nil
+}
+
+func (r *Reconciler) beforeInstallComponents(ctx spi.ComponentContext) {
+	r.createRancherIngressAndCertCopies(ctx)
 }

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -123,6 +123,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			// if the VZ state is not Ready, it must be Reconciling or Upgrading
 			// in either case, go right to installComponents
 			tracker.vzState = vzStateInstallComponents
+			r.beforeInstallComponents(spiCtx)
 
 		case vzStateSetGlobalInstallStatus:
 			spiCtx.Log().Oncef("Writing Install Started condition to the Verrazzano status for generation: %d", spiCtx.ActualCR().Generation)
@@ -131,11 +132,11 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 				return ctrl.Result{Requeue: true}, err
 			}
 			tracker.vzState = vzStateInstallComponents
-			// since we updated the status, requeue to pick up new changesf
+			r.beforeInstallComponents(spiCtx)
+			// since we updated the status, requeue to pick up new changes
 			return ctrl.Result{Requeue: true}, nil
 
 		case vzStateInstallComponents:
-			r.beforeInstallComponents(spiCtx)
 			res, err := r.installComponents(spiCtx, tracker, preUpgrade)
 			if err != nil || res.Requeue {
 				return res, err

--- a/platform-operator/controllers/verrazzano/reconcile/rancher.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package reconcile
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// createRancherIngressAndCertCopies - creates copies of Rancher ingress and cert secret if
+// they exist. If there is a DNS update in progress, we want to do this so that the old DNS
+// continues to work as long as there is a good DNS entry, so that managed clusters can continue
+// connecting using the old Rancher DNS in their kubeconfig, until they are updated with the new DNS.
+func (r *Reconciler) createRancherIngressAndCertCopies(ctx spi.ComponentContext) {
+	ok, rancherComp := registry.FindComponent(rancher.ComponentName)
+	if !ok {
+		return
+	}
+	for _, ingressName := range rancherComp.GetIngressNames(ctx) {
+		ing := netv1.Ingress{}
+		err := r.Get(context.TODO(), ingressName, &ing)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				ctx.Log().Infof("Cannot make a copy of Rancher ingress %s/%s - get ingress failed: %v", ingressName.Namespace, ingressName.Name, err)
+			}
+			continue
+		}
+		newIngressTLSList := r.createIngressCertSecretCopies(ctx, ing)
+		// generate a new name for the ingress copy
+		newIngName := generateNewName(ingressName.Name)
+		newIngressNSN := types.NamespacedName{Name: newIngName, Namespace: ingressName.Namespace}
+		err = r.createIngressCopy(newIngressNSN, ing, newIngressTLSList)
+		if err != nil {
+			ctx.Log().Infof("Failed to create a copy of Rancher ingress %s/%s - create ingress failed: %v", ingressName.Namespace, ingressName.Name, err)
+			continue
+		}
+		ctx.Log().Infof("Created copy of Rancher ingress %v, new ingress is %v", ingressName, newIngressNSN)
+	}
+}
+
+func (r *Reconciler) createIngressCopy(newIngressName types.NamespacedName, existingIngress netv1.Ingress, newIngressTLSList []netv1.IngressTLS) error {
+	newIngSpec := existingIngress.Spec.DeepCopy()
+	newIngSpec.TLS = newIngressTLSList
+	newIng := netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   newIngressName.Namespace,
+			Name:        newIngressName.Name,
+			Labels:      existingIngress.Labels,
+			Annotations: existingIngress.Annotations,
+		},
+		Spec: *newIngSpec,
+	}
+	return r.Create(context.TODO(), &newIng)
+}
+
+func (r *Reconciler) createIngressCertSecretCopies(ctx spi.ComponentContext, ing netv1.Ingress) []netv1.IngressTLS {
+	newIngressTLSList := []netv1.IngressTLS{}
+	for _, ingTLS := range ing.Spec.TLS {
+		if ingTLS.SecretName != "" {
+			tlsSecret := corev1.Secret{}
+			tlsSecretName := types.NamespacedName{Namespace: ing.Namespace, Name: ingTLS.SecretName}
+			err := r.Get(context.TODO(), tlsSecretName, &tlsSecret)
+			if err == nil {
+				newSecretNSN := types.NamespacedName{Name: generateNewName(tlsSecret.Name), Namespace: tlsSecret.Namespace}
+				if err := r.createSecretCopy(newSecretNSN, tlsSecret); err != nil {
+					ctx.Log().Infof("Failed to create copy %v of Rancher TLS secret %v", newSecretNSN, tlsSecretName)
+				}
+				newIngressTLS := ingTLS.DeepCopy()
+				newIngressTLS.SecretName = newSecretNSN.Name
+				newIngressTLSList = append(newIngressTLSList, *newIngressTLS)
+			}
+		}
+	}
+	return newIngressTLSList
+}
+
+func (r *Reconciler) createSecretCopy(newName types.NamespacedName, existingSecret corev1.Secret) error {
+	newSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   newName.Namespace,
+			Name:        newName.Name,
+			Labels:      existingSecret.Labels,
+			Annotations: existingSecret.Annotations,
+		},
+		Data: existingSecret.Data,
+	}
+	return r.Create(context.TODO(), &newSecret)
+}
+
+func generateNewName(existingName string) string {
+	return existingName + "-" + uuid.NewString()[:7]
+}

--- a/platform-operator/controllers/verrazzano/reconcile/rancher.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
@@ -74,6 +75,7 @@ func (r *Reconciler) createIngressCopy(newIngressName types.NamespacedName, exis
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, ingress, func() error {
 		ingress.Labels = existingIngress.Labels
+		ingress.Labels[constants.VerrazzanoManagedLabelKey] = "true"
 		ingress.Annotations = existingIngress.Annotations
 		ingress.Spec = *existingIngress.Spec.DeepCopy()
 		ingress.Spec.TLS = newIngressTLSList

--- a/platform-operator/controllers/verrazzano/reconcile/rancher.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher.go
@@ -75,6 +75,9 @@ func (r *Reconciler) createIngressCopy(newIngressName types.NamespacedName, exis
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, ingress, func() error {
 		ingress.Labels = existingIngress.Labels
+		if ingress.Labels == nil {
+			ingress.Labels = map[string]string{}
+		}
 		ingress.Labels[constants.VerrazzanoManagedLabelKey] = "true"
 		ingress.Annotations = existingIngress.Annotations
 		ingress.Spec = *existingIngress.Spec.DeepCopy()

--- a/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
@@ -20,26 +20,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
-	host1 := "rancher1.somedomain.com"
-	host2 := "rancher2.somedomain.com"
-	host3 := "rancher3.otherdomain.com"
-	secret1 := "secret1"
-	secret2 := "secret2"
-	rancherSecret1 := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: common.CattleSystem,
-			Name:      secret1,
-			Annotations: map[string]string{
-				"cert-manager.io/certificate-name": "verrazzano-ca-certificate",
-				"cert-manager.io/common-name":      "verrazzano-root-ca-abcdef",
-			},
-		},
-		Data: map[string][]byte{
-			"ca.crt":  []byte("cacert"),
-			"tls.crt": []byte("tls cert"),
-		},
-	}
+const host1 = "rancher1.somedomain.com"
+const host2 = "rancher2.somedomain.com"
+const host3 = "rancher3.otherdomain.com"
+const secret1 = "secret1"
+const secret2 = "secret2"
+
+// GIVEN The Rancher ingress and cert copies do not already exist
+// WHEN createRancherIngressAndCertCopies is called
+// THEN the copies of the ingress and cert(s) are created and there is no error
+func TestCreate_createRancherIngressAndCertCopies(t *testing.T) {
+	rancherSecret1 := createRancherSecret(secret1)
 	rancherSecret2 := rancherSecret1.DeepCopy()
 	rancherSecret2.Name = secret2
 	rancherSecret2.Annotations["extraAnnotation"] = "extraAnnotationValue"
@@ -56,14 +47,14 @@ func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
 				{Host: host3},
 			},
 			TLS: []netv1.IngressTLS{
-				{SecretName: "secret1", Hosts: []string{host1, host2}},
-				{SecretName: "secret2", Hosts: []string{host3}},
+				{SecretName: secret1, Hosts: []string{host1, host2}},
+				{SecretName: secret2, Hosts: []string{host3}},
 			},
 		},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
-		WithObjects(&rancherSecret1, rancherSecret2, &rancherIngress).Build()
+		WithObjects(rancherSecret1, rancherSecret2, &rancherIngress).Build()
 
 	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, false)
 	reconciler := newVerrazzanoReconciler(ctx.Client())
@@ -79,26 +70,110 @@ func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
 		expectedLabels = map[string]string{}
 	}
 	expectedLabels[constants2.VerrazzanoManagedLabelKey] = "true"
+	verifyIngressCopyEqualToOriginal(t, ingressList, &rancherIngress)
+
+	secretList := corev1.SecretList{}
+	err = c.List(context.TODO(), &secretList)
+	asserts.NoError(t, err)
+	asserts.Equal(t, 4, len(secretList.Items))
+}
+
+func createRancherSecret(secretName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      secret1,
+			Annotations: map[string]string{
+				"cert-manager.io/certificate-name": "verrazzano-ca-certificate",
+				"cert-manager.io/common-name":      "verrazzano-root-ca-abcdef",
+			},
+		},
+		Data: map[string][]byte{
+			"ca.crt":  []byte("cacert"),
+			"tls.crt": []byte("tls cert"),
+		},
+	}
+}
+
+// GIVEN The Rancher ingress and cert copies already exist
+// WHEN createRancherIngressAndCertCopies is called
+// THEN the existing copies are updated and there is no error
+func TestUpdate_createRancherIngressAndCertCopies(t *testing.T) {
+	rancherSecret1 := createRancherSecret(secret1)
+	rancherIngress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      constants.RancherIngress,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{Host: host1},
+			},
+			TLS: []netv1.IngressTLS{
+				{SecretName: secret1, Hosts: []string{host1, host2}},
+			},
+		},
+	}
+
+	// if the existing copy of the secret has different content, it should be updated
+	existingCopyOfRancherSecret := rancherSecret1.DeepCopy()
+	existingCopyOfRancherSecret.Name = "vz-" + rancherSecret1.Name
+	existingCopyOfRancherSecret.Data["tls.crt"] = []byte("someothervalue")
+
+	// if the existing copy of the ingress has a different hostname, it should be updated
+	existingCopyOfRancherIngress := rancherIngress.DeepCopy()
+	existingCopyOfRancherIngress.Name = "vz-" + rancherIngress.Name
+	existingCopyOfRancherIngress.Spec.Rules[0].Host = host2
+	existingCopyOfRancherIngress.Spec.TLS[0].SecretName = existingCopyOfRancherSecret.Name
+
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
+		WithObjects(rancherSecret1, existingCopyOfRancherSecret, rancherIngress, existingCopyOfRancherIngress).Build()
+
+	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, false)
+	reconciler := newVerrazzanoReconciler(ctx.Client())
+	reconciler.createRancherIngressAndCertCopies(ctx)
+
+	ingressList := netv1.IngressList{}
+	err := c.List(context.TODO(), &ingressList)
+	asserts.NoError(t, err)
+	asserts.Equal(t, 2, len(ingressList.Items))
+
+	verifyIngressCopyEqualToOriginal(t, ingressList, rancherIngress)
+
+	secretList := corev1.SecretList{}
+	err = c.List(context.TODO(), &secretList)
+	asserts.NoError(t, err)
+	asserts.Equal(t, 2, len(secretList.Items))
+	// the data in both secrets should be the same as in the rancherSecret1 (existing secret copy
+	// should have been updated to match rancherSecret1)
+	asserts.Equal(t, rancherSecret1.Data, secretList.Items[0].Data)
+	asserts.Equal(t, rancherSecret1.Data, secretList.Items[1].Data)
+}
+
+func verifyIngressCopyEqualToOriginal(t *testing.T, ingressList netv1.IngressList, original *netv1.Ingress) {
+	expectedLabels := original.Labels
+	if expectedLabels == nil {
+		expectedLabels = map[string]string{}
+	}
+	expectedLabels[constants2.VerrazzanoManagedLabelKey] = "true"
 	for _, ing := range ingressList.Items {
-		if ing.Name == rancherIngress.Name {
-			asserts.Equal(t, rancherIngress, ing)
+		if ing.Name == original.Name {
+			asserts.Equal(t, *original, ing)
 		} else {
-			asserts.Equal(t, rancherIngress.Namespace, ing.Namespace)
-			asserts.Equal(t, rancherIngress.Annotations, ing.Annotations)
+			asserts.Equal(t, original.Namespace, ing.Namespace)
+			asserts.Equal(t, original.Annotations, ing.Annotations)
 			asserts.Equal(t, expectedLabels, ing.Labels)
-			asserts.Equal(t, rancherIngress.Spec.Rules, ing.Spec.Rules)
+			asserts.Equal(t, original.Spec.Rules, ing.Spec.Rules)
 
 			// should have same number of TLS entries but with different content
-			asserts.Equal(t, len(rancherIngress.Spec.TLS), len(ing.Spec.TLS))
-			for i, tls := range rancherIngress.Spec.TLS {
+			asserts.Equal(t, len(original.Spec.TLS), len(ing.Spec.TLS))
+
+			for i, tls := range original.Spec.TLS {
+				// host name should have been updated since it is different from the existing copy
 				asserts.Equal(t, tls.Hosts, ing.Spec.TLS[i].Hosts)
 				asserts.Equal(t, ing.Spec.TLS[i].SecretName, "vz-"+tls.SecretName)
 			}
 		}
 	}
 
-	secretList := corev1.SecretList{}
-	err = c.List(context.TODO(), &secretList)
-	asserts.NoError(t, err)
-	asserts.Equal(t, 4, len(secretList.Items))
 }

--- a/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
@@ -86,7 +86,7 @@ func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
 			asserts.Equal(t, len(rancherIngress.Spec.TLS), len(ing.Spec.TLS))
 			for i, tls := range rancherIngress.Spec.TLS {
 				asserts.Equal(t, tls.Hosts, ing.Spec.TLS[i].Hosts)
-				asserts.Contains(t, ing.Spec.TLS[i].SecretName, tls.SecretName+"-")
+				asserts.Equal(t, ing.Spec.TLS[i].SecretName, "vz-"+tls.SecretName)
 			}
 		}
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	asserts "github.com/stretchr/testify/assert"
+	constants2 "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -73,13 +74,18 @@ func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
 	asserts.NoError(t, err)
 	asserts.Equal(t, 2, len(ingressList.Items))
 
+	expectedLabels := rancherIngress.Labels
+	if expectedLabels == nil {
+		expectedLabels = map[string]string{}
+	}
+	expectedLabels[constants2.VerrazzanoManagedLabelKey] = "true"
 	for _, ing := range ingressList.Items {
 		if ing.Name == rancherIngress.Name {
 			asserts.Equal(t, rancherIngress, ing)
 		} else {
 			asserts.Equal(t, rancherIngress.Namespace, ing.Namespace)
 			asserts.Equal(t, rancherIngress.Annotations, ing.Annotations)
-			asserts.Equal(t, rancherIngress.Labels, ing.Labels)
+			asserts.Equal(t, expectedLabels, ing.Labels)
 			asserts.Equal(t, rancherIngress.Spec.Rules, ing.Spec.Rules)
 
 			// should have same number of TLS entries but with different content

--- a/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/rancher_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	asserts "github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconciler_createRancherIngressAndCertCopies(t *testing.T) {
+	host1 := "rancher1.somedomain.com"
+	host2 := "rancher2.somedomain.com"
+	host3 := "rancher3.otherdomain.com"
+	secret1 := "secret1"
+	secret2 := "secret2"
+	rancherSecret1 := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      secret1,
+			Annotations: map[string]string{
+				"cert-manager.io/certificate-name": "verrazzano-ca-certificate",
+				"cert-manager.io/common-name":      "verrazzano-root-ca-abcdef",
+			},
+		},
+		Data: map[string][]byte{
+			"ca.crt":  []byte("cacert"),
+			"tls.crt": []byte("tls cert"),
+		},
+	}
+	rancherSecret2 := rancherSecret1.DeepCopy()
+	rancherSecret2.Name = secret2
+	rancherSecret2.Annotations["extraAnnotation"] = "extraAnnotationValue"
+
+	rancherIngress := netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      constants.RancherIngress,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{Host: host1},
+				{Host: host2},
+				{Host: host3},
+			},
+			TLS: []netv1.IngressTLS{
+				{SecretName: "secret1", Hosts: []string{host1, host2}},
+				{SecretName: "secret2", Hosts: []string{host3}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).
+		WithObjects(&rancherSecret1, rancherSecret2, &rancherIngress).Build()
+
+	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, false)
+	reconciler := newVerrazzanoReconciler(ctx.Client())
+	reconciler.createRancherIngressAndCertCopies(ctx)
+
+	ingressList := netv1.IngressList{}
+	err := c.List(context.TODO(), &ingressList)
+	asserts.NoError(t, err)
+	asserts.Equal(t, 2, len(ingressList.Items))
+
+	for _, ing := range ingressList.Items {
+		if ing.Name == rancherIngress.Name {
+			asserts.Equal(t, rancherIngress, ing)
+		} else {
+			asserts.Equal(t, rancherIngress.Namespace, ing.Namespace)
+			asserts.Equal(t, rancherIngress.Annotations, ing.Annotations)
+			asserts.Equal(t, rancherIngress.Labels, ing.Labels)
+			asserts.Equal(t, rancherIngress.Spec.Rules, ing.Spec.Rules)
+
+			// should have same number of TLS entries but with different content
+			asserts.Equal(t, len(rancherIngress.Spec.TLS), len(ing.Spec.TLS))
+			for i, tls := range rancherIngress.Spec.TLS {
+				asserts.Equal(t, tls.Hosts, ing.Spec.TLS[i].Hosts)
+				asserts.Contains(t, ing.Spec.TLS[i].SecretName, tls.SecretName+"-")
+			}
+		}
+	}
+
+	secretList := corev1.SecretList{}
+	err = c.List(context.TODO(), &secretList)
+	asserts.NoError(t, err)
+	asserts.Equal(t, 4, len(secretList.Items))
+}

--- a/tests/e2e/multicluster/multicluster_helper.go
+++ b/tests/e2e/multicluster/multicluster_helper.go
@@ -273,6 +273,7 @@ func getCluster(name, kcfgDir string, count int) *Cluster {
 	if _, err := os.Stat(kcfgPath); errs.Is(err, os.ErrNotExist) {
 		return nil
 	}
+
 	return newCluster(name, kcfgPath)
 }
 
@@ -480,6 +481,15 @@ func (c *Cluster) Register(managed *Cluster) error {
 	}
 	managed.Apply(reg)
 	return nil
+}
+
+func (c *Cluster) GetVMC(name string) (*mcapi.VerrazzanoManagedCluster, error) {
+	mcCli, err := mcClient.NewForConfig(c.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return mcCli.ClustersV1alpha1().
+		VerrazzanoManagedClusters(constants.VerrazzanoMultiClusterNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 func (c *Cluster) GetManifest(name string) ([]byte, error) {

--- a/tests/e2e/multicluster/multicluster_helper.go
+++ b/tests/e2e/multicluster/multicluster_helper.go
@@ -405,7 +405,7 @@ func (c *Cluster) getCacrt() ([]byte, error) {
 	return c.GetSecretData(constants.VerrazzanoSystemNamespace, "verrazzano-tls", "ca.crt")
 }
 
-func (c *Cluster) apply(data []byte) {
+func (c *Cluster) Apply(data []byte) {
 	gomega.Eventually(func() bool {
 		err := apply(data, c.restConfig)
 		if err != nil {
@@ -478,7 +478,7 @@ func (c *Cluster) Register(managed *Cluster) error {
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("manifest %v error: %v", managed.Name, err))
 	}
-	managed.apply(reg)
+	managed.Apply(reg)
 	return nil
 }
 
@@ -542,7 +542,7 @@ spec:
 `
 	caname := fmt.Sprintf("gen-ca-%v", uuid.NewString()[:7])
 	cacert := fmt.Sprintf(caCertTemp, caname, caname, caname)
-	c.apply([]byte(cacert))
+	c.Apply([]byte(cacert))
 	gomega.Eventually(func() bool {
 		casec, err := c.GetSecret(constants.CertManagerNamespace, caname)
 		if err != nil || errors.IsNotFound(err) || casec == nil {

--- a/tests/e2e/pkg/common.go
+++ b/tests/e2e/pkg/common.go
@@ -7,19 +7,21 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"io"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"net/http"
 	neturl "net/url"
 	"os"
 	"reflect"
 	"regexp"
-	"sigs.k8s.io/yaml"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
 
 	v12 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 
@@ -732,4 +734,11 @@ func CreateOverridesOrDie(yamlString string) []v1beta1.Overrides {
 			},
 		},
 	}
+}
+
+func IsVerrazzanoManaged(labels map[string]string) bool {
+	if val, ok := labels[constants.VerrazzanoManagedLabelKey]; ok {
+		return val == "true"
+	}
+	return false
 }

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -128,15 +128,15 @@ func getExpectedConsoleURLs(kubeConfig string) ([]string, error) {
 		if strings.HasPrefix(ingressHost, "elasticsearch") || strings.HasPrefix(ingressHost, "kibana") {
 			continue
 		}
-		// If it's not the console ingress, or it is and the console is enabled, add it to the expected set of URLs
-		if !isConsoleIngressHost(ingressHost) || consoleURLExpected {
-			expectedUrls = append(expectedUrls, fmt.Sprintf("https://%s", ingressHost))
-		}
 		// Any verrazzano-managed ingresses in the Rancher namespace are created for managed clusters to be
 		// able to use an older DNS name to connect to Rancher proxy until the managed clusters are updated.
 		// Those will not exist in the VZ resource.
 		if ingress.Namespace == constants.RancherSystemNamespace && pkg.IsVerrazzanoManaged(ingress.Labels) {
 			continue
+		}
+		// If it's not the console ingress, or it is and the console is enabled, add it to the expected set of URLs
+		if !isConsoleIngressHost(ingressHost) || consoleURLExpected {
+			expectedUrls = append(expectedUrls, fmt.Sprintf("https://%s", ingressHost))
 		}
 	}
 

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 
@@ -130,6 +131,12 @@ func getExpectedConsoleURLs(kubeConfig string) ([]string, error) {
 		// If it's not the console ingress, or it is and the console is enabled, add it to the expected set of URLs
 		if !isConsoleIngressHost(ingressHost) || consoleURLExpected {
 			expectedUrls = append(expectedUrls, fmt.Sprintf("https://%s", ingressHost))
+		}
+		// Any verrazzano-managed ingresses in the Rancher namespace are created for managed clusters to be
+		// able to use an older DNS name to connect to Rancher proxy until the managed clusters are updated.
+		// Those will not exist in the VZ resource.
+		if ingress.Namespace == constants.RancherSystemNamespace && pkg.IsVerrazzanoManaged(ingress.Labels) {
+			continue
 		}
 	}
 

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -218,8 +218,9 @@ func reapplyManagedClusterRegManifest() {
 	for _, managedCluster := range managedClusters {
 		reg, err := adminCluster.GetManifest(managedCluster.Name)
 		if err != nil {
-			pkg.Log(pkg.Error, fmt.Sprintf("manifest %v error: %v", managedCluster.Name, err))
+			pkg.Log(pkg.Error, fmt.Sprintf("could not get manifest for managed cluster %v error: %v", managedCluster.Name, err))
 		}
+		pkg.Log(pkg.Info, fmt.Sprintf("Reapplying registration manifest for managed cluster %s", managedCluster.Name))
 		managedCluster.Apply(reg)
 	}
 }

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -266,10 +266,9 @@ func waitForManifestSecretUpdated(managedClusterName string, newCACert string) {
 		if updated {
 			pkg.Log(pkg.Info, fmt.Sprintf("%s took %v updated", manifestSecretName, time.Since(start)))
 			return nil
-		} else {
-			pkg.Log(pkg.Info, fmt.Sprintf("%s not updated", manifestSecretName))
-			return fmt.Errorf("manifest secret for cluster %s not updated with new CA cert", managedClusterName)
 		}
+		pkg.Log(pkg.Info, fmt.Sprintf("%s not updated", manifestSecretName))
+		return fmt.Errorf("manifest secret for cluster %s not updated with new CA cert", managedClusterName)
 	}).WithTimeout(waitTimeout).WithPolling(pollingInterval).
 		Should(gomega.Not(gomega.HaveOccurred()))
 }

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -198,7 +198,7 @@ func verifyManagedFluentd(since time.Time) {
 			logs := managedCluster.FluentdLogs(5, since)
 			ok := checkFluentdLogs(logs)
 			if !ok {
-				pkg.Log(pkg.Error, fmt.Sprintf("%v Fluentd is not read: \n%v\n", managedCluster.Name, logs))
+				pkg.Log(pkg.Error, fmt.Sprintf("%v Fluentd is not ready: \n%v\n", managedCluster.Name, logs))
 			}
 			return ok
 		}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("scrape target of %s is not ready", managedCluster.Name))

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -168,7 +168,12 @@ func verifyManagedClusterAdminKubeconfig(managedCluster *multicluster.Cluster, a
 			pkg.Log(pkg.Error, fmt.Sprintf("Kubeconfig in %s of %s has nil clusters[0].cluster.certificate-authority-data", aocnst.MCAgentSecret, managedCluster.Name))
 			return false
 		}
-		if admCaCrt == newCaCrtData.(string) {
+		newCaCrt, err := base64.StdEncoding.DecodeString(newCaCrtData.(string))
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Could not decode certificate-authority-data in the kubeconfig in %s: %v", aocnst.MCAgentSecret, err))
+			return false
+		}
+		if admCaCrt == string(newCaCrt) {
 			pkg.Log(pkg.Info, fmt.Sprintf("%v of %v took %v updated", aocnst.MCAgentSecret, managedCluster.Name, time.Since(start)))
 			return true
 		}

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -158,7 +158,7 @@ func verifyManagedClusterAdminKubeconfig(managedCluster *multicluster.Cluster, a
 			pkg.Log(pkg.Error, fmt.Sprintf("Failed parsing admin kubeconfig JSON: %v", err))
 			return false
 		}
-		newCaCrt := parsedKubeconfig.Path("certificate-authority-data").Data().(string)
+		newCaCrt := parsedKubeconfig.Search("clusters", "cluster", 0, "certificate-authority-data").Data().(string)
 		if newCaCrt == admCaCrt {
 			pkg.Log(pkg.Error, fmt.Sprintf("%v of %v took %v updated", aocnst.MCAgentSecret, managedCluster.Name, time.Since(start)))
 		} else {

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -242,11 +242,11 @@ func waitForVMCReadyAfterTime(managedClusterName string, afterTime time.Time) {
 			return false
 		}
 		readyCond := findStatusCondition(vmc.Status.Conditions, v1alpha1.ConditionReady)
-		if !readyCond.LastTransitionTime.After(afterTime) {
-			return false
+		if readyCond.LastTransitionTime.After(afterTime) {
+			return true
 		}
-		return true
-	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("VMC ready condition for %s not updated after CA change", managedClusterName))
+		return false
+	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("VMC ready condition for %s not updated after CA change at %v", managedClusterName, afterTime))
 }
 
 func findStatusCondition(conditions []v1alpha1.Condition, condType v1alpha1.ConditionType) *v1alpha1.Condition {

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -60,7 +60,6 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 var _ = BeforeSuite(beforeSuite)
 
 var afterSuite = t.AfterSuiteFunc(func() {
-	// verifyManagedClustersFluentdConnection()
 })
 
 var _ = AfterSuite(afterSuite)
@@ -227,10 +226,8 @@ func verifyRegistration() {
 // managed clusters can be reliably updated to use the new CA cert. Otherwise intermittent timing
 // related failures may occur
 func reapplyManagedClusterRegManifest(newCACert string) {
-	// CAUpdateTime := time.Now()
 	for _, managedCluster := range managedClusters {
 		waitForManifestSecretUpdated(managedCluster.Name, newCACert)
-		// waitForVMCReadyAfterTime(managedCluster.Name, CAUpdateTime)
 		gomega.Eventually(func() error {
 			reg, err := adminCluster.GetManifest(managedCluster.Name)
 			if err != nil {
@@ -240,7 +237,7 @@ func reapplyManagedClusterRegManifest(newCACert string) {
 			pkg.Log(pkg.Info, fmt.Sprintf("Reapplying registration manifest for managed cluster %s", managedCluster.Name))
 			managedCluster.Apply(reg)
 			return nil
-		}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(gomega.BeNil(), fmt.Sprintf("Reapply registration manifest failed for cluster %s", managedCluster.Name))
+		}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(gomega.Not(gomega.HaveOccurred()), fmt.Sprintf("Reapply registration manifest failed for cluster %s", managedCluster.Name))
 	}
 }
 

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -67,13 +67,14 @@ var _ = t.Describe("Update admin-cluster cert-manager", Label("f:platform-lcm.up
 		t.It("admin-cluster cert-manager custom CA", func() {
 			start := time.Now()
 			oldIngressCaCrt := updateAdminClusterCA()
+			// TODO DEVA reapply registration for managed cluster
 			verifyCaSync(oldIngressCaCrt)
 			// verify new logs are flowing after updating admin cert
 			verifyManagedFluentd(start)
 		})
 	})
-	t.Describe("multicluster cert-manager verify", Label("f:platform-lcm.multicluster-verify"), func() {
-		t.It("admin-cluster cert-manager default self-signed CA", func() {
+	t.Describe("multicluster cert-manager verify cleanup", Label("f:platform-lcm.multicluster-verify"), func() {
+		t.It("admin-cluster cert-manager revert to default self-signed CA", func() {
 			start := time.Now()
 			oldIngressCaCrt := revertToDefaultCertManager()
 			verifyCaSync(oldIngressCaCrt)
@@ -141,7 +142,7 @@ func verifyCaSyncToManagedClusters(admCaCrt string) {
 	}
 }
 
-func verifyManagedClusterKubeconfig(managedCluster *multicluster.Cluster, admCaCrt string, kubeconfigKey string) {
+func verifyManagedClusterKubeconfig(managedCluster *multicluster.Cluster, admCaCrt, kubeconfigKey string) {
 	start := time.Now()
 	gomega.Eventually(func() bool {
 		newKubeconfig := managedCluster.

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -81,7 +81,6 @@ var _ = t.Describe("Update admin-cluster cert-manager", Label("f:platform-lcm.up
 		t.It("admin-cluster cert-manager revert to default self-signed CA", func() {
 			start := time.Now()
 			oldIngressCaCrt := revertToDefaultCertManager()
-			reapplyManagedClusterRegManifest(oldIngressCaCrt)
 			verifyCaSync(oldIngressCaCrt)
 			verifyManagedFluentd(start)
 		})

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -253,8 +253,9 @@ func waitForManifestSecretUpdated(managedClusterName string, newCACert string) {
 			resourceContainer, err := gabs.ParseJSON(jsonDoc)
 			if err != nil {
 				pkg.Log(pkg.Error, fmt.Sprintf("Could not parse JSON manifest secret: %v", err))
+				return false
 			}
-			if resourceContainer.Search("metadata", "name").String() == pocnst.MCAgentSecret {
+			if resourceContainer.Search("metadata", "name").Data() == pocnst.MCAgentSecret {
 				kubeconfigData := resourceContainer.Search("data", mcconstants.KubeconfigKey)
 				return kubeconfigContainsCACert(kubeconfigData, newCACert)
 			}
@@ -269,7 +270,7 @@ func kubeconfigContainsCACert(kubeconfigData *gabs.Container, newCACert string) 
 		pkg.Log(pkg.Error, "Could not find admin kubeconfig data in manifest")
 		return false
 	}
-	kubeconfig, err := base64.StdEncoding.DecodeString(kubeconfigData.String())
+	kubeconfig, err := base64.StdEncoding.DecodeString(kubeconfigData.Data().(string))
 	if err != nil {
 		pkg.Log(pkg.Error, fmt.Sprintf("Could not base64 decode kubeconfig in manifest: %v", err))
 		return false
@@ -277,6 +278,36 @@ func kubeconfigContainsCACert(kubeconfigData *gabs.Container, newCACert string) 
 	encodedCACert := base64.StdEncoding.EncodeToString([]byte(newCACert))
 	return strings.Contains(string(kubeconfig), encodedCACert)
 }
+
+/*func Test_mytest(t *testing.T) {
+	managedClusterName := "managed1"
+	manifestBytes, err := os.ReadFile("/Users/desagar/tmp/VZ-7637/manifest.yaml")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Could not get manifest secret for managed cluster %s: %v", managedClusterName, err))
+	}
+	newCACertBytes, err := os.ReadFile("/Users/desagar/tmp/VZ-7637/newCACert.crt")
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Could not get ca cert %v", err))
+	}
+	newCACert := string(newCACertBytes)
+	yamlDocs := bytes.Split(manifestBytes, []byte("---\n"))
+	for _, yamlDoc := range yamlDocs {
+		jsonDoc, err := yaml.YAMLToJSON(yamlDoc)
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Could not parse YAML in manifest to JSON %v", err))
+		}
+		resourceContainer, err := gabs.ParseJSON(jsonDoc)
+		if err != nil {
+			pkg.Log(pkg.Error, fmt.Sprintf("Could not parse JSON manifest secret: %v", err))
+		}
+		if resourceContainer.Search("metadata", "name").Data() == pocnst.MCAgentSecret {
+			kubeconfigData := resourceContainer.Search("data", mcconstants.KubeconfigKey)
+			asserts.True(t, kubeconfigContainsCACert(kubeconfigData, newCACert))
+			return
+		}
+	}
+	asserts.Fail(t, "did not find it")
+}*/
 
 /*
 func waitForVMCReadyAfterTime(managedClusterName string, afterTime time.Time) {

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -78,7 +78,7 @@ var _ = t.Describe("Update admin-cluster cert-manager", Label("f:platform-lcm.up
 		t.It("admin-cluster cert-manager revert to default self-signed CA", func() {
 			start := time.Now()
 			oldIngressCaCrt := revertToDefaultCertManager()
-			reapplyManagedClusterRegManifest("")
+			reapplyManagedClusterRegManifest(oldIngressCaCrt)
 			verifyCaSync(oldIngressCaCrt)
 			verifyManagedFluentd(start)
 		})

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -256,6 +256,7 @@ func waitForManifestSecretUpdated(managedClusterName string, newCACert string) {
 				pkg.Log(pkg.Error, fmt.Sprintf("Could not parse JSON manifest secret: %v", err))
 				return false
 			}
+			pkg.Log(pkg.Info, fmt.Sprintf("Waiting for %s to contain updated admin kubeconfig for %s", pocnst.MCAgentSecret, managedClusterName))
 			if resourceContainer.Search("metadata", "name").Data() == pocnst.MCAgentSecret {
 				kubeconfigData := resourceContainer.Search("data", mcconstants.KubeconfigKey)
 				return kubeconfigContainsCACert(kubeconfigData, newCACert)

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -167,7 +167,7 @@ func verifyManagedClusterAdminKubeconfig(managedCluster *multicluster.Cluster, a
 			pkg.Log(pkg.Error, fmt.Sprintf("%v of %v is not updated", aocnst.MCAgentSecret, managedCluster.Name))
 		}
 		return admCaCrt == newCaCrt
-	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Sync CA %v", managedCluster.Name))
+	}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("Sync admin-kubeconfig %v", managedCluster.Name))
 }
 
 func verifyManagedClusterRegistration(managedCluster *multicluster.Cluster, admCaCrt, cakey string) {


### PR DESCRIPTION
Before DNS updates, copy the Rancher ingress and TLS secret(s) so that managed clusters can use the old DNS name to access the admin cluster until the update is propagated.