### PR TITLE
Remove prometheus sub-component from verrazzano-monitoring-operator in BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -234,11 +234,6 @@
               "helmFullImageKey": "monitoringOperator.grafanaImage"
             },
             {
-              "image": "prometheus",
-              "tag": "v2.38.0-20221103235927-b3e1d8ed",
-              "helmFullImageKey": "monitoringOperator.prometheusImage"
-            },
-            {
               "image": "opensearch",
               "tag": "1.2.3-20221128202334-b9a03fdef55",
               "helmFullImageKey": "monitoringOperator.esImage"


### PR DESCRIPTION
This PR updates verrazzano-bom.json to use the same image for sub-component "prometheus" under components verrazzano-monitoring-operator and prometheus-operator