### PR TITLE
PSR connect retry

### DIFF
--- a/tools/psr/backend/main.go
+++ b/tools/psr/backend/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package main
@@ -12,7 +12,10 @@ import (
 
 func main() {
 	vzlog2.InitLogs(kzap.Options{})
-	log := vzlog.DefaultLogger()
+	log, _ := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+		Name: "PSR",
+		ID:   "1",
+	})
 	log.Info("Starting PSR backend")
 
 	// Run the worker forever or until it quits

--- a/tools/psr/backend/pkg/k8sclient/client.go
+++ b/tools/psr/backend/pkg/k8sclient/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package k8sclient
@@ -6,13 +6,13 @@ package k8sclient
 import (
 	"fmt"
 	vzv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vpoClient "github.com/verrazzano/verrazzano/platform-operator/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	k8sapiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
-
-	vpoClient "github.com/verrazzano/verrazzano/platform-operator/clientset/versioned"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 // PsrClient contains the client sets for accessing various resource
@@ -22,8 +22,25 @@ type PsrClient struct {
 	DynClient   dynamic.Interface
 }
 
-// NewPsrClient returns the set of clients used by PSR
+// NewPsrClient returns a PSR client.
+// Try several times to get the client.  This fixes timing issue
+// where connections fails if Istio sidecar not ready
 func NewPsrClient() (PsrClient, error) {
+	const max = 15
+	var retErr error
+	for i := 1; i <= max; i++ {
+		c, err := tryNewPsrClient()
+		if err == nil {
+			return c, nil
+		}
+		retErr = err
+		time.Sleep(1 * time.Second)
+	}
+	return PsrClient{}, retErr
+}
+
+// tryNewPsrClient returns the set of clients used by PSR
+func tryNewPsrClient() (PsrClient, error) {
 	p := PsrClient{}
 
 	// Create the controller runtime client and add core resources to the scheme


### PR DESCRIPTION
When running PSR worker in the mesh, there is a timing problem where connection can fail if the worker starts before the istio sidecar proxy. Do some connection retries to fix this issue. This fixes the OpenSearch scale and WebLogic scale problems we were seeing.
