### PR TITLE
VZ-8212: Update helm charts to enable k8s 1.25 support for PodDisruptionBudget

### DIFF
--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.controller.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.applicationSet.enabled .Values.applicationSet.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.applicationSet.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-notifications/bots/slack/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-notifications/bots/slack/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled .Values.notifications.bots.slack.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.notifications.fullname" . }}-bot

--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-notifications/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-notifications/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.notifications.enabled .Values.notifications.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.notifications.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.repoServer.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.repoServer.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/argocd-server/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/argocd-server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.server.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/dex/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/dex/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.dex.enabled .Values.dex.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.dex.fullname" . }}

--- a/platform-operator/thirdparty/charts/argo-cd/templates/redis/pdb.yaml
+++ b/platform-operator/thirdparty/charts/argo-cd/templates/redis/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $redisHa := index .Values "redis-ha" -}}
 {{- if and .Values.redis.enabled (not $redisHa.enabled) .Values.redis.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.redis.fullname" . }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.podDisruptionBudget.enabled }}
-apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.podDisruptionBudget.enabled }}
-apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.thanosRuler.enabled .Values.thanosRuler.podDisruptionBudget.enabled }}
-apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/templates/pdb.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: {{ include "k8s-prometheus-adapter.pdb.apiVersion" . }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/templates/pdb.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}


### PR DESCRIPTION
PodDisruptionBudget for the policy/v1beta1 API version is not supported in k8s v1.25. So the existing manifests should be migrated to policy/v1 API version. Therefore, this PR will use the appropriate API version based on the underlying k8s version. 
Source: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25