### PR TITLE
VZ-8153: Making prometheus a-la-carte and remove dependency on NGINX and Authproxy

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -136,7 +136,7 @@ func postInstallUpgrade(ctx spi.ComponentContext) error {
 		ExtraAnnotations: common.SameSiteCookieAnnotations(prometheusName),
 	}
 
-	if vzcr.IsNGINXEnabled(ctx.EffectiveCR()) && vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
+	if vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {
 		if err := common.CreateOrUpdateSystemComponentIngress(ctx, props); err != nil {
 			return err
 		}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -135,8 +135,11 @@ func postInstallUpgrade(ctx spi.ComponentContext) error {
 		// Enable sticky sessions, so there is no UI query skew in multi-replica prometheus clusters
 		ExtraAnnotations: common.SameSiteCookieAnnotations(prometheusName),
 	}
-	if err := common.CreateOrUpdateSystemComponentIngress(ctx, props); err != nil {
-		return err
+
+	if vzcr.IsNGINXEnabled(ctx.EffectiveCR()) && vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
+		if err := common.CreateOrUpdateSystemComponentIngress(ctx, props); err != nil {
+			return err
+		}
 	}
 	if err := createOrUpdatePrometheusAuthPolicy(ctx); err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package operator
@@ -189,6 +189,9 @@ func (c prometheusComponent) GetIngressNames(ctx spi.ComponentContext) []types.N
 
 	if vzcr.IsPrometheusEnabled(ctx.EffectiveCR()) {
 		ns := ComponentNamespace
+		if !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) && !vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
+			return ingressNames
+		}
 		if vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
 			ns = authproxy.ComponentNamespace
 		}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -189,7 +189,7 @@ func (c prometheusComponent) GetIngressNames(ctx spi.ComponentContext) []types.N
 
 	if vzcr.IsPrometheusEnabled(ctx.EffectiveCR()) {
 		ns := ComponentNamespace
-		if !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) && !vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
+		if !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {
 			return ingressNames
 		}
 		if vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package operator

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package operator

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -264,43 +264,130 @@ func TestPostInstallUpgrade(t *testing.T) {
 	// GIVEN the Prometheus Operator is being installed or upgraded
 	// WHEN the postInstallUpgrade function is called
 	// THEN the function does not return an error
+
 	oldConfig := config.Get()
 	defer config.Set(oldConfig)
 	config.Set(config.OperatorConfig{
 		VerrazzanoRootDir: "../../../../../..",
 	})
 
-	vz := &vzapi.Verrazzano{
-		Spec: vzapi.VerrazzanoSpec{
-			Components: vzapi.ComponentSpec{
+	enabled := true
+	disabled := false
+	time := metav1.Now()
+
+	var tests = []struct {
+		name    string
+		vz      vzapi.Verrazzano
+		ingress netv1.Ingress
+		cert    certapiv1.Certificate
+	}{
+		{
+			name: "TestPostInstallUpgrade When everything is disabled",
+			vz: vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{
+				AuthProxy:          &vzapi.AuthProxyComponent{Enabled: &disabled},
+				Ingress:            &vzapi.IngressNginxComponent{Enabled: &disabled},
+				Prometheus:         &vzapi.PrometheusComponent{Enabled: &disabled},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{Enabled: &disabled},
 				DNS: &vzapi.DNSComponent{
 					OCI: &vzapi.OCI{
 						DNSZoneName: "mydomain.com",
+					},
+				},
+			}}},
+			ingress: netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+			},
+			cert: certapiv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
+				Status: certapiv1.CertificateStatus{
+					Conditions: []certapiv1.CertificateCondition{
+						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+					},
+				},
+			},
+		},
+		{
+			name: "TestPostInstallUpgrade When authproxy, nginx, prometheus, and prometheus operator enabled",
+			vz: vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{
+				AuthProxy:          &vzapi.AuthProxyComponent{Enabled: &enabled},
+				Ingress:            &vzapi.IngressNginxComponent{Enabled: &enabled},
+				Prometheus:         &vzapi.PrometheusComponent{Enabled: &enabled},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{Enabled: &enabled},
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						DNSZoneName: "mydomain.com",
+					},
+				},
+			}}},
+			ingress: netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+			},
+			cert: certapiv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
+				Status: certapiv1.CertificateStatus{
+					Conditions: []certapiv1.CertificateCondition{
+						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+					},
+				},
+			},
+		},
+		{
+			name: "TestPostInstallUpgrade When nginx, prometheus, and prometheus operator enabled",
+			vz: vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{
+				AuthProxy:          &vzapi.AuthProxyComponent{Enabled: &disabled},
+				Ingress:            &vzapi.IngressNginxComponent{Enabled: &enabled},
+				Prometheus:         &vzapi.PrometheusComponent{Enabled: &enabled},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{Enabled: &enabled},
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						DNSZoneName: "mydomain.com",
+					},
+				},
+			}}},
+			ingress: netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: vzconst.PrometheusOperatorNamespace},
+			},
+			cert: certapiv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: vzconst.PrometheusOperatorNamespace},
+				Status: certapiv1.CertificateStatus{
+					Conditions: []certapiv1.CertificateCondition{
+						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+					},
+				},
+			},
+		},
+		{
+			name: "TestPostInstallUpgrade When only prometheus, and prometheus operator enabled",
+			vz: vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{
+				AuthProxy:          &vzapi.AuthProxyComponent{Enabled: &disabled},
+				Ingress:            &vzapi.IngressNginxComponent{Enabled: &disabled},
+				Prometheus:         &vzapi.PrometheusComponent{Enabled: &enabled},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{Enabled: &enabled},
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						DNSZoneName: "mydomain.com",
+					},
+				},
+			}}},
+			cert: certapiv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: vzconst.PrometheusOperatorNamespace},
+				Status: certapiv1.CertificateStatus{
+					Conditions: []certapiv1.CertificateCondition{
+						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
 					},
 				},
 			},
 		},
 	}
 
-	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&test.ingress, &test.cert).Build()
+			ctx := spi.NewFakeContext(client, &test.vz, nil, false)
+			err := postInstallUpgrade(ctx)
+			assert.NoError(t, err)
+		})
 	}
-
-	time := metav1.Now()
-	cert := &certapiv1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
-		Status: certapiv1.CertificateStatus{
-			Conditions: []certapiv1.CertificateCondition{
-				{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
-			},
-		},
-	}
-
-	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(ingress, cert).Build()
-	ctx := spi.NewFakeContext(client, vz, nil, false)
-
-	err := postInstallUpgrade(ctx)
-	assert.NoError(t, err)
 }
 
 // TestAppendIstioOverrides tests that the Istio overrides get applied


### PR DESCRIPTION
This PR includes the changes to the prometheus component files
> Conditionally check/update ingresses for prometheus based on NGINX enabled/disabled to make prometheus a-la-carte