### PR TITLE
Backport JWT fix for VZ-8312

### DIFF
--- a/application-operator/constants/constants.go
+++ b/application-operator/constants/constants.go
@@ -50,6 +50,9 @@ const LabelIstioInjectionDefault = "enabled"
 // LabelWorkloadType - the type of workload, such as WebLogic
 const LabelWorkloadType = "verrazzano.io/workload-type"
 
+// LabelIngressTraitNsn - Namespaced name of the ingress trait
+const LabelIngressTraitNsn = "verrazzano.io/ingress-trait"
+
 // WorkloadTypeWeblogic indicates the workload is WebLogic
 const WorkloadTypeWeblogic = "weblogic"
 

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -266,7 +266,7 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 				authzPolicyName := fmt.Sprintf("%s-rule-%d-authz", trait.Name, index)
 				r.createOrUpdateVirtualService(ctx, trait, rule, allHostsForTrait, vsName, services, gateway, &status, log)
 				r.createOrUpdateDestinationRule(ctx, trait, rule, drName, &status, log, services)
-				r.createOrUpdateAuthorizationPolicies(ctx, rule, authzPolicyName, allHostsForTrait, &status, log)
+				r.createOrUpdateAuthorizationPolicies(ctx, trait, rule, authzPolicyName, allHostsForTrait, &status, log)
 			}
 		}
 	}
@@ -707,7 +707,7 @@ func (r *Reconciler) mutateVirtualService(virtualService *istioclient.VirtualSer
 	return nil
 }
 
-//createOfUpdateDestinationRule creates or updates the DestinationRule.
+// createOfUpdateDestinationRule creates or updates the DestinationRule.
 func (r *Reconciler) createOrUpdateDestinationRule(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, name string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger, services []*corev1.Service) {
 	if rule.Destination.HTTPCookie != nil {
 		destinationRule := &istioclient.DestinationRule{
@@ -775,15 +775,64 @@ func (r *Reconciler) mutateDestinationRule(destinationRule *istioclient.Destinat
 	return controllerutil.SetControllerReference(trait, destinationRule, r.Scheme)
 }
 
-//createOrUpdateAuthorizationPolicies creates or updates the authorization policies associated with the paths defined in the ingress rule.
-func (r *Reconciler) createOrUpdateAuthorizationPolicies(ctx context.Context, rule vzapi.IngressRule, namePrefix string, hosts []string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
+// createOrUpdateAuthorizationPolicies creates or updates the AuthorizationPolicy associated with the
+// paths defined in the ingress rule.
+//
+// Ingress AuthorizationPolicies are used in conjunction with RequestPolicies (created by the user) to handle
+// requests with JWT headers. If any path uses an AuthorizationPolicy, we need to add a rule in that AuthorizationPolicy
+// for every path. This is needed otherwise a request to a path without an AuthorizationPolicy will get
+// rejected.  For example, if the /greet endpoint has an AuthorizationPolicy, the / endpoint will get rejected unless
+// we have a rule for path / as shown in the following example (the first rule):
+//
+//	 rules:
+//	- to:
+//	  - operation:
+//	      hosts:
+//	      - hello-helidon.hello-helidon.1.2.3.4.nip.io
+//	      paths:
+//	      - /
+//	- from:
+//	  - source:
+//	      requestPrincipals:     ====>  This is the indicator that an AuthorizationPolicy is needed
+//	      - '*'
+//	  to:
+//	  - operation:
+//	      hosts:
+//	      - hello-helidon.hello-helidon.1.2.3.4.nip.io
+//	      paths:
+//	      - /greet
+func (r *Reconciler) createOrUpdateAuthorizationPolicies(ctx context.Context, trait *vzapi.IngressTrait, rule vzapi.IngressRule, namePrefix string, hosts []string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) {
+	// If any path needs an AuthorizationPolicy then add one for every path
+	var addAuthPolicy bool
 	for _, path := range rule.Paths {
 		if path.Policy != nil {
+			addAuthPolicy = true
+		}
+	}
+	for _, path := range rule.Paths {
+		if addAuthPolicy {
+			requireFrom := true
+
+			// Add a policy rule if one is missing
+			if path.Policy == nil {
+				path.Policy = &vzapi.AuthorizationPolicy{
+					Rules: []*vzapi.AuthorizationRule{{}},
+				}
+				// No from field required, this is just a path being added
+				requireFrom = false
+			}
+
 			pathSuffix := strings.Replace(path.Path, "/", "", -1)
 			policyName := namePrefix
 			if pathSuffix != "" {
 				policyName = fmt.Sprintf("%s-%s", policyName, pathSuffix)
 			}
+			// Create the AuthorizationPolicy resource.
+			// Note that this is created in istio-system. If we create this in the application namespace,
+			// which is also a valid option, requests to the protected endpoint without a JWT token bypass
+			// the JWT check because the default AuthorizationPolicy (e.g. hello-helidon) allows access from the
+			// Istio IngressGateway to the application.  This problem is solved by putting the AuthorizationPolicy
+			// in the istio-system namespace.
 			authzPolicy := &clisecurity.AuthorizationPolicy{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       authzPolicyKind,
@@ -792,10 +841,11 @@ func (r *Reconciler) createOrUpdateAuthorizationPolicies(ctx context.Context, ru
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      policyName,
 					Namespace: constants.IstioSystemNamespace,
+					Labels:    map[string]string{constants.LabelIngressTraitNsn: getIngressTraitNsn(trait.Namespace, trait.Name)},
 				},
 			}
 			res, err := controllerutil.CreateOrUpdate(ctx, r.Client, authzPolicy, func() error {
-				return r.mutateAuthorizationPolicy(authzPolicy, path.Policy, path.Path, hosts)
+				return r.mutateAuthorizationPolicy(authzPolicy, path.Policy, path.Path, hosts, requireFrom)
 			})
 
 			ref := vzapi.QualifiedResourceRelation{APIVersion: authzPolicyAPIVersion, Kind: authzPolicyKind, Name: namePrefix, Role: "authorizationpolicy"}
@@ -810,16 +860,17 @@ func (r *Reconciler) createOrUpdateAuthorizationPolicies(ctx context.Context, ru
 	}
 }
 
-// mutateDestinationRule changes the destination rule based upon a traits configuration
-func (r *Reconciler) mutateAuthorizationPolicy(authzPolicy *clisecurity.AuthorizationPolicy, vzPolicy *vzapi.AuthorizationPolicy, path string, hosts []string) error {
+// mutateAuthorizationPolicy changes the destination rule based upon a trait's configuration
+func (r *Reconciler) mutateAuthorizationPolicy(authzPolicy *clisecurity.AuthorizationPolicy, vzPolicy *vzapi.AuthorizationPolicy, path string, hosts []string, requireFrom bool) error {
 	policyRules := make([]*v1beta1.Rule, len(vzPolicy.Rules))
 	var err error
 	for i, authzRule := range vzPolicy.Rules {
-		policyRules[i], err = createAuthorizationPolicyRule(authzRule, path, hosts)
+		policyRules[i], err = createAuthorizationPolicyRule(authzRule, path, hosts, requireFrom)
 		if err != nil {
 			return err
 		}
 	}
+
 	authzPolicy.Spec = v1beta1.AuthorizationPolicy{
 		Selector: &v1beta12.WorkloadSelector{
 			MatchLabels: map[string]string{"istio": "ingressgateway"},
@@ -831,29 +882,29 @@ func (r *Reconciler) mutateAuthorizationPolicy(authzPolicy *clisecurity.Authoriz
 }
 
 // createAuthorizationPolicyRule uses the provided information to create an istio authorization policy rule
-func createAuthorizationPolicyRule(rule *vzapi.AuthorizationRule, path string, hosts []string) (*v1beta1.Rule, error) {
-	if rule.From == nil {
+func createAuthorizationPolicyRule(rule *vzapi.AuthorizationRule, path string, hosts []string, requireFrom bool) (*v1beta1.Rule, error) {
+	authzRule := v1beta1.Rule{}
+
+	if requireFrom && rule.From == nil {
 		return nil, fmt.Errorf("Authorization Policy requires 'From' clause")
 	}
-	source := &v1beta1.Source{
-		RequestPrincipals: rule.From.RequestPrincipals,
-	}
-	paths := &v1beta1.Operation{
-		Paths: []string{path},
-		Hosts: hosts,
-	}
-	authzRule := v1beta1.Rule{
-		From: []*v1beta1.Rule_From{
-			{
-				Source: source,
+	if rule.From != nil {
+		authzRule.From = []*v1beta1.Rule_From{
+			{Source: &v1beta1.Source{
+				RequestPrincipals: rule.From.RequestPrincipals},
 			},
-		},
-		To: []*v1beta1.Rule_To{
-			{
-				Operation: paths,
-			},
-		},
+		}
 	}
+
+	if len(path) > 0 {
+		authzRule.To = []*v1beta1.Rule_To{{
+			Operation: &v1beta1.Operation{
+				Hosts: hosts,
+				Paths: []string{path},
+			},
+		}}
+	}
+
 	if rule.When != nil {
 		conditions := []*v1beta1.Condition{}
 		for _, vzCondition := range rule.When {
@@ -940,8 +991,9 @@ func (r *Reconciler) isIstioIngressGatewayUpdated(updateEvent event.UpdateEvent)
 	return false
 }
 
-//createIngressTraitReconcileRequests Used by the Console ingress watcher to map a detected change in the ingress
-//  to requests to reconcile any existing application IngressTrait objects
+// createIngressTraitReconcileRequests Used by the Console ingress watcher to map a detected change in the ingress
+//
+//	to requests to reconcile any existing application IngressTrait objects
 func (r *Reconciler) createIngressTraitReconcileRequests() []reconcile.Request {
 	requests := []reconcile.Request{}
 
@@ -1285,9 +1337,11 @@ func convertAPIVersionAndKindToNamespacedName(apiVersion string, kind string) ty
 
 // buildAppFullyQualifiedHostName generates a DNS host name for the application using the following structure:
 // <app>.<namespace>.<dns-subdomain>  where
-//   app is the OAM application name
-//   namespace is the namespace of the OAM application
-//   dns-subdomain is The DNS subdomain name
+//
+//	app is the OAM application name
+//	namespace is the namespace of the OAM application
+//	dns-subdomain is The DNS subdomain name
+//
 // For example: sales.cars.example.com
 func buildAppFullyQualifiedHostName(cli client.Reader, trait *vzapi.IngressTrait) (string, error) {
 	appName, ok := trait.Labels[oam.LabelAppName]
@@ -1303,8 +1357,10 @@ func buildAppFullyQualifiedHostName(cli client.Reader, trait *vzapi.IngressTrait
 
 // buildNamespacedDomainName generates a domain name for the application using the following structure:
 // <namespace>.<dns-subdomain>  where
-//   namespace is the namespace of the OAM application
-//   dns-subdomain is The DNS subdomain name
+//
+//	namespace is the namespace of the OAM application
+//	dns-subdomain is The DNS subdomain name
+//
 // For example: cars.example.com
 func buildNamespacedDomainName(cli client.Reader, trait *vzapi.IngressTrait) (string, error) {
 	const externalDNSKey = "external-dns.alpha.kubernetes.io/target"
@@ -1363,4 +1419,8 @@ func buildDomainNameForWildcard(cli client.Reader, trait *vzapi.IngressTrait, su
 	}
 	domain := IP + "." + suffix
 	return domain, nil
+}
+
+func getIngressTraitNsn(namespace string, name string) string {
+	return fmt.Sprintf("%s-%s", namespace, name)
 }

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -58,19 +58,20 @@ import (
 )
 
 const (
-	testTraitName           = "test-trait"
-	testTraitPortName       = "https-test-trait"
-	apiVersion              = "oam.verrazzano.io/v1alpha1"
-	traitKind               = "IngressTrait"
-	testNamespace           = "test-space"
-	expectedTraitVSName     = "test-trait-rule-0-vs"
-	expectedAuthzPolicyName = "test-trait-rule-0-authz-test-path"
-	expectedAppGWName       = "test-space-myapp-gw"
-	testWorkloadName        = "test-workload-name"
-	testWorkloadID          = "test-workload-uid"
-	istioIngressGatewayName = "istio-ingressgateway"
-	istioSystemNamespace    = "istio-system"
-	testName                = "test-name"
+	testTraitName                   = "test-trait"
+	testTraitPortName               = "https-test-trait"
+	apiVersion                      = "oam.verrazzano.io/v1alpha1"
+	traitKind                       = "IngressTrait"
+	testNamespace                   = "test-space"
+	expectedTraitVSName             = "test-trait-rule-0-vs"
+	expectedAuthzPolicyName         = "test-trait-rule-0-authz-test-path"
+	expectedAuthzPolicyNameRootPath = "test-trait-rule-0-authz"
+	expectedAppGWName               = "test-space-myapp-gw"
+	testWorkloadName                = "test-workload-name"
+	testWorkloadID                  = "test-workload-uid"
+	istioIngressGatewayName         = "istio-ingressgateway"
+	istioSystemNamespace            = "istio-system"
+	testName                        = "test-name"
 )
 
 var (
@@ -370,6 +371,228 @@ func TestSuccessfullyCreateNewIngressWithAuthorizationPolicy(t *testing.T) {
 	createVSSuccessExpectations(mock)
 	traitAuthzPolicyNotFoundExpectation(mock)
 	createAuthzPolicySuccessExpectations(mock, assert, 1, 1)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 3)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest(testNamespace, testTraitName)
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestSuccessfullyCreateIngressWithAuthorizationPolicy2Paths tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that specifies an authorization policy for the test path
+// and a root path
+// WHEN the trait exists but the ingress does not
+// THEN ensure that the trait and the authorization policy are created.
+func TestSuccessfullyCreateIngressWithAuthorizationPolicy2Paths(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       traitKind}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Labels:    map[string]string{oam.LabelAppName: "myapp", oam.LabelAppComponent: "mycomp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{
+					{Path: "/"},
+					{
+						Path: "/test-path",
+						Policy: &vzapi.AuthorizationPolicy{
+							Rules: []*vzapi.AuthorizationRule{
+								{
+									From: &vzapi.AuthorizationRuleFrom{RequestPrincipals: []string{"*"}},
+									When: []*vzapi.AuthorizationRuleCondition{
+										{
+											Key:    "testKey",
+											Values: []string{"testValue"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName}
+			return nil
+		})
+	// Expect a call to update the ingress trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, options ...client.UpdateOption) error {
+			assert.Equal(testNamespace, trait.Namespace)
+			assert.Equal(testTraitName, trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal(finalizerName, trait.Finalizers[0])
+			return nil
+		})
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	getGatewayForTraitNotFoundExpectations(mock)
+
+	// Expect a call to create the ingress/gateway resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
+			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
+			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
+			return nil
+		})
+	// Expect a call to get the app config and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
+			app.TypeMeta = metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ApplicationConfiguration",
+			}
+			return nil
+		})
+
+	traitVSNotFoundExpectation(mock)
+	createVSSuccessExpectations(mock)
+	traitAuthzPolicyRootPathNotFoundExpectation(mock)
+	traitAuthzPolicyNotFoundExpectation(mock)
+	createAuthzPolicyRootPathSuccessExpectations(mock, assert, 1, 0)
+	createAuthzPolicySuccessExpectations(mock, assert, 1, 1)
+	getMockStatusWriterExpectations(mock, mockStatus)
+
+	mockStatus.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, opts ...client.UpdateOption) error {
+			assert.Len(trait.Status.Conditions, 1)
+			assert.Len(trait.Status.Resources, 4)
+			return nil
+		})
+
+	// Create and make the request
+	request := newRequest(testNamespace, testTraitName)
+	reconciler := newIngressTraitReconciler(mock)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+
+	// Validate the results
+	mocker.Finish()
+	assert.NoError(err)
+	assert.Equal(true, result.Requeue)
+	assert.Equal(time.Duration(0), result.RequeueAfter)
+}
+
+// TestSuccessfullyCreateIngressWithAuthorizationPolicyNoPaths tests the Reconcile method for the following use case.
+// GIVEN a request to reconcile an ingress trait resource that specifies an authorization policy for no endpoints in the
+// ingress path.
+// WHEN the trait exists but the ingress does not
+// THEN ensure that the trait and the authorization policy are created.
+func TestSuccessfullyCreateIngressWithAuthorizationPolicyNoPaths(t *testing.T) {
+	assert := asserts.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	mockStatus := mocks.NewMockStatusWriter(mocker)
+	// Expect a call to get the ingress trait resource.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: testTraitName}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, trait *vzapi.IngressTrait) error {
+			trait.TypeMeta = metav1.TypeMeta{
+				APIVersion: apiVersion,
+				Kind:       traitKind}
+			trait.ObjectMeta = metav1.ObjectMeta{
+				Namespace: name.Namespace,
+				Name:      name.Name,
+				Labels:    map[string]string{oam.LabelAppName: "myapp", oam.LabelAppComponent: "mycomp"}}
+			trait.Spec.Rules = []vzapi.IngressRule{{
+				Hosts: []string{"test-host"},
+				Paths: []vzapi.IngressPath{
+					{
+						Policy: &vzapi.AuthorizationPolicy{
+							Rules: []*vzapi.AuthorizationRule{
+								{
+									From: &vzapi.AuthorizationRuleFrom{RequestPrincipals: []string{"*"}},
+									When: []*vzapi.AuthorizationRuleCondition{
+										{
+											Key:    "testKey",
+											Values: []string{"testValue"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}}}
+			trait.Spec.TLS = vzapi.IngressSecurity{SecretName: "cert-secret"}
+			trait.Spec.WorkloadReference = oamrt.TypedReference{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName}
+			return nil
+		})
+	// Expect a call to update the ingress trait resource with a finalizer.
+	mock.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, trait *vzapi.IngressTrait, options ...client.UpdateOption) error {
+			assert.Equal(testNamespace, trait.Namespace)
+			assert.Equal(testTraitName, trait.Name)
+			assert.Len(trait.Finalizers, 1)
+			assert.Equal(finalizerName, trait.Finalizers[0])
+			return nil
+		})
+
+	workLoadResourceExpectations(mock)
+	workloadResourceDefinitionExpectations(mock)
+	listChildDeploymentExpectations(mock, assert)
+	childServiceExpectations(mock, assert)
+	getGatewayForTraitNotFoundExpectations(mock)
+
+	// Expect a call to create the ingress/gateway resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, gateway *istioclient.Gateway, opts ...client.CreateOption) error {
+			assert.Equal(istionet.ServerTLSSettings_SIMPLE, gateway.Spec.Servers[0].Tls.Mode, "Wrong Tls Mode")
+			assert.Equal("cert-secret", gateway.Spec.Servers[0].Tls.CredentialName, "Wrong secret name")
+			return nil
+		})
+	// Expect a call to get the app config and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: testNamespace, Name: "myapp"}, gomock.Not(gomock.Nil())).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, app *v1alpha2.ApplicationConfiguration) error {
+			app.TypeMeta = metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ApplicationConfiguration",
+			}
+			return nil
+		})
+
+	traitVSNotFoundExpectation(mock)
+	createVSSuccessExpectations(mock)
+	traitAuthzPolicyRootPathNotFoundExpectation(mock)
+	createAuthzPolicyRootPathSuccessExpectations(mock, assert, 1, 1)
 	getMockStatusWriterExpectations(mock, mockStatus)
 
 	mockStatus.EXPECT().
@@ -3541,7 +3764,7 @@ func TestUpdateGatewayServersList(t *testing.T) {
 // IngressTrait definitions.  Post-1.3, we replace this with a 1:1 mapping of Server objects to IngressTrait.
 // Each Server object will define port settings for all hosts in the IngressTrait and be recomputed on each reconcile.
 //
-// On startup, the operator will reconcile all existing IngressTraits which will create the new mappings
+// # On startup, the operator will reconcile all existing IngressTraits which will create the new mappings
 //
 // GIVEN a request to update the gateway servers list for an ingress trait resource
 // WHEN we are upgrading from a release before 1.3 where the Gateway maintains a single Server object for all hosts for an application
@@ -3981,6 +4204,21 @@ func traitVSNotFoundExpectation(mock *mocks.MockClient) {
 		Return(k8serrors.NewNotFound(schema.GroupResource{Group: testNamespace, Resource: "VirtualService"}, expectedTraitVSName))
 }
 
+func createAuthzPolicyRootPathSuccessExpectations(mock *mocks.MockClient, assert *asserts.Assertions, numRules int, numCondtions int) {
+	// Expect a call to create the authorization policy resource and return success
+	mock.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, authorizationPolicy *v1beta1.AuthorizationPolicy, opts ...client.CreateOption) error {
+			assert.Equal(expectedAuthzPolicyNameRootPath, authorizationPolicy.Name, "wrong name")
+			assert.Equal(istioSystemNamespace, authorizationPolicy.Namespace, "wrong namespace")
+			assert.Len(authorizationPolicy.Spec.Rules, numRules, "wrong number of rules")
+			for _, rule := range authorizationPolicy.Spec.Rules {
+				assert.Len(rule.When, numCondtions, "wrong number of conditions")
+			}
+			return nil
+		})
+}
+
 func createAuthzPolicySuccessExpectations(mock *mocks.MockClient, assert *asserts.Assertions, numRules int, numCondtions int) {
 	// Expect a call to create the authorization policy resource and return success
 	mock.EXPECT().
@@ -4001,6 +4239,13 @@ func traitAuthzPolicyNotFoundExpectation(mock *mocks.MockClient) {
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: expectedAuthzPolicyName}, gomock.Not(gomock.Nil())).
 		Return(k8serrors.NewNotFound(schema.GroupResource{Group: istioSystemNamespace, Resource: "AuthorizationPolicy"}, expectedAuthzPolicyName))
+}
+
+func traitAuthzPolicyRootPathNotFoundExpectation(mock *mocks.MockClient) {
+	// Expect a call to get the authorization policy resource for path only related to the ingress trait and return that it is not found.
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: istioSystemNamespace, Name: expectedAuthzPolicyNameRootPath}, gomock.Not(gomock.Nil())).
+		Return(k8serrors.NewNotFound(schema.GroupResource{Group: istioSystemNamespace, Resource: "AuthorizationPolicy"}, expectedAuthzPolicyNameRootPath))
 }
 
 func childServiceExpectations(mock *mocks.MockClient, assert *asserts.Assertions) {

--- a/application-operator/controllers/ingresstrait/ingresstrait_ops.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_ops.go
@@ -6,13 +6,13 @@ package ingresstrait
 import (
 	"context"
 	"fmt"
+	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clisecurity "istio.io/client-go/pkg/apis/security/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-
-	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 
 	certapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/verrazzano/verrazzano/application-operator/constants"
@@ -47,34 +47,26 @@ func cleanup(trait *vzapi.IngressTrait, client client.Client, log vzlog.Verrazza
 }
 
 func cleanupPolicies(trait *vzapi.IngressTrait, c client.Client, log vzlog.VerrazzanoLogger) error {
-	rules := trait.Spec.Rules
-	for index, rule := range rules {
-		namePrefix := fmt.Sprintf("%s-rule-%d-authz", trait.Name, index)
-		for _, path := range rule.Paths {
-			if path.Policy != nil {
-				pathSuffix := strings.Replace(path.Path, "/", "", -1)
-				policyName := fmt.Sprintf("%s-%s", namePrefix, pathSuffix)
-				authzPolicy := &clisecurity.AuthorizationPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      policyName,
-						Namespace: constants.IstioSystemNamespace,
-					},
-				}
-				// Delete the authz policy, ignore not found
-				log.Debugf("Deleting authorization policy: %s", authzPolicy.Name)
-				err := c.Delete(context.TODO(), authzPolicy, &client.DeleteOptions{})
-				if err != nil {
-					if k8serrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-						log.Debugf("NotFound deleting authorization policy %s", authzPolicy.Name)
-						return nil
-					}
-					log.Errorf("Failed deleting the authorization policy %s", authzPolicy.Name)
-				}
-				log.Debugf("Ingress rule path authorization policy %s deleted", authzPolicy.Name)
-			}
-		}
+	// Find all AuthorizationPolicies created for this IngressTrait
+	traitNameReq, _ := labels.NewRequirement(constants.LabelIngressTraitNsn, selection.Equals, []string{getIngressTraitNsn(trait.Namespace, trait.Name)})
+	selector := labels.NewSelector().Add(*traitNameReq)
+	authPolicyList := clisecurity.AuthorizationPolicyList{}
+	err := c.List(context.TODO(), &authPolicyList, &client.ListOptions{Namespace: "", LabelSelector: selector})
+	if err != nil {
+		log.Errorf("Failed listing the authorization policies %s")
 	}
-
+	for i, authPolicy := range authPolicyList.Items {
+		// Delete the policy, ignore not found
+		log.Debugf("Deleting authorization policy: %s", authPolicy.Name)
+		err := c.Delete(context.TODO(), &authPolicyList.Items[i], &client.DeleteOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				log.Oncef("NotFound deleting authorization policy %s", authPolicy.Name)
+			}
+			return log.ErrorfNewErr("Failed deleting the authorization policy %s", authPolicy.Name)
+		}
+		log.Oncef("Ingress rule path authorization policy %s deleted", authPolicy.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Backport JWTS fixes to 1.5
Fix 3 issues with IngressTraits

-     authorizationPolicy with missing path fails to create AuthorizationPolicy
-     Rule with path but no authorizationPolicy needs to create AuthorizationPolicy if any other rule includes authorizationPolicy. If this is not done, then all requests (regardless of path) do JWT validation
-     When IngressTrait is delete the AuthorizationPolicies in istio-system for that trait were not being deleted.

