### PR TITLE
VZ-8784: Update HorizontalPodAutoscaler charts to support k8s 1.25

### DIFF
--- a/platform-operator/thirdparty/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
 {{- if not .Values.controller.keda.enabled }}
 
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/platform-operator/thirdparty/charts/ingress-nginx/templates/default-backend-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.defaultBackend.enabled .Values.defaultBackend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta1" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/platform-operator/thirdparty/charts/keycloak/templates/hpa.yaml
+++ b/platform-operator/thirdparty/charts/keycloak/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
HorizontalPodAutoscaler for versions autoscaling/v2beta2 and autoscaling/v1beta1  is deprecated in v1.23+. Therefore this PR migrates the affected charts to autoscaling/v2 from k8s 1.23 version. 