### PR TITLE
VZ-8748: Check for Config Changes in compStateInstallEnd State

### DIFF
--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -284,10 +284,6 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
-                // Verrazzano may continue reconciling even after the `vz install` command exits, so
-                // wait a bit before running the verify-install tests.
-                sleep time: 5, unit: 'MINUTES'
-
                 runGinkgoRandomize('verify-install')
             }
             post {

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -298,7 +298,7 @@ func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp 
 	if !checkConfigUpdated(compContext, componentStatus) || !comp.IsEnabled(compContext.EffectiveCR()) {
 		return false
 	}
-	// Do not restart the component install if monitoring of install overrides is disabled
+	// if monitoring overrides is disabled, updates are prevented for override changes and the install process should be bypassed
 	if !comp.MonitorOverrides(compContext) {
 		compContext.Log().Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
 		return false

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -298,7 +298,7 @@ func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp 
 	if !checkConfigUpdated(compContext, componentStatus) || !comp.IsEnabled(compContext.EffectiveCR()) {
 		return false
 	}
-	if !comp.MonitorOverrides(compContext) && comp.IsEnabled(compContext.EffectiveCR()) {
+	if !comp.MonitorOverrides(compContext) {
 		compContext.Log().Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
 		return false
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -209,8 +209,18 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 			}
 			compTracker.installState = compStateInstallEnd
 		}
-
 	}
+
+	// The component previously finished installing, but check for any mid-installation updates
+	if checkConfigUpdated(compContext, componentStatus) && comp.IsEnabled(compContext.EffectiveCR()) {
+		compLog.Infof("MARCO:       %s config update detected", compName)
+		compTracker.installState = compStateInstallInitDetermineComponentState
+		if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
+			compLog.ErrorfThrottled("Error writing component PreInstall state to the status: %v", err)
+		}
+		return ctrl.Result{Requeue: true}
+	}
+
 	// Component has been installed
 	return ctrl.Result{}
 }

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -298,6 +298,7 @@ func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp 
 	if !checkConfigUpdated(compContext, componentStatus) || !comp.IsEnabled(compContext.EffectiveCR()) {
 		return false
 	}
+	// Do not restart the component install if monitoring of install overrides is disabled
 	if !comp.MonitorOverrides(compContext) {
 		compContext.Log().Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
 		return false

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -212,7 +212,9 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 	}
 
 	// The component previously finished installing, but check for any mid-installation updates
-	if checkConfigUpdated(compContext, componentStatus) && comp.IsEnabled(compContext.EffectiveCR()) {
+	if spiCtx.ActualCR().Status.State != vzapi.VzStateUpgrading && spiCtx.ActualCR().Status.State != vzapi.VzStatePaused &&
+		checkConfigUpdated(compContext, componentStatus) && comp.IsEnabled(compContext.EffectiveCR()) {
+
 		if !comp.MonitorOverrides(compContext) && comp.IsEnabled(spiCtx.EffectiveCR()) {
 			compContext.Log().Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
 		} else {

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -58,7 +58,7 @@ var (
 )
 
 // TestStartUpdate tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Reconciling State
 func TestStartUpdate(t *testing.T) {
@@ -94,7 +94,7 @@ func TestStartUpdate(t *testing.T) {
 }
 
 // TestCompleteUpdateReadyComponent tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install has been started
+// GIVEN a request to reconcile a verrazzano resource after install has been started
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Ready State
 func TestCompleteUpdateReadyComponent(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCompleteUpdateReadyComponent(t *testing.T) {
 }
 
 // TestCompleteUpdateDisabledComponent tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install has been started
+// GIVEN a request to reconcile a verrazzano resource after install has been started
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Ready State
 func TestCompleteUpdateDisabledComponent(t *testing.T) {
@@ -174,7 +174,7 @@ func TestCompleteUpdateDisabledComponent(t *testing.T) {
 }
 
 // TestNoUpdateSameGeneration tests the reconcile func with same generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the same LastReconciledGeneration as verrazzano CR
 // THEN ensure a Ready State
 func TestNoUpdateSameGeneration(t *testing.T) {
@@ -207,7 +207,7 @@ func TestNoUpdateSameGeneration(t *testing.T) {
 }
 
 // TestUpdateWithUpgrade tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure an Upgrading State
 func TestUpdateWithUpgrade(t *testing.T) {
@@ -241,7 +241,7 @@ func TestUpdateWithUpgrade(t *testing.T) {
 }
 
 // TestUpdateOnUpdate tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Reconciling State
 func TestUpdateOnUpdate(t *testing.T) {
@@ -279,7 +279,7 @@ func TestUpdateOnUpdate(t *testing.T) {
 }
 
 // TestUpdateFalseMonitorChanges tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration but MonitorOverrides returns false
 // THEN ensure a Ready State
 func TestUpdateFalseMonitorChanges(t *testing.T) {


### PR DESCRIPTION
Changes:

- This PR removes the `sleep` command in ci/dynamic-updates/JenkinsfileUpdateDuringInstall.
- The bug described in VZ-8748 is fixed by adding code in `installSingleComponent` in install_component.go.
- A unit test is added in install_test.go.

Before these changes, the `installSingleComponent` function did not check for config changes once the component was already in state `compStateInstallEnd`. The bug fix adds this check and restarts the component to pre-install if appropriate.