### PR TITLE
Switch release 1.4 to use the JAO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def VERRAZZANO_DEV_VERSION = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 pipeline {
     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def VERRAZZANO_DEV_VERSION = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 pipeline {
     options {

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -17,7 +17,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "EXP_tvlaonfig_1.4-large"
+            label "1.4-large"
         }
     }
 

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -17,7 +17,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "VM.Standard2.8_1_4"
+            label "EXP_tvlaonfig_1.4-large"
         }
     }
 

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -7,7 +7,7 @@ import groovy.transform.Field
 def GIT_COMMIT_TO_USE = ""
 @Field
 def LAST_CLEAN_BACKEND_COMMIT = ""
-def agentLabel = "EXP_tvlaonfig_1.4-small"
+def agentLabel = "1.4-small"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -7,7 +7,7 @@ import groovy.transform.Field
 def GIT_COMMIT_TO_USE = ""
 @Field
 def LAST_CLEAN_BACKEND_COMMIT = ""
-def agentLabel = env.JOB_NAME.contains('master') ? "phx-small" : "small"
+def agentLabel = "EXP_tvlaonfig_1.4-small"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -13,7 +13,7 @@ def LAST_PERIODIC_RUN_COMMIT = ""
 def VERRAZZANO_DEV_VERSION = ""
 @Field
 def RELEASABLE_IMAGES_OBJECT_STORE = ""
-def agentLabel = "EXP_tvlaonfig_1.4-small"
+def agentLabel = "1.4-small"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -13,7 +13,7 @@ def LAST_PERIODIC_RUN_COMMIT = ""
 def VERRAZZANO_DEV_VERSION = ""
 @Field
 def RELEASABLE_IMAGES_OBJECT_STORE = ""
-def agentLabel = "VM.Standard2.2_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-small"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "EXP_tvlaonfig_1.4-small"
+def agentLabel = "1.4-small"
 
 pipeline {
     options {

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "VM.Standard2.2_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-small"
 
 pipeline {
     options {

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -22,6 +22,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
+            label "EXP_tvlaonfig_1.4-large"
         }
     }
 

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -22,7 +22,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "EXP_tvlaonfig_1.4-large"
+            label "1.4-large"
         }
     }
 

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "EXP_tvlaonfig_1.4-small"
+def agentLabel = "1.4-small"
 def branchSpecificSchedule = getCronSchedule()
 def GIT_COMMIT_TO_USE = ""
 

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "VM.Standard2.2_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-small"
 def branchSpecificSchedule = getCronSchedule()
 def GIT_COMMIT_TO_USE = ""
 

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -13,8 +13,8 @@ pipeline {
 
     agent {
        docker {
-            image "${RUNNER_DOCKER_IMAGE}"
-            args "${RUNNER_DOCKER_ARGS}"
+            image "${RUNNER_DOCKER_IMAGE_1_4}"
+            args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
             label "${agentLabel}"

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = env.JOB_NAME.contains('master') ? "phx-large" : "large"
+def agentLabel = "EXP_tvlaonfig_1.4-large-phx"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large-phx"
+def agentLabel = "1.4-large-phx"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 targetsKey = "targets"

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 targetsKey = "targets"

--- a/ci/generic/Jenkinsfile-singletarget
+++ b/ci/generic/Jenkinsfile-singletarget
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/generic/Jenkinsfile-singletarget
+++ b/ci/generic/Jenkinsfile-singletarget
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -8,7 +8,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 pipeline {
     options {

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -8,7 +8,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 pipeline {
     options {

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -11,7 +11,7 @@
 // -> Cleanup resources
 
 def testEnvironments=["OCNE"]
-def agentLabel="EXP_tvlaonfig_1.4-large"
+def agentLabel="1.4-large"
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions=["us-ashburn-1"]
 def availableDomains=["hXgQ:US-ASHBURN-AD-1", "hXgQ:US-ASHBURN-AD-2", "hXgQ:US-ASHBURN-AD-3"]

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -11,7 +11,7 @@
 // -> Cleanup resources
 
 def testEnvironments=["OCNE"]
-def agentLabel="VM.Standard2.8_1_4"
+def agentLabel="EXP_tvlaonfig_1.4-large"
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions=["us-ashburn-1"]
 def availableDomains=["hXgQ:US-ASHBURN-AD-1", "hXgQ:US-ASHBURN-AD-2", "hXgQ:US-ASHBURN-AD-3"]

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -5,7 +5,7 @@ def DOCKER_IMAGE_TAG
 // Pin to PHX for now for testing; tarball is located only in PHX at present, and takes 15+ mins to download to LHR at runtime
 // - at some point, we can either enable bucket replication or have the pipeline push it to more regions
 //def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
-def agentLabel = "phxlarge_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large-phx"
 def ocirRegion = "phx"
 def ocirRegistry = "${ocirRegion}.ocir.io"
 def imageRepoSubPath=""

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -4,8 +4,7 @@
 def DOCKER_IMAGE_TAG
 // Pin to PHX for now for testing; tarball is located only in PHX at present, and takes 15+ mins to download to LHR at runtime
 // - at some point, we can either enable bucket replication or have the pipeline push it to more regions
-//def agentLabel = env.JOB_NAME.contains('master') ? "phxlarge" : "VM.Standard2.8"
-def agentLabel = "EXP_tvlaonfig_1.4-large-phx"
+def agentLabel = "1.4-large-phx"
 def ocirRegion = "phx"
 def ocirRegistry = "${ocirRegion}.ocir.io"
 def imageRepoSubPath=""

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -3,7 +3,7 @@
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 pipeline {
     options {

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -3,7 +3,7 @@
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 pipeline {
     options {

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
        docker {
             image "${RUNNER_DOCKER_IMAGE_1_4}"
             args "${RUNNER_DOCKER_ARGS_1_4}"
-            label "EXP_tvlaonfig_1.4-small"
+            label "1.4-small"
             registryCredentialsId 'ocir-pull-and-push-account'
         }
     }

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
        docker {
             image "${RUNNER_DOCKER_IMAGE_1_4}"
             args "${RUNNER_DOCKER_ARGS_1_4}"
-            label "VM.Standard2.2_1_4"
+            label "EXP_tvlaonfig_1.4-small"
             registryCredentialsId 'ocir-pull-and-push-account'
         }
     }

--- a/ci/test-examples/Jenkinsfile
+++ b/ci/test-examples/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label 'small'
+            label 'EXP_tvlaonfig_1.4-small'
         }
     }
 

--- a/ci/test-examples/Jenkinsfile
+++ b/ci/test-examples/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label 'EXP_tvlaonfig_1.4-small'
+            label '1.4-small'
         }
     }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "EXP_tvlaonfig_1.4-large"
+            label "1.4-large"
         }
     }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_4}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
+            label "EXP_tvlaonfig_1.4-large"
         }
     }
 

--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "VM.Standard2.2_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-small"
 def branchSpecificSchedule = getCronSchedule()
 
 pipeline {

--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "EXP_tvlaonfig_1.4-small"
+def agentLabel = "1.4-small"
 def branchSpecificSchedule = getCronSchedule()
 
 pipeline {

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 
 def listOfUpgradeJobs
 def upgradeJobsStageMapping

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 
 def listOfUpgradeJobs
 def upgradeJobsStageMapping

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "VM.Standard2.8_1_4"
+def agentLabel = "EXP_tvlaonfig_1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "EXP_tvlaonfig_1.4-large"
+def agentLabel = "1.4-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {


### PR DESCRIPTION
This switches the release-1.4 jobs from using labels provisioned by the Jenkins OCI to using labels provisioned by the Jenkins Agent Operator.