### PR TITLE
VZ-8097: Pod-security for cert-manager

### DIFF
--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # NOTE: The image you're looking for isn't here. The cert-manager-controller image now comes from

--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -31,3 +31,39 @@ containerSecurityContext:
   capabilities:
    drop:
    - ALL
+
+# Pod Security Context for cert-manager-cainjector
+cainjector.securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container Security Context for cert-manager-cainjector
+cainjector.containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  capabilities:
+    drop:
+      - ALL
+
+# Pod Security Context for cert-manager-webhook
+webhook.securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container Security Context for cert-manager-webhook
+webhook.containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  capabilities:
+    drop:
+      - ALL

--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -12,7 +12,16 @@ ingressShim:
 # file (verrazzano-bom.json), and the override string is built in the install_cert_manager() shell function
 # in the 2-install-system-components.sh install script
 
+# Pod Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container Security Context to be set on the controller component container
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext:
   allowPrivilegeEscalation: false
   privileged: false
   readOnlyRootFilesystem: true
@@ -20,9 +29,5 @@ securityContext:
   runAsUser: 65534
   runAsGroup: 65534
   capabilities:
-    drop:
-      - ALL
-
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+   drop:
+   - ALL

--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -33,37 +33,35 @@ containerSecurityContext:
    - ALL
 
 # Pod Security Context for cert-manager-cainjector
-cainjector.securityContext:
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
-
-# Container Security Context for cert-manager-cainjector
-cainjector.containerSecurityContext:
-  allowPrivilegeEscalation: false
-  privileged: false
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 65534
-  runAsGroup: 65534
-  capabilities:
-    drop:
-      - ALL
+cainjector:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    capabilities:
+      drop:
+        - ALL
 
 # Pod Security Context for cert-manager-webhook
-webhook.securityContext:
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
-
-# Container Security Context for cert-manager-webhook
-webhook.containerSecurityContext:
-  allowPrivilegeEscalation: false
-  privileged: false
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 65534
-  runAsGroup: 65534
-  capabilities:
-    drop:
-      - ALL
+webhook:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    capabilities:
+      drop:
+        - ALL

--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -12,3 +12,17 @@ ingressShim:
 # file (verrazzano-bom.json), and the override string is built in the install_cert_manager() shell function
 # in the 2-install-system-components.sh install script
 
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  capabilities:
+    drop:
+      - ALL
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault

--- a/platform-operator/thirdparty/charts/cert-manager/Chart.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.9.1-vz1.5
+appVersion: v1.9.1
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png

--- a/platform-operator/thirdparty/charts/cert-manager/Chart.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.9.1
+appVersion: v1.9.1-vz1.5
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -48,11 +48,6 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"restic",
 	},
-	"cert-manager": {
-		"cert-manager",
-		"cert-manager-cainjector",
-		"cert-manager-webhook",
-	},
 }
 
 var skipContainers = []string{}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -45,9 +45,9 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"restic",
 	},
-    "cert-manager": {
-        "external-dns",
-    },
+	"cert-manager": {
+		"external-dns",
+	},
 }
 
 var skipContainers = []string{"jaeger-collector", "jaeger-query", "jaeger-agent"}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -45,6 +45,9 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"restic",
 	},
+    "cert-manager": {
+        "external-dns",
+    },
 }
 
 var skipContainers = []string{"jaeger-collector", "jaeger-query", "jaeger-agent"}

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -48,6 +48,11 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"restic",
 	},
+	"cert-manager": {
+		"cert-manager",
+		"cert-manager-cainjector",
+		"cert-manager-webhook",
+	},
 }
 
 var skipContainers = []string{}
@@ -143,6 +148,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Entry("Checking pod security in verrazzano-backup", "verrazzano-backup"),
 		Entry("Checking pod security in ingress-nginx", "ingress-nginx"),
 		Entry("Checking pod security in mysql-operator", "mysql-operator"),
+		Entry("Checking pod security in cert-manager", "cert-manager"),
 	)
 })
 

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -143,7 +143,6 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Entry("Checking pod security in verrazzano-backup", "verrazzano-backup"),
 		Entry("Checking pod security in ingress-nginx", "ingress-nginx"),
 		Entry("Checking pod security in mysql-operator", "mysql-operator"),
-		Entry("Checking pod security in cert-manager", "cert-manager"),
 	)
 })
 

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -143,6 +143,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Entry("Checking pod security in verrazzano-backup", "verrazzano-backup"),
 		Entry("Checking pod security in ingress-nginx", "ingress-nginx"),
 		Entry("Checking pod security in mysql-operator", "mysql-operator"),
+		Entry("Checking pod security in cert-manager", "cert-manager"),
 	)
 })
 


### PR DESCRIPTION
This PR have the changes to meet the pod-security-standards for the cert-manager deployment
Summary of changes:
> Updates to deployments.yaml for cert-manager to increase security by overrides
> UT to validate the cert-manager meets standards