### PR TITLE
VZ-8141: Disable mysql operator on managed-cluster profile

### DIFF
--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -238,7 +238,7 @@ spec:
     kubeStateMetrics:
       enabled: true
     mySQLOperator:
-      enabled: true
+      enabled: false
     kibana:
       enabled: false
       replicas: 1

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -238,7 +238,7 @@ spec:
     kubeStateMetrics:
       enabled: true
     mySQLOperator:
-      enabled: true
+      enabled: false
     kibana:
       enabled: true
       replicas: 1

--- a/platform-operator/manifests/profiles/v1alpha1/managed-cluster.yaml
+++ b/platform-operator/manifests/profiles/v1alpha1/managed-cluster.yaml
@@ -4,6 +4,8 @@ spec:
   components:
     keycloak:
       enabled: false
+    mySQLOperator:
+      enabled: false
     rancher:
       enabled: false
     elasticsearch:

--- a/platform-operator/manifests/profiles/v1beta1/managed-cluster.yaml
+++ b/platform-operator/manifests/profiles/v1beta1/managed-cluster.yaml
@@ -4,6 +4,8 @@ spec:
   components:
     keycloak:
       enabled: false
+    mySQLOperator:
+      enabled: false
     rancher:
       enabled: false
     opensearch:


### PR DESCRIPTION
Modifies the managed-cluster profile YAML manifests to disable the `mySQLOperator` component.
Also modifies some test data for unit tests.