### PR TITLE
Change OL 7.9 image tag so we pick up a newer version of 7.9

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -271,7 +271,7 @@
             },
             {
               "image": "oraclelinux",
-              "tag": "7.9",
+              "tag": "7",
               "helmFullImageKey": "monitoringOperator.esInitImage"
             }
           ]


### PR DESCRIPTION
Guidance from OL release engineering is that we use OL tag `7` if we want the latest build, and not tag `7.9`.