### PR TITLE
VZ-8651: Fix bug-report to capture Projects and VerrazzanoManagedCluster in multi-cluster install

### DIFF
--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -117,6 +117,11 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 	if len(additionalNS) > 0 {
 		captureAdditionalResources(client, kubeClient, dynamicClient, vzHelper, bugReportDir, additionalNS, podLogs)
 	}
+
+	// Capture Verrazzano Projects and VerrazzanoManagedCluster
+	if err := captureMultiClusterResources(dynamicClient, bugReportDir, vzHelper); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -299,7 +304,26 @@ func captureAdditionalResources(client clipkg.Client, kubeClient kubernetes.Inte
 			pkghelpers.LogError(fmt.Sprintf("There is an error with capturing the logs: %s", err.Error()))
 		}
 	}
-	if err := pkghelpers.CaptureMultiClusterResources(dynamicClient, additionalNS, bugReportDir, vzHelper); err != nil {
+	if err := pkghelpers.CaptureMultiClusterOAMResources(dynamicClient, additionalNS, bugReportDir, vzHelper); err != nil {
 		pkghelpers.LogError(fmt.Sprintf("There is an error in capturing the multi-cluster resources : %s", err.Error()))
 	}
+}
+
+// captureMultiClusterResources captures Projects and VerrazzanoManagedCluster resource
+func captureMultiClusterResources(dynamicClient dynamic.Interface, captureDir string, vzHelper pkghelpers.VZHelper) error {
+	// Return nil when dynamicClient is nil, useful to get clean unit tests
+	if dynamicClient == nil {
+		return nil
+	}
+
+	// Capture Verrazzano projects in verrazzano-mc namespace
+	if err := pkghelpers.CaptureVerrazzanoProjects(dynamicClient, captureDir, vzHelper); err != nil {
+		return err
+	}
+
+	// Capture Verrazzano projects in verrazzano-mc namespace
+	if err := pkghelpers.CaptureVerrazzanoManagedCluster(dynamicClient, captureDir, vzHelper); err != nil {
+		return err
+	}
+	return nil
 }

--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -383,8 +383,8 @@ func CaptureOAMResources(dynamicClient dynamic.Interface, nsList []string, captu
 	return nil
 }
 
-// CaptureMultiClusterResources captures resources useful to debug issues in multi-cluster environment
-func CaptureMultiClusterResources(dynamicClient dynamic.Interface, nsList []string, captureDir string, vzHelper VZHelper) error {
+// CaptureMultiClusterOAMResources captures OAM resources in multi-cluster environment
+func CaptureMultiClusterOAMResources(dynamicClient dynamic.Interface, nsList []string, captureDir string, vzHelper VZHelper) error {
 	for _, ns := range nsList {
 		// Capture multi-cluster components and application configurations
 		if err := captureMCComponents(dynamicClient, ns, captureDir, vzHelper); err != nil {
@@ -394,16 +394,6 @@ func CaptureMultiClusterResources(dynamicClient dynamic.Interface, nsList []stri
 		if err := captureMCAppConfigurations(dynamicClient, ns, captureDir, vzHelper); err != nil {
 			return err
 		}
-	}
-
-	// Capture Verrazzano projects in verrazzano-mc namespace
-	if err := captureVerrazzanoProjects(dynamicClient, captureDir, vzHelper); err != nil {
-		return err
-	}
-
-	// Capture Verrazzano projects in verrazzano-mc namespace
-	if err := captureVerrazzanoManagedCluster(dynamicClient, captureDir, vzHelper); err != nil {
-		return err
 	}
 	return nil
 }
@@ -569,8 +559,8 @@ func captureMCAppConfigurations(dynamicClient dynamic.Interface, namespace, capt
 	return nil
 }
 
-// captureAppConfigurations captures the Verrazzano projects in the verrazzano-mc namespace, as a JSON file
-func captureVerrazzanoProjects(dynamicClient dynamic.Interface, captureDir string, vzHelper VZHelper) error {
+// CaptureVerrazzanoProjects captures the Verrazzano projects in the verrazzano-mc namespace, as a JSON file
+func CaptureVerrazzanoProjects(dynamicClient dynamic.Interface, captureDir string, vzHelper VZHelper) error {
 	vzProjectConfigs, err := dynamicClient.Resource(GetVzProjectsConfigScheme()).Namespace(vzconstants.VerrazzanoMultiClusterNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		return nil
@@ -588,8 +578,8 @@ func captureVerrazzanoProjects(dynamicClient dynamic.Interface, captureDir strin
 	return nil
 }
 
-// captureVerrazzanoManagedCluster captures VerrazzanoManagedCluster in verrazzano-mc namespace, as a JSON file
-func captureVerrazzanoManagedCluster(dynamicClient dynamic.Interface, captureDir string, vzHelper VZHelper) error {
+// CaptureVerrazzanoManagedCluster captures VerrazzanoManagedCluster in verrazzano-mc namespace, as a JSON file
+func CaptureVerrazzanoManagedCluster(dynamicClient dynamic.Interface, captureDir string, vzHelper VZHelper) error {
 	vmcConfigs, err := dynamicClient.Resource(GetManagedClusterConfigScheme()).Namespace(vzconstants.VerrazzanoMultiClusterNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		return nil


### PR DESCRIPTION
This PR fixed bug-report to capture VerrazzanoManagedCluster and Projects always in a multi-cluster environment in release-1.4. Without this change, the CLI collects these resources only when flag --include-namespaces is set.