### PR TITLE
Fix mockgen commands in Makefiles

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -98,8 +98,8 @@ uninstall-crds: manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
 
 .PHONY: manifests
 manifests: application-manifests

--- a/cluster-operator/Makefile
+++ b/cluster-operator/Makefile
@@ -84,8 +84,8 @@ uninstall-crds: manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
 
 .PHONY: manifests
 manifests: cluster-manifests

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -110,9 +110,9 @@ manifests: platform-manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/component_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi ComponentContext,ComponentInfo,ComponentInstaller,ComponentUpgrader,Component
-	mockgen -destination=mocks/controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/runtime_controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/controller Controller
+	mockgen --build_flags=--mod=mod -destination=mocks/component_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi ComponentContext,ComponentInfo,ComponentInstaller,ComponentUpgrader,Component
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/runtime_controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/controller Controller
 
 #
 # Docker-related tasks


### PR DESCRIPTION
At some point `make mock-gen` stopped working. Running it produces errors similar to this:
```
$ make mock-gen
mockgen -destination=mocks/component_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi ComponentContext,ComponentInfo,ComponentInstaller,ComponentUpgrader,Component
prog.go:12:2: cannot find package "github.com/verrazzano/verrazzano/vendor/github.com/golang/mock/mockgen/model" in:
	/go/src/github.com/verrazzano/verrazzano/vendor/github.com/golang/mock/mockgen/model
prog.go:12:2: cannot find package "github.com/verrazzano/verrazzano/vendor/github.com/golang/mock/mockgen/model" in:
	/go/src/github.com/verrazzano/verrazzano/vendor/github.com/golang/mock/mockgen/model
prog.go:12:2: no required module provides package github.com/golang/mock/mockgen/model: go.mod file not found in current directory or any parent directory; see 'go help modules'
prog.go:14:2: no required module provides package github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi: go.mod file not found in current directory or any parent directory; see 'go help modules'
```

This PR adds a switch to the mockgen invocations that fixes the errors and results in the correct generation of unit test mocks.