### PR TITLE
VZ-8618: Update helm charts to disable psp for k8s 1.25

### DIFF
--- a/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,5 +17,6 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "cainjector.fullname" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -18,5 +19,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "cainjector.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/cainjector-psp.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -47,5 +48,6 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/psp-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -15,4 +16,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "cert-manager.fullname" . }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/psp-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -46,4 +47,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,5 +21,6 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "startupapicheck.fullname" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -22,5 +23,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "startupapicheck.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/startupapicheck-psp.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -47,5 +48,6 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,4 +16,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "webhook.fullname" . }}
-{{- end }} 
+{{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "webhook.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/templates/webhook-psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -51,4 +52,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/external-dns/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/external-dns/templates/psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -35,4 +36,5 @@ spec:
     ranges:
     - min: 1001
       max: 1001
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/ingress-nginx/templates/controller-role.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/templates/controller-role.yaml
@@ -100,6 +100,7 @@ rules:
     verbs:
       - create
       - patch
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']
@@ -109,5 +110,6 @@ rules:
     {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}]
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-role.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-role.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -19,4 +20,5 @@ rules:
     {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}-backend]
     {{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -18,4 +19,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/templates/psp.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -33,4 +34,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -36,4 +37,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,4 +17,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-state-metrics.fullname" . }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -13,4 +14,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/templates/psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.psp.create -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -64,3 +65,4 @@ subjects:
   name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
   namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
 {{- end -}}
+{{- end }}

--- a/platform-operator/thirdparty/charts/rancher-backup/templates/hardened.yaml
+++ b/platform-operator/thirdparty/charts/rancher-backup/templates/hardened.yaml
@@ -75,6 +75,7 @@ subjects:
     name: {{ include "backupRestore.fullname" . }}-patch-sa
     namespace: {{ .Release.Namespace }}
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -105,6 +106,7 @@ spec:
   readOnlyRootFilesystem: false
   volumes:
     - 'secret'
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/platform-operator/thirdparty/charts/rancher-backup/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/rancher-backup/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -27,3 +28,4 @@ spec:
   volumes:
     - 'persistentVolumeClaim'
     - 'secret'
+{{- end }}


### PR DESCRIPTION
PodSecurityPolicy has been removed in k8s 1.25 version. Therefore updating the  affected helm charts to make sure podSecurityPolicy is not created during helm upgrade or installation on k8s 1.25