### PR TITLE
Deregister script in e2e tests should not delete registration secret on managed cluster. This is now automated, and we can rely on that since deregister always happens post upgrade

### DIFF
--- a/tests/e2e/config/scripts/deregister_managed_cluster.sh
+++ b/tests/e2e/config/scripts/deregister_managed_cluster.sh
@@ -25,5 +25,4 @@ echo MANAGED_KUBECONFIG: ${MANAGED_KUBECONFIG}
 
 echo "Deleting VMC on admin cluster ${MANAGED_CLUSTER_NAME}"
 kubectl --kubeconfig ${ADMIN_KUBECONFIG} -n verrazzano-mc delete vmc ${MANAGED_CLUSTER_NAME}
-echo "Deleting cluster registration secret on managed cluster"
-kubectl --kubeconfig ${MANAGED_KUBECONFIG} -n verrazzano-system delete secret verrazzano-cluster-registration
+echo "Deleted VMC, relying on automatic cleanup on managed cluster"


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
