### PR TITLE
WKO 3.4.6 and WME 2.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Fixes:
 - Fixed IngressTrait related AuthorizationPolicy cleanup when application is deleted.
 - Fixed the query for the Service variable in WebLogic Grafana dashboard.
 
+Component version updates:
+
+- WebLogic Kubernetes Operator v3.4.6
+- WebLogic Monitoring Exporter v2.1.2
+
 ### v1.4.3
 Fixes:
 

--- a/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: v1
@@ -6,5 +6,5 @@ name: weblogic-operator
 description: Helm chart for configuring the WebLogic operator.
 
 type: application
-version: 3.4.5
-appVersion: 3.4.5
+version: 3.4.6
+appVersion: 3.4.6

--- a/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/platform-operator/thirdparty/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorDeployment" }}
@@ -43,6 +43,10 @@ spec:
       {{- end }}
       {{- with .affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # serviceAccount specifies the name of the ServiceAccount in the operator's namespace that the
 # operator will use to make requests to the Kubernetes API server.
 # The customer is responsible for creating the ServiceAccount in the same namespace as this Helm release.
-# If not specified, the the operator will use the Helm release namespace's 'default' ServiceAccount.
+# If not specified, the operator will use the Helm release namespace's 'default' ServiceAccount.
 serviceAccount: "default"
 
 # domainNamespaceSelectionStrategy specifies how the operator will select the set of namespaces
@@ -63,7 +63,7 @@ domainNamespaces:
 enableClusterRoleBinding: false
 
 # image specifies the container image containing the operator.
-image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.4.5"
+image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.4.6"
 
 # imagePullPolicy specifies the image pull policy for the operator's container image.
 imagePullPolicy: IfNotPresent
@@ -153,6 +153,11 @@ javaLoggingFileCount: 10
 # will be added to the operator's deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 # for more information on affinity and anti-affinity.
 #affinity:
+
+# tolerations and taints work together to ensure that pods are not scheduled on inappropriate nodes. If the tolerations value is specified,
+# then this content will be added to the operator's deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# for more information on tolerations and taints.
+#tolerations:
 
 # Values related to debugging the operator.
 # Customers should not need to use the following properties

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -315,7 +315,7 @@
     },
     {
       "name": "weblogic-operator",
-      "version": "3.4.5",
+      "version": "3.4.6",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -323,12 +323,12 @@
           "images": [
             {
               "image": "weblogic-kubernetes-operator",
-              "tag": "3.4.5",
+              "tag": "3.4.6",
               "helmFullImageKey": "image"
             },
             {
               "image": "weblogic-monitoring-exporter",
-              "tag": "2.1.1",
+              "tag": "2.1.2",
               "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]


### PR DESCRIPTION
Update the 1.4 maintenance branch for WebLogic Kubernetes Operator 3.4.6 and WebLogic Monitoring Exporter 2.1.2.

WKO 4.0.5 will come in the next few days and then I'll have a PR for 1.5 and master. 