### PR TITLE
VZ-7315: Add deprecation warning for multicluster APIs to be removed in v2.0.0

### DIFF
--- a/application-operator/apis/clusters/v1alpha1/multiclustercomponent_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclustercomponent_types.go
@@ -33,7 +33,7 @@ type ComponentTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mccomp;mccomps
 // +kubebuilder:subresource:status
-// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterComponent is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterComponent is deprecated and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster."
 
 // MultiClusterComponent specifies the MultiCluster Component API.
 type MultiClusterComponent struct {

--- a/application-operator/apis/clusters/v1alpha1/multiclustercomponent_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclustercomponent_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
@@ -33,6 +33,7 @@ type ComponentTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mccomp;mccomps
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterComponent is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
 
 // MultiClusterComponent specifies the MultiCluster Component API.
 type MultiClusterComponent struct {

--- a/application-operator/apis/clusters/v1alpha1/multiclusterconfigmap_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclusterconfigmap_types.go
@@ -41,7 +41,7 @@ type ConfigMapTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mccm;mccms
 // +kubebuilder:subresource:status
-// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterConfigMap is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterConfigMap is deprecated and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster."
 
 // MultiClusterConfigMap specifies the MultiCluster ConfigMap API.
 type MultiClusterConfigMap struct {

--- a/application-operator/apis/clusters/v1alpha1/multiclusterconfigmap_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclusterconfigmap_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
@@ -41,6 +41,7 @@ type ConfigMapTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mccm;mccms
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterConfigMap is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
 
 // MultiClusterConfigMap specifies the MultiCluster ConfigMap API.
 type MultiClusterConfigMap struct {

--- a/application-operator/apis/clusters/v1alpha1/multiclustersecret_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclustersecret_types.go
@@ -41,7 +41,7 @@ type SecretTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mcsecret;mcsecrets
 // +kubebuilder:subresource:status
-// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterSecret is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterSecret is deprecated and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster."
 
 // MultiClusterSecret specifies the MultiCluster Secret API.
 type MultiClusterSecret struct {

--- a/application-operator/apis/clusters/v1alpha1/multiclustersecret_types.go
+++ b/application-operator/apis/clusters/v1alpha1/multiclustersecret_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
@@ -41,6 +41,7 @@ type SecretTemplate struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mcsecret;mcsecrets
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="clusters.verrazzano.io/v1alpha1 MultiClusterSecret is deprecated and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration."
 
 // MultiClusterSecret specifies the MultiCluster Secret API.
 type MultiClusterSecret struct {

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,10 @@ spec:
     singular: multiclustercomponent
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterComponent is deprecated
+      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MultiClusterComponent specifies the MultiCluster Component API.

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustercomponents.yaml
@@ -22,7 +22,7 @@ spec:
   versions:
   - deprecated: true
     deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterComponent is deprecated
-      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+      and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
@@ -22,7 +22,7 @@ spec:
   versions:
   - deprecated: true
     deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterConfigMap is deprecated
-      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+      and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclusterconfigmaps.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,10 @@ spec:
     singular: multiclusterconfigmap
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterConfigMap is deprecated
+      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MultiClusterConfigMap specifies the MultiCluster ConfigMap API.

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
@@ -22,7 +22,7 @@ spec:
   versions:
   - deprecated: true
     deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterSecret is deprecated
-      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+      and will be removed in v2.0.0. See https://verrazzano.io/v1.5/docs/reference/migration/#multicluster.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/crds/clusters.verrazzano.io_multiclustersecrets.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -20,7 +20,10 @@ spec:
     singular: multiclustersecret
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: clusters.verrazzano.io/v1alpha1 MultiClusterSecret is deprecated
+      and will be removed in v2.0.0. See https://verrazzano.io/latest/docs/reference/migration.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MultiClusterSecret specifies the MultiCluster Secret API.


### PR DESCRIPTION
This pull request adds a deprecation warning for MultiClusterComponent, MultiClusterConfigMap, and MultiClusterSecret APIs that are being removed in v2.0.0.