### PR TITLE
Fix Uninstall Resiliency Error from removing MySQL operator from managed-cluster profile

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -395,9 +395,10 @@ def runVerifyTests(stageName, iteration) {
 }
 
 def generateVerifyUninstallStages() {
+    boolean mySQLOperatorEnabled = params.INSTALL_PROFILE != 'managed-cluster'
     uninstallTests = [
         "verifycrds": {
-            runGinkgo('uninstall/verifycrds')
+            runGinkgoWithPassThroughs('uninstall/verifycrds', mySQLOperatorEnabled)
         },
         "verifyrancher": {
             runGinkgo('uninstall/verifyrancher')
@@ -582,6 +583,21 @@ def runGinkgo(testSuitePath, dumpDir = '', kubeconfig = '') {
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+        """
+    }
+}
+
+def runGinkgoWithPassThroughs(testSuitePath, mySQLOperatorEnabled, dumpDir = '', kubeconfig = '') {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            if [ ! -z "${dumpDir}" ]; then
+                export DUMP_DIRECTORY=${dumpDir}
+            fi
+            if [ ! -z "${kubeConfig}" ]; then
+                export KUBECONFIG="${kubeConfig}"
+            fi
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --mySQLOperatorEnabled=${mySQLOperatorEnabled}
         """
     }
 }

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -395,10 +395,9 @@ def runVerifyTests(stageName, iteration) {
 }
 
 def generateVerifyUninstallStages() {
-    boolean mySQLOperatorEnabled = params.INSTALL_PROFILE != 'managed-cluster'
     uninstallTests = [
         "verifycrds": {
-            runGinkgoWithPassThroughs('uninstall/verifycrds', mySQLOperatorEnabled)
+            runGinkgo('uninstall/verifycrds')
         },
         "verifyrancher": {
             runGinkgo('uninstall/verifyrancher')
@@ -583,21 +582,6 @@ def runGinkgo(testSuitePath, dumpDir = '', kubeconfig = '') {
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
-        """
-    }
-}
-
-def runGinkgoWithPassThroughs(testSuitePath, mySQLOperatorEnabled, dumpDir = '', kubeconfig = '') {
-    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-        sh """
-            if [ ! -z "${dumpDir}" ]; then
-                export DUMP_DIRECTORY=${dumpDir}
-            fi
-            if [ ! -z "${kubeConfig}" ]; then
-                export KUBECONFIG="${kubeConfig}"
-            fi
-            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --mySQLOperatorEnabled=${mySQLOperatorEnabled}
         """
     }
 }

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -1,20 +1,13 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verifycrds
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 )
-
-var mySQLOperatorEnabled bool
-
-func init() {
-	flag.BoolVar(&mySQLOperatorEnabled, "mySQLOperatorEnabled", true, "mySQLOperatorEnabled describes whether the mySQLOperator component is enabled")
-}
 
 func TestVerifyCRDs(test *testing.T) {
 	t.RegisterFailHandler()

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verifycrds

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -4,10 +4,17 @@
 package verifycrds
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 )
+
+var mySQLOperatorEnabled bool
+
+func init() {
+	flag.BoolVar(&mySQLOperatorEnabled, "mySQLOperatorEnabled", true, "mySQLOperatorEnabled describes whether the mySQLOperator component is enabled")
+}
 
 func TestVerifyCRDs(test *testing.T) {
 	t.RegisterFailHandler()

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -1,13 +1,20 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verifycrds
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 )
+
+var mySQLOperatorEnabled bool
+
+func init() {
+	flag.BoolVar(&mySQLOperatorEnabled, "mySQLOperatorEnabled", true, "mySQLOperatorEnabled describes whether the mySQLOperator component is enabled")
+}
 
 func TestVerifyCRDs(test *testing.T) {
 	t.RegisterFailHandler()

--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -140,10 +140,12 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 		checkCrds(crds, map[string]bool{"coherence.coherence.oracle.com": false}, "coherence.coherence.oracle.com")
 	})
 
-	t.It("Check for expected MySQL Operator CRDs", func() {
-		checkCrds(crds, mysqloperatorcrds, "mysql.oracle.com")
-		checkCrds(crds, mysqloperatorcrds, "zalando.org")
-	})
+	if mySQLOperatorEnabled {
+		t.It("Check for expected MySQL Operator CRDs", func() {
+			checkCrds(crds, mysqloperatorcrds, "mysql.oracle.com")
+			checkCrds(crds, mysqloperatorcrds, "zalando.org")
+		})
+	}
 
 	t.It("Check for unexpected CRDs", func() {
 		var unexpectedCRDs []string

--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -140,12 +140,10 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 		checkCrds(crds, map[string]bool{"coherence.coherence.oracle.com": false}, "coherence.coherence.oracle.com")
 	})
 
-	if mySQLOperatorEnabled {
-		t.It("Check for expected MySQL Operator CRDs", func() {
-			checkCrds(crds, mysqloperatorcrds, "mysql.oracle.com")
-			checkCrds(crds, mysqloperatorcrds, "zalando.org")
-		})
-	}
+	t.It("Check for expected MySQL Operator CRDs", func() {
+		checkCrds(crds, mysqloperatorcrds, "mysql.oracle.com")
+		checkCrds(crds, mysqloperatorcrds, "zalando.org")
+	})
 
 	t.It("Check for unexpected CRDs", func() {
 		var unexpectedCRDs []string


### PR DESCRIPTION
89829cb65c0760b53f59d3d6d4169564da43b6b4 introduced an error in the uninstall resiliency tests in `tests/e2e/uninstall/verifycrds/verify_crds_test.go`. CRDs for the MySQL operator are still expected to exist, but 89829cb65c0760b53f59d3d6d4169564da43b6b4 removed that component from the managed-cluster profile.

This PR fixes this by checking if the install profile is managed-cluster, and, if it is, then the MySQL operator CRDs are not checked for.