### PR TITLE
fix-broken-link

### DIFF
--- a/examples/ha/README.md
+++ b/examples/ha/README.md
@@ -6,6 +6,6 @@ The `ha-oci-ccm.yaml` file is provided as an example of how to achieve high avai
 
 The `ha-ext-lb.yaml` file is provided as an example of how to achieve high availability using the `prod` profile and external load balancers.
 
-For more information on how to use these example files, see [Configure High Availability](https://build.verrazzano.io/latest/docs/setup/customizing/ha/).
+For more information on how to use these example files, see [Configure High Availability](https://build.verrazzano.io/latest/docs/customize/ha/).
 
 Copyright (c) 2022, Oracle and/or its affiliates.


### PR DESCRIPTION
Directory location for Customizing HA was changed and broke this link.
