### PR TITLE
Fix  x509: certificate signed by unknown authority error during vz install

### DIFF
--- a/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify/verify_preupgrade_test.go
@@ -61,7 +61,7 @@ func updateConfigMap() {
 		testJobFound := false
 		updateMap := false
 		for _, nsc := range scrapeConfigs {
-			scrapeConfig := nsc.(map[interface{}]interface{})
+			scrapeConfig := nsc.(map[string]interface{})
 			// Change the default value of an existing default job
 			if scrapeConfig[vzconst.PrometheusJobNameKey] == "prometheus" && scrapeConfig["scrape_interval"].(string) != vzconst.TestPrometheusJobScrapeInterval {
 				scrapeConfig["scrape_interval"] = vzconst.TestPrometheusJobScrapeInterval

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helpers
@@ -401,8 +401,8 @@ func vpoIsReady(client clipkg.Client) (bool, error) {
 	return true, nil
 }
 
-// deleteLeftoverPlatformOperator deletes leftover verrazzano-operator deployment after an abort.
-// This allows for the verrazzano-operator validatingWebhookConfiguration to be updated with an updated caBundle.
+// deleteLeftoverPlatformOperator deletes leftover verrazzano-platform-operator deployments after an abort.
+// This allows for the verrazzano-platform-operator validatingWebhookConfiguration to be updated with an updated caBundle.
 func deleteLeftoverPlatformOperator(client clipkg.Client) error {
 	vpoDeployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -412,8 +412,20 @@ func deleteLeftoverPlatformOperator(client clipkg.Client) error {
 	}
 	if err := client.Delete(context.TODO(), &vpoDeployment); err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("Failed to delete leftover verrazzano-operator deployement: %s", err.Error())
+			return fmt.Errorf("Failed to delete leftover %s deployment: %s", constants.VerrazzanoPlatformOperator, err.Error())
 		}
 	}
+	vpoWebHookDeployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: vzconstants.VerrazzanoInstallNamespace,
+			Name:      constants.VerrazzanoPlatformOperatorWebhook,
+		},
+	}
+	if err := client.Delete(context.TODO(), &vpoWebHookDeployment); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("Failed to delete leftover %s deployment: %s", constants.VerrazzanoPlatformOperatorWebhook, err.Error())
+		}
+	}
+
 	return nil
 }

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install
@@ -172,8 +172,8 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			return err
 		}
 
-		// Delete leftover verrazzano-operator deployment after an abort.
-		// This allows for the verrazzano-operator validatingWebhookConfiguration to be updated with the correct caBundle.
+		// Delete leftover verrazzano-platform-operator deployments after an abort.
+		// This allows for the verrazzano-platform-operator validatingWebhookConfiguration to be updated with the correct caBundle.
 		err = cmdhelpers.DeleteFunc(client)
 		if err != nil {
 			return err


### PR DESCRIPTION
This pull request fixes a **x509: certificate signed by unknown authority** error during vz install.
The error was seen with the following steps:
1. vz install (install of v1.5.0)
2. kubectl delete vz verrazzano
3. vz install (install of v1.5.0)