### PR TITLE
VZ-8518: Update Keycloak, VMO, NGINX ingress and External DNS images in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230209064251-9eca7e983",
+              "tag": "v1.3.1-20230302040354-bf21e9603",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.3.1-20230209064251-9eca7e983",
+              "tag": "v1.3.1-20230302040354-bf21e9603",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -87,7 +87,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.12.2-20230131195426-86e7710e",
+              "tag": "v0.12.2-20230302040401-49b4f66e",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"
@@ -195,7 +195,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230209064251-9eca7e983",
+              "tag": "v1.3.1-20230302040354-bf21e9603",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -219,7 +219,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.5.1-20230227082155-c9b0966",
+              "tag": "v1.5.1-20230302101425-8972c60",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },
@@ -250,7 +250,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230209064251-9eca7e983",
+              "tag": "v1.3.1-20230302040354-bf21e9603",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -445,7 +445,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230208153258-215619ca63",
+              "tag": "v20.0.1-20230301104410-055767339d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -479,7 +479,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.3.1-20230209064251-9eca7e983",
+              "tag": "v1.3.1-20230302040354-bf21e9603",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
             }


### PR DESCRIPTION
This PR updates the following images

1. Keycloak image contains the change to upgrade Wildfly Elytron module
2. VMO, NGINX ingress and External DNS images include the change to update golang.org/x/net and golang.org/x/text