### PR TITLE
VZ-7556: Fix bug to allow users to change the VZ CR during install

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -22,6 +22,9 @@ var Debug bool
 // cmdRunner needed for unit tests
 var runner vzos.CmdRunner = vzos.DefaultRunner{}
 
+// number of times runHelm will retry running its Helm command
+const maxRetry = 5
+
 // Helm chart status values: unknown, deployed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade or pending-rollback
 const ChartNotFound = "NotFound"
 const ChartStatusDeployed = "deployed"
@@ -213,7 +216,6 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 
 	// Try to upgrade several times.  Sometimes upgrade fails with "already exists" or "no deployed release".
 	// We have seen from tests that doing a retry will eventually succeed if these 2 errors occur.
-	const maxRetry = 5
 	for i := 1; i <= maxRetry; i++ {
 		cmd := exec.Command("helm", cmdArgs...)
 

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -237,7 +237,7 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 				releaseName, string(stderr))
 			return stdout, stderr, err
 		}
-		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %s of %s", operation, releaseName, i+1, maxRetry)
+		log.Infof("Failed running Helm command for operation %s and release %s. Retrying %d of %d", operation, releaseName, i+1, maxRetry)
 	}
 
 	return stdout, stderr, nil

--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helm
@@ -230,7 +230,7 @@ func runHelm(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 			log.Debugf("Successfully ran Helm command for operation %s and release %s", operation, releaseName)
 			break
 		}
-		if i == 1 || i == maxRetry {
+		if i == maxRetry {
 			log.Errorf("Failed running Helm command for release %s: stderr %s",
 				releaseName, string(stderr))
 			return stdout, stderr, err

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helm
@@ -21,7 +21,7 @@ const missingRelease = "no_release"
 // retryRunner is used to test retrying a Helm upgrade after first attempts do not succeed
 type retryRunner struct {
 	attemptsBeforeSuccess int
-	retries int
+	retries               int
 }
 
 // upgradeRunner is used to test Helm upgrade without actually running an OS exec command
@@ -724,28 +724,28 @@ func Test_runHelm(t *testing.T) {
 	log := vzlog.DefaultLogger()
 
 	tests := []struct {
-		numFailures int
+		numFailures    int
 		expectedStdout []byte
 		expectedStderr []byte
-		expectedErr error
+		expectedErr    error
 	}{
 		{
-			numFailures: 0,
+			numFailures:    0,
 			expectedStdout: []byte("success"),
 			expectedStderr: []byte(""),
-			expectedErr: nil,
+			expectedErr:    nil,
 		},
 		{
-			numFailures: maxRetry - 1,
+			numFailures:    maxRetry - 1,
 			expectedStdout: []byte("success"),
 			expectedStderr: []byte(""),
-			expectedErr: nil,
+			expectedErr:    nil,
 		},
 		{
-			numFailures: maxRetry + 1,
+			numFailures:    maxRetry + 1,
 			expectedStdout: []byte(""),
 			expectedStderr: []byte("not enough retries"),
-			expectedErr: errors.New("not enough retries error"),
+			expectedErr:    errors.New("not enough retries error"),
 		},
 	}
 

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -18,6 +18,12 @@ const chartdir = "my_charts"
 const release = "my_release"
 const missingRelease = "no_release"
 
+// retryRunner is used to test retrying a Helm upgrade after first attempts do not succeed
+type retryRunner struct {
+	attemptsBeforeSuccess int
+	retries int
+}
+
 // upgradeRunner is used to test Helm upgrade without actually running an OS exec command
 type upgradeRunner struct {
 	t *testing.T
@@ -709,6 +715,58 @@ func Test_maskSensitiveData(t *testing.T) {
 		defaultBackend.image.repository=ghcr.io/verrazzano/nginx-ingress-default-backend,controller.service.type=LoadBalancer`
 	maskedStr = maskSensitiveData(str)
 	assert.Equal(t, str, maskedStr)
+}
+
+// Test_runHelm tests the runHelm function
+func Test_runHelm(t *testing.T) {
+	defer SetDefaultRunner()
+	operation := "operation"
+	log := vzlog.DefaultLogger()
+
+	tests := []struct {
+		numFailures int
+		expectedStdout []byte
+		expectedStderr []byte
+		expectedErr error
+	}{
+		{
+			numFailures: 0,
+			expectedStdout: []byte("success"),
+			expectedStderr: []byte(""),
+			expectedErr: nil,
+		},
+		{
+			numFailures: maxRetry - 1,
+			expectedStdout: []byte("success"),
+			expectedStderr: []byte(""),
+			expectedErr: nil,
+		},
+		{
+			numFailures: maxRetry + 1,
+			expectedStdout: []byte(""),
+			expectedStderr: []byte("not enough retries"),
+			expectedErr: errors.New("not enough retries error"),
+		},
+	}
+
+	for _, tt := range tests {
+		SetCmdRunner(&retryRunner{
+			attemptsBeforeSuccess: tt.numFailures,
+		})
+		stdout, stderr, err := runHelm(log, release, ns, chartdir, operation, false, []string{}, false)
+		assert.Equal(t, stdout, tt.expectedStdout)
+		assert.Equal(t, stderr, tt.expectedStderr)
+		assert.Equal(t, err, tt.expectedErr)
+	}
+}
+
+// Run should return a success or error depending on how many times Run has been called previously
+func (r *retryRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
+	if r.retries < r.attemptsBeforeSuccess {
+		r.retries++
+		return []byte(""), []byte("not enough retries"), errors.New("not enough retries error")
+	}
+	return []byte("success"), []byte(""), nil
 }
 
 // Run should assert the command parameters are correct then return a success with stdout contents

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -171,6 +171,7 @@ func (r rancherComponent) ValidateUpdate(old *vzapi.Verrazzano, new *vzapi.Verra
 - note: VZ-5241 the rancher-operator-namespace is no longer used in 2.6.3
 - Copy TLS certificates for Rancher if using the default Verrazzano CA
 - Create additional LetsEncrypt TLS certificates for Rancher if using LE
+- Delete the bootstrap-secret if it exists
 */
 func (r rancherComponent) PreInstall(ctx spi.ComponentContext) error {
 	vz := ctx.EffectiveCR()

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -6,6 +6,10 @@ package rancher
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -17,9 +21,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 // ComponentName is the name of the component
@@ -179,6 +180,9 @@ func (r rancherComponent) PreInstall(ctx spi.ComponentContext) error {
 		return err
 	}
 	if err := copyDefaultCACertificate(log, c, vz); err != nil {
+		return err
+	}
+	if err := removeBootstrapSecretIfExists(log, c); err != nil {
 		return err
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -135,8 +135,9 @@ func TestIsEnabled(t *testing.T) {
 }
 
 func TestPreInstall(t *testing.T) {
+	bootstrapSecret := createBootstrapSecret()
 	caSecret := createCASecret()
-	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret).Build()
+	c := fake.NewClientBuilder().WithScheme(getScheme()).WithObjects(&caSecret, &bootstrapSecret).Build()
 	ctx := spi.NewFakeContext(c, &vzDefaultCA, false)
 	assert.Nil(t, NewComponent().PreInstall(ctx))
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -100,6 +100,18 @@ func createCASecret() v1.Secret {
 	}
 }
 
+func createBootstrapSecret() v1.Secret {
+	return v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.CattleSystem,
+			Name:      BootstrapSecret,
+		},
+		Data: map[string][]byte{
+			"bootstrapPassword": []byte("blahblah"),
+		},
+	}
+}
+
 func createRancherPodListWithAllRunning() v1.PodList {
 	return v1.PodList{
 		Items: []v1.Pod{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package rancher


### PR DESCRIPTION
This addresses a bug in Verrazzano v1.3 that prevents users from making changes to the Verrazzano CR during install.

This bug was due to missing Helm labels and annotations in the Rancher component's `bootstrap-secret` Secret. This PR fixes this by ensuring that `bootstrap-secret` is deleted in the Rancher preinstall, so that its recreation during Rancher install goes smoothly.

This PR also fixes a slightly related bug where Helm CLI upgrade command was not being retried upon failure.

This PR also adds to the unit tests relevant to my changes.