### PR TITLE
VZ-7748: Disable pod security policy resource creation for k8s 1.25

### DIFF
--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -195,3 +195,16 @@ helm repo update
 rm -rf argo-cd
 helm fetch argocd/argo-cd --untar=true --version=${ARGOCD_CHART_VERSION}
 ```
+
+### Prometheus Node Exporter
+
+The `prometheus-community/prometheus-node-exporter` folder was created by running the followiong commands:
+
+```shell
+export PROMETHEUS_NODE_EXPORTER_CHAT_VERSION=3.1.0
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+rm -rf prometheus-community
+helm fetch prometheus-community/prometheus-node-exporter --untar=true --version=${PROMETHEUS_NODE_EXPORTER_CHAT_VERSION}
+```
+

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -46,5 +47,6 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR disables creation of Pod Security Policy resource through helm chart for k8s 1.25 version 