### PR TITLE
Add verrazzano_component label to kubelet and kube-state-metrics metrics

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -244,3 +244,9 @@ const RancherBackupNamesSpace = "cattle-resources-system"
 const VerrazzanoManagedKey = "verrazzano.io/namespace"
 
 const ExternalDNSNamespace = "cert-manager"
+
+// ServiceMonitorNameKubelet indicates the name of serviceMonitor resource for kubelet monitoring
+const ServiceMonitorNameKubelet = "prometheus-operator-kube-p-kubelet"
+
+// ServiceMonitorNameKubeStateMetrics indicates the name of serviceMonitor resource for kube-state-metrics monitoring
+const ServiceMonitorNameKubeStateMetrics = "kube-state-metrics"

--- a/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
+++ b/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
@@ -8,6 +8,288 @@ customLabels:
 prometheus:
   monitor:
     honorLabels: true
+    metricRelabelings:
+      # Add verrazzano_component label
+      - action: replace
+        regex: (verrazzano-monitoring);(alertManager);(alertmanager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;alertManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(applicationOperator);(verrazzano-application-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;applicationOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (argocd);(argoCd);(argocd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;argoCd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(authProxy);(verrazzano-authproxy-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;authProxy;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(certManager);(cert-manager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;certManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(clusterOperator);(verrazzano-cluster-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(coherenceOperator);(coherence-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;coherenceOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(console);(verrazzano-console-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;console;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(dns);(external-dns-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;dns;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (ingress-nginx);(ingressNGINX);(ingress-controller-ingress-nginx-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;ingressNGINX;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (istio-system);(istio);(istio[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;istio;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(jaegerOperator);(jaeger-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;jaegerOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(keycloak-[a-z0-9-]+|mysql-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(datadir-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(kiali);(vmi-system-kiali-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kiali;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(kubeStateMetrics);(kube-state-metrics-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kubeStateMetrics;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(monitoringOperator);(verrazzano-monitoring-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;monitoringOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (mysql-operator);(mySQLOperator);(mysql-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;mySQLOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(oam);(oam-kubernetes-runtime-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;oam;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+|elasticsearch-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearchDashboards);(vmi-system-osd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearchDashboards;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-install);(platformOperator);(verrazzano-platform-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;platformOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-prometheus-operator-kube-p-prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusAdapter);(prometheus-adapter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusAdapter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusNodeExporter);(prometheus-node-exporter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusNodeExporter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusOperator);(prometheus-operator-kube-p-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-fleet-system|cattle-fleet-local-system|cattle-system);(rancher);(rancher-[a-z0-9-]+|fleet-[a-z0-9-]+|gitjob-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancher;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-resources-system);(rancherBackup);(rancher-backup-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancherBackup;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(weblogicOperator);(weblogic-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;weblogicOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
 metricLabelsAllowlist:
   - deployments=[app.oam.dev/name,app.oam.dev/component]
   - pods=[app.oam.dev/name,app.oam.dev/component]

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -104,6 +104,594 @@ kubelet:
       - action: replace
         targetLabel: verrazzano_cluster
         replacement: local
+    cAdvisorMetricRelabelings:
+      # Drop less useful container CPU metrics.
+      - sourceLabels: [__name__]
+        action: drop
+        regex: 'container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)'
+      # Drop less useful container / always zero filesystem metrics.
+      - sourceLabels: [__name__]
+        action: drop
+        regex: 'container_fs_(io_current|io_time_seconds_total|io_time_weighted_seconds_total|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)'
+      # Drop less useful / always zero container memory metrics.
+      - sourceLabels: [__name__]
+        action: drop
+        regex: 'container_memory_(mapped_file|swap)'
+      # Drop less useful container process metrics.
+      - sourceLabels: [__name__]
+        action: drop
+        regex: 'container_(file_descriptors|tasks_state|threads_max)'
+      # Drop container spec metrics that overlap with kube-state-metrics.
+      - sourceLabels: [__name__]
+        action: drop
+        regex: 'container_spec.*'
+      # Drop cgroup metrics with no pod.
+      - sourceLabels: [id, pod]
+        action: drop
+        regex: '.+;'
+      # Add verrazzano_component label
+      - action: replace
+        regex: (verrazzano-monitoring);(alertManager);(alertmanager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;alertManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(applicationOperator);(verrazzano-application-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;applicationOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (argocd);(argoCd);(argocd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;argoCd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(authProxy);(verrazzano-authproxy-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;authProxy;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(certManager);(cert-manager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;certManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(clusterOperator);(verrazzano-cluster-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(coherenceOperator);(coherence-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;coherenceOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(console);(verrazzano-console-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;console;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(dns);(external-dns-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;dns;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (ingress-nginx);(ingressNGINX);(ingress-controller-ingress-nginx-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;ingressNGINX;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (istio-system);(istio);(istio[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;istio;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(jaegerOperator);(jaeger-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;jaegerOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(keycloak-[a-z0-9-]+|mysql-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(datadir-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(kiali);(vmi-system-kiali-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kiali;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(kubeStateMetrics);(kube-state-metrics-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kubeStateMetrics;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(monitoringOperator);(verrazzano-monitoring-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;monitoringOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (mysql-operator);(mySQLOperator);(mysql-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;mySQLOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(oam);(oam-kubernetes-runtime-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;oam;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+|elasticsearch-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearchDashboards);(vmi-system-osd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearchDashboards;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-install);(platformOperator);(verrazzano-platform-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;platformOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-prometheus-operator-kube-p-prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusAdapter);(prometheus-adapter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusAdapter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusNodeExporter);(prometheus-node-exporter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusNodeExporter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusOperator);(prometheus-operator-kube-p-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-fleet-system|cattle-fleet-local-system|cattle-system);(rancher);(rancher-[a-z0-9-]+|fleet-[a-z0-9-]+|gitjob-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancher;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-resources-system);(rancherBackup);(rancher-backup-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancherBackup;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(weblogicOperator);(weblogic-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;weblogicOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+    probesMetricRelabelings:
+      # Add verrazzano_component label
+      - action: replace
+        regex: (verrazzano-monitoring);(alertManager);(alertmanager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;alertManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(applicationOperator);(verrazzano-application-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;applicationOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (argocd);(argoCd);(argocd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;argoCd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(authProxy);(verrazzano-authproxy-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;authProxy;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(certManager);(cert-manager-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;certManager;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(clusterOperator);(verrazzano-cluster-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(coherenceOperator);(coherence-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;coherenceOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(console);(verrazzano-console-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;console;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cert-manager);(dns);(external-dns-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;dns;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(grafana);(vmi-system-grafana-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;grafana;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (ingress-nginx);(ingressNGINX);(ingress-controller-ingress-nginx-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;ingressNGINX;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (istio-system);(istio);(istio[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;istio;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(jaegerOperator);(jaeger-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;jaegerOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(keycloak-[a-z0-9-]+|mysql-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (keycloak);(keycloak);(datadir-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;keycloak;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(kiali);(vmi-system-kiali-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kiali;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(kubeStateMetrics);(kube-state-metrics-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;kubeStateMetrics;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(monitoringOperator);(verrazzano-monitoring-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;monitoringOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (mysql-operator);(mySQLOperator);(mysql-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;mySQLOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(oam);(oam-kubernetes-runtime-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;oam;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearch);(vmi-system-es-[a-z0-9-]+|elasticsearch-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearch;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(opensearchDashboards);(vmi-system-osd-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;opensearchDashboards;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-install);(platformOperator);(verrazzano-platform-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;platformOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-prometheus-operator-kube-p-prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheus);(prometheus-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheus;
+        sourceLabels:
+        - namespace
+        - persistentvolumeclaim
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusAdapter);(prometheus-adapter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusAdapter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusNodeExporter);(prometheus-node-exporter-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusNodeExporter;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(prometheusOperator);(prometheus-operator-kube-p-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;prometheusOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-fleet-system|cattle-fleet-local-system|cattle-system);(rancher);(rancher-[a-z0-9-]+|fleet-[a-z0-9-]+|gitjob-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancher;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (cattle-resources-system);(rancherBackup);(rancher-backup-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;rancherBackup;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(weblogicOperator);(weblogic-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;weblogicOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
 coreDns:
   serviceMonitor:
     relabelings:

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -318,4 +319,35 @@ func GetServiceMonitor(namespace, name string) (*promoperapi.ServiceMonitor, err
 		return nil, err
 	}
 	return serviceMonitor, nil
+}
+
+// ScrapeTargetsHealthy validates the health of the scrape targets for the given scrapePools
+func ScrapeTargetsHealthy(scrapePools []string) (bool, error) {
+	targets, err := ScrapeTargets()
+	if err != nil {
+		Log(Error, fmt.Sprintf("Error getting scrape targets: %v", err))
+		return false, err
+	}
+	for _, scrapePool := range scrapePools {
+		found := false
+		for _, target := range targets {
+			targetScrapePool := Jq(target, "scrapePool").(string)
+			if strings.Contains(targetScrapePool, scrapePool) {
+				found = true
+				// If any of the target health is not "up" return false
+				health := Jq(target, "health")
+				if health != "up" {
+					scrapeURL := Jq(target, "scrapeUrl").(string)
+					Log(Error, fmt.Sprintf("target with scrapePool %s and scrapeURL %s is not ready with health %s", targetScrapePool, scrapeURL, health))
+					return false, fmt.Errorf("target with scrapePool %s and scrapeURL %s is not healthy", targetScrapePool, scrapeURL)
+				}
+			}
+		}
+		// If target with scrapePool not found, then return false and error
+		if !found {
+			Log(Error, fmt.Sprintf("target with scrapePool %s is not found", scrapePool))
+			return false, fmt.Errorf("target with scrapePool %s not found", scrapePool)
+		}
+	}
+	return true, nil
 }


### PR DESCRIPTION
The regex for each component for pod level metrics is added in pattern
- `"(<namespace>);(<componentName>);(<regex-pattern-for-pod>)(.*)"`
and for pvc level metrics
- `"(<namespace>);(<componentName>);(<regex-pattern-for-pvc>)(.*)"
so that capture group `$2` will give target value of `verrazzano_component`

Also added an e2e test to check health status of `kubelet` and `kube-state-metrics` endpoints