### PR TITLE
Revert cattle-agent network policy conditional creation

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -295,7 +295,6 @@ spec:
           protocol: TCP
 
 {{- end }}
-{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher cluster agent
 # Ingress: deny all
@@ -311,6 +310,7 @@ spec:
       app: cattle-cluster-agent
   policyTypes:
     - Ingress
+{{- if .Values.rancher.enabled }}
 ---
 # Network policy for Rancher UI/API
 # Ingress: allow nginx ingress

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -297,6 +297,7 @@ spec:
 {{- end }}
 ---
 # Network policy for Rancher cluster agent
+# - always create this policy in case the target cluster is intended to be a managed cluster
 # Ingress: deny all
 # Egress: allow all
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Reverts a change in 3423d70079df0c45ad8440d2e7b86d405e382f4d that conditionally created the Rancher cattle-agent policy if Rancher was enabled; we always need this policy in place in case the cluster ever becomes registered as a managed cluster.