### PR TITLE
VZ-8879: Fix upgrade path job with appropriate latest version based on the current branch

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -129,6 +129,7 @@ pipeline {
                     """
                     def props = readProperties file: '.verrazzano-development-version'
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
+                    LATEST_RELEASE_VERSION = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} latest-version-for-branch ${VERRAZZANO_DEV_VERSION}").trim()
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
                     // update the description with some meaningful info
@@ -175,7 +176,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
@@ -333,7 +334,7 @@ pipeline {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
-                                def latestRelease = getLatestReleaseVersion()
+                                def latestRelease = LATEST_RELEASE_VERSION
                                 echo "Printing latest release version: ${latestRelease}"
                                 build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
@@ -565,18 +566,4 @@ def metricBuildDuration() {
     }
 }
 
-@NonCPS
-List extractReleaseTags(final String fileContent) {
-    List releases = []
-    fileContent.eachLine { tag ->
-        releases << tag
-    }
-    return releases
-}
 
-def getLatestReleaseVersion() {
-    final String releaseTags = readFile(file: "${workspace}/tags.txt")
-    list gitTags = extractReleaseTags(releaseTags)
-    echo "gitTags = ${gitTags}"
-    return gitTags.pop()
-}

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -35,9 +35,6 @@ pipeline {
                         description: 'This is the wildcard DNS domain',
                         trim: true)
         booleanParam (description: 'Whether to emit metrics from the pipeline', name: 'EMIT_METRICS', defaultValue: true)
-        string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.1.2",
-                description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'TAGGED_TESTS',
                 defaultValue: '',
                 description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
@@ -112,10 +109,6 @@ pipeline {
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
-                    def excludeReleases = params.EXCLUDE_RELEASES
-                    def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
-                    VERSION_FOR_INSTALL = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} install-version ${excludeReleasesList}").trim()
-                    INTERIM_UPGRADE_VERSION = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} interim-version ${excludeReleasesList}").trim()
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
                     def currentCommitHash = env.GIT_COMMIT
@@ -145,21 +138,6 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'vpo.killed')
                                 ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CHAOS_TEST_TYPE', value: 'vpo.killed')
-                                    ], wait: true
-                            }
                         }
                     }
                 }
@@ -177,21 +155,6 @@ pipeline {
                                         booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                         string(name: 'CHAOS_TEST_TYPE', value: 'ephemeral.storage.upgrade')
                                 ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                            string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                            string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                            string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                            string(name: 'CHAOS_TEST_TYPE', value: 'ephemeral.storage.upgrade')
-                                    ], wait: true
-                            }
                         }
                     }
                 }
@@ -209,21 +172,6 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'helm.chart.corrupted')
                             ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CHAOS_TEST_TYPE', value: 'helm.chart.corrupted')
-                                ], wait: true
-                            }
                         }
                     }
                 }
@@ -241,21 +189,6 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'uninstall.failed.upgrade')
                             ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CHAOS_TEST_TYPE', value: 'uninstall.failed.upgrade')
-                                ], wait: true
-                            }
                         }
                     }
                 }
@@ -273,21 +206,6 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failed.upgrade')
                             ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failed.upgrade')
-                                ], wait: true
-                            }
                         }
                     }
                 }
@@ -305,21 +223,6 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failing.upgrade')
                             ], wait: true
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
-                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
-                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failing.upgrade')
-                                ], wait: true
-                            }
                         }
                     }
                 }
@@ -351,7 +254,6 @@ def isPagerDutyEnabled() {
     }
     return false
 }
-
 
 // Called in Stage Clean workspace and checkout steps
 @NonCPS
@@ -523,4 +425,3 @@ def getCronSchedule() {
     }
     return ""
 }
-

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -35,6 +35,9 @@ pipeline {
                         description: 'This is the wildcard DNS domain',
                         trim: true)
         booleanParam (description: 'Whether to emit metrics from the pipeline', name: 'EMIT_METRICS', defaultValue: true)
+        string (name: 'EXCLUDE_RELEASES',
+                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.1.2",
+                description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'TAGGED_TESTS',
                 defaultValue: '',
                 description: 'A comma separated list of build tags for tests that should be executed (e.g. unstable_test). Default:',
@@ -109,6 +112,10 @@ pipeline {
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
                     TIMESTAMP = sh(returnStdout: true, script: "date +%Y%m%d%H%M%S").trim()
                     SHORT_COMMIT_HASH = sh(returnStdout: true, script: "git rev-parse --short=8 HEAD").trim()
+                    def excludeReleases = params.EXCLUDE_RELEASES
+                    def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
+                    VERSION_FOR_INSTALL = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} install-version ${excludeReleasesList}").trim()
+                    INTERIM_UPGRADE_VERSION = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} interim-version ${excludeReleasesList}").trim()
                     // update the description with some meaningful info
                     currentBuild.description = SHORT_COMMIT_HASH + " : " + env.GIT_COMMIT + " : " + GIT_COMMIT_TO_USE
                     def currentCommitHash = env.GIT_COMMIT
@@ -138,6 +145,21 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'vpo.killed')
                                 ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CHAOS_TEST_TYPE', value: 'vpo.killed')
+                                    ], wait: true
+                            }
                         }
                     }
                 }
@@ -155,6 +177,21 @@ pipeline {
                                         booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                         string(name: 'CHAOS_TEST_TYPE', value: 'ephemeral.storage.upgrade')
                                 ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                            string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                            string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                            string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                            string(name: 'CHAOS_TEST_TYPE', value: 'ephemeral.storage.upgrade')
+                                    ], wait: true
+                            }
                         }
                     }
                 }
@@ -172,6 +209,21 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'helm.chart.corrupted')
                             ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CHAOS_TEST_TYPE', value: 'helm.chart.corrupted')
+                                ], wait: true
+                            }
                         }
                     }
                 }
@@ -189,6 +241,21 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'uninstall.failed.upgrade')
                             ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CHAOS_TEST_TYPE', value: 'uninstall.failed.upgrade')
+                                ], wait: true
+                            }
                         }
                     }
                 }
@@ -206,6 +273,21 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failed.upgrade')
                             ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failed.upgrade')
+                                ], wait: true
+                            }
                         }
                     }
                 }
@@ -223,6 +305,21 @@ pipeline {
                                     booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
                                     string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failing.upgrade')
                             ], wait: true
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-chaos-tests/${CLEAN_BRANCH_NAME}",
+                                    parameters: [
+                                        string(name: 'GIT_COMMIT_FOR_UPGRADE', value: env.GIT_COMMIT),
+                                        string(name: 'VERSION_FOR_INSTALL', value: VERSION_FOR_INSTALL),
+                                        string(name: 'INTERIM_UPGRADE_VERSION', value: INTERIM_UPGRADE_VERSION),
+                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                        string(name: 'CHAOS_TEST_TYPE', value: 'upgrade.failing.upgrade')
+                                ], wait: true
+                            }
                         }
                     }
                 }
@@ -254,6 +351,7 @@ def isPagerDutyEnabled() {
     }
     return false
 }
+
 
 // Called in Stage Clean workspace and checkout steps
 @NonCPS
@@ -425,3 +523,4 @@ def getCronSchedule() {
     }
     return ""
 }
+

--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	VersionForInstall        = "install-version"
+	InterimVersionForUpgrade = "interim-version"
+)
+
+func main() {
+
+	//Parse command line arguments to extract params
+	help := false
+	flag.BoolVar(&help, "help", false, "Display usage help")
+	flag.Parse()
+	if help {
+		printUsage()
+		os.Exit(0)
+	}
+	workspace, versionType, excludeReleaseTags := parseCliArgs(flag.Args())
+
+	//Extract release tags from git tag command.
+	releaseTags := getReleaseTags(workspace, excludeReleaseTags)
+	if versionType == InterimVersionForUpgrade {
+		interimRelease := getInterimRelease(releaseTags)
+		fmt.Print(interimRelease)
+	} else if versionType == VersionForInstall {
+		installRelease := getInstallRelease(releaseTags)
+		fmt.Print(installRelease)
+	} else {
+		fmt.Printf("invalid command line argument for derive version type \n")
+	}
+}
+
+func parseCliArgs(args []string) (string, string, []string) {
+	var workspace, versionType string
+	var excludeReleaseTags []string
+
+	if len(args) < 1 {
+		fmt.Printf("\nno command line arguments were specified\n")
+		printUsage()
+		os.Exit(1)
+	}
+
+	if len(args) > 0 {
+		// Receive working directory as a command line argument.
+		workspace = args[0]
+		// Receive version type such as interimVersionForUpgrade or versionForInstall argument
+		versionType = args[1]
+	} else {
+		fmt.Printf("no worspace path and version type line arguments were specified\n")
+		os.Exit(1)
+	}
+
+	if len(args) > 2 {
+		for index, arg := range args {
+			if index > 1 {
+				excludeReleaseTags = append(excludeReleaseTags, arg)
+			}
+		}
+	}
+	return workspace, versionType, excludeReleaseTags
+}
+
+func getReleaseTags(workspace string, excludeReleaseTags []string) []string {
+	// Change the working directory to the verrazzano workspace
+	err := os.Chdir(workspace)
+	if err != nil {
+		fmt.Printf("\nunable to change the current working directory %v", err.Error())
+	}
+	// Execute git tag command.
+	cmd := exec.Command("git", "tag")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("\nunable to execute git tag command %v", err.Error())
+	}
+
+	// Split the output by newline and store it in a slice
+	gitTags := strings.Split(string(out), "\n")
+
+	// Extract release tags from gitTags
+	var releaseTags []string
+
+	for _, tag := range gitTags {
+		if strings.HasPrefix(tag, "v") && !strings.HasPrefix(tag, "v0") {
+			// Exclude the release tags if tag exists in excludeReleaseTags
+			if !DoesTagExistsInExcludeList(tag, excludeReleaseTags) {
+				releaseTags = append(releaseTags, tag)
+			}
+		}
+	}
+	return releaseTags
+}
+
+// DoesTagExistsInExcludeList returns true if the tag exists in excludeReleasetag
+func DoesTagExistsInExcludeList(releaseTag string, excludeReleaseTags []string) bool {
+	for _, excludeTag := range excludeReleaseTags {
+		if excludeTag == releaseTag {
+			return true
+		}
+	}
+	return false
+}
+
+func getInterimRelease(releaseTags []string) string {
+	// Get the latest release tag
+	latestReleaseTag := releaseTags[len(releaseTags)-1]
+	releaseTags = releaseTags[:len(releaseTags)-1]
+
+	//Split the string excluding prefix 'v' into major and minor version values
+	latestReleaseTagSplit := strings.Split(strings.TrimPrefix(latestReleaseTag, "v"), ".")
+	majorVersionValue := parseInt(latestReleaseTagSplit[0])
+	minorInterimVersionValue := parseInt(latestReleaseTagSplit[1]) - 1
+
+	// Handles the major release case, e.g. where the latest version is 2.0.0 and the previous version is 1.4.2
+	if minorInterimVersionValue < 0 {
+		minorInterimVersionValue = 0
+		majorVersionValue = parseInt(latestReleaseTagSplit[0]) - 1
+		for _, version := range releaseTags {
+			versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+			if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) > minorInterimVersionValue {
+				minorInterimVersionValue = parseInt(versionSplit[1])
+			}
+		}
+	}
+
+	// Iterate over all releases to configure the latest patch release
+	latestPatch := 0
+	var interimRelease string
+	for _, version := range releaseTags {
+		versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+		if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) == minorInterimVersionValue {
+			if parseInt(versionSplit[2]) > latestPatch {
+				latestPatch = parseInt(versionSplit[2])
+			}
+			interimRelease = fmt.Sprintf("%s.%d.%d", versionSplit[0], minorInterimVersionValue, latestPatch)
+		}
+	}
+
+	// Return the interim release tag
+	return fmt.Sprintf("v%s\n", interimRelease)
+}
+
+func getInstallRelease(releaseTags []string) string {
+	// Get the latest release tag
+	latestReleaseTag := releaseTags[len(releaseTags)-1]
+	releaseTags = releaseTags[:len(releaseTags)-1]
+
+	//Split the string excluding prefix 'v' into major and minor version values
+	latestReleaseTagSplit := strings.Split(strings.TrimPrefix(latestReleaseTag, "v"), ".")
+	majorVersionValue := parseInt(latestReleaseTagSplit[0])
+	minorInstallVersionValue := parseInt(latestReleaseTagSplit[1]) - 2
+
+	// Handles the major release case, e.g. where the latest version is 2.0.0 and the previous version is 1.4.2
+	if minorInstallVersionValue < 0 {
+		majorVersionValue = parseInt(latestReleaseTagSplit[0]) - 1
+		majorReleaseDecrementCount := 0
+
+		//Handles the case where we have releases such as 2.0.0. 3.0.0, 4.0.0
+		totalMinorReleaseCounter := 0
+		for _, version := range releaseTags {
+			versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+			if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) != 0 {
+				totalMinorReleaseCounter++
+			}
+		}
+
+		if totalMinorReleaseCounter == 0 {
+			majorVersionValue = majorVersionValue - totalMinorReleaseCounter - 1
+			majorReleaseDecrementCount = parseInt(latestReleaseTagSplit[0]) - majorVersionValue
+		}
+
+		minorInstallVersionDiff := minorInstallVersionValue
+		minorInstallVersionValue = 0
+		for _, version := range releaseTags {
+			versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+			if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) > minorInstallVersionValue {
+				if majorReleaseDecrementCount < 2 && minorInstallVersionDiff < -2 {
+					minorInstallVersionValue = parseInt(versionSplit[1]) - 1
+					//fmt.Println(minorInstallVersionValue)
+				} else {
+					minorInstallVersionValue = parseInt(versionSplit[1])
+				}
+			}
+		}
+	}
+
+	// Iterate over all releases to configure the latest patch release
+	latestPatch := 0
+	var installRelease string
+	for _, version := range releaseTags {
+		versionSplit := strings.Split(strings.TrimPrefix(version, "v"), ".")
+		if parseInt(versionSplit[0]) == majorVersionValue && parseInt(versionSplit[1]) == minorInstallVersionValue {
+			if parseInt(versionSplit[2]) > latestPatch {
+				latestPatch = parseInt(versionSplit[2])
+			}
+			installRelease = fmt.Sprintf("%s.%d.%d", versionSplit[0], minorInstallVersionValue, latestPatch)
+		}
+	}
+
+	// Return the interim release tag
+	return fmt.Sprintf("v%s\n", installRelease)
+}
+
+func parseInt(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		fmt.Printf("\nunable to convert the given string to int %s, %v", s, err.Error())
+	}
+	return n
+}
+
+// printUsage Prints the help for this program
+func printUsage() {
+	usageString := `
+
+go run derive_upgrade_version.go [args] workspace version-type exclude-releases
+
+Args:
+	[workspace]  Uses the workspace path to retrieve the list of release tags using git tag command
+	[version-type]     Specify version to derive
+	[exclude-releases] list of release tags to exclude 
+Options:
+	--help	prints usage
+`
+	fmt.Print(usageString)
+}

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+// TestGetInstallReleaseWithoutMajorVersion Tests the getInstallRelease function
+// WHEN with git release tags major version change does not exist
+// THEN install release version with two minor release difference is expected
+func TestGetInstallReleaseWithoutMajorVersion(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "install-version"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2"}
+	assert.Equal(t, "v1.2.2\n", getInstallRelease(releaseTags))
+}
+
+// TestGetInstallReleaseWithMajorRelease Tests the getInstallRelease function
+// WHEN with git release tags major version change exists
+// THEN install release version with two minor release difference is expected
+func TestGetInstallReleaseWithMajorRelease(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "install-version"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "v2.0.0", "v2.1.0"}
+	assert.Equal(t, "v1.5.0\n", getInstallRelease(releaseTags))
+}
+
+// TestGetInterimReleaseWithoutMajorVersion Tests the getInterimRelease function
+// WHEN with git release tags major version change does not exist
+// THEN interim release version with one minor release difference is expected
+func TestGetInterimReleaseWithoutMajorVersion(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "interim-version"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2"}
+	assert.Equal(t, "v1.3.8\n", getInterimRelease(releaseTags))
+}
+
+// TestGetInterimReleaseWithMajorVersion Tests the getInterimRelease function
+// WHEN with git release tags major version change exists
+// THEN interim release version with one minor release difference is expected
+func TestGetInterimReleaseWithMajorVersion(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "interim-version"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
+	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
+}

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -47,3 +47,13 @@ func TestGetInterimReleaseWithMajorVersion(t *testing.T) {
 	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
 	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
 }
+
+// TestGetLatestReleaseForBranch tests the getLatestReleaseForCurrentBranch function
+// WHEN Verrazzano development version input is given from a current branch
+// THEN latest release with one minor release difference is expected.
+func TestGetLatestReleaseForBranch(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "latest-version-for-branch", "1.4.3"})
+	releaseTags := []string{"v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.1.0", "v1.1.1", "v1.1.2", "v1.2.0", "v1.2.1", "v1.2.2", "v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3", "v1.3.4", "v1.3.5", "v1.3.6", "v1.3.7", "v1.3.8", "v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "2.0.0"}
+	assert.Equal(t, "v1.3.8", getLatestReleaseForCurrentBranch(releaseTags))
+}


### PR DESCRIPTION
Backport the below fix to release-1.4:

Whenever a new commit is merged, an upgrade job is triggered with the latest release version for master. The latest release version remains constant irrespective of the branch.
Ex: For release-1.4, the latest release should be 1.3.8. However, it still populates 1.5.1.

This PR retrieves the latest release based on the development version of the current branch to resolve the above issue.
