### PR TITLE
VZ-8130: fix OpenSearch wait target version

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-monitoring-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-monitoring-operator/values.yaml
@@ -14,7 +14,7 @@ monitoringOperator:
   defaultSimpleCompReplicas: 1
   defaultPrometheusReplicas: 1
   alertManagerImage: "noimage"
-  esWaitTargetVersion: 1.2.3
+  esWaitTargetVersion: 2.3.0
   oidcAuthEnabled: true
   RequestMemory: 48Mi
 


### PR DESCRIPTION
The ESWaitTargetVersion variable is set as an environment variable in VMO container through a helm chart option. This PR is a one liner fix to update the correct wait target version for OpenSearch
