### PR TITLE
VZ-7954: Fix to stop recreating cluster registration tokens

### DIFF
--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -345,8 +345,7 @@ func getCACertFromManagedClusterSecret(rc *rancherutil.RancherConfig, clusterID,
 // getRegistrationYAMLFromRancher creates a registration token in Rancher for the managed cluster and uses the
 // returned token to fetch the registration (manifest) YAML.
 func getRegistrationYAMLFromRancher(rc *rancherutil.RancherConfig, rancherClusterID string, log vzlog.VerrazzanoLogger) (string, error) {
-	action := http.MethodPost
-	payload := `{"type": "clusterRegistrationToken", "clusterId": "` + rancherClusterID + `"}`
+
 	reqURL := rc.BaseURL + clusterRegTokenPath
 	headers := map[string]string{"Content-Type": "application/json"}
 	headers["Authorization"] = "Bearer " + rc.APIAccessToken
@@ -354,10 +353,12 @@ func getRegistrationYAMLFromRancher(rc *rancherutil.RancherConfig, rancherCluste
 	var token string
 	token, err := getRegistrationTokenFromRancher(rc, rancherClusterID, log)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
-
 	if token == "" {
+		action := http.MethodPost
+		payload := `{"type": "clusterRegistrationToken", "clusterId": "` + rancherClusterID + `"}`
+
 		response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, payload, rc, log)
 		if err != nil {
 			return "", err
@@ -376,8 +377,7 @@ func getRegistrationYAMLFromRancher(rc *rancherutil.RancherConfig, rancherCluste
 	}
 	// Rancher 2.5.x added the cluster ID to the manifest URL.
 	manifestURL := rc.BaseURL + manifestPath + token + "_" + rancherClusterID + ".yaml"
-
-	action = http.MethodGet
+	action := http.MethodGet
 	response, manifestContent, err := rancherutil.SendRequest(action, manifestURL, headers, "", rc, log)
 
 	if err != nil {
@@ -402,12 +402,15 @@ type ClusterRegistrationTokens struct {
 
 func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClusterID string, log vzlog.VerrazzanoLogger) (string, error) {
 
+	log.Infof("Calling getRegistrationTokenFromRancher")
 	action := http.MethodGet
-	reqURL := rc.BaseURL + "v3/clusterregistrationtoken?state=active&&clusterId=" + rancherClusterID
+	reqURL := rc.BaseURL + clusterRegTokenPath + "?state=active&&clusterId=" + rancherClusterID
 	headers := map[string]string{"Content-Type": "application/json"}
 	headers["Authorization"] = "Bearer " + rc.APIAccessToken
 
-	response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, "", rc, log)
+	response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, "{}", rc, log)
+	log.Infof("Called getRegistrationTokenFromRancher")
+	log.Info(response)
 	if err != nil {
 		return "", err
 	}
@@ -417,6 +420,7 @@ func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClust
 	}
 
 	data, err := httputil.ExtractFieldFromResponseBodyOrReturnError(manifestContent, "data", "unable to find data token in Rancher response")
+	log.Infof("Extracted data")
 	if err != nil {
 		return "", err
 	}
@@ -431,7 +435,7 @@ func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClust
 	}
 
 	log.Infof("No active clusterRegistrationToken found")
-	return "", nil
+	return "", err
 }
 
 // createOrUpdateSecretRancherProxy simulates the controllerutil create or update function through the Rancher Proxy API for secrets

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -6,6 +6,8 @@ package vmc
 import (
 	"crypto/md5" //nolint:gosec //#gosec G501 // package used for caching only, not security
 	"fmt"
+	"io"
+	"net/http"
 	"github.com/Jeffail/gabs/v2"
 	cons "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
@@ -13,14 +15,12 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	"github.com/verrazzano/verrazzano/pkg/rancherutil"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmc

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -6,8 +6,6 @@ package vmc
 import (
 	"crypto/md5" //nolint:gosec //#gosec G501 // package used for caching only, not security
 	"fmt"
-	"io"
-	"net/http"
 	"github.com/Jeffail/gabs/v2"
 	cons "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/httputil"
@@ -15,12 +13,14 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/mcconstants"
 	"github.com/verrazzano/verrazzano/pkg/rancherutil"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -354,7 +354,7 @@ func getRegistrationYAMLFromRancher(rc *rancherutil.RancherConfig, rancherCluste
 	var token string
 	token, err := getRegistrationTokenFromRancher(rc, rancherClusterID, log)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if token == "" {
@@ -411,7 +411,7 @@ func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClust
 	if err != nil {
 		return "", err
 	}
-	
+
 	err = httputil.ValidateResponseCode(response, http.StatusOK)
 	if err != nil {
 		return "", err

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmc

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -403,14 +403,15 @@ type ClusterRegistrationTokens struct {
 func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClusterID string, log vzlog.VerrazzanoLogger) (string, error) {
 
 	action := http.MethodGet
-	reqURL := rc.BaseURL + "v3/clusterregistrationtoken?state=active&&clusterId=" + rancherClusterID
+	reqURL := rc.BaseURL + clusterRegTokenPath + "?state=active&&clusterId=" + rancherClusterID
 	headers := map[string]string{"Content-Type": "application/json"}
 	headers["Authorization"] = "Bearer " + rc.APIAccessToken
 
-	response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, "", rc, log)
+	response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, "{}", rc, log)
 	if err != nil {
 		return "", err
 	}
+	
 	err = httputil.ValidateResponseCode(response, http.StatusOK)
 	if err != nil {
 		return "", err

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -408,6 +408,9 @@ func getRegistrationTokenFromRancher(rc *rancherutil.RancherConfig, rancherClust
 	headers["Authorization"] = "Bearer " + rc.APIAccessToken
 
 	response, manifestContent, err := rancherutil.SendRequest(action, reqURL, headers, "", rc, log)
+	if err != nil {
+		return "", err
+	}
 	err = httputil.ValidateResponseCode(response, http.StatusOK)
 	if err != nil {
 		return "", err

--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -63,11 +63,6 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	if vmc.Labels != nil && vmc.Labels[rancher.CreatedByLabel] == rancher.CreatedByVerrazzano && len(vmc.Status.RancherRegistration.ClusterID) == 0 {
 		r.log.Progressf("Waiting for Verrazzano-created VMC named %s to have a cluster id in the status before attempting to fetch Rancher registration manifest", vmc.Name)
 		vzVMCWaitingForClusterID = true
-	}
-	if vmc != nil && clusterapi.RegistrationCompleted == vmc.Status.RancherRegistration.Status {
-		// Check the registration status and skip creating new registration tokens
-		msg := fmt.Sprintf("Registration of managed cluster completed for cluster %s", vmc.Name)
-		r.log.Once(msg)
 	} else {
 		// register the cluster with Rancher - the cluster will show as "pending" until the
 		// Rancher YAML is applied on the managed cluster

--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -63,6 +63,11 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 	if vmc.Labels != nil && vmc.Labels[rancher.CreatedByLabel] == rancher.CreatedByVerrazzano && len(vmc.Status.RancherRegistration.ClusterID) == 0 {
 		r.log.Progressf("Waiting for Verrazzano-created VMC named %s to have a cluster id in the status before attempting to fetch Rancher registration manifest", vmc.Name)
 		vzVMCWaitingForClusterID = true
+	}
+	if vmc != nil && clusterapi.RegistrationCompleted == vmc.Status.RancherRegistration.Status {
+		// Check the registration status and skip creating new registration tokens
+		msg := fmt.Sprintf("Registration of managed cluster completed for cluster %s", vmc.Name)
+		r.log.Once(msg)
 	} else {
 		// register the cluster with Rancher - the cluster will show as "pending" until the
 		// Rancher YAML is applied on the managed cluster

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -1357,7 +1357,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			_, err := io.ReadAll(req.Body)
 			asserts.NoError(err)
 
-			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"unit-test-token","state":"active"}]}`)))
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,
@@ -1434,7 +1434,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			asserts.NoError(err)
 
 			// return a response with the CRT
-			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"manifest-token","state":"active"}]}`)))
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"manifest-token","state":"active","clusterId":"some-cluster"}]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,
@@ -2195,7 +2195,7 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 
 	manifestToken := "unit-test-manifest-token"
 
-	// Expect an HTTP request to create the registration token in Rancher
+	// Expect an HTTP request to get the registration token in Rancher
 	requestSenderMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
@@ -2205,7 +2205,7 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 			_, err := io.ReadAll(req.Body)
 			asserts.NoError(err)
 
-			// return a response with the CRT
+			// return a response with the empty data, no CRT exists for this cluster
 			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -1357,7 +1357,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			_, err := io.ReadAll(req.Body)
 			asserts.NoError(err)
 
-			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"unit-test-token"}]}`)))
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"unit-test-token","state":"active"}]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,
@@ -1434,7 +1434,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			asserts.NoError(err)
 
 			// return a response with the CRT
-			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"manifest-token"}]}`)))
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"manifest-token","state":"active"}]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,
@@ -2207,7 +2207,6 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 
 			// return a response with the CRT
 			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[]}`)))
-			//r = io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"` + manifestToken + `"}]}`)))
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       r,

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -2171,7 +2171,7 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 
 	manifestToken := "unit-test-manifest-token"
 
-	// Expect an HTTP request to create the registration token in Rancher
+	Expect an HTTP request to create the registration token in Rancher
 	requestSenderMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
@@ -2194,6 +2194,14 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 				Request:    &http.Request{Method: http.MethodPost},
 			}
 			return resp, nil
+		})
+
+	// Expect an HTTP request to fetch the registration token in rancher
+	requestSenderMock.EXPECT().
+		Do(gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			asserts.Contains(clusterRegTokenPath+"?state=active&&clusterId="+unitTestRancherClusterID, req.URL.Path)
+			return nil, nil
 		})
 
 	// Expect an HTTP request to fetch the manifest YAML from Rancher

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -1348,6 +1348,24 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
+	// Expect an HTTP request to get the registration token in Rancher for the clusterId
+	mockRequestSender.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			asserts.Contains(clusterRegTokenPath, req.URL.Path)
+
+			_, err := io.ReadAll(req.Body)
+			asserts.NoError(err)
+
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"unit-test-token"}]}`)))
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodGet},
+			}
+			return resp, nil
+		})
+
 	// Expect an HTTP request to create the registration token in Rancher but the call fails
 	mockRequestSender.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
@@ -1406,15 +1424,21 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 			return resp, nil
 		})
 
-	// Expect an HTTP request to create the registration token in Rancher
+	// Expect an HTTP request to get the registration token in Rancher for the clusterId
 	mockRequestSender.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
-			r := io.NopCloser(bytes.NewReader([]byte(`{"token":"manifest-token"}`)))
+			asserts.Contains(clusterRegTokenPath, req.URL.Path)
+
+			_, err := io.ReadAll(req.Body)
+			asserts.NoError(err)
+
+			// return a response with the CRT
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"manifest-token"}]}`)))
 			resp := &http.Response{
-				StatusCode: http.StatusCreated,
+				StatusCode: http.StatusOK,
 				Body:       r,
-				Request:    &http.Request{Method: http.MethodPost},
+				Request:    &http.Request{Method: http.MethodGet},
 			}
 			return resp, nil
 		})

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -2171,7 +2171,7 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 
 	manifestToken := "unit-test-manifest-token"
 
-	Expect an HTTP request to create the registration token in Rancher
+	// Expect an HTTP request to create the registration token in Rancher
 	requestSenderMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
@@ -2194,14 +2194,6 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 				Request:    &http.Request{Method: http.MethodPost},
 			}
 			return resp, nil
-		})
-
-	// Expect an HTTP request to fetch the registration token in rancher
-	requestSenderMock.EXPECT().
-		Do(gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).
-		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
-			asserts.Contains(clusterRegTokenPath+"?state=active&&clusterId="+unitTestRancherClusterID, req.URL.Path)
-			return nil, nil
 		})
 
 	// Expect an HTTP request to fetch the manifest YAML from Rancher

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -2175,6 +2175,27 @@ func expectRegisterClusterWithRancherHTTPCalls(t *testing.T, requestSenderMock *
 	requestSenderMock.EXPECT().
 		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
 		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+			asserts.Contains(clusterRegTokenPath, req.URL.Path)
+
+			// assert that the cluster ID in the request body is what we expect
+			_, err := io.ReadAll(req.Body)
+			asserts.NoError(err)
+
+			// return a response with the CRT
+			r := io.NopCloser(bytes.NewReader([]byte(`{"data":[]}`)))
+			//r = io.NopCloser(bytes.NewReader([]byte(`{"data":[{"token":"` + manifestToken + `"}]}`)))
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       r,
+				Request:    &http.Request{Method: http.MethodGet},
+			}
+			return resp, nil
+		})
+
+	// Expect an HTTP request to create the registration token in Rancher
+	requestSenderMock.EXPECT().
+		Do(gomock.Not(gomock.Nil()), mockmatchers.MatchesURI(clusterRegTokenPath)).
+		DoAndReturn(func(httpClient *http.Client, req *http.Request) (*http.Response, error) {
 			asserts.Equal(clusterRegTokenPath, req.URL.Path)
 
 			// assert that the cluster ID in the request body is what we expect

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -3,6 +3,8 @@
 package httputil_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -19,6 +21,20 @@ func TestExtractTokenFromResponseBody(t *testing.T) {
 	asserts.Error(err)
 	asserts.Empty(token)
 
+	filename := "/Users/sdosapat/vz-7954/response_out_raw_formatted_2"
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		return
+	}
+	// Convert the byte slice to a string
+	str := string(data)
+	data1, err := httputil.ExtractFieldFromResponseBodyOrReturnError(str, "data")
+	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(data1, "token")
+	fmt.Println("sdosapat " + token)
+	//asserts.NoError(err)
+	//asserts.Equal(`[{"abcd":"efgh"}]`, token)
+
 	// Valid response
 	body = `{"token": "abcd"}`
 	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(body, "token")
@@ -29,7 +45,6 @@ func TestExtractTokenFromResponseBody(t *testing.T) {
 	body = `{"token": [{"abcd": "efgh"}]}`
 	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(body, "token")
 	asserts.NoError(err)
-	asserts.Equal(`[{"abcd":"efgh"}]`, token)
 
 	// Expected error message
 	body = `{"notoken": "yes"}`

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package httputil_test
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package httputil_test
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package httputil_test
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package httputil_test
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package httputil_test
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -3,8 +3,6 @@
 package httputil_test
 
 import (
-	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -21,20 +19,6 @@ func TestExtractTokenFromResponseBody(t *testing.T) {
 	asserts.Error(err)
 	asserts.Empty(token)
 
-	filename := "/Users/sdosapat/vz-7954/response_out_raw_formatted_2"
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		fmt.Println("Error reading file:", err)
-		return
-	}
-	// Convert the byte slice to a string
-	str := string(data)
-	data1, err := httputil.ExtractFieldFromResponseBodyOrReturnError(str, "data")
-	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(data1, "token")
-	fmt.Println("sdosapat " + token)
-	//asserts.NoError(err)
-	//asserts.Equal(`[{"abcd":"efgh"}]`, token)
-
 	// Valid response
 	body = `{"token": "abcd"}`
 	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(body, "token")
@@ -45,6 +29,7 @@ func TestExtractTokenFromResponseBody(t *testing.T) {
 	body = `{"token": [{"abcd": "efgh"}]}`
 	token, err = httputil.ExtractFieldFromResponseBodyOrReturnError(body, "token")
 	asserts.NoError(err)
+	asserts.Equal(`[{"abcd":"efgh"}]`, token)
 
 	// Expected error message
 	body = `{"notoken": "yes"}`


### PR DESCRIPTION
- Changes to rancher.go to get the existing CRT token before creating one