### PR TITLE
VZ-8117-pod sec for velero

### DIFF
--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
@@ -36,6 +36,9 @@ func AppendOverrides(compContext spi.ComponentContext, _ string, _ string, _ str
 		{Key: "initContainers[0].imagePullPolicy", Value: "IfNotPresent"},
 		{Key: "initContainers[0].volumeMounts[0].name", Value: "plugins"},
 		{Key: "initContainers[0].volumeMounts[0].mountPath", Value: "/target"},
+		{Key: "initContainers[0].securityContext.allowPrivilegeEscalation", Value: "false"},
+		{Key: "initContainers[0].securityContext.capabilities.drop[0]", Value: "ALL"},
+		{Key: "initContainers[0].securityContext.privileged", Value: "false"},
 		{Key: "metrics.serviceMonitor.namespace", Value: ComponentNamespace},
 	}
 	kvs = append(kvs, arguments...)

--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package velero

--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
@@ -9,15 +9,13 @@ import (
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
-	prometheusOperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
-
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,7 +74,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "velero-override-static-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
-			Dependencies:              []string{networkpolicies.ComponentName, prometheusOperator.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DaemonsetNames:  daemonSets,
 				DeploymentNames: deployments,

--- a/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/velero/velero_operator_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package velero

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -34,7 +34,7 @@ configMaps:
       velero.io/plugin-config: ""
       velero.io/restic: RestoreItemAction
 podSecurityContext:
-  runAsGroup: 999
+  runAsGroup: 65534
   runAsNonRoot: true
   runAsUser: 1000
   seccompProfile:

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -12,7 +12,7 @@ restic:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
-      add: []
+      add: ["NET_BIND_SERVICE"]
     readOnlyRootFilesystem: false
 metrics:
   serviceMonitor:
@@ -43,5 +43,5 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
-    add: []
+    add: ["NET_BIND_SERVICE"]
   readOnlyRootFilesystem: true

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -8,6 +8,18 @@ podAnnotations:
 restic:
   annotations:
     traffic.sidecar.istio.io/excludeOutboundPorts: "443"
+  podSecurityContext:
+    runAsGroup: 999
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+      add: []
+    readOnlyRootFilesystem: true
 metrics:
   serviceMonitor:
     enabled: true
@@ -23,7 +35,19 @@ deployRestic: true
 snapshotsEnabled: false
 upgradeCRDs: false
 configMaps:
- restic-restore-action-config:
-   labels:
-     velero.io/plugin-config: ""
-     velero.io/restic: RestoreItemAction
+  restic-restore-action-config:
+    labels:
+      velero.io/plugin-config: ""
+      velero.io/restic: RestoreItemAction
+podSecurityContext:
+  runAsGroup: 999
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+    add: []
+  readOnlyRootFilesystem: true

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022,2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 image:

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -45,3 +45,4 @@ containerSecurityContext:
     drop: ["ALL"]
     add: ["NET_BIND_SERVICE"]
   readOnlyRootFilesystem: true
+  privileged: false

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 image:

--- a/platform-operator/helm_config/overrides/velero-override-static-values.yaml
+++ b/platform-operator/helm_config/overrides/velero-override-static-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022,2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 image:
@@ -8,18 +8,12 @@ podAnnotations:
 restic:
   annotations:
     traffic.sidecar.istio.io/excludeOutboundPorts: "443"
-  podSecurityContext:
-    runAsGroup: 999
-    runAsNonRoot: true
-    runAsUser: 1000
-    seccompProfile:
-      type: RuntimeDefault
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
       add: []
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
 metrics:
   serviceMonitor:
     enabled: true

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -38,6 +38,9 @@ var skipPods = map[string][]string{
 		"vmi-system",
 		"weblogic-operator",
 	},
+	"verrazzano-backup": {
+		"restic",
+	},
 }
 
 var skipContainers = []string{"istio-proxy"}
@@ -97,6 +100,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 	t.DescribeTable("Check pod security in system namespaces", testFunc,
 		Entry("Checking pod security in verrazzano-install", "verrazzano-install"),
 		Entry("Checking pod security in verrazzano-system", "verrazzano-system"),
+		Entry("Checking pod security in verrazzano-backup", "verrazzano-backup"),
 	)
 })
 


### PR DESCRIPTION
- Enable pod sec as per https://kubernetes.io/docs/concepts/security/pod-security-standards/ for velero and restic pods. 
- Update pod sec tests for velero
- Remove prometheus dependency from velero install
