### PR TITLE
VZ-8707 VZ-8763: flip VMO image containing bug fixes in 1.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Fixes:
 
 - Fixed the query for the Service variable in WebLogic Grafana dashboard.
 - Updated component images to resolve CVEs.
+- Fixed upgrade issue with PVCs getting deleted when OpenSearch master node's StatefulSet was occasionally killed during upgrade.
+- Fixed OpenSearch plugin install to fail only the master nodes in case of plugin install failure.
 
 ### v1.5.0
 Features:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -219,7 +219,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.5.1-20230216174844-f452ec4",
+              "tag": "v1.5.1-20230224073644-7eb85b1",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Flip the VMO image to fix:

- VZ-8707: Change OS master node's PVC ownerRef to VMI to fix upgrade when Sts gets randomly nuked by VMO post component upgrade.

- VZ-8763: Modify plugin install logic to fail only the master node in case of install failure.
