### PR TITLE
Make verrazzano-admins group cluster-admin in Rancher

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -156,6 +156,7 @@ const (
 
 // roles and groups
 const (
+	ClusterAdminRoleName        = "cluster-admin"
 	AdminRoleName               = "admin"
 	VerrazzanoAdminRoleName     = "verrazzano-admin"
 	ViewRoleName                = "view"
@@ -192,7 +193,7 @@ var GVKRoleTemplate = common.GetRancherMgmtAPIGVKForKind("RoleTemplate")
 var GroupRolePairs = []map[string]string{
 	{
 		GroupKey:       VerrazzanoAdminsGroupName,
-		ClusterRoleKey: AdminRoleName,
+		ClusterRoleKey: ClusterAdminRoleName,
 	},
 	{
 		GroupKey:       VerrazzanoAdminsGroupName,


### PR DESCRIPTION
This change updates the verrazzano-admins Rancher ClusterRoleTemplateBinding to use the cluster-admin role instead of the admin. This will grant Keycloak users in the verrazzano-admins group privs to do pretty much anything in Rancher.