### PR TITLE
VZ-8100 - use system health dashboard for upgrade testing of Grafana dashboards, instead of the removed host metrics dashboard

### DIFF
--- a/tests/e2e/grafana-db/grafana_test.go
+++ b/tests/e2e/grafana-db/grafana_test.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,7 +91,7 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 	// WHEN a GET call is made  to Grafana with the system dashboard UID,
 	// THEN the dashboard metadata of the corresponding testDashboard is returned.
 	It("Get details of the system Grafana Dashboard", func() {
-		pkg.TestSystemGrafanaDashboard(pollingInterval, waitTimeout)
+		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 	})
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
@@ -154,7 +155,7 @@ var _ = t.Describe("Test Grafana Dashboard Persistence", Label("f:observability.
 	// WHEN a GET call is made  to Grafana with the UID of the system dashboard,
 	// THEN the dashboard metadata of the corresponding System dashboard is returned.
 	It("Get details of the system Grafana dashboard", func() {
-		pkg.TestSystemGrafanaDashboard(pollingInterval, waitTimeout)
+		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 	})
 
 	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/grafana-db/grafana_test.go
+++ b/tests/e2e/grafana-db/grafana_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafanadb

--- a/tests/e2e/pkg/grafana.go
+++ b/tests/e2e/pkg/grafana.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/pkg/grafana.go
+++ b/tests/e2e/pkg/grafana.go
@@ -7,20 +7,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+
+	"net/http"
+	"strings"
 
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"strings"
 )
 
 const (
-	grafanaErrMsgFmt         = "Failed to GET Grafana testDashboard: status=%d: body=%s"
-	testDashboardTitle       = "E2ETestDashboard"
-	systemDashboardTitle     = "Host Metrics"
-	openSearchMetricsDbTitle = "OpenSearch Summary Dashboard"
+	grafanaErrMsgFmt           = "Failed to GET Grafana testDashboard: status=%d: body=%s"
+	testDashboardTitle         = "E2ETestDashboard"
+	systemHealthDashboardTitle = "System Health"
+	openSearchMetricsDbTitle   = "OpenSearch Summary Dashboard"
 )
 
 type DashboardMetadata struct {
@@ -160,9 +162,9 @@ func TestOpenSearchGrafanaDashBoard(pollingInterval time.Duration, timeout time.
 	}).WithPolling(pollingInterval).WithTimeout(timeout).Should(gomega.BeTrue())
 }
 
-func TestSystemGrafanaDashboard(pollingInterval time.Duration, timeout time.Duration) {
-	// UID of system testDashboard, which is created by the VMO on startup.
-	uid := "H0xWYyyik"
+func TestSystemHealthGrafanaDashboard(pollingInterval time.Duration, timeout time.Duration) {
+	// UID of system health dashboard, which is created by the VMO on startup.
+	uid := "Q4BkmcOVk"
 	gomega.Eventually(func() bool {
 		resp, err := GetGrafanaDashboard(uid)
 		if err != nil {
@@ -175,7 +177,7 @@ func TestSystemGrafanaDashboard(pollingInterval time.Duration, timeout time.Dura
 		}
 		body := make(map[string]map[string]string)
 		json.Unmarshal(resp.Body, &body)
-		return strings.Contains(body["dashboard"]["title"], systemDashboardTitle)
+		return strings.Contains(body["dashboard"]["title"], systemHealthDashboardTitle)
 	}).WithPolling(pollingInterval).WithTimeout(timeout).Should(gomega.BeTrue())
 }
 

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -48,9 +48,10 @@ var _ = t.Describe("Post Upgrade Grafana Dashboard", Label("f:observability.logg
 	// WHEN a GET call is made  to Grafana with the UID of the system dashboard,
 	// THEN the dashboard metadata of the corresponding System dashboard is returned.
 	t.It("Get details of the system Grafana dashboard", func() {
-		kubeConfigPath, err := pkg.GetKubeConfigLocation()
+		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 		Expect(err).To(BeNil(), fmt.Sprintf(pkg.KubeConfigErrorFmt, err))
-		systemHealthDashboardExists := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+		systemHealthDashboardExists, err := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+                Expect(err).To(BeNil(), fmt.Sprintf("could not find verrazzzano min version: %v", err))
 		if systemHealthDashboardExists {
 			pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 		}

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -49,6 +47,12 @@ var _ = t.Describe("Post Upgrade Grafana Dashboard", Label("f:observability.logg
 	// WHEN a GET call is made  to Grafana with the UID of the system dashboard,
 	// THEN the dashboard metadata of the corresponding System dashboard is returned.
 	t.It("Get details of the system Grafana dashboard", func() {
+		kubeConfigPath, err := pkg.GetKubeConfigLocation()
+		Expect(err).To(BeNil(), fmt.Sprintf(pkg.KubeConfigErrorFmt, err))
+		systemHealthDashboardExists := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+		if systemHealthDashboardExists {
+			pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
+		}
 		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 	})
 

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -8,7 +8,8 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-
+        . "github.com/onsi/ginkgo/v2"
+        . "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-        . "github.com/onsi/ginkgo/v2"
-        . "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -51,7 +51,7 @@ var _ = t.Describe("Post Upgrade Grafana Dashboard", Label("f:observability.logg
 		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 		Expect(err).To(BeNil(), fmt.Sprintf(pkg.KubeConfigErrorFmt, err))
 		systemHealthDashboardExists, err := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
-                Expect(err).To(BeNil(), fmt.Sprintf("could not find verrazzzano min version: %v", err))
+		Expect(err).To(BeNil(), fmt.Sprintf("could not find verrazzzano min version: %v", err))
 		if systemHealthDashboardExists {
 			pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 		}

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana

--- a/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/post-upgrade/grafana/grafana_test.go
@@ -5,8 +5,9 @@ package grafana
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,7 +49,7 @@ var _ = t.Describe("Post Upgrade Grafana Dashboard", Label("f:observability.logg
 	// WHEN a GET call is made  to Grafana with the UID of the system dashboard,
 	// THEN the dashboard metadata of the corresponding System dashboard is returned.
 	t.It("Get details of the system Grafana dashboard", func() {
-		pkg.TestSystemGrafanaDashboard(pollingInterval, waitTimeout)
+		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 	})
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -6,10 +6,11 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,7 +86,7 @@ var _ = t.Describe("Pre Upgrade Grafana Dashboard", Label("f:observability.loggi
 	// WHEN a GET call is made  to Grafana with the system dashboard UID,
 	// THEN the dashboard metadata of the corresponding testDashboard is returned.
 	t.It("Get details of the system Grafana Dashboard", func() {
-		pkg.TestSystemGrafanaDashboard(pollingInterval, waitTimeout)
+		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 	})
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
@@ -86,7 +85,12 @@ var _ = t.Describe("Pre Upgrade Grafana Dashboard", Label("f:observability.loggi
 	// WHEN a GET call is made  to Grafana with the system dashboard UID,
 	// THEN the dashboard metadata of the corresponding testDashboard is returned.
 	t.It("Get details of the system Grafana Dashboard", func() {
-		pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
+		kubeConfigPath, err := pkg.GetKubeConfigLocation()
+		Expect(err).To(BeNil(), fmt.Sprintf(pkg.KubeConfigErrorFmt, err))
+		systemHealthDashboardExists := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+		if systemHealthDashboardExists {
+			pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
+		}
 	})
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -85,9 +85,10 @@ var _ = t.Describe("Pre Upgrade Grafana Dashboard", Label("f:observability.loggi
 	// WHEN a GET call is made  to Grafana with the system dashboard UID,
 	// THEN the dashboard metadata of the corresponding testDashboard is returned.
 	t.It("Get details of the system Grafana Dashboard", func() {
-		kubeConfigPath, err := pkg.GetKubeConfigLocation()
+		kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 		Expect(err).To(BeNil(), fmt.Sprintf(pkg.KubeConfigErrorFmt, err))
-		systemHealthDashboardExists := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+		systemHealthDashboardExists, err := pkg.IsVerrazzanoMinVersion("1.5.0", kubeConfigPath)
+		Expect(err).To(BeNil(), fmt.Sprintf("could not find verrazzzano min version: %v", err))
 		if systemHealthDashboardExists {
 			pkg.TestSystemHealthGrafanaDashboard(pollingInterval, waitTimeout)
 		}

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-        . "github.com/onsi/ginkgo/v2"
-        . "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )

--- a/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/grafana/grafana_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-
-	. "github.com/onsi/gomega"
+        . "github.com/onsi/ginkgo/v2"
+        . "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )


### PR DESCRIPTION


Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
