### PR TITLE
VZ-8053.  Update pod security tests to test for non-standard capabilities

### DIFF
--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -65,7 +65,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	for ns := range skipPods {
-		ns := ns
+		ns := ns // needed to avoid the spec closure from capturing and retaining the last key in the map; see Ginkgo docs
 		t.ItMinimumVersion(fmt.Sprintf("Chek security for pods in namespace %s", ns), "1.5.0", kubeconfigPath, func() {
 			var podList *corev1.PodList
 			var err error

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -6,15 +6,14 @@ package security
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"strings"
 	"time"
 
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -82,10 +81,12 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 			return podList, err
 		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
 
+		t.Logs.Debugf("Podlist length: %v", len(podList.Items))
+
 		var errors []error
 		pods := podList.Items
 		for _, pod := range pods {
-			t.Logs.Infof("Checking pod %s/%s", ns, pod.Name)
+			t.Logs.Debugf("Checking pod %s/%s", ns, pod.Name)
 			if shouldSkipPod(pod.Name, ns) {
 				continue
 			}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -65,7 +65,8 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Fail(fmt.Sprintf("Failed to get default kubeconfig path: %s", err.Error()))
 	}
 	for ns := range skipPods {
-		t.ItMinimumVersion(fmt.Sprintf("for pods in namespace %s", ns), "1.5.0", kubeconfigPath, func() {
+		ns := ns
+		t.ItMinimumVersion(fmt.Sprintf("Chek security for pods in namespace %s", ns), "1.5.0", kubeconfigPath, func() {
 			var podList *corev1.PodList
 			var err error
 			Eventually(func() (*corev1.PodList, error) {
@@ -75,6 +76,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 
 			pods := podList.Items
 			for _, pod := range pods {
+				t.Logs.Infof("Checking pod %s/%s", ns, pod.Name)
 				if shouldSkipPod(pod.Name, ns) {
 					continue
 				}


### PR DESCRIPTION
Update pod security e2e tests to check for `Add` capabilities for any non-standard capabilities added

Also, reorganized the tests a bit:
- converted to a test table
- changed tests to accumulate all errors for a namespace and display them on failure, and not short-circuit on the first error

Sample failure report

```

  Expected
      <[]error | len:6, cap:6>: [
          <*errors.errorString | 0xc000760100>{
              s: "SecurityContext not configured correctly for pod verrazzano-application-operator-84f7658754-t5q7t, container verrazzano-application-operator, Privileged != false",
          },
          <*errors.errorString | 0xc000760140>{
              s: "SecurityContext not configured correctly for pod verrazzano-application-operator-84f7658754-t5q7t, container verrazzano-application-operator, AllowPrivilegeEscalation != false",
          },
          <*errors.errorString | 0xc000760190>{
              s: "only NET_BIND_SERVICE capability allowed, found unexpected capabilities added to container verrazzano-application-operator in pod verrazzano-application-operator-84f7658754-t5q7t: [NET_BIND_SERVICE MKNOD]",
          },
          <*errors.errorString | 0xc000760220>{
              s: "SecurityContext not configured correctly for pod verrazzano-authproxy-f9d8767f6-54np9, container verrazzano-authproxy, Privileged != false",
          },
          <*errors.errorString | 0xc000760260>{
              s: "SecurityContext not configured correctly for pod verrazzano-authproxy-f9d8767f6-54np9, container verrazzano-authproxy, AllowPrivilegeEscalation != false",
          },
          <*errors.errorString | 0xc0007602b0>{
              s: "only NET_BIND_SERVICE capability allowed, found unexpected capabilities added to container verrazzano-authproxy in pod verrazzano-authproxy-f9d8767f6-54np9: [NET_BIND_SERVICE MKNOD]",
          },
      ]
```