### PR TITLE
VZ-7975: Check for scrape targets instead of every metric in tests

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -278,14 +278,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 		// WHEN the application configuration uses a default metrics trait
 		// THEN confirm that all the scrape targets are healthy
 		t.It("Verify all scrape targets are healthy for the application", func() {
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", robertCoh, "robert-helidon"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "bob-books", componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", robertCoh, "robert-helidon"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "bob-books", componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 		// Verify Istio Prometheus scraped metrics
 		// GIVEN a deployed Bob's Books application

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -261,60 +261,15 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 		})
 	})
 	t.Context("Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
-		// Verify application Prometheus scraped metrics
+		// Verify application Prometheus scraped targets
 		// GIVEN a deployed Bob's Books application
 		// WHEN the application configuration uses a default metrics trait
-		// THEN confirm that metrics are being collected
-		t.It("Retrieve application Prometheus scraped metrics", func() {
+		// THEN confirm that all the scrape targets are healthy
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "bobbys-helidon-stock-application")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "robert-helidon")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "bobby-helidon")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "robert-helidon")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobbys-front-end")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobs-bookstore")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobbys-front-end")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobs-bookstore")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("vendor:coherence_cluster_size", "coherenceCluster", "bobbys-coherence")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("vendor:coherence_cluster_size", "coherenceCluster", "roberts-coherence")
+						return pkg.ScrapeTargetsHealthy(namespace)
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
@@ -328,31 +283,6 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				func() {
 					Eventually(func() bool {
 						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobbys-helidon-stock-application")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "robert-helidon")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobbys-front-end")
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobs-bookstore")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", "bobbys-front-end-adminserver")
-					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", "bobs-bookstore-adminserver")
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bobsbooks

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -26,6 +26,17 @@ const (
 	longPollingInterval      = 20 * time.Second
 	imagePullWaitTimeout     = 40 * time.Minute
 	imagePullPollingInterval = 30 * time.Second
+
+	// application specific constants
+	robertCoh        = "robert-coh"
+	bobsBookStore    = "bobs-bookstore"
+	robertsCoherence = "roberts-coherence"
+
+	// various labels
+	k8sLabelDomainUID     = "kubernetes.labels.weblogic_domainUID"
+	k8sLabelWLServerName  = "kubernetes.labels.weblogic_serverName"
+	k8sPodName            = "kubernetes.pod_name"
+	k8sLabelContainerName = "kubernetes.container_name"
 )
 
 var (
@@ -270,7 +281,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() (bool, error) {
-						var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", "robert-coh", "robert-helidon"}
+						var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", robertCoh, "robert-helidon"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "bob-books", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
@@ -313,10 +324,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobbys-front-end",
-							"kubernetes.labels.weblogic_serverName": "AdminServer",
-							"kubernetes.pod_name":                   "bobbys-front-end-adminserver",
-							"kubernetes.container_name":             "weblogic-server",
+							k8sLabelDomainUID:     "bobbys-front-end",
+							k8sLabelWLServerName:  "AdminServer",
+							k8sPodName:            "bobbys-front-end-adminserver",
+							k8sLabelContainerName: "weblogic-server",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -328,10 +339,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobbys-front-end",
-							"kubernetes.labels.weblogic_serverName": "AdminServer",
-							"kubernetes.pod_name":                   "bobbys-front-end-adminserver",
-							"kubernetes.container_name":             "fluentd-stdout-sidecar",
+							k8sLabelDomainUID:     "bobbys-front-end",
+							k8sLabelWLServerName:  "AdminServer",
+							k8sPodName:            "bobbys-front-end-adminserver",
+							k8sLabelContainerName: "fluentd-stdout-sidecar",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -343,10 +354,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-managed-server1 log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobbys-front-end",
-							"kubernetes.labels.weblogic_serverName": "managed-server1",
-							"kubernetes.pod_name":                   "bobbys-front-end-managed-server1",
-							"kubernetes.container_name":             "weblogic-server",
+							k8sLabelDomainUID:     "bobbys-front-end",
+							k8sLabelWLServerName:  "managed-server1",
+							k8sPodName:            "bobbys-front-end-managed-server1",
+							k8sLabelContainerName: "weblogic-server",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -395,8 +406,8 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
 								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "kubernetes.labels.weblogic_domainUID", Value: "bobbys-front-end"},
-								{Key: "kubernetes.labels.weblogic_serverName", Value: "managed-server1"},
+								{Key: k8sLabelDomainUID, Value: "bobbys-front-end"},
+								{Key: k8sLabelWLServerName, Value: "managed-server1"},
 								{Key: "messageID", Value: "BEA-"},         //matches BEA-*
 								{Key: "message", Value: "Tunneling Ping"}, //"Tunneling Ping" in last line
 								{Key: "serverName", Value: "bobbys-front-end-managed-server1"},
@@ -448,10 +459,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobs-bookstore-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobs-bookstore",
-							"kubernetes.labels.weblogic_serverName": "AdminServer",
-							"kubernetes.pod_name":                   "bobs-bookstore-adminserver",
-							"kubernetes.container_name":             "weblogic-server",
+							k8sLabelDomainUID:     bobsBookStore,
+							k8sLabelWLServerName:  "AdminServer",
+							k8sPodName:            "bobs-bookstore-adminserver",
+							k8sLabelContainerName: "weblogic-server",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -463,10 +474,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobs-bookstore-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobs-bookstore",
-							"kubernetes.labels.weblogic_serverName": "AdminServer",
-							"kubernetes.pod_name":                   "bobs-bookstore-adminserver",
-							"kubernetes.container_name":             "fluentd-stdout-sidecar",
+							k8sLabelDomainUID:     bobsBookStore,
+							k8sLabelWLServerName:  "AdminServer",
+							k8sPodName:            "bobs-bookstore-adminserver",
+							k8sLabelContainerName: "fluentd-stdout-sidecar",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -478,10 +489,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobs-bookstore-managed-server1 log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.weblogic_domainUID":  "bobs-bookstore",
-							"kubernetes.labels.weblogic_serverName": "managed-server1",
-							"kubernetes.pod_name":                   "bobs-bookstore-managed-server1",
-							"kubernetes.container_name":             "weblogic-server",
+							k8sLabelDomainUID:     bobsBookStore,
+							k8sLabelWLServerName:  "managed-server1",
+							k8sPodName:            "bobs-bookstore-managed-server1",
+							k8sLabelContainerName: "weblogic-server",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -495,8 +506,8 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
 								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: "kubernetes.labels.weblogic_domainUID", Value: "bobs-bookstore"},
-								{Key: "kubernetes.labels.weblogic_serverName", Value: "managed-server1"},
+								{Key: k8sLabelDomainUID, Value: bobsBookStore},
+								{Key: k8sLabelWLServerName, Value: "managed-server1"},
 								{Key: "messageID", Value: "BEA-"},                //matches BEA-*
 								{Key: "message", Value: "Admin Traffic Enabled"}, //"Admin Traffic Enabled" in last line
 								{Key: "serverName", Value: "bobs-bookstore-managed-server1"},
@@ -530,10 +541,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent roberts-coherence-0 log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.coherenceCluster":                "roberts-coherence",
-							"kubernetes.labels.app_oam_dev\\/component.keyword": "robert-coh",
-							"kubernetes.pod_name":                               "roberts-coherence-0",
-							"kubernetes.container_name.keyword":                 "coherence",
+							"kubernetes.labels.coherenceCluster":                robertsCoherence,
+							"kubernetes.labels.app_oam_dev\\/component.keyword": robertCoh,
+							k8sPodName:                          "roberts-coherence-0",
+							"kubernetes.container_name.keyword": "coherence",
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -546,13 +557,13 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
-								{Key: "kubernetes.labels.app_oam_dev/component", Value: "robert-coh"},
-								{Key: "kubernetes.labels.coherenceCluster", Value: "roberts-coherence"},
-								{Key: "kubernetes.pod_name", Value: "roberts-coherence-0"},
+								{Key: "kubernetes.labels.app_oam_dev/component", Value: robertCoh},
+								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: k8sPodName, Value: "roberts-coherence-0"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: "kubernetes.container_name", Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
 							[]pkg.Match{ //MustNot
-								{Key: "kubernetes.container_name", Value: "coherence"}})
+								{Key: k8sLabelContainerName, Value: "coherence"}})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 				})
 			},
@@ -564,11 +575,11 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
-								{Key: "kubernetes.labels.coherenceCluster", Value: "roberts-coherence"},
-								{Key: "kubernetes.pod_name", Value: "roberts-coherence-1"},
+								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: k8sPodName, Value: "roberts-coherence-1"},
 								{Key: "kubernetes.container_name.keyword", Value: "coherence"}},
 							[]pkg.Match{ //MustNot
-								{Key: "kubernetes.container_name", Value: "fluentd-stdout-sidecar"},
+								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"},
 							})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 
@@ -582,10 +593,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
-								{Key: "kubernetes.labels.coherenceCluster", Value: "roberts-coherence"},
-								{Key: "kubernetes.pod_name", Value: "roberts-coherence-1"},
+								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: k8sPodName, Value: "roberts-coherence-1"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: "kubernetes.container_name", Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
 							[]pkg.Match{})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 				})
@@ -602,7 +613,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 								{Key: "kubernetes.labels.coherenceCluster", Value: "bobbys-coherence"},
 								{Key: "coherence.cluster.name", Value: "bobbys-coherence"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: "kubernetes.container_name", Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
 							[]pkg.Match{})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 				})

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -40,6 +40,7 @@ var (
 		"bobbys-helidon-stock-application",
 		"robert-helidon",
 		"mysql"}
+	appName = "bobs-books"
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -269,7 +270,8 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", "robert-coh", "robert-helidon"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "bob-books", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -28,15 +28,19 @@ const (
 	imagePullPollingInterval = 30 * time.Second
 
 	// application specific constants
-	robertCoh        = "robert-coh"
-	bobsBookStore    = "bobs-bookstore"
-	robertsCoherence = "roberts-coherence"
+	robertCoh            = "robert-coh"
+	bobsBookStore        = "bobs-bookstore"
+	robertsCoherence     = "roberts-coherence"
+	bobbysFrontEnd       = "bobbys-front-end"
+	managedServer1       = "managed-server1"
+	fluentdStdoutSidecar = "fluentd-stdout-sidecar"
 
 	// various labels
-	k8sLabelDomainUID     = "kubernetes.labels.weblogic_domainUID"
-	k8sLabelWLServerName  = "kubernetes.labels.weblogic_serverName"
-	k8sPodName            = "kubernetes.pod_name"
-	k8sLabelContainerName = "kubernetes.container_name"
+	k8sLabelDomainUID        = "kubernetes.labels.weblogic_domainUID"
+	k8sLabelWLServerName     = "kubernetes.labels.weblogic_serverName"
+	k8sPodName               = "kubernetes.pod_name"
+	k8sLabelContainerName    = "kubernetes.container_name"
+	K8sLabelCoherenceCluster = "kubernetes.labels.coherenceCluster"
 )
 
 var (
@@ -320,7 +324,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							k8sLabelDomainUID:     "bobbys-front-end",
+							k8sLabelDomainUID:     bobbysFrontEnd,
 							k8sLabelWLServerName:  "AdminServer",
 							k8sPodName:            "bobbys-front-end-adminserver",
 							k8sLabelContainerName: "weblogic-server",
@@ -335,10 +339,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-adminserver log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							k8sLabelDomainUID:     "bobbys-front-end",
+							k8sLabelDomainUID:     bobbysFrontEnd,
 							k8sLabelWLServerName:  "AdminServer",
 							k8sPodName:            "bobbys-front-end-adminserver",
-							k8sLabelContainerName: "fluentd-stdout-sidecar",
+							k8sLabelContainerName: fluentdStdoutSidecar,
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -350,8 +354,8 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent bobbys-front-end-managed-server1 log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
-							k8sLabelDomainUID:     "bobbys-front-end",
-							k8sLabelWLServerName:  "managed-server1",
+							k8sLabelDomainUID:     bobbysFrontEnd,
+							k8sLabelWLServerName:  managedServer1,
 							k8sPodName:            "bobbys-front-end-managed-server1",
 							k8sLabelContainerName: "weblogic-server",
 						})
@@ -367,7 +371,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: "subSystem.keyword", Value: "WorkManager"},
 								{Key: "serverName.keyword", Value: "bobbys-front-end-adminserver"},
 								{Key: "serverName2.keyword", Value: "AdminServer"},
@@ -384,7 +388,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: "subSystem", Value: "WorkManager"},
 								{Key: "serverName", Value: "bobbys-front-end-adminserver"},
 								{Key: "serverName2", Value: "AdminServer"},
@@ -401,9 +405,9 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
-								{Key: k8sLabelDomainUID, Value: "bobbys-front-end"},
-								{Key: k8sLabelWLServerName, Value: "managed-server1"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
+								{Key: k8sLabelDomainUID, Value: bobbysFrontEnd},
+								{Key: k8sLabelWLServerName, Value: managedServer1},
 								{Key: "messageID", Value: "BEA-"},         //matches BEA-*
 								{Key: "message", Value: "Tunneling Ping"}, //"Tunneling Ping" in last line
 								{Key: "serverName", Value: "bobbys-front-end-managed-server1"},
@@ -420,10 +424,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: "subSystem.keyword", Value: "WorkManager"},
 								{Key: "serverName.keyword", Value: "bobbys-front-end-managed-server1"},
-								{Key: "serverName2.keyword", Value: "managed-server1"},
+								{Key: "serverName2.keyword", Value: managedServer1},
 								{Key: "message", Value: "standby threads"}},
 							[]pkg.Match{})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
@@ -437,10 +441,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: "subSystem", Value: "WorkManager"},
 								{Key: "serverName", Value: "bobbys-front-end-managed-server1"},
-								{Key: "serverName2", Value: "managed-server1"},
+								{Key: "serverName2", Value: managedServer1},
 								{Key: "message", Value: "Self-tuning"}},
 							[]pkg.Match{})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
@@ -473,7 +477,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 							k8sLabelDomainUID:     bobsBookStore,
 							k8sLabelWLServerName:  "AdminServer",
 							k8sPodName:            "bobs-bookstore-adminserver",
-							k8sLabelContainerName: "fluentd-stdout-sidecar",
+							k8sLabelContainerName: fluentdStdoutSidecar,
 						})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})
@@ -486,7 +490,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.LogRecordFound(bobsIndexName, time.Now().Add(-24*time.Hour), map[string]string{
 							k8sLabelDomainUID:     bobsBookStore,
-							k8sLabelWLServerName:  "managed-server1",
+							k8sLabelWLServerName:  managedServer1,
 							k8sPodName:            "bobs-bookstore-managed-server1",
 							k8sLabelContainerName: "weblogic-server",
 						})
@@ -501,9 +505,9 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(bobsIndexName,
 							[]pkg.Match{
-								{Key: "kubernetes.container_name.keyword", Value: "fluentd-stdout-sidecar"},
+								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: k8sLabelDomainUID, Value: bobsBookStore},
-								{Key: k8sLabelWLServerName, Value: "managed-server1"},
+								{Key: k8sLabelWLServerName, Value: managedServer1},
 								{Key: "messageID", Value: "BEA-"},                //matches BEA-*
 								{Key: "message", Value: "Admin Traffic Enabled"}, //"Admin Traffic Enabled" in last line
 								{Key: "serverName", Value: "bobs-bookstore-managed-server1"},
@@ -537,7 +541,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 				t.It("Verify recent roberts-coherence-0 log record exists", func() {
 					Eventually(func() bool {
 						return pkg.LogRecordFound(indexName, time.Now().Add(-24*time.Hour), map[string]string{
-							"kubernetes.labels.coherenceCluster":                robertsCoherence,
+							K8sLabelCoherenceCluster:                            robertsCoherence,
 							"kubernetes.labels.app_oam_dev\\/component.keyword": robertCoh,
 							k8sPodName:                          "roberts-coherence-0",
 							"kubernetes.container_name.keyword": "coherence",
@@ -554,10 +558,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
 								{Key: "kubernetes.labels.app_oam_dev/component", Value: robertCoh},
-								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: K8sLabelCoherenceCluster, Value: robertsCoherence},
 								{Key: k8sPodName, Value: "roberts-coherence-0"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: fluentdStdoutSidecar}},
 							[]pkg.Match{ //MustNot
 								{Key: k8sLabelContainerName, Value: "coherence"}})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
@@ -571,11 +575,11 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
-								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: K8sLabelCoherenceCluster, Value: robertsCoherence},
 								{Key: k8sPodName, Value: "roberts-coherence-1"},
 								{Key: "kubernetes.container_name.keyword", Value: "coherence"}},
 							[]pkg.Match{ //MustNot
-								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"},
+								{Key: k8sLabelContainerName, Value: fluentdStdoutSidecar},
 							})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 
@@ -589,10 +593,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 					Eventually(func() bool {
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
-								{Key: "kubernetes.labels.coherenceCluster", Value: robertsCoherence},
+								{Key: K8sLabelCoherenceCluster, Value: robertsCoherence},
 								{Key: k8sPodName, Value: "roberts-coherence-1"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: fluentdStdoutSidecar}},
 							[]pkg.Match{})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 				})
@@ -606,10 +610,10 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 						return pkg.FindLog(indexName,
 							[]pkg.Match{
 								{Key: "kubernetes.labels.app_oam_dev/component", Value: "bobby-coh"},
-								{Key: "kubernetes.labels.coherenceCluster", Value: "bobbys-coherence"},
+								{Key: K8sLabelCoherenceCluster, Value: "bobbys-coherence"},
 								{Key: "coherence.cluster.name", Value: "bobbys-coherence"},
 								{Key: "product", Value: "Oracle Coherence"},
-								{Key: k8sLabelContainerName, Value: "fluentd-stdout-sidecar"}},
+								{Key: k8sLabelContainerName, Value: fluentdStdoutSidecar}},
 							[]pkg.Match{})
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Expected to find a systemd log record")
 				})

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -269,7 +269,7 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
+					Eventually(func() (bool, error) {
 						var componentNames = []string{"bobby-coh", "bobby-helidon", "bobby-wls", "bobs-mysql-deployment", "bobs-mysql-service", "bobs-orders-wls", "robert-coh", "robert-helidon"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "bob-books", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidon

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -134,30 +134,20 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 	})
-	// Verify Prometheus scraped metrics
+	// Verify Prometheus scraped targets
 	// GIVEN OAM hello-helidon app is deployed
 	// WHEN the component and appconfig without metrics-trait(using default) are created
-	// THEN the application metrics must be accessible
+	// THEN the application's all scrape targets must be healthy
 	t.Describe("for Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
-		t.It("Retrieve Prometheus scraped metrics", func() {
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			if skipVerify {
 				Skip(skipVerifications)
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(appMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appComponentMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appConfigMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterProcsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterDiskIoNow, longWaitTimeout, longPollingInterval).Should(BeTrue())
+					Eventually(func() bool {
+						return pkg.ScrapeTargetsHealthy(namespace)
+					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
 		})
@@ -295,24 +285,4 @@ func appEndpointAccessible(url string, hostname string) bool {
 		return false
 	}
 	return true
-}
-
-func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", helloHelidon)
-}
-
-func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", helloHelidon)
-}
-
-func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "hello-helidon-component")
-}
-
-func nodeExporterProcsRunning() bool {
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
-}
-
-func nodeExporterDiskIoNow() bool {
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -143,14 +143,10 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"hello-helidon-component"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"hello-helidon-component"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 	})
 

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -145,7 +145,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
+					Eventually(func() (bool, error) {
 						var componentNames = []string{"hello-helidon-component"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -146,7 +146,8 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{"hello-helidon-component"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -178,14 +178,10 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 	// THEN the application scrape targets must be healthy
 	t.Describe("Metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Verify all scrape targets are healthy for the application", func() {
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"helidon-config-component"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "helidon-config-appconf", componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"helidon-config-component"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "helidon-config-appconf", componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 	})
 

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -172,21 +172,17 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 		})
 	})
 
-	// Verify Prometheus scraped metrics
+	// Verify Prometheus scraped targets
 	// GIVEN OAM helidon-config app is deployed
 	// WHEN the component and appconfig without metrics-trait(using default) are created
-	// THEN the application metrics must be accessible
+	// THEN the application scrape targets must be healthy
 	t.Describe("Metrics.", Label("f:observability.monitoring.prom"), func() {
-		t.It("Retrieve Prometheus scraped metrics", func() {
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
-					Eventually(appMetricsExists, waitTimeout, pollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appComponentMetricsExists, waitTimeout, pollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appConfigMetricsExists, waitTimeout, pollingInterval).Should(BeTrue())
+					Eventually(func() bool {
+						return pkg.ScrapeTargetsHealthy(namespace)
+					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
 		})
@@ -229,16 +225,4 @@ func helidonConfigPodsRunning() bool {
 		AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
 	}
 	return result
-}
-
-func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "helidon-config")
-}
-
-func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "helidon-config-appconf")
-}
-
-func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "helidon-config-component")
 }

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -181,7 +181,8 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{"helidon-config-component"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "helidon-config-appconf", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonconfig

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -180,7 +180,7 @@ var _ = t.Describe("Helidon Config OAM App test", Label("f:app-lcm.oam",
 		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
+					Eventually(func() (bool, error) {
 						var componentNames = []string{"helidon-config-component"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "helidon-config-appconf", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package socks

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -279,14 +279,10 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 		}
 		if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeconfigPath); ok {
 			t.It("Verify all scrape targets are healthy for the application", func() {
-				pkg.Concurrently(
-					func() {
-						Eventually(func() (bool, error) {
-							var componentNames = []string{"carts", "catalog", "orders", "payment", "shipping", "users"}
-							return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "sockshop-appconf", componentNames))
-						}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-					},
-				)
+				Eventually(func() (bool, error) {
+					var componentNames = []string{"carts", "catalog", "orders", "payment", "shipping", "users"}
+					return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "sockshop-appconf", componentNames))
+				}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 			})
 		}
 	})

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -281,7 +281,7 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 			t.It("Verify all scrape targets are healthy for the application", func() {
 				pkg.Concurrently(
 					func() {
-						Eventually(func() bool {
+						Eventually(func() (bool, error) {
 							var componentNames = []string{"carts", "catalog", "orders", "payment", "shipping", "users"}
 							return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "sockshop-appconf", componentNames))
 						}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -285,15 +285,6 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 						func() {
 							Eventually(appMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
 						},
-						func() {
-							Eventually(coherenceMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(appComponentMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(appConfigMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
-						},
 					)
 				} else if getVariant() == "spring" {
 					pkg.Concurrently(
@@ -302,34 +293,6 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 								return springMetricExists("carts")
 							}, waitTimeout, pollingInterval).Should(BeTrue())
 						},
-						func() {
-							Eventually(func() bool {
-								return springMetricExists("catalog")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return springMetricExists("orders")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return springMetricExists("payment")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return springMetricExists("shipping")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return springMetricExists("users")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(coherenceMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
-						},
 					)
 				} else if getVariant() == "micronaut" {
 					pkg.Concurrently(
@@ -337,34 +300,6 @@ var _ = t.Describe("Sock Shop test", Label("f:app-lcm.oam",
 							Eventually(func() bool {
 								return micronautMetricExists("carts")
 							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return micronautMetricExists("catalog")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return micronautMetricExists("orders")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return micronautMetricExists("payment")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return micronautMetricExists("shipping")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(func() bool {
-								return micronautMetricExists("users")
-							}, waitTimeout, pollingInterval).Should(BeTrue())
-						},
-						func() {
-							Eventually(coherenceMetricExists, waitTimeout, pollingInterval).Should(BeTrue())
 						},
 					)
 				}
@@ -453,20 +388,6 @@ func sockshopPodsRunning() bool {
 // appMetricExists checks whether app related metrics are available
 func appMetricExists() bool {
 	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "carts-coh")
-}
-
-func coherenceMetricExists() bool {
-	return pkg.MetricsExist("vendor:coherence_service_messages_local", "role", "Orders")
-}
-
-// appComponentMetricExists checks whether component related metrics are available
-func appComponentMetricExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", sockshopAppName)
-}
-
-// appConfigMetricExists checks whether config metrics are available
-func appConfigMetricExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "orders")
 }
 
 // springMetricExists checks whether sample Spring metrics is available for a given component

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -149,14 +149,10 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"hello-helidon-component"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-helidon", componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"hello-helidon-component"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-helidon", componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 	})
 

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -152,7 +152,8 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{"hello-helidon-component"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-helidon", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -151,7 +151,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
+					Eventually(func() (bool, error) {
 						var componentNames = []string{"hello-helidon-component"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-helidon", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidonsvc

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -140,30 +140,20 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 		})
 	})
 
-	// Verify Prometheus scraped metrics
+	// Verify Prometheus scraped targets
 	// GIVEN OAM hello-helidon app is deployed
 	// WHEN the component and appconfig without metrics-trait(using default) are created
-	// THEN the application metrics must be accessible
+	// THEN the application scrape targets must be healthy
 	t.Describe("for Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
-		t.It("Retrieve Prometheus scraped metrics", func() {
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			if skipVerify {
 				Skip(skipVerifications)
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(appMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appComponentMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appConfigMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterProcsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterDiskIoNow, longWaitTimeout, longPollingInterval).Should(BeTrue())
+					Eventually(func() bool {
+						return pkg.ScrapeTargetsHealthy(namespace)
+					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
 		})
@@ -364,24 +354,4 @@ func appEndpointAccess(url string, hostname string, token string, requestShouldS
 		}
 	}
 	return true
-}
-
-func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "hello-helidon-svc-application")
-}
-
-func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon-svc-application")
-}
-
-func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "hello-helidon-deploy-component")
-}
-
-func nodeExporterProcsRunning() bool {
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
-}
-
-func nodeExporterDiskIoNow() bool {
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -149,14 +149,10 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			if skipVerify {
 				Skip(skipVerifications)
 			}
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"hello-helidon-component"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"hello-helidon-component"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 	})
 

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helidon

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -152,7 +152,8 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{"hello-helidon-component"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -151,7 +151,7 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
+					Eventually(func() (bool, error) {
 						var componentNames = []string{"hello-helidon-component"}
 						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, helloHelidon, componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -140,30 +140,20 @@ var _ = t.Describe("Hello Helidon OAM App test", Label("f:app-lcm.oam",
 		})
 	})
 
-	// Verify Prometheus scraped metrics
+	// Verify Prometheus scraped targets
 	// GIVEN OAM hello-helidon app is deployed
 	// WHEN the component and appconfig without metrics-trait(using default) are created
-	// THEN the application metrics must be accessible
+	// THEN the application scrape targets must be healthy
 	t.Describe("for Metrics.", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
-		t.It("Retrieve Prometheus scraped metrics", func() {
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			if skipVerify {
 				Skip(skipVerifications)
 			}
 			pkg.Concurrently(
 				func() {
-					Eventually(appMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appComponentMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(appConfigMetricsExists, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterProcsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(nodeExporterDiskIoNow, longWaitTimeout, longPollingInterval).Should(BeTrue())
+					Eventually(func() bool {
+						return pkg.ScrapeTargetsHealthy(namespace)
+					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
 		})
@@ -318,24 +308,4 @@ func appEndpointAccess(url string, hostname string, token string, requestShouldS
 		}
 	}
 	return true
-}
-
-func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", helloHelidon)
-}
-
-func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", helloHelidon)
-}
-
-func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "hello-helidon-component")
-}
-
-func nodeExporterProcsRunning() bool {
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
-}
-
-func nodeExporterDiskIoNow() bool {
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
 }

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -199,13 +199,13 @@ func ScrapeTargetsHealthy(scrapePools []string) bool {
 					return isHealthy
 				}
 			}
-			// If target with scrapePool not found, then return false
-			if !found {
-				Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", Jq(target, "scrapePool"), Jq(target, "scrapeUrl"), Jq(target, "health")))
-				return isHealthy
-			}
-			isHealthy = true
 		}
+		// If target with scrapePool not found, then return false
+		if !found {
+			Log(Error, fmt.Sprintf("target with scrapePool %s is not found", scrapePool))
+			return isHealthy
+		}
+		isHealthy = true
 	}
 	return isHealthy
 }

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -355,7 +355,7 @@ func GetServiceMonitor(namespace, name string) (*promoperapi.ServiceMonitor, err
 func GetScrapePools(namespace, appName string, componentNames []string) []string {
 	var scrapePools []string
 	for _, comp := range componentNames {
-		scrapePool := "serviceMonitor" + namespace + GetAppServiceMonitorName(namespace, appName, comp)
+		scrapePool := "serviceMonitor/" + namespace + "/" + GetAppServiceMonitorName(namespace, appName, comp)
 		scrapePools = append(scrapePools, scrapePool)
 		Log(Info, fmt.Sprintf("scrapePool %s for %s", scrapePool, appName))
 	}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -357,7 +357,7 @@ func GetScrapePools(namespace, appName string, componentNames []string) []string
 	for _, comp := range componentNames {
 		scrapePool := "serviceMonitor/" + namespace + "/" + GetAppServiceMonitorName(namespace, appName, comp)
 		scrapePools = append(scrapePools, scrapePool)
-		Log(Info, fmt.Sprintf("scrapePool %s for %s", scrapePool, appName))
+		Log(Info, fmt.Sprintf("ScrapePool %s for %s", scrapePool, appName))
 	}
 	return scrapePools
 

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -197,7 +197,7 @@ func ScrapeTargetsHealthy(scrapePools []string) (bool, error) {
 				// If any of the target health is not "up" return false
 				if Jq(target, "health") != "up" {
 					scrapeURL := Jq(target, "scrapeUrl").(string)
-					Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", targetScrapePool, scrapeURL, Jq(target, "scrapeUrl"), Jq(target, "health")))
+					Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", targetScrapePool, scrapeURL, Jq(target, "health")))
 					return isHealthy, errors.New("target with scrapePool" + targetScrapePool + "and scrapeURL" + scrapeURL + "is not healthy")
 				}
 			}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -180,23 +180,32 @@ func MetricsExist(metricsName, key, value string) bool {
 }
 
 // ScrapeTargetsHealthy validates the health of the scrape targets for the given namespace
-func ScrapeTargetsHealthy(namespace string) bool {
+func ScrapeTargetsHealthy(scrapePools []string) bool {
 	targets, err := ScrapeTargets()
 	if err != nil {
 		Log(Error, fmt.Sprintf("Error getting scrape targets: %v", err))
 		return false
 	}
 	isHealthy := false
-	for _, target := range targets {
-		targetScrapePool := Jq(target, "scrapePool").(string)
-		if strings.Contains(targetScrapePool, namespace) {
-			// If any of the target health is not "up" return false
-			if Jq(target, "health") != "up" {
+	for _, scrapePool := range scrapePools {
+		found := false
+		for _, target := range targets {
+			targetScrapePool := Jq(target, "scrapePool").(string)
+			if strings.Contains(targetScrapePool, scrapePool) {
+				found = true
+				// If any of the target health is not "up" return false
+				if Jq(target, "health") != "up" {
+					Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", Jq(target, "scrapePool"), Jq(target, "scrapeUrl"), Jq(target, "health")))
+					return isHealthy
+				}
+			}
+			// If target with scrapePool not found, then return false
+			if !found {
 				Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", Jq(target, "scrapePool"), Jq(target, "scrapeUrl"), Jq(target, "health")))
 				return isHealthy
 			}
+			isHealthy = true
 		}
-		isHealthy = true
 	}
 	return isHealthy
 }
@@ -341,4 +350,15 @@ func GetServiceMonitor(namespace, name string) (*promoperapi.ServiceMonitor, err
 		return nil, err
 	}
 	return serviceMonitor, nil
+}
+
+func GetScrapePools(namespace, appName string, componentNames []string) []string {
+	var scrapePools []string
+	for _, comp := range componentNames {
+		scrapePool := "serviceMonitor" + namespace + GetAppServiceMonitorName(namespace, appName, comp)
+		scrapePools = append(scrapePools, scrapePool)
+		Log(Info, fmt.Sprintf("scrapePool %s for %s", scrapePool, appName))
+	}
+	return scrapePools
+
 }

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -205,26 +205,16 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 	})
 
 	t.Context("Metrics", Label("f:observability.monitoring.prom"), FlakeAttempts(5), func() {
-		// Verify application Prometheus scraped metrics
+		// Verify application Prometheus scraped targets
 		// GIVEN the sample WebLogic app is deployed
 		// WHEN the application configuration uses a default metrics trait
-		// THEN confirm that metrics are being collected
-		t.It("Retrieve application Prometheus scraped metrics", func() {
+		// THEN confirm that all the scrape targets are healthy
+		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", wlDomain)
-					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", wlDomain)
-					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
-				},
-				func() {
-					Eventually(func() bool {
-						return pkg.MetricsExist("wls_server_state_val", "weblogic_domainName", wlDomain)
-					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
+						return pkg.ScrapeTargetsHealthy(namespace)
+					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
 		})

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package weblogic

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -213,7 +213,7 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						var scrapePools = []string{"weblogic-workload"}
+						var scrapePools = []string{namespace}
 						return pkg.ScrapeTargetsHealthy(scrapePools)
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -210,14 +210,10 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 		// WHEN the application configuration uses a default metrics trait
 		// THEN confirm that all the scrape targets are healthy
 		t.It("Verify all scrape targets are healthy for the application", func() {
-			pkg.Concurrently(
-				func() {
-					Eventually(func() (bool, error) {
-						var componentNames = []string{"hello-domain"}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-appconf", componentNames))
-					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
-				},
-			)
+			Eventually(func() (bool, error) {
+				var componentNames = []string{"hello-domain"}
+				return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-appconf", componentNames))
+			}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 		})
 
 		// Verify Istio Prometheus scraped metrics

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package weblogic

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -212,9 +212,9 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 		t.It("Verify all scrape targets are healthy for the application", func() {
 			pkg.Concurrently(
 				func() {
-					Eventually(func() bool {
-						var scrapePools = []string{namespace}
-						return pkg.ScrapeTargetsHealthy(scrapePools)
+					Eventually(func() (bool, error) {
+						var componentNames = []string{"hello-domain"}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "hello-appconf", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -213,8 +213,8 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						var componentNames = []string{""}
-						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "wls", componentNames))
+						var scrapePools = []string{"weblogic-workload"}
+						return pkg.ScrapeTargetsHealthy(scrapePools)
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -213,7 +213,8 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.ScrapeTargetsHealthy(namespace)
+						var componentNames = []string{""}
+						return pkg.ScrapeTargetsHealthy(pkg.GetScrapePools(namespace, "wls", componentNames))
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)


### PR DESCRIPTION
Most of the end-to-end tests that validate metrics do so by querying Prometheus for various metrics to ensure they have been collected. It should be sufficient for this type of test to verify that Prometheus is able to scrape the expected endpoints. This PR replaces the logic from checking each metric to just checking the scrape target endpoints' health.