### PR TITLE
Use release build of thanos v0.28.0 in bom

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -788,7 +788,7 @@
           "images": [
             {
               "image": "thanos",
-              "tag": "v0.28.0-20230306212904-40834118",
+              "tag": "v0.28.0-20230307214739-f86032ae",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
The BFS pipeline for the release build of Thanos v0.28.0 is now functional. This PR replaces the image tag in the BOM with the official release build.