### PR TITLE
VZ-8707 VZ-8763: latest VMO tag to fix upgrade and plugin bugs

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -223,7 +223,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.6.0-20230216162915-dd6e2de",
+              "tag": "v1.6.0-20230224051054-fa7ca84",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Flip the VMO image to fix:

- VZ-8707: Change OS master node's PVC ownerRef to VMI to fix upgrade when Sts gets randomly nuked by VMO post component upgrade.

- VZ-8763: Modify plugin install logic to fail only the master node in case of install failure.
