### PR TITLE
VZ-8648 Allow component disable

### DIFF
--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -45,7 +45,7 @@ type reconcileState string
 type installTracker struct {
 	vzState reconcileState
 	gen     int64
-	compMap map[string]*componentInstallContext
+	compMap map[string]*componentTrackerContext
 }
 
 // installTrackerMap has a map of InstallTrackers with key from VZ name, namespace, and UID
@@ -65,7 +65,7 @@ func getInstallTracker(cr *vzapi.Verrazzano) *installTracker {
 		vuc = &installTracker{
 			vzState: vzStateReconcileWatchedComponents,
 			gen:     cr.Generation,
-			compMap: make(map[string]*componentInstallContext),
+			compMap: make(map[string]*componentTrackerContext),
 		}
 		installTrackerMap[key] = vuc
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package reconcile

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -281,6 +281,10 @@ func chooseCompState(componentStatus *vzapi.ComponentStatusDetails) componentIns
 func skipComponentFromDetermineComponentState(compContext spi.ComponentContext, comp spi.Component, preUpgrade bool) bool {
 	if !comp.IsEnabled(compContext.EffectiveCR()) {
 		compContext.Log().Oncef("Component %s is disabled, skipping install", comp.Name())
+		if isCurrentlyInstalled(compContext, comp) {
+			compContext.Log().Oncef("Installed component %s has been disabled, uninstalling", comp.Name())
+			return false
+		}
 		// User has disabled component in Verrazzano CR, don't install
 		return true
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
@@ -84,24 +84,24 @@ func TestChooseCompState(t *testing.T) {
 func TestReconcilerInstallSingleComponent(t *testing.T) {
 	type args struct {
 		spiCtx         spi.ComponentContext
-		installContext *componentInstallContext
+		installContext *componentTrackerContext
 		comp           spi.Component
 		preUpgrade     bool
 	}
-	compContext := &componentInstallContext{
-		state: compStateInstallInitDisabled,
+	compContext := &componentTrackerContext{
+		installState: compStateInstallInitDisabled,
 	}
-	compCtxWithPreInstall := &componentInstallContext{
-		state: compStatePreInstall,
+	compCtxWithPreInstall := &componentTrackerContext{
+		installState: compStatePreInstall,
 	}
-	compCtxWithInstall := &componentInstallContext{
-		state: compStateInstall,
+	compCtxWithInstall := &componentTrackerContext{
+		installState: compStateInstall,
 	}
-	compCtxWithWait := &componentInstallContext{
-		state: compStateInstallWaitReady,
+	compCtxWithWait := &componentTrackerContext{
+		installState: compStateInstallWaitReady,
 	}
-	compCtxWithPostInstall := &componentInstallContext{
-		state: compStatePostInstall,
+	compCtxWithPostInstall := &componentTrackerContext{
+		installState: compStatePostInstall,
 	}
 
 	mockClient := fake.NewClientBuilder().Build()

--- a/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package reconcile

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -74,7 +74,7 @@ type uninstallState string
 type UninstallTracker struct {
 	vzState uninstallState
 	gen     int64
-	compMap map[string]*componentTackerContext
+	compMap map[string]*componentTrackerContext
 }
 
 // UninstallTrackerMap has a map of UninstallTrackers, one entry per Verrazzano CR resource generation
@@ -172,7 +172,7 @@ func getUninstallTracker(cr *installv1alpha1.Verrazzano) *UninstallTracker {
 		vuc = &UninstallTracker{
 			vzState: vzStateUninstallStart,
 			gen:     cr.Generation,
-			compMap: make(map[string]*componentTackerContext),
+			compMap: make(map[string]*componentTrackerContext),
 		}
 		UninstallTrackerMap[key] = vuc
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -74,7 +74,7 @@ type uninstallState string
 type UninstallTracker struct {
 	vzState uninstallState
 	gen     int64
-	compMap map[string]*componentUninstallContext
+	compMap map[string]*componentTackerContext
 }
 
 // UninstallTrackerMap has a map of UninstallTrackers, one entry per Verrazzano CR resource generation
@@ -172,7 +172,7 @@ func getUninstallTracker(cr *installv1alpha1.Verrazzano) *UninstallTracker {
 		vuc = &UninstallTracker{
 			vzState: vzStateUninstallStart,
 			gen:     cr.Generation,
-			compMap: make(map[string]*componentUninstallContext),
+			compMap: make(map[string]*componentTackerContext),
 		}
 		UninstallTrackerMap[key] = vuc
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
@@ -24,13 +24,13 @@ import (
 func TestReconcilerUninstallSingleComponent(t *testing.T) {
 	type args struct {
 		spiCtx           spi.ComponentContext
-		UninstallContext *componentUninstallContext
+		UninstallContext *componentTackerContext
 		comp             spi.Component
 	}
-	compContext := &componentUninstallContext{
+	compContext := &componentTackerContext{
 		state: compStateUninstallStart,
 	}
-	compCtxWithUninstall := &componentUninstallContext{
+	compCtxWithUninstall := &componentTackerContext{
 		state: compStateUninstall,
 	}
 

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
@@ -24,14 +24,14 @@ import (
 func TestReconcilerUninstallSingleComponent(t *testing.T) {
 	type args struct {
 		spiCtx           spi.ComponentContext
-		UninstallContext *componentTackerContext
+		UninstallContext *componentTrackerContext
 		comp             spi.Component
 	}
-	compContext := &componentTackerContext{
-		state: compStateUninstallStart,
+	compContext := &componentTrackerContext{
+		uninstallState: compStateUninstallStart,
 	}
-	compCtxWithUninstall := &componentTackerContext{
-		state: compStateUninstall,
+	compCtxWithUninstall := &componentTrackerContext{
+		uninstallState: compStateUninstall,
 	}
 
 	mockClient := fake.NewClientBuilder().Build()

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package reconcile

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade.go
@@ -59,7 +59,7 @@ type VerrazzanoUpgradeState string
 type upgradeTracker struct {
 	vzState VerrazzanoUpgradeState
 	gen     int64
-	compMap map[string]*componentUpgradeContext
+	compMap map[string]*componentTrackerContext
 }
 
 // upgradeTrackerMap has a map of upgradeTrackers, one entry per Verrazzano CR resource generation
@@ -245,7 +245,7 @@ func getUpgradeTracker(cr *installv1alpha1.Verrazzano) *upgradeTracker {
 		vuc = &upgradeTracker{
 			vzState: vzStateStart,
 			gen:     cr.Generation,
-			compMap: make(map[string]*componentUpgradeContext),
+			compMap: make(map[string]*componentTrackerContext),
 		}
 		upgradeTrackerMap[key] = vuc
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
@@ -42,11 +42,6 @@ const (
 	compStateUpgradeEnd componentUpgradeState = "compStateEnd"
 )
 
-// componentUpgradeContext has the upgrade context for a Verrazzano component upgrade
-type componentUpgradeContext struct {
-	state componentUpgradeState
-}
-
 // upgradeComponents will upgrade the components as required
 func (r *Reconciler) upgradeComponents(log vzlog.VerrazzanoLogger, cr *installv1alpha1.Verrazzano, tracker *upgradeTracker) (ctrl.Result, error) {
 	spiCtx, err := spi.NewContext(log, r.Client, cr, nil, r.DryRun)
@@ -69,13 +64,13 @@ func (r *Reconciler) upgradeComponents(log vzlog.VerrazzanoLogger, cr *installv1
 }
 
 // upgradeSingleComponent upgrades a single component
-func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgradeContext *componentUpgradeContext, comp spi.Component) (ctrl.Result, error) {
+func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgradeContext *componentTrackerContext, comp spi.Component) (ctrl.Result, error) {
 	compName := comp.Name()
 	compContext := spiCtx.Init(compName).Operation(vzconst.UpgradeOperation)
 	compLog := compContext.Log()
 
-	for upgradeContext.state != compStateUpgradeEnd {
-		switch upgradeContext.state {
+	for upgradeContext.upgradeState != compStateUpgradeEnd {
+		switch upgradeContext.upgradeState {
 		case compStateUpgradeInit:
 			// Check if component is installed, if not continue
 			installed, err := comp.IsInstalled(compContext)
@@ -88,10 +83,10 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 				if err := r.updateComponentStatus(compContext, "Upgrade started", installv1alpha1.CondUpgradeStarted); err != nil {
 					return ctrl.Result{Requeue: true}, err
 				}
-				upgradeContext.state = compStatePreUpgrade
+				upgradeContext.upgradeState = compStatePreUpgrade
 			} else {
 				compLog.Oncef("Component %s is not installed; upgrade being skipped", compName)
-				upgradeContext.state = compStateUpgradeEnd
+				upgradeContext.upgradeState = compStateUpgradeEnd
 			}
 
 		case compStatePreUpgrade:
@@ -100,7 +95,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 				compLog.Errorf("Failed pre-upgrade for component %s: %v", compName, err)
 				return ctrl.Result{}, err
 			}
-			upgradeContext.state = compStateUpgrade
+			upgradeContext.upgradeState = compStateUpgrade
 
 		case compStateUpgrade:
 			compLog.Progressf("Component %s upgrade running", compName)
@@ -111,7 +106,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 				// requeue for 30 to 60 seconds later
 				return controller.NewRequeueWithDelay(30, 60, time.Second), nil
 			}
-			upgradeContext.state = compStateUpgradeWaitReady
+			upgradeContext.upgradeState = compStateUpgradeWaitReady
 
 		case compStateUpgradeWaitReady:
 			if !comp.IsReady(compContext) {
@@ -119,7 +114,7 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 				return newRequeueWithDelay(), nil
 			}
 			compLog.Progressf("Component %s is ready after being upgraded", compName)
-			upgradeContext.state = compStatePostUpgrade
+			upgradeContext.upgradeState = compStatePostUpgrade
 
 		case compStatePostUpgrade:
 			compLog.Oncef("Component %s post-upgrade running", compName)
@@ -127,14 +122,14 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 				compLog.Errorf("Failed post-upgrade for component %s: %v", compName, err)
 				return ctrl.Result{}, err
 			}
-			upgradeContext.state = compStateUpgradeDone
+			upgradeContext.upgradeState = compStateUpgradeDone
 
 		case compStateUpgradeDone:
 			compLog.Oncef("Component %s has successfully upgraded", compName)
 			if err := r.updateComponentStatus(compContext, "Upgrade complete", installv1alpha1.CondUpgradeComplete); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
-			upgradeContext.state = compStateUpgradeEnd
+			upgradeContext.upgradeState = compStateUpgradeEnd
 		}
 	}
 	// Component has been upgraded
@@ -142,11 +137,11 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 }
 
 // getComponentUpgradeContext gets the upgrade context for the component
-func (vuc *upgradeTracker) getComponentUpgradeContext(compName string) *componentUpgradeContext {
+func (vuc *upgradeTracker) getComponentUpgradeContext(compName string) *componentTrackerContext {
 	context, ok := vuc.compMap[compName]
 	if !ok {
-		context = &componentUpgradeContext{
-			state: compStateUpgradeInit,
+		context = &componentTrackerContext{
+			upgradeState: compStateUpgradeInit,
 		}
 		vuc.compMap[compName] = context
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package reconcile

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
@@ -1902,7 +1902,7 @@ func initStates(cr *vzapi.Verrazzano, vzState VerrazzanoUpgradeState, compName s
 	tracker := getUpgradeTracker(cr)
 	tracker.vzState = vzState
 	upgradeContext := tracker.getComponentUpgradeContext(compName)
-	upgradeContext.state = compState
+	upgradeContext.upgradeState = compState
 }
 
 // reconcileUpgradeLoop


### PR DESCRIPTION
This changes modifies the installSingleComponent state machine to allow component uninstall. It also combines the componentTrackerContexts into one type with unique fields for the install upgrade and uninstall. This PR is a iteration on https://github.com/verrazzano/verrazzano/pull/5315