### PR TITLE
VZ-8151: Allow changes to the VZ CR during initial install

### DIFF
--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helm
@@ -17,6 +17,12 @@ const ns = "my_namespace"
 const chartdir = "my_charts"
 const release = "my_release"
 const missingRelease = "no_release"
+
+// retryRunner is used to test retrying a Helm upgrade after first attempts do not succeed
+type retryRunner struct {
+	attemptsBeforeSuccess int
+	retries               int
+}
 
 // upgradeRunner is used to test Helm upgrade without actually running an OS exec command
 type upgradeRunner struct {
@@ -735,6 +741,58 @@ func Test_maskSensitiveData(t *testing.T) {
 		defaultBackend.image.repository=ghcr.io/verrazzano/nginx-ingress-default-backend,controller.service.type=LoadBalancer`
 	maskedStr = maskSensitiveData(str)
 	assert.Equal(t, str, maskedStr)
+}
+
+// Test_runHelm tests the runHelm function
+func Test_runHelm(t *testing.T) {
+	defer SetDefaultRunner()
+	operation := "operation"
+	log := vzlog.DefaultLogger()
+
+	tests := []struct {
+		numFailures    int
+		expectedStdout []byte
+		expectedStderr []byte
+		expectedErr    error
+	}{
+		{
+			numFailures:    0,
+			expectedStdout: []byte("success"),
+			expectedStderr: []byte(""),
+			expectedErr:    nil,
+		},
+		{
+			numFailures:    maxRetry - 1,
+			expectedStdout: []byte("success"),
+			expectedStderr: []byte(""),
+			expectedErr:    nil,
+		},
+		{
+			numFailures:    maxRetry + 1,
+			expectedStdout: []byte(""),
+			expectedStderr: []byte("not enough retries"),
+			expectedErr:    errors.New("not enough retries error"),
+		},
+	}
+
+	for _, tt := range tests {
+		SetCmdRunner(&retryRunner{
+			attemptsBeforeSuccess: tt.numFailures,
+		})
+		stdout, stderr, err := runHelm(log, release, ns, chartdir, operation, false, []string{}, false)
+		assert.Equal(t, stdout, tt.expectedStdout)
+		assert.Equal(t, stderr, tt.expectedStderr)
+		assert.Equal(t, err, tt.expectedErr)
+	}
+}
+
+// Run should return a success or error depending on how many times Run has been called previously
+func (r *retryRunner) Run(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
+	if r.retries < r.attemptsBeforeSuccess {
+		r.retries++
+		return []byte(""), []byte("not enough retries"), errors.New("not enough retries error")
+	}
+	return []byte("success"), []byte(""), nil
 }
 
 // Run should assert the command parameters are correct then return a success with stdout contents

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -89,11 +89,13 @@ func NewComponent() spi.Component {
 	}
 }
 
-// Reconcile - the only condition currently being handled by this function is to restore
-// the Keycloak configuration when the MySQL pod gets restarted and ephemeral storage is being used.
+// Reconcile - first checks whether Keycloak is installed yet, then
+// handles the condition to restore the Keycloak configuration when the MySQL pod gets restarted
+// and ephemeral storage is being used.
 func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
+	// First decide to continue with installation based on whether Keycloak is installed already
 	installed, err := c.IsInstalled(ctx)
-	if err != nil || !installed {
+	if !installed {
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -92,6 +92,11 @@ func NewComponent() spi.Component {
 // Reconcile - the only condition currently being handled by this function is to restore
 // the Keycloak configuration when the MySQL pod gets restarted and ephemeral storage is being used.
 func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
+	installed, err := c.IsInstalled(ctx)
+	if err != nil || !installed {
+		return err
+	}
+
 	// If the Keycloak component is ready, confirm the configuration is working.
 	// If ephemeral storage is being used, the Keycloak configuration will be rebuilt if needed.
 	if c.isKeycloakReady(ctx) {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -93,7 +93,7 @@ func NewComponent() spi.Component {
 // handles the condition to restore the Keycloak configuration when the MySQL pod gets restarted
 // and ephemeral storage is being used.
 func (c KeycloakComponent) Reconcile(ctx spi.ComponentContext) error {
-	// First decide to continue with installation based on whether Keycloak is installed already
+	// If Keycloak still needs to be installed for the first time, return a nil error to continue installation
 	installed, err := c.IsInstalled(ctx)
 	if !installed {
 		return err

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package keycloak
@@ -13,13 +13,17 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var kcComponent = NewComponent()
+var (
+	kcComponent = NewComponent()
+	testScheme  = runtime.NewScheme()
+)
 
 // TestIsEnabled tests the Keycloak IsEnabled call
 // GIVEN a Keycloak component
@@ -72,6 +76,18 @@ func TestIsEnabled(t *testing.T) {
 			assert.Equal(t, tt.isEnabled, kcComponent.IsEnabled(ctx.EffectiveCR()))
 		})
 	}
+}
+
+// TestReconcile tests the Keycloak Reconcile call
+// GIVEN a Keycloak component
+//
+// WHEN I call Reconcile with defaults, before Keycloak is actually installed
+// THEN a nil error is returned
+func TestReconcile(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, false)
+	err := NewComponent().Reconcile(ctx)
+	assert.NoError(t, err)
 }
 
 // TestPreinstall tests the Keycloak PreInstall call

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -186,10 +186,10 @@ func checkGenerationUpdated(spiCtx spi.ComponentContext) bool {
 // if it a watched component
 func (r *Reconciler) reconcileWatchedComponents(spiCtx spi.ComponentContext) error {
 	for _, comp := range registry.GetComponents() {
-		spiCtx.Log().Debugf("Reconciling watched component %", comp.Name())
+		spiCtx.Log().Debugf("Reconciling watched component %s", comp.Name())
 		if r.IsWatchedComponent(comp.GetJSONName()) {
 			if err := comp.Reconcile(spiCtx); err != nil {
-				spiCtx.Log().ErrorfThrottled("Error reconciling watched component %: %v", comp.Name(), err)
+				spiCtx.Log().ErrorfThrottled("Error reconciling watched component %s: %v", comp.Name(), err)
 				return err
 			}
 			r.ClearWatch(comp.GetJSONName())


### PR DESCRIPTION
Bug:
If the Verrazzano Custom Resource is changed during the initial install, then the Verrazzano installation gets stuck.

This happens if due to an error reported by Keycloak's `Reconcile` function, preventing the install from continuing. Specifically, if Keycloak calls `Reconcile` before the `keycloak` StatefulSet is created, then Keycloak's `Reconcile` function stalls the Verrazzano installation waiting for the StatefulSet to be created, which never happens at this point in the code.

Changes in this PR:

- Adds a condition in Keycloak's `Reconcile` function that handles the case where the Keycloak component is being reconciled during initial installation. This is the main fix to the above bug.
- Adds a bug fix from https://github.com/verrazzano/verrazzano/commit/1fbe23a4a8e1ec2347240e19b17751f6ffceb4f8 found from fixing a similar issue in release-1.3, dealing with retrying the Helm CLI `helm upgrade` commands in `helmcli.go`.
- Adds to relevant unit testing.