### PR TITLE
VZ-7931 part-deux: Fix serviceName variable query for muti-value serverName

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/WebLogic/weblogic_dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/WebLogic/weblogic_dashboard.json
@@ -3818,7 +3818,7 @@
           "value": ""
         },
         "datasource": null,
-        "definition": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\",weblogic_serverName=\"$serverName\"},service)",
+        "definition": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3828,7 +3828,7 @@
         "name": "serviceName",
         "options": [],
         "query": {
-          "query": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\",weblogic_serverName=\"$serverName\"},service)",
+          "query": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\"},service)",
           "refId": "Prometheus-service-Variable-Query"
         },
         "refresh": 2,

--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/WebLogic/weblogic_dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/WebLogic/weblogic_dashboard.json
@@ -3818,7 +3818,7 @@
           "value": ""
         },
         "datasource": null,
-        "definition": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\"},service)",
+        "definition": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\", weblogic_serverName=~\"$serverName\"},service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3828,7 +3828,7 @@
         "name": "serviceName",
         "options": [],
         "query": {
-          "query": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\"},service)",
+          "query": "label_values(wls_jvm_uptime{verrazzano_cluster=~\"$vzcluster\", weblogic_domainUID=\"$domainName\", weblogic_clusterName=\"$clusterName\", weblogic_serverName=~\"$serverName\"},service)",
           "refId": "Prometheus-service-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
Our WLS grafana db has serverName and serviceName as grafana dashboard variables that appear at the top of the dashboards and can be selected via a drop-down. 

`serviceName` in WLS depends on cluster and domain name (`<domain-uid>-cluster-<clusterName>`), and not on `serverName`. When two or more serverNames were selected from the drop-down in grafana, the customers were not getting any data since the serviceNames were empty in the drop-down because of the erroneous query, the dashboards worked when only one of the serverName was selected. 

As soon as I removed `serverName` from the `serviceName` variable query in their dashboard, the dashboards started to work fine again with multiple or All of the `serverName` selected. This PR is to fix this the erroneous query to fetch serviceName correctly.

Update: As suggested by Ravi, adding ~ to the original query while specifying serverName also worked for multi-value queries.
