### PR TITLE
Update BOM to use latest prometheus and alertmanager release builds (#5424)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -503,7 +503,7 @@
           "images": [
             {
               "image": "alertmanager",
-              "tag": "v0.24.0-20230209062327-fb73d30f",
+              "tag": "v0.24.0-20230221214421-a20fd08d",
               "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
               "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
             }
@@ -515,7 +515,7 @@
           "images": [
             {
               "image": "prometheus",
-              "tag": "v2.38.0-20230209074214-5cc7f3b4",
+              "tag": "v2.38.0-20230221215349-cf7b5418",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"
             }


### PR DESCRIPTION
Backport a couple of image updates to the release-1.5 branch.
