### PR TITLE
Exclude mysql in verrazzano-install namespace from pod security check

### DIFF
--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -30,7 +30,9 @@ const (
 )
 
 var skipPods = map[string][]string{
-	"verrazzano-install": {},
+	"verrazzano-install": {
+		"mysql",
+	},
 	"verrazzano-system": {
 		"coherence-operator",
 		"fluentd",


### PR DESCRIPTION
When USE_DB_FOR_GRAFANA is enabled in the KIND ATs, an instance of MySQL is installed in the `verrazzano-install` namespace.  This is causing the `verify-install/security` tests to fail as that deployment does not have the expected security settings on the MySQL container.

This PR will add an exclusion for the "external" MySQL DB for the test for now, and we will examine a follow-up PR to put the MySQL DB in another namespace.