### PR TITLE
removed GitHub action step to enable auto merge

### DIFF
--- a/.github/workflows/upstream-pull-request.yml
+++ b/.github/workflows/upstream-pull-request.yml
@@ -27,13 +27,3 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Approve PR
-        run: gh pr review --approve "${{ env.PR_URL }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable Automatic Merge
-        run: gh pr merge --auto --squash "${{ env.PR_URL }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-pull-request.yml
+++ b/.github/workflows/upstream-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Open PR to main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - name: Create Pull Request
@@ -25,5 +25,15 @@ jobs:
             -b "*Automated Pull Request*  Updating Rancher image in BOM for ${{ github.ref }}" \
             -r "ddsharpe,robertpatrick"
           echo 'EOF' >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        run: gh pr review --approve "${{ env.PR_URL }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable Automatic Merge
+        run: gh pr merge --auto --squash "${{ env.PR_URL }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-pull-request.yml
+++ b/.github/workflows/upstream-pull-request.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: Upstream-Pull-Request-For-Rancher
 

--- a/.github/workflows/upstream-pull-request.yml
+++ b/.github/workflows/upstream-pull-request.yml
@@ -27,8 +27,3 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable Automatic Merge
-        run: gh pr merge --auto --squash "${{ env.PR_URL }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub workflow step to enable auto merge is failing due to user permissions with the workflow user.  This change is a short term fix to remove auto-merge from the workflow until there is time to research and correct the user permission for the workflow.
