### PR TITLE
Use Verrazzano BFS for Rancher kubectl

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -736,13 +736,12 @@
           ]
         },
         {
-          "registry": "docker.io",
-          "repository": "rancher",
+          "repository": "verrazzano/rancher",
           "name": "rancher-backup-kubectl",
           "images": [
             {
               "image": "kubectl",
-              "tag": "v1.20.2",
+              "tag": "v1.20.2-20230124220617-b4579ed",
               "helmFullImageKey": "global.kubectl.repository",
               "helmTagKey": "global.kubectl.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -741,7 +741,7 @@
           "images": [
             {
               "image": "kubectl",
-              "tag": "v1.20.2-20230124220617-b4579ed",
+              "tag": "v1.20.2-20230125170623-2f0ea54",
               "helmFullImageKey": "global.kubectl.repository",
               "helmTagKey": "global.kubectl.tag"
             }


### PR DESCRIPTION
Use the Verrazzano build-from-source Rancher kubectl image instead of the image from docker.io.