### PR TITLE
Updated kube-state-metrics image by rebuilding

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -554,7 +554,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.6.0-20221202183421-fda95595",
+              "tag": "v2.6.0-20230120172545-fda95595",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
PR to update the rebuilt kube-state-metrics image only for the CVE fixes