### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: saturday


### PR DESCRIPTION
Based on a conversation with Mike G. and others, suggesting this PR to enable Dependabot. I have it set to run each Saturday so that any automatic tests for PR's created by Dependabot would not use compute resources during the work week.

Dependabot will detect and create PR's for any available dependency update. We are still responsible for license validation prior to merging a PR. Nothing in this change will automatically merge dependency updates.

