### PR TITLE
VZ-8217.  Example using VerrazzanoHelidonWorkload as a generic workload type

### DIFF
--- a/examples/generic-workload/springboot-generic-app.yaml
+++ b/examples/generic-workload/springboot-generic-app.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Example of using the VerrazzanoHelidonWorkload as a "generic" workload type to implement custom security
+# settings, which is not supported by the OAM ContainerizedWorkload
+apiVersion: core.oam.dev/v1alpha2
+kind: ApplicationConfiguration
+metadata:
+  name: springboot-generic-appconf
+  annotations:
+    version: v1.0.0
+    description: "Spring Boot application"
+spec:
+  components:
+    - componentName: springboot-generic-component
+      traits:
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: MetricsTrait
+            spec:
+              scraper: verrazzano-system/vmi-system-prometheus-0
+              path: "/actuator/prometheus"
+        - trait:
+            apiVersion: oam.verrazzano.io/v1alpha1
+            kind: IngressTrait
+            metadata:
+              name: generic-workload-ingress
+            spec:
+              rules:
+                - paths:
+                    - path: "/"
+                      pathType: Prefix
+

--- a/examples/generic-workload/springboot-generic-comp.yaml
+++ b/examples/generic-workload/springboot-generic-comp.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Example of using the VerrazzanoHelidonWorkload as a "generic" workload type to implement custom security
+# settings, which is not supported by the OAM ContainerizedWorkload
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
+metadata:
+  name: springboot-generic-component
+spec:
+  workload:
+    apiVersion: oam.verrazzano.io/v1alpha1
+    kind: VerrazzanoHelidonWorkload
+    metadata:
+      name: springboot-generic-workload
+      labels:
+        app: springboot-generic
+        version: v1
+    spec:
+      deploymentTemplate:
+        metadata:
+          name: springboot-generic-deployment
+        podSpec:
+          securityContext:
+            runAsUser: 1000  # run as non-root user; does not have exist in the container /etc/passwd
+            runAsGroup: 1000 # run as non-root group; does not have exist in the container /etc/group
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: springboot-container
+              image: "ghcr.io/verrazzano/example-springboot:1.0.0-1-20220513221156-7da0d32"
+              ports:
+                - containerPort: 8080
+                  name: springboot
+              securityContext:
+                privileged: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL


### PR DESCRIPTION
Creates a new example using VerrazzanoHelidonWorkload to create a Springboot deployment with custom securityContext settings
