### PR TITLE
VZ-8702: Upgrade Rancher image tags (#5427)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -130,14 +130,14 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.6.8-20230213180120-e07716258",
+              "tag": "v2.6.8-20230221221104-40baa52fa",
               "dashboard": "v2.6.8-20230213174539-1e3c4622",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.6.8-20230213180120-e07716258"
+              "tag": "v2.6.8-20230221221104-40baa52fa"
             }
           ]
         },


### PR DESCRIPTION
Backport Rancher image upgrade to release-1.5 branch. The Rancher dashboard tag is the same (release-1.5 compared with master) so this did not require rebuilding the Rancher image for 1.5.
