### PR TITLE
VZ-8144 kube state metrics pod security

### DIFF
--- a/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
+++ b/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
@@ -10,3 +10,16 @@ prometheus:
     honorLabels: true
 metricLabelsAllowlist:
   - deployments=[app.oam.dev/name,app.oam.dev/component]
+
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  readOnlyRootFilesystem: true

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -59,7 +59,12 @@ type podExceptions struct {
 }
 
 var exceptionPods = map[string]podExceptions{
-	"node-exporter": {allowHostPath: true},
+	"node-exporter": {
+		allowHostPath:    true,
+		allowHostNetwork: true,
+		allowHostPID:     true,
+		allowHostPort:    true,
+	},
 }
 
 var (

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -52,7 +52,10 @@ var skipContainers = []string{}
 var skipInitContainers = []string{"istio-init"}
 
 type podExceptions struct {
-	allowHostPath bool
+	allowHostPath    bool
+	allowHostNetwork bool
+	allowHostPID     bool
+	allowHostPort    bool
 }
 
 var exceptionPods = map[string]podExceptions{
@@ -121,13 +124,37 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 func expectPodSecurityForNamespace(pod corev1.Pod) []error {
 	var errors []error
 
+	// get pod exceptions
 	isException, exception := isExceptionPod(pod)
+
+	// ensure hostpath is not set unless it is an exception
 	if !isException || !exception.allowHostPath {
-		// ensure hostpath is not set
 		for _, vol := range pod.Spec.Volumes {
 			if vol.HostPath != nil {
 				errors = append(errors, fmt.Errorf("Pod Security not configured for pod %s, HostPath is set, HostPath = %s  Type = %s",
 					pod.Name, vol.HostPath.Path, *vol.HostPath.Type))
+			}
+		}
+	}
+
+	// ensure hostnetwork is not set unless it is an exception
+	if pod.Spec.HostNetwork && (!isException || !exception.allowHostNetwork) {
+		errors = append(errors, fmt.Errorf("Pod Security not configured for pod %s, HostNetwork is set", pod.Name))
+	}
+
+	// ensure hostPID is not set unless it is an exception
+	if pod.Spec.HostPID && (!isException || !exception.allowHostPID) {
+		errors = append(errors, fmt.Errorf("Pod Security not configured for pod %s, HostPID is set", pod.Name))
+	}
+
+	// ensure host port is not set unless it is an exception
+	if !isException || !exception.allowHostPort {
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.HostPort != 0 {
+					errors = append(errors, fmt.Errorf("Pod Security not configured for pod %s, HostPort is set, HostPort = %v",
+						pod.Name, port.HostPort))
+				}
 			}
 		}
 	}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -42,7 +42,6 @@ var skipPods = map[string][]string{
 	},
 	"verrazzano-monitoring": {
 		"node-exporter",
-		"kube-state-metrics",
 		"jaeger",
 	},
 	"verrazzano-backup": {


### PR DESCRIPTION
This change adds pod security for Kube State Metrics and updates the e2e test. This also modifies the tests to include more checks for things like hostNetwork and hostPID.