### PR TITLE
Disable cron schedule for release-1.2 periodics

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def GIT_COMMIT_TO_USE

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -621,11 +621,7 @@ def isPagerDutyEnabled() {
 }
 
 def getCronSchedule() {
-    if (env.BRANCH_NAME.equals("master")) {
-        return "H */2 * * *"
-    } else if (env.BRANCH_NAME.startsWith("release-1")) {
-        return "@daily"
-    }
+    // This release and previous releases are no longer actively supported not running periodically
     return ""
 }
 


### PR DESCRIPTION
Disable the release 1.2 periodics, these no longer will pass due to old OKE versions and we are not supporting 1.2 (use 1.3, 1.4)
