### PR TITLE
Upgrade kiali and kube-state-metrics images (#5441)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -378,7 +378,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.57.1-20230209072051-f8743fd9",
+              "tag": "v1.57.1-20230223193254-0e6b42d8",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }
@@ -553,7 +553,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.6.0-20230209065128-fda95595",
+              "tag": "v2.6.0-20230223191441-e3cc4e3d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
VZ-8700, VZ-8701: Upgrade kiali and kube-state-metrics images

Cherry pick image updates from release-1.5 branch.