### PR TITLE
Fix mysql regex

### DIFF
--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -31,8 +31,8 @@ const (
 	capNetBindService = "NET_BIND_SERVICE"
 	capDacOverride    = "DAC_OVERRIDE"
 
-	// MySQL ignore pattern
-	mysqlPattern = "^mysql-([\\d]+)$"
+	// MySQL ignore pattern; skip mysql-# or mysql-xxxx-xxxx pod names, but not mysql-router-#
+	mysqlPattern = "^mysql-([\\d]+|[A-Za-z0-9]-[A-Za-z0-9]).*$"
 )
 
 var skipPods = map[string][]string{


### PR DESCRIPTION
Update the mysql pod exclusion regex to exclude statefulset types as well as `Deployment` pod instances, but not `mysql-router-n` pods.
