### PR TITLE
VZ-8213.  Pod security for External DNS

### DIFF
--- a/platform-operator/helm_config/overrides/external-dns-values.yaml
+++ b/platform-operator/helm_config/overrides/external-dns-values.yaml
@@ -15,3 +15,21 @@ sources:
   - ingress
   - istio-gateway
 triggerLoopOnEvent: true
+
+# Verrazzano container security standards
+securityContext:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+
+# Verrazzano pod security standards
+podSecurityContext:
+  runAsGroup: 99
+  runAsNonRoot: true
+  runAsUser: 99
+  seccompProfile:
+    type: RuntimeDefault

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -50,9 +50,6 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"^restic.*$",
 	},
-	"cert-manager": {
-		"^external-dns.*$",
-	},
 }
 
 var skipContainers = []string{"jaeger-collector", "jaeger-query", "jaeger-agent"}


### PR DESCRIPTION
Add pod and container security settings conforming to the VZ pod security standards
- update e2e test to remove external-dns from the skipPods list