### PR TITLE
VZ-8542: Grafana dashboard fixes

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Helidon/helidon_dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Helidon/helidon_dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": 12853,
   "graphTooltip": 0,
-  "iteration": 1649078542279,
+  "iteration": 1675288749097,
   "links": [],
   "panels": [
     {
@@ -246,7 +246,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -348,7 +348,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -447,7 +447,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -549,7 +549,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -665,7 +665,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1039,7 +1039,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1140,7 +1140,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.11",
+      "pluginVersion": "7.5.17",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1209,9 +1209,9 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "text": "managed1",
-          "value": "managed1"
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "Prometheus",
         "definition": "label_values(verrazzano_cluster)",
@@ -1335,5 +1335,5 @@
   "timezone": "",
   "title": "Helidon Monitoring Dashboard",
   "uid": "TkcxbEtWz",
-  "version": 1
+  "version": 2
 }

--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Istio/istio-mesh-dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Istio/istio-mesh-dashboard.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
+  "iteration": 1675288308220,
   "links": [],
   "panels": [
     {
@@ -1891,7 +1891,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -1908,23 +1907,7 @@
         "label": "Verrazzano Cluster",
         "multi": true,
         "name": "vzcluster",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "local",
-            "value": "local"
-          },
-          {
-            "selected": false,
-            "text": "managed1",
-            "value": "managed1"
-          }
-        ],
+        "options": [],
         "query": {
           "query": "label_values(verrazzano_cluster)",
           "refId": "StandardVariableQuery"
@@ -1973,5 +1956,5 @@
   "timezone": "browser",
   "title": "Istio Mesh Dashboard",
   "uid": "G8wLrJIZk",
-  "version": 6
+  "version": 7
 }

--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/JVM/jvm-micrometer.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/JVM/jvm-micrometer.json
@@ -30,8 +30,7 @@
   "editable": true,
   "gnetId": 4701,
   "graphTooltip": 1,
-  "id": 67,
-  "iteration": 1674081343448,
+  "iteration": 1675288087287,
   "links": [],
   "panels": [
     {
@@ -2335,319 +2334,6 @@
       "points": false,
       "renderer": "flot",
       "repeat": "jvm_memory_pool_heap",
-      "scopedVars": {
-        "jvm_memory_pool_heap": {
-          "selected": false,
-          "text": "Eden Space",
-          "value": "Eden Space"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_heap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 36
-      },
-      "hiddenSeries": false,
-      "id": 134,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 3,
-      "scopedVars": {
-        "jvm_memory_pool_heap": {
-          "selected": false,
-          "text": "Survivor Space",
-          "value": "Survivor Space"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_heap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 36
-      },
-      "hiddenSeries": false,
-      "id": 135,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 3,
-      "scopedVars": {
-        "jvm_memory_pool_heap": {
-          "selected": false,
-          "text": "Tenured Gen",
-          "value": "Tenured Gen"
-        }
-      },
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
@@ -2808,625 +2494,6 @@
       "points": false,
       "renderer": "flot",
       "repeat": "jvm_memory_pool_nonheap",
-      "scopedVars": {
-        "jvm_memory_pool_nonheap": {
-          "selected": false,
-          "text": "Metaspace",
-          "value": "Metaspace"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_nonheap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 44
-      },
-      "hiddenSeries": false,
-      "id": 136,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 78,
-      "scopedVars": {
-        "jvm_memory_pool_nonheap": {
-          "selected": false,
-          "text": "Compressed Class Space",
-          "value": "Compressed Class Space"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_nonheap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 44
-      },
-      "hiddenSeries": false,
-      "id": 137,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 78,
-      "scopedVars": {
-        "jvm_memory_pool_nonheap": {
-          "selected": false,
-          "text": "CodeHeap 'profiled nmethods'",
-          "value": "CodeHeap 'profiled nmethods'"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_nonheap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 51
-      },
-      "hiddenSeries": false,
-      "id": 138,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 78,
-      "scopedVars": {
-        "jvm_memory_pool_nonheap": {
-          "selected": false,
-          "text": "CodeHeap 'non-profiled nmethods'",
-          "value": "CodeHeap 'non-profiled nmethods'"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "used",
-          "metric": "",
-          "refId": "A",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_committed_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commited",
-          "metric": "",
-          "refId": "B",
-          "step": 1800
-        },
-        {
-          "exemplar": true,
-          "expr": "jvm_memory_max_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\", container != \"istio-proxy\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "max",
-          "metric": "",
-          "refId": "C",
-          "step": 1800
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$jvm_memory_pool_nonheap",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "x-axis": true,
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "y-axis": true,
-      "y_formats": [
-        "mbytes",
-        "short"
-      ],
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {
-        "leftLogBase": 1,
-        "leftMax": null,
-        "leftMin": null,
-        "rightLogBase": 1,
-        "rightMax": null,
-        "rightMin": null
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 51
-      },
-      "hiddenSeries": false,
-      "id": 139,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 3,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1674081343448,
-      "repeatPanelId": 78,
-      "scopedVars": {
-        "jvm_memory_pool_nonheap": {
-          "selected": false,
-          "text": "CodeHeap 'non-nmethods'",
-          "value": "CodeHeap 'non-nmethods'"
-        }
-      },
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
@@ -3524,7 +2591,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 51
       },
       "id": 131,
       "panels": [],
@@ -3548,7 +2615,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 98,
@@ -3646,7 +2713,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 59
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 101,
@@ -3756,7 +2823,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 99,
@@ -3853,7 +2920,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 59
       },
       "id": 132,
       "panels": [],
@@ -3887,7 +2954,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 37,
@@ -4003,7 +3070,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 38,
@@ -4102,7 +3169,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 67
       },
       "id": 133,
       "panels": [],
@@ -4136,7 +3203,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 75
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 33,
@@ -4263,7 +3330,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 75
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 83,
@@ -4380,7 +3447,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 75
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 85,
@@ -4507,7 +3574,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 75
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 84,
@@ -4621,23 +3688,12 @@
         "label": "Verrazzano Cluster",
         "multi": false,
         "name": "vzcluster",
-        "options": [
-          {
-            "selected": true,
-            "text": "local",
-            "value": "local"
-          },
-          {
-            "selected": false,
-            "text": "managed1",
-            "value": "managed1"
-          }
-        ],
+        "options": [],
         "query": {
           "query": "label_values(verrazzano_cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 0,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -4650,9 +3706,10 @@
       {
         "allValue": null,
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "springboot",
-          "value": "springboot"
+          "text": "None",
+          "value": ""
         },
         "datasource": "Prometheus",
         "definition": "label_values(jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\"}, application)",
@@ -4682,9 +3739,10 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "10.244.0.69:8080",
-          "value": "10.244.0.69:8080"
+          "text": "None",
+          "value": ""
         },
         "datasource": "Prometheus",
         "definition": "label_values(jvm_memory_used_bytes{verrazzano_cluster=~\"$vzcluster\", application=\"$application\"}, instance)",
@@ -4812,5 +3870,5 @@
   "timezone": "browser",
   "title": "JVM (Micrometer)",
   "uid": "Rr7lnBhVz",
-  "version": 5
+  "version": 6
 }

--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Verrazzano Application/verrazzano-application-dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Verrazzano Application/verrazzano-application-dashboard.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 70,
-  "iteration": 1674069174741,
+  "iteration": 1675287875757,
   "links": [],
   "panels": [
     {
@@ -743,7 +742,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "local",
           "value": "local"
         },
@@ -756,23 +755,12 @@
         "label": "Verrazzano Cluster",
         "multi": false,
         "name": "vzcluster",
-        "options": [
-          {
-            "selected": true,
-            "text": "local",
-            "value": "local"
-          },
-          {
-            "selected": false,
-            "text": "managed1",
-            "value": "managed1"
-          }
-        ],
+        "options": [],
         "query": {
           "query": "label_values(verrazzano_cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 0,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -785,9 +773,10 @@
       {
         "allValue": null,
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "sockshop-appconf",
-          "value": "sockshop-appconf"
+          "text": "None",
+          "value": ""
         },
         "datasource": null,
         "definition": "label_values(up{verrazzano_cluster=~\"$vzcluster\"}, app_oam_dev_name)",
@@ -854,5 +843,5 @@
   "timezone": "",
   "title": "Application Status",
   "uid": "gwdOx4h4z4345er",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
A few of the dashboards had hard-coded values for "Verrazzano Cluster" and were not dynamically updating. Also removed values due to dashboards being saved with data in them ("sockshop" for example).

Note: I was a little surprised by the volume of changes in the JVM dashboard. I think the chunks removed were exemplars and/or repeating rows that were included because the dashboard was saved with application data, but I'm not 100% sure about that.