### PR TITLE
VZ-7910: Make Rancher uninstall non-blocking

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -129,6 +129,7 @@ func NewComponent() spi.Component {
 			},
 			GetInstallOverridesFunc: GetOverrides,
 		},
+		monitor: &postUninstallMonitorType{},
 	}
 }
 
@@ -445,7 +446,7 @@ func (r rancherComponent) PostUninstall(ctx spi.ComponentContext) error {
 		ctx.Log().Debug("Rancher postUninstall dry run")
 		return nil
 	}
-	return postUninstall(ctx)
+	return postUninstall(ctx, r.monitor)
 }
 
 // MonitorOverrides checks whether monitoring of install overrides is enabled or not

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -73,6 +73,9 @@ type envVar struct {
 
 type rancherComponent struct {
 	helm.HelmComponent
+
+	// internal monitor object for running the Rancher uninstall tool in the background
+	monitor postUninstallMonitor
 }
 
 var certificates = []types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -73,9 +73,6 @@ type envVar struct {
 
 type rancherComponent struct {
 	helm.HelmComponent
-
-	// internal monitor object for running the Rancher uninstall tool in the background
-	monitor postUninstallMonitor
 }
 
 var certificates = []types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -136,6 +136,7 @@ func postUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error
 	return forkPostUninstallFunc(ctx, monitor)
 }
 
+// forkPostUninstall - the Rancher uninstall system tool blocks, so fork it to the background
 func forkPostUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error {
 	ctx.Log().Debugf("Creating background post-uninstall goroutine for Rancher")
 
@@ -148,6 +149,7 @@ func forkPostUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) e
 	return ctrlerrors.RetryableError{Source: ComponentName}
 }
 
+// run - run the Rancher uninstall in another goroutine
 func (m *postUninstallMonitorType) run(args postUninstallRoutineParams) {
 	m.running = true
 	m.resultCh = make(chan bool, 2)
@@ -171,6 +173,7 @@ func (m *postUninstallMonitorType) run(args postUninstallRoutineParams) {
 	m.inputCh <- args
 }
 
+// invokeRancherSystemToolAndCleanup - responsible for the actual deletion of resources
 func invokeRancherSystemToolAndCleanup(ctx spi.ComponentContext) error {
 	// List all the namespaces that need to be cleaned from Rancher components
 	nsList := corev1.NamespaceList{}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -15,7 +15,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/os"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -178,52 +177,52 @@ func (m *postUninstallMonitorType) run(args postUninstallRoutineParams) {
 			}
 		}
 
-		// FIXME: maybe don't run these in the background
-		// Remove the Rancher webhooks
-		err = deleteWebhooks(ctx)
-		if err != nil {
-			outputCh <- false
-			return
-		}
+		// // FIXME: maybe don't run these in the background
+		// // Remove the Rancher webhooks
+		// err = deleteWebhooks(ctx)
+		// if err != nil {
+		// 	outputCh <- false
+		// 	return
+		// }
 
-		// Delete the Rancher resources that need to be matched by a string
-		err = deleteMatchingResources(ctx)
-		if err != nil {
-			outputCh <- false
-			return
-		}
+		// // Delete the Rancher resources that need to be matched by a string
+		// err = deleteMatchingResources(ctx)
+		// if err != nil {
+		// 	outputCh <- false
+		// 	return
+		// }
 
-		// Delete the remaining Rancher ConfigMaps
-		err = resource.Resource{
-			Name:      controllerCMName,
-			Namespace: constants.KubeSystem,
-			Client:    ctx.Client(),
-			Object:    &corev1.ConfigMap{},
-			Log:       ctx.Log(),
-		}.Delete()
-		if err != nil {
-			outputCh <- false
-			return
-		}
-		err = resource.Resource{
-			Name:      lockCMName,
-			Namespace: constants.KubeSystem,
-			Client:    ctx.Client(),
-			Object:    &corev1.ConfigMap{},
-			Log:       ctx.Log(),
-		}.Delete()
-		if err != nil {
-			outputCh <- false
-			return
-		}
+		// // Delete the remaining Rancher ConfigMaps
+		// err = resource.Resource{
+		// 	Name:      controllerCMName,
+		// 	Namespace: constants.KubeSystem,
+		// 	Client:    ctx.Client(),
+		// 	Object:    &corev1.ConfigMap{},
+		// 	Log:       ctx.Log(),
+		// }.Delete()
+		// if err != nil {
+		// 	outputCh <- false
+		// 	return
+		// }
+		// err = resource.Resource{
+		// 	Name:      lockCMName,
+		// 	Namespace: constants.KubeSystem,
+		// 	Client:    ctx.Client(),
+		// 	Object:    &corev1.ConfigMap{},
+		// 	Log:       ctx.Log(),
+		// }.Delete()
+		// if err != nil {
+		// 	outputCh <- false
+		// 	return
+		// }
 
-		crds := getCRDList(ctx)
+		// crds := getCRDList(ctx)
 
-		// Remove any Rancher custom resources that remain
-		removeCRs(ctx, crds)
+		// // Remove any Rancher custom resources that remain
+		// removeCRs(ctx, crds)
 
-		// Remove any Rancher CRD finalizers that may be causing CRD deletion to hang
-		removeCRDFinalizers(ctx, crds)
+		// // Remove any Rancher CRD finalizers that may be causing CRD deletion to hang
+		// removeCRDFinalizers(ctx, crds)
 
 		outputCh <- true
 	}(m.inputCh, m.resultCh)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -58,9 +58,11 @@ var rancherSystemNS = []string{
 
 // create func vars for unit tests
 type forkPostUninstallFuncSig func(ctx spi.ComponentContext, monitor postUninstallMonitor) error
+
 var forkPostUninstallFunc forkPostUninstallFuncSig = forkPostUninstall
 
 type postUninstallFuncSig func(ctx spi.ComponentContext) error
+
 var postUninstallFunc postUninstallFuncSig = invokeRancherSystemToolAndCleanup
 
 // postUninstallRoutineParams - Used to pass args to the postUninstall goroutine

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -57,8 +57,9 @@ var rancherSystemNS = []string{
 }
 
 type forkPostUninstallFuncSig func(ctx spi.ComponentContext, monitor postUninstallMonitor) error
-
 var forkPostUninstallFunc forkPostUninstallFuncSig = forkPostUninstall
+
+// FIXME: define postUninstallFuncSig and postUninstallFunc here, then call postUninstallFunc inside run()?
 
 // postUninstallRoutineParams - Used to pass args to the postUninstall goroutine
 type postUninstallRoutineParams struct {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -56,6 +56,7 @@ var rancherSystemNS = []string{
 	"local",
 }
 
+// create func vars for unit tests
 type forkPostUninstallFuncSig func(ctx spi.ComponentContext, monitor postUninstallMonitor) error
 var forkPostUninstallFunc forkPostUninstallFuncSig = forkPostUninstall
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -6,13 +6,11 @@ package rancher
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/os"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	osexec "os/exec"
 	"regexp"
 	"strings"
-
-	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/os"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
@@ -54,58 +52,6 @@ var rancherSystemNS = []string{
 	"fleet-default",
 	"fleet-local",
 	"local",
-}
-
-// postUninstallRoutineParams - Used to pass args to the postUninstall goroutine
-type postUninstallRoutineParams struct {
-	overrides     string
-	// TODO: fill in fields/parameters
-}
-
-// uninstallMonitor - Represents a monitor object used by the component to monitor a background goroutine used for running
-// rancher uninstall operations asynchronously.
-type postUninstallMonitor interface {
-	// checkResult - Checks for a result from the install goroutine; returns either the result of the operation, or an error indicating
-	// the install is still in progress
-	checkResult() (bool, error)
-	// reset - Resets the monitor and closes any open channels
-	reset()
-	// isRunning - returns true of the monitor/goroutine are active
-	isRunning() bool
-	// run - Run the install with the specified args
-	run(args postUninstallRoutineParams)
-}
-
-type postUninstallMonitorType struct {
-	running  bool
-	resultCh chan bool
-	inputCh  chan postUninstallRoutineParams
-}
-
-// checkResult - checks for a result from the goroutine
-// - returns false and a retry error if it's still running, or the result from the channel and nil if an answer was received
-func (m *postUninstallMonitorType) checkResult() (bool, error) {
-	select {
-	case result := <-m.resultCh:
-		return result, nil
-	default:
-		return false, ctrlerrors.RetryableError{Source: ComponentName}
-	}
-	// FIXME: verify this is correct
-}
-
-// reset - reset the monitor and close the channel
-func (m *postUninstallMonitorType) reset() {
-	m.running = false
-	close(m.resultCh)
-	close(m.inputCh)
-	// FIXME: verify this is correct
-}
-
-// isRunning - returns true of the monitor/goroutine are active
-func (m *postUninstallMonitorType) isRunning() bool {
-	return m.running
-	// FIXME: verify this is correct
 }
 
 // postUninstall removes the objects after the Helm uninstall process finishes
@@ -173,18 +119,6 @@ func postUninstall(ctx spi.ComponentContext) error {
 	removeCRDFinalizers(ctx, crds)
 
 	return nil
-}
-
-func forkPostUninstall() error {
-	// TODO: write this. Including input parameters
-	// will call monitor.run() at some point
-	return nil
-}
-
-func (m *postUninstallMonitorType) run(args postUninstallRoutineParams) {
-	// TODO: write this.
-	// will call something in another goroutine at some point.
-	return
 }
 
 // deleteWebhooks takes care of deleting the Webhook resources from Rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -128,12 +128,7 @@ func postUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error
 }
 
 func forkPostUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error {
-	log := ctx.Log()
-	log.Debugf("Creating background post-uninstall goroutine for Rancher")
-
-	// clone zap logger
-	clone := log.GetZapLogger().With()
-	log.SetZapLogger(clone)
+	ctx.Log().Debugf("Creating background post-uninstall goroutine for Rancher")
 
 	monitor.run(
 		postUninstallRoutineParams{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -180,7 +180,9 @@ func invokeRancherSystemToolAndCleanup(ctx spi.ComponentContext) error {
 	for i, ns := range nsList.Items {
 		if isRancherNamespace(&nsList.Items[i]) {
 			ctx.Log().Infof("Running the Rancher uninstall system tool for namespace %s", ns.Name)
-			stdErr, err := invokeRancherSystemTool(ns.Name)
+			args := []string{"remove", "-c", "/home/verrazzano/kubeconfig", "--namespace", ns.Name, "--force"}
+			cmd := osexec.Command(rancherSystemTool, args...) //nolint:gosec //#nosec G204
+			_, stdErr, err := os.DefaultRunner{}.Run(cmd)
 			if err != nil {
 				return ctx.Log().ErrorNewErr("Failed to run system tools for Rancher deletion: %s: %v", stdErr, err)
 			}
@@ -437,11 +439,4 @@ func isRancherNamespace(ns *corev1.Namespace) bool {
 // setRancherSystemTool sets the Rancher system tool to an arbitrary command
 func setRancherSystemTool(cmd string) {
 	rancherSystemTool = cmd
-}
-
-func invokeRancherSystemTool(nsName string) (stdErr []byte, err error) {
-	args := []string{"remove", "-c", "/home/verrazzano/kubeconfig", "--namespace", nsName, "--force"}
-	cmd := osexec.Command(rancherSystemTool, args...) //nolint:gosec //#nosec G204
-	_, stdErr, err = os.DefaultRunner{}.Run(cmd)
-	return
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -15,6 +15,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/os"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -177,52 +178,52 @@ func (m *postUninstallMonitorType) run(args postUninstallRoutineParams) {
 			}
 		}
 
-		// // FIXME: maybe don't run these in the background
-		// // Remove the Rancher webhooks
-		// err = deleteWebhooks(ctx)
-		// if err != nil {
-		// 	outputCh <- false
-		// 	return
-		// }
+		// FIXME: maybe don't run these in the background
+		// Remove the Rancher webhooks
+		err = deleteWebhooks(ctx)
+		if err != nil {
+			outputCh <- false
+			return
+		}
 
-		// // Delete the Rancher resources that need to be matched by a string
-		// err = deleteMatchingResources(ctx)
-		// if err != nil {
-		// 	outputCh <- false
-		// 	return
-		// }
+		// Delete the Rancher resources that need to be matched by a string
+		err = deleteMatchingResources(ctx)
+		if err != nil {
+			outputCh <- false
+			return
+		}
 
-		// // Delete the remaining Rancher ConfigMaps
-		// err = resource.Resource{
-		// 	Name:      controllerCMName,
-		// 	Namespace: constants.KubeSystem,
-		// 	Client:    ctx.Client(),
-		// 	Object:    &corev1.ConfigMap{},
-		// 	Log:       ctx.Log(),
-		// }.Delete()
-		// if err != nil {
-		// 	outputCh <- false
-		// 	return
-		// }
-		// err = resource.Resource{
-		// 	Name:      lockCMName,
-		// 	Namespace: constants.KubeSystem,
-		// 	Client:    ctx.Client(),
-		// 	Object:    &corev1.ConfigMap{},
-		// 	Log:       ctx.Log(),
-		// }.Delete()
-		// if err != nil {
-		// 	outputCh <- false
-		// 	return
-		// }
+		// Delete the remaining Rancher ConfigMaps
+		err = resource.Resource{
+			Name:      controllerCMName,
+			Namespace: constants.KubeSystem,
+			Client:    ctx.Client(),
+			Object:    &corev1.ConfigMap{},
+			Log:       ctx.Log(),
+		}.Delete()
+		if err != nil {
+			outputCh <- false
+			return
+		}
+		err = resource.Resource{
+			Name:      lockCMName,
+			Namespace: constants.KubeSystem,
+			Client:    ctx.Client(),
+			Object:    &corev1.ConfigMap{},
+			Log:       ctx.Log(),
+		}.Delete()
+		if err != nil {
+			outputCh <- false
+			return
+		}
 
-		// crds := getCRDList(ctx)
+		crds := getCRDList(ctx)
 
-		// // Remove any Rancher custom resources that remain
-		// removeCRs(ctx, crds)
+		// Remove any Rancher custom resources that remain
+		removeCRs(ctx, crds)
 
-		// // Remove any Rancher CRD finalizers that may be causing CRD deletion to hang
-		// removeCRDFinalizers(ctx, crds)
+		// Remove any Rancher CRD finalizers that may be causing CRD deletion to hang
+		removeCRDFinalizers(ctx, crds)
 
 		outputCh <- true
 	}(m.inputCh, m.resultCh)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -56,6 +56,10 @@ var rancherSystemNS = []string{
 	"local",
 }
 
+type forkPostUninstallFuncSig func(ctx spi.ComponentContext, monitor postUninstallMonitor) error
+
+var forkPostUninstallFunc forkPostUninstallFuncSig = forkPostUninstall
+
 // postUninstallRoutineParams - Used to pass args to the postUninstall goroutine
 type postUninstallRoutineParams struct {
 	ctx spi.ComponentContext
@@ -124,7 +128,7 @@ func postUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error
 		ctx.Log().Debug("Error during rancher post-uninstall, retrying")
 	}
 
-	return forkPostUninstall(ctx, monitor)
+	return forkPostUninstallFunc(ctx, monitor)
 }
 
 func forkPostUninstall(ctx spi.ComponentContext, monitor postUninstallMonitor) error {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -81,7 +81,7 @@ func TestPostUninstall(t *testing.T) {
 
 // TestBackgroundPostUninstallCompletedSuccessfully tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
-// WHEN the monitor goroutine failed to successfully complete
+// WHEN the goroutine is not finished running, but has a successful result in the monitor and no error
 // THEN postUninstall returns nil without calling the forkPostUninstall function
 func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 	a := assert.New(t)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -540,10 +540,6 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
 
-	comp := rancherComponent {
-
-	}
-
 	tt := tests[2]
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
@@ -552,7 +548,6 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
-		fmt.Println("+++++ MARCO: returning no error from rancherUninstallToolFunc.")
 		return []byte(""), nil
 	}
 	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()
@@ -590,7 +585,6 @@ func Test_forkPostUninstallFailure(t *testing.T) {
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
-		fmt.Println("+++++ MARCO: returning an error from rancherUninstallToolFunc.")
 		return []byte(""), fmt.Errorf("Unexpected error on uninstall")
 	}
 	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -81,8 +81,8 @@ func TestPostUninstall(t *testing.T) {
 
 // TestBackgroundPostUninstallCompletedSuccessfully tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
-// WHEN the monitor goroutine fails to successfully complete FIXME: alter description
-// THEN the post-uninstall returns nil without calling the forkPostUninstall function
+// WHEN the monitor goroutine failed to successfully complete
+// THEN postUninstall returns nil without calling the forkPostUninstall function
 func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
@@ -108,7 +108,7 @@ func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 // TestPostUninstall tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
 // WHEN the the monitor goroutine failed to successfully complete
-// THEN the postUninstall function calls the forkPostUninstall function and returns a retry error
+// THEN the postUninstall function calls the forkPostUninstall function and returns a RetryableError
 func TestBackgroundPostUninstallRetryOnFailure(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -37,6 +37,7 @@ func (f *fakeMonitor) run(args postUninstallRoutineParams) {}
 func (f *fakeMonitor) checkResult() (bool, error)          { return f.result, f.err }
 func (f *fakeMonitor) reset()                              {}
 func (f *fakeMonitor) isRunning() bool                     { return f.running }
+
 var _ postUninstallMonitor = &fakeMonitor{}
 
 var nonRanNSName = "local-not-rancher"
@@ -148,8 +149,8 @@ var nonRancherPV v1.PersistentVolume = v1.PersistentVolume{
 	},
 }
 var delTimestamp metav1.Time = metav1.NewTime(time.Now())
-var crdAPIVersion string = "apiextensions.k8s.io/v1"
-var crdKind string = "CustomResourceDefinition"
+var crdAPIVersion = "apiextensions.k8s.io/v1"
+var crdKind = "CustomResourceDefinition"
 var rancherClusterCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       crdKind,
@@ -384,9 +385,12 @@ var tests = []testStruct{
 func TestPostUninstall(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
+	testObjects := []clipkg.Object{
+		&nonRancherNs,
+		&rancherNs,
+	}
 
-	tt := tests[2]
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
 	crd1 := v12.CustomResourceDefinition{}
@@ -410,9 +414,12 @@ func TestPostUninstall(t *testing.T) {
 func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
+	testObjects := []clipkg.Object{
+		&nonRancherNs,
+		&rancherNs,
+	}
 
-	tt := tests[2]
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
 	crd1 := v12.CustomResourceDefinition{}
@@ -436,9 +443,12 @@ func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 func TestBackgroundPostUninstallRetryOnFailure(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
+	testObjects := []clipkg.Object{
+		&nonRancherNs,
+		&rancherNs,
+	}
 
-	tt := tests[2]
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
 	crd1 := v12.CustomResourceDefinition{}
@@ -465,9 +475,12 @@ func TestBackgroundPostUninstallRetryOnFailure(t *testing.T) {
 func Test_forkPostUninstallSuccess(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
+	testObjects := []clipkg.Object{
+		&nonRancherNs,
+		&rancherNs,
+	}
 
-	tt := tests[2]
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
 	crd1 := v12.CustomResourceDefinition{}
@@ -502,9 +515,12 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 func Test_forkPostUninstallFailure(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
+	testObjects := []clipkg.Object{
+		&nonRancherNs,
+		&rancherNs,
+	}
 
-	tt := tests[2]
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
 	crd1 := v12.CustomResourceDefinition{}
@@ -551,7 +567,7 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 
 			err := invokeRancherSystemToolAndCleanup(ctx)
 			a.Nil(err)
-			
+
 			// MutatingWebhookConfigurations should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.MutatingWebhookConfiguration{})
 			a.True(apierrors.IsNotFound(err))
@@ -608,7 +624,7 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 // WHEN the namespace belings to Rancher or not
 // THEN we see true if it is and false if not
 func TestIsRancherNamespace(t *testing.T) {
-	a:= assert.New(t)
+	a := assert.New(t)
 
 	a.True(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/stretchr/testify/assert"
-	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -37,26 +36,24 @@ type fakeMonitor struct {
 func (f *fakeMonitor) run(args postUninstallRoutineParams) {}
 func (f *fakeMonitor) checkResult() (bool, error)          { return f.result, f.err }
 func (f *fakeMonitor) reset()                              {}
-func (f *fakeMonitor) init()                               {}
-func (f *fakeMonitor) sendResult(r bool)                   {}
 func (f *fakeMonitor) isRunning() bool                     { return f.running }
 var _ postUninstallMonitor = &fakeMonitor{}
 
-var nonRanNSName string = "local-not-rancher"
-var rancherNSName string = "local"
-var rancherNSName2 string = "fleet-rancher"
-var rancherCrName string = "proxy-1234"
-var mwcName string = "mutating-webhook-configuration"
-var vwcName string = "validating-webhook-configuration"
-var pvName string = "pvc-12345"
-var pv2Name string = "ocid1.volume.oc1.ca-toronto-1.12345"
-var rbName string = "rb-test"
-var nonRancherRBName string = "testrb"
-var randPV string = "randomPV"
-var randCR string = "randomCR"
-var randCRB string = "randomCRB"
-var rancherCRDName string = "definitelyrancher.cattle.io"
-var nonRancherCRDName string = "other.cattle"
+var nonRanNSName = "local-not-rancher"
+var rancherNSName = "local"
+var rancherNSName2 = "fleet-rancher"
+var rancherCrName = "proxy-1234"
+var mwcName = "mutating-webhook-configuration"
+var vwcName = "validating-webhook-configuration"
+var pvName = "pvc-12345"
+var pv2Name = "ocid1.volume.oc1.ca-toronto-1.12345"
+var rbName = "rb-test"
+var nonRancherRBName = "testrb"
+var randPV = "randomPV"
+var randCR = "randomCR"
+var randCRB = "randomCRB"
+var rancherCRDName = "definitelyrancher.cattle.io"
+var nonRancherCRDName = "other.cattle"
 
 var nonRancherNs v1.Namespace = v1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +237,7 @@ type testStruct struct {
 	nonRancherTest bool
 }
 
-var tests []testStruct = []testStruct{
+var tests = []testStruct{
 	{
 		name: "test empty cluster",
 	},
@@ -540,7 +537,7 @@ func Test_forkPostUninstallFailure(t *testing.T) {
 // WHEN the objects exist in the cluster
 // THEN all objects are deleted
 func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
-	assert := assert.New(t)
+	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
 
 	setRancherSystemTool("echo")
@@ -553,55 +550,55 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 			err := invokeRancherSystemToolAndCleanup(ctx)
-			assert.Nil(err)
+			a.Nil(err)
 			
 			// MutatingWebhookConfigurations should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.MutatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			err = c.Get(context.TODO(), types.NamespacedName{Name: mwcName}, &admv1.MutatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// ValidatingWebhookConfigurations should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.ValidatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			err = c.Get(context.TODO(), types.NamespacedName{Name: vwcName}, &admv1.ValidatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// ClusterRole should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCrName}, &rbacv1.ClusterRole{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// ClusterRoleBinding should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &rbacv1.ClusterRoleBinding{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			if tt.nonRancherTest {
 				// Verify that non-Rancher components did not get cleaned up
 				err = c.Get(context.TODO(), types.NamespacedName{Name: randCR}, &rbacv1.ClusterRole{})
-				assert.Nil(err)
+				a.Nil(err)
 				err = c.Get(context.TODO(), types.NamespacedName{Name: randCRB}, &rbacv1.ClusterRoleBinding{})
-				assert.Nil(err)
+				a.Nil(err)
 				err = c.Get(context.TODO(), types.NamespacedName{Name: randPV}, &v1.PersistentVolume{})
-				assert.Nil(err)
+				a.Nil(err)
 				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherRBName}, &rbacv1.RoleBinding{})
-				assert.Nil(err)
+				a.Nil(err)
 				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherCRDName}, &v12.CustomResourceDefinition{})
-				assert.Nil(err)
+				a.Nil(err)
 			}
 			// ConfigMaps should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: controllerCMName}, &v1.ConfigMap{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			err = c.Get(context.TODO(), types.NamespacedName{Name: lockCMName}, &v1.ConfigMap{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// Persistent volume should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: pvName}, &v1.PersistentVolume{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			err = c.Get(context.TODO(), types.NamespacedName{Name: pv2Name}, &v1.PersistentVolume{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// Role Binding should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: rbName}, &rbacv1.RoleBinding{})
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 			// Rancher CRD finalizer should have been deleted which should cause it to go away
 			// since it had a deletion timestamp
 			crd := v12.CustomResourceDefinition{}
 			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd)
-			assert.True(apierrors.IsNotFound(err))
+			a.True(apierrors.IsNotFound(err))
 		})
 	}
 }
@@ -611,14 +608,14 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 // WHEN the namespace belings to Rancher or not
 // THEN we see true if it is and false if not
 func TestIsRancherNamespace(t *testing.T) {
-	assert := asserts.New(t)
+	a:= assert.New(t)
 
-	assert.True(isRancherNamespace(&v1.Namespace{
+	a.True(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cattle-system",
 		},
 	}))
-	assert.True(isRancherNamespace(&v1.Namespace{
+	a.True(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "p-12345",
 			Annotations: map[string]string{
@@ -626,7 +623,7 @@ func TestIsRancherNamespace(t *testing.T) {
 			},
 		},
 	}))
-	assert.True(isRancherNamespace(&v1.Namespace{
+	a.True(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "local",
 			Annotations: map[string]string{
@@ -634,7 +631,7 @@ func TestIsRancherNamespace(t *testing.T) {
 			},
 		},
 	}))
-	assert.False(isRancherNamespace(&v1.Namespace{
+	a.False(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "p-12345",
 			Annotations: map[string]string{
@@ -642,7 +639,7 @@ func TestIsRancherNamespace(t *testing.T) {
 			},
 		},
 	}))
-	assert.False(isRancherNamespace(&v1.Namespace{
+	a.False(isRancherNamespace(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "p-12345",
 		},

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -5,9 +5,10 @@ package rancher
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
@@ -375,7 +376,8 @@ func TestPostUninstall(t *testing.T) {
 			crd1 := v12.CustomResourceDefinition{}
 			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
-			err := postUninstall(ctx)
+			monitor := &postUninstallMonitorType{}
+			err := postUninstall(ctx, monitor)
 			assert.NoError(err)
 
 			// MutatingWebhookConfigurations should not exist

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -25,6 +25,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+type fakeMonitor struct {
+	result  bool
+	err     error
+	running bool
+}
+
+func (f *fakeMonitor) run(args postUninstallRoutineParams) {
+}
+
+func (f *fakeMonitor) checkResult() (bool, error) { return f.result, f.err }
+
+func (f *fakeMonitor) reset() {}
+
+func (f *fakeMonitor) init() {}
+
+func (f *fakeMonitor) sendResult(r bool) {}
+
+func (f *fakeMonitor) isRunning() bool { return f.running }
+
+var _ postUninstallMonitor = &fakeMonitor{}
+
 // TestPostUninstall tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
 // WHEN the objects exist in the cluster

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -4,25 +4,11 @@
 package rancher
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	asserts "github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	admv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	v12 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type fakeMonitor struct {
@@ -49,407 +35,33 @@ var _ postUninstallMonitor = &fakeMonitor{}
 // TestPostUninstall tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
 // WHEN the objects exist in the cluster
-// THEN no error is returned and all objects are deleted
+// THEN the post-uninstall starts a new attempt and returns a RetryableError to requeue
 func TestPostUninstall(t *testing.T) {
-	assert := asserts.New(t)
-	vz := v1alpha1.Verrazzano{}
+	// TODO: write this
+}
 
-	nonRanNSName := "local-not-rancher"
-	rancherNSName := "local"
-	rancherNSName2 := "fleet-rancher"
-	rancherCrName := "proxy-1234"
-	mwcName := "mutating-webhook-configuration"
-	vwcName := "validating-webhook-configuration"
-	pvName := "pvc-12345"
-	pv2Name := "ocid1.volume.oc1.ca-toronto-1.12345"
-	rbName := "rb-test"
-	nonRancherRBName := "testrb"
-	randPV := "randomPV"
-	randCR := "randomCR"
-	randCRB := "randomCRB"
-	rancherCRDName := "definitelyrancher.cattle.io"
-	nonRancherCRDName := "other.cattle"
+// TestBackgroundPostUninstallCompletedSuccessfully tests the post uninstall process for Rancher
+// GIVEN a call to postUninstall
+// WHEN the monitor goroutine fails to successfully complete
+// THEN the post-uninstall returns nil without calling the forkPostUninstall function
+func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
+	// TODO: write this
+}
 
-	nonRancherNs := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nonRanNSName,
-		},
-	}
-	rancherNs := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rancherNSName,
-		},
-	}
-	rancherNs2 := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rancherNSName2,
-		},
-	}
-	mutWebhook := admv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
-		},
-	}
-	mutWebhook2 := admv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: mwcName,
-		},
-	}
-	valWebhook := admv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
-		},
-	}
-	valWebhook2 := admv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: vwcName,
-		},
-	}
-	crRancher := rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rancherCrName,
-		},
-	}
-	crbRancher := rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
-		},
-	}
-	crNotRancher := rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: randCR,
-		},
-	}
-	crbNotRancher := rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: randCRB,
-		},
-	}
-	rbRancher := rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: rbName,
-		},
-	}
-	rbNotRancher := rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nonRancherRBName,
-		},
-	}
-	controllerCM := v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerCMName,
-			Namespace: constants.KubeSystem,
-		},
-	}
-	lockCM := v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      lockCMName,
-			Namespace: constants.KubeSystem,
-		},
-	}
-	rancherPV := v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: pvName,
-		},
-	}
-	rancherPV2 := v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: pv2Name,
-		},
-	}
-	nonRancherPV := v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: randPV,
-		},
-	}
-	delTimestamp := metav1.NewTime(time.Now())
-	crdAPIVersion := "apiextensions.k8s.io/v1"
-	crdKind := "CustomResourceDefinition"
-	rancherClusterCRD := v12.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       crdKind,
-			APIVersion: crdAPIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              rancherCRDName,
-			Finalizers:        []string{"somefinalizer"},
-			DeletionTimestamp: &delTimestamp,
-		},
-		Spec: v12.CustomResourceDefinitionSpec{
-			Group: "management.cattle.io",
-			Names: v12.CustomResourceDefinitionNames{
-				Kind: "Setting",
-			},
-			Scope: "Cluster",
-			Versions: []v12.CustomResourceDefinitionVersion{
-				{
-					Name: "v3",
-				},
-			},
-		},
-	}
-	rancherNamespacedCRD := v12.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       crdKind,
-			APIVersion: crdAPIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "projects.management.cattle.io",
-		},
-		Spec: v12.CustomResourceDefinitionSpec{
-			Group: "management.cattle.io",
-			Names: v12.CustomResourceDefinitionNames{
-				Kind: "Project",
-			},
-			Scope: "Namespaced",
-			Versions: []v12.CustomResourceDefinitionVersion{
-				{
-					Name: "v3",
-				},
-			},
-		},
-	}
-	nonRancherCRD := v12.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       crdKind,
-			APIVersion: crdAPIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nonRancherCRDName,
-		},
-		Spec: v12.CustomResourceDefinitionSpec{
-			Group:                 "cattle.io",
-			Names:                 v12.CustomResourceDefinitionNames{},
-			Scope:                 "",
-			Versions:              nil,
-			Conversion:            nil,
-			PreserveUnknownFields: false,
-		},
-	}
-	settingCR := unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "management.cattle.io/v3",
-			"kind":       "Setting",
-			"metadata": map[string]interface{}{
-				"name": "cr-name",
-			},
-		},
-	}
-	projectCR := unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "management.cattle.io/v3",
-			"kind":       "Project",
-			"metadata": map[string]interface{}{
-				"namespace": "cr-namespace",
-				"name":      "cr-name",
-			},
-		},
-	}
-	tests := []struct {
-		name           string
-		objects        []clipkg.Object
-		nonRancherTest bool
-	}{
-		{
-			name: "test empty cluster",
-		},
-		{
-			name: "test non Rancher ns",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-			},
-		},
-		{
-			name: "test Rancher ns",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-			},
-		},
-		{
-			name: "test multiple Rancher ns",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-			},
-		},
-		{
-			name: "test mutating webhook",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&mutWebhook2,
-			},
-		},
-		{
-			name: "test validating webhook",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&valWebhook,
-				&valWebhook2,
-			},
-		},
-		{
-			name: "test CR and CRB",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&valWebhook,
-				&crRancher,
-				&crbRancher,
-			},
-		},
-		{
-			name: "test non Rancher components",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&crNotRancher,
-				&crbNotRancher,
-				&nonRancherPV,
-				&rbNotRancher,
-				&nonRancherCRD,
-			},
-			nonRancherTest: true,
-		},
-		{
-			name: "test config maps",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&valWebhook,
-				&crRancher,
-				&crbRancher,
-				&crNotRancher,
-				&crbNotRancher,
-				&controllerCM,
-				&lockCM,
-			},
-		},
-		{
-			name: "test persistent volume",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&valWebhook,
-				&crRancher,
-				&crbRancher,
-				&crNotRancher,
-				&crbNotRancher,
-				&controllerCM,
-				&lockCM,
-				&rancherPV,
-				&rancherPV2,
-			},
-		},
-		{
-			name: "test clusterRole binding",
-			objects: []clipkg.Object{
-				&nonRancherNs,
-				&rancherNs,
-				&rancherNs2,
-				&mutWebhook,
-				&valWebhook,
-				&crRancher,
-				&crbRancher,
-				&crNotRancher,
-				&crbNotRancher,
-				&controllerCM,
-				&lockCM,
-				&rancherPV,
-				&rancherPV2,
-				&rbRancher,
-			},
-		},
-		{
-			name: "test CRD finalizer cleanup",
-			objects: []clipkg.Object{
-				&rancherClusterCRD,
-			},
-		},
-		{
-			name: "test Rancher CR cleanup",
-			objects: []clipkg.Object{
-				&rancherClusterCRD,
-				&settingCR,
-				&rancherNamespacedCRD,
-				&projectCR,
-			},
-		},
-	}
-	setRancherSystemTool("echo")
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
-			ctx := spi.NewFakeContext(c, &vz, nil, false)
+// TestPostUninstall tests the post uninstall process for Rancher
+// GIVEN a call to postUninstall
+// WHEN the the monitor goroutine failed to successfully complete
+// THEN the postUninstall function calls the forkPostUninstall function and returns a retry error
+func TestBackgroundPostUninstallRetryOnFailure(t *testing.T) {
+	// TODO: write this
+}
 
-			crd1 := v12.CustomResourceDefinition{}
-			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
+func Test_forkPostUninstallSuccess(t *testing.T) {
+	// TODO: write this
+}
 
-			monitor := &postUninstallMonitorType{}
-			err := postUninstall(ctx, monitor)
-			assert.NoError(err)
-
-			// MutatingWebhookConfigurations should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.MutatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
-			err = c.Get(context.TODO(), types.NamespacedName{Name: mwcName}, &admv1.MutatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
-			// ValidatingWebhookConfigurations should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.ValidatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
-			err = c.Get(context.TODO(), types.NamespacedName{Name: vwcName}, &admv1.ValidatingWebhookConfiguration{})
-			assert.True(apierrors.IsNotFound(err))
-			// ClusterRole should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCrName}, &rbacv1.ClusterRole{})
-			assert.True(apierrors.IsNotFound(err))
-			// ClusterRoleBinding should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &rbacv1.ClusterRoleBinding{})
-			assert.True(apierrors.IsNotFound(err))
-			if tt.nonRancherTest {
-				// Verify that non-Rancher components did not get cleaned up
-				err = c.Get(context.TODO(), types.NamespacedName{Name: randCR}, &rbacv1.ClusterRole{})
-				assert.Nil(err)
-				err = c.Get(context.TODO(), types.NamespacedName{Name: randCRB}, &rbacv1.ClusterRoleBinding{})
-				assert.Nil(err)
-				err = c.Get(context.TODO(), types.NamespacedName{Name: randPV}, &v1.PersistentVolume{})
-				assert.Nil(err)
-				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherRBName}, &rbacv1.RoleBinding{})
-				assert.Nil(err)
-				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherCRDName}, &v12.CustomResourceDefinition{})
-				assert.Nil(err)
-			}
-			// ConfigMaps should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: controllerCMName}, &v1.ConfigMap{})
-			assert.True(apierrors.IsNotFound(err))
-			err = c.Get(context.TODO(), types.NamespacedName{Name: lockCMName}, &v1.ConfigMap{})
-			assert.True(apierrors.IsNotFound(err))
-			// Persistent volume should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: pvName}, &v1.PersistentVolume{})
-			assert.True(apierrors.IsNotFound(err))
-			err = c.Get(context.TODO(), types.NamespacedName{Name: pv2Name}, &v1.PersistentVolume{})
-			assert.True(apierrors.IsNotFound(err))
-			// Role Binding should not exist
-			err = c.Get(context.TODO(), types.NamespacedName{Name: rbName}, &rbacv1.RoleBinding{})
-			assert.True(apierrors.IsNotFound(err))
-			// Rancher CRD finalizer should have been deleted which should cause it to go away
-			// since it had a deletion timestamp
-			crd := v12.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd)
-			assert.True(apierrors.IsNotFound(err))
-		})
-	}
+func Test_forkPostUninstallFailure(t *testing.T) {
+	// TODO: write this
 }
 
 // TestIsRancherNamespace tests the namespace belongs to Rancher
@@ -457,6 +69,7 @@ func TestPostUninstall(t *testing.T) {
 // WHEN the namespace belings to Rancher or not
 // THEN we see true if it is and false if not
 func TestIsRancherNamespace(t *testing.T) {
+	// FIXME: perhaps need to change this?
 	assert := asserts.New(t)
 
 	assert.True(isRancherNamespace(&v1.Namespace{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -4,11 +4,27 @@
 package rancher
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stretchr/testify/assert"
 	asserts "github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v12 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type fakeMonitor struct {
@@ -32,12 +48,438 @@ func (f *fakeMonitor) isRunning() bool { return f.running }
 
 var _ postUninstallMonitor = &fakeMonitor{}
 
+var nonRanNSName string = "local-not-rancher"
+var rancherNSName string = "local"
+var rancherNSName2 string = "fleet-rancher"
+var rancherCrName string = "proxy-1234"
+var mwcName string = "mutating-webhook-configuration"
+var vwcName string = "validating-webhook-configuration"
+var pvName string = "pvc-12345"
+var pv2Name string = "ocid1.volume.oc1.ca-toronto-1.12345"
+var rbName string = "rb-test"
+var nonRancherRBName string = "testrb"
+var randPV string = "randomPV"
+var randCR string = "randomCR"
+var randCRB string = "randomCRB"
+var rancherCRDName string = "definitelyrancher.cattle.io"
+var nonRancherCRDName string = "other.cattle"
+
+var nonRancherNs v1.Namespace = v1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: nonRanNSName,
+	},
+}
+var rancherNs v1.Namespace = v1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: rancherNSName,
+	},
+}
+var rancherNs2 v1.Namespace = v1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: rancherNSName2,
+	},
+}
+var mutWebhook admv1.MutatingWebhookConfiguration = admv1.MutatingWebhookConfiguration{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: webhookName,
+	},
+}
+var mutWebhook2 admv1.MutatingWebhookConfiguration = admv1.MutatingWebhookConfiguration{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: mwcName,
+	},
+}
+var valWebhook admv1.ValidatingWebhookConfiguration = admv1.ValidatingWebhookConfiguration{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: webhookName,
+	},
+}
+var valWebhook2 admv1.ValidatingWebhookConfiguration = admv1.ValidatingWebhookConfiguration{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: vwcName,
+	},
+}
+var crRancher rbacv1.ClusterRole = rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: rancherCrName,
+	},
+}
+var crbRancher rbacv1.ClusterRoleBinding = rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: webhookName,
+	},
+}
+var crNotRancher rbacv1.ClusterRole = rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: randCR,
+	},
+}
+var crbNotRancher rbacv1.ClusterRoleBinding = rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: randCRB,
+	},
+}
+var rbRancher rbacv1.RoleBinding = rbacv1.RoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: rbName,
+	},
+}
+var rbNotRancher rbacv1.RoleBinding = rbacv1.RoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: nonRancherRBName,
+	},
+}
+var controllerCM v1.ConfigMap = v1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      controllerCMName,
+		Namespace: constants.KubeSystem,
+	},
+}
+var lockCM v1.ConfigMap = v1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      lockCMName,
+		Namespace: constants.KubeSystem,
+	},
+}
+var rancherPV v1.PersistentVolume = v1.PersistentVolume{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: pvName,
+	},
+}
+var rancherPV2 v1.PersistentVolume = v1.PersistentVolume{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: pv2Name,
+	},
+}
+var nonRancherPV v1.PersistentVolume = v1.PersistentVolume{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: randPV,
+	},
+}
+var delTimestamp metav1.Time = metav1.NewTime(time.Now())
+var crdAPIVersion string = "apiextensions.k8s.io/v1"
+var crdKind string = "CustomResourceDefinition"
+var rancherClusterCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       crdKind,
+		APIVersion: crdAPIVersion,
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:              rancherCRDName,
+		Finalizers:        []string{"somefinalizer"},
+		DeletionTimestamp: &delTimestamp,
+	},
+	Spec: v12.CustomResourceDefinitionSpec{
+		Group: "management.cattle.io",
+		Names: v12.CustomResourceDefinitionNames{
+			Kind: "Setting",
+		},
+		Scope: "Cluster",
+		Versions: []v12.CustomResourceDefinitionVersion{
+			{
+				Name: "v3",
+			},
+		},
+	},
+}
+var rancherNamespacedCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       crdKind,
+		APIVersion: crdAPIVersion,
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "projects.management.cattle.io",
+	},
+	Spec: v12.CustomResourceDefinitionSpec{
+		Group: "management.cattle.io",
+		Names: v12.CustomResourceDefinitionNames{
+			Kind: "Project",
+		},
+		Scope: "Namespaced",
+		Versions: []v12.CustomResourceDefinitionVersion{
+			{
+				Name: "v3",
+			},
+		},
+	},
+}
+var nonRancherCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       crdKind,
+		APIVersion: crdAPIVersion,
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: nonRancherCRDName,
+	},
+	Spec: v12.CustomResourceDefinitionSpec{
+		Group:                 "cattle.io",
+		Names:                 v12.CustomResourceDefinitionNames{},
+		Scope:                 "",
+		Versions:              nil,
+		Conversion:            nil,
+		PreserveUnknownFields: false,
+	},
+}
+var settingCR unstructured.Unstructured = unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Setting",
+		"metadata": map[string]interface{}{
+			"name": "cr-name",
+		},
+	},
+}
+var projectCR unstructured.Unstructured = unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Project",
+		"metadata": map[string]interface{}{
+			"namespace": "cr-namespace",
+			"name":      "cr-name",
+		},
+	},
+}
+
+type testStruct struct {
+	name           string
+	objects        []clipkg.Object
+	nonRancherTest bool
+}
+var tests []testStruct = []testStruct {
+	{
+		name: "test empty cluster",
+	},
+	{
+		name: "test non Rancher ns",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+		},
+	},
+	{
+		name: "test Rancher ns",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+		},
+	},
+	{
+		name: "test multiple Rancher ns",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+		},
+	},
+	{
+		name: "test mutating webhook",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&mutWebhook2,
+		},
+	},
+	{
+		name: "test validating webhook",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&valWebhook,
+			&valWebhook2,
+		},
+	},
+	{
+		name: "test CR and CRB",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&valWebhook,
+			&crRancher,
+			&crbRancher,
+		},
+	},
+	{
+		name: "test non Rancher components",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&crNotRancher,
+			&crbNotRancher,
+			&nonRancherPV,
+			&rbNotRancher,
+			&nonRancherCRD,
+		},
+		nonRancherTest: true,
+	},
+	{
+		name: "test config maps",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&valWebhook,
+			&crRancher,
+			&crbRancher,
+			&crNotRancher,
+			&crbNotRancher,
+			&controllerCM,
+			&lockCM,
+		},
+	},
+	{
+		name: "test persistent volume",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&valWebhook,
+			&crRancher,
+			&crbRancher,
+			&crNotRancher,
+			&crbNotRancher,
+			&controllerCM,
+			&lockCM,
+			&rancherPV,
+			&rancherPV2,
+		},
+	},
+	{
+		name: "test clusterRole binding",
+		objects: []clipkg.Object{
+			&nonRancherNs,
+			&rancherNs,
+			&rancherNs2,
+			&mutWebhook,
+			&valWebhook,
+			&crRancher,
+			&crbRancher,
+			&crNotRancher,
+			&crbNotRancher,
+			&controllerCM,
+			&lockCM,
+			&rancherPV,
+			&rancherPV2,
+			&rbRancher,
+		},
+	},
+	{
+		name: "test CRD finalizer cleanup",
+		objects: []clipkg.Object{
+			&rancherClusterCRD,
+		},
+	},
+	{
+		name: "test Rancher CR cleanup",
+		objects: []clipkg.Object{
+			&rancherClusterCRD,
+			&settingCR,
+			&rancherNamespacedCRD,
+			&projectCR,
+		},
+	},
+}
+
+// TODO: write description. Should cover the old TestPostUninstall
+func TestPostUninstallAllObjectsDeleted(t *testing.T) {
+	// TODO: write this
+	assert := assert.New(t)
+	vz := v1alpha1.Verrazzano{}
+
+	setRancherSystemTool("echo")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+			ctx := spi.NewFakeContext(c, &vz, nil, false)
+
+			crd1 := v12.CustomResourceDefinition{}
+			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
+
+			m := &postUninstallMonitorType{}
+			err := postUninstall(ctx, m)
+			assert.NoError(err)
+
+			// MutatingWebhookConfigurations should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.MutatingWebhookConfiguration{})
+			assert.True(apierrors.IsNotFound(err))
+			err = c.Get(context.TODO(), types.NamespacedName{Name: mwcName}, &admv1.MutatingWebhookConfiguration{})
+			assert.True(apierrors.IsNotFound(err))
+			// ValidatingWebhookConfigurations should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.ValidatingWebhookConfiguration{})
+			assert.True(apierrors.IsNotFound(err))
+			err = c.Get(context.TODO(), types.NamespacedName{Name: vwcName}, &admv1.ValidatingWebhookConfiguration{})
+			assert.True(apierrors.IsNotFound(err))
+			// ClusterRole should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCrName}, &rbacv1.ClusterRole{})
+			assert.True(apierrors.IsNotFound(err))
+			// ClusterRoleBinding should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &rbacv1.ClusterRoleBinding{})
+			assert.True(apierrors.IsNotFound(err))
+			if tt.nonRancherTest {
+				// Verify that non-Rancher components did not get cleaned up
+				err = c.Get(context.TODO(), types.NamespacedName{Name: randCR}, &rbacv1.ClusterRole{})
+				assert.Nil(err)
+				err = c.Get(context.TODO(), types.NamespacedName{Name: randCRB}, &rbacv1.ClusterRoleBinding{})
+				assert.Nil(err)
+				err = c.Get(context.TODO(), types.NamespacedName{Name: randPV}, &v1.PersistentVolume{})
+				assert.Nil(err)
+				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherRBName}, &rbacv1.RoleBinding{})
+				assert.Nil(err)
+				err = c.Get(context.TODO(), types.NamespacedName{Name: nonRancherCRDName}, &v12.CustomResourceDefinition{})
+				assert.Nil(err)
+			}
+			// ConfigMaps should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: controllerCMName}, &v1.ConfigMap{})
+			assert.True(apierrors.IsNotFound(err))
+			err = c.Get(context.TODO(), types.NamespacedName{Name: lockCMName}, &v1.ConfigMap{})
+			assert.True(apierrors.IsNotFound(err))
+			// Persistent volume should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: pvName}, &v1.PersistentVolume{})
+			assert.True(apierrors.IsNotFound(err))
+			err = c.Get(context.TODO(), types.NamespacedName{Name: pv2Name}, &v1.PersistentVolume{})
+			assert.True(apierrors.IsNotFound(err))
+			// Role Binding should not exist
+			err = c.Get(context.TODO(), types.NamespacedName{Name: rbName}, &rbacv1.RoleBinding{})
+			assert.True(apierrors.IsNotFound(err))
+			// Rancher CRD finalizer should have been deleted which should cause it to go away
+			// since it had a deletion timestamp
+			crd := v12.CustomResourceDefinition{}
+			err = c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd)
+			assert.True(apierrors.IsNotFound(err))
+		})
+	}
+}
+
 // TestPostUninstall tests the post uninstall process for Rancher
 // GIVEN a call to postUninstall
 // WHEN the objects exist in the cluster
 // THEN the post-uninstall starts a new attempt and returns a RetryableError to requeue
 func TestPostUninstall(t *testing.T) {
 	// TODO: write this
+	a := assert.New(t)
+	vz := v1alpha1.Verrazzano{}
+
+	tt := tests[2]
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
+	ctx := spi.NewFakeContext(c, &vz, nil, false)
+
+	crd1 := v12.CustomResourceDefinition{}
+	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
+
+	expectedErr := ctrlerrors.RetryableError{Source: ComponentName}
+	forkPostUninstallFunc = func(_ spi.ComponentContext, _ postUninstallMonitor) error {
+		return expectedErr
+	}
+	defer func() { forkPostUninstallFunc = forkPostUninstall }()
+
+	monitor := &fakeMonitor{result: true, running: false}
+	err := postUninstall(ctx, monitor)
+	a.Equal(expectedErr, err, "Uninstall returned an unexpected error")
 }
 
 // TestBackgroundPostUninstallCompletedSuccessfully tests the post uninstall process for Rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
@@ -22,6 +21,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	v12 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -42,20 +42,6 @@ var _ postUninstallMonitor = &fakeMonitor{}
 
 var nonRanNSName = "local-not-rancher"
 var rancherNSName = "local"
-var rancherNSName2 = "fleet-rancher"
-var rancherCrName = "proxy-1234"
-var mwcName = "mutating-webhook-configuration"
-var vwcName = "validating-webhook-configuration"
-var pvName = "pvc-12345"
-var pv2Name = "ocid1.volume.oc1.ca-toronto-1.12345"
-var rbName = "rb-test"
-var nonRancherRBName = "testrb"
-var randPV = "randomPV"
-var randCR = "randomCR"
-var randCRB = "randomCRB"
-var rancherCRDName = "definitelyrancher.cattle.io"
-var nonRancherCRDName = "other.cattle"
-
 var nonRancherNs v1.Namespace = v1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: nonRanNSName,
@@ -64,317 +50,6 @@ var nonRancherNs v1.Namespace = v1.Namespace{
 var rancherNs v1.Namespace = v1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: rancherNSName,
-	},
-}
-var rancherNs2 v1.Namespace = v1.Namespace{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: rancherNSName2,
-	},
-}
-var mutWebhook admv1.MutatingWebhookConfiguration = admv1.MutatingWebhookConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: webhookName,
-	},
-}
-var mutWebhook2 admv1.MutatingWebhookConfiguration = admv1.MutatingWebhookConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: mwcName,
-	},
-}
-var valWebhook admv1.ValidatingWebhookConfiguration = admv1.ValidatingWebhookConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: webhookName,
-	},
-}
-var valWebhook2 admv1.ValidatingWebhookConfiguration = admv1.ValidatingWebhookConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: vwcName,
-	},
-}
-var crRancher rbacv1.ClusterRole = rbacv1.ClusterRole{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: rancherCrName,
-	},
-}
-var crbRancher rbacv1.ClusterRoleBinding = rbacv1.ClusterRoleBinding{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: webhookName,
-	},
-}
-var crNotRancher rbacv1.ClusterRole = rbacv1.ClusterRole{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: randCR,
-	},
-}
-var crbNotRancher rbacv1.ClusterRoleBinding = rbacv1.ClusterRoleBinding{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: randCRB,
-	},
-}
-var rbRancher rbacv1.RoleBinding = rbacv1.RoleBinding{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: rbName,
-	},
-}
-var rbNotRancher rbacv1.RoleBinding = rbacv1.RoleBinding{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: nonRancherRBName,
-	},
-}
-var controllerCM v1.ConfigMap = v1.ConfigMap{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      controllerCMName,
-		Namespace: constants.KubeSystem,
-	},
-}
-var lockCM v1.ConfigMap = v1.ConfigMap{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      lockCMName,
-		Namespace: constants.KubeSystem,
-	},
-}
-var rancherPV v1.PersistentVolume = v1.PersistentVolume{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: pvName,
-	},
-}
-var rancherPV2 v1.PersistentVolume = v1.PersistentVolume{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: pv2Name,
-	},
-}
-var nonRancherPV v1.PersistentVolume = v1.PersistentVolume{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: randPV,
-	},
-}
-var delTimestamp metav1.Time = metav1.NewTime(time.Now())
-var crdAPIVersion = "apiextensions.k8s.io/v1"
-var crdKind = "CustomResourceDefinition"
-var rancherClusterCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       crdKind,
-		APIVersion: crdAPIVersion,
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:              rancherCRDName,
-		Finalizers:        []string{"somefinalizer"},
-		DeletionTimestamp: &delTimestamp,
-	},
-	Spec: v12.CustomResourceDefinitionSpec{
-		Group: "management.cattle.io",
-		Names: v12.CustomResourceDefinitionNames{
-			Kind: "Setting",
-		},
-		Scope: "Cluster",
-		Versions: []v12.CustomResourceDefinitionVersion{
-			{
-				Name: "v3",
-			},
-		},
-	},
-}
-var rancherNamespacedCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       crdKind,
-		APIVersion: crdAPIVersion,
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "projects.management.cattle.io",
-	},
-	Spec: v12.CustomResourceDefinitionSpec{
-		Group: "management.cattle.io",
-		Names: v12.CustomResourceDefinitionNames{
-			Kind: "Project",
-		},
-		Scope: "Namespaced",
-		Versions: []v12.CustomResourceDefinitionVersion{
-			{
-				Name: "v3",
-			},
-		},
-	},
-}
-var nonRancherCRD v12.CustomResourceDefinition = v12.CustomResourceDefinition{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       crdKind,
-		APIVersion: crdAPIVersion,
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: nonRancherCRDName,
-	},
-	Spec: v12.CustomResourceDefinitionSpec{
-		Group:                 "cattle.io",
-		Names:                 v12.CustomResourceDefinitionNames{},
-		Scope:                 "",
-		Versions:              nil,
-		Conversion:            nil,
-		PreserveUnknownFields: false,
-	},
-}
-var settingCR unstructured.Unstructured = unstructured.Unstructured{
-	Object: map[string]interface{}{
-		"apiVersion": "management.cattle.io/v3",
-		"kind":       "Setting",
-		"metadata": map[string]interface{}{
-			"name": "cr-name",
-		},
-	},
-}
-var projectCR unstructured.Unstructured = unstructured.Unstructured{
-	Object: map[string]interface{}{
-		"apiVersion": "management.cattle.io/v3",
-		"kind":       "Project",
-		"metadata": map[string]interface{}{
-			"namespace": "cr-namespace",
-			"name":      "cr-name",
-		},
-	},
-}
-
-type testStruct struct {
-	name           string
-	objects        []clipkg.Object
-	nonRancherTest bool
-}
-
-var tests = []testStruct{
-	{
-		name: "test empty cluster",
-	},
-	{
-		name: "test non Rancher ns",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-		},
-	},
-	{
-		name: "test Rancher ns",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-		},
-	},
-	{
-		name: "test multiple Rancher ns",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-		},
-	},
-	{
-		name: "test mutating webhook",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&mutWebhook2,
-		},
-	},
-	{
-		name: "test validating webhook",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&valWebhook,
-			&valWebhook2,
-		},
-	},
-	{
-		name: "test CR and CRB",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&valWebhook,
-			&crRancher,
-			&crbRancher,
-		},
-	},
-	{
-		name: "test non Rancher components",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&crNotRancher,
-			&crbNotRancher,
-			&nonRancherPV,
-			&rbNotRancher,
-			&nonRancherCRD,
-		},
-		nonRancherTest: true,
-	},
-	{
-		name: "test config maps",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&valWebhook,
-			&crRancher,
-			&crbRancher,
-			&crNotRancher,
-			&crbNotRancher,
-			&controllerCM,
-			&lockCM,
-		},
-	},
-	{
-		name: "test persistent volume",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&valWebhook,
-			&crRancher,
-			&crbRancher,
-			&crNotRancher,
-			&crbNotRancher,
-			&controllerCM,
-			&lockCM,
-			&rancherPV,
-			&rancherPV2,
-		},
-	},
-	{
-		name: "test clusterRole binding",
-		objects: []clipkg.Object{
-			&nonRancherNs,
-			&rancherNs,
-			&rancherNs2,
-			&mutWebhook,
-			&valWebhook,
-			&crRancher,
-			&crbRancher,
-			&crNotRancher,
-			&crbNotRancher,
-			&controllerCM,
-			&lockCM,
-			&rancherPV,
-			&rancherPV2,
-			&rbRancher,
-		},
-	},
-	{
-		name: "test CRD finalizer cleanup",
-		objects: []clipkg.Object{
-			&rancherClusterCRD,
-		},
-	},
-	{
-		name: "test Rancher CR cleanup",
-		objects: []clipkg.Object{
-			&rancherClusterCRD,
-			&settingCR,
-			&rancherNamespacedCRD,
-			&projectCR,
-		},
 	},
 }
 
@@ -392,9 +67,6 @@ func TestPostUninstall(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
-
-	crd1 := v12.CustomResourceDefinition{}
-	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	expectedErr := ctrlerrors.RetryableError{Source: ComponentName}
 	forkPostUninstallFunc = func(_ spi.ComponentContext, _ postUninstallMonitor) error {
@@ -422,9 +94,6 @@ func TestBackgroundPostUninstallCompletedSuccessfully(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
-	crd1 := v12.CustomResourceDefinition{}
-	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
-
 	forkPostUninstallFunc = func(_ spi.ComponentContext, _ postUninstallMonitor) error {
 		a.Fail("Unexpected call to forkPostUninstall() function")
 		return nil
@@ -450,9 +119,6 @@ func TestBackgroundPostUninstallRetryOnFailure(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
-
-	crd1 := v12.CustomResourceDefinition{}
-	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	forkFuncCalled := false
 	expectedErr := ctrlerrors.RetryableError{Source: ComponentName}
@@ -482,9 +148,6 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
-
-	crd1 := v12.CustomResourceDefinition{}
-	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	postUninstallFunc = func(ctx spi.ComponentContext) error {
 		return nil
@@ -523,9 +186,6 @@ func Test_forkPostUninstallFailure(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(testObjects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
 
-	crd1 := v12.CustomResourceDefinition{}
-	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
-
 	postUninstallFunc = func(ctx spi.ComponentContext) error {
 		return fmt.Errorf("Unexpected error on uninstall")
 	}
@@ -556,6 +216,330 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
 
+	rancherNSName2 := "fleet-rancher"
+	rancherCrName := "proxy-1234"
+	mwcName := "mutating-webhook-configuration"
+	vwcName := "validating-webhook-configuration"
+	pvName := "pvc-12345"
+	pv2Name := "ocid1.volume.oc1.ca-toronto-1.12345"
+	rbName := "rb-test"
+	nonRancherRBName := "testrb"
+	randPV := "randomPV"
+	randCR := "randomCR"
+	randCRB := "randomCRB"
+	rancherCRDName := "definitelyrancher.cattle.io"
+	nonRancherCRDName := "other.cattle"
+
+	rancherNs2 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rancherNSName2,
+		},
+	}
+	mutWebhook := admv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookName,
+		},
+	}
+	mutWebhook2 := admv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mwcName,
+		},
+	}
+	valWebhook := admv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookName,
+		},
+	}
+	valWebhook2 := admv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vwcName,
+		},
+	}
+	crRancher := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rancherCrName,
+		},
+	}
+	crbRancher := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookName,
+		},
+	}
+	crNotRancher := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randCR,
+		},
+	}
+	crbNotRancher := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randCRB,
+		},
+	}
+	rbRancher := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rbName,
+		},
+	}
+	rbNotRancher := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nonRancherRBName,
+		},
+	}
+	controllerCM := v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllerCMName,
+			Namespace: constants.KubeSystem,
+		},
+	}
+	lockCM := v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lockCMName,
+			Namespace: constants.KubeSystem,
+		},
+	}
+	rancherPV := v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+		},
+	}
+	rancherPV2 := v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pv2Name,
+		},
+	}
+	nonRancherPV := v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randPV,
+		},
+	}
+
+	delTimestamp := metav1.NewTime(time.Now())
+	crdAPIVersion := "apiextensions.k8s.io/v1"
+	crdKind := "CustomResourceDefinition"
+	rancherClusterCRD := v12.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       crdKind,
+			APIVersion: crdAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              rancherCRDName,
+			Finalizers:        []string{"somefinalizer"},
+			DeletionTimestamp: &delTimestamp,
+		},
+		Spec: v12.CustomResourceDefinitionSpec{
+			Group: "management.cattle.io",
+			Names: v12.CustomResourceDefinitionNames{
+				Kind: "Setting",
+			},
+			Scope: "Cluster",
+			Versions: []v12.CustomResourceDefinitionVersion{
+				{
+					Name: "v3",
+				},
+			},
+		},
+	}
+	rancherNamespacedCRD := v12.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       crdKind,
+			APIVersion: crdAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "projects.management.cattle.io",
+		},
+		Spec: v12.CustomResourceDefinitionSpec{
+			Group: "management.cattle.io",
+			Names: v12.CustomResourceDefinitionNames{
+				Kind: "Project",
+			},
+			Scope: "Namespaced",
+			Versions: []v12.CustomResourceDefinitionVersion{
+				{
+					Name: "v3",
+				},
+			},
+		},
+	}
+	nonRancherCRD := v12.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       crdKind,
+			APIVersion: crdAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nonRancherCRDName,
+		},
+		Spec: v12.CustomResourceDefinitionSpec{
+			Group:                 "cattle.io",
+			Names:                 v12.CustomResourceDefinitionNames{},
+			Scope:                 "",
+			Versions:              nil,
+			Conversion:            nil,
+			PreserveUnknownFields: false,
+		},
+	}
+	settingCR := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "Setting",
+			"metadata": map[string]interface{}{
+				"name": "cr-name",
+			},
+		},
+	}
+	projectCR := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "Project",
+			"metadata": map[string]interface{}{
+				"namespace": "cr-namespace",
+				"name":      "cr-name",
+			},
+		},
+	}
+	tests := []struct {
+		name           string
+		objects        []clipkg.Object
+		nonRancherTest bool
+	}{
+		{
+			name: "test empty cluster",
+		},
+		{
+			name: "test non Rancher ns",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+			},
+		},
+		{
+			name: "test Rancher ns",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+			},
+		},
+		{
+			name: "test multiple Rancher ns",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+			},
+		},
+		{
+			name: "test mutating webhook",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&mutWebhook2,
+			},
+		},
+		{
+			name: "test validating webhook",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&valWebhook,
+				&valWebhook2,
+			},
+		},
+		{
+			name: "test CR and CRB",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&valWebhook,
+				&crRancher,
+				&crbRancher,
+			},
+		},
+		{
+			name: "test non Rancher components",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&crNotRancher,
+				&crbNotRancher,
+				&nonRancherPV,
+				&rbNotRancher,
+				&nonRancherCRD,
+			},
+			nonRancherTest: true,
+		},
+		{
+			name: "test config maps",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&valWebhook,
+				&crRancher,
+				&crbRancher,
+				&crNotRancher,
+				&crbNotRancher,
+				&controllerCM,
+				&lockCM,
+			},
+		},
+		{
+			name: "test persistent volume",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&valWebhook,
+				&crRancher,
+				&crbRancher,
+				&crNotRancher,
+				&crbNotRancher,
+				&controllerCM,
+				&lockCM,
+				&rancherPV,
+				&rancherPV2,
+			},
+		},
+		{
+			name: "test clusterRole binding",
+			objects: []clipkg.Object{
+				&nonRancherNs,
+				&rancherNs,
+				&rancherNs2,
+				&mutWebhook,
+				&valWebhook,
+				&crRancher,
+				&crbRancher,
+				&crNotRancher,
+				&crbNotRancher,
+				&controllerCM,
+				&lockCM,
+				&rancherPV,
+				&rancherPV2,
+				&rbRancher,
+			},
+		},
+		{
+			name: "test CRD finalizer cleanup",
+			objects: []clipkg.Object{
+				&rancherClusterCRD,
+			},
+		},
+		{
+			name: "test Rancher CR cleanup",
+			objects: []clipkg.Object{
+				&rancherClusterCRD,
+				&settingCR,
+				&rancherNamespacedCRD,
+				&projectCR,
+			},
+		},
+	}
+
 	setRancherSystemTool("echo")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -566,7 +550,7 @@ func TestInvokeRancherSystemToolAndCleanup(t *testing.T) {
 			c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 			err := invokeRancherSystemToolAndCleanup(ctx)
-			a.Nil(err)
+			a.NoError(err)
 
 			// MutatingWebhookConfigurations should not exist
 			err = c.Get(context.TODO(), types.NamespacedName{Name: webhookName}, &admv1.MutatingWebhookConfiguration{})

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -540,6 +540,10 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 	a := assert.New(t)
 	vz := v1alpha1.Verrazzano{}
 
+	comp := rancherComponent {
+
+	}
+
 	tt := tests[2]
 	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(tt.objects...).Build()
 	ctx := spi.NewFakeContext(c, &vz, nil, false)
@@ -548,6 +552,7 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
+		fmt.Println("+++++ MARCO: returning no error from rancherUninstallToolFunc.")
 		return []byte(""), nil
 	}
 	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()
@@ -585,6 +590,7 @@ func Test_forkPostUninstallFailure(t *testing.T) {
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
 	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
+		fmt.Println("+++++ MARCO: returning an error from rancherUninstallToolFunc.")
 		return []byte(""), fmt.Errorf("Unexpected error on uninstall")
 	}
 	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -16,7 +16,6 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -547,10 +546,10 @@ func Test_forkPostUninstallSuccess(t *testing.T) {
 	crd1 := v12.CustomResourceDefinition{}
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
-	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
-		return []byte(""), nil
+	postUninstallFunc = func(ctx spi.ComponentContext) error {
+		return nil
 	}
-	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()
+	defer func() { postUninstallFunc = invokeRancherSystemToolAndCleanup }()
 
 	var monitor = &postUninstallMonitorType{}
 	err := forkPostUninstall(ctx, monitor)
@@ -584,10 +583,10 @@ func Test_forkPostUninstallFailure(t *testing.T) {
 	crd1 := v12.CustomResourceDefinition{}
 	c.Get(context.TODO(), types.NamespacedName{Name: rancherCRDName}, &crd1)
 
-	rancherUninstallToolFunc = func(log vzlog.VerrazzanoLogger, nsName string) ([]byte, error) {
-		return []byte(""), fmt.Errorf("Unexpected error on uninstall")
+	postUninstallFunc = func(ctx spi.ComponentContext) error {
+		return fmt.Errorf("Unexpected error on uninstall")
 	}
-	defer func() { rancherUninstallToolFunc = invokeRancherSystemTool }()
+	defer func() { postUninstallFunc = invokeRancherSystemToolAndCleanup }()
 
 	var monitor = &postUninstallMonitorType{}
 	err := forkPostUninstall(ctx, monitor)


### PR DESCRIPTION
The post-uninstall process of the Rancher component blocks the uninstallation of the other components due to using the Rancher uninstall system tool. This PR changes Rancher's post-uninstall to run in a background goroutine in order to prevent it from blocking rest of the uninstall process.

The unit tests in `rancher_uninstall_test.go` are modified in order to address the changes to the code.

The changes made are similar to how the Istio component installs in a background goroutine.