### PR TITLE
VZ-8879: Fix upgrade path job with appropriate latest version based on the current branch

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -127,6 +127,7 @@ pipeline {
                     """
                     def props = readProperties file: '.verrazzano-development-version'
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    LATEST_RELEASE_VERSION = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} latest-version-for-branch ${VERRAZZANO_DEV_VERSION}").trim()
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
@@ -172,7 +173,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
@@ -248,7 +249,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 echo "Printing latest release version: ${latestRelease}"
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
@@ -498,18 +499,4 @@ def getSuspectList(commitList, userMappings) {
     return retValue
 }
 
-@NonCPS
-List extractReleaseTags(final String fileContent) {
-    List releases = []
-    fileContent.eachLine { tag ->
-        releases << tag
-    }
-    return releases
-}
 
-def getLatestReleaseVersion() {
-    final String releaseTags = readFile(file: "${workspace}/tags.txt")
-    list gitTags = extractReleaseTags(releaseTags)
-    echo "gitTags = ${gitTags}"
-    return gitTags.pop()
-}

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -47,3 +47,13 @@ func TestGetInterimReleaseWithMajorVersion(t *testing.T) {
 	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
 	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
 }
+
+// TestGetLatestReleaseForBranch tests the getLatestReleaseForCurrentBranch function
+// WHEN Verrazzano development version input is given from a current branch
+// THEN latest release with one minor release difference is expected.
+func TestGetLatestReleaseForBranch(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "latest-version-for-branch", "1.4.3"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
+	assert.Equal(t, "v1.3.8", getLatestReleaseForCurrentBranch(releaseTags))
+}


### PR DESCRIPTION
Backport the below fix for release-1.5:

Whenever a new commit is merged, an upgrade job is triggered with the latest release version for master. The latest release version remains constant irrespective of the branch.
Ex: For release-1.4, the latest release should be 1.3.8. However, it still populates 1.5.1.

This PR retrieves the latest release based on the development version of the current branch to resolve the above issue.
