### PR TITLE
VZ-8616: ArgoCD multicluster fixes

### DIFF
--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -30,11 +31,13 @@ import (
 )
 
 const (
-	clusterSecretName               = "argocd-cluster-secret"    //nolint:gosec
-	argocdClusterTokenTTLEnvVarName = "ARGOCD_CLUSTER_TOKEN_TTL" //nolint:gosec
-	createTimestamp                 = "verrazzano.io/create-timestamp"
-	expiresAtTimestamp              = "verrazzano.io/expires-at-timestamp"
-	clusterroletemplatebindingsPath = "/v3/clusterroletemplatebindings"
+	clusterSecretName                      = "argocd-cluster-secret"    //nolint:gosec
+	argocdClusterTokenTTLEnvVarName        = "ARGOCD_CLUSTER_TOKEN_TTL" //nolint:gosec
+	createTimestamp                        = "verrazzano.io/create-timestamp"
+	expiresAtTimestamp                     = "verrazzano.io/expires-at-timestamp"
+	clusterroletemplatebindingsPath        = "/v3/clusterroletemplatebindings"
+	clusterroletemplatebindingByUserIDPath = "/v3/clusterroletemplatebindings?userId="
+	dataField                              = "data"
 )
 
 func (r *VerrazzanoManagedClusterReconciler) isArgoCDEnabled() (bool, error) {
@@ -170,7 +173,7 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateArgoCDSecret(rc *ranc
 	return err
 }
 
-func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *corev1.Secret, rc *rancherutil.RancherConfig, clusterID, cluserName string, rancherURL string, caData []byte) error {
+func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *corev1.Secret, rc *rancherutil.RancherConfig, clusterName, clusterID, rancherURL string, caData []byte) error {
 	token := rc.APIAccessToken
 	if secret.Annotations == nil {
 		secret.Annotations = map[string]string{}
@@ -193,19 +196,29 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 		lifespan := timeExpires.Sub(timeCreated)
 		createNewToken = now.After(timeCreated.Add(lifespan * 3 / 4))
 	}
-	if createNewToken {
+	if okCreated && !okExpires {
+		//get token by userId/clusterId
+		userID, err := r.getArgoCDClusterUserID()
+		if err != nil {
+			return err
+		}
+		response, err := rancherutil.GetTokenByUser(rc, r.log, userID, clusterID)
+		if err != nil {
+			return err
+		}
+		if response.ExpiresAt != "" {
+			secret.Annotations[expiresAtTimestamp] = response.ExpiresAt
+		}
+	}
+	if createNewToken && okExpires {
 		// Obtain a new token with ttl set using bearer token obtained
 		ttl := os.Getenv(argocdClusterTokenTTLEnvVarName)
-		newToken, tokenName, err := rancherutil.CreateTokenWithTTL(rc, r.log, ttl, clusterID)
+		newToken, createTS, err := rancherutil.CreateTokenWithTTL(rc, r.log, ttl, clusterID)
 		if err != nil {
 			return err
 		}
-		attrs, err := rancherutil.GetTokenByName(rc, r.log, tokenName)
-		if err != nil {
-			return err
-		}
-		secret.Annotations[createTimestamp] = attrs.Created
-		secret.Annotations[expiresAtTimestamp] = attrs.ExpiresAt
+		secret.Annotations[createTimestamp] = createTS
+		delete(secret.Annotations, expiresAtTimestamp)
 		token = newToken
 	}
 
@@ -215,7 +228,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 	secret.Type = corev1.SecretTypeOpaque
 	secret.ObjectMeta.Labels = map[string]string{"argocd.argoproj.io/secret-type": "cluster"}
 
-	secret.StringData["name"] = cluserName
+	secret.StringData["name"] = clusterName
 	secret.StringData["server"] = rancherURL
 
 	rancherConfig := &ArgoCDRancherConfig{
@@ -249,6 +262,28 @@ func (r *VerrazzanoManagedClusterReconciler) updateArgoCDClusterRoleBindingTempl
 		return err
 	}
 
+	// Send a request to see if the clusterroletemplatebinding for the given user exists
+	reqURL := rc.BaseURL + clusterroletemplatebindingByUserIDPath + url.PathEscape(userID) + "&clusterId=" + url.PathEscape(vmc.Status.RancherRegistration.ClusterID)
+	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken}
+	response, body, err := rancherutil.SendRequest(http.MethodGet, reqURL, headers, "", rc, r.log)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound {
+		return err
+	}
+
+	if response.StatusCode == http.StatusOK {
+		data, err := httputil.ExtractFieldFromResponseBodyOrReturnError(body, dataField, "failed to locate the data field of the response body")
+		if err != nil {
+			return r.log.ErrorfNewErr("Failed to find clusterroletemplatebinding given the userId %s: %v", userID, err)
+		}
+		if data != "[]" {
+			r.log.Once("clusterroletemplatebinding for user: %s was located, skipping the creation process", userID)
+			return nil
+		}
+	}
+
 	action := http.MethodPost
 	payloadData := map[string]string{
 		"userId":         userID,
@@ -259,10 +294,10 @@ func (r *VerrazzanoManagedClusterReconciler) updateArgoCDClusterRoleBindingTempl
 	if err != nil {
 		return r.log.ErrorfNewErr("Failed to encode payload object: %v", err)
 	}
-	reqURL := rc.BaseURL + clusterroletemplatebindingsPath
-	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken, "Content-Type": "application/json"}
+	reqURL = rc.BaseURL + clusterroletemplatebindingsPath
+	headers = map[string]string{"Authorization": "Bearer " + rc.APIAccessToken, "Content-Type": "application/json"}
 
-	response, _, err := rancherutil.SendRequest(action, reqURL, headers, string(payload), rc, r.log)
+	response, _, err = rancherutil.SendRequest(action, reqURL, headers, string(payload), rc, r.log)
 	if err != nil {
 		return err
 	}

--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -202,10 +202,11 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 		if err != nil {
 			return err
 		}
-		expiresAt, err := rancherutil.GetTokenWithFilter(rc, r.log, userID, clusterID)
+		created, expiresAt, err := rancherutil.GetTokenWithFilter(rc, r.log, userID, clusterID)
 		if err != nil {
 			return err
 		}
+		secret.Annotations[createTimestamp] = created
 		if expiresAt != "" {
 			secret.Annotations[expiresAtTimestamp] = expiresAt
 		}

--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -202,15 +202,16 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 		if err != nil {
 			return err
 		}
-		response, err := rancherutil.GetTokenByUser(rc, r.log, userID, clusterID)
+		expiresAt, err := rancherutil.GetTokenWithFilter(rc, r.log, userID, clusterID)
 		if err != nil {
 			return err
 		}
-		if response.ExpiresAt != "" {
-			secret.Annotations[expiresAtTimestamp] = response.ExpiresAt
+		if expiresAt != "" {
+			secret.Annotations[expiresAtTimestamp] = expiresAt
 		}
+		createNewToken = false
 	}
-	if createNewToken && okExpires {
+	if createNewToken {
 		// Obtain a new token with ttl set using bearer token obtained
 		ttl := os.Getenv(argocdClusterTokenTTLEnvVarName)
 		newToken, createTS, err := rancherutil.CreateTokenWithTTL(rc, r.log, ttl, clusterID)

--- a/cluster-operator/controllers/vmc/argocd_test.go
+++ b/cluster-operator/controllers/vmc/argocd_test.go
@@ -193,13 +193,24 @@ func expectHTTPLoginRequests(httpMock *mocks.MockRequestSender) *mocks.MockReque
 
 func expectHTTPClusterRoleTemplateUpdateRequests(httpMock *mocks.MockRequestSender) *mocks.MockRequestSender {
 	httpMock.EXPECT().
-		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterroletemplatebindingsPath)).
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURIMethod(http.MethodPost, clusterroletemplatebindingsPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
 			r := io.NopCloser(bytes.NewReader([]byte(`{}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       r,
 				Request:    &http.Request{Method: http.MethodPost},
+			}
+			return resp, nil
+		})
+	httpMock.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURIMethod(http.MethodGet, clusterroletemplatebindingsPath)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[]}`)))
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodGet},
 			}
 			return resp, nil
 		})

--- a/cluster-operator/controllers/vmc/argocd_test.go
+++ b/cluster-operator/controllers/vmc/argocd_test.go
@@ -174,8 +174,6 @@ func TestMutateArgoCDClusterSecretWithRefresh(t *testing.T) {
 
 	err = r.mutateArgoCDClusterSecret(secret, rc, vmc.Name, clusterID, rancherURL, caData)
 	assert.NoError(t, err)
-	assert.Equal(t, secret.Annotations[createTimestamp], "yyy")
-	assert.Equal(t, secret.Annotations[expiresAtTimestamp], "zzz")
 }
 
 func expectHTTPLoginRequests(httpMock *mocks.MockRequestSender) *mocks.MockRequestSender {
@@ -209,19 +207,6 @@ func expectHTTPClusterRoleTemplateUpdateRequests(httpMock *mocks.MockRequestSend
 }
 
 func expectHTTPRequests(httpMock *mocks.MockRequestSender) *mocks.MockRequestSender {
-	// Expect an HTTP request to get created & expiresAt attributes of the token
-	httpMock.EXPECT().
-		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(tokensPath+"/testToken")).
-		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
-			var resp *http.Response
-			r := io.NopCloser(bytes.NewReader([]byte("{\"created\":\"yyy\", \"expiresAt\": \"zzz\"}")))
-			resp = &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       r,
-			}
-			return resp, nil
-		})
-
 	// Expect an HTTP request to obtain a new token
 	httpMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(tokensPath)).

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -231,52 +231,44 @@ func CreateTokenWithTTL(rc *RancherConfig, log vzlog.VerrazzanoLogger, ttl, clus
 	return tokenResponse.Token, tokenResponse.Created, nil
 }
 
-// GetTokenWithFilter get expiresAt attribute of a user token with filter
-func GetTokenWithFilter(rc *RancherConfig, log vzlog.VerrazzanoLogger, userID, clusterID string) (string, error) {
+type TokenAttrs struct {
+	Created   string `json:"created"`
+	ClusterId string `json:"clusterId"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+// GetTokenWithFilter get created expiresAt attribute of a user token with filter
+func GetTokenWithFilter(rc *RancherConfig, log vzlog.VerrazzanoLogger, userID, clusterID string) (string, string, error) {
 	action := http.MethodGet
 	reqURL := rc.BaseURL + tokensPath + "?userId=" + url.PathEscape(userID) + "&clusterId=" + url.PathEscape(clusterID)
 	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken}
 
 	response, responseBody, err := SendRequest(action, reqURL, headers, "", rc, log)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	err = httputil.ValidateResponseCode(response, http.StatusOK)
 	if err != nil {
-		return "", log.ErrorfNewErr("Failed to validate response: %v", err)
+		return "", "", log.ErrorfNewErr("Failed to validate response: %v", err)
 	}
 
 	data, err := httputil.ExtractFieldFromResponseBodyOrReturnError(responseBody, "data", "failed to locate the data field of the response body")
 	if err != nil {
-		return "", log.ErrorfNewErr("Failed to find data in Rancher response: %v", err)
+		return "", "", log.ErrorfNewErr("Failed to find data in Rancher response: %v", err)
 	}
 
-	var items []interface{}
+	var items []TokenAttrs
 	json.Unmarshal([]byte(data), &items)
 	if err != nil {
-		return "", log.ErrorfNewErr("Failed to parse response: %v", err)
+		return "", "", log.ErrorfNewErr("Failed to parse response: %v", err)
 	}
 	for _, item := range items {
-		var i map[string]interface{}
-		var ok bool
-		if i, ok = item.(map[string]interface{}); !ok {
-			log.Infof("Expected item to be of type 'map[string]interface{}': %s", responseBody)
-			continue
-		}
-		var clusterId, expiresTS interface{} //nolint:revive
-		if clusterId, ok = i["clusterId"]; !ok {
-			log.Infof("Expected to find 'clusterId' field in Rancher cluster data: %s", responseBody)
-		}
-		if expiresTS, ok = i["expiresAt"]; !ok {
-			log.Infof("Expected to find 'expiresAt' field in Rancher cluster data: %s", responseBody)
-			continue
-		}
-		if clusterId == clusterID {
-			return expiresTS.(string), nil
+		if item.ClusterId == clusterID {
+			return item.Created, item.ExpiresAt, nil
 		}
 	}
-	return "", nil
+	return "", "", log.ErrorfNewErr("Failed to find the token in Rancher response")
 }
 
 // getProxyURL returns an HTTP proxy from the environment if one is set, otherwise an empty string

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -193,7 +193,7 @@ type Payload struct {
 	TTL       int    `json:"ttl"`
 }
 
-type TokenResponse struct {
+type TokenPostResponse struct {
 	Token   string `json:"token"`
 	Created string `json:"created"`
 }
@@ -222,18 +222,18 @@ func CreateTokenWithTTL(rc *RancherConfig, log vzlog.VerrazzanoLogger, ttl, clus
 		return "", "", log.ErrorfNewErr("Failed to validate response: %v", err)
 	}
 
-	var tokenResponse TokenResponse
-	err = json.Unmarshal([]byte(responseBody), &tokenResponse)
+	var tokenPostResponse TokenPostResponse
+	err = json.Unmarshal([]byte(responseBody), &tokenPostResponse)
 	if err != nil {
 		return "", "", log.ErrorfNewErr("Failed to parse response: %v", err)
 	}
 
-	return tokenResponse.Token, tokenResponse.Created, nil
+	return tokenPostResponse.Token, tokenPostResponse.Created, nil
 }
 
-type TokenAttrs struct {
+type TokenGetResponse struct {
 	Created   string `json:"created"`
-	ClusterId string `json:"clusterId"`
+	ClusterID string `json:"clusterId"`
 	ExpiresAt string `json:"expiresAt"`
 }
 
@@ -258,13 +258,13 @@ func GetTokenWithFilter(rc *RancherConfig, log vzlog.VerrazzanoLogger, userID, c
 		return "", "", log.ErrorfNewErr("Failed to find data in Rancher response: %v", err)
 	}
 
-	var items []TokenAttrs
+	var items []TokenGetResponse
 	json.Unmarshal([]byte(data), &items)
 	if err != nil {
 		return "", "", log.ErrorfNewErr("Failed to parse response: %v", err)
 	}
 	for _, item := range items {
-		if item.ClusterId == clusterID {
+		if item.ClusterID == clusterID {
 			return item.Created, item.ExpiresAt, nil
 		}
 	}

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -199,8 +199,8 @@ type Payload struct {
 }
 
 type TokenResponse struct {
-	Token string `json:"token"`
-	Name  string `json:"name"`
+	Token           string `json:"token"`
+	CreateTimestamp string `json:"createTimestamp"`
 }
 
 // CreateTokenWithTTL creates a user token with ttl (in minutes)
@@ -233,13 +233,13 @@ func CreateTokenWithTTL(rc *RancherConfig, log vzlog.VerrazzanoLogger, ttl, clus
 		return "", "", log.ErrorfNewErr("Failed to parse response: %v", err)
 	}
 
-	return tokenResponse.Token, tokenResponse.Name, nil
+	return tokenResponse.Token, tokenResponse.CreateTimestamp, nil
 }
 
-// GetTokenByName get created & expiresAt attribute of a user token
-func GetTokenByName(rc *RancherConfig, log vzlog.VerrazzanoLogger, tokenName string) (*TokenAttrs, error) {
+// GetTokenByUser get created & expiresAt attribute of a user token with filter
+func GetTokenByUser(rc *RancherConfig, log vzlog.VerrazzanoLogger, userID, clusterID string) (*TokenAttrs, error) {
 	action := http.MethodGet
-	reqURL := rc.BaseURL + tokensPath + "/" + tokenName
+	reqURL := rc.BaseURL + tokensPath + "?userId=" + url.PathEscape(userID) + "&clusterId=" + url.PathEscape(clusterID)
 	headers := map[string]string{"Authorization": "Bearer " + rc.APIAccessToken}
 
 	response, responseBody, err := SendRequest(action, reqURL, headers, "", rc, log)


### PR DESCRIPTION
VZ-8616: ArgoCD multicluster fixes

1. Use vmc name as cluster name to be shown in the argo UI
2. Check clusterroletemplatebinding exists before POST
3. Only create the token once and then on reconcile get it until it has an expiration
