### PR TITLE
Fix mockgen commands (#5495) (release-1.5)

### DIFF
--- a/application-operator/Makefile
+++ b/application-operator/Makefile
@@ -98,8 +98,8 @@ uninstall-crds: manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
 
 .PHONY: manifests
 manifests: application-manifests

--- a/cluster-operator/Makefile
+++ b/cluster-operator/Makefile
@@ -84,8 +84,8 @@ uninstall-crds: manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_client_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_manager_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime Manager
 
 .PHONY: manifests
 manifests: cluster-manifests

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -110,9 +110,9 @@ manifests: platform-manifests
 # Generate mocks
 .PHONY: mock-gen
 mock-gen:
-	mockgen -destination=mocks/component_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi ComponentContext,ComponentInfo,ComponentInstaller,ComponentUpgrader,Component
-	mockgen -destination=mocks/controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
-	mockgen -destination=mocks/runtime_controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/controller Controller
+	mockgen --build_flags=--mod=mod -destination=mocks/component_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi ComponentContext,ComponentInfo,ComponentInstaller,ComponentUpgrader,Component
+	mockgen --build_flags=--mod=mod -destination=mocks/controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter
+	mockgen --build_flags=--mod=mod -destination=mocks/runtime_controller_mock.go -package=mocks -copyright_file=hack/boilerplate.go.txt sigs.k8s.io/controller-runtime/pkg/controller Controller
 
 #
 # Docker-related tasks


### PR DESCRIPTION
Backport of fix to the mock-gen commands in the operator Makefiles on the release-1.5 branch.

See https://github.com/verrazzano/verrazzano/pull/5495 for details.