### PR TITLE
VZ-8243: fix parameters calling verrazzano-dynamic-config-install-tests in periodics

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -445,7 +445,7 @@ pipeline {
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'WAIT_FOR_RESOURCE_BEFORE_UPDATE', value: 'mysql statefulset')
+                                        string(name: 'WAIT_FOR_RESOURCE_BEFORE_UPDATE', value: 'keycloak auth secret')
                                     ], wait: true
                             }
                         }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -439,9 +439,8 @@ pipeline {
                             script {
                                 build job: "verrazzano-dynamic-config-install-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.22'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
@@ -464,9 +463,8 @@ pipeline {
                             script {
                                 build job: "verrazzano-dynamic-config-install-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.22'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),


### PR DESCRIPTION
https://github.com/verrazzano/verrazzano/pull/5430 introduced modifications to the periodics pipeline.

This aims to fix errors found there. The `prepare_jenkins_at_environment.sh` script was failing, complaining about not having all required environment variables set. I believe that `VERRAZZANO_OPERATOR_IMAGE` was set as empty when calling the new pipeline from periodics, causing the failures.

Other problems found were also fixed. 
