### PR TITLE
VZ-8711 Add sidecar implementation to the Prometheus instance

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -93,7 +93,7 @@ const KibanaIngress = "vmi-system-kibana"
 const PrometheusIngress = "vmi-system-prometheus"
 
 // ThanosIngress is the name of the ingress for Thanos
-const ThanosIngress = "thanos"
+const ThanosIngress = "thanos-sidecar"
 
 // GlobalImagePullSecName is the name of the global image pull secret
 const GlobalImagePullSecName = "verrazzano-container-registry"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -92,8 +92,8 @@ const KibanaIngress = "vmi-system-kibana"
 // PrometheusIngress is the name of the ingress for Prometheus
 const PrometheusIngress = "vmi-system-prometheus"
 
-// ThanosIngress is the name of the ingress for Thanos
-const ThanosIngress = "thanos-sidecar"
+// ThanosSidecarIngress is the name of the ingress for the Thanos sidecar
+const ThanosSidecarIngress = "thanos-sidecar"
 
 // GlobalImagePullSecName is the name of the global image pull secret
 const GlobalImagePullSecName = "verrazzano-container-registry"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -92,6 +92,9 @@ const KibanaIngress = "vmi-system-kibana"
 // PrometheusIngress is the name of the ingress for Prometheus
 const PrometheusIngress = "vmi-system-prometheus"
 
+// ThanosIngress is the name of the ingress for Thanos
+const ThanosIngress = "thanos"
+
 // GlobalImagePullSecName is the name of the global image pull secret
 const GlobalImagePullSecName = "verrazzano-container-registry"
 

--- a/platform-operator/controllers/verrazzano/component/common/ingress.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/common/ingress.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress.go
@@ -6,6 +6,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
@@ -104,4 +105,15 @@ func CreateOrUpdateSystemComponentIngress(ctx spi.ComponentContext, props Ingres
 		return ctx.Log().ErrorfNewErr("Failed creating/updating ingress %s: %v", props.IngressName, err)
 	}
 	return err
+}
+
+// DeleteSystemComponentIngress deletes an ingress for a Verrazzano system component
+func DeleteSystemComponentIngress(ctx spi.ComponentContext, name string) error {
+	ingress := netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: constants.VerrazzanoSystemNamespace},
+	}
+	if err := client.IgnoreNotFound(ctx.Client().Delete(context.TODO(), &ingress)); err != nil {
+		return ctx.Log().ErrorfNewErr("Failed to delete Ingress %s/%s: %v", constants.VerrazzanoSystemNamespace, name, err)
+	}
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/common/ingress.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress.go
@@ -20,7 +20,6 @@ import (
 
 type IngressProperties struct {
 	IngressName      string
-	IngressNamespace string
 	HostName         string
 	TLSSecretName    string
 	ExtraAnnotations map[string]string
@@ -38,11 +37,11 @@ func SameSiteCookieAnnotations(cookieName string) map[string]string {
 	}
 }
 
-// CreateOrUpdateComponentIngress creates or updates an ingress for a component
-func CreateOrUpdateComponentIngress(ctx spi.ComponentContext, props IngressProperties) error {
+// CreateOrUpdateSystemComponentIngress creates or updates an ingress for a Verrazzano system component
+func CreateOrUpdateSystemComponentIngress(ctx spi.ComponentContext, props IngressProperties) error {
 	// create the ingress in the same namespace as Auth Proxy, note that we cannot use authproxy.ComponentNamespace here because it creates an import cycle
 	ingress := netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: props.IngressName, Namespace: props.IngressNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: props.IngressName, Namespace: constants.VerrazzanoSystemNamespace},
 	}
 
 	_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &ingress, func() error {

--- a/platform-operator/controllers/verrazzano/component/common/ingress.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress.go
@@ -20,6 +20,7 @@ import (
 
 type IngressProperties struct {
 	IngressName      string
+	IngressNamespace string
 	HostName         string
 	TLSSecretName    string
 	ExtraAnnotations map[string]string
@@ -37,11 +38,11 @@ func SameSiteCookieAnnotations(cookieName string) map[string]string {
 	}
 }
 
-// CreateOrUpdateSystemComponentIngress creates or updates an ingress for a Verrazzano system component
-func CreateOrUpdateSystemComponentIngress(ctx spi.ComponentContext, props IngressProperties) error {
+// CreateOrUpdateComponentIngress creates or updates an ingress for a component
+func CreateOrUpdateComponentIngress(ctx spi.ComponentContext, props IngressProperties) error {
 	// create the ingress in the same namespace as Auth Proxy, note that we cannot use authproxy.ComponentNamespace here because it creates an import cycle
 	ingress := netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: props.IngressName, Namespace: constants.VerrazzanoSystemNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: props.IngressName, Namespace: props.IngressNamespace},
 	}
 
 	_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client(), &ingress, func() error {

--- a/platform-operator/controllers/verrazzano/component/common/ingress.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress.go
@@ -6,7 +6,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
@@ -17,6 +16,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type IngressProperties struct {

--- a/platform-operator/controllers/verrazzano/component/common/ingress_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/common/ingress_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/ingress_test.go
@@ -90,3 +90,53 @@ func TestCreateOrUpdateSystemComponentIngress(t *testing.T) {
 	assert.Equal(t, constants.VerrazzanoAuthProxyServiceName, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name)
 	assert.Empty(t, ingress.Annotations["external-dns.alpha.kubernetes.io/target"])
 }
+
+// TestDeleteSystemComponentIngress tests the DeleteSystemComponentIngress function
+func TestDeleteSystemComponentIngress(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = vzapi.AddToScheme(scheme)
+
+	vz := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						DNSZoneName: "mydomain.com",
+					},
+				},
+			},
+		},
+	}
+
+	// GIVEN a component context and a Verrazzano CR
+	// WHEN  the DeleteSystemComponentIngress function is called when no ingresses are present
+	// THEN  the function call succeeds and no ingress is found
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := spi.NewFakeContext(client, vz, nil, false)
+	err := DeleteSystemComponentIngress(ctx, testIngressName)
+	assert.NoError(t, err)
+
+	ingress := &netv1.Ingress{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: testIngressName}, ingress)
+	assert.Error(t, err)
+
+	// GIVEN a component context and a Verrazzano CR
+	// WHEN  the DeleteSystemComponentIngress function is called with an ingress present
+	// THEN  the function call succeeds and the ingress is deleted
+	ingress = &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      testIngressName,
+		},
+	}
+	client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(ingress).Build()
+
+	ctx = spi.NewFakeContext(client, vz, nil, false)
+	err = DeleteSystemComponentIngress(ctx, testIngressName)
+	assert.NoError(t, err)
+
+	ingress = &netv1.Ingress{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: testIngressName}, ingress)
+	assert.Error(t, err)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -291,7 +291,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		// format "subcomponentName": "helmDefaultKey"
 		alertmanagerName: "prometheusOperator.alertmanagerDefaultBaseImage",
 		prometheusName:   "prometheusOperator.prometheusDefaultBaseImage",
-		thanosName:       "prometheus.thanos.image",
+		thanosName:       "prometheus.prometheusOperator.thanos.image",
 	}
 	kvs, err = appendDefaultImageOverrides(ctx, kvs, defaultImages)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -51,6 +51,7 @@ const (
 
 	prometheusName     = "prometheus"
 	alertmanagerName   = "alertmanager"
+	thanosName         = "thanos"
 	configReloaderName = "prometheus-config-reloader"
 
 	pvcName                  = "prometheus-prometheus-operator-kube-p-prometheus-db-prometheus-prometheus-operator-kube-p-prometheus-0"
@@ -285,11 +286,12 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		return kvs, err
 	}
 
-	// Replace default images for subcomponents Alertmanager and Prometheus
+	// Replace default images for subcomponents Alertmanager, Prometheus, and Thanos
 	defaultImages := map[string]string{
 		// format "subcomponentName": "helmDefaultKey"
 		alertmanagerName: "prometheusOperator.alertmanagerDefaultBaseImage",
 		prometheusName:   "prometheusOperator.prometheusDefaultBaseImage",
+		thanosName:       "prometheusOperator.prometheusSpec.thanos.image",
 	}
 	kvs, err = appendDefaultImageOverrides(ctx, kvs, defaultImages)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -716,26 +716,24 @@ func createOrUpdateIngresses(ctx spi.ComponentContext) error {
 		return nil
 	}
 	promProps := common.IngressProperties{
-		IngressName:      constants.PrometheusIngress,
-		IngressNamespace: constants.VerrazzanoSystemNamespace,
-		HostName:         prometheusHostName,
-		TLSSecretName:    prometheusCertificateName,
+		IngressName:   constants.PrometheusIngress,
+		HostName:      prometheusHostName,
+		TLSSecretName: prometheusCertificateName,
 		// Enable sticky sessions, so there is no UI query skew in multi-replica prometheus clusters
 		ExtraAnnotations: common.SameSiteCookieAnnotations(prometheusName),
 	}
-	if err := common.CreateOrUpdateComponentIngress(ctx, promProps); err != nil {
+	if err := common.CreateOrUpdateSystemComponentIngress(ctx, promProps); err != nil {
 		return err
 	}
 
 	thanosProps := common.IngressProperties{
-		IngressName:      constants.ThanosIngress,
-		IngressNamespace: constants.VerrazzanoMonitoringNamespace,
-		HostName:         thanosHostName,
-		TLSSecretName:    thanosCertificateName,
+		IngressName:   constants.ThanosIngress,
+		HostName:      thanosHostName,
+		TLSSecretName: thanosCertificateName,
 		// Enable sticky sessions, so there is no UI query skew in multi-replica prometheus clusters
 		ExtraAnnotations: common.SameSiteCookieAnnotations(thanosHostName),
 	}
-	return common.CreateOrUpdateComponentIngress(ctx, thanosProps)
+	return common.CreateOrUpdateSystemComponentIngress(ctx, thanosProps)
 }
 
 // newNetworkPolicy returns a populated NetworkPolicySpec with ingress rules for Prometheus

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -291,7 +291,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		// format "subcomponentName": "helmDefaultKey"
 		alertmanagerName: "prometheusOperator.alertmanagerDefaultBaseImage",
 		prometheusName:   "prometheusOperator.prometheusDefaultBaseImage",
-		thanosName:       "prometheus.prometheusOperator.thanos.image",
+		thanosName:       "prometheus.prometheusSpec.thanos.image",
 	}
 	kvs, err = appendDefaultImageOverrides(ctx, kvs, defaultImages)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -291,7 +291,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		// format "subcomponentName": "helmDefaultKey"
 		alertmanagerName: "prometheusOperator.alertmanagerDefaultBaseImage",
 		prometheusName:   "prometheusOperator.prometheusDefaultBaseImage",
-		thanosName:       "prometheus.prometheusSpec.thanos.image",
+		thanosName:       "prometheus.thanos.image",
 	}
 	kvs, err = appendDefaultImageOverrides(ctx, kvs, defaultImages)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -729,11 +729,17 @@ func createOrUpdateIngresses(ctx spi.ComponentContext) error {
 	}
 
 	// Only create the Thanos Ingress if it is enabled in the Prometheus Spec
-	if thanosEnabled, err := isThanosEnabled(ctx); !thanosEnabled || err != nil {
+	thanosEnabled, err := isThanosEnabled(ctx)
+	if err != nil {
 		return err
 	}
+	// Delete the existing ingress if the sidecar becomes disabled
+	if !thanosEnabled {
+		return common.DeleteSystemComponentIngress(ctx, constants.ThanosSidecarIngress)
+	}
+
 	thanosProps := common.IngressProperties{
-		IngressName:   constants.ThanosIngress,
+		IngressName:   constants.ThanosSidecarIngress,
 		HostName:      thanosHostName,
 		TLSSecretName: thanosCertificateName,
 		// Enable sticky sessions, so there is no UI query skew in multi-replica prometheus clusters

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -291,7 +291,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		// format "subcomponentName": "helmDefaultKey"
 		alertmanagerName: "prometheusOperator.alertmanagerDefaultBaseImage",
 		prometheusName:   "prometheusOperator.prometheusDefaultBaseImage",
-		thanosName:       "prometheusOperator.prometheusSpec.thanos.image",
+		thanosName:       "prometheus.prometheusSpec.thanos.image",
 	}
 	kvs, err = appendDefaultImageOverrides(ctx, kvs, defaultImages)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -43,8 +43,8 @@ const (
 	prometheusHostName        = "prometheus.vmi.system"
 	prometheusCertificateName = "system-tls-prometheus"
 
-	thanosHostName        = "thanos"
-	thanosCertificateName = "monitoring-tls-thanos"
+	thanosHostName        = "thanos-sidecar"
+	thanosCertificateName = "system-tls-thanos-sidecar"
 
 	istioPrometheus = "prometheus-server"
 )

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -193,7 +193,7 @@ func (c prometheusComponent) GetIngressNames(ctx spi.ComponentContext) []types.N
 		return ingressNames
 	}
 
-	ns := ComponentNamespace
+	ns := constants.VerrazzanoSystemNamespace
 	if vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
 		ns = authproxy.ComponentNamespace
 	}
@@ -203,7 +203,7 @@ func (c prometheusComponent) GetIngressNames(ctx spi.ComponentContext) []types.N
 	})
 	return append(ingressNames, types.NamespacedName{
 		Namespace: ns,
-		Name:      constants.ThanosIngress,
+		Name:      constants.ThanosSidecarIngress,
 	})
 }
 

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component_test.go
@@ -146,10 +146,10 @@ func TestPostInstall(t *testing.T) {
 	time := metav1.Now()
 
 	var tests = []struct {
-		name    string
-		vz      vzapi.Verrazzano
-		ingress v1.Ingress
-		cert    certapiv1.Certificate
+		name        string
+		vz          vzapi.Verrazzano
+		ingressList []v1.Ingress
+		certList    []certapiv1.Certificate
 	}{
 		{
 			name: "TestPostInstall When everything is disabled",
@@ -164,14 +164,18 @@ func TestPostInstall(t *testing.T) {
 					},
 				},
 			}}},
-			ingress: v1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+			ingressList: []v1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+				},
 			},
-			cert: certapiv1.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
-				Status: certapiv1.CertificateStatus{
-					Conditions: []certapiv1.CertificateCondition{
-						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+			certList: []certapiv1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
 					},
 				},
 			},
@@ -189,14 +193,18 @@ func TestPostInstall(t *testing.T) {
 					},
 				},
 			}}},
-			ingress: v1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+			ingressList: []v1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+				},
 			},
-			cert: certapiv1.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
-				Status: certapiv1.CertificateStatus{
-					Conditions: []certapiv1.CertificateCondition{
-						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+			certList: []certapiv1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
 					},
 				},
 			},
@@ -214,15 +222,19 @@ func TestPostInstall(t *testing.T) {
 					},
 				},
 			}}},
-			ingress: v1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: constants.VerrazzanoMonitoringNamespace},
+			ingressList: []v1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: constants.VerrazzanoSystemNamespace},
+				},
 			},
 
-			cert: certapiv1.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: constants.VerrazzanoMonitoringNamespace},
-				Status: certapiv1.CertificateStatus{
-					Conditions: []certapiv1.CertificateCondition{
-						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+			certList: []certapiv1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: constants.VerrazzanoSystemNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
 					},
 				},
 			},
@@ -240,11 +252,55 @@ func TestPostInstall(t *testing.T) {
 					},
 				},
 			}}},
-			cert: certapiv1.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: constants.VerrazzanoMonitoringNamespace},
-				Status: certapiv1.CertificateStatus{
-					Conditions: []certapiv1.CertificateCondition{
-						{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+			certList: []certapiv1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: constants.VerrazzanoMonitoringNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TestPostInstall When thanos is enabled",
+			vz: vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{
+				AuthProxy:          &vzapi.AuthProxyComponent{Enabled: &enabled},
+				Ingress:            &vzapi.IngressNginxComponent{Enabled: &enabled},
+				Prometheus:         &vzapi.PrometheusComponent{Enabled: &enabled},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{Enabled: &enabled},
+				Thanos:             &vzapi.ThanosComponent{Enabled: &enabled},
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						DNSZoneName: "mydomain.com",
+					},
+				},
+			}}},
+			ingressList: []v1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.PrometheusIngress, Namespace: authproxy.ComponentNamespace},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.ThanosSidecarIngress, Namespace: authproxy.ComponentNamespace},
+				},
+			},
+
+			certList: []certapiv1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: prometheusCertificateName, Namespace: authproxy.ComponentNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: thanosCertificateName, Namespace: authproxy.ComponentNamespace},
+					Status: certapiv1.CertificateStatus{
+						Conditions: []certapiv1.CertificateCondition{
+							{Type: certapiv1.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: &time},
+						},
 					},
 				},
 			},
@@ -253,7 +309,15 @@ func TestPostInstall(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&test.ingress, &test.cert).Build()
+			clientObj := fake.NewClientBuilder().WithScheme(testScheme)
+			for i := range test.ingressList {
+				clientObj = clientObj.WithObjects(&test.ingressList[i])
+			}
+			for i := range test.certList {
+				clientObj = clientObj.WithObjects(&test.certList[i])
+			}
+			client := clientObj.Build()
+
 			ctx := spi.NewFakeContext(client, &test.vz, nil, false, profilesRelativePath)
 			err := NewComponent().PostInstall(ctx)
 			assert.NoError(t, err)

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -180,7 +180,7 @@ func TestAppendOverrides(t *testing.T) {
 	var err error
 	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 26)
+	assert.Len(t, kvs, 27)
 
 	assert.Equal(t, "ghcr.io/verrazzano/prometheus-config-reloader", bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.repository"))
 	assert.NotEmpty(t, bom.FindKV(kvs, "prometheusOperator.prometheusConfigReloader.image.tag"))
@@ -190,6 +190,7 @@ func TestAppendOverrides(t *testing.T) {
 
 	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.alertmanagerDefaultBaseImage"), "ghcr.io/verrazzano/alertmanager:"))
 	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheusOperator.prometheusDefaultBaseImage"), "ghcr.io/verrazzano/prometheus:"))
+	assert.True(t, strings.HasPrefix(bom.FindKV(kvs, "prometheus.prometheusSpec.thanos.image"), "ghcr.io/verrazzano/thanos:"))
 
 	assert.Equal(t, "true", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 
@@ -215,7 +216,7 @@ func TestAppendOverrides(t *testing.T) {
 
 	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 26)
+	assert.Len(t, kvs, 27)
 
 	assert.Equal(t, "false", bom.FindKV(kvs, "prometheusOperator.admissionWebhooks.certManager.enabled"))
 
@@ -237,7 +238,7 @@ func TestAppendOverrides(t *testing.T) {
 
 	kvs, err = AppendOverrides(ctx, "", "", "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 12)
+	assert.Len(t, kvs, 13)
 
 	assert.Equal(t, "false", bom.FindKV(kvs, "prometheus.enabled"))
 }

--- a/platform-operator/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/controllers/verrazzano/testdata/test_bom.json
@@ -662,6 +662,25 @@
           ]
         }
       ]
+    },
+    {
+      "name": "thanos",
+      "version": "v0.28.0",
+      "subcomponents": [
+        {
+          "repository": "verrazzano",
+          "name": "thanos",
+          "images": [
+            {
+              "image": "thanos",
+              "tag": "v0.28.0-20230306212904-40834118",
+              "helmRegKey": "image.registry",
+              "helmFullImageKey": "image.repository",
+              "helmTagKey": "image.tag"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vzinstance

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
@@ -6,6 +6,7 @@ package vzinstance
 import (
 	"context"
 	"fmt"
+	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
@@ -43,7 +44,7 @@ func TestGetInstanceInfo(t *testing.T) {
 
 	// Expect a call to get the Verrazzano resource.
 	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		List(gomock.Any(), gomock.AssignableToTypeOf(&networkingv1.IngressList{}), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList, opts ...client.ListOption) error {
 			ingressList.Items = []networkingv1.Ingress{
 				{
@@ -106,6 +107,12 @@ func TestGetInstanceInfo(t *testing.T) {
 			return nil
 		})
 
+	mock.EXPECT().
+		List(gomock.Any(), gomock.AssignableToTypeOf(&promoperapi.PrometheusList{}), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, promList *promoperapi.PrometheusList, opts ...client.ListOption) error {
+			return nil
+		})
+
 	enabled := true
 	vz := &v1alpha1.Verrazzano{
 		Spec: v1alpha1.VerrazzanoSpec{
@@ -149,7 +156,7 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 
 	// Expect a call to get the Verrazzano resource.
 	mock.EXPECT().
-		List(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		List(gomock.Any(), gomock.AssignableToTypeOf(&networkingv1.IngressList{}), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, ingressList *networkingv1.IngressList, opts ...client.ListOption) error {
 			ingressList.Items = []networkingv1.Ingress{
 				{
@@ -185,6 +192,12 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 					},
 				},
 			}
+			return nil
+		})
+
+	mock.EXPECT().
+		List(gomock.Any(), gomock.AssignableToTypeOf(&promoperapi.PrometheusList{}), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, promList *promoperapi.PrometheusList, opts ...client.ListOption) error {
 			return nil
 		})
 

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -428,6 +428,8 @@ data:
                 check_host = backend..me.hostSuffix
             elseif backend == 'jaeger' then
                 check_host = backend..me.hostSuffix
+            elseif backend == 'thanos-sidecar' then
+                check_host = backend..me.hostSuffix
             else
                 check_host = backend..vmi_system..me.hostSuffix
             end
@@ -1204,7 +1206,7 @@ data:
         elseif backend == 'prometheus' then
             allowedOrigins = os.getenv("VZ_PROMETHEUS_ALLOWED_ORIGINS")
         elseif backend == 'thanos-sidecar' then
-            allowedOrigins = os.getenv("VZ_THANOS_ALLOWED_ORIGINS")
+            allowedOrigins = os.getenv("VZ_THANOS_SIDECAR_ALLOWED_ORIGINS")
         elseif backend == 'kibana' then
             allowedOrigins = os.getenv("VZ_KIBANA_ALLOWED_ORIGINS")
         elseif backend == 'osd' then
@@ -1253,7 +1255,7 @@ data:
     env VZ_CONSOLE_ALLOWED_ORIGINS;
     env VZ_GRAFANA_ALLOWED_ORIGINS;
     env VZ_PROMETHEUS_ALLOWED_ORIGINS;
-    env VZ_THANOS_ALLOWED_ORIGINS;
+    env VZ_THANOS_SIDECAR_ALLOWED_ORIGINS;
     env VZ_KIBANA_ALLOWED_ORIGINS;
     env VZ_ES_ALLOWED_ORIGINS;
     env VZ_KIALI_ALLOWED_ORIGINS;

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -514,6 +514,8 @@ data:
             serverUrl = me.makeVmiBackendUrl(backend, '3000')
         elseif backend == 'prometheus' then
             serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '9090')
+        elseif backend == 'thanos' then
+            serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '10901')
         elseif backend == 'kibana' then
             serverUrl = me.makeVmiBackendUrl('osd', '5601')
         elseif backend == 'osd' then
@@ -1201,6 +1203,8 @@ data:
             allowedOrigins = os.getenv("VZ_GRAFANA_ALLOWED_ORIGINS")
         elseif backend == 'prometheus' then
             allowedOrigins = os.getenv("VZ_PROMETHEUS_ALLOWED_ORIGINS")
+        elseif backend == 'thanos' then
+            allowedOrigins = os.getenv("VZ_THANOS_ALLOWED_ORIGINS")
         elseif backend == 'kibana' then
             allowedOrigins = os.getenv("VZ_KIBANA_ALLOWED_ORIGINS")
         elseif backend == 'osd' then
@@ -1249,6 +1253,7 @@ data:
     env VZ_CONSOLE_ALLOWED_ORIGINS;
     env VZ_GRAFANA_ALLOWED_ORIGINS;
     env VZ_PROMETHEUS_ALLOWED_ORIGINS;
+    env VZ_THANOS_ALLOWED_ORIGINS;
     env VZ_KIBANA_ALLOWED_ORIGINS;
     env VZ_ES_ALLOWED_ORIGINS;
     env VZ_KIALI_ALLOWED_ORIGINS;

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -514,7 +514,7 @@ data:
             serverUrl = me.makeVmiBackendUrl(backend, '3000')
         elseif backend == 'prometheus' then
             serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '9090')
-        elseif backend == 'thanos' then
+        elseif backend == 'thanos-sidecar' then
             serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '10901')
         elseif backend == 'kibana' then
             serverUrl = me.makeVmiBackendUrl('osd', '5601')
@@ -1203,7 +1203,7 @@ data:
             allowedOrigins = os.getenv("VZ_GRAFANA_ALLOWED_ORIGINS")
         elseif backend == 'prometheus' then
             allowedOrigins = os.getenv("VZ_PROMETHEUS_ALLOWED_ORIGINS")
-        elseif backend == 'thanos' then
+        elseif backend == 'thanos-sidecar' then
             allowedOrigins = os.getenv("VZ_THANOS_ALLOWED_ORIGINS")
         elseif backend == 'kibana' then
             allowedOrigins = os.getenv("VZ_KIBANA_ALLOWED_ORIGINS")

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -309,7 +309,7 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.priorityClassName }}
   priorityClassName: {{ .Values.prometheus.prometheusSpec.priorityClassName }}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.thanos }}
+{{- if and (.Values.prometheus.prometheusSpec.thanos) (eq .Values.prometheus.thanos.integration "sidecar") }}
   thanos:
 {{ toYaml .Values.prometheus.prometheusSpec.thanos | indent 4 }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
@@ -2006,6 +2006,12 @@ prometheus:
     nodePort: 30901
     httpNodePort: 30902
 
+  ## Thanos enum for picking the integration type
+  ## the integration types are disabled and sidecar
+  ##
+  thanos:
+    integration: disabled
+
   ## Configuration for Prometheus service
   ##
   service:


### PR DESCRIPTION
- Adds an optional Thanos sidecar to the Prometheus
- Adds ingress to the installation of Prometheus if Thanos sidecar is enabled
- Updates helm overrides to allow default sidecar configuration

**Local testing:**
- Installed with and without the sidecar value set to make sure nothing was installed
- Installed with the sidecar value set and removed it to see if the sidecar became disabled
- Installed with the disabled value and changed it to the sidecar to see if the sidecar got added