### PR TITLE
Reduce excessive logging in cluster-operator when waiting for managed cluster active state and Prometheus host to be populated

### DIFF
--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -141,7 +141,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncCACertSecret(vmc *clusterapi.Ve
 		return false, err
 	}
 	if !isActive {
-		r.log.Infof("Waiting for managed cluster with id %s to become active before fetching CA cert", clusterID)
+		r.log.Progressf("Waiting for managed cluster with id %s to become active before fetching CA cert", clusterID)
 		return false, nil
 	}
 

--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmc

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"time"
+
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/keycloak"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -233,7 +234,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 	}
 
 	if vmc.Status.PrometheusHost == "" {
-		log.Infof("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
+		log.Progressf("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
 	} else {
 		log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
 		err = r.syncPrometheusScraper(ctx, vmc)


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
