### PR TITLE
VZ-8179.  Add pod security settings to mysql-operator chart

### DIFF
--- a/platform-operator/thirdparty/charts/mysql-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/mysql-operator/templates/deployment.yaml
@@ -49,7 +49,16 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
       volumes:
         - name: mysqlsh-home
           emptyDir: {}
       serviceAccountName: mysql-operator-sa
+      securityContext:
+        runAsGroup: 27  # mysql group
+        runAsUser: 27   # mysql user
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -24,9 +24,16 @@ type TestFramework struct {
 
 func NewTestFramework(pkg string) *TestFramework {
 	t := new(TestFramework)
+
 	t.Pkg = pkg
-	t.Metrics, _ = metrics.NewLogger(pkg, metrics.MetricsIndex)
-	t.Logs, _ = metrics.NewLogger(pkg, metrics.TestLogIndex, "stdout")
+
+	logLevel, isSet := os.LookupEnv("FRAMEWORK_LOG_LEVEL")
+	if !isSet {
+		logLevel = "info"
+	}
+	t.Metrics, _ = metrics.NewLogger(pkg, metrics.MetricsIndex, logLevel)
+	t.Logs, _ = metrics.NewLogger(pkg, metrics.TestLogIndex, logLevel, "stdout")
+
 	t.initDumpDirectoryIfNecessary()
 	return t
 }

--- a/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
+++ b/tests/e2e/pkg/test/framework/ginkgo_wrapper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package framework

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package metrics

--- a/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
+++ b/tests/e2e/pkg/test/framework/metrics/ginkgo_metrics.go
@@ -64,14 +64,18 @@ func internalLogger() *zap.SugaredLogger {
 }
 
 // NewLogger generates a new logger, and tees ginkgo output to the search db
-func NewLogger(pkg string, ind string, paths ...string) (*zap.SugaredLogger, error) {
+func NewLogger(pkg string, ind string, level string, paths ...string) (*zap.SugaredLogger, error) {
 	var messageKey = zapcore.OmitKey
 	if ind == TestLogIndex {
 		messageKey = "msg"
 	}
+	logLevel, err := zap.ParseAtomicLevel(level)
+	if err != nil {
+		return nil, err
+	}
 	cfg := zap.Config{
 		Encoding: "json",
-		Level:    zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		Level:    logLevel,
 		EncoderConfig: zapcore.EncoderConfig{
 
 			MessageKey: messageKey,

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -129,6 +129,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		for _, pod := range pods {
 			t.Logs.Debugf("Checking pod %s/%s", ns, pod.Name)
 			if shouldSkipPod(pod.Name, ns) {
+				t.Logs.Debugf("Pod %s/%s on skip list, continuing...", ns, pod.Name)
 				continue
 			}
 			errors = append(errors, expectPodSecurityForNamespace(pod)...)
@@ -141,6 +142,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Entry("Checking pod security in verrazzano-monitoring", "verrazzano-monitoring"),
 		Entry("Checking pod security in verrazzano-backup", "verrazzano-backup"),
 		Entry("Checking pod security in ingress-nginx", "ingress-nginx"),
+		Entry("Checking pod security in mysql-operator", "mysql-operator"),
 	)
 })
 


### PR DESCRIPTION
Add pod security settings to `mysql-operator` chart
- there are no values hooks in the deployment template
- add env var hooks for setting test framework debug level