### PR TITLE
VZ-8656: Removed deprecated k8s version from bom (#5418)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -710,5 +710,11 @@
         }
       ]
     }
+  ],
+  "supportedKubernetesVersions": [
+    "v1.21.0",
+    "v1.22.0",
+    "v1.23.0",
+    "v1.24.0"
   ]
 }


### PR DESCRIPTION
This PR backports the change to remove deprecated k8s version v1.20 from BOM file.