### PR TITLE
VZ-8243: Add Verify-install stages to dynamic-config-install-tests

### DIFF
--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -331,6 +331,9 @@ def startDCInstallTestJob(additionalParams) {
         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
         string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
     ]
     jobParameters = jobParameters + additionalParams
 

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -272,6 +272,10 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
+                // Verrazzano may continue reconciling even after the `vz install` command exits, so
+                // wait a bit before running the verify-install tests.
+                sleep 5m
+
                 runGinkgoRandomize('verify-install')
             }
             post {

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -272,6 +272,10 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
+                // temporary change to ensure this step fails
+                sh """
+                    exit 1
+                """
                 // Verrazzano may continue reconciling even after the `vz install` command exits, so
                 // wait a bit before running the verify-install tests.
                 sleep time: 5, unit: 'MINUTES'

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -274,7 +274,7 @@ pipeline {
             steps {
                 // Verrazzano may continue reconciling even after the `vz install` command exits, so
                 // wait a bit before running the verify-install tests.
-                // sleep time: 5, unit: 'MINUTES'
+                sleep time: 5, unit: 'MINUTES'
 
                 runGinkgoRandomize('verify-install')
             }

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -274,7 +274,7 @@ pipeline {
             steps {
                 // Verrazzano may continue reconciling even after the `vz install` command exits, so
                 // wait a bit before running the verify-install tests.
-                sleep 5m
+                sleep time: 5, unit: 'MINUTES'
 
                 runGinkgoRandomize('verify-install')
             }

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -92,6 +92,9 @@ pipeline {
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-snapshots"
         CAPTURE_FULL_CLUSTER="${params.CAPTURE_FULL_CLUSTER}"
 
+        // Environment variable for Verrazzano CLI executable
+        VZ_COMMAND="${GO_REPO_PATH}/vz"
+
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
 
@@ -101,6 +104,7 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
+        VZ_CLI_TARGZ="vz-linux-amd64.tar.gz"
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
@@ -189,6 +193,14 @@ pipeline {
                     // update the description with some meaningful info
                     setDisplayName()
                     currentBuild.description = params.KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
+                }
+                script {
+                    sh """
+                        echo "Downloading VZ CLI from object storage"
+                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/${VZ_CLI_TARGZ} --file ${VZ_CLI_TARGZ}
+                        tar xzf ${VZ_CLI_TARGZ} -C ${GO_REPO_PATH}
+                        ${VZ_COMMAND} version
+                    """
                 }
             }
         }

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -92,9 +92,6 @@ pipeline {
         TEST_DUMP_ROOT="${WORKSPACE}/test-cluster-snapshots"
         CAPTURE_FULL_CLUSTER="${params.CAPTURE_FULL_CLUSTER}"
 
-        // Environment variable for Verrazzano CLI executable
-        VZ_COMMAND="${GO_REPO_PATH}/vz"
-
         VERRAZZANO_INSTALL_LOGS_DIR="${WORKSPACE}/verrazzano/platform-operator/scripts/install/build/logs"
         VERRAZZANO_INSTALL_LOG="verrazzano-install.log"
 
@@ -104,7 +101,6 @@ pipeline {
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
-        VZ_CLI_TARGZ="vz-linux-amd64.tar.gz"
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')
@@ -193,14 +189,6 @@ pipeline {
                     // update the description with some meaningful info
                     setDisplayName()
                     currentBuild.description = params.KUBERNETES_CLUSTER_VERSION + " : " + SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + params.GIT_COMMIT_TO_USE
-                }
-                script {
-                    sh """
-                        echo "Downloading VZ CLI from object storage"
-                        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/${VZ_CLI_TARGZ} --file ${VZ_CLI_TARGZ}
-                        tar xzf ${VZ_CLI_TARGZ} -C ${GO_REPO_PATH}
-                        ${VZ_COMMAND} version
-                    """
                 }
             }
         }

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -274,7 +274,7 @@ pipeline {
             steps {
                 // Verrazzano may continue reconciling even after the `vz install` command exits, so
                 // wait a bit before running the verify-install tests.
-                sleep time: 5, unit: 'MINUTES'
+                // sleep time: 5, unit: 'MINUTES'
 
                 runGinkgoRandomize('verify-install')
             }

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -42,6 +42,18 @@ pipeline {
                 description: 'This is the API crd version.',
                 // 1st choice is the default value
                 choices: [ "v1beta1", "v1alpha1"])
+        string (name: 'TAGGED_TESTS',
+                defaultValue: '',
+                description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
+                trim: true)
+        string (name: 'INCLUDED_TESTS',
+                defaultValue: '.*',
+                description: 'A regex matching any fully qualified test file that should be executed (e.g. examples/helidon/). Default: .*',
+                trim: true)
+        string (name: 'EXCLUDED_TESTS',
+                defaultValue: '_excluded_test',
+                description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
+                trim: true)
         booleanParam (description: 'Whether to create the cluster with Calico for AT testing (defaults to true)', name: 'CREATE_CLUSTER_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
@@ -266,6 +278,38 @@ pipeline {
                 }
             }
         }
+
+        stage('Verify Tests') {
+            environment {
+                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
+            }
+            steps {
+                runGinkgoRandomize('verify-install')
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                }
+            }
+        }
+
+        stage('Infra Tests') {
+            environment {
+                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-infra-tests"
+            }
+            steps {
+                script {
+                    parallel generateVerifyInfraStages("${TEST_DUMP_ROOT}/post-install-infra-tests")
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                }
+            }
+        }
     }
 
     post {
@@ -310,6 +354,32 @@ pipeline {
         cleanup {
             deleteDir()
         }
+    }
+}
+
+def generateVerifyInfraStages(dumpRoot) {
+    return [
+        "verify-infra restapi": {
+            runGinkgoRandomize('verify-infra/restapi', "${dumpRoot}/verify-infra-restapi")
+        },
+        "verify-infra oam": {
+            runGinkgoRandomize('verify-infra/oam', "${dumpRoot}/verify-infra-oam")
+        },
+        "verify-infra vmi": {
+            runGinkgoRandomize('verify-infra/vmi', "${dumpRoot}/verify-infra-vmi")
+        },
+    ]
+}
+
+def runGinkgoRandomize(testSuitePath, dumpDir = '') {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            if [ ! -z "${dumpDir}" ]; then
+                export DUMP_DIRECTORY=${dumpDir}
+            fi
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+        """
     }
 }
 

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -284,10 +284,6 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
-                // temporary change to ensure this step fails
-                sh """
-                    exit 1
-                """
                 // Verrazzano may continue reconciling even after the `vz install` command exits, so
                 // wait a bit before running the verify-install tests.
                 sleep time: 5, unit: 'MINUTES'

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -218,7 +218,7 @@ pipeline {
                         success {
                             script {
                                 if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
-                                    dumpK8sCluster('dynamic-install-post-install-cluster-snapshot1')
+                                    dumpK8sCluster('dynamic-install-post-install-cluster-snapshot')
                                 }
                             }
                         }
@@ -279,6 +279,13 @@ pipeline {
                 runGinkgoRandomize('verify-install')
             }
             post {
+                failure {
+                    script {
+                        if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                            dumpK8sCluster('dynamic-install-verify-install-failed-cluster-snapshot')
+                        }
+                    }
+                }
                 always {
                     archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
                     junit testResults: '**/*test-result.xml', allowEmptyResults: true
@@ -296,6 +303,13 @@ pipeline {
                 }
             }
             post {
+                failure {
+                    script {
+                        if ( fileExists(env.TESTS_EXECUTED_FILE) ) {
+                            dumpK8sCluster('dynamic-install-verify-infra-failed-cluster-snapshot')
+                        }
+                    }
+                }
                 always {
                     archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
                     junit testResults: '**/*test-result.xml', allowEmptyResults: true

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -357,9 +357,6 @@ def generateVerifyInfraStages(dumpRoot) {
         "verify-infra oam": {
             runGinkgoRandomize('verify-infra/oam', "${dumpRoot}/verify-infra-oam")
         },
-        "verify-infra vmi": {
-            runGinkgoRandomize('verify-infra/vmi', "${dumpRoot}/verify-infra-vmi")
-        },
     ]
 }
 


### PR DESCRIPTION
This PR adds verify-install and verify-infra stages to the new `verrazzano-dynamic-config-install-tests` pipeline.

I added these verification tests, using `ci/dynamic-updates/Jenkinsfile` as a guideline:
- `verify-install`
- `verify-infra-restapi`
- `verify-infra-oam`


This PR also modifies `ci/dynamic-updates/JenkinsfileTrigger` to pass in required parameters into the `verrazzano-dynamic-config-install-tests` pipeline.