### PR TITLE
VZ-8210: Increase timeout waiting for ready pods in end-to-end test

### DIFF
--- a/tests/e2e/pkg/update/validation.go
+++ b/tests/e2e/pkg/update/validation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package update
@@ -11,6 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+)
+
+const (
+	longWaitTimeout     = 10 * time.Minute
+	longPollingInterval = 30 * time.Second
 )
 
 func ValidatePods(deployName string, labelName string, nameSpace string, expectedPodsRunning uint32, hasPending bool) {
@@ -38,7 +43,7 @@ func ValidatePods(deployName string, labelName string, nameSpace string, expecte
 			return fmt.Errorf("Deployment name %s: expect pending pods %t, but got %t", deployName, hasPending, pendingPods)
 		}
 		return nil
-	}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "expect to get correct number of running and pending pods")
+	}, longWaitTimeout, longPollingInterval).Should(gomega.BeNil(), "expect to get correct number of running and pending pods")
 }
 
 func ValidatePodMemoryRequest(labels map[string]string, nameSpace, containerPrefix string, expectedMemory string) {

--- a/tests/e2e/pkg/update/validation.go
+++ b/tests/e2e/pkg/update/validation.go
@@ -5,12 +5,14 @@ package update
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (


### PR DESCRIPTION
There is an intermittent failure in the Istio auth policy test when the test is waiting for pods to become ready. The error looks like:
```
[2023-01-26T18:55:09.583Z]   Timed out after 300.003s.
[2023-01-26T18:55:09.583Z]   expect to get correct number of running and pending pods
[2023-01-26T18:55:09.583Z]   Expected
[2023-01-26T18:55:09.583Z]       <*errors.errorString | 0xc0005810b0>: {
[2023-01-26T18:55:09.583Z]           s: "Deployment name sleep: expect 1 running pods, but got 2",
[2023-01-26T18:55:09.583Z]       }
```
The reason this is happening is that during the test application installation, the deployment for the sleep workload is updated, which causes a rollout of the deployment and a new replicaset to be created. The existing sleep pod is not terminated until the new sleep pod is ready. There is a small window where two sleep pods are running and ready at the same time. If the `Eventually` times out during this window, the above error occurs.

To fix this, I've increased the timeout on the `Eventually` which should give the old sleep workload pod time to terminate.