### PR TITLE
VZ-7955: Remove cattle.io namespaced resources to prevent namespace in Terminating status

### DIFF
--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -51,6 +51,9 @@ func (r Resource) RemoveFinalizersAndDelete() error {
 func (r Resource) RemoveFinalizers() error {
 	val := reflect.ValueOf(r.Object)
 	kind := val.Elem().Type().Name()
+	if kind == "Unstructured" {
+		kind = r.Object.GetObjectKind().GroupVersionKind().Kind
+	}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Namespace, Name: r.Name}, r.Object)
 	if client.IgnoreNotFound(err) != nil {
 		return r.Log.ErrorfNewErr("Failed to get the resource of type %s, named %s/%s: %v", kind, r.Object.GetNamespace(), r.Object.GetName(), err)

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -26,6 +26,9 @@ func (r Resource) Delete() error {
 	r.Object.SetNamespace(r.Namespace)
 	val := reflect.ValueOf(r.Object)
 	kind := val.Elem().Type().Name()
+	if kind == "Unstructured" {
+		kind = r.Object.GetObjectKind().GroupVersionKind().Kind
+	}
 	err := r.Client.Delete(context.TODO(), r.Object)
 	if client.IgnoreNotFound(err) != nil {
 		return r.Log.ErrorfNewErr("Failed to delete the resource of type %s, named %s/%s: %v", kind, r.Object.GetNamespace(), r.Object.GetName(), err)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -163,11 +163,11 @@ func getCRDList(ctx spi.ComponentContext) *v1.CustomResourceDefinitionList {
 	return crds
 }
 
-// removeCRs deletes any remaining Rancher cattle.io cluster scoped custom resources
+// removeCRs deletes any remaining Rancher cattle.io custom resources
 func removeCRs(ctx spi.ComponentContext, crds *v1.CustomResourceDefinitionList) {
-	ctx.Log().Oncef("Removing Rancher cluster scoped custom resources")
+	ctx.Log().Oncef("Removing Rancher custom resources")
 	for _, crd := range crds.Items {
-		if strings.HasSuffix(crd.Name, ".cattle.io") && crd.Spec.Scope == v1.ClusterScoped {
+		if strings.HasSuffix(crd.Name, ".cattle.io") {
 			for _, version := range crd.Spec.Versions {
 				rancherCRs := unstructured.UnstructuredList{}
 				rancherCRs.SetAPIVersion(fmt.Sprintf("%s/%s", crd.Spec.Group, version.Name))
@@ -181,10 +181,11 @@ func removeCRs(ctx spi.ComponentContext, crds *v1.CustomResourceDefinitionList) 
 				for _, rancherCR := range rancherCRs.Items {
 					cr := rancherCR
 					resource.Resource{
-						Name:   cr.GetName(),
-						Client: ctx.Client(),
-						Object: &cr,
-						Log:    ctx.Log(),
+						Namespace: cr.GetNamespace(),
+						Name:      cr.GetName(),
+						Client:    ctx.Client(),
+						Object:    &cr,
+						Log:       ctx.Log(),
 					}.RemoveFinalizersAndDelete()
 
 				}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -143,7 +143,7 @@ func TestPostUninstall(t *testing.T) {
 	delTimestamp := metav1.NewTime(time.Now())
 	crdAPIVersion := "apiextensions.k8s.io/v1"
 	crdKind := "CustomResourceDefinition"
-	rancherCRD := v12.CustomResourceDefinition{
+	rancherClusterCRD := v12.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       crdKind,
 			APIVersion: crdAPIVersion,
@@ -159,6 +159,27 @@ func TestPostUninstall(t *testing.T) {
 				Kind: "Setting",
 			},
 			Scope: "Cluster",
+			Versions: []v12.CustomResourceDefinitionVersion{
+				{
+					Name: "v3",
+				},
+			},
+		},
+	}
+	rancherNamespacedCRD := v12.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       crdKind,
+			APIVersion: crdAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "projects.management.cattle.io",
+		},
+		Spec: v12.CustomResourceDefinitionSpec{
+			Group: "management.cattle.io",
+			Names: v12.CustomResourceDefinitionNames{
+				Kind: "Project",
+			},
+			Scope: "Namespaced",
 			Versions: []v12.CustomResourceDefinitionVersion{
 				{
 					Name: "v3",
@@ -189,6 +210,16 @@ func TestPostUninstall(t *testing.T) {
 			"kind":       "Setting",
 			"metadata": map[string]interface{}{
 				"name": "cr-name",
+			},
+		},
+	}
+	projectCR := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "Project",
+			"metadata": map[string]interface{}{
+				"namespace": "cr-namespace",
+				"name":      "cr-name",
 			},
 		},
 	}
@@ -322,14 +353,16 @@ func TestPostUninstall(t *testing.T) {
 		{
 			name: "test CRD finalizer cleanup",
 			objects: []clipkg.Object{
-				&rancherCRD,
+				&rancherClusterCRD,
 			},
 		},
 		{
 			name: "test Rancher CR cleanup",
 			objects: []clipkg.Object{
-				&rancherCRD,
+				&rancherClusterCRD,
 				&settingCR,
+				&rancherNamespacedCRD,
+				&projectCR,
 			},
 		},
 	}


### PR DESCRIPTION
This pull request removes cattle.io namespaced resources that were previously not being deleted. During an uninstall on an OCNE environment the local namespace was left in a terminating status because of resource not being deleted.