### PR TITLE
VZ-7917 fix missing logging output on uninstall

### DIFF
--- a/platform-operator/controllers/verrazzano/status/availability.go
+++ b/platform-operator/controllers/verrazzano/status/availability.go
@@ -151,10 +151,11 @@ func newLogger(vz *vzapi.Verrazzano) (vzlog.VerrazzanoLogger, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The ID below needs to be different from the main thread, so add a suffix"
 	return vzlog.ForZapLogger(&vzlog.ResourceConfig{
 		Name:           vz.Name,
 		Namespace:      vz.Namespace,
-		ID:             string(vz.UID),
+		ID:             string(vz.UID) + "health",
 		Generation:     vz.Generation,
 		ControllerName: "availability",
 	}, zaplog), nil


### PR DESCRIPTION
Fix missing logs caused by the health check thread using the same logger as the reconcile thread.