### PR TITLE
Mask bearer token in log message

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
@@ -134,7 +134,7 @@ func createVZClusterUser(ctx spi.ComponentContext) error {
 	logMsg := fmt.Sprintf("Sending request message: Type: %s, URL: %s, headers: %v, payload %s", http.MethodPost, reqURL, headers, payload)
 	// Mask the bearer token in the log message
 	logMsg = vzpassword.MaskFunction("Authorization:Bearer ")(logMsg)
-	ctx.Log().Infof(logMsg)
+	ctx.Log().Debugf(logMsg)
 
 	response, _, err = rancherutil.SendRequest(http.MethodPost, reqURL, headers, string(payload), rc, ctx.Log())
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
@@ -130,7 +130,12 @@ func createVZClusterUser(ctx spi.ComponentContext) error {
 	}
 
 	headers["Content-Type"] = "application/json"
-	ctx.Log().Infof("Sending request message: Type: %s, URL: %s, headers: %v, payload %s", http.MethodPost, reqURL, headers, payload)
+
+	logMsg := fmt.Sprintf("Sending request message: Type: %s, URL: %s, headers: %v, payload %s", http.MethodPost, reqURL, headers, payload)
+	// Mask the bearer token in the log message
+	logMsg = vzpassword.MaskFunction("Authorization:Bearer ")(logMsg)
+	ctx.Log().Infof(logMsg)
+
 	response, _, err = rancherutil.SendRequest(http.MethodPost, reqURL, headers, string(payload), rc, ctx.Log())
 	if err != nil {
 		return ctx.Log().ErrorfNewErr("Failed to create the Verrazzano cluster user in Rancher: %v", err)


### PR DESCRIPTION
When installing the cluster operator and Rancher is enabled, the VPO makes an API call to create a user. The request is logged and the auth bearer token showed up in clear text in the log. This PR masks the token.

Snippet from a log with the fix:
```
..."clusteroperator/cluster_operator.go:137","message":"Sending request message: 
Type: POST, URL: https://ingress-controller-ingress-nginx-controller.ingress-nginx/v3/users,
headers: map[Authorization:Bearer ****** Content-Type:application/json], payload...
```