### PR TITLE
VZ-8214 - grafana pod security, use new VMO image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -219,7 +219,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.5.0-20230117174214-101ecd2",
+              "tag": "v1.5.0-20230118191805-e5557e2",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -44,7 +44,6 @@ var skipPods = map[string][]string{
 	},
 	"verrazzano-system": {
 		"^coherence-operator.*$",
-		"^vmi-system-grafana.*$",
 		"^weblogic-operator.*$",
 	},
 	"verrazzano-backup": {


### PR DESCRIPTION
Use the new VMO image that fixes pod security for Grafana.
Change test to check Grafana pod.