### PR TITLE
Topic argocd e2e tests

### DIFF
--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -310,6 +310,7 @@ pipeline {
                             yq -i eval '.spec.components.grafana.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.console.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/vz-update1.yaml
+                            yq -i eval '.spec.components.argoCd.enabled = true' ${WORKSPACE}/vz-update1.yaml
                         """
                         script {
                             if(params.CRD_API_VERSION == "v1alpha1"){

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -470,6 +470,14 @@ pipeline {
                                         runGinkgoKeepGoing('examples/helidon')
                                     }
                                 }
+                                stage('argocd helidon deploy') {
+                                    environment {
+                                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-argocd-helidon"
+                                    }
+                                    steps {
+                                        runGinkgoKeepGoing('examples/argocd-helidon')
+                                    }
+                                }
                                 stage('weblogic workload') {
                                     environment {
                                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-workload"

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -88,6 +88,7 @@ yq eval -i '.spec.components.prometheusPushgateway.enabled = true' ${INSTALL_CON
 yq eval -i '.spec.components.velero.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.rancherBackup.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.jaegerOperator.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+yq eval -i '.spec.components.argoCd.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 
 # Configure the custom resource to install Verrazzano on Kind
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -74,6 +74,9 @@ const IngressNamespace = "ingress-nginx"
 // and its related components.
 const PrometheusOperatorNamespace = "verrazzano-monitoring"
 
+// ArgoCDNamespace - the Argocd namespace
+const ArgoCDNamespace = "argocd"
+
 // LabelIstioInjection - constant for a Kubernetes label that is applied by Verrazzano
 const LabelIstioInjection = "istio-injection"
 

--- a/tests/e2e/config/scripts/hello-helidon-argocd-application.yaml
+++ b/tests/e2e/config/scripts/hello-helidon-argocd-application.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app1
+  namespace: argocd
+spec:
+  destination:
+    name: ''
+    namespace: argocd-helidon
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: 'examples/hello-helidon'
+    repoURL: 'https://github.com/verrazzano/verrazzano'
+    targetRevision: master
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+
+

--- a/tests/e2e/examples/argocd-helidon/argocd_helidon_suite_test.go
+++ b/tests/e2e/examples/argocd-helidon/argocd_helidon_suite_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var skipDeploy bool
-var skipUndeploy bool
 var namespace string
 var skipVerify bool
 

--- a/tests/e2e/examples/argocd-helidon/argocd_helidon_suite_test.go
+++ b/tests/e2e/examples/argocd-helidon/argocd_helidon_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package argocd
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+var skipDeploy bool
+var skipUndeploy bool
+var namespace string
+var skipVerify bool
+
+func init() {
+	flag.BoolVar(&skipDeploy, "skipDeploy", false, "skipDeploy skips the call to install the application")
+	flag.StringVar(&namespace, "namespace", argoCdHelidon, "namespace is the app namespace")
+	flag.BoolVar(&skipVerify, "skipVerify", false, "skipVerify skips the post deployment app validations")
+}
+
+func TestArgoCDHelidonExample(test *testing.T) {
+	t.RegisterFailHandler()
+	ginkgo.RunSpecs(test, "Argo CD Hello Helidon Suite")
+}

--- a/tests/e2e/examples/argocd-helidon/argocd_helidon_test.go
+++ b/tests/e2e/examples/argocd-helidon/argocd_helidon_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package argocd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	dump "github.com/verrazzano/verrazzano/tests/e2e/pkg/test/clusterdump"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	longWaitTimeout            = 20 * time.Minute
+	longPollingInterval        = 20 * time.Second
+	shortPollingInterval       = 10 * time.Second
+	shortWaitTimeout           = 5 * time.Minute
+	imagePullWaitTimeout       = 40 * time.Minute
+	imagePullPollingInterval   = 30 * time.Second
+	skipVerifications          = "Skip Verifications"
+	argoCdHelidon              = "argocd-helidon"
+	nodeExporterJobName        = "node-exporter"
+	helloHelidonDeploymentName = "hello-helidon-deployment"
+)
+
+var (
+	t = framework.NewTestFramework("argocd")
+	// yamlApplier              = k8sutil.YAMLApplier{}
+	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
+)
+
+var beforeSuite = t.BeforeSuiteFunc(func() {
+	if !skipDeploy {
+		start := time.Now()
+		pkg.CreateArgoCDGitApplication()
+		metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
+
+		Eventually(func() bool {
+			return pkg.ContainerImagePullWait(namespace, expectedPodsHelloHelidon)
+		}, imagePullWaitTimeout, imagePullPollingInterval).Should(BeTrue())
+	}
+
+	// Verify hello-helidon-deployment pod is running
+	// GIVEN OAM hello-helidon app is deployed
+	// WHEN the component and appconfig are created
+	// THEN the expected pod must be running in the test namespace
+	if !skipVerify {
+		Eventually(helloHelidonPodsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
+	}
+	beforeSuitePassed = true
+})
+
+var _ = BeforeSuite(beforeSuite)
+
+var failed = false
+var beforeSuitePassed = false
+
+var _ = t.AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var afterSuite = t.AfterSuiteFunc(func() {
+	if failed || !beforeSuitePassed {
+		dump.ExecuteBugReport(namespace)
+	}
+})
+
+var _ = t.Describe("Argo CD Helidon Suite", Label("f:app-lcm.oam",
+	"f:app-lcm.helidon-workload"), func() {
+	var host = ""
+	var err error
+	// Get the host from the Istio gateway resource.
+	// GIVEN the Istio gateway for the hello-helidon namespace
+	// WHEN GetHostnameFromGateway is called
+	// THEN return the host name found in the gateway.
+	t.BeforeEach(func() {
+		Eventually(func() (string, error) {
+			host, err = k8sutil.GetHostnameFromGateway(namespace, "")
+			return host, err
+		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()))
+	})
+
+	// Verify Hello Helidon app is working
+	// GIVEN OAM hello-helidon app is deployed
+	// WHEN the component and appconfig with ingress trait are created
+	// THEN the application endpoint must be accessible
+	t.Describe("for Ingress.", Label("f:mesh.ingress"), func() {
+		t.It("Access /greet App Url.", func() {
+			if skipVerify {
+				Skip(skipVerifications)
+			}
+			url := fmt.Sprintf("https://%s/greet", host)
+			Eventually(func() bool {
+				return appEndpointAccessible(url, host)
+			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
+		})
+	})
+})
+
+func helloHelidonPodsRunning() bool {
+	result, err := pkg.PodsRunning(namespace, expectedPodsHelloHelidon)
+	if err != nil {
+		AbortSuite(fmt.Sprintf("One or more pods are not running in the namespace: %v, error: %v", namespace, err))
+	}
+	return result
+}
+
+func appEndpointAccessible(url string, hostname string) bool {
+	req, err := retryablehttp.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while creating new request=%v", err)
+		return false
+	}
+
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while getting kubeconfig location=%v", err)
+		return false
+	}
+
+	httpClient, err := pkg.GetVerrazzanoHTTPClient(kubeconfigPath)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while getting new httpClient=%v", err)
+		return false
+	}
+	req.Host = hostname
+	req.Close = true
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logs.Errorf("Unexpected error while making http request=%v", err)
+		if resp != nil && resp.Body != nil {
+			bodyRaw, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Logs.Errorf("Unexpected error while marshallling error response=%v", err)
+				return false
+			}
+
+			t.Logs.Errorf("Error Response=%v", string(bodyRaw))
+			resp.Body.Close()
+		}
+		return false
+	}
+
+	bodyRaw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Logs.Errorf("Unexpected error marshallling response=%v", err)
+		return false
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Logs.Errorf("Unexpected status code=%v", resp.StatusCode)
+		return false
+	}
+	// HTTP Server headers should never be returned.
+	for headerName, headerValues := range resp.Header {
+		if strings.EqualFold(headerName, "Server") {
+			t.Logs.Errorf("Unexpected Server header=%v", headerValues)
+			return false
+		}
+	}
+	bodyStr := string(bodyRaw)
+	if !strings.Contains(bodyStr, "Hello World") {
+		t.Logs.Errorf("Unexpected response body=%v", bodyStr)
+		return false
+	}
+	return true
+}

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -47,6 +47,9 @@ func VerifyArgoCDApplicationAccess(log *zap.SugaredLogger) error {
 	var err error
 
 	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		return err
+	}
 	argocdAdminPassword, err := eventuallyGetArgocdAdminPassword(log)
 	if err != nil {
 		return err

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -39,6 +39,9 @@ func VerifyArgocdApplicationAccess(log *zap.SugaredLogger, kubeConfigPath string
 	var err error
 
 	argocdAdminPassword, err := eventuallyGetArgocdAdminPassword(log)
+	if err != nil {
+		return err
+	}
 	httpClient, err := GetVerrazzanoHTTPClient(kubeConfigPath)
 	if err != nil {
 		log.Error(fmt.Sprintf("Error getting argocd admin password: %v", err))

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -95,7 +94,6 @@ func eventuallyGetArgocdAdminPassword(log *zap.SugaredLogger) (string, error) {
 func getArgoCDUserToken(log *zap.SugaredLogger, argoCDURL string, username string, password string, httpClient *retryablehttp.Client) (string, error) {
 	argoCDLoginURL := fmt.Sprintf("%s/%s", argoCDURL, "api/v1/session")
 	payload := `{"Username": "` + username + `", "Password": "` + password + `"}`
-	//http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	response, err := httpClient.Post(argoCDLoginURL, "application/json", strings.NewReader(payload))
 	if err != nil {
 		log.Error(fmt.Sprintf("Error getting argocd admin token: %v", err))
@@ -124,25 +122,6 @@ func getArgoCDUserToken(log *zap.SugaredLogger, argoCDURL string, username strin
 	}
 
 	return token, nil
-}
-
-// GetArgoCDURL fetches the Argocd URL from the cluster
-func GetArgoCDURL(log *zap.SugaredLogger) (string, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		log.Errorf("Failed to get kubeconfigPath with error: %v", err)
-		return "", err
-	}
-	api, err := GetAPIEndpoint(kubeconfigPath)
-	if err != nil {
-		log.Errorf("Unable to fetch api endpoint due to %v", zap.Error(err))
-		return "", err
-	}
-	ingress, err := api.GetIngress("argocd", "argocd-server")
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host), nil
 }
 
 func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token string) (bool, error) {

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/httputil"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// VerifyArgoCDAccess verifies that Argocd is accessible.
+func VerifyArgoCDAccess(log *zap.SugaredLogger, kubeconfigPath string) error {
+	var err error
+
+	api := EventuallyGetAPIEndpoint(kubeconfigPath)
+	argocdURL := EventuallyGetURLForIngress(log, api, "argocd", "argocd-server", "https")
+	httpClient := EventuallyVerrazzanoRetryableHTTPClient()
+	var httpResponse *HTTPResponse
+
+	gomega.Eventually(func() (*HTTPResponse, error) {
+		httpResponse, err = GetWebPageWithClient(httpClient, argocdURL, "")
+		return httpResponse, err
+	}, waitTimeout, pollingInterval).Should(HasStatus(http.StatusOK))
+
+	gomega.Expect(CheckNoServerHeader(httpResponse)).To(gomega.BeTrue(), "Found unexpected server header in response")
+	return nil
+}
+
+func VerifyArgocdApplicationAccess(log *zap.SugaredLogger, kubeConfigPath string) error {
+	var err error
+
+	argocdAdminPassword, err := eventuallyGetArgocdAdminPassword(log)
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting argocd admin password: %v", err))
+		return err
+	}
+
+	api := EventuallyGetAPIEndpoint(kubeConfigPath)
+	argocdURL := EventuallyGetURLForIngress(log, api, "argocd", "argocd-server", "https")
+
+	token, err := getArgoCDUserToken(log, argocdURL, "admin", string(argocdAdminPassword))
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting user token from Argocd: %v", err))
+		return err
+	}
+	var emptyList bool
+	gomega.Eventually(func() (bool, error) {
+		contains, err := GetApplicationsWithClient(log, argocdURL, token)
+		emptyList = contains
+		return emptyList, err
+	}, waitTimeout, pollingInterval).Should(gomega.BeTrue())
+
+	gomega.Expect(emptyList).To(gomega.BeTrue(), "Argocd UI is accessible and no applications are deployed")
+	return nil
+}
+
+func eventuallyGetArgocdAdminPassword(log *zap.SugaredLogger) (string, error) {
+	var err error
+	var secret *corev1.Secret
+	gomega.Eventually(func() error {
+		secret, err = GetSecret("argocd", "argocd-initial-admin-secret")
+		if err != nil {
+			log.Error(fmt.Sprintf("Error getting argocd-initial-admin-secret, retrying: %v", err))
+		}
+		return err
+	}, waitTimeout, pollingInterval).Should(gomega.BeNil())
+
+	if secret == nil {
+		return "", fmt.Errorf("Unable to get argocd admin secret")
+	}
+
+	var argocdAdminPassword []byte
+	var ok bool
+	if argocdAdminPassword, ok = secret.Data["password"]; !ok {
+		return "", fmt.Errorf("Error getting argocd admin credentials")
+	}
+
+	return string(argocdAdminPassword), nil
+}
+
+func getArgoCDUserToken(log *zap.SugaredLogger, argoCDURL string, username string, password string) (string, error) {
+	argoCDLoginURL := fmt.Sprintf("%s/%s", argoCDURL, "api/v1/session")
+	payload := `{"Username": "` + username + `", "Password": "` + password + `"}`
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	response, err := http.Post(argoCDLoginURL, "application/json", strings.NewReader(payload))
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting argocd admin token: %v", err))
+		return "", err
+	}
+
+	err = httputil.ValidateResponseCode(response, http.StatusOK)
+	if err != nil {
+		log.Errorf("Invalid response code when fetching argocd token: %v", err)
+		return "", err
+	}
+
+	defer response.Body.Close()
+
+	// extract the response body
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Errorf("Failed to read argocd token response: %v", err)
+		return "", err
+	}
+
+	token, err := httputil.ExtractFieldFromResponseBodyOrReturnError(string(body), "token", "unable to find token in Argocd response")
+	if err != nil {
+		log.Errorf("Failed to extra token from argocd response: %v", err)
+		return "", err
+	}
+
+	return token, nil
+}
+
+// GetArgoCDURL fetches the Argocd URL from the cluster
+func GetArgoCDURL(log *zap.SugaredLogger) (string, error) {
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		log.Errorf("Failed to get kubeconfigPath with error: %v", err)
+		return "", err
+	}
+	api, err := GetAPIEndpoint(kubeconfigPath)
+	if err != nil {
+		log.Errorf("Unable to fetch api endpoint due to %v", zap.Error(err))
+		return "", err
+	}
+	ingress, err := api.GetIngress("argocd", "argocd-server")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host), nil
+}
+
+func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token string) (bool, error) {
+	argoCDLoginURL := fmt.Sprintf("%s/%s", argoCDURL, "api/v1/applications")
+	client := &http.Client{}
+	var bearer = "Bearer " + token
+
+	//http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	req, err := http.NewRequest("GET", argoCDLoginURL, nil)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Add("Authorization", bearer)
+	response, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	err = httputil.ValidateResponseCode(response, http.StatusOK)
+	if err != nil {
+		log.Errorf("Invalid response code when fetching argocd token: %v", err)
+		return false, err
+	}
+
+	defer response.Body.Close()
+
+	// extract the response body
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Errorf("Failed to read argocd  response: %v", err)
+		return false, err
+	}
+
+	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(string(body), "metadata", "unable to find metadata in Argocd response")
+	if err != nil {
+		log.Errorf("Failed to extract token from argocd response: %v", err)
+		return false, err
+	}
+
+	exists := strings.Contains(token, "resourceVersion")
+	return exists, nil
+
+}

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -150,8 +150,7 @@ func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token s
 	client := &http.Client{}
 	var bearer = "Bearer " + token
 
-	//nosec
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} /* #nosec G402 */
 	req, err := http.NewRequest("GET", argoCDLoginURL, nil)
 	if err != nil {
 		return false, err

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -135,6 +135,7 @@ func getArgoCDUserToken(log *zap.SugaredLogger, argoCDURL string, username strin
 	return token, nil
 }
 
+// GetApplicationsWithClient returns true if the user is able to access the applications page post Argo CD install
 func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token string) (bool, error) {
 	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
 	if err != nil {
@@ -187,9 +188,7 @@ func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token s
 
 }
 
-// CreateArgoCDGitApplication Creates a Fake Git Repo
-// Adds the Hello Helidon component and application files to the Git repo
-// Commits the changes to the repo
+// CreateArgoCDGitApplication creates an application in Argo CD by conencting to the Git repo
 // Applies the Argo CD Application to the kubernetes cluster
 func CreateArgoCDGitApplication() error {
 	Log(Info, "Create Argo CD Application Project")

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -4,6 +4,7 @@
 package pkg
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -149,7 +150,7 @@ func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token s
 	client := &http.Client{}
 	var bearer = "Bearer " + token
 
-	//http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	req, err := http.NewRequest("GET", argoCDLoginURL, nil)
 	if err != nil {
 		return false, err

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,7 @@ func VerifyArgoCDAccess(log *zap.SugaredLogger, kubeconfigPath string) error {
 	var err error
 
 	api := EventuallyGetAPIEndpoint(kubeconfigPath)
-	argocdURL := EventuallyGetURLForIngress(log, api, "argocd", "argocd-server", "https")
+	argocdURL := EventuallyGetURLForIngress(log, api, constants.ArgoCDNamespace, "argocd-server", "https")
 	httpClient := EventuallyVerrazzanoRetryableHTTPClient()
 	var httpResponse *HTTPResponse
 
@@ -49,7 +50,7 @@ func VerifyArgocdApplicationAccess(log *zap.SugaredLogger, kubeConfigPath string
 	}
 
 	api := EventuallyGetAPIEndpoint(kubeConfigPath)
-	argocdURL := EventuallyGetURLForIngress(log, api, "argocd", "argocd-server", "https")
+	argocdURL := EventuallyGetURLForIngress(log, api, constants.ArgoCDNamespace, "argocd-server", "https")
 
 	token, err := getArgoCDUserToken(log, argocdURL, "admin", string(argocdAdminPassword), httpClient)
 	if err != nil {
@@ -71,7 +72,7 @@ func eventuallyGetArgocdAdminPassword(log *zap.SugaredLogger) (string, error) {
 	var err error
 	var secret *corev1.Secret
 	gomega.Eventually(func() error {
-		secret, err = GetSecret("argocd", "argocd-initial-admin-secret")
+		secret, err = GetSecret(constants.ArgoCDNamespace, "argocd-initial-admin-secret")
 		if err != nil {
 			log.Error(fmt.Sprintf("Error getting argocd-initial-admin-secret, retrying: %v", err))
 		}

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -140,7 +140,7 @@ func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token s
 	if err != nil {
 		return false, err
 	}
-	
+
 	httpClient, err := GetVerrazzanoHTTPClient(kubeConfigPath)
 	if err != nil {
 		log.Error(fmt.Sprintf("Error getting argocd admin password: %v", err))

--- a/tests/e2e/pkg/argocd.go
+++ b/tests/e2e/pkg/argocd.go
@@ -150,6 +150,7 @@ func GetApplicationsWithClient(log *zap.SugaredLogger, argoCDURL string, token s
 	client := &http.Client{}
 	var bearer = "Bearer " + token
 
+	//nosec
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	req, err := http.NewRequest("GET", argoCDLoginURL, nil)
 	if err != nil {

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -915,6 +915,19 @@ func IsRancherBackupEnabled(kubeconfigPath string) bool {
 	return *vz.Spec.Components.RancherBackup.Enabled
 }
 
+// IsArgoCDEnabled returns false if the Argocd component is not set, or the value of its Enabled field otherwise
+func IsArgoCDEnabled(kubeconfigPath string) bool {
+	vz, err := GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error Verrazzano Resource: %v", err))
+		return false
+	}
+	if vz.Spec.Components.ArgoCD == nil || vz.Spec.Components.ArgoCD.Enabled == nil {
+		return false
+	}
+	return *vz.Spec.Components.ArgoCD.Enabled
+}
+
 // APIExtensionsClientSet returns a Kubernetes ClientSet for this cluster.
 func APIExtensionsClientSet() (*apiextv1.ApiextensionsV1Client, error) {
 	config, err := k8sutil.GetKubeConfig()

--- a/tests/e2e/registry/registry_test.go
+++ b/tests/e2e/registry/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package registry
@@ -49,6 +49,7 @@ var listOfNamespaces = []string{
 	"monitoring",
 	"verrazzano-install",
 	"verrazzano-mc",
+	"argocd",
 	constants.VerrazzanoSystemNamespace,
 	constants.VerrazzanoMonitoringNamespace,
 }

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -101,6 +101,9 @@ func getConsoleURLsFromResource(kubeconfig string) ([]string, error) {
 	if vz.Status.VerrazzanoInstance.JaegerURL != nil {
 		consoleUrls = append(consoleUrls, *vz.Status.VerrazzanoInstance.JaegerURL)
 	}
+	if vz.Status.VerrazzanoInstance.ArgoCDURL != nil {
+		consoleUrls = append(consoleUrls, *vz.Status.VerrazzanoInstance.ArgoCDURL)
+	}
 
 	return consoleUrls, nil
 }

--- a/tests/e2e/verify-infra/restapi/argocd_url_test.go
+++ b/tests/e2e/verify-infra/restapi/argocd_url_test.go
@@ -22,28 +22,29 @@ var _ = t.Describe("argocd", Label("f:infra-lcm",
 				t.Logs.Error(fmt.Sprintf("Error getting kubeconfig: %v", err))
 				t.Fail(err.Error())
 			}
+
 			if pkg.IsArgoCDEnabled(kubeconfigPath) {
-
-				start := time.Now()
-				err = pkg.VerifyArgoCDAccess(t.Logs, kubeconfigPath)
-				if err != nil {
-					t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
-					t.Fail(err.Error())
-				}
-
-				metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
-
-				start = time.Now()
-				t.Logs.Info("Accessing the Argocd Applications")
-				err = pkg.VerifyArgocdApplicationAccess(t.Logs, kubeconfigPath)
-				if err != nil {
-					t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
-					t.Fail(err.Error())
-				}
-
-				metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
-
+				Skip("Skipping Argo CD access test as Argo CD is not enabled.")
 			}
+
+			start := time.Now()
+			err = pkg.VerifyArgoCDAccess(t.Logs, kubeconfigPath)
+			if err != nil {
+				t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
+				t.Fail(err.Error())
+			}
+
+			metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
+
+			start = time.Now()
+			t.Logs.Info("Accessing the Argocd Applications")
+			err = pkg.VerifyArgocdApplicationAccess(t.Logs, kubeconfigPath)
+			if err != nil {
+				t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
+				t.Fail(err.Error())
+			}
+
+			metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
 
 		})
 	})

--- a/tests/e2e/verify-infra/restapi/argocd_url_test.go
+++ b/tests/e2e/verify-infra/restapi/argocd_url_test.go
@@ -8,27 +8,32 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 )
 
-var _ = t.Describe("argocd", Label("f:infra-lcm",
+var _ = t.Describe("Argo CD", Label("f:infra-lcm",
 	"f:ui.console"), func() {
-	t.Context("test to", func() {
-		t.It("Verify argocd access and configuration", func() {
-			kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-			if err != nil {
-				t.Logs.Error(fmt.Sprintf("Error getting kubeconfig: %v", err))
-				t.Fail(err.Error())
-			}
 
-			if pkg.IsArgoCDEnabled(kubeconfigPath) {
-				Skip("Skipping Argo CD access test as Argo CD is not enabled.")
-			}
+	t.BeforeEach(func() {
+		var err error
+		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+		Expect(err).ShouldNot(HaveOccurred())
 
+		//Skip the test if Argo CD is disabled
+		if !pkg.IsArgoCDEnabled(kubeconfigPath) {
+			Skip("Skipping Argo CD access test as Argo CD is not enabled.")
+		}
+
+	})
+
+	t.Context("is enabled", func() {
+		t.It("Web URL and the applications page is accessible", func() {
 			start := time.Now()
-			err = pkg.VerifyArgoCDAccess(t.Logs, kubeconfigPath)
+			// Verifying if the Argo CD Ingress URL is accessible
+			err := pkg.VerifyArgoCDAccess(t.Logs)
 			if err != nil {
 				t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
 				t.Fail(err.Error())
@@ -38,9 +43,10 @@ var _ = t.Describe("argocd", Label("f:infra-lcm",
 
 			start = time.Now()
 			t.Logs.Info("Accessing the Argocd Applications")
-			err = pkg.VerifyArgocdApplicationAccess(t.Logs, kubeconfigPath)
+			//Verifying if the Applications page is accessible after login
+			err = pkg.VerifyArgoCDApplicationAccess(t.Logs)
 			if err != nil {
-				t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
+				t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd application: %v", err))
 				t.Fail(err.Error())
 			}
 

--- a/tests/e2e/verify-infra/restapi/argocd_url_test.go
+++ b/tests/e2e/verify-infra/restapi/argocd_url_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package restapi_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
+)
+
+var _ = t.Describe("argocd", Label("f:infra-lcm",
+	"f:ui.console"), func() {
+	t.Context("test to", func() {
+		t.It("Verify argocd access and configuration", func() {
+			kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+			if err != nil {
+				t.Logs.Error(fmt.Sprintf("Error getting kubeconfig: %v", err))
+				t.Fail(err.Error())
+			}
+			if pkg.IsArgoCDEnabled(kubeconfigPath) {
+
+				start := time.Now()
+				err = pkg.VerifyArgoCDAccess(t.Logs, kubeconfigPath)
+				if err != nil {
+					t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
+					t.Fail(err.Error())
+				}
+
+				metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
+
+				start = time.Now()
+				t.Logs.Info("Accessing the Argocd Applications")
+				err = pkg.VerifyArgocdApplicationAccess(t.Logs, kubeconfigPath)
+				if err != nil {
+					t.Logs.Error(fmt.Sprintf("Error verifying access to Argocd: %v", err))
+					t.Fail(err.Error())
+				}
+
+				metrics.Emit(t.Metrics.With("argocd_access_elapsed_time", time.Since(start).Milliseconds()))
+
+			}
+
+		})
+	})
+})

--- a/tests/e2e/verify-install/bom-validator/bom_validator_test.go
+++ b/tests/e2e/verify-install/bom-validator/bom_validator_test.go
@@ -83,6 +83,7 @@ var allowedNamespaces = []string{
 	"^keycloak",
 	"^monitoring",
 	"^verrazzano-*",
+	"^argocd",
 }
 
 var vBom verrazzanoBom                                  // BOM from platform operator in struct form

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -581,12 +581,12 @@ func verifyArgoCDClientURIs(keycloakClient *Client, env string) bool {
 		return false
 	}
 
-	// Verify rancher redirectUI
+	// Verify Argo CD redirectUI
 	if !verifyURIs(keycloakClient.RedirectUris, argocdURI+env, 1) {
 		t.Logs.Error(fmt.Printf("Expected 1 ArgoCD redirect URIs. Found %+v\n", keycloakClient.RedirectUris))
 		return false
 	}
-	// Verify rancher web origin
+	// Verify Argo CD web origin
 	if !verifyURIs(keycloakClient.WebOrigins, argocdURI+env, 1) {
 		t.Logs.Error(fmt.Printf("Expected 1 ArgoCD weborigin URIs. Found %+v\n", keycloakClient.RedirectUris))
 		return false

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package keycloak

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verrazzano_test

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -861,9 +861,8 @@ func validateArgoCDResources() {
 	var err error
 
 	if argocdEnabled {
-		var pods []corev1.Pod
-
 		Eventually(func() bool {
+			var pods []corev1.Pod
 			pods, err = pkg.GetPodsFromSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/instance": "argocd"}}, constants.ArgoCDNamespace)
 			if err != nil {
 				t.Logs.Error("Failed to get Argocd pods: %v", err)

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -870,6 +870,7 @@ func validateArgoCDResources() {
 				return false
 			}
 			if len(pods) < 1 {
+				t.Logs.Error("No pods exist in the Argo CD namespace")
 				return false
 			}
 			return true

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -873,7 +873,7 @@ func validateArgoCDResources() {
 				return false
 			}
 			return true
-		}, waitTimeout, pollingInterval).ShouldNot(BeNil())
+		}, waitTimeout, pollingInterval).Should(BeTrue())
 
 		Eventually(func() (bool, error) {
 			return pkg.DoesStatefulSetExist(constants.ArgoCDNamespace, "argocd-application-controller")


### PR DESCRIPTION
With the Argo CD integrated into verrazzano, we need to add e2e tests for Argo CD verification.
By default, Argo CD is disabled in all profiles, so we are testing for Argo CD in the below 2 tests by explicitly enabling it - 
* Dynamic-update
* Private-registry

