### PR TITLE
VZ-8656: Removed deprecated k8s version v1.20 from BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -776,7 +776,6 @@
     }
   ],
   "supportedKubernetesVersions": [
-    "v1.20.0",
     "v1.21.0",
     "v1.22.0",
     "v1.23.0",


### PR DESCRIPTION
This PR backports the change to remove deprecated k8s version v1.20 from BOM file.