### PR TITLE
VZ-8186 Update BOM for shell image update to add symbolic link from v…

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -147,7 +147,7 @@
           "images": [
             {
               "image": "shell",
-              "tag": "v0.1.18-20221011201404-0c5784f"
+              "tag": "v0.1.18-20230118204621-374cc3f"
             },
             {
               "image": "rancher-webhook",


### PR DESCRIPTION
…im to vi

kubectl edit command's default editor is vi, but the shell image was missing the symbolic link from vim to vi. This new image fixes that.
