### PR TITLE
VZ-8879: Fix upgrade path job with appropriate latest version based on the current branch

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -127,6 +127,7 @@ pipeline {
                     """
                     def props = readProperties file: '.verrazzano-development-version'
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    LATEST_RELEASE_VERSION = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} latest-version-for-branch ${VERRAZZANO_DEV_VERSION}").trim()
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
@@ -172,7 +173,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
@@ -248,7 +249,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 echo "Printing latest release version: ${latestRelease}"
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
@@ -498,18 +499,4 @@ def getSuspectList(commitList, userMappings) {
     return retValue
 }
 
-@NonCPS
-List extractReleaseTags(final String fileContent) {
-    List releases = []
-    fileContent.eachLine { tag ->
-        releases << tag
-    }
-    return releases
-}
 
-def getLatestReleaseVersion() {
-    final String releaseTags = readFile(file: "${workspace}/tags.txt")
-    list gitTags = extractReleaseTags(releaseTags)
-    echo "gitTags = ${gitTags}"
-    return gitTags.pop()
-}

--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -12,8 +12,14 @@ import (
 )
 
 const (
-	VersionForInstall        = "install-version"
-	InterimVersionForUpgrade = "interim-version"
+	VersionForInstall             = "install-version"
+	InterimVersionForUpgrade      = "interim-version"
+	LatestVersionForCurrentBranch = "latest-version-for-branch"
+)
+
+var (
+	workspace, versionType, developmentVersion string
+	excludeReleaseTags                         []string
 )
 
 func main() {
@@ -26,7 +32,7 @@ func main() {
 		printUsage()
 		os.Exit(0)
 	}
-	workspace, versionType, excludeReleaseTags := parseCliArgs(flag.Args())
+	parseCliArgs(flag.Args())
 
 	//Extract release tags from git tag command.
 	releaseTags := getReleaseTags(workspace, excludeReleaseTags)
@@ -36,14 +42,15 @@ func main() {
 	} else if versionType == VersionForInstall {
 		installRelease := getInstallRelease(releaseTags)
 		fmt.Print(installRelease)
+	} else if versionType == LatestVersionForCurrentBranch {
+		latestRelease := getLatestReleaseForCurrentBranch(releaseTags)
+		fmt.Println(latestRelease)
 	} else {
 		fmt.Printf("invalid command line argument for derive version type \n")
 	}
 }
 
-func parseCliArgs(args []string) (string, string, []string) {
-	var workspace, versionType string
-	var excludeReleaseTags []string
+func parseCliArgs(args []string) {
 
 	if len(args) < 1 {
 		fmt.Printf("\nno command line arguments were specified\n")
@@ -63,12 +70,16 @@ func parseCliArgs(args []string) (string, string, []string) {
 
 	if len(args) > 2 {
 		for index, arg := range args {
+			fmt.Println(index, "  "+arg)
 			if index > 1 {
+				if versionType == LatestVersionForCurrentBranch {
+					developmentVersion = arg
+					return
+				}
 				excludeReleaseTags = append(excludeReleaseTags, arg)
 			}
 		}
 	}
-	return workspace, versionType, excludeReleaseTags
 }
 
 func getReleaseTags(workspace string, excludeReleaseTags []string) []string {
@@ -109,6 +120,28 @@ func DoesTagExistsInExcludeList(releaseTag string, excludeReleaseTags []string) 
 		}
 	}
 	return false
+}
+
+func getLatestReleaseForCurrentBranch(releaseTags []string) string {
+
+	developmentVersionSplit := strings.Split(developmentVersion, ".")
+	//Split the string excluding prefix 'v' into major and minor version values
+	majorVersionValue := parseInt(developmentVersionSplit[0])
+	minorVersionValue := parseInt(developmentVersionSplit[1]) - 1
+
+	latestPatch := 0
+	var latestRelease string
+	for _, version := range releaseTags {
+		versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+		if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) == minorVersionValue {
+			if parseInt(versionSplit[2]) > latestPatch {
+				latestPatch = parseInt(versionSplit[2])
+			}
+			latestRelease = fmt.Sprintf("%s.%d.%d", versionSplit[0], minorVersionValue, latestPatch)
+		}
+	}
+
+	return latestRelease
 }
 
 func getInterimRelease(releaseTags []string) string {

--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -126,6 +126,7 @@ func getLatestReleaseForCurrentBranch(releaseTags []string) string {
 
 	developmentVersionSplit := strings.Split(developmentVersion, ".")
 	//Split the string excluding prefix 'v' into major and minor version values
+	fmt.Println(developmentVersionSplit)
 	majorVersionValue := parseInt(developmentVersionSplit[0])
 	minorVersionValue := parseInt(developmentVersionSplit[1]) - 1
 

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -47,3 +47,13 @@ func TestGetInterimReleaseWithMajorVersion(t *testing.T) {
 	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
 	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
 }
+
+// TestGetLatestReleaseForBranch tests the getLatestReleaseForCurrentBranch function
+// WHEN Verrazzano development version input is given from a current branch
+// THEN latest release with one minor release difference is expected.
+func TestGetLatestReleaseForBranch(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "latest-version-for-branch", "1.4.3"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
+	assert.Equal(t, "1.3.8", getLatestReleaseForCurrentBranch(releaseTags))
+}


### PR DESCRIPTION
Whenever a new commit is merged, an upgrade job is triggered with the latest release version for master. The latest release version remains constant irrespective of the branch.
Ex: For release-1.4, the latest release should be 1.3.8. However, it still populates 1.5.1.

This PR retrieves the latest release based on the development version of the current branch to resolve the above issue. 