### PR TITLE
VZ-7965: Fetch namespaces from component registry

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,8 +5,6 @@ package constants
 
 import (
 	"time"
-
-	platformOperatorConstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 )
 
 // RestartVersionAnnotation - the annotation used by user to tell Verrazzano application to restart its components
@@ -175,71 +173,19 @@ const VerrazzanoClusterRancherUsername = "vz-cluster-reg"
 
 // Components Names
 const (
-	OamKubernetesRuntime          = "oam-kubernetes-runtime"
-	KialiServer                   = "kiali-server"
-	WeblogicOperator              = "weblogic-operator"
-	VerrazzanoAuthproxy           = "verrazzano-authproxy"
-	Istio                         = "istio"
-	ExternalDNS                   = "external-dns"
-	VerrazzanoApplicationOperator = "verrazzano-application-operator"
-	CoherenceOperator             = "coherence-operator"
-	IngressController             = "ingress-controller"
-	IngressDefaultBackend         = "ingress-controller-ingress-nginx-defaultbackend"
-	MySQL                         = "mysql"
-	CertManager                   = "cert-manager"
-	Rancher                       = "rancher"
-	PrometheusPushgateway         = "prometheus-pushgateway"
-	PrometheusAdapter             = "prometheus-adapter"
-	KubeStateMetrics              = "kube-state-metrics"
-	PrometheusNodeExporter        = "prometheus-node-exporter"
-	PrometheusOperator            = "prometheus-operator"
-	Keycloak                      = "keycloak"
-	VerrazzanoMonitoringOperator  = "verrazzano-monitoring-operator"
-	Grafana                       = "grafana"
-	JaegerOperator                = "jaeger-operator"
-	OpensearchDashboards          = "opensearch-dashboards"
-	Opensearch                    = "opensearch"
-	Velero                        = "velero"
-	VerrazzanoConsole             = "verrazzano-console"
-	Verrazzano                    = "verrazzano"
-	Fluentd                       = "fluentd"
-	RancherBackup                 = "rancher-backup"
-	MySQLOperator                 = "mysql-operator"
+	Istio                 = "istio"
+	ExternalDNS           = "external-dns"
+	IngressController     = "ingress-controller"
+	IngressDefaultBackend = "ingress-controller-ingress-nginx-defaultbackend"
+	MySQL                 = "mysql"
+	CertManager           = "cert-manager"
+	Rancher               = "rancher"
+	Keycloak              = "keycloak"
+	Grafana               = "grafana"
+	JaegerOperator        = "jaeger-operator"
+	Opensearch            = "opensearch"
+	Velero                = "velero"
+	Verrazzano            = "verrazzano"
+	Fluentd               = "fluentd"
+	MySQLOperator         = "mysql-operator"
 )
-
-const (
-	RancherFleetSystemNamespace      = "cattle-fleet-system"
-	RancherFleetLocalSystemNamespace = "cattle-fleet-local-system"
-)
-
-var ComponentNameToNamespacesMap = map[string][]string{
-	OamKubernetesRuntime:          {VerrazzanoSystemNamespace},
-	KialiServer:                   {VerrazzanoSystemNamespace},
-	WeblogicOperator:              {VerrazzanoSystemNamespace},
-	VerrazzanoAuthproxy:           {VerrazzanoSystemNamespace},
-	Istio:                         {IstioSystemNamespace},
-	ExternalDNS:                   {CertManagerNamespace},
-	VerrazzanoApplicationOperator: {VerrazzanoSystemNamespace},
-	CoherenceOperator:             {VerrazzanoSystemNamespace},
-	IngressController:             {platformOperatorConstants.IngressNginxNamespace},
-	MySQL:                         {KeycloakNamespace},
-	CertManager:                   {CertManagerNamespace},
-	Rancher:                       {RancherSystemNamespace, RancherFleetSystemNamespace, RancherFleetLocalSystemNamespace},
-	PrometheusPushgateway:         {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	PrometheusAdapter:             {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	KubeStateMetrics:              {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	PrometheusNodeExporter:        {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	PrometheusOperator:            {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	Keycloak:                      {KeycloakNamespace},
-	VerrazzanoMonitoringOperator:  {VerrazzanoSystemNamespace},
-	Grafana:                       {VerrazzanoSystemNamespace},
-	JaegerOperator:                {platformOperatorConstants.VerrazzanoMonitoringNamespace},
-	OpensearchDashboards:          {VerrazzanoSystemNamespace},
-	Opensearch:                    {VerrazzanoSystemNamespace},
-	Velero:                        {platformOperatorConstants.VeleroNameSpace},
-	VerrazzanoConsole:             {VerrazzanoSystemNamespace},
-	Verrazzano:                    {VerrazzanoSystemNamespace},
-	Fluentd:                       {VerrazzanoSystemNamespace},
-	RancherBackup:                 {platformOperatorConstants.RancherBackupNamesSpace},
-	MySQLOperator:                 {MySQLOperatorNamespace},
-}

--- a/tools/vz/pkg/analysis/internal/util/cluster/install.go
+++ b/tools/vz/pkg/analysis/internal/util/cluster/install.go
@@ -7,8 +7,8 @@ package cluster
 import (
 	encjson "encoding/json"
 	"fmt"
-	pkgconst "github.com/verrazzano/verrazzano/pkg/constants"
 	installv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis/internal/util/files"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis/internal/util/report"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
@@ -458,12 +458,12 @@ func getUniqueNamespaces(log *zap.SugaredLogger, compsNoMessages []string) []str
 	var uniqueNamespaces []string
 
 	for _, comp := range compsNoMessages {
-		componentNamespace, ok := pkgconst.ComponentNameToNamespacesMap[comp]
-		if !ok {
+		found, component := registry.FindComponent(comp)
+		if !found {
 			log.Debugf("Couldn't find the namespace related to %s component", comp)
 			continue
 		}
-		uniqueNamespaces = append(uniqueNamespaces, componentNamespace...)
+		uniqueNamespaces = append(uniqueNamespaces, component.Namespace())
 	}
 	uniqueNamespaces = helpers.RemoveDuplicate(uniqueNamespaces)
 	return uniqueNamespaces

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core"
 	"github.com/spf13/cobra"
-	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	v1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	vzconstants "github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/github"
 	"io"
@@ -189,7 +189,10 @@ func GetNamespacesForAllComponents(vz v1beta1.Verrazzano) []string {
 	allComponents := getAllComponents(vz)
 	var nsList []string
 	for _, eachComp := range allComponents {
-		nsList = append(nsList, constants.ComponentNameToNamespacesMap[eachComp]...)
+		found, comp := registry.FindComponent(eachComp)
+		if found {
+			nsList = append(nsList, comp.Namespace())
+		}
 	}
 	if len(nsList) > 0 {
 		nsList = RemoveDuplicate(nsList)


### PR DESCRIPTION
This PR removes the map that holds the component namespace mapping used by VZ cli tool, now tool will fetch the namespaces directly from the component registry. 