### PR TITLE
VZ-8753: Increase timeout for uninstall resiliency tests suite

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -7,7 +7,7 @@ EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {
     options {
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 150, unit: 'MINUTES')
         skipDefaultCheckout true
         timestamps ()
     }


### PR DESCRIPTION
 Increase timeout for uninstall resiliency tests suite, the new rancher-cleanup job is taking longer to uninstall Rancher.