### PR TITLE
VZ-8243: remove reference to Mark in JenkinsfileUpdateDuringInstall

### DIFF
--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -364,7 +364,7 @@ pipeline {
                 rm archive.zip
             """
             script {
-                if (env.BRANCH_NAME == "master" || env.BRANCH_NAME ==~ "release-.*" || env.BRANCH_NAME ==~ "mark/*") {
+                if (env.BRANCH_NAME == "master" || env.BRANCH_NAME ==~ "release-.*") {
                     slackSend ( message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nView the log at:\n ${env.BUILD_URL}\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}" )
                 }
             }


### PR DESCRIPTION
This removes a reference to branches owned by Mark in `ci/dynamic-updates/JenkinsfileUpdateDuringInstall`.
