### PR TITLE
VZ-8845: Increase timeout for uninstall in test pipelines

### DIFF
--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -347,7 +347,7 @@ pipeline {
         stage('Uninstall Verrazzano') {
             steps {
                 sh """
-                    ${GO_REPO_PATH}/vz uninstall --timeout 30m
+                    ${GO_REPO_PATH}/vz uninstall --timeout 45m
                 """
             }
             post {

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -468,7 +468,7 @@ def uninstallVerrazzano(vpoLogsDir) {
         // Delete VZ in the background
         while (true) {
             echo "Deleting the Verrazzano resource..."
-            result = sh(returnStatus: true, script: "${VZ_COMMAND} uninstall --timeout=20m")
+            result = sh(returnStatus: true, script: "${VZ_COMMAND} uninstall --timeout=45m")
             if (result == 0) {
                 break
             }

--- a/ci/upgrade/Jenkinsfile
+++ b/ci/upgrade/Jenkinsfile
@@ -544,7 +544,7 @@ pipeline {
                     try {
                         sh """
                             echo "Uninstalling Verrazzano"
-                            ${GO_REPO_PATH}/vz uninstall
+                            ${GO_REPO_PATH}/vz uninstall --timeout 45m
                         """
                     } catch (err) {
                         currentBuild.result = "FAILURE"


### PR DESCRIPTION
The rancher-cleanup job requires more time to uninstall Rancher, which sometimes makes the uninstall run longer than the previous pipeline timeout settings.
