### PR TITLE
VZ-8053.  Pod security for verrazzano-authproxy

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -127,6 +127,12 @@ spec:
         volumeMounts:
         - mountPath: /api-config
           name: api-config
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - image: {{ .Values.metricsImageName }}:{{ .Values.metricsImageVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         name: verrazzano-authproxy-metrics
@@ -156,7 +162,19 @@ spec:
             port: http-metrics
           failureThreshold: 3
           periodSeconds: 3
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       serviceAccountName: {{ .Values.name }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -131,6 +131,8 @@ spec:
           privileged: false
           allowPrivilegeEscalation: false
           capabilities:
+            add:
+              - NET_BIND_SERVICE
             drop:
               - ALL
       - image: {{ .Values.metricsImageName }}:{{ .Values.metricsImageVersion }}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -170,8 +170,8 @@ spec:
               - ALL
       serviceAccountName: {{ .Values.name }}
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 999
+        runAsUser: 101  # nginx container user
+        runAsGroup: 101 # nginx container group
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
Make `verrazzano-authproxy` conform to the VZ pod security standard.

- run unprivileged
- run as non-root (baked in www-data in image)
- drop all capabilities, but adds NET_BIND_SERVICE as an exception
- no hostpaths

The NET_BIND_SERVICE capability is required to allow the container to come up.  We'll have to investigate how we can remove this capability; within authproxy we don't use any unprivileged ports it seems.