### PR TITLE
VZ-8312 IngressTrait JWT fixes

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -50,6 +50,9 @@ const LabelIstioInjectionDefault = "enabled"
 // LabelWorkloadType - the type of workload, such as WebLogic
 const LabelWorkloadType = "verrazzano.io/workload-type"
 
+// LabelIngressTraitNsn - Namespaced name of the ingress trait
+const LabelIngressTraitNsn = "verrazzano.io/ingress-trait"
+
 // WorkloadTypeWeblogic indicates the workload is WebLogic
 const WorkloadTypeWeblogic = "weblogic"
 

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -57,19 +57,20 @@ import (
 )
 
 const (
-	testTraitName           = "test-trait"
-	testTraitPortName       = "https-test-trait"
-	apiVersion              = "oam.verrazzano.io/v1alpha1"
-	traitKind               = "IngressTrait"
-	testNamespace           = "test-space"
-	expectedTraitVSName     = "test-trait-rule-0-vs"
-	expectedAuthzPolicyName = "test-trait-rule-0-authz-test-path"
-	expectedAppGWName       = "test-space-myapp-gw"
-	testWorkloadName        = "test-workload-name"
-	testWorkloadID          = "test-workload-uid"
-	istioIngressGatewayName = "istio-ingressgateway"
-	istioSystemNamespace    = "istio-system"
-	testName                = "test-name"
+	testTraitName                   = "test-trait"
+	testTraitPortName               = "https-test-trait"
+	apiVersion                      = "oam.verrazzano.io/v1alpha1"
+	traitKind                       = "IngressTrait"
+	testNamespace                   = "test-space"
+	expectedTraitVSName             = "test-trait-rule-0-vs"
+	expectedAuthzPolicyName         = "test-trait-rule-0-authz-test-path"
+	expectedAuthzPolicyNameRootPath = "test-trait-rule-0-authz"
+	expectedAppGWName               = "test-space-myapp-gw"
+	testWorkloadName                = "test-workload-name"
+	testWorkloadID                  = "test-workload-uid"
+	istioIngressGatewayName         = "istio-ingressgateway"
+	istioSystemNamespace            = "istio-system"
+	testName                        = "test-name"
 )
 
 var (
@@ -369,6 +370,228 @@ func TestSuccessfullyCreateNewIngressWithAuthorizationPolicy(t *testing.T) {
 	createVSSuccessExpectations(mock)
 	traitAuthzPolicyNotFoundExpectation(mock)
 	createAuthzPolicySuccessExpectations(mock, assert, 1, 1)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 3)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest(testNamespace, testTraitName)
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestSuccessfullyCreateIngressWithAuthorizationPolicy2Paths tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that specifies an authorization policy for the test path
+// and a root path
+// WHEN the trait exists but the ingress does not
+// THEN ensure that the trait and the authorization policy are created.
+func TestSuccessfullyCreateIngressWithAuthorizationPolicy2Paths(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       traitKind}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Labels:    map[string]string{oam.LabelAppName: "myapp", oam.LabelAppComponent: "mycomp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{
+					{Path: "/"},
+					{
+						Path: "/test-path",
+						Policy: &vzapi.AuthorizationPolicy{
+							Rules: []*vzapi.AuthorizationRule{
+								{
+									From: &vzapi.AuthorizationRuleFrom{RequestPrincipals: []string{"*"}},
+									When: []*vzapi.AuthorizationRuleCondition{
+										{
+											Key:    "testKey",
+											Values: []string{"testValue"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName}
+			return nil
+		})
+	// Expect a call to update the ingress trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, options ...client.UpdateOption) error {
+			assert.Equal(testNamespace, trait.Namespace)
+			assert.Equal(testTraitName, trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal(finalizerName, trait.Finalizers[0])
+			return nil
+		})
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	getGatewayForTraitNotFoundExpectations(mock)
+
+	// Expect a call to create the ingress/gateway resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
+			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
+			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
+			return nil
+		})
+	// Expect a call to get the app config and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
+			app.TypeMeta = metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ApplicationConfiguration",
+			}
+			return nil
+		})
+
+	traitVSNotFoundExpectation(mock)
+	createVSSuccessExpectations(mock)
+	traitAuthzPolicyRootPathNotFoundExpectation(mock)
+	traitAuthzPolicyNotFoundExpectation(mock)
+	createAuthzPolicyRootPathSuccessExpectations(mock, assert, 1, 0)
+	createAuthzPolicySuccessExpectations(mock, assert, 1, 1)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 4)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest(testNamespace, testTraitName)
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestSuccessfullyCreateIngressWithAuthorizationPolicyNoPaths tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that specifies an authorization policy for no endpoints in the
+// ingress path.
+// WHEN the trait exists but the ingress does not
+// THEN ensure that the trait and the authorization policy are created.
+func TestSuccessfullyCreateIngressWithAuthorizationPolicyNoPaths(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       traitKind}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Labels:    map[string]string{oam.LabelAppName: "myapp", oam.LabelAppComponent: "mycomp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{
+					{
+						Policy: &vzapi.AuthorizationPolicy{
+							Rules: []*vzapi.AuthorizationRule{
+								{
+									From: &vzapi.AuthorizationRuleFrom{RequestPrincipals: []string{"*"}},
+									When: []*vzapi.AuthorizationRuleCondition{
+										{
+											Key:    "testKey",
+											Values: []string{"testValue"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName}
+			return nil
+		})
+	// Expect a call to update the ingress trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, options ...client.UpdateOption) error {
+			assert.Equal(testNamespace, trait.Namespace)
+			assert.Equal(testTraitName, trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal(finalizerName, trait.Finalizers[0])
+			return nil
+		})
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	getGatewayForTraitNotFoundExpectations(mock)
+
+	// Expect a call to create the ingress/gateway resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
+			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
+			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
+			return nil
+		})
+	// Expect a call to get the app config and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
+			app.TypeMeta = metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ApplicationConfiguration",
+			}
+			return nil
+		})
+
+	traitVSNotFoundExpectation(mock)
+	createVSSuccessExpectations(mock)
+	traitAuthzPolicyRootPathNotFoundExpectation(mock)
+	createAuthzPolicyRootPathSuccessExpectations(mock, assert, 1, 1)
 	getMockStatusWriterExpectations(mock, mockStatus)
 
 	mockStatus.EXPECT().
@@ -3980,6 +4203,21 @@ func traitVSNotFoundExpectation(mock *mocks.MockClient) {
 		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "VirtualService"}, expectedTraitVSName))
 }
 
+func createAuthzPolicyRootPathSuccessExpectations(mock *mocks.MockClient, assert *asserts.Assertions, numRules int, numCondtions int) {
+	// Expect a call to create the authorization policy resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, authorizationPolicy *v1beta1.AuthorizationPolicy, opts ...client.CreateOption) error {
+			assert.Equal(expectedAuthzPolicyNameRootPath, authorizationPolicy.Name, "wrong name")
+			assert.Equal(istioSystemNamespace, authorizationPolicy.Namespace, "wrong namespace")
+			assert.Len(authorizationPolicy.Spec.Rules, numRules, "wrong number of rules")
+			for _, rule := range authorizationPolicy.Spec.Rules {
+				assert.Len(rule.When, numCondtions, "wrong number of conditions")
+			}
+			return nil
+		})
+}
+
 func createAuthzPolicySuccessExpectations(mock *mocks.MockClient, assert *asserts.Assertions, numRules int, numCondtions int) {
 	// Expect a call to create the authorization policy resource and return success
 	mock.EXPECT().
@@ -3993,6 +4231,13 @@ func createAuthzPolicySuccessExpectations(mock *mocks.MockClient, assert *assert
 			}
 			return nil
 		})
+}
+
+func traitAuthzPolicyRootPathNotFoundExpectation(mock *mocks.MockClient) {
+	// Expect a call to get the authorization policy resource for path only related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: expectedAuthzPolicyNameRootPath}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: istioSystemNamespace, Resource: "AuthorizationPolicy"}, expectedAuthzPolicyNameRootPath))
 }
 
 func traitAuthzPolicyNotFoundExpectation(mock *mocks.MockClient) {

--- a/application-operator/controllers/ingresstrait/ingresstrait_ops.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_ops.go
@@ -6,13 +6,13 @@ package ingresstrait
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
-	"strings"
-
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clisecurity "istio.io/client-go/pkg/apis/security/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	certapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
@@ -47,34 +47,26 @@ func cleanup(trait *vzapi.IngressTrait, client client.Client, log vzlog.Verrazza
 }
 
 func cleanupPolicies(trait *vzapi.IngressTrait, c client.Client, log vzlog.VerrazzanoLogger) error {
-	rules := trait.Spec.Rules
-	for index, rule := range rules {
-		namePrefix := fmt.Sprintf("%s-rule-%d-authz", trait.Name, index)
-		for _, path := range rule.Paths {
-			if path.Policy != nil {
-				pathSuffix := strings.Replace(path.Path, "/", "", -1)
-				policyName := fmt.Sprintf("%s-%s", namePrefix, pathSuffix)
-				authzPolicy := &clisecurity.AuthorizationPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      policyName,
-						Namespace: constants.IstioSystemNamespace,
-					},
-				}
-				// Delete the authz policy, ignore not found
-				log.Debugf("Deleting authorization policy: %s", authzPolicy.Name)
-				err := c.Delete(context.TODO(), authzPolicy, &client.DeleteOptions{})
-				if err != nil {
-					if k8serrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-						log.Debugf("NotFound deleting authorization policy %s", authzPolicy.Name)
-						return nil
-					}
-					log.Errorf("Failed deleting the authorization policy %s", authzPolicy.Name)
-				}
-				log.Debugf("Ingress rule path authorization policy %s deleted", authzPolicy.Name)
-			}
-		}
+	// Find all AuthorizationPolicies created for this IngressTrait
+	traitNameReq, _ := labels.NewRequirement(constants.LabelIngressTraitNsn, selection.Equals, []string{getIngressTraitNsn(trait.Namespace, trait.Name)})
+	selector := labels.NewSelector().Add(*traitNameReq)
+	authPolicyList := clisecurity.AuthorizationPolicyList{}
+	err := c.List(context.TODO(), &authPolicyList, &client.ListOptions{Namespace: "", LabelSelector: selector})
+	if err != nil {
+		log.Errorf("Failed listing the authorization policies %s")
 	}
-
+	for i, authPolicy := range authPolicyList.Items {
+		// Delete the policy, ignore not found
+		log.Debugf("Deleting authorization policy: %s", authPolicy.Name)
+		err := c.Delete(context.TODO(), authPolicyList.Items[i], &client.DeleteOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				log.Oncef("NotFound deleting authorization policy %s", authPolicy.Name)
+			}
+			return log.ErrorfNewErr("Failed deleting the authorization policy %s", authPolicy.Name)
+		}
+		log.Oncef("Ingress rule path authorization policy %s deleted", authPolicy.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick to 1.5
Fix 3 issues with IngressTraits and JWT

1. AuthorizationPolicy with missing path fails to create AuthorizationPolicy Rule with path but no authorizationPolicy needs to Create AuthorizationPolicy if any other rule includes authorizationPolicy. If this is not done, then all requests (regardless of path) do JWT validation
2. When IngressTrait is delete the AuthorizationPolicies in istio-system for that trait were not being deleted

