### PR TITLE
VZ-8174: Make mysqlcheck timeout configurable

### DIFF
--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
@@ -290,7 +290,7 @@ func (mc *MySQLChecker) RepairMySQLRouterPodsCrashLoopBackoff() error {
 
 // restartMySQLOperator - restart the MySQL Operator pod
 func restartMySQLOperator(log vzlog.VerrazzanoLogger, client clipkg.Client, reason string) error {
-	log.Info("Restarting the mysql-operator to see if it will repair: %s", reason)
+	log.Infof("Restarting the mysql-operator to see if it will repair: %s", reason)
 
 	operPod, err := getMySQLOperatorPod(log, client)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
@@ -29,7 +29,6 @@ const (
 	componentNamespace       = "keycloak"
 	componentName            = "mysql"
 	mysqlRouterComponentName = "mysqlrouter"
-	repairTimeoutPeriod      = 2 * time.Minute
 )
 
 var (
@@ -118,7 +117,7 @@ func RepairICStuckDeleting(ctx spi.ComponentContext) error {
 	}
 
 	// Initiate repair only if time to wait period has been exceeded
-	expiredTime := getInitialTimeICUninstallChecked().Add(repairTimeoutPeriod)
+	expiredTime := getInitialTimeICUninstallChecked().Add(GetMySQLChecker().RepairTimeout)
 	if time.Now().After(expiredTime) {
 		return restartMySQLOperator(ctx.Log(), ctx.Client(), "InnoDBCluster stuck deleting")
 	}

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds.go
@@ -28,7 +28,7 @@ const (
 	helmReleaseName     = "mysql"
 	componentNamespace  = "keycloak"
 	componentName       = "mysql"
-	repairTimeoutPeriod = 5 * time.Minute
+	repairTimeoutPeriod = 2 * time.Minute
 )
 
 var (
@@ -156,7 +156,7 @@ func (mc *MySQLChecker) RepairMySQLPodsWaitingReadinessGates() error {
 		}
 
 		// Initiate repair only if time to wait period has been exceeded
-		expiredTime := getLastTimeReadinessGateChecked().Add(repairTimeoutPeriod)
+		expiredTime := getLastTimeReadinessGateChecked().Add(mc.RepairTimeout)
 		if time.Now().After(expiredTime) {
 			return restartMySQLOperator(mc.log, mc.client, "MySQL pods waiting for readiness gates")
 		}
@@ -259,7 +259,7 @@ func (mc *MySQLChecker) RepairMySQLPodStuckDeleting() error {
 		}
 
 		// Initiate repair only if time to wait period has been exceeded
-		expiredTime := getInitialTimeMySQLPodsStuckChecked().Add(repairTimeoutPeriod)
+		expiredTime := getInitialTimeMySQLPodsStuckChecked().Add(mc.RepairTimeout)
 		if time.Now().After(expiredTime) {
 			if err := restartMySQLOperator(mc.log, mc.client, "MySQL pods stuck terminating"); err != nil {
 				return err

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds_test.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysql_workarounds_test.go
@@ -25,11 +25,12 @@ import (
 var (
 	testScheme                = runtime.NewScheme()
 	innoDBClusterStatusFields = []string{"status", "cluster", "status"}
+	checkPeriodDuration       = time.Duration(1) * time.Second
+	timeoutDuration           = time.Duration(120) * time.Second
 )
 
 const (
 	innoDBClusterStatusOnline = "ONLINE"
-	MySQLCheckPeriodSeconds   = 1
 )
 
 func init() {
@@ -74,7 +75,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	// Set up the initial context
 	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
 	fakeCtx := spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err := NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err := NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 	assert.True(t, getLastTimeReadinessGateChecked().IsZero())
 
@@ -90,7 +91,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	mySQLPod.Status.Conditions = []v1.PodCondition{{Type: "gate1", Status: v1.ConditionTrue}, {Type: "gate2", Status: v1.ConditionFalse}}
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod, mySQLOperatorPod).Build()
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 
 	// Expect timer to get started when ond of the conditions is not met.  The mysql-operator pod should still exist.
@@ -100,7 +101,7 @@ func TestRepairMySQLPodsWaitingReadinessGates(t *testing.T) {
 	err = cli.Get(context.TODO(), types.NamespacedName{Namespace: mysqloperator.ComponentNamespace, Name: mysqloperator.ComponentName}, &pod)
 	assert.NoError(t, err)
 
-	// Set the last time readiness gate checked to exceed the timeout period.  Expect the mysql-operator to get recycled.
+	// Set the last time readiness gate checked to exceed the RepairTimeout period.  Expect the mysql-operator to get recycled.
 	setInitialTimeReadinessGateChecked(time.Now().Add(-time.Hour * 2))
 	err = mysqlCheck.RepairMySQLPodsWaitingReadinessGates()
 	assert.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
@@ -226,7 +227,7 @@ func TestRepairMySQLPodsStuckTerminating(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod0, mySQLPod1).Build()
 	resetInitialTimeMySQLPodsStuckChecked()
 	fakeCtx := spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err := NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err := NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 
 	err = mysqlCheck.RepairMySQLPodStuckDeleting()
@@ -237,7 +238,7 @@ func TestRepairMySQLPodsStuckTerminating(t *testing.T) {
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLPod0, mySQLPod1, mySQLPod2).Build()
 	resetInitialTimeMySQLPodsStuckChecked()
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 
 	err = mysqlCheck.RepairMySQLPodStuckDeleting()
@@ -248,7 +249,7 @@ func TestRepairMySQLPodsStuckTerminating(t *testing.T) {
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mySQLOperatorPod, mySQLPod0, mySQLPod1, mySQLPod2).Build()
 	setInitialTimeMySQLPodsStuckChecked(time.Now().Add(-time.Hour * 2))
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 
 	err = mysqlCheck.RepairMySQLPodStuckDeleting()
@@ -264,7 +265,7 @@ func TestRepairMySQLPodsStuckTerminating(t *testing.T) {
 	cli = fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
 	resetInitialTimeMySQLPodsStuckChecked()
 	fakeCtx = spi.NewFakeContext(cli, nil, nil, false)
-	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), time.Duration(MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err = NewMySQLChecker(fakeCtx.Client(), checkPeriodDuration, timeoutDuration)
 	assert.NoError(t, err)
 
 	err = mysqlCheck.RepairMySQLPodStuckDeleting()

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker.go
@@ -19,14 +19,15 @@ const (
 // MySQLChecker periodically checks the state of MySQL related pods and repairs
 // any that are found to be in a stuck state (e.g. terminating, waiting for readiness gates).
 type MySQLChecker struct {
-	client   clipkg.Client
-	tickTime time.Duration
-	log      vzlog.VerrazzanoLogger
-	shutdown chan int // The channel on which shutdown signals are sent/received
+	client        clipkg.Client
+	tickTime      time.Duration
+	RepairTimeout time.Duration
+	log           vzlog.VerrazzanoLogger
+	shutdown      chan int // The channel on which shutdown signals are sent/received
 }
 
 // NewMySQLChecker - instantiate a MySQLChecker context
-func NewMySQLChecker(c clipkg.Client, tick time.Duration) (*MySQLChecker, error) {
+func NewMySQLChecker(c clipkg.Client, tick time.Duration, timeout time.Duration) (*MySQLChecker, error) {
 	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
 		Name:           componentName,
 		Namespace:      componentNamespace,
@@ -40,9 +41,10 @@ func NewMySQLChecker(c clipkg.Client, tick time.Duration) (*MySQLChecker, error)
 	}
 
 	return &MySQLChecker{
-		client:   c,
-		tickTime: tick,
-		log:      log,
+		client:        c,
+		tickTime:      tick,
+		RepairTimeout: timeout,
+		log:           log,
 	}, nil
 }
 

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker.go
@@ -16,6 +16,10 @@ const (
 	channelBufferSize = 100
 )
 
+// mySQLChecker - holds global instance of MySQLChecker.  Required by MySQL workaround
+// functions that don't have access to the MySQLChecker context.
+var mySQLChecker *MySQLChecker
+
 // MySQLChecker periodically checks the state of MySQL related pods and repairs
 // any that are found to be in a stuck state (e.g. terminating, waiting for readiness gates).
 type MySQLChecker struct {
@@ -40,12 +44,18 @@ func NewMySQLChecker(c clipkg.Client, tick time.Duration, timeout time.Duration)
 		return nil, err
 	}
 
-	return &MySQLChecker{
+	mySQLChecker = &MySQLChecker{
 		client:        c,
 		tickTime:      tick,
 		RepairTimeout: timeout,
 		log:           log,
-	}, nil
+	}
+	return mySQLChecker, nil
+}
+
+// GetMySQLChecker - returns the value of mySQLChecker
+func GetMySQLChecker() *MySQLChecker {
+	return mySQLChecker
 }
 
 // Start starts the MySQLChecker if it is not already running.

--- a/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker_test.go
+++ b/platform-operator/controllers/verrazzano/mysqlcheck/mysqlchecker_test.go
@@ -26,6 +26,6 @@ func TestStart(t *testing.T) {
 
 func newTestMySQLCheck() *MySQLChecker {
 	c := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	mysqlChecker, _ := NewMySQLChecker(c, 1*time.Second)
+	mysqlChecker, _ := NewMySQLChecker(c, 1*time.Second, 1*time.Second)
 	return mysqlChecker
 }

--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -72,22 +72,27 @@ type OperatorConfig struct {
 	// MySQLCheckPeriodSeconds period for MySQL check background task in seconds; a value of 0 disables MySQL checks
 	MySQLCheckPeriodSeconds int64
 
+	// MySQLRepairTimeoutSeconds is the amount of time the MySQL check background thread will allow to transpire between
+	// detecting a possible condition to repair, and initiating the repair logic.
+	MySQLRepairTimeoutSeconds int64
+
 	// DryRun Run installs in a dry-run mode
 	DryRun bool
 }
 
 // The singleton instance of the operator config
 var instance = OperatorConfig{
-	CertDir:                  "/etc/webhook/certs",
-	MetricsAddr:              ":8080",
-	LeaderElectionEnabled:    false,
-	VersionCheckEnabled:      true,
-	RunWebhookInit:           false,
-	RunWebhooks:              false,
-	WebhookValidationEnabled: true,
-	VerrazzanoRootDir:        rootDir,
-	HealthCheckPeriodSeconds: 60,
-	MySQLCheckPeriodSeconds:  60,
+	CertDir:                   "/etc/webhook/certs",
+	MetricsAddr:               ":8080",
+	LeaderElectionEnabled:     false,
+	VersionCheckEnabled:       true,
+	RunWebhookInit:            false,
+	RunWebhooks:               false,
+	WebhookValidationEnabled:  true,
+	VerrazzanoRootDir:         rootDir,
+	HealthCheckPeriodSeconds:  60,
+	MySQLCheckPeriodSeconds:   60,
+	MySQLRepairTimeoutSeconds: 120,
 }
 
 // Set saves the operator config.  This should only be called at operator startup and during unit tests

--- a/platform-operator/internal/config/config_test.go
+++ b/platform-operator/internal/config/config_test.go
@@ -26,6 +26,7 @@ func TestConfigDefaults(t *testing.T) {
 	asserts.Equal(":8080", conf.MetricsAddr, "MetricsAddr is incorrect")
 	asserts.Equal(int64(60), conf.HealthCheckPeriodSeconds, "Default health check period is correct")
 	asserts.Equal(int64(60), conf.MySQLCheckPeriodSeconds, "Default MySQL check period is correct")
+	asserts.Equal(int64(120), conf.MySQLRepairTimeoutSeconds, "Default MySQL repair timeout is correct")
 	asserts.True(conf.VersionCheckEnabled, "VersionCheckEnabled is incorrect")
 	asserts.False(conf.RunWebhooks, "RunWebhooks is incorrect")
 	asserts.True(conf.WebhookValidationEnabled, "WebhookValidationEnabled is incorrect")

--- a/platform-operator/internal/operatorinit/run_operator.go
+++ b/platform-operator/internal/operatorinit/run_operator.go
@@ -72,7 +72,7 @@ func StartPlatformOperator(config config.OperatorConfig, log *zap.SugaredLogger,
 	}
 
 	// Setup MySQL checker
-	mysqlCheck, err := mysqlcheck.NewMySQLChecker(mgr.GetClient(), time.Duration(config.MySQLCheckPeriodSeconds)*time.Second)
+	mysqlCheck, err := mysqlcheck.NewMySQLChecker(mgr.GetClient(), time.Duration(config.MySQLCheckPeriodSeconds)*time.Second, time.Duration(config.MySQLRepairTimeoutSeconds)*time.Second)
 	if err != nil {
 		return errors.Wrap(err, "Failed starting MySQLChecker")
 	}

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -89,6 +89,8 @@ func main() {
 		"Health check period seconds; set to 0 to disable health checks")
 	flag.Int64Var(&config.MySQLCheckPeriodSeconds, "mysql-check-period", config.MySQLCheckPeriodSeconds,
 		"MySQL check period seconds; set to 0 to disable MySQL checks")
+	flag.Int64Var(&config.MySQLRepairTimeoutSeconds, "mysql-repair-timeout", config.MySQLRepairTimeoutSeconds,
+		"MySQL repair timeout seconds")
 
 	// Add the zap logger flag set to the CLI.
 	opts := kzap.Options{}


### PR DESCRIPTION
Make mysqlcheck timeout configurable and reduce the default timeout from 5 minutes to 2 minutes.