### PR TITLE
VZ-7331: Jaeger 1.37.0 images with OpenSearch 2.x support and override draft-js dependency from 0.10.5 to 0.11.0

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -618,7 +618,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -629,7 +629,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -640,7 +640,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -651,7 +651,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -662,7 +662,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -673,7 +673,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -684,7 +684,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.37.0-20221208173448-f5925558",
+              "tag": "1.37.0-20221219184221-55f6b454",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]

--- a/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221005191655-798e1e8b"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221005191655-798e1e8b"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"


### PR DESCRIPTION
- jaeger-ui: override draft-js from 0.10.5 to 0.11.0 due to Facebook patents
- jaeger: OpenSearch 2.x support