### PR TITLE
Add checksum annotation to cluster operator deployment

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
+      annotations:
+        verrazzano.io/checksum: {{ tpl (toYaml .Values) . | sha256sum }}
     spec:
       containers:
       - name: {{ .Values.name }}


### PR DESCRIPTION
If the cluster operator cluster selector configuration changes in the VZ CR, we are not bouncing the cluster operator so that it picks up the updated configmap contents. This PR adds a checksum annotation so that any changes in the Helm values will trigger a deployment rollout.

To test I did the following:
1. Applied a VZ CR with no cluster operator overrides
2. After install completed, applied a new VZ CR that enabled cluster sync with a label selector
3. Verified the cluster operator was restarted and that it picked up the right configmap data
4. Applied a new VZ CR that changed the label selector
5. Verified the cluster operator was restarted and that it picked up the right configmap data