### PR TITLE
Move release-1.2 provisioning to use the new JAO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -10,7 +10,7 @@ def VERRAZZANO_DEV_VERSION = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 pipeline {
     options {

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 // This is temporary, to experiment with the Git settings in the Jenkins pipelines
@@ -17,7 +17,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_2}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "VM.Standard2.8_1_2"
+            label "1.2-large"
         }
     }
 

--- a/ci/JenkinsfileFlakyTests
+++ b/ci/JenkinsfileFlakyTests
@@ -1,8 +1,8 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def GIT_COMMIT_TO_USE
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 def TESTS_FAILED = false
 def tarfilePrefix="verrazzano_periodic"
 def storeLocation=""

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -1,11 +1,11 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def GIT_COMMIT_TO_USE
 def LAST_CLEAN_PERIODIC_COMMIT
 def VERRAZZANO_DEV_VERSION
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 def TESTS_FAILED = false
 def tarfilePrefix="verrazzano_periodic"
 def storeLocation=""

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -1,7 +1,7 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 pipeline {
     options {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -1,8 +1,8 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 pipeline {
     options {

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 // This runs tests for OCI service integrations
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1" ]

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 // This runs the acceptance tests on an OKE cluster with OCI DNS
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = env.JOB_NAME.contains('-dns-') ? "" : env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1" ]

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -1,11 +1,11 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
 // Pin to PHX for now for testing; tarball is located only in PHX at present, and takes 15+ mins to download to LHR at runtime
 // - at some point, we can either enable bucket replication or have the pipeline push it to more regions
 //def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
-def agentLabel = "phxlarge"
+def agentLabel = "1.2-large-phx"
 def ocirRegion = "phx"
 def ocirRegistry = "${ocirRegion}.ocir.io"
 def imageRepoSubPath=""

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -1,9 +1,9 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 
 pipeline {
     options {

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 pipeline {
@@ -11,7 +11,7 @@ pipeline {
        docker {
             image "${RUNNER_DOCKER_IMAGE_1_2}"
             args "${RUNNER_DOCKER_ARGS_1_2}"
-            label "VM.Standard2.8_1_2"
+            label "1.2-large"
             registryCredentialsId 'ocir-pull-and-push-account'
         }
     }

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -1,8 +1,8 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge_1_2" : "VM.Standard2.8_1_2"
+def agentLabel = "1.2-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {


### PR DESCRIPTION
We are moving our Jenkins runner provisioning to be handled by the Jenkins Agent Operator now instead of the Jenkins OCI plugin.

The new labels are ones that the PRODUCTION JAO is handling.

This will address the need for manually provisioning instances for older release lines and other cases, and will make managing out cloud instance configurations much easier overall (and easier to automate)
