### PR TITLE
VZ-7748: Fix CHART path and typo in Readme file

### DIFF
--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -201,10 +201,10 @@ helm fetch argocd/argo-cd --untar=true --version=${ARGOCD_CHART_VERSION}
 The `prometheus-community/prometheus-node-exporter` folder was created by running the followiong commands:
 
 ```shell
-export PROMETHEUS_NODE_EXPORTER_CHAT_VERSION=3.1.0
+export PROMETHEUS_NODE_EXPORTER_CHART_VERSION=3.1.0
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 rm -rf prometheus-community
-helm fetch prometheus-community/prometheus-node-exporter --untar=true --version=${PROMETHEUS_NODE_EXPORTER_CHAT_VERSION}
+helm fetch prometheus-community/prometheus-node-exporter --untar=true --version=${PROMETHEUS_NODE_EXPORTER_CHART_VERSION}
 ```
 

--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -204,7 +204,7 @@ The `prometheus-community/prometheus-node-exporter` folder was created by runnin
 export PROMETHEUS_NODE_EXPORTER_CHART_VERSION=3.1.0
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
-rm -rf prometheus-community
+rm -rf prometheus-community/prometheus-node-exporter 
 helm fetch prometheus-community/prometheus-node-exporter --untar=true --version=${PROMETHEUS_NODE_EXPORTER_CHART_VERSION}
 ```
 


### PR DESCRIPTION
This PR fixes the Prometheus node exporter path and a typo in Readmefile. 