### PR TITLE
add more cluster nodes in OCNE acceptance tests

### DIFF
--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
             trim: true)
         string (
             name: "WORKER_NODE_COUNT",
-            defaultValue: '4',
+            defaultValue: '5',
             description: 'Number of OCNE worker nodes',
             trim: true)
         choice (

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
             trim: true)
         string (
             name: "WORKER_NODE_COUNT",
-            defaultValue: '3',
+            defaultValue: '4',
             description: 'Number of OCNE worker nodes',
             trim: true)
         choice (


### PR DESCRIPTION
OCNE acceptance tests fails intermittently as some of the big applications won't finished deploying. Increase the node count from 3 to 5 in the OCNE cluster.