### PR TITLE
Fix uninstall/verifycrds e2e test

### DIFF
--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -148,7 +148,6 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 
 	t.It("Check for unexpected CRDs", func() {
 		var unexpectedCRDs []string
-		//var crdsFound = make(map[string]bool)
 		for _, crd := range crds.Items {
 			// Anything other than these CRDs being checked are unexpected after an uninstall
 			if strings.HasSuffix(crd.Name, "projectcalico.org") ||
@@ -162,25 +161,13 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 				strings.HasSuffix(crd.Name, "mysql.oracle.com") ||
 				strings.HasSuffix(crd.Name, "zalando.org") ||
 				strings.HasSuffix(crd.Name, "metallb.io") ||
-				//strings.HasSuffix(crd.Name, "weblogic.oracle") ||
+				strings.HasSuffix(crd.Name, "weblogic.oracle") ||
 				strings.HasSuffix(crd.Name, "coherence.oracle.com") {
-				unexpectedCRDs = append(unexpectedCRDs, crd.Name)
-				//crdsFound[crd.Name] = true
 				continue
 			}
-			//crdsFound[crd.Name] = false
+			unexpectedCRDs = append(unexpectedCRDs, crd.Name)
 		}
 		Expect(unexpectedCRDs).To(BeEmpty())
-		//unexpectedCrd := false
-		//for key, value := range crdsFound {
-		//	if value == false {
-		//		unexpectedCrd = true
-		//		pkg.Log(pkg.Error, fmt.Sprintf("Unexpected CRD was found: %s", key))
-		//	}
-		//}
-		//if unexpectedCrd {
-		//	Fail("Unexpected CRDs were found in the cluster")
-		//}
 	})
 })
 

--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -167,7 +167,7 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 			}
 			unexpectedCRDs = append(unexpectedCRDs, crd.Name)
 		}
-		Expect(unexpectedCRDs).To(BeEmpty())
+		Expect(unexpectedCRDs).To(BeEmpty(), "Found unexpected CRDs remaining after uninstall")
 	})
 })
 

--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -145,7 +147,8 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 	})
 
 	t.It("Check for unexpected CRDs", func() {
-		var crdsFound = make(map[string]bool)
+		var unexpectedCRDs []string
+		//var crdsFound = make(map[string]bool)
 		for _, crd := range crds.Items {
 			// Anything other than these CRDs being checked are unexpected after an uninstall
 			if strings.HasSuffix(crd.Name, "projectcalico.org") ||
@@ -159,24 +162,25 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 				strings.HasSuffix(crd.Name, "mysql.oracle.com") ||
 				strings.HasSuffix(crd.Name, "zalando.org") ||
 				strings.HasSuffix(crd.Name, "metallb.io") ||
-				crd.Name == "domains.weblogic.oracle" ||
-				crd.Name == "coherence.coherence.oracle.com" {
-				crdsFound[crd.Name] = true
+				//strings.HasSuffix(crd.Name, "weblogic.oracle") ||
+				strings.HasSuffix(crd.Name, "coherence.oracle.com") {
+				unexpectedCRDs = append(unexpectedCRDs, crd.Name)
+				//crdsFound[crd.Name] = true
 				continue
 			}
-			crdsFound[crd.Name] = false
+			//crdsFound[crd.Name] = false
 		}
-
-		unexpectedCrd := false
-		for key, value := range crdsFound {
-			if value == false {
-				unexpectedCrd = true
-				pkg.Log(pkg.Error, fmt.Sprintf("Unexpected CRD was found: %s", key))
-			}
-		}
-		if unexpectedCrd {
-			Fail("Unexpected CRDs were found in the cluster")
-		}
+		Expect(unexpectedCRDs).To(BeEmpty())
+		//unexpectedCrd := false
+		//for key, value := range crdsFound {
+		//	if value == false {
+		//		unexpectedCrd = true
+		//		pkg.Log(pkg.Error, fmt.Sprintf("Unexpected CRD was found: %s", key))
+		//	}
+		//}
+		//if unexpectedCrd {
+		//	Fail("Unexpected CRDs were found in the cluster")
+		//}
 	})
 })
 


### PR DESCRIPTION
Ignore all `weblogic.oracle` and `coherence.oracle.com` CRDs in the uninstall CRDs checks, and clean up test output.