### PR TITLE
Add verrazzano-cluster-operator pod logs to VZ bug-report

### DIFF
--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -72,6 +72,8 @@ const VerrazzanoRequirementsValidatorWebhook = "verrazzano-platform-requirements
 
 const VerrazzanoApplicationOperator = "verrazzano-application-operator"
 
+const VerrazzanoClusterOperator = "verrazzano-cluster-operator"
+
 const VerrazzanoMonitoringOperator = "verrazzano-monitoring-operator"
 
 const VerrazzanoUninstall = "verrazzano-uninstall"


### PR DESCRIPTION
Looking at failed pipelines that included VZ bug-report cluster snapshots, I noticed that the cluster operator logs were missing. This PR adds them.