### PR TITLE
Re-enable PSR writelogs metrics tests

### DIFF
--- a/ci/psr/Makefile
+++ b/ci/psr/Makefile
@@ -25,7 +25,7 @@ install:
 
 # Executes test suite(s) against the target Verrazzano install
 test: export TEST_ROOT = ${PSR_PATH}/tests
-test: export TEST_SUITES ?= scenarios/opensearch/...
+test: export TEST_SUITES ?= ${TEST_ROOT}/...
 test: export PSR_COMMAND ?= psrctl
 test: export TEST_NAMESPACE ?= psrtest
 test: export IMAGE_PULL_SECRET ?= verrazzano-container-registry

--- a/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
@@ -4,6 +4,8 @@
 package s1
 
 import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/tools/psr/tests/pkg/constants"
 	"net/http"
 	"time"
 
@@ -92,18 +94,18 @@ var _ = t.Describe("ops-s1", Label("f:psr-ops-s1"), func() {
 	// GIVEN a Verrazzano installation
 	// WHEN  all opensearch PSR workers are running
 	// THEN  metrics can be found for all opensearch PSR workers
-	//t.DescribeTable("Verify Opensearch ops-s1 Worker Metrics",
-	//	func(metricName string) {
-	//		Eventually(func() bool {
-	//			return pkg.MetricsExistInCluster(metricName, common.GetMetricLabels(""), kubeconfig)
-	//		}, waitTimeout, pollingInterval).Should(BeTrue(),
-	//			fmt.Sprintf("No metrics found for %s", metricName))
-	//	},
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedCharsTotal), constants.WriteLogsLoggedCharsTotal),
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedLinesTotalCountMetric), constants.WriteLogsLoggedLinesTotalCountMetric),
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoopCountTotalMetric), constants.WriteLogsLoopCountTotalMetric),
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerLastLoopNanosMetric), constants.WriteLogsWorkerLastLoopNanosMetric),
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerRunningSecondsTotalMetric), constants.WriteLogsWorkerRunningSecondsTotalMetric),
-	//	Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerThreadCountTotalMetric), constants.WriteLogsWorkerThreadCountTotalMetric),
-	//)
+	t.DescribeTable("Verify Opensearch ops-s1 Worker Metrics",
+		func(metricName string) {
+			Eventually(func() bool {
+				return pkg.MetricsExistInCluster(metricName, common.GetMetricLabels(""), kubeconfig)
+			}, waitTimeout, pollingInterval).Should(BeTrue(),
+				fmt.Sprintf("No metrics found for %s", metricName))
+		},
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedCharsTotal), constants.WriteLogsLoggedCharsTotal),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedLinesTotalCountMetric), constants.WriteLogsLoggedLinesTotalCountMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoopCountTotalMetric), constants.WriteLogsLoopCountTotalMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerLastLoopNanosMetric), constants.WriteLogsWorkerLastLoopNanosMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerRunningSecondsTotalMetric), constants.WriteLogsWorkerRunningSecondsTotalMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerThreadCountTotalMetric), constants.WriteLogsWorkerThreadCountTotalMetric),
+	)
 })

--- a/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
@@ -113,11 +113,11 @@ var _ = t.Describe("ops-s2", Label("f:psr-ops-s2"), func() {
 		Entry(fmt.Sprintf("Verify metric %s", constants.GetLogsWorkerRunningSecondsTotalMetric), constants.GetLogsWorkerRunningSecondsTotalMetric),
 		Entry(fmt.Sprintf("Verify metric %s", constants.GetLogsWorkerThreadCountTotalMetric), constants.GetLogsWorkerThreadCountTotalMetric),
 
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedCharsTotal), constants.WriteLogsLoggedCharsTotal),
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedLinesTotalCountMetric), constants.WriteLogsLoggedLinesTotalCountMetric),
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoopCountTotalMetric), constants.WriteLogsLoopCountTotalMetric),
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerLastLoopNanosMetric), constants.WriteLogsWorkerLastLoopNanosMetric),
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerRunningSecondsTotalMetric), constants.WriteLogsWorkerRunningSecondsTotalMetric),
-		//Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerThreadCountTotalMetric), constants.WriteLogsWorkerThreadCountTotalMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedCharsTotal), constants.WriteLogsLoggedCharsTotal),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoggedLinesTotalCountMetric), constants.WriteLogsLoggedLinesTotalCountMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsLoopCountTotalMetric), constants.WriteLogsLoopCountTotalMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerLastLoopNanosMetric), constants.WriteLogsWorkerLastLoopNanosMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerRunningSecondsTotalMetric), constants.WriteLogsWorkerRunningSecondsTotalMetric),
+		Entry(fmt.Sprintf("Verify metric %s", constants.WriteLogsWorkerThreadCountTotalMetric), constants.WriteLogsWorkerThreadCountTotalMetric),
 	)
 })


### PR DESCRIPTION
Picks up the fixes for the writelogs metrics and re-enable writelog metrics tests.
- Modify PSR tests target to run everything under tests dir