### PR TITLE
use instance shape VM.Standard2.4 in OCNE acceptance tests

### DIFF
--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -171,6 +171,7 @@ pipeline {
         TF_VAR_olcne_version="${params.OCNE_VERSION}"
         TF_VAR_s3_bucket_access_key=credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key=credentials('oci-s3-bucket-secret-key')
+        TF_VAR_instance_shape="VM.Standard2.4"
 
         // OCI variables
         OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING='True'


### PR DESCRIPTION
OCNE acceptance tests fails intermittently as some of the big applications won't finished deploying.  Increase the instance shape from VM.Standard2.2 to VM.Standard2.4 for the OCNE cluster nodes.