### PR TITLE
VZ-8114: Pod security for Jaeger Operator and Jaeger.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_mc.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_mc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package operator
@@ -47,18 +47,42 @@ spec:
 {{end}}
   ingress:
     enabled: false
+    securityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
   strategy: production
   query:
     replicas: 0
+    securityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
   collector:
     options:
       collector:
         tags: verrazzano_cluster={{.ClusterName}}
+    securityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
   storage:
     dependencies:
       enabled: false
     esIndexCleaner:
       enabled: false
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
     type: elasticsearch
     options:
       es:

--- a/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 rbac:
   # Specifies whether RBAC resources should be created
@@ -13,10 +13,29 @@ jaeger:
       proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     ingress:
       enabled: false
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
     collector:
       options:
         collector:
           tags: verrazzano_cluster=local
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+    query:
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
     storage:
       dependencies:
         enabled: false
@@ -27,6 +46,19 @@ jaeger:
         schedule: "55 23 * * *"
         # Number of times to retry before considering the job as failed
         backoffLimit: 2
+        securityContext:
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
       options:
         es:
           index-prefix: verrazzano
+
+securityContext:
+  runAsGroup: 65534
+  runAsNonRoot: true
+  runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault

--- a/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/jaeger-operator-values.yaml
@@ -62,3 +62,13 @@ securityContext:
   runAsUser: 1001
   seccompProfile:
     type: RuntimeDefault
+
+containerSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 65534
+  runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL

--- a/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
       volumes:
       - name: cert
         secret:

--- a/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml
@@ -83,3 +83,5 @@ affinity: {}
 securityContext: {}
 
 priorityClassName:
+
+containerSecurityContext: {}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -40,9 +40,6 @@ var skipPods = map[string][]string{
 		"vmi-system",
 		"weblogic-operator",
 	},
-	"verrazzano-monitoring": {
-		"jaeger",
-	},
 	"verrazzano-backup": {
 		"restic",
 	},

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -39,6 +39,9 @@ var skipPods = map[string][]string{
 		"vmi-system",
 		"weblogic-operator",
 	},
+	"verrazzano-monitoring": {
+		"jaeger",
+	},
 	"verrazzano-backup": {
 		"restic",
 	},

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -50,7 +50,7 @@ var skipPods = map[string][]string{
 	},
 }
 
-var skipContainers = []string{}
+var skipContainers = []string{"jaeger-operator", "jaeger-collector", "jaeger-query", "jaeger-agent"}
 var skipInitContainers = []string{"istio-init"}
 
 type podExceptions struct {

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -42,15 +42,12 @@ var skipPods = map[string][]string{
 		"vmi-system",
 		"weblogic-operator",
 	},
-	"verrazzano-monitoring": {
-		"jaeger",
-	},
 	"verrazzano-backup": {
 		"restic",
 	},
 }
 
-var skipContainers = []string{"jaeger-operator", "jaeger-collector", "jaeger-query", "jaeger-agent"}
+var skipContainers = []string{"jaeger-collector", "jaeger-query", "jaeger-agent"}
 var skipInitContainers = []string{"istio-init"}
 
 type podExceptions struct {


### PR DESCRIPTION
Pod security for Jaeger Operator and Jaeger.

Verrazzano currently uses Jaeger 1.37.0. Custom Resource Definition for Jaeger 1.37.0 and below does not support container security context settings. Helm charts for Jaeger Operator updated for container security context.