### PR TITLE
Remove prometheus image from verrazzano-monitoring-operator in verrazzano-bom.json

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -243,11 +243,6 @@
               "helmFullImageKey": "monitoringOperator.grafanaImage"
             },
             {
-              "image": "prometheus",
-              "tag": "v2.34.0-20220809191930-6df068d2",
-              "helmFullImageKey": "monitoringOperator.prometheusImage"
-            },
-            {
               "image": "opensearch",
               "tag": "1.2.3-20220810140719-c1dbc115d8a",
               "helmFullImageKey": "monitoringOperator.esImage"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -244,7 +244,7 @@
             },
             {
               "image": "prometheus",
-              "tag": "v2.34.0-1",
+              "tag": "v2.34.0-20220809191930-6df068d2",
               "helmFullImageKey": "monitoringOperator.prometheusImage"
             },
             {


### PR DESCRIPTION
This PR updates verrazzano-bom.json to use the same image for sub-component "prometheus" under components verrazzano-monitoring-operator and prometheus-operator
